### PR TITLE
Path of autoload.php

### DIFF
--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -67,7 +67,7 @@ understand the flexibility of the framework.
 
 PHP autoloading can be configured via ``autoload.php``::
 
-    // src/autoload.php
+    // app/autoload.php
     use Symfony\Component\ClassLoader\UniversalClassLoader;
 
     $loader = new UniversalClassLoader();


### PR DESCRIPTION
I changed the file path autoload.php in the "The Architecture" chapter of the "Quick Tour" guide.
