### PR TITLE
Form doc fix

### DIFF
--- a/guides/forms/overview.rst
+++ b/guides/forms/overview.rst
@@ -50,11 +50,12 @@ method ``configure()`` to initialize the form with a set of fields.
 .. code-block:: php
 
     // src/Sensio/HelloBundle/Contact/ContactForm.php
-    use Symfony\Component\Form
-    use Symfony\Component\Form\TextField
-    use Symfony\Component\Form\TextareaField
-    use Symfony\Component\Form\EmailField
-    use Symfony\Component\Form\CheckboxField
+    namespace Sensio\HelloBundle\Contact;
+
+    use Symfony\Component\Form\Form;
+    use Symfony\Component\Form\TextField;
+    use Symfony\Component\Form\TextareaField;
+    use Symfony\Component\Form\CheckboxField;
     
     class ContactForm extends Form
     {
@@ -64,7 +65,7 @@ method ``configure()`` to initialize the form with a set of fields.
                 'max_length' => 100,
             )));
             $this->add(new TextareaField('message'));
-            $this->add(new EmailField('sender'));
+            $this->add(new TextField('sender'));
             $this->add(new CheckboxField('ccmyself', array(
                 'required' => false,
             )));
@@ -73,7 +74,7 @@ method ``configure()`` to initialize the form with a set of fields.
 
 A form consists of ``Field`` objects. In this case, our form has the fields
 ``subject``, ``message``, ``sender`` and ``ccmyself``. ``TextField``,
-``TextareaField``, ``EmailField`` and ``CheckboxField`` are only four of the
+``TextareaField`` and ``CheckboxField`` are only three of the
 available form fields; a full list can be found in :doc:`Form fields
 <fields>`.
 
@@ -87,8 +88,8 @@ The standard pattern for using a form in a controller looks like this:
     // src/Sensio/HelloBundle/Controller/HelloController.php
     public function contactAction()
     {
-        $contactRequest = new ContactRequest();
-        $form = ContactForm::create($this->get('form.context'));
+        $contactRequest = new ContactRequest( $this->get( 'mailer' ) );
+        $form = ContactForm::create($this->get('form.context'), 'contact');
         
         // If a POST request, write submitted data into $contactRequest
         // and validate it
@@ -122,8 +123,8 @@ and settings that a form needs to work.
     
     .. code-block:: php
     
-        use Symfony\Component\Form\FormContext
-        use Symfony\Component\HttpFoundation\Request
+        use Symfony\Component\Form\FormContext;
+        use Symfony\Component\HttpFoundation\Request;
         
         $context = FormContext::buildDefault();
         $request = Request::createFromGlobals();
@@ -139,6 +140,8 @@ class could look like this:
 .. code-block:: php
 
     // src/Sensio/HelloBundle/Contact/ContactRequest.php
+    namespace Sensio\HelloBundle\Contact;
+
     class ContactRequest
     {
         protected $subject = 'Subject...';
@@ -204,6 +207,8 @@ data.
 .. code-block:: php
 
     // src/Sensio/HelloBundle/Contact/ContactRequest.php
+    namespace Sensio\HelloBundle\Contact;
+
     class ContactRequest
     {
         /**
@@ -318,6 +323,7 @@ can do so by using the other built-in form rendering helpers.
     # src/Sensio/HelloBundle/Resources/views/Hello/contact.html.twig
     {% extends 'HelloBundle::layout.html.twig' %}
 
+    {% block content %}
     <form action="#" method="post" {{ form_enctype(form) }}>
         {{ form_errors(form) }}
         
@@ -332,6 +338,7 @@ can do so by using the other built-in form rendering helpers.
         {{ form_hidden(form) }}
         <input type="submit" />
     </form>
+    {% endblock %}
     
 Symfony2 comes with the following helpers:
 


### PR DESCRIPTION
- Adjusted the namespace and import usages to be accurate and correct
- Removed references to EmailField, which does not exist.
- Added a reference to "mailer" for when ContactRequest is instantiated, because it is required for the constructor.
- Added a name to the form::create() method, because it is required for form submission
- Modified template to put form in a block, as required by twig parsing
