### PR TITLE
Small fixes to Quick Tour

### DIFF
--- a/glossary.rst
+++ b/glossary.rst
@@ -18,3 +18,9 @@ Glossary
         A *Bundle* is a structured set of files (PHP files, stylesheets,
         JavaScripts, images, ...) that *implements* a single feature (a blog,
         a forum, ...) and which can be easily shared with other developers.
+
+    Environment
+        *Environments* are different sets of configuration, that share the same
+        PHP code. So basically, environments and configuration are synonyms. For
+        each application, Symfony provides three default environments:
+        *production* (``prod``), *test* (``test``), and *development* (``dev``).

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -12,9 +12,9 @@ Symfony2 stand apart from the framework crowd, let's dive into it now.
 The Directory Structure
 -----------------------
 
-The directory structure of a Symfony :term:`application` is rather flexible
+The directory structure of a Symfony :term:`project` is rather flexible
 but the directory structure of a sandbox reflects the typical and recommended
-structure of a Symfony application:
+structure of a Symfony project:
 
 * ``app/``: This directory contains the application configuration;
 
@@ -148,7 +148,7 @@ method of the ``AppKernel`` class::
             //new Symfony\Bundle\TwigBundle\TwigBundle(),
 
             // register your bundles
-            new Application\AppBundle\AppBundle(),
+            new Application\HelloBundle\HelloBundle(),
         );
 
         if ($this->isDebug()) {

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -238,7 +238,7 @@ The code is pretty straightforward but let's explain this code line by line:
   see later in this tutorial).
 
 * *line 9*: Each controller is made of several actions. As per the
-  configuration, the hello page is handled by the ``index`` action (the third
+  configuration, the *hello* page is handled by the ``index`` action (the third
   part of the ``_controller`` routing value). This method receives the
   resource placeholder values as arguments (``$name`` in our case).
 
@@ -279,7 +279,7 @@ Environments
 ------------
 
 Now that you have a better understanding on how Symfony works, have a closer
-look at the bottom of the page; you will notice a small bar with the Symfony
+look at the bottom of the *hello* page; you will notice a small bar with the Symfony
 and PHP logos. It is called the "Web Debug Toolbar" and it is the developer's
 best friend. Of course, such a tool must not be displayed when you deploy your
 application to your production servers. That's why you will find another front


### PR DESCRIPTION
Fixed some ambiguities and added _environment_ term definition to glossary to fix a broken reference that I found it in the "Quick Tour > The Architecture" tutorial.
