### PR TITLE
Make Doctrine sections more visible

### DIFF
--- a/guides/doctrine/dbal/index.rst
+++ b/guides/doctrine/dbal/index.rst
@@ -1,6 +1,10 @@
 Database Abstraction Layer
 ==========================
 
+Learn about Doctrine's Database Abstraction Layer and how it can help you
+perform almost any complex task in a database-agnostic, object-oriented
+way.
+
 .. toctree::
    :maxdepth: 2
 

--- a/guides/doctrine/migrations/index.rst
+++ b/guides/doctrine/migrations/index.rst
@@ -1,6 +1,9 @@
 Database Migrations
 ===================
 
+Learn about Doctrine's database migration tool and start migrating your database
+schema safer and more effectively.
+
 .. toctree::
    :maxdepth: 2
 

--- a/guides/doctrine/mongodb-odm/index.rst
+++ b/guides/doctrine/mongodb-odm/index.rst
@@ -1,6 +1,9 @@
 MongoDB Object Document Mapper
 ==============================
 
+Doctrine's MongoDB Object Document Mapper allows for PHP objects to be persisted
+to and retrieved from a MongoDB document database.
+
 .. toctree::
    :maxdepth: 2
 

--- a/guides/doctrine/orm/index.rst
+++ b/guides/doctrine/orm/index.rst
@@ -1,6 +1,9 @@
 Object Relational Mapper
 ========================
 
+Doctrine's Object Relational Mapper allows for PHP objects to be persisted
+to and retrieved from almost any relational database.
+
 .. toctree::
    :maxdepth: 2
 

--- a/guides/map.rst.inc
+++ b/guides/map.rst.inc
@@ -6,10 +6,10 @@
 
 * **Doctrine**:
 
-  * :doc:`DBAL </guides/doctrine/dbal/overview>` | 
-  * :doc:`ORM </guides/doctrine/orm/overview>` | 
-  * :doc:`Migrations </guides/doctrine/migrations/overview>` | 
-  * :doc:`MongoDB </guides/doctrine/mongodb-odm/overview>`
+  * :doc:`DBAL </guides/doctrine/dbal/index>` |
+  * :doc:`ORM </guides/doctrine/orm/index>` |
+  * :doc:`Migrations </guides/doctrine/migrations/index>` |
+  * :doc:`MongoDB </guides/doctrine/mongodb-odm/index>`
 
 * **Testing**:
 


### PR DESCRIPTION
Hey Fabien-

This comes from a comment on the dev board that the doctrine sub-sections have pages that aren't very visible (e.g. it _looks_ very much like ORM is just one page - the other pages aren't easily found). This had also confused me originally.

I think this is a good interim solution - things might change again as the docs fill out.

Thanks
