### PR TITLE
added a small correction to the HelloExtension example code

### DIFF
--- a/cookbook/bundles/extension.rst
+++ b/cookbook/bundles/extension.rst
@@ -33,6 +33,7 @@ that extends
 
     // HelloBundle/DependencyInjection/HelloExtension.php
     use Symfony\Component\DependencyInjection\Extension\Extension;
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
 
     class HelloExtension extends Extension
     {


### PR DESCRIPTION
The example code was not easy copy/paste so I added

```
use Symfony\Component\DependencyInjection\ContainerBuilder;
```

Otherwise you will get errors saying load() is not compatible with ExtensionInterface::load.
