### PR TITLE
Updated commands and references to the DoctrineFixturesBundle

### DIFF
--- a/cookbook/doctrine/doctrine_fixtures.rst
+++ b/cookbook/doctrine/doctrine_fixtures.rst
@@ -21,8 +21,15 @@ Add the following to ``bin/vendors.sh``, right after the "Monolog" entry:
 .. code-block:: text
 
     # Doctrine Fixtures
-    install_git doctrine-fixtures git://github.com/doctrine/data-fixtures.git
+    install_git doctrine-fixtures https://github.com/doctrine/data-fixtures.git
 
+And also, the following after the "WebConfiguratorBundle" entry:
+
+.. code-block:: text
+
+    # DoctrineFixturesBundle
+    install_git DoctrineFixturesBundle https://github.com/symfony/DoctrineFixturesBundle.git
+ 
 Update vendors and rebuild the bootstrap file:
 
 .. code-block:: bash
@@ -100,13 +107,13 @@ Executing Fixtures
 ------------------
 
 Once your fixtures have been written, you can load them via the command
-line by using the ``doctrine:data:load`` command:
+line by using the ``doctrine:fixtures:load`` command:
 
 .. code-block:: bash
 
-    $ php app/console doctrine:data:load
+    $ php app/console doctrine:fixtures:load
 
-If you're using the ODM, use the ``doctrine:mongodb:data:load`` command instead:
+If you're using the ODM, use the ``doctrine:mongodb:fixtures:load`` command instead:
 
 .. code-block:: bash
 
@@ -129,14 +136,14 @@ Both commands come with a few options:
 
 .. note::
 
-   If using the ``doctrine:mongodb:data:load`` task, replace the ``--em=``
+   If using the ``doctrine:mongodb:fixtures:load`` task, replace the ``--em=``
    option with ``--dm=`` to manually specify the document manager.
 
 A full example use might look like this:
 
 .. code-block:: bash
 
-   $ php app/console doctrine:data:load --fixtures=/path/to/fixture1 --fixtures=/path/to/fixture2 --append --em=foo_manager
+   $ php app/console doctrine:fixtures:load --fixtures=/path/to/fixture1 --fixtures=/path/to/fixture2 --append --em=foo_manager
 
 Sharing Objects between Fixtures
 --------------------------------


### PR DESCRIPTION
Added reference to install the `DoctrineFixturesBundle`

Updated the console command from :data:load to :fixtures:load, per commit:
https://github.com/symfony/DoctrineFixturesBundle/commit/f45a3008d6e2ddd42c6bcee49f75750fa652b254

and discussed here:
https://github.com/symfony/symfony/pull/379

Changed the clone url from git to https, to keep consistent with the symfony-standard `vendors.sh`:
https://github.com/symfony/symfony-standard/commit/c932c4c521f121f20875ea5c0f24d7e0e3dbe19f
