### PR TITLE
Fixed typo in documentation with "path" twig statement

### DIFF
--- a/guides/security/authentication.rst
+++ b/guides/security/authentication.rst
@@ -330,7 +330,7 @@ And the corresponding template:
             <div>{{ error }}</div>
         {% endif %}
 
-        <form action="{% path "_security_check" %}" method="post">
+        <form action="{{ path('_security_check') }}" method="post">
             <label for="username">Username:</label>
             <input type="text" id="username" name="_username" value="{{ last_username }}" />
 

--- a/quick_tour/the_view.rst
+++ b/quick_tour/the_view.rst
@@ -227,7 +227,7 @@ updated by changing the configuration:
 
 .. code-block:: jinja
 
-    <a href="{% path 'hello' with { 'name': 'Thomas' } %}">Greet Thomas!</a>
+    <a href="{{ path('hello', { 'name': 'Thomas' }) }}">Greet Thomas!</a>
 
 The ``path`` tag takes the route name and an array of parameters as arguments.
 The route name is the main key under which routes are referenced and the


### PR DESCRIPTION
Hi Fabien,

This is a small documentation fix about wrong Twig syntax.

Hugo.
