### PR TITLE
Updated security config filename

### DIFF
--- a/contributing/code/bugs.rst
+++ b/contributing/code/bugs.rst
@@ -1,8 +1,8 @@
 Reporting a Bug
 ===============
 
-Whenever you find a bug in Symfony, we kindly ask you to report it. It helps
-us make a better Symfony.
+Whenever you find a bug in Symfony2, we kindly ask you to report it. It helps
+us make a better Symfony2.
 
 .. caution::
    If you think you've found a security issue, please use the special

--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -2,7 +2,7 @@ Submitting a Patch
 ==================
 
 Patches are the best way to provide a bug fix or to propose enhancements to
-Symfony.
+Symfony2.
 
 Initial Setup
 -------------

--- a/contributing/code/security.rst
+++ b/contributing/code/security.rst
@@ -1,7 +1,7 @@
 Reporting a Security Issue
 ==========================
 
-Found a security issue in Symfony? Don't use the mailing-list or the bug
+Found a security issue in Symfony2? Don't use the mailing-list or the bug
 tracker. All security issues must be sent to **security [at]
 symfony-project.com** instead. Emails sent to this address are forwarded to
 the Symfony core-team private mailing-list.

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -1,9 +1,9 @@
 Coding Standards
 ================
 
-When contributing code to Symfony, you must follow its coding standards. To
+When contributing code to Symfony2, you must follow its coding standards. To
 make a long story short, here is the golden rule: *Imitate the existing
-Symfony code*.
+Symfony2 code*.
 
 Structure
 ---------

--- a/guides/bundles/configuration.rst
+++ b/guides/bundles/configuration.rst
@@ -242,7 +242,7 @@ When creating an extension, follow these simple conventions:
 * The extension should provide an XSD schema.
 
 If you follow these simple conventions, your extensions will be registered
-automatically by Symfony. If not, override the Bundle
+automatically by Symfony2. If not, override the Bundle
 :method:`Symfony\\Component\\HttpKernel\\Bundle\\Bundle::registerExtensions` method::
 
     class HelloBundle extends Bundle

--- a/guides/event/recipes.rst
+++ b/guides/event/recipes.rst
@@ -46,9 +46,9 @@ time. But when you have a long list of dependencies, using setter injection
 can be the way to go, especially for optional dependencies.
 
 .. tip::
-   If you use dependency injection like we did in the two examples above, you can
-   then easily use the Symfony Dependency Injection Component to elegantly manage
-   these objects.
+   If you use dependency injection like we did in the two examples above, you
+   can then easily use the Symfony2 Dependency Injection component to elegantly
+   manage these objects.
 
 Doing something before or after a Method Call
 ---------------------------------------------
@@ -142,9 +142,9 @@ Eventually, add the new ``bar`` method to the ``Foo`` class::
 Modifying Arguments
 -------------------
 
-If you want to allow third party classes to modify arguments passed to a
-method just before that method is executed, add a ``filter`` event at the
-beginning of the method::
+If you want to allow third party classes to modify arguments passed to a method
+just before that method is executed, add a ``filter`` event at the beginning of
+the method::
 
     class Foo
     {

--- a/guides/security/authentication.rst
+++ b/guides/security/authentication.rst
@@ -25,7 +25,7 @@ basic authentication:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 backend:
@@ -42,7 +42,7 @@ basic authentication:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall pattern="/admin/.*">
                 <form-login />
@@ -56,7 +56,7 @@ basic authentication:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'backend' => array('pattern' => '/admin/.*', 'http_basic' => true, 'logout' => true),
@@ -99,7 +99,7 @@ You can configure a firewall to use more than one authentication mechanisms:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 backend:
@@ -111,7 +111,7 @@ You can configure a firewall to use more than one authentication mechanisms:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall pattern="/admin/.*">
                 <x509 />
@@ -123,7 +123,7 @@ You can configure a firewall to use more than one authentication mechanisms:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'backend' => array(
@@ -156,7 +156,7 @@ Configuring HTTP basic authentication is as simple as it can get:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
@@ -164,7 +164,7 @@ Configuring HTTP basic authentication is as simple as it can get:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall>
                 <http-basic />
@@ -173,7 +173,7 @@ Configuring HTTP basic authentication is as simple as it can get:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main' => array('http_basic' => true),
@@ -189,7 +189,7 @@ Configuring HTTP digest authentication is as simple as it can get:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
@@ -197,7 +197,7 @@ Configuring HTTP digest authentication is as simple as it can get:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall>
                 <http-digest />
@@ -206,7 +206,7 @@ Configuring HTTP digest authentication is as simple as it can get:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main' => array('http_digest' => true),
@@ -227,7 +227,7 @@ nowadays:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
@@ -235,7 +235,7 @@ nowadays:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall>
                 <form-login />
@@ -244,7 +244,7 @@ nowadays:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main' => array('form_login' => true),
@@ -342,7 +342,7 @@ configuration example that shows how to override them all:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
@@ -357,7 +357,7 @@ configuration example that shows how to override them all:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall>
                 <form-login
@@ -374,7 +374,7 @@ configuration example that shows how to override them all:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main' => array('form_login' => array(
@@ -398,7 +398,7 @@ X.509 certificates are a great way to authenticate users if you know them all:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
@@ -406,7 +406,7 @@ X.509 certificates are a great way to authenticate users if you know them all:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall>
                 <x509 />
@@ -415,7 +415,7 @@ X.509 certificates are a great way to authenticate users if you know them all:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main' => array('x509' => true),
@@ -469,7 +469,7 @@ access a resource restricted by an access control rule:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
@@ -477,7 +477,7 @@ access a resource restricted by an access control rule:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall>
                 <anonymous />
@@ -486,7 +486,7 @@ access a resource restricted by an access control rule:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main' => array('anonymous' => true),
@@ -517,7 +517,7 @@ cookie will be ever created by Symfony2):
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
@@ -526,7 +526,7 @@ cookie will be ever created by Symfony2):
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall stateless="true">
                 <http-basic />
@@ -535,7 +535,7 @@ cookie will be ever created by Symfony2):
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main' => array('http_basic' => true, 'stateless' => true),
@@ -559,7 +559,7 @@ done by activating the ``switch-user`` listener:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
@@ -568,7 +568,7 @@ done by activating the ``switch-user`` listener:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall>
                 <http-basic />
@@ -578,7 +578,7 @@ done by activating the ``switch-user`` listener:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main'=> array('http_basic' => true, 'switch_user' => true),
@@ -603,7 +603,7 @@ security, also change the parameter name via the ``parameter`` setting:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
@@ -612,7 +612,7 @@ security, also change the parameter name via the ``parameter`` setting:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall>
                 <http-basic />
@@ -622,7 +622,7 @@ security, also change the parameter name via the ``parameter`` setting:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main'=> array(
@@ -642,7 +642,7 @@ listener:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
@@ -651,7 +651,7 @@ listener:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall>
                 <http-basic />
@@ -661,7 +661,7 @@ listener:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main'=> array('http_basic' => true, 'logout' => true),
@@ -676,16 +676,16 @@ are redirected to ``/``. This can be easily changed via the ``path`` and
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
                     http_basic: true
-                    logout:     { path: /signout, target: signin }
+                    logout:     { path: /signout, target: /signin }
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall>
                 <http-basic />
@@ -695,7 +695,7 @@ are redirected to ``/``. This can be easily changed via the ``path`` and
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main'=> array(
@@ -716,7 +716,7 @@ firewall, or just for an authentication mechanism:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             providers:
                 default:
@@ -740,7 +740,7 @@ firewall, or just for an authentication mechanism:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <provider name="default">
                 <password-encoder>sha1</password-encoder>
@@ -763,7 +763,7 @@ firewall, or just for an authentication mechanism:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'providers' => array(
                 'default' => array(

--- a/guides/security/authorization.rst
+++ b/guides/security/authorization.rst
@@ -17,7 +17,7 @@ defined in your configuration:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             access_control:
                 - { path: /admin/.*, role: ROLE_ADMIN }
@@ -25,7 +25,7 @@ defined in your configuration:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <access-control>
                 <rule path="/admin/.*" role="ROLE_ADMIN" />
@@ -35,7 +35,7 @@ defined in your configuration:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'access_control' => array(
                 array('path' => '/admin/.*', 'role' => 'ROLE_ADMIN'),
@@ -67,7 +67,7 @@ Access control rules can match a request in many different ways:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             access_control:
                 # match the path info
@@ -84,7 +84,7 @@ Access control rules can match a request in many different ways:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <access-control>
                 <!-- match the path info -->
@@ -102,7 +102,7 @@ Access control rules can match a request in many different ways:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'access_control' => array(
                 // match the path info
@@ -131,7 +131,7 @@ HTTPS:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             access_control:
                 - { path: /admin/.*, role: ROLE_ADMIN, requires_channel: https }
@@ -139,7 +139,7 @@ HTTPS:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <access-control>
                 <rule path="/admin/.*" role="ROLE_ADMIN" requires-channel="https" />
@@ -149,7 +149,7 @@ HTTPS:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'access_control' => array(
                 array('path' => '/admin/.*', 'role' => 'ROLE_ADMIN', 'requires_channel' => 'https'),

--- a/guides/security/overview.rst
+++ b/guides/security/overview.rst
@@ -140,7 +140,7 @@ Here is how you can secure your application with HTTP basic authentication:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 main:
@@ -148,7 +148,7 @@ Here is how you can secure your application with HTTP basic authentication:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall>
                 <http-basic />
@@ -157,7 +157,7 @@ Here is how you can secure your application with HTTP basic authentication:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'main' => array('http-basic' => true),
@@ -171,7 +171,7 @@ mechanisms for different parts of the application:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             firewalls:
                 backend:
@@ -183,7 +183,7 @@ mechanisms for different parts of the application:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall pattern="/admin/.*">
                 <http-basic />
@@ -194,7 +194,7 @@ mechanisms for different parts of the application:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'firewalls' => array(
                 'backend' => array('pattern' => '/admin/.*', 'http-basic' => true),
@@ -222,7 +222,7 @@ configuration:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             providers:
                 main:
@@ -231,7 +231,7 @@ configuration:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <provider>
                 <user name="foo" password="foo" />
@@ -240,7 +240,7 @@ configuration:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'provider' => array(
                 'main' => array('users' => array(
@@ -274,7 +274,7 @@ your application resources based user roles:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             providers:
                 main:
@@ -285,7 +285,7 @@ your application resources based user roles:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <provider>
                 <user name="foo" password="foo" roles="ROLE_USER,ROLE_ADMIN" />
@@ -298,7 +298,7 @@ your application resources based user roles:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'provider' => array(
                 'main' => array('users' => array(

--- a/guides/security/users.rst
+++ b/guides/security/users.rst
@@ -140,7 +140,7 @@ backend or a prototype. It is also the best provider when writing unit tests:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             providers:
                 main:
@@ -154,7 +154,7 @@ backend or a prototype. It is also the best provider when writing unit tests:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <provider name="main">
                 <user name="foo" password="foo" roles="ROLE_USER" />
@@ -169,7 +169,7 @@ backend or a prototype. It is also the best provider when writing unit tests:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'providers' => array(
                 'main' => array('users' => array(
@@ -205,7 +205,7 @@ yourself:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             providers:
                 main:
@@ -214,7 +214,7 @@ yourself:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <provider name="main">
                 <password-encoder>sha1</password-encoder>
@@ -224,7 +224,7 @@ yourself:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'providers' => array(
                 'main' => array(
@@ -309,7 +309,7 @@ rules by creating a role hierarchy:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security.config:
             role_hierarchy:
                 ROLE_ADMIN:       ROLE_USER
@@ -317,7 +317,7 @@ rules by creating a role hierarchy:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <role-hierarchy>
                 <role id="ROLE_ADMIN">ROLE_USER</role>
@@ -327,7 +327,7 @@ rules by creating a role hierarchy:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', 'config', array(
             'role_hierarchy' => array(
                 'ROLE_ADMIN'       => 'ROLE_USER',

--- a/guides/tools/YAML.rst
+++ b/guides/tools/YAML.rst
@@ -356,7 +356,7 @@ Comments can be added in YAML by prefixing them with a hash mark (``#``):
 Dynamic YAML files
 ~~~~~~~~~~~~~~~~~~
 
-In Symfony, a YAML file can contain PHP code that is evaluated just before the
+In Symfony2, a YAML file can contain PHP code that is evaluated just before the
 parsing occurs:
 
 .. code-block:: yaml

--- a/guides/translation.rst
+++ b/guides/translation.rst
@@ -114,7 +114,7 @@ unique identifier:
                         <target>J'aime Symfony2</target>
                     </trans-unit>
                     <trans-unit id="2">
-                        <source>symfony.great</source>
+                        <source>symfony2.great</source>
                         <target>J'aime Symfony2</target>
                     </trans-unit>
                 </body>
@@ -125,7 +125,7 @@ unique identifier:
 
         return array(
             'Symfony2 is great' => 'J\'aime Symfony2',
-            'symfony.great'     => 'J\'aime Symfony2',
+            'symfony2.great'     => 'J\'aime Symfony2',
         );
 
 .. note::

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -12,9 +12,9 @@ Symfony2 stand apart from the framework crowd, let's dive into it now.
 The Directory Structure
 -----------------------
 
-The directory structure of a Symfony :term:`application` is rather flexible
+The directory structure of a Symfony2 :term:`application` is rather flexible
 but the directory structure of a sandbox reflects the typical and recommended
-structure of a Symfony application:
+structure of a Symfony2 application:
 
 * ``app/``: This directory contains the application configuration;
 
@@ -105,7 +105,7 @@ stored in the ``src/`` directory::
     ));
     $loader->register();
 
-The ``UniversalClassLoader`` from Symfony is used to autoload files that
+The ``UniversalClassLoader`` from Symfony2 is used to autoload files that
 respect either the technical interoperability `standards`_ for PHP 5.3
 namespaces or the PEAR naming `convention`_ for classes. As you can see
 here, all dependencies are stored under the ``vendor/`` directory, but this is
@@ -119,12 +119,12 @@ The Bundle System
 -----------------
 
 This section starts to scratch the surface of one of the greatest and more
-powerful features of Symfony, its :term:`bundle` system.
+powerful features of Symfony2, its :term:`bundle` system.
 
 A bundle is kind of like a plugin in other software. But why is it called
-bundle and not plugin then? Because everything is a bundle in Symfony, from
+bundle and not plugin then? Because everything is a bundle in Symfony2, from
 the core framework features to the code you write for your application.
-Bundles are first-class citizens in Symfony. This gives you the flexibility to
+Bundles are first-class citizens in Symfony2. This gives you the flexibility to
 use pre-built features packaged in third-party bundles or to distribute your
 own bundles. It makes it so easy to pick and choose which features to enable
 in your application and optimize them the way you want.
@@ -363,8 +363,8 @@ specific configuration file:
         ));
 
 As we have seen in the previous part, an application is made of bundles as
-defined in the ``registerBundles()`` method but how does Symfony know where to
-look for bundles? Symfony is quite flexible in this regard. The
+defined in the ``registerBundles()`` method but how does Symfony2 know where to
+look for bundles? Symfony2 is quite flexible in this regard. The
 ``registerBundleDirs()`` method must return an associative array that maps
 namespaces to any valid directory (local or global ones)::
 
@@ -378,9 +378,9 @@ namespaces to any valid directory (local or global ones)::
     }
 
 So, when you reference the ``HelloBundle`` in a controller name or in a template
-name, Symfony will look for it under the given directories.
+name, Symfony2 will look for it under the given directories.
 
-Do you understand now why Symfony is so flexible? Share your bundles between
+Do you understand now why Symfony2 is so flexible? Share your bundles between
 applications, store them locally or globally, your choice.
 
 .. index::
@@ -390,7 +390,7 @@ Vendors
 -------
 
 Odds are your application will depend on third-party libraries. Those should
-be stored in the ``src/vendor/`` directory. It already contains the Symfony
+be stored in the ``src/vendor/`` directory. It already contains the Symfony2
 libraries, the SwiftMailer library, the Doctrine ORM, the Propel ORM, the Twig
 templating system, and a selection of the Zend Framework classes.
 
@@ -401,12 +401,12 @@ templating system, and a selection of the Zend Framework classes.
 Cache and Logs
 --------------
 
-Symfony is probably one of the fastest full-stack frameworks around. But how
+Symfony2 is probably one of the fastest full-stack frameworks around. But how
 can it be so fast if it parses and interprets tens of YAML and XML files for
 each request? This is partly due to its cache system. The application
 configuration is only parsed for the very first request and then compiled down
 to plain PHP code stored in the ``cache/`` application directory. In the
-development environment, Symfony is smart enough to flush the cache when you
+development environment, Symfony2 is smart enough to flush the cache when you
 change a file. But in the production one, it is your responsibility to clear
 the cache when you update your code or change its configuration.
 
@@ -441,14 +441,14 @@ Final Thoughts
 --------------
 
 Call me crazy, but after reading this part, you should be comfortable with
-moving things around and making Symfony work for you. Everything is done in
-Symfony to stand out of your way. So, feel free to rename and move directories
+moving things around and making Symfony2 works for you. Everything is done in
+Symfony2 to stand out of your way. So, feel free to rename and move directories
 around as you see fit.
 
 And that's all for the quick tour. From testing to sending emails, you still
-need to learn of lot to become a Symfony master. Ready to dig into these
-topics now? Look no further, go to the official `guides`_ page and pick any
-topic you want.
+need to learn a lot to become a Symfony2 master. Ready to dig into these topics
+now? Look no further, go to the official `guides`_ page and pick any topic you
+want.
 
 .. _standards:  http://groups.google.com/group/php-standards/web/psr-0-final-proposal
 .. _convention: http://pear.php.net/

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -18,11 +18,11 @@ Download and Install
 First, check that you have at least PHP 5.3.2 installed and correctly
 configured to work with a web server like Apache.
 
-Ready? Let's start by downloading Symfony. To get started even faster, we are
-going to use the "Symfony sandbox". It is a Symfony project where all the
+Ready? Let's start by downloading Symfony2. To get started even faster, we are
+going to use the "Symfony2 sandbox". It is a Symfony2 project where all the
 required libraries and some simple controllers are already included; the basic
 configuration is also already done. The great advantage of the sandbox over
-other types of installation is that you can start experimenting with Symfony
+other types of installation is that you can start experimenting with Symfony2
 immediately.
 
 Download the `sandbox`_, and unpack it in your root web directory. You
@@ -50,24 +50,24 @@ Check the Configuration
 -----------------------
 
 To avoid some headaches further down the line, check that your configuration
-can run a Symfony project smoothly by requesting the following URL:
+can run a Symfony2 project smoothly by requesting the following URL:
 
     http://localhost/sandbox/web/check.php
 
 Read the script output carefully and fix any problem that it finds.
 
-Now, request your first "real" Symfony webpage:
+Now, request your first "real" Symfony2 webpage:
 
     http://localhost/sandbox/web/index_dev.php/
 
-Symfony should congratulate you for your hard work so far!
+Symfony2 should congratulate you for your hard work so far!
 
 Your first Application
 ----------------------
 
 The sandbox comes with a simple Hello World ":term:`application`" and that's
-the application we will use to learn more about Symfony. Go to the following
-URL to be greeted by Symfony (replace Fabien with your first name):
+the application we will use to learn more about Symfony2. Go to the following
+URL to be greeted by Symfony2 (replace Fabien with your first name):
 
     http://localhost/sandbox/web/index_dev.php/hello/Fabien
 
@@ -91,7 +91,7 @@ Fabien!``).
 Configuration
 ~~~~~~~~~~~~~
 
-But how does Symfony route the request to your code? Simply by reading some
+But how does Symfony2 route the request to your code? Simply by reading some
 configuration file.
 
 All Symfony2 configuration files can be written in either PHP, XML, or `YAML`_
@@ -111,7 +111,7 @@ very easy).
 Routing
 ~~~~~~~
 
-So, Symfony routes the request by reading the routing configuration file:
+So, Symfony2 routes the request by reading the routing configuration file:
 
 .. configuration-block::
 
@@ -228,7 +228,7 @@ The controller is responsible for returning a representation of the resource
 
 The code is pretty straightforward but let's explain this code line by line:
 
-* *line 3*: Symfony takes advantage of new PHP 5.3 features and as such, all
+* *line 3*: Symfony2 takes advantage of new PHP 5.3 features and as such, all
   controllers are properly namespaced (the namespace is the first part of the
   ``_controller`` routing value: ``HelloBundle``).
 
@@ -246,8 +246,8 @@ The code is pretty straightforward but let's explain this code line by line:
   (``HelloBundle:Hello:index``) with the variables passed as a second
   argument.
 
-But what is a :term:`bundle`? All the code you write in a Symfony project is
-organized in bundles. In Symfony speak, a bundle is a structured set of files
+But what is a :term:`bundle`? All the code you write in a Symfony2 project is
+organized in bundles. In Symfony2 speak, a bundle is a structured set of files
 (PHP files, stylesheets, JavaScripts, images, ...) that implements a single
 feature (a blog, a forum, ...) and which can be easily shared with other
 developers. In our example, we only have one bundle, ``HelloBundle``.
@@ -267,8 +267,8 @@ is made of HTML and simple PHP expressions:
 
     Hello <?php echo $name ?>!
 
-Congratulations! You have looked at your first Symfony piece of code. That was
-not so hard, was it? Symfony makes it really easy to implement web sites
+Congratulations! You have looked at your first Symfony2 piece of code. That was
+not so hard, was it? Symfony2 makes it really easy to implement web sites
 better and faster.
 
 .. index::
@@ -278,13 +278,13 @@ better and faster.
 Environments
 ------------
 
-Now that you have a better understanding on how Symfony works, have a closer
-look at the bottom of the page; you will notice a small bar with the Symfony
+Now that you have a better understanding on how Symfony2 works, have a closer
+look at the bottom of the page; you will notice a small bar with the Symfony2
 and PHP logos. It is called the "Web Debug Toolbar" and it is the developer's
 best friend. Of course, such a tool must not be displayed when you deploy your
 application to your production servers. That's why you will find another front
-controller in the ``web/`` directory (``index.php``), optimized for the production
-environment:
+controller in the ``web/`` directory (``index.php``), optimized for the
+production environment:
 
     http://localhost/sandbox/web/index.php/hello/Fabien
 
@@ -299,7 +299,7 @@ better looking URL:
 
     http://localhost/hello/Fabien
 
-To make the production environment as fast as possible, Symfony maintains a
+To make the production environment as fast as possible, Symfony2 maintains a
 cache under the ``app/cache/`` directory. When you make changes, you need to
 manually remove the cached files. That's why you should always use the
 development front controller (``index_dev.php``) when working on a project.
@@ -310,7 +310,7 @@ Final Thoughts
 The 10 minutes are over. By now, you should be able to create your own simple
 routes, controllers, and templates. As an exercise, try to build something
 more useful than the Hello application! But if you are eager to learn more
-about Symfony, you can read the next part of this tutorial right away, where
+about Symfony2, you can read the next part of this tutorial right away, where
 we dive more into the templating system.
 
 .. _sandbox: http://symfony-reloaded.org/code#sandbox

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -20,8 +20,8 @@ Formats
 Nowadays, a web application should be able to deliver more than just HTML
 pages. From XML for RSS feeds or Web Services, to JSON for Ajax requests,
 there are plenty of different formats to choose from. Supporting those formats
-in Symfony is straightforward. Edit ``routing.yml`` and add a ``_format`` with a
-value of ``xml``:
+in Symfony2 is straightforward. Edit ``routing.yml`` and add a ``_format`` with
+a value of ``xml``:
 
 .. configuration-block::
 
@@ -58,8 +58,8 @@ Then, add an ``index.xml.php`` template along side ``index.php``:
     </hello>
 
 That's all there is to it. No need to change the controller. For standard
-formats, Symfony will also automatically choose the best ``Content-Type`` header
-for the response. If you want to support different formats for a single
+formats, Symfony2 will also automatically choose the best ``Content-Type``
+header for the response. If you want to support different formats for a single
 action, use the ``:_format`` placeholder in the pattern instead:
 
 .. configuration-block::
@@ -178,9 +178,9 @@ If you want to redirect the user to another page, use the ``redirect()`` method:
 
     $this->redirect($this->generateUrl('hello', array('name' => 'Lucas')));
 
-The ``generateUrl()`` is the same method as the ``generate()`` method we used on
-the ``router`` helper before. It takes the route name and an array of parameters
-as arguments and returns the associated friendly URL.
+The ``generateUrl()`` is the same method as the ``generate()`` method we used
+on the ``router`` helper before. It takes the route name and an array of
+parameters as arguments and returns the associated friendly URL.
 
 You can also easily forward the action to another one with the ``forward()``
 method. As for the ``actions`` helper, it makes an internal sub-request, but it
@@ -220,9 +220,9 @@ helper:
 The Session
 -----------
 
-Even if the HTTP protocol is stateless, Symfony provides a nice session object
+Even if the HTTP protocol is stateless, Symfony2 provides a nice session object
 that represents the client (be it a real person using a browser, a bot, or a
-web service). Between two requests, Symfony stores the attributes in a cookie
+web service). Between two requests, Symfony2 stores the attributes in a cookie
 by using the native PHP sessions.
 
 Storing and retrieving information from the session can be easily achieved

--- a/quick_tour/the_view.rst
+++ b/quick_tour/the_view.rst
@@ -19,7 +19,7 @@ Decorating Templates
 --------------------
 
 More often than not, templates in a project share common elements, like the
-well-know header and footer. In Symfony, we like to think about this problem
+well-know header and footer. In Symfony2, we like to think about this problem
 differently: a template can be decorated by another one.
 
 The ``index.php`` template is decorated by ``layout.php``, thanks to the
@@ -48,7 +48,7 @@ Now, let's have a look at the ``layout.php`` file:
 
     <?php $view['slots']->output('_content') ?>
 
-The layout is itself decorated by another layout (``::layout.php``). Symfony
+The layout is itself decorated by another layout (``::layout.php``). Symfony2
 supports multiple decoration levels: a layout can itself be decorated by
 another one. When the bundle part of the template name is empty, views are
 looked for in the ``app/views/`` directory. This directory store global views
@@ -72,8 +72,8 @@ For both layouts, the ``$view['slots']->output('_content')`` expression is
 replaced by the content of the child template, ``index.php`` and
 ``layout.php`` respectively (more on slots in the next section).
 
-As you can see, Symfony provides methods on a mysterious ``$view`` object. In a
-template, the ``$view`` variable is always available and refers to a special
+As you can see, Symfony2 provides methods on a mysterious ``$view`` object. In
+a template, the ``$view`` variable is always available and refers to a special
 object that provides a bunch of methods and properties that make the template
 engine tick.
 
@@ -192,17 +192,17 @@ you more about those.
 Template Helpers
 ----------------
 
-The Symfony templating system can be easily extended via helpers. Helpers are
+The Symfony2 templating system can be easily extended via helpers. Helpers are
 PHP objects that provide features useful in a template context. ``actions`` and
-``slots`` are two of the built-in Symfony helpers.
+``slots`` are two of the built-in Symfony2 helpers.
 
 Links between Pages
 ~~~~~~~~~~~~~~~~~~~
 
-Speaking of web applications, creating links between different pages is a
-must. Instead of hardcoding URLs in templates, the ``router`` helper knows how
-to generate URLs based on the routing configuration. That way, all your URLs
-can be easily updated by changing the configuration:
+Speaking of web applications, creating links between different pages is a must.
+Instead of hardcoding URLs in templates, the ``router`` helper knows how to
+generate URLs based on the routing configuration. That way, all your URLs can
+be easily updated by changing the configuration:
 
 .. code-block:: html+php
 
@@ -225,7 +225,7 @@ Using Assets: images, JavaScripts, and stylesheets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 What would the Internet be without images, JavaScripts, and stylesheets?
-Symfony provides three helpers to deal with them easily: ``assets``,
+Symfony2 provides three helpers to deal with them easily: ``assets``,
 ``javascripts``, and ``stylesheets``:
 
 .. code-block:: html+php
@@ -257,17 +257,17 @@ need to also add the following code in your main layout:
 Final Thoughts
 --------------
 
-The Symfony templating system is simple yet powerful. Thanks to layouts,
+The Symfony2 templating system is simple yet powerful. Thanks to layouts,
 slots, templating and action inclusions, it is very easy to organize your
 templates in a logical and extensible way.
 
-You have only been working with Symfony for about 20 minutes, and you can
-already do pretty amazing stuff with it. That's the power of Symfony. Learning
+You have only been working with Symfony2 for about 20 minutes, and you can
+already do pretty amazing stuff with it. That's the power of Symfony2. Learning
 the basics is easy, and you will soon learn that this simplicity is hidden
 under a very flexible architecture.
 
 But I get ahead of myself. First, you need to learn more about the controller
 and that's exactly the topic of the next part of this tutorial. Ready for
-another 10 minutes with Symfony?
+another 10 minutes with Symfony2?
 
 .. _Twig: http://www.twig-project.org/

--- a/quick_tour/the_view_with_twig.rst
+++ b/quick_tour/the_view_with_twig.rst
@@ -10,11 +10,11 @@ your templates more concise and more friendly for web designers.
 Final Thoughts
 --------------
 
-You have only been working with Symfony for about 20 minutes, and you can
-already do pretty amazing stuff with it. That's the power of Symfony. Learning
+You have only been working with Symfony2 for about 20 minutes, and you can
+already do pretty amazing stuff with it. That's the power of Symfony2. Learning
 the basics is easy, and you will soon learn that this simplicity is hidden
 under a very flexible architecture.
 
 But I get ahead of myself. First, you need to learn more about the controller
 and that's exactly the topic of the next part of this tutorial. Ready for
-another 10 minutes with Symfony?
+another 10 minutes with Symfony2?


### PR DESCRIPTION
As explained in the overview documentation, all following examples in the security documentation are supposed to be in an external file. However, that is not the case as the called file is the default config file.
