### PR TITLE
Changed "::layout.html.twig" to "::base.html.twig"

### DIFF
--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -294,7 +294,7 @@ controller, and ``index.html.twig`` the template:
        :linenos:
 
         {# src/Acme/StudyBundle/Resources/views/Hello/index.html.twig #}
-        {% extends '::layout.html.twig' %}
+        {% extends '::base.html.twig' %}
 
         {% block body %}
             Hello {{ name }}!


### PR DESCRIPTION
In the current release the layout file in the app dir is called
"base.html.twig". This patch makes the tutorial work better out of the
box.
