### PR TITLE
Fix documentation style on directives and parenthesis typo

### DIFF
--- a/contributing/code/bugs.rst
+++ b/contributing/code/bugs.rst
@@ -5,8 +5,9 @@ Whenever you find a bug in Symfony2, we kindly ask you to report it. It helps
 us make a better Symfony2.
 
 .. caution::
-   If you think you've found a security issue, please use the special
-   doc:`procedure <security>` instead.
+
+    If you think you've found a security issue, please use the special
+    doc:`procedure <security>` instead.
 
 Before submitting a bug:
 

--- a/contributing/code/license.rst
+++ b/contributing/code/license.rst
@@ -5,11 +5,11 @@ Symfony2 is released under the MIT license.
 
 According to `Wikipedia`_:
 
-  "It is a permissive license, meaning that it permits reuse within
-  proprietary software on the condition that the license is distributed with
-  that software. The license is also GPL-compatible, meaning that the GPL
-  permits combination and redistribution with software that uses the MIT
-  License."
+    "It is a permissive license, meaning that it permits reuse within
+    proprietary software on the condition that the license is distributed with
+    that software. The license is also GPL-compatible, meaning that the GPL
+    permits combination and redistribution with software that uses the MIT
+    License."
 
 The License
 -----------

--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -67,7 +67,7 @@ topic branch:
     ticket number is a good convention for bug fixes).
 
 The above command automatically switches the code to the newly created branch
-(check the branch you are working on with `git branch`.)
+(check the branch you are working on with `git branch`).
 
 Work on the code as much as you want and commit as much as you want; but keep
 in mind the following:

--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -24,8 +24,9 @@ Set up your user information with your real name and a working email address:
     $ git config --global user.email you@example.com
 
 .. tip::
-   If you are new to Git, we highly recommend you to read the excellent and free
-   `ProGit`_ book.
+
+    If you are new to Git, we highly recommend you to read the excellent and
+    free `ProGit`_ book.
 
 Get the Symfony2 code source:
 
@@ -61,8 +62,9 @@ topic branch:
     $ git checkout -b BRANCH_NAME
 
 .. tip::
-   Use a descriptive name for your branch (`ticket_XXX` where `XXX` is the ticket
-   number is a good convention for bug fixes).
+
+    Use a descriptive name for your branch (`ticket_XXX` where `XXX` is the
+    ticket number is a good convention for bug fixes).
 
 The above command automatically switches the code to the newly created branch
 (check the branch you are working on with `git branch`.)
@@ -82,11 +84,13 @@ in mind the following:
 * Write good commit messages.
 
 .. tip::
-   A good commit message is composed of a summary (the first line), optionally
-   followed by a blank line and a more detailed description. The summary should
-   start with the Component you are working on in square brackets
-   (`[DependencyInjection]`, `[FrameworkBundle]`, ...). Use a verb (`fixed ...`,
-   `added ...`, ...) to start the summary and don't add a period at the end.
+
+    A good commit message is composed of a summary (the first line), optionally
+    followed by a blank line and a more detailed description. The summary
+    should start with the Component you are working on in square brackets
+    (`[DependencyInjection]`, `[FrameworkBundle]`, ...). Use a verb
+    (`fixed ...`, `added ...`, ...) to start the summary and don't add a period
+    at the end.
 
 Submitting a Patch
 ------------------

--- a/contributing/code/security.rst
+++ b/contributing/code/security.rst
@@ -17,4 +17,5 @@ confirmed, the core-team works on a solution following these steps:
 5. Publish the post on the official Symfony blog.
 
 .. note::
-   While we are working on a patch, please do not reveal the issue publicly.
+
+    While we are working on a patch, please do not reveal the issue publicly.

--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -39,7 +39,8 @@ To install them all, run the `install_vendors.sh` script:
     $ sh install_vendors.sh
 
 .. note::
-   Note that the script takes some time to finish.
+
+    Note that the script takes some time to finish.
 
 After installation, you can update the vendors anytime with the
 `update_vendors.sh` script:
@@ -64,8 +65,9 @@ The output should display `OK`. If not, you need to figure out what's going on
 and if the tests are broken because of your modifications.
 
 .. tip::
-   Run the test suite before applying your modifications to check that they run
-   fine on your configuration.
+
+    Run the test suite before applying your modifications to check that they
+    run fine on your configuration.
 
 Code Coverage
 -------------
@@ -81,7 +83,8 @@ Check the code coverage by opening the generated `cov/index.html` page in a
 browser.
 
 .. tip::
-   The code coverage only works if you have XDebug enabled and all dependencies
-   installed.
+
+    The code coverage only works if you have XDebug enabled and all
+    dependencies installed.
 
 .. _install: http://www.phpunit.de/manual/current/en/installation.html

--- a/contributing/documentation/format.rst
+++ b/contributing/documentation/format.rst
@@ -49,7 +49,8 @@ the highlighted pseudo-language:
         <?php echo $this->foobar(); ?>
 
 .. note::
-   A list of supported languages is available on the `Pygments website`_.
+
+    A list of supported languages is available on the `Pygments website`_.
 
 Configuration Blocks
 ~~~~~~~~~~~~~~~~~~~~

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -25,8 +25,9 @@ If you want to submit a patch, clone the official documentation repository:
     $ git clone git://github.com/symfony/symfony-docs.git
 
 .. note::
-  The Symfony2 documentation is licensed under a Creative Commons
-  Attribution-Share Alike 3.0 Unported :doc:`License <license>`.
+
+    The Symfony2 documentation is licensed under a Creative Commons
+    Attribution-Share Alike 3.0 Unported :doc:`License <license>`.
 
 Reporting an Issue
 ------------------

--- a/contributing/documentation/translations.rst
+++ b/contributing/documentation/translations.rst
@@ -21,8 +21,9 @@ for. Here is the list of the official *master* repositories:
 * *Romanian*: http://github.com/sebastian-ionescu/symfony-docs-ro
 
 .. note::
-   If you want to contribute translations for a new language, read the
-   :ref:`dedicated section <translations-adding-a-new-language>`.
+
+    If you want to contribute translations for a new language, read the
+    :ref:`dedicated section <translations-adding-a-new-language>`.
 
 Joining the Translation Team
 ----------------------------
@@ -76,7 +77,8 @@ reorganized, ...). The translation team need to closely follow the English
 repository and apply changes to the translated documents as soon as possible.
 
 .. caution::
-   Non maintained languages are removed from the official list of
-   repositories as obsolete documentation is dangerous.
+
+    Non maintained languages are removed from the official list of
+    repositories as obsolete documentation is dangerous.
 
 .. _Symfony docs mailing-list: http://groups.google.com/group/symfony-docs

--- a/guides/bundles/best_practices.rst
+++ b/guides/bundles/best_practices.rst
@@ -25,8 +25,9 @@ A bundle is also a PHP namespace, composed of several segments:
 * The **bundle name**.
 
 .. caution::
-   The vendor namespace and the category namespaces are only possible as of
-   Symfony2 PR3.
+
+    The vendor namespace and the category namespaces are only possible as of
+    Symfony2 PR3.
 
 The bundle name must follow these simple rules:
 
@@ -76,8 +77,9 @@ The following files are mandatory:
 * ``Resources/doc/index.rst``: The root file for the Bundle documentation.
 
 .. note::
-   These conventions ensure that automated tools can rely on this default
-   structure to work.
+
+    These conventions ensure that automated tools can rely on this default
+    structure to work.
 
 The depth of sub-directories should be kept to the minimal for most used
 classes and files (2 levels at a maximum). More levels can be defined for
@@ -166,9 +168,10 @@ extend :class:`Symfony\\Foundation\\DependencyInjection\\ContainerAware`
 instead.
 
 .. note::
+
     If you have a look at :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller`
-    methods, you will see that they are only nice shortcuts to ease the learning
-    curve.
+    methods, you will see that they are only nice shortcuts to ease the
+    learning curve.
 
 Templates
 ---------
@@ -178,8 +181,9 @@ must not provide a main layout, but extend a default ``base`` template (which
 must provide two slots: ``content`` and ``head``).
 
 .. note::
-   The only other template engine supported is Twig, but only for specific
-   cases.
+
+    The only other template engine supported is Twig, but only for specific
+    cases.
 
 Translation Files
 -----------------

--- a/guides/bundles/configuration.rst
+++ b/guides/bundles/configuration.rst
@@ -140,8 +140,9 @@ configuration file:
         $container->loadFromExtension('hello', 'config', array());
 
 .. note::
-   You can create as many ``xxxLoad()`` methods as you want to define more
-   configuration blocks for your extension.
+
+    You can create as many ``xxxLoad()`` methods as you want to define more
+    configuration blocks for your extension.
 
 Parsing a Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -219,8 +220,9 @@ The global parameters are the following:
 * ``kernel.charset``
 
 .. caution::
-   All parameter and service names starting with a ``_`` are reserved for the
-   framework, and new ones must not be defined by bundles.
+
+    All parameter and service names starting with a ``_`` are reserved for the
+    framework, and new ones must not be defined by bundles.
 
 .. index::
    pair: Convention; Configuration
@@ -282,5 +284,6 @@ method::
     }
 
 .. caution::
-   Symfony2 tries to be as explicit as possible. So, registering a default
-   configuration automatically is probably not a good idea.
+
+    Symfony2 tries to be as explicit as possible. So, registering a default
+    configuration automatically is probably not a good idea.

--- a/guides/cache/http.rst
+++ b/guides/cache/http.rst
@@ -60,7 +60,7 @@ header when none is set by the developer by following these rules:
 
 * But if at least one ``Cache-Control`` directive is set, and no 'public' or
   ``private`` directives have been explicitly added, Symfony2 adds the
-  ``private`` directive automatically (except when ``s-maxage`` is set.)
+  ``private`` directive automatically (except when ``s-maxage`` is set).
 
 .. tip::
 
@@ -232,7 +232,7 @@ issue. Under this model, you mainly save bandwidth as the representation is
 not sent twice to the same client (a 304 response is sent instead). But if you
 design your application carefully, you might be able to get the bare minimum
 data needed to send a 304 response and save CPU also; and if needed, perform
-the more heavy tasks (see below for an implementation example.)
+the more heavy tasks (see below for an implementation example).
 
 .. index::
    single: Cache; Etag header
@@ -399,7 +399,7 @@ Public vs Private Responses
 
 As explained at the beginning of this document, Symfony2 is very conservative
 and makes all Responses private by default (the exact rules are described
-there.)
+there).
 
 If you want to use a shared cache, you must remember to explicitly add the
 ``public`` directive to ``Cache-Control``::
@@ -619,7 +619,7 @@ standalone is ``false``.
 
     Symfony2 detects if a gateway cache supports ESI via another Akamaï
     specification that is supported out of the box by the Symfony2 reverse
-    proxy (a working configuration for Varnish is also provided below.)
+    proxy (a working configuration for Varnish is also provided below).
 
 For the ESI include tag to work properly, you must define the ``_internal``
 route:

--- a/guides/doctrine/dbal/overview.rst
+++ b/guides/doctrine/dbal/overview.rst
@@ -9,8 +9,9 @@ sits on top of `PDO`_ and offers an intuitive and flexible API for
 communicating with the most popular relational databases that exist today!
 
 .. tip::
-   You can read more about the Doctrine DBAL on the official `documentation`_
-   website.
+
+    You can read more about the Doctrine DBAL on the official `documentation`_
+    website.
 
 To get started you just need to enable and configure the DBAL:
 

--- a/guides/doctrine/migrations/overview.rst
+++ b/guides/doctrine/migrations/overview.rst
@@ -9,8 +9,9 @@ layer and offers you the ability to programmatically deploy new versions of
 your database schema in a safe and standardized way.
 
 .. tip::
-   You can read more about the Doctrine Database Migrations on the projects
-   `documentation`_.
+
+    You can read more about the Doctrine Database Migrations on the projects
+    `documentation`_.
 
 All of the migrations functionality is contained in a few console commands:
 

--- a/guides/doctrine/mongodb-odm/overview.rst
+++ b/guides/doctrine/mongodb-odm/overview.rst
@@ -9,8 +9,9 @@ it works and architecture. You only deal with plain PHP objects and they are
 persisted transparently without imposing on your domain model.
 
 .. tip::
-   You can read more about the Doctrine MongoDB Object Document Mapper on the
-   projects `documentation`_.
+
+    You can read more about the Doctrine MongoDB Object Document Mapper on the
+    projects `documentation`_.
 
 To get started working with Doctrine and the MongoDB Object Document Mapper you
 just need to enable it:

--- a/guides/doctrine/orm/overview.rst
+++ b/guides/doctrine/orm/overview.rst
@@ -9,8 +9,9 @@ powerful DataBase Abstraction Layer (DBAL). It provides transparent
 persistence for PHP objects.
 
 .. tip::
-   You can read more about the Doctrine Object Relational Mapper on the
-   official `documentation`_ website.
+
+    You can read more about the Doctrine Object Relational Mapper on the
+    official `documentation`_ website.
 
 To get started, enable and configure the :doc:`Doctrine DBAL
 </guides/doctrine/dbal/overview>`, then enable the ORM:
@@ -61,10 +62,11 @@ any PHP class::
     }
 
 .. tip::
-    When defining your entities, you can omit the getter/setter methods and
-    let Doctrine create them for you with the ``doctrine:generate:entities``
-    command. This only works after you create the mapping information (see
-    below.)
+
+     When defining your entities, you can omit the getter/setter methods and
+     let Doctrine create them for you with the ``doctrine:generate:entities``
+     command. This only works after you create the mapping information (see
+     below).
 
 To let Doctrine manage your classes (entities in Doctrine2 speak), you need to
 write mapping information with annotations, XML, or YAML:
@@ -128,9 +130,10 @@ write mapping information with annotations, XML, or YAML:
         </doctrine-mapping>
 
 .. note::
-   If you use YAML or XML to describe your entities, you can omit the creation
-   of the Entity class, and let the ``doctrine:generate:entities`` command do
-   it for you.
+
+    If you use YAML or XML to describe your entities, you can omit the creation
+    of the Entity class, and let the ``doctrine:generate:entities`` command do
+    it for you.
 
 Create the database and the schema related to your metadata information with
 the following commands:

--- a/guides/emails.rst
+++ b/guides/emails.rst
@@ -104,8 +104,9 @@ The mailer is accessible via the ``mailer`` service; from an action::
     }
 
 .. note::
-   To keep things decoupled, the email body has been stored in a template,
-   rendered with the ``renderView()`` method.
+
+    To keep things decoupled, the email body has been stored in a template,
+    rendered with the ``renderView()`` method.
 
 Using Gmail
 -----------

--- a/guides/event/overview.rst
+++ b/guides/event/overview.rst
@@ -50,9 +50,10 @@ Here are some examples of good event names:
 * response.filter_content
 
 .. note::
-   You can of course extend the ``Event`` class to specialize an event further,
-   or enforce some constraints, but most of the time it adds an unnecessary
-   level of complexity.
+
+    You can of course extend the ``Event`` class to specialize an event
+    further, or enforce some constraints, but most of the time it adds an
+    unnecessary level of complexity.
 
 Besides its name, an ``Event`` instance can store additional data about the
 notified event:
@@ -111,11 +112,12 @@ The ``connect()`` method takes two arguments:
 * A PHP callable to call when the event is notified.
 
 .. note::
-   A `PHP callable`_ is a PHP variable that can be used by the
-   ``call_user_func()`` function and returns ``true`` when passed to the
-   ``is_callable()`` function. It can be a ``\Closure`` instance, a string
-   representing a function, or an array representing an object method or a
-   class method.
+
+    A `PHP callable`_ is a PHP variable that can be used by the
+    ``call_user_func()`` function and returns ``true`` when passed to the
+    ``is_callable()`` function. It can be a ``\Closure`` instance, a string
+    representing a function, or an array representing an object method or a
+    class method.
 
 Once a listener is registered with the dispatcher, it waits until the event is
 notified. For the above example, the dispatcher calls ``$callable`` whenever
@@ -123,12 +125,14 @@ the ``user.change_culture`` event is notified; the listener receives an
 ``Event`` instance as an argument.
 
 .. note::
-   The listeners are called by the event dispatcher in the same order you
-   connected them.
+
+    The listeners are called by the event dispatcher in the same order you
+    connected them.
 
 .. tip::
-   If you use the Symfony2 MVC framework, listeners are automatically
-   registered based on your :ref:`configuration <kernel_listener_tag>`.
+
+    If you use the Symfony2 MVC framework, listeners are automatically
+    registered based on your :ref:`configuration <kernel_listener_tag>`.
 
 .. index::
    single: Event Dispatcher; Notification

--- a/guides/event/recipes.rst
+++ b/guides/event/recipes.rst
@@ -46,9 +46,10 @@ time. But when you have a long list of dependencies, using setter injection
 can be the way to go, especially for optional dependencies.
 
 .. tip::
-   If you use dependency injection like we did in the two examples above, you
-   can then easily use the Symfony2 Dependency Injection component to elegantly
-   manage these objects.
+
+    If you use dependency injection like we did in the two examples above, you
+    can then easily use the Symfony2 Dependency Injection component to
+    elegantly manage these objects.
 
 Doing something before or after a Method Call
 ---------------------------------------------

--- a/guides/forms/overview.rst
+++ b/guides/forms/overview.rst
@@ -75,9 +75,10 @@ Let's create a simple template to render the form:
     </form>
 
 .. note::
-   Form rendering in templates is covered in two dedicated chapters: one for
-   :doc:`PHP templates </guides/forms/view>`, and one for :doc:`Twig templates
-   </guides/forms/twig>`.
+
+    Form rendering in templates is covered in two dedicated chapters: one for
+    :doc:`PHP templates </guides/forms/view>`, and one for :doc:`Twig templates
+    </guides/forms/twig>`.
 
 When the user submits the form, we also need to handle the submitted data. All
 the data is stored in a POST parameter with the name of the form::

--- a/guides/forms/view.rst
+++ b/guides/forms/view.rst
@@ -112,13 +112,15 @@ parameter.
         </form>
         
 .. note::
-   As you can see, Twig filters are prefixed with "render_". Other than the 
-   methods of the "form" helper, these filters are global and prone to
-   naming collisions.
+
+    As you can see, Twig filters are prefixed with "render_". Other than the
+    methods of the "form" helper, these filters are global and prone to
+    naming collisions.
 
 .. tip::
-   By default, the ``errors`` helper generates a ``<ul>`` list, but this
-   can be easily customized as you will see later in this document.
+
+    By default, the ``errors`` helper generates a ``<ul>`` list, but this
+    can be easily customized as you will see later in this document.
 
 Last but not the least, a form containing a file input must contain the
 ``enctype`` attribute; use the ``enctype`` helper to take render it:
@@ -170,8 +172,9 @@ The ``render`` helper renders the HTML representation of a field:
         <?php echo $view['form']->render($form['title']) ?>
 
 .. note::
-   The field's template is selected based on the field's class name, as you will
-   learn later.
+
+    The field's template is selected based on the field's class name, as you will
+    learn later.
 
 The ``label`` helper renders the ``<label>`` tag associated with the field:
 
@@ -199,7 +202,8 @@ label:
         <?php echo $view['form']->label($form['title'], 'Give me a title') ?>
 
 .. note::
-   Symfony2 automatically internationalizes all labels and error messages.
+
+    Symfony2 automatically internationalizes all labels and error messages.
 
 The ``errors`` helper renders the field errors:
 
@@ -488,5 +492,6 @@ parent class - ``FieldGroup`` - is used instead:
         <?php echo $view['form']->hidden($field) ?>
 
 .. caution::
-   The ``render`` method is not very flexible and should only be used to
-   build prototypes.
+
+    The ``render`` method is not very flexible and should only be used to
+    build prototypes.

--- a/guides/internals/kernel.rst
+++ b/guides/internals/kernel.rst
@@ -41,9 +41,10 @@ name (a "class::method" string, like
 ``Bundle\BlogBundle\PostController:indexAction``).
 
 .. tip::
-   The default implementation uses the
-   :class:`Symfony\\Bundle\\FrameworkBundle\\RequestListener` to define the
-   ``_controller`` Request attribute (see below).
+
+    The default implementation uses the
+    :class:`Symfony\\Bundle\\FrameworkBundle\\RequestListener` to define the
+    ``_controller`` Request attribute (see below).
 
 The
 :method:`Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface::getArguments`
@@ -53,16 +54,16 @@ the Request attributes.
 
 .. sidebar:: Matching Controller method arguments from Request attributes
 
-   For each method argument, Symfony2 tries to get the value of a Request
-   attribute with the same name. If it is not defined, the argument default
-   value is used if defined::
+    For each method argument, Symfony2 tries to get the value of a Request
+    attribute with the same name. If it is not defined, the argument default
+    value is used if defined::
 
-       // Symfony2 will look for an 'id' attribute (mandatory)
-       // and an 'admin' one (optional)
-       public function showAction($id, $admin = true)
-       {
-           // ...
-       }
+        // Symfony2 will look for an 'id' attribute (mandatory)
+        // and an 'admin' one (optional)
+        public function showAction($id, $admin = true)
+        {
+            // ...
+        }
 
 .. index::
   single: Internals; Request Handling
@@ -140,8 +141,9 @@ method::
     }
 
 .. tip::
-   If you are not yet familiar with the Symfony2 Event Dispatcher, read the
-   :doc:`dedicated chapter </guides/event/overview>` first.
+
+    If you are not yet familiar with the Symfony2 Event Dispatcher, read the
+    :doc:`dedicated chapter </guides/event/overview>` first.
 
 .. index::
    single: Event; core.request

--- a/guides/internals/overview.rst
+++ b/guides/internals/overview.rst
@@ -9,18 +9,20 @@ That makes me very happy! This section is an in-depth explanation of the
 Symfony2 internals.
 
 .. note::
-   You need to read this section only if you want to understand how Symfony2
-   works behind the scene, or if you want to extend Symfony2.
+
+    You need to read this section only if you want to understand how Symfony2
+    works behind the scene, or if you want to extend Symfony2.
 
 The Symfony2 code is made of several independent layers. Each layer is built
 on top of the previous one.
 
 .. tip::
-   Autoloading is not managed by the framework directly; it's done
-   independently with the help of the
-   :class:`Symfony\\Component\\HttpFoundation\\UniversalClassLoader` class and
-   the ``src/autoload.php`` file. Read the :doc:`dedicated chapter
-   </guides/tools/autoloader>` for more information.
+
+    Autoloading is not managed by the framework directly; it's done
+    independently with the help of the
+    :class:`Symfony\\Component\\HttpFoundation\\UniversalClassLoader` class
+    and the ``src/autoload.php`` file. Read the :doc:`dedicated chapter
+    </guides/tools/autoloader>` for more information.
 
 ``HttpFoundation`` Component
 ----------------------------
@@ -41,8 +43,9 @@ variables:
   :class:`Symfony\\Component\\HttpFoundation\\SessionStorage\\SessionStorageInterface`
   interface abstract session management ``session_*()`` functions.
 
-.. seealso:: Read more about the :doc:`HttpFoundation <http_foundation>`
-   component.
+.. seealso::
+
+    Read more about the :doc:`HttpFoundation <http_foundation>` component.
 
 ``HttpKernel`` Component
 ------------------------

--- a/guides/internals/profiler.rst
+++ b/guides/internals/profiler.rst
@@ -14,11 +14,12 @@ profiler, the web debug toolbar, and the web profiler are all already
 configured with sensible settings.
 
 .. note::
-   The profiler collects information for all requests (simple requests,
-   redirects, exceptions, Ajax requests, ESI requests; and for all HTTP
-   methods and all formats). It means that for a single URL, you can have
-   several associated profiling data (one per external request/response
-   pair).
+
+    The profiler collects information for all requests (simple requests,
+    redirects, exceptions, Ajax requests, ESI requests; and for all HTTP
+    methods and all formats). It means that for a single URL, you can have
+    several associated profiling data (one per external request/response
+    pair).
 
 Visualizing Profiling Data
 --------------------------
@@ -35,8 +36,9 @@ If the summary provided by the Web Debug Toolbar is not enough, click on the
 token link (a string made of 13 random characters) to access the Web Profiler.
 
 .. note::
-   If the token is not clickable, it means that the profiler routes are not
-   registered (see below for configuration information).
+
+    If the token is not clickable, it means that the profiler routes are not
+    registered (see below for configuration information).
 
 Analyzing Profiling data with the Web Profiler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -71,8 +73,9 @@ check various things and enforce some metrics::
     }
 
 .. tip::
-   Read the API for built-in `data collectors`_ to learn more about their
-   interfaces.
+
+    Read the API for built-in `data collectors`_ to learn more about their
+    interfaces.
 
 If a test fails because of profiling data (too many DB queries for instance),
 you might want to use the Web Profiler to analyze the request after the tests
@@ -84,9 +87,10 @@ finish. It's easy to achieve if you embed the token in the error message::
     );
 
 .. caution::
-    The profiler store can be different depending on the environment
-    (especially if you use the SQLite store, which is the default configured
-    one).
+
+     The profiler store can be different depending on the environment
+     (especially if you use the SQLite store, which is the default configured
+     one).
 
 Accessing the Profiling information
 -----------------------------------
@@ -102,9 +106,10 @@ HTTP header of the Response::
     $profiler = $container->get('profiler')->getFromToken($token);
 
 .. tip::
-   When the profiler is enabled but not the web debug toolbar, or when you
-   want to get the token for an Ajax request, use a tool like Firebug to get
-   the value of the ``X-Debug-Token`` HTTP header.
+
+    When the profiler is enabled but not the web debug toolbar, or when you
+    want to get the token for an Ajax request, use a tool like Firebug to get
+    the value of the ``X-Debug-Token`` HTTP header.
 
 You can also set the token from your code, based for instance on the username
 or any other information, to ease the retrieval later on::
@@ -347,9 +352,10 @@ The ``collect()`` method is responsible for storing the data it wants to give
 access to in local properties.
 
 .. caution::
-   As the profiler serializes data collector instances, you should not store
-   objects that cannot be serialized (like PDO objects), or you need to provide
-   your own ``serialize()`` method.
+
+    As the profiler serializes data collector instances, you should not
+    store objects that cannot be serialized (like PDO objects), or you need
+    to provide your own ``serialize()`` method.
 
 Most of the time, it is convenient to extend
 :class:`Symfony\\Component\\HttpKernel\\DataCollector\\DataCollector` and

--- a/guides/security/authentication.rst
+++ b/guides/security/authentication.rst
@@ -75,7 +75,7 @@ basic authentication:
 Each firewall configuration is activated when the incoming request matches the
 regular expression defined by the ``pattern`` setting. This pattern must match
 the request path info (``preg_match('#^'.PATTERN_VALUE.'$#',
-$request->getPathInfo())``.)
+$request->getPathInfo())``).
 
 .. tip::
 
@@ -155,7 +155,7 @@ X.509 certificate, an Authorization HTTP header, or use a form to login.
     authentication mechanisms, Symfony2 automatically defines a default entry
     point (in the example above, the login form; but if the user send an
     Authorization HTTP header with wrong credentials, Symfony2 will use the
-    HTTP basic entry point.)
+    HTTP basic entry point).
 
 .. note::
 
@@ -499,7 +499,7 @@ working configuration for Apache:
     </VirtualHost>
 
 By default, the username is the email declared in the certificate (the value
-of the ``SSL_CLIENT_S_DN_Email`` environment variable.)
+of the ``SSL_CLIENT_S_DN_Email`` environment variable).
 
 .. tip::
 
@@ -549,7 +549,7 @@ restricted by a more restrictive access control rule:
 As anonymous users are authenticated, the ``isAuthenticated()`` method returns
 ``true``. To check is the user is anonymous, check for the
 ``IS_AUTHENTICATED_ANONYMOUSLY`` role instead (note that all non-anonymous
-users have the ``IS_AUTHENTICATED_FULLY`` role.)
+users have the ``IS_AUTHENTICATED_FULLY`` role).
 
 .. index::
    single: Security; Stateless Authentication
@@ -606,7 +606,7 @@ Impersonating a User
 
 Sometimes, it's useful to be able to switch from one user to another without
 having to logout and login again (for instance when you are debugging or try
-to understand a bug a user see and you cannot reproduce.) This can be easily
+to understand a bug a user see and you cannot reproduce). This can be easily
 done by activating the ``switch-user`` listener:
 
 .. configuration-block::

--- a/guides/security/authorization.rst
+++ b/guides/security/authorization.rst
@@ -59,7 +59,7 @@ if he is not authenticated yet.
 In the example above, we match requests based on their path info, but there
 are many other ways as you will learn in the next section.
 
-..tip::
+.. tip::
 
     Symfony2 automatically adds a special role based on the anonymous flag:
     ``IS_AUTHENTICATED_ANONYMOUSLY`` for anonymous users and

--- a/guides/security/overview.rst
+++ b/guides/security/overview.rst
@@ -9,7 +9,7 @@ providing authentication and authorization.
 
 *Authentication* ensures that the user is who he claims to be. *Authorization*
 refers to the process of deciding whether a user is allowed to perform an
-action or not (authorization comes after authentication.)
+action or not (authorization comes after authentication).
 
 This document is a quick overview of these main concepts, but the real power
 is distilled in three other documents: :doc:`Users </guides/security/users>`,

--- a/guides/security/users.rst
+++ b/guides/security/users.rst
@@ -403,9 +403,9 @@ method::
 .. tip::
 
     Be aware that anonymous users are considered authenticated. If you want to
-    check if a user is "fully authenticated" (non-anonymous), you need to
-    check if the user has the special ``IS_AUTHENTICATED_FULLY`` role (or
-    check that the user has not the ``IS_AUTHENTICATED_ANONYMOUSLY`` role).
+    check if a user is "fully authenticated" (non-anonymous), you need to check
+    if the user has the special ``IS_AUTHENTICATED_FULLY`` role (or check that
+    the user has not the ``IS_AUTHENTICATED_ANONYMOUSLY`` role).
 
 .. index::
    single: Security; Roles

--- a/guides/security/users.rst
+++ b/guides/security/users.rst
@@ -102,7 +102,7 @@ For most use case, use
 
 When encoding your passwords, it's better to also define a unique salt per user
 (the ``getSalt()`` method can return the primary key if users are persisted in
-a database for instance.)
+a database for instance).
 
 .. index::
    single: Security; AdvancedAccountInterface
@@ -416,7 +416,7 @@ Roles
 A User can have as many roles as needed. Roles are usually defined as strings,
 but they can be any object implementing
 :class:`Symfony\\Component\\Security\\Role\\RoleInterface` (roles are always
-objects internally.) Roles defined as strings should begin with the ``ROLE_``
+objects internally). Roles defined as strings should begin with the ``ROLE_``
 prefix to be automatically managed by Symfony2.
 
 The roles are used by the access decision manager to secure resources. Read

--- a/guides/symfony1.rst
+++ b/guides/symfony1.rst
@@ -17,5 +17,6 @@ bundles, create sub-namespaces for controllers, sub-directories for templates,
 different semantic configurations, separate routing configurations, and so on.
 
 .. tip::
-   Read the definition of a :term:`Project`, an :term:`Application`, and a
-   :term:`Bundle` in the glossary.
+
+    Read the definition of a :term:`Project`, an :term:`Application`, and a
+    :term:`Bundle` in the glossary.

--- a/guides/templating/Twig.rst
+++ b/guides/templating/Twig.rst
@@ -35,7 +35,8 @@ template::
     Hello {{ $name }}!
 
 .. note::
-   The Twig templates must use the ``twig`` extension.
+
+    The Twig templates must use the ``twig`` extension.
 
 And here is a typical layout:
 

--- a/guides/testing/client.rst
+++ b/guides/testing/client.rst
@@ -7,8 +7,9 @@ The Test Client
 The test Client simulates an HTTP client like a browser.
 
 .. note::
-   The test Client is based on the ``BrowserKit`` and the ``Crawler``
-   components.
+
+    The test Client is based on the ``BrowserKit`` and the ``Crawler``
+    components.
 
 Making Requests
 ---------------
@@ -36,8 +37,9 @@ HTTP method and the form URL, it gives you a nice API to upload files, and it
 merges the submitted values with the form default ones, and more.
 
 .. tip::
-   The Crawler is documented in its own :doc:`section <crawler>`. Read it to
-   learn more about the ``Link`` and ``Form`` objects.
+
+    The Crawler is documented in its own :doc:`section <crawler>`. Read it to
+    learn more about the ``Link`` and ``Form`` objects.
 
 But you can also simulate form submissions and complex requests with the
 additional arguments of the ``request()`` method::

--- a/guides/testing/configuration.rst
+++ b/guides/testing/configuration.rst
@@ -15,8 +15,9 @@ Each application has its own PHPUnit configuration, stored in the
 create a ``phpunit.xml`` file to tweak the configuration for your local machine.
 
 .. tip::
-   Store the ``phpunit.xml.dist`` file in your code repository, and ignore the
-   ``phpunit.xml`` file.
+
+    Store the ``phpunit.xml.dist`` file in your code repository, and ignore the
+    ``phpunit.xml`` file.
 
 By default, only the tests stored in the ``Application`` namespace are run by
 the ``phpunit`` command. But you can easily add more namespaces. For instance,
@@ -99,5 +100,6 @@ You can also override HTTP headers on a per request basis::
     ));
 
 .. tip::
-   To provide your own Client, override the ``test.client.class`` parameter, or
-   define a ``test.client`` service.
+
+    To provide your own Client, override the ``test.client.class`` parameter,
+    or define a ``test.client`` service.

--- a/guides/testing/crawler.rst
+++ b/guides/testing/crawler.rst
@@ -78,8 +78,9 @@ each method returns a new Crawler instance for the matching nodes::
         ->first();
 
 .. tip::
-   Use the ``count()`` function to get the number of nodes stored in a Crawler:
-   ``count($crawler)``
+
+    Use the ``count()`` function to get the number of nodes stored in a Crawler:
+    ``count($crawler)``
 
 Extracting Information
 ----------------------
@@ -120,7 +121,8 @@ The Client ``click()`` method takes a ``Link`` instance as returned by the
     $client->click($link);
 
 .. tip::
-   The ``links()`` method returns an array of ``Link`` objects for all nodes.
+
+    The ``links()`` method returns an array of ``Link`` objects for all nodes.
 
 Forms
 -----
@@ -191,8 +193,9 @@ their type::
     $form['photo']->upload('/path/to/lucas.jpg');
 
 .. tip::
-   You can get the values that will be submitted by calling the ``getValues()``
-   method. The uploaded files are available in a separate array returned by
-   ``getFiles()``. The ``getPhpValues()`` and ``getPhpFiles()`` also return the
-   submitted values, but in the PHP format (it converts the keys with square
-   brackets notation to PHP arrays).
+
+    You can get the values that will be submitted by calling the ``getValues()``
+    method. The uploaded files are available in a separate array returned by
+    ``getFiles()``. The ``getPhpValues()`` and ``getPhpFiles()`` also return
+    the submitted values, but in the PHP format (it converts the keys with
+    square brackets notation to PHP arrays).

--- a/guides/testing/overview.rst
+++ b/guides/testing/overview.rst
@@ -16,7 +16,8 @@ conventions. This part does not document PHPUnit itself, but if you don't know
 it yet, you can read its excellent `documentation`_.
 
 .. note::
-   Symfony2 works with PHPUnit 3.5 or later.
+
+    Symfony2 works with PHPUnit 3.5 or later.
 
 The default PHPUnit configuration looks for tests under ``Tests/``
 sub-directory of your bundles:
@@ -47,7 +48,8 @@ Running the test suite for a given application is straightforward:
     $ phpunit
 
 .. tip::
-   Code coverage can be generated with the ``--coverage-html`` option.
+
+    Code coverage can be generated with the ``--coverage-html`` option.
 
 .. index::
    single: Tests; Unit Tests
@@ -120,8 +122,9 @@ The ``request()`` method returns a ``Crawler`` object which can be used to
 select elements in the Response, to click on links, and to submit forms.
 
 .. tip::
-   The Crawler can only be used if the Response content is an XML or an HTML
-   document.
+
+    The Crawler can only be used if the Response content is an XML or an HTML
+    document.
 
 Click on a link by first selecting it with the Crawler using either a XPath
 expression or a CSS selector, then use the Client to click on it::

--- a/guides/testing/recipes.rst
+++ b/guides/testing/recipes.rst
@@ -39,8 +39,9 @@ Insulated clients transparently execute their requests in a dedicated and
 clean PHP process, thus avoiding any side-effects.
 
 .. tip::
-   As an insulated client is slower, you can keep one client in the main
-   process, and insulate the other ones.
+
+    As an insulated client is slower, you can keep one client in the main
+    process, and insulate the other ones.
 
 Testing Redirection
 -------------------
@@ -106,8 +107,9 @@ check that the profiler is indeed available (it is enabled by default in the
     }
 
 .. note::
-   The profiler information are available even if you insulate the client or if
-   you use an HTTP layer for your tests.
+
+    The profiler information are available even if you insulate the client or
+    if you use an HTTP layer for your tests.
 
 Container
 ---------
@@ -123,8 +125,9 @@ Be warned that this does not work if you insulate the client or if you use an
 HTTP layer.
 
 .. tip::
-   If the information you need to check are available from the profiler, use
-   them instead.
+
+    If the information you need to check are available from the profiler, use
+    them instead.
 
 .. index::
    single: Tests; Assertions

--- a/guides/tools/YAML.rst
+++ b/guides/tools/YAML.rst
@@ -15,9 +15,10 @@ The Symfony2 :namespace:`Symfony\\Component\\Yaml` Component knows how to
 parse YAML and dump a PHP array to YAML.
 
 .. note::
-   Even if the YAML format can describe complex nested data structure, this
-   guide only describes the minimum set of features needed to use YAML as a
-   configuration file format.
+
+    Even if the YAML format can describe complex nested data structure, this
+    guide only describes the minimum set of features needed to use YAML as a
+    configuration file format.
 
 Reading YAML Files
 ------------------
@@ -42,8 +43,9 @@ occurred::
     }
 
 .. tip::
-   As the parser is reentrant, you can use the same parser object to load
-   different YAML strings.
+
+    As the parser is reentrant, you can use the same parser object to load
+    different YAML strings.
 
 When loading a YAML file, it is sometimes better to use the
 :method:`Symfony\\Component\\Yaml\\Yaml::load` wrapper method::
@@ -78,8 +80,9 @@ to its YAML representation::
     file_put_contents('/path/to/file.yaml', $yaml);
 
 .. note::
-   There are some limitations: the dumper is not able to dump resources and
-   dumping PHP objects is considered an alpha feature.
+
+    There are some limitations: the dumper is not able to dump resources and
+    dumping PHP objects is considered an alpha feature.
 
 If you only need to dump one array, you can use the
 :method:`Symfony\\Component\\Yaml\\Yaml::dump` static method shortcut::
@@ -143,8 +146,9 @@ Quoted styles are useful when a string starts or ends with one or more relevant
 spaces.
 
 .. tip::
-   The double-quoted style provides a way to express arbitrary strings, by
-   using ``\`` escape sequences. It is very useful when you need to embed a
+
+    The double-quoted style provides a way to express arbitrary strings, by
+     using ``\`` escape sequences. It is very useful when you need to embed a
    ``\n`` or a unicode character in a string.
 
 When a string contains line breaks, you can use the literal style, indicated
@@ -169,8 +173,9 @@ where each line break is replaced by a space:
       without carriage returns.
 
 .. note::
-   Notice the two spaces before each line in the previous examples. They won't
-   appear in the resulting PHP strings.
+
+    Notice the two spaces before each line in the previous examples. They won't
+    appear in the resulting PHP strings.
 
 Numbers
 ~~~~~~~
@@ -261,7 +266,8 @@ which is equivalent to this PHP code::
     array('PHP' => 5.2, 'MySQL' => 5.1, 'Apache' => '2.2.20');
 
 .. note::
-   In a mapping, a key can be any valid scalar.
+
+    In a mapping, a key can be any valid scalar.
 
 The number of spaces between the colon and the value does not matter:
 
@@ -350,8 +356,9 @@ Comments can be added in YAML by prefixing them with a hash mark (``#``):
     "Symfony2": { PHP: 5.3, Doctrine: 2.0 } # Comment at the end of a line
 
 .. note::
-   Comments are simply ignored by the YAML parser and do not need to be
-   indented according to the current level of nesting in a collection.
+
+    Comments are simply ignored by the YAML parser and do not need to be
+    indented according to the current level of nesting in a collection.
 
 Dynamic YAML files
 ~~~~~~~~~~~~~~~~~~

--- a/guides/tools/autoloader.rst
+++ b/guides/tools/autoloader.rst
@@ -35,8 +35,9 @@ straightforward::
 The autoloader is useful only if you add some libraries to autoload.
 
 .. note::
-   The autoloader is automatically registered in a Symfony2 application (see
-   ``src/autoload.php``).
+
+    The autoloader is automatically registered in a Symfony2 application (see
+    ``src/autoload.php``).
 
 If the classes to autoload use namespaces, use the
 :method:`Symfony\\Component\\HttpFoundation\\UniversalClassLoader::registerNamespace` or
@@ -63,8 +64,9 @@ methods::
     ));
 
 .. note::
-   Some libraries also need that their root path be registered in the PHP
-   include path (``set_include_path()``).
+
+    Some libraries also need that their root path be registered in the PHP
+    include path (``set_include_path()``).
 
 Classes from a sub-namespace or a sub-hierarchy of PEAR classes can be looked
 for in a location list to ease the vendoring of a sub-set of classes for large

--- a/guides/tools/finder.rst
+++ b/guides/tools/finder.rst
@@ -29,10 +29,11 @@ recursively. The Finder class uses a fluent interface, so all methods return
 the Finder instance.
 
 .. tip::
-   A Finder instance is a PHP `Iterator`_. So, instead of iterating over the
-   Finder with ``foreach``, you can also convert it to an array with the
-   :phpfunction:`iterator_to_array` method, or get the number of items with
-   :phpfunction:`iterator_count`.
+
+    A Finder instance is a PHP `Iterator`_. So, instead of iterating over the
+    Finder with ``foreach``, you can also convert it to an array with the
+    :phpfunction:`iterator_to_array` method, or get the number of items with
+    :phpfunction:`iterator_count`.
 
 Criteria
 --------
@@ -76,7 +77,8 @@ And it also works with user-defined streams::
     }
 
 .. note::
-   Read the `Streams`_ documentation to learn how to create your own streams.
+
+    Read the `Streams`_ documentation to learn how to create your own streams.
 
 Files or Directories
 ~~~~~~~~~~~~~~~~~~~~~
@@ -108,8 +110,9 @@ Sort the result by name or by type (directories first, then files)::
     $finder->sortByType();
 
 .. note::
-   Notice that the ``sort*`` methods need to get all matching elements to do
-   their jobs. For large iterators, it is slow.
+
+    Notice that the ``sort*`` methods need to get all matching elements to do
+    their jobs. For large iterators, it is slow.
 
 You can also define your own sorting algorithm with ``sort()`` method::
 

--- a/guides/translation.rst
+++ b/guides/translation.rst
@@ -46,10 +46,11 @@ The ``fallback`` attribute defines the fallback locale when a translation does
 not exist in the user locale.
 
 .. tip::
-   When a translation does not exist for a locale, the translator tries to find
-   the translation for the language (``fr`` when the locale is ``fr_FR`` for
-   instance); if it also fails, it looks for a translation for the fallback
-   locale.
+
+    When a translation does not exist for a locale, the translator tries to
+    find the translation for the language (``fr`` when the locale is ``fr_FR``
+    for instance); if it also fails, it looks for a translation for the
+    fallback locale.
 
 The locale used in translations is the one stored in the user session.
 
@@ -68,8 +69,9 @@ If you have placeholders in strings, pass their values as the second argument::
     $t = $this->get('translator')->trans('Symfony2 is {{ what }}!', array('{{ what }}' => 'great'));
 
 .. note::
-   The placeholders can have any form, but using the ``{{ var }}`` notation
-   allows the message to be used in Twig templates.
+
+    The placeholders can have any form, but using the ``{{ var }}`` notation
+    allows the message to be used in Twig templates.
 
 By default, the translator looks for messages in the default ``messages``
 domain. Override it via the third argument::
@@ -192,10 +194,11 @@ unique identifier:
             );
 
 .. note::
-   You can also store translations in a database, or any other storage by
-   providing a custom class implementing the
-   :class:`Symfony\\Component\\Translation\\Loader\\LoaderInterface` interface.
-   See below to learn how to register custom loaders.
+
+    You can also store translations in a database, or any other storage by
+    providing a custom class implementing the
+    :class:`Symfony\\Component\\Translation\\Loader\\LoaderInterface` interface.
+    See below to learn how to register custom loaders.
 
 Pluralization
 -------------
@@ -240,8 +243,9 @@ translation context (note that the tags do not need to be the same in the
 original message and in the translated one).
 
 .. tip:
-   As tags are optional, the translator doesn't use them (the translator will
-   only get a string based on its position in the string).
+
+    As tags are optional, the translator doesn't use them (the translator will
+    only get a string based on its position in the string).
 
 Sometimes, you want a different translation for specific cases (for ``0``, or
 when the count is large enough, when the count is negative, ...). For such
@@ -269,7 +273,8 @@ delimiter can be ``[`` (exclusive) or ``]`` (inclusive). Beside numbers, you
 can use ``-Inf`` and ``+Inf`` for the infinite.
 
 .. note::
-   Symfony2 uses the `ISO 31-11`_ for intervals notation.
+
+    Symfony2 uses the `ISO 31-11`_ for intervals notation.
 
 The translator
 :method:`Symfony\\Component\\Translation\\Translator::transChoice` method

--- a/guides/translation.rst
+++ b/guides/translation.rst
@@ -90,7 +90,7 @@ Store translations for messages found in a bundle under the
 
 Each message file must be named according to the following pattern:
 ``domain.locale.loader`` (the domain name, followed by a dot (``.``), followed
-by the locale name, followed by a dot (``.``), followed by the loader name.)
+by the locale name, followed by a dot (``.``), followed by the loader name).
 
 The loader can be the name of any registered loader. By default, Symfony2
 provides the following loaders:

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -100,10 +100,10 @@ very easy).
 
 .. tip::
 
-   The sandbox defaults to YAML, but you can easily switch to XML or PHP by
-   editing the ``app/AppKernel.php`` file. You can switch now by looking at
-   the bottom of this file for instructions (the tutorials show the
-   configuration for all supported formats).
+    The sandbox defaults to YAML, but you can easily switch to XML or PHP by
+    editing the ``app/AppKernel.php`` file. You can switch now by looking at
+    the bottom of this file for instructions (the tutorials show the
+    configuration for all supported formats).
 
 .. index::
    single: Routing


### PR DESCRIPTION
Hi, 
I just fixed the style for note, tip, caution, ... directives due to your last commits to be more coherent.
I fixed also some parenthesis position.
