### PR TITLE
Changed the vendors.sh name reference

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -31,22 +31,18 @@ The test suite need the following third-party libraries:
 * Swiftmailer
 * Twig
 
-To install them all, run the `install_vendors.sh` script:
+To install them all, run the `vendors.sh` script:
 
 .. code-block:: bash
 
-    $ sh install_vendors.sh
+    $ sh vendors.sh
 
 .. note::
 
     Note that the script takes some time to finish.
 
-After installation, you can update the vendors anytime with the
-`update_vendors.sh` script:
-
-.. code-block:: bash
-
-    $ sh update_vendors.sh
+After installation, you can update the vendors anytime by running the
+`vendors.sh` script again.
 
 Running
 -------


### PR DESCRIPTION
Changed the `vendors.sh` script reference, for running tests.

This file was renamed back in:
https://github.com/symfony/symfony/commit/eafd391c179dc7279b7543f9a9203d7e3fbb5d52#vendors.sh 
