### PR TITLE
Misc typo fixes

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -438,7 +438,7 @@ files in the application and to configure the autoloader:
 
     $loader = new Symfony\Component\ClassLoader\UniversalClassLoader();
     $loader->registerNamespaces(array(
-        'Symfony'                        => __DIR__.'/vendor/symfony/src',
+        'Symfony' => __DIR__.'/vendor/symfony/src',
     ));
 
     $loader->register();

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -268,7 +268,7 @@ of writing the HTML inside the controller, use a template instead::
 .. note::
 
    In order to use the ``render()`` method, you must extend the
-   :class:`Symfony\Bundle\FrameworkBundle\Controller\Controller` class, which
+   :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller` class, which
    adds shortcuts for tasks that are common inside controllers.
 
 The ``render()`` method creates a ``Response`` object filled with the content

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -619,8 +619,8 @@ tools later.
 
 .. tip::
 
-   Whenever creating a new bundle or using a third-party bundle, be sure
-   to always make sure that the bundle has been enabled in ``registerBundles()``.
+   Whenever creating a new bundle or using a third-party bundle, always make
+   sure the bundle has been enabled in ``registerBundles()``.
 
 Bundle Directory Structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -66,7 +66,7 @@ to the ``app/autoload.php`` file (see the :ref:`Autoloading sidebar<autoloading-
 .. code-block:: php
 
         $loader->registerNamespaces(array(
-            'Acme'                         => __DIR__.'/../src',
+            'Acme' => __DIR__.'/../src',
             // ...
         ));
 
@@ -466,7 +466,7 @@ about each of these directories in later chapters.
     behalf the instance you need a class::
     
         $loader->registerNamespaces(array(
-            'Acme'                         => __DIR__.'/../src',
+            'Acme' => __DIR__.'/../src',
             // ...
         ));
     

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1121,7 +1121,7 @@ and in Symfony2, that's absolutely fine.
 Learn more from the Cookbook
 ----------------------------
 
-* :doc:`/cookbook/controller/PHP`
+* :doc:`/cookbook/templating/PHP`
 * :doc:`/cookbook/controller/error_pages`
 
 .. _`Twig`: http://www.twig-project.org

--- a/book/validation.rst
+++ b/book/validation.rst
@@ -212,7 +212,7 @@ For more information, see the :doc:`Forms</book/forms>` chapter.
 Configuration
 -------------
 
-To use the Symfony2 validator, ensure that it's enable in your application
+To use the Symfony2 validator, ensure that it's enabled in your application
 configuration:
 
 .. configuration-block::

--- a/glossary.rst
+++ b/glossary.rst
@@ -27,7 +27,7 @@ Glossary
         lives inside a bundle. (see :ref:`page-creation-bundles`)
 
    Front Controller
-        A *Front Controller* is a short PHP that lives in the web directory
+        A *Front Controller* is a short PHP script that lives in the web directory
         of your project. Typically, *all* requests are handled by executing
         the same front controller, whose job is to bootstrap the Symfony
         application.


### PR DESCRIPTION
Fixes a few small issues I found while reading through the documentation.  The following were fixed:
- Two broken links
- Extra whitespace
- Verb tense typo
- Missing word
- Redundant phrase

All of this is documented in the commit log :)
