### PR TITLE
File type docs

### DIFF
--- a/cookbook/forms/advanced_file_type.rst
+++ b/cookbook/forms/advanced_file_type.rst
@@ -16,9 +16,12 @@ option.  This option will specify where the asset should be placed.
 
     namespace Acme\MyBundle\Form;
 
-    use Acme\MyBundle\EventListener;
-
-    // ... other namespaces
+    use Symfony\Component\Form\Extension\Core\Type\FileType;
+    use Symfony\Component\Form\FormBuilder;
+    use Symfony\Component\Form\ReversedTransformer;
+    use Symfony\Component\Form\Extension\Core\DataTransformer\FileToStringTransformer;
+    use Symfony\Component\Form\Extension\Core\DataTransformer\FileToArrayTransformer;
+    use Acme\StoreBundle\EventListener\MoveFileUploadListener;
 
     class AssetType extends FileType
     {
@@ -60,7 +63,11 @@ class takes the new file location as its first argument.
 
     namespace Acme\MyBundle\EventListener;
 
-    // ... other namespaces
+    use Symfony\Component\Form\Events;
+    use Symfony\Component\Form\Event\FilterDataEvent;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Component\HttpFoundation\File\File;
+    use Symfony\Component\HttpFoundation\File\UploadedFile;
 
     class MoveFileUploadListener implements EventSubscriberInterface
     {

--- a/cookbook/forms/advanced_file_type.rst
+++ b/cookbook/forms/advanced_file_type.rst
@@ -11,7 +11,7 @@ We will first need to create a new field type class.  We will extend ``FileType`
 for this example, and call our class ``AssetType``, as it represents the
 location we will be placing our assets.  Our field type will support the
 options ``path`` and ``keep_filename``.  The ``path`` option will specify
-where the asset should be placed, and the ``keep_filename`` option, when 
+where the asset should be placed, and the ``keep_filename`` option, when
 set to ``true`` will retain the uploaded file's name.
 
 .. code-block:: html+php
@@ -40,7 +40,7 @@ set to ``true`` will retain the uploaded file's name.
                     new FileToStringTransformer()))
                 ->appendNormTransformer(new FileToArrayTransformer())
                 ->addEventSubscriber(new MoveFileUploadListener(
-                    $this->assetDir . '/' . $options['path'], 
+                    $this->assetDir . '/' . $options['path'],
                     $options['keep_filename']), 10)
                 ->add('file', 'field')
                 ->add('token', 'hidden')
@@ -57,7 +57,7 @@ set to ``true`` will retain the uploaded file's name.
     }
 
 The main difference between our class and ``FileType`` is the ``MoveFileUploadListener``
-class.  This replaces the ``FixFileUploadListener`` that was there before.  
+class.  This replaces the ``FixFileUploadListener`` that was there before.
 The difference is that ``MoveFileUploadListener`` is a class listening to
 the form event, and will execute before the field values are returned. This
 class takes a destination as its first argument, and whether or not to preserve
@@ -139,11 +139,11 @@ are services, this can be configured in your dependency injection configuration.
         $container->setDefinition('form.type.file', $definition);
 
 .. note::
-    The tag ``form.type`` on your service tells the Form Factory to accept 
+    The tag ``form.type`` on your service tells the Form Factory to accept
     this service as a field type.  In other words, any service with this
     tag can be loaded as a form type.  Give your tag a unique alias to
     create a new form type, rather than substituting out an existing one.
-    
+
 All ``file`` form types will now use your ``AssetType`` class.  The example
 below illustrates the use of the new AssetType class.  We add an ``attachment``
 file field to the ``GenericBlog`` class, and tell it to place the files in
@@ -157,11 +157,11 @@ the ``uploads/attachments`` directory, and to preserve the filename.
         {
             $builder->add('name');
             $builder->add('attachment', 'file', array(
-                'path' => 'uploads/attachments', 
+                'path' => 'uploads/attachments',
                 'keep_filename' => true
             ));
         }
-        
+
         public function getDefaultOptions(array $options)
         {
             return array(

--- a/cookbook/forms/advanced_file_type.rst
+++ b/cookbook/forms/advanced_file_type.rst
@@ -12,9 +12,7 @@ for this example, and call our class ``AssetType``, as it represents the
 location we will be placing our assets.  Our field type will support a ``path``
 option.  This option will specify where the asset should be placed.
 
-.. code-block:: html+php
-
-    <?php
+.. code-block:: php
 
     namespace Acme\MyBundle\Form;
 
@@ -58,9 +56,7 @@ The difference is that ``MoveFileUploadListener`` is a class listening to
 the form event, and will execute before the field values are returned. This
 class takes the new file location as its first argument.
 
-.. code-block:: html+php
-
-    <?php
+.. code-block:: php
 
     namespace Acme\MyBundle\EventListener;
 

--- a/cookbook/forms/advanced_file_type.rst
+++ b/cookbook/forms/advanced_file_type.rst
@@ -71,11 +71,11 @@ class takes the new file location as its first argument.
 
     class MoveFileUploadListener implements EventSubscriberInterface
     {
-        protected $newLocation;
+        protected $path;
 
-        public function __construct($newLocation)
+        public function __construct($path)
         {
-            $this->newLocation = $newLocation;
+            $this->path = $path;
         }
 
         public static function getSubscribedEvents()
@@ -90,7 +90,22 @@ class takes the new file location as its first argument.
             // Newly uploaded file
             if ($data['file'] instanceof UploadedFile && $data['file']->isValid()) {
                 $data['name'] = $data['file']->getName() . $data['file']->getExtension();
-                $data['file']->move($this->newLocation, $data['name']);
+                $data['file']->move($this->path, $data['name']);
+            }
+
+            // Existing uploaded file
+            if (!$data['file'] && $data['name']) {
+                $path = $this->path . DIRECTORY_SEPARATOR . $data ['name'];
+
+                if (file_exists($path)) {
+                    $data['file'] = new File($path);
+                }
+            }
+
+            // Clear other fields if we still don't have a file, but keep
+            // possible existing files of the field
+            if (!$data['file']) {
+                $data = $form->getNormData();
             }
 
             $event->setData($data);

--- a/cookbook/forms/advanced_file_type.rst
+++ b/cookbook/forms/advanced_file_type.rst
@@ -116,6 +116,8 @@ are services, this can be configured in your dependency injection configuration.
             form.type.file:
                 class: Acme\MyBundle\Form\AssetType
                 arguments: [path/to/web/dir]
+                tags:
+                    - { name: form.type, alias: file }
 
     .. code-block:: xml
 
@@ -132,11 +134,16 @@ are services, this can be configured in your dependency injection configuration.
         // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
 
-        $container->setDefinition('form.type.file', new Definition(
-            'Acme\MyBundle\Form\AssetType',
-            array('path/to/web/dir'),
-        ));
+        $definition = new Definition('Acme\MyBundle\Form\AssetType', array('path/to/web/dir'));
+        $definition->addTag('form.type', array('alias' => 'file'));
+        $container->setDefinition('form.type.file', $definition);
 
+.. note::
+    The tag ``form.type`` on your service tells the Form Factory to accept 
+    this service as a field type.  In other words, any service with this
+    tag can be loaded as a form type.  Give your tag a unique alias to
+    create a new form type, rather than substituting out an existing one.
+    
 All ``file`` form types will now use your ``AssetType`` class.  The example
 below illustrates the use of the new AssetType class.  We add an ``attachment``
 file field to the ``GenericBlog`` class, and tell it to place the files in

--- a/cookbook/forms/advanced_file_type.rst
+++ b/cookbook/forms/advanced_file_type.rst
@@ -89,9 +89,8 @@ class takes the new file location as its first argument.
 
             // Newly uploaded file
             if ($data['file'] instanceof UploadedFile && $data['file']->isValid()) {
-                $filename = sprintf('%s.%s', $data['file']->getName(), $data['file']->getExtension());
-                $data['file']->move($this->newLocation, $filename);
-                $data['name'] = $filename;
+                $data['name'] = $data['file']->getName() . $data['file']->getExtension();
+                $data['file']->move($this->newLocation, $data['name']);
             }
 
             $event->setData($data);

--- a/cookbook/forms/advanced_file_type.rst
+++ b/cookbook/forms/advanced_file_type.rst
@@ -1,15 +1,18 @@
 Advanced File Type Usage
 ========================
 
-The following cookbook recipe outlines how to extend the FileType field to customize the location of your uploads
+The following cookbook recipe outlines how to extend the FileType field
+to customize the location of your uploads
 
 Create a new field type
 -----------------------
 
-We will first need to create a new field type class.  We will extend ``FileType`` for this example, and call our class
-``AssetType``, as it represents the location we will be placing our assets.  Our field type will support the options
-``path`` and ``keep_filename``.  The ``path`` option will specify where the asset should be placed, and the ``keep_filename``
-option, when set to ``true`` will retain the uploaded file's name.
+We will first need to create a new field type class.  We will extend ``FileType``
+for this example, and call our class ``AssetType``, as it represents the
+location we will be placing our assets.  Our field type will support the
+options ``path`` and ``keep_filename``.  The ``path`` option will specify
+where the asset should be placed, and the ``keep_filename`` option, when 
+set to ``true`` will retain the uploaded file's name.
 
 .. code-block:: html+php
 
@@ -33,9 +36,12 @@ option, when set to ``true`` will retain the uploaded file's name.
         public function buildForm(FormBuilder $builder, array $options)
         {
             $builder
-                ->appendNormTransformer(new ReversedTransformer(new FileToStringTransformer()))
+                ->appendNormTransformer(new ReversedTransformer(
+                    new FileToStringTransformer()))
                 ->appendNormTransformer(new FileToArrayTransformer())
-                ->addEventSubscriber(new MoveFileUploadListener($this->assetDir . '/' . $options['path'], $options['keep_filename']), 10)
+                ->addEventSubscriber(new MoveFileUploadListener(
+                    $this->assetDir . '/' . $options['path'], 
+                    $options['keep_filename']), 10)
                 ->add('file', 'field')
                 ->add('token', 'hidden')
                 ->add('name', 'hidden');
@@ -50,10 +56,12 @@ option, when set to ``true`` will retain the uploaded file's name.
         }
     }
 
-The main difference between our class and ``FileType`` is the ``MoveFileUploadListener`` class.  This replaces the
-``FixFileUploadListener`` that was there before.  The difference is that ``MoveFileUploadListener`` is a class listening
-to the form event, and will execute before the field values are returned.  This class takes a destination as its first
-argument, and whether or not to preserve the original filename as the second argument.
+The main difference between our class and ``FileType`` is the ``MoveFileUploadListener``
+class.  This replaces the ``FixFileUploadListener`` that was there before.  
+The difference is that ``MoveFileUploadListener`` is a class listening to
+the form event, and will execute before the field values are returned. This
+class takes a destination as its first argument, and whether or not to preserve
+the original filename as the second argument.
 
 .. code-block:: html+php
 
@@ -85,7 +93,8 @@ argument, and whether or not to preserve the original filename as the second arg
 
             // Newly uploaded file
             if ($data['file'] instanceof UploadedFile && $data['file']->isValid()) {
-                $data['file']->move($this->newLocation, $this->keepFilename ? $data['file']->getOriginalName() : null);
+                $filename = $this->keepFilename ? $data['file']->getOriginalName() : null;
+                $data['file']->move($this->newLocation, $filename);
                 $data['name'] = $data['file']->getName();
             }
 
@@ -93,9 +102,10 @@ argument, and whether or not to preserve the original filename as the second arg
         }
     }
 
-This function moves the file to its new location, sets the new name in the event data, and returns the data successfully.
-The final step remaining is setting our new field type in our service container.  Because all field types are services,
-this can be configured in your dependency injection configuration.
+This function moves the file to its new location, sets the new name in the
+event data, and returns the data successfully. The final step remaining is
+setting our new field type in our service container.  Because all field types
+are services, this can be configured in your dependency injection configuration.
 
 .. configuration-block::
 
@@ -127,9 +137,10 @@ this can be configured in your dependency injection configuration.
             array('path/to/web/dir'),
         ));
 
-All ``file`` form types will now use your ``AssetType`` class.  The example below illustrates the use of the
-new AssetType class.  We add an ``attachment`` file field to the ``GenericBlog`` class, and tell it to place
-the files in the ``uploads/attachments`` directory, and to preserve the filename.
+All ``file`` form types will now use your ``AssetType`` class.  The example
+below illustrates the use of the new AssetType class.  We add an ``attachment``
+file field to the ``GenericBlog`` class, and tell it to place the files in
+the ``uploads/attachments`` directory, and to preserve the filename.
 
 .. code-block:: php
 

--- a/cookbook/forms/advanced_file_type.rst
+++ b/cookbook/forms/advanced_file_type.rst
@@ -1,0 +1,153 @@
+Advanced File Type Usage
+========================
+
+The following cookbook recipe outlines how to extend the FileType field to customize the location of your uploads
+
+Create a new field type
+-----------------------
+
+We will first need to create a new field type class.  We will extend ``FileType`` for this example, and call our class
+``AssetType``, as it represents the location we will be placing our assets.  Our field type will support the options
+``path`` and ``keep_filename``.  The ``path`` option will specify where the asset should be placed, and the ``keep_filename``
+option, when set to ``true`` will retain the uploaded file's name.
+
+.. code-block:: html+php
+
+    <?php
+
+    namespace Acme\MyBundle\Form;
+
+    use Acme\MyBundle\EventListener;
+
+    // ... other namespaces
+
+    class AssetType extends FileType
+    {
+        private $assetDir;
+
+        public function __construct($assetDir)
+        {
+            $this->assetDir = $assetDir;
+        }
+
+        public function buildForm(FormBuilder $builder, array $options)
+        {
+            $builder
+                ->appendNormTransformer(new ReversedTransformer(new FileToStringTransformer()))
+                ->appendNormTransformer(new FileToArrayTransformer())
+                ->addEventSubscriber(new MoveFileUploadListener($this->assetDir . '/' . $options['path'], $options['keep_filename']), 10)
+                ->add('file', 'field')
+                ->add('token', 'hidden')
+                ->add('name', 'hidden');
+        }
+
+        public function getDefaultOptions(array $options)
+        {
+            return array(
+                'path' => 'uploads',
+                'keep_filename' => true,
+            );
+        }
+    }
+
+The main difference between our class and ``FileType`` is the ``MoveFileUploadListener`` class.  This replaces the
+``FixFileUploadListener`` that was there before.  The difference is that ``MoveFileUploadListener`` is a class listening
+to the form event, and will execute before the field values are returned.  This class takes a destination as its first
+argument, and whether or not to preserve the original filename as the second argument.
+
+.. code-block:: html+php
+
+    <?php
+
+    namespace Acme\MyBundle\EventListener;
+
+    // ... other namespaces
+
+    class MoveFileUploadListener implements EventSubscriberInterface
+    {
+        protected $newLocation;
+        protected $keepFilename;
+
+        public function __construct($newLocation, $keepFilename = false)
+        {
+            $this->newLocation = $newLocation;
+            $this->keepFilename = $keepFilename;
+        }
+
+        public static function getSubscribedEvents()
+        {
+            return Events::onBindClientData;
+        }
+
+        public function onBindClientData(FilterDataEvent $event)
+        {
+            $data = $event->getData();
+
+            // Newly uploaded file
+            if ($data['file'] instanceof UploadedFile && $data['file']->isValid()) {
+                $data['file']->move($this->newLocation, $this->keepFilename ? $data['file']->getOriginalName() : null);
+                $data['name'] = $data['file']->getName();
+            }
+
+            $event->setData($data);
+        }
+    }
+
+This function moves the file to its new location, sets the new name in the event data, and returns the data successfully.
+The final step remaining is setting our new field type in our service container.  Because all field types are services,
+this can be configured in your dependency injection configuration.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/services.yml
+        services:
+            form.type.file:
+                class: Acme\MyBundle\Form\AssetType
+                arguments: [path/to/web/dir]
+
+    .. code-block:: xml
+
+        <!-- app/config/services.xml -->
+        <services>
+            <service id="form.type.file" class="Acme\MyBundle\Form\AssetType">
+                <tag name="form.type" alias="file" />
+                <argument>path/to/web/dir</argument>
+            </service>
+        </services>
+
+    .. code-block:: php
+
+        // app/config/services.php
+        use Symfony\Component\DependencyInjection\Definition;
+
+        $container->setDefinition('form.type.file', new Definition(
+            'Acme\MyBundle\Form\AssetType',
+            array('path/to/web/dir'),
+        ));
+
+All ``file`` form types will now use your ``AssetType`` class.  The example below illustrates the use of the
+new AssetType class.  We add an ``attachment`` file field to the ``GenericBlog`` class, and tell it to place
+the files in the ``uploads/attachments`` directory, and to preserve the filename.
+
+.. code-block:: php
+
+    class GenericBlogType extends AbstractType
+    {
+        public function buildForm(FormBuilder $builder, array $options)
+        {
+            $builder->add('name');
+            $builder->add('attachment', 'file', array(
+                'path' => 'uploads/attachments', 
+                'keep_filename' => true
+            ));
+        }
+        
+        public function getDefaultOptions(array $options)
+        {
+            return array(
+                'data_class' => 'Acme\MyBundle\Entity\GenericBlog'
+            );
+        }
+    }

--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -28,17 +28,17 @@ move the file to a specific path, take the configuration example below:
         'type'  => 'object',
     ));
 
-Your entity will now be passed a ``File`` instance when it is bound.  You 
+Your entity will now be passed a ``File`` instance when it is bound.  You
 can modify your entity setter like this:
 
 .. code-block:: php
 
-    public function setAttachment(File $attachment) 
-    { 
+    public function setAttachment(File $attachment)
+    {
         $attachment->move('/path/to/save/file');
         $this->attachment = basename($attachment->getPath());
     }
-    
+
 See the cookbook for examples of advanced usage.
 
 Options
@@ -46,6 +46,6 @@ Options
 
 * ``type`` [type: string, default: ``string``]
   The input will be returned from the widget in this format.  Valid options
-  are ``string`` and ``object``.  If set  to ``object``, an instance of  
+  are ``string`` and ``object``.  If set  to ``object``, an instance of
   :class:Symfony\\Component\\HttpFoundation\\File\\File is returned.  If
   set to ``string``, the path of the newly uploaded file is returned.

--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -19,8 +19,8 @@ The ``file`` type represents a file input in your form.
 Basic Usage
 -----------
 
-Files are uploaded to the server and set to a cached path by default.  To move the file to a
-specific path, take the configuration example below
+Files are uploaded to the server and set to a cached path by default.  To
+move the file to a specific path, take the configuration example below:
 
 .. code-block:: php
 
@@ -28,7 +28,8 @@ specific path, take the configuration example below
         'type'  => 'object',
     ));
 
-Your entity will now be passed a ``File`` instance when it is bound.  You can modify your entity setter like this:
+Your entity will now be passed a ``File`` instance when it is bound.  You 
+can modify your entity setter like this:
 
 .. code-block:: php
 
@@ -44,7 +45,7 @@ Options
 -------
 
 * ``type`` [type: string, default: ``string``]
-  The input will be returned from the widget in this format.  Valid options are ``string`` 
-  and ``object``.  If set  to ``object``, an instance of  
-  :class:Symfony\\Component\\HttpFoundation\\File\\File is returned.  If set to ``string``, 
-  the path of the newly uploaded file is returned.
+  The input will be returned from the widget in this format.  Valid options
+  are ``string`` and ``object``.  If set  to ``object``, an instance of  
+  :class:Symfony\\Component\\HttpFoundation\\File\\File is returned.  If
+  set to ``string``, the path of the newly uploaded file is returned.

--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -4,4 +4,47 @@
 ``file`` Field Type
 ===================
 
-See :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\FileType`.
+The ``file`` type represents a file input in your form.
+
++-------------+---------------------------------------------------------------------+
+| Rendered as | ``input`` ``file`` field                                            |
++-------------+---------------------------------------------------------------------+
+| Options     | - ``type``                                                          |
++-------------+---------------------------------------------------------------------+
+| Parent type | :doc:`form</reference/forms/types/form>`                            |
++-------------+---------------------------------------------------------------------+
+| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\FileType`  |
++-------------+---------------------------------------------------------------------+
+
+Basic Usage
+-----------
+
+Files are uploaded to the server and set to a cached path by default.  To move the file to a
+specific path, take the configuration example below
+
+.. code-block:: php
+
+    $builder->add('attachment', 'file', array(
+        'type'  => 'object',
+    ));
+
+Your entity will now be passed a ``File`` instance when it is bound.  You can modify your entity setter like this:
+
+.. code-block:: php
+
+    public function setAttachment(File $attachment) 
+    { 
+        $attachment->move('/path/to/save/file');
+        $this->attachment = basename($attachment->getPath());
+    }
+    
+See the cookbook for examples of advanced usage.
+
+Options
+-------
+
+* ``type`` [type: string, default: ``string``]
+  The input will be returned from the widget in this format.  Valid options are ``string`` 
+  and ``object``.  If set  to ``object``, an instance of  
+  :class:Symfony\\Component\\HttpFoundation\\File\\File is returned.  If set to ``string``, 
+  the path of the newly uploaded file is returned.


### PR DESCRIPTION
Documents file field type, adds a cookbook example.

The file field type docs shows a basic usage example, while the cookbook shows a way to extend the field to place uploaded files into a given directory automatically.
