### PR TITLE
More details to lower the threshold for beginners

### DIFF
--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -155,10 +155,11 @@ are a few examples of the routing configuration file for our application:
         return $collection;
 
 The first few lines of the routing configuration file define the code that is 
-executed when the user requests the "``/``" resource (i.e. the homepage). 
+executed when the user requests the resource specified by the pattern "``/``" (i.e. the homepage).
+Here, it executes the "``index``" method of the "``Default``" controller inside the "``FrameworkBundle``"
 
-If you're comfortable with routing, take a look at the last directive of 
-the configuration file. Symfony2 can include routing information from 
+Let's take a look at the last directive of 
+the configuration file: Symfony2 can include routing information from 
 other routing configuration files by using the ``import`` directive. In this
 case, we want to import the routing configuration from ``HelloBundle``. A
 bundle is like a plugin that has added power and we'll talk more about them
@@ -200,9 +201,9 @@ later. For now, let's look at the routing configuration that we've imported:
 
         return $collection;
 
-As you can see, the "``/hello/{name}``" resource pattern (a string enclosed
-in curly brackets like ``{name}`` is a placeholder) is mapped to a controller,
-referenced by the ``_controller`` value.
+As you can see, the "``/hello/{name}``" resource pattern is mapped to a controller,
+referenced by the ``_controller`` value. The string enclosed in curly brackets (``{name}``) is a placeholder
+and defines an argument that will be available in the controller.
 
 .. index::
    single: Controller
@@ -234,26 +235,33 @@ The controller defines actions to handle users requests and prepares responses
         }
     }
 
-The code is pretty straightforward but let's explain it line by line:
+Let's explain this code line by line:
 
 * *line 3*: Symfony2 takes advantage of new PHP 5.3 namespacing features,
-  and all controllers should be properly namespaced (though this is not
-  required). In this example, the controller lives in the bundle named ``HelloBundle``,
+  and all controllers should be properly namespaced. As you can see, the namespace has
+  a correlation to the actual file location. This is not required, but a best practice.
+  In this example, the controller lives in the bundle named ``HelloBundle``,
   which forms the first part of the ``_controller`` routing value.
+   
 
 * *line 7*: The controller name is the combination of the second part of the
   ``_controller`` routing value  (``Hello``) and the word ``Controller``. It
   extends the built-in ``Controller`` class, which provides useful shortcuts
-  (as we will see later in this tutorial).
+  (as we will see later in this tutorial). The ``Controller`` resides in ``Symfony\Bundle\FrameworkBundle\Controller\Controller``
+  which we defined in line 5  
 
-* *line 9*: Each controller is made of several actions. As per the routing
+* *line 9*: Each controller consists of several actions. As per the routing
   configuration, the hello page is handled by the ``index`` action (the third
   part of the ``_controller`` routing value). This method receives the
   placeholder values as arguments (``$name`` in our case).
 
 * *line 11*: The ``render()`` method loads and renders a template file
   (``HelloBundle:Hello:index.html.twig``) with the variables passed as a
-  second argument.
+  second argument. In our example, this corresponds to the file
+  ``src\Sensio\HelloBundle\Resources\views\Hello\index.html.twig``.
+
+Bundles
+~~~~~~~
 
 But what is a :term:`bundle`? All the code you write in a Symfony2 project is
 organized in bundles. In Symfony2 speak, a bundle is a structured set of files


### PR DESCRIPTION
Some parts have been changed or explained more explicitly.
The intention was to lower the threshold for beginners.
This means, some more explanation of the namespace usage as not every developer is currently 100% familiar with its usage and we should rather take them by the hand to enjoy namespaces than scare them off.
