### PR TITLE
Fix dbal charset

### DIFF
--- a/book/doctrine/dbal/configuration.rst
+++ b/book/doctrine/dbal/configuration.rst
@@ -44,7 +44,7 @@ further:
                 memory:               true
                 unix_socket:          /tmp/mysql.sock
                 wrapper_class:        MyDoctrineDbalConnectionWrapper
-                charset:              UTF-8
+                charset:              UTF8
                 logging:              %kernel.debug%
                 platform_service:     MyOwnDatabasePlatformService
 
@@ -66,7 +66,7 @@ further:
                 memory="true"
                 unix-socket="/tmp/mysql.sock"
                 wrapper-class="MyDoctrineDbalConnectionWrapper"
-                charset="UTF-8"
+                charset="UTF8"
                 logging="%kernel.debug%"
                 platform-service="MyOwnDatabasePlatformService"
             />


### PR DESCRIPTION
Using "UTF-8" as charset with MySQL causes a fatal error.
"UTF-8" should be "UTF8" (without dashes)
