### PR TITLE
Some typos + a doc breadcrumb bug

### DIFF
--- a/book/security/users.rst
+++ b/book/security/users.rst
@@ -211,10 +211,10 @@ will make the associated checks automatically::
     }
 
 * ``isAccountNonExpired()``: Returns ``true`` when the user's account has
-  expired;
-* ``isAccountNonLocked()``: Returns ``true`` when the user is locked;
+  not expired;
+* ``isAccountNonLocked()``: Returns ``true`` when the user is not locked;
 * ``isCredentialsNonExpired()``: Returns ``true`` when the user's credentials
-  (password) has expired;
+  (password) has not expired;
 * ``isEnabled()``: Returns ``true`` when the user is enabled.
 
 .. note::

--- a/cookbook/testing/http_authorization.rst
+++ b/cookbook/testing/http_authorization.rst
@@ -1,7 +1,7 @@
 .. index::
-   single: Tests; HTTP Authorization
+   single: Tests; HTTP Authentication
 
-How to simulate HTTP Authorization in a Functional Test
+How to simulate HTTP Authentication in a Functional Test
 =======================================================
 
 If your application needs HTTP authentication, pass the username and password


### PR DESCRIPTION
IMHO the changed cookbook file should ALSO be RENAMED to "authentication"

I also found a strange bug (NOT in my COMMIT):
On http://symfony.com/what-is-symfony page, if you follow the "Security Policy" link, you reach the http://symfony.com/doc/2.0/contributing/code%252Fsecurity.html page (did you spot the %252F?). And there, the Documentation link in the breadcrumb is invalid.
