### PR TITLE
Missing comma in YML configuration example

### DIFF
--- a/cookbook/request/mime_type.rst
+++ b/cookbook/request/mime_type.rst
@@ -70,7 +70,7 @@ file and register it as a listener by adding the ``kernel.listener`` tag:
             acme.demobundle.listener.request:
                 class: Acme\DemoBundle\RequestListener
                 tags:
-                    - { name: kernel.listener event: onCoreRequest }
+                    - { name: kernel.listener, event: onCoreRequest }
 
     .. code-block:: php
 


### PR DESCRIPTION
The configuration sample doesn't work without the comma. Added it.

This is my first pull-request, be gentle. Please let me know if I'm doing it wrong. :)
