### PR TITLE
Rename text referencing "guides" to reference "chapters"

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -60,7 +60,7 @@ maps a URI to that controller.
 .. note::
 
     Though similarly named, a "front controller" is different from the
-    "controllers" we'll talk about in this guide. A front controller
+    "controllers" we'll talk about in this chapter. A front controller
     is a short PHP file that lives in your web directory and through which
     all requests are directed. A typical application will have a production
     front controller (e.g. ``app.php``) and a development front controller
@@ -131,7 +131,7 @@ Mapping a URI to a Controller
 Our new controller returns a simple HTML page. To render this controller
 at a specific URL, we need to create a route to it.
 
-We'll talk about the ``Routing`` component in detail in the :doc:`Routing guide</book/routing>`,
+We'll talk about the ``Routing`` component in detail in the :doc:`Routing chapter</book/routing>`,
 but let's create a simple route to our controller:
 
 .. configuration-block::
@@ -390,7 +390,7 @@ class, which is designed specifically to redirect the user to another URL::
 The ``generateUrl()`` method is just a shortcut that calls ``generate()``
 on the ``router`` service. It takes the route name and an array of parameters
 as arguments and returns the associated friendly URL. See the :doc:`Routing </book/routing>`
-guide for more information.
+chapter for more information.
 
 By default, the ``redirect`` method does a 302 (temporary) redirect. To perform
 a 301 (permanent) redirect, modify the second argument::
@@ -475,7 +475,7 @@ returns a ``Response`` object with the content from the template::
     return $this->render('HelloBundle:Hello:index.html.twig', array('name' => $name));
 
 The Symfony templating engine is explained in great detail in the :doc:`Templating </book/templating>`
-guide.
+chapter.
 
 .. tip::
 
@@ -506,7 +506,7 @@ via the ``get()`` method. Here are several common services you might need::
 
 The are countless other services available and you are encouraged to define
 your own. For more information, see the :doc:`Extending Symfony </book/extending_symfony>`
-guide.
+chapter.
 
 .. index::
    single: Controller; Managing errors

--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -4,7 +4,7 @@ From flat PHP to Symfony2
 .. tip::
 
    If you're familiar with the MVC philosophy, you can choose to skip this
-   guide. Still, Symfony2's approach to organized code and application
+   chapter. Still, Symfony2's approach to organized code and application
    flow is so fresh and simple that we hope everyone will continuing reading.
 
 The goal of any web application is simple: to process each HTTP request and

--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -239,7 +239,7 @@ misses.
     your traffic increases.
 
     For more information on using Varnish with Symfony2, see the
-    :doc:`How to use Varnish </cookbook/cache/varnish>` cookbook guide.
+    :doc:`How to use Varnish </cookbook/cache/varnish>` cookbook chapter.
 
 .. note::
 

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -147,7 +147,7 @@ to personally greet the user.
 
   The routing system has many more great features for creating flexible
   and powerful URI structures in your application. For more details, see
-  the guide all about :doc:`Routing </book/routing>`.
+  the chapter all about :doc:`Routing </book/routing>`.
 
 Create the Controller
 ~~~~~~~~~~~~~~~~~~~~~
@@ -460,7 +460,7 @@ in your application and to optimize them the way you want.
 
 .. note::
 
-   While we'll cover the basics here, an entire guide is devoted to the topic
+   While we'll cover the basics here, an entire chapter is devoted to the topic
    of :doc:`/book/bundles`.
 
 A bundle is simply a structured set of files within a directory that
@@ -747,7 +747,7 @@ cached files and allow them to rebuild::
 .. note::
 
     The ``test`` environment is used when running automated tests and cannot
-    be accessed directly through the browser. See the :doc:`testing guide </book/testing>`
+    be accessed directly through the browser. See the :doc:`testing chapter </book/testing>`
     for more details.
 
 .. index::
@@ -867,7 +867,7 @@ in mind:
 * each **environment** is accessible via a different front controller (e.g.
   ``app.php`` and ``app_dev.php``) and loads a different configuration file.
 
-From here, each guide will introduce you to more and more powerful tools
+From here, each chapter will introduce you to more and more powerful tools
 and advanced concepts. The more you know about Symfony2, the more you'll
 appreciate the flexibility of its architecture and the power it gives you
 to rapidly develop applications.

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -12,7 +12,7 @@ your product inventory, or another object that processes data from a third-party
 API. The point is that a modern application does many things and is organized
 into many objects that handle each task.
 
-In this guide, we'll talk about a special PHP object in Symfony2 that helps
+In this chapter, we'll talk about a special PHP object in Symfony2 that helps
 you instantiate, organize and retrieve the many objects of your application.
 This object, called a service container, will allow you to standardize and
 centralize the way objects are constructed in your application. The container

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -9,7 +9,7 @@ handling each request that comes into a Symfony2 application. In reality,
 the controller delegates the most of the heavy work to other places so that
 code can be tested and reused. When a controller needs to generate HTML,
 CSS or any other content, it hands the work off to the templating engine.
-In this guide, you'll learn how to write powerful templates that can be
+In this chapter, you'll learn how to write powerful templates that can be
 used to return content to the user, populate email bodies, and more. You'll
 learn shortcuts, clever ways to extend templates and how to reuse template
 code.
@@ -106,7 +106,7 @@ alternating ``odd``, ``even`` classes:
       </div>
     {% endfor %}
 
-Throughout this guide, template examples will be shown in both Twig and PHP.
+Throughout this chapter, template examples will be shown in both Twig and PHP.
 
 .. sidebar:: Why Twig?
 
@@ -1083,7 +1083,7 @@ but can return any other format based on the format requested by the user.
 The request format is most often managed by the routing, where a route can
 be configured so that ``/contact`` sets the request format to ``html`` while
 ``/contact.xml`` sets the format to ``xml``. For more information, see the
-:doc:`Routing</book/routing>` guide.
+:doc:`Routing</book/routing>` chapter.
 
 Final Thoughts
 --------------

--- a/book/validator/constraints.rst
+++ b/book/validator/constraints.rst
@@ -124,7 +124,7 @@ Getters
 
 The next validation technique is to constrain the return value of a method.
 Symfony2 allows you to constrain any public method whose name starts with
-"get" or "is". In this guide, this is commonly referred to as "getter".
+"get" or "is". In this chapter, this is commonly referred to as "getter".
 
 The benefit of this technique is that it allows you to validate your object
 dynamically. Depending on the state of your object, the method may return

--- a/cookbook/symfony1.rst
+++ b/cookbook/symfony1.rst
@@ -7,7 +7,7 @@ at its core, the skills used to master a symfony1 project continue to be
 very relevant when developing in Symfony2. Sure, ``app.yml`` is gone, but
 routing, controllers and templates all remain.
 
-In this guide, we'll walk through the differences between symfony1 and Symfony2.
+In this chapter, we'll walk through the differences between symfony1 and Symfony2.
 As you'll see, many tasks are tackled in a slightly different way. You'll
 come to appreciate these minor differences as they promote stable, predictable,
 testable and decoupled code in your Symfony2 applications.

--- a/reference/YAML.rst
+++ b/reference/YAML.rst
@@ -17,7 +17,7 @@ parse YAML and dump a PHP array to YAML.
 .. note::
 
     Even if the YAML format can describe complex nested data structure, this
-    guide only describes the minimum set of features needed to use YAML as a
+    chapter only describes the minimum set of features needed to use YAML as a
     configuration file format.
 
 Reading YAML Files


### PR DESCRIPTION
References to "guides" in the text were leftover from before "guides" were renamed to "book" in commit 6272eece. These changes assume every page in the docs is called a "chapter".

New pieces of the book reference "chapters" so this change updates the old text.
