### PR TITLE
Fixed #9607: fixed wrong link in documentation

### DIFF
--- a/glossary.rst
+++ b/glossary.rst
@@ -52,5 +52,5 @@ Glossary
         article or the `HTTP 1.1 RFC`_.
 
 .. _`service-oriented architecture`: http://wikipedia.org/wiki/Service-oriented_architecture
-.. _`HTTP Wikipedia`: http://www.w3.org/Protocols/rfc2616/rfc2616.html
+.. _`HTTP Wikipedia`: http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
 .. _`HTTP 1.1 RFC`: http://www.w3.org/Protocols/rfc2616/rfc2616.html


### PR DESCRIPTION
This pull request fixes the ticket #9607: http://trac.symfony-project.org/ticket/9607
