### PR TITLE
Typo fixed in http_cache chapter

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -847,7 +847,7 @@ matter), Symfony2 uses the standard ``render`` helper to configure ESI tags:
 
     .. code-block:: jinja
 
-        {% render '...:list' with {}, {'standalone': true} %}
+        {% render '...:news' with {}, {'standalone': true} %}
 
     .. code-block:: php
 


### PR DESCRIPTION
YAML ESI code example should be news instead of list, as its pointing to newsActions.
PHP code  is fine.
Regards
