### PR TITLE
symfony-doc typos

### DIFF
--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -123,7 +123,7 @@ defined in ``app/config/routing.yml`` configuration file:
         type:     annotation
         prefix:   /demo
 
-The first three lines of the routing configuration file define the code that
+The first three lines after the comment define the code that
 is executed when the user requests the "``/``" resource (i.e. the welcome
 page). When requested, the ``AcmeDemoBundle:Welcome:index`` controller will be
 executed.

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -72,7 +72,7 @@ Symfony2 should welcome and congratulate you for your hard work so far!
 Understanding the Fundamentals
 ------------------------------
 
-One of the main goal of a framework is to ensure the `Separation of Concerns`_.
+One of the main goals of a framework is to ensure the `Separation of Concerns`_.
 It keeps your code organized and allows your application to evolve
 easily over time by avoiding the mix of database calls, HTML tags, and
 business logic in the same script. To achieve this goal, you must learn about


### PR DESCRIPTION
two small typos in the quick tour fixed.
