### PR TITLE
Fix typo

### DIFF
--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -60,7 +60,7 @@ Then, add an ``index.xml.php`` template along side ``index.php``:
 That's all there is to it. No need to change the controller. For standard
 formats, Symfony2 will also automatically choose the best ``Content-Type``
 header for the response. If you want to support different formats for a single
-action, use the ``:_format`` placeholder in the pattern instead:
+action, use the ``{_format}`` placeholder in the pattern instead:
 
 .. configuration-block::
 


### PR DESCRIPTION
Fixed :_format => {_format} in the quick tour (Controller chapter).
