### PR TITLE
new import resources notation issue with @ on yaml files

### DIFF
--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -124,7 +124,7 @@ So, Symfony2 routes the request by reading the routing configuration file:
             defaults: { _controller: FrameworkBundle:Default:index }
 
         hello:
-            resource: @HelloBundle/Resources/config/routing.yml
+            resource: "@HelloBundle/Resources/config/routing.yml"
 
     .. code-block:: xml
 


### PR DESCRIPTION
Just added quotes on resources import to make the yaml file valid as suggested on the dev-mailing-list:
https://groups.google.com/d/msg/symfony-devs/cudAyOwgWBE/PJR_uNjaIhcJ
and pull request on the sandbox:
https://github.com/symfony/symfony-sandbox/pull/23
