### PR TITLE
Minor suggestion for translation docs

### DIFF
--- a/guides/translation.rst
+++ b/guides/translation.rst
@@ -62,7 +62,7 @@ Translations are available through the ``translator`` service
 :method:`Symfony\\Component\\Translation\\Translator::trans` method to
 translate a message::
 
-    $t = $this->get('translator')->trans('Symfony2 is great!');
+    $t = $this->get('translator')->trans('Symfony2 is great');
 
 If you have placeholders in strings, pass their values as the second argument::
 
@@ -76,7 +76,7 @@ If you have placeholders in strings, pass their values as the second argument::
 By default, the translator looks for messages in the default ``messages``
 domain. Override it via the third argument::
 
-    $t = $this->get('translator')->trans('Symfony2 is great!', array(), 'applications');
+    $t = $this->get('translator')->trans('Symfony2 is great', array(), 'applications');
 
 Catalogues
 ----------
@@ -303,7 +303,7 @@ The translator service is accessible in PHP templates through the
 
 .. code-block:: html+php
 
-    <?php echo $view['translator']->trans('Symfony2 is great!') ?>
+    <?php echo $view['translator']->trans('Symfony2 is great') ?>
 
     <?php echo $view['translator']->transChoice(
         '{0} There is no apples|{1} There is one apple|]1,Inf[ There are {{ count }} apples',
@@ -319,7 +319,7 @@ with message translation:
 
 .. code-block:: jinja
 
-    {% trans "Symfony2 is great!" %}
+    {% trans "Symfony2 is great" %}
 
     {% trans %}
         Foo {{ name }}


### PR DESCRIPTION
As explained in http://groups.google.com/group/symfony-devs/browse_frm/thread/81aaf1361279db81?hl=en#, different strings can cause confusion if one copy pastes code from the tutorial, he can run into dificulties because strings are similar but not identical, and translation will not work. Beginers usually pastes the code from docs, and it should work.
