### PR TITLE
Dead links: fix API reference links.

### DIFF
--- a/book/bundles.rst
+++ b/book/bundles.rst
@@ -184,8 +184,8 @@ As a best practice, controllers in a bundle that's meant to be distributed
 to others must not extend the
 :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller` base class.
 They can implement
-:class:`Symfony\\Foundation\\DependencyInjection\\ContainerAwareInterface` or
-extend :class:`Symfony\\Foundation\\DependencyInjection\\ContainerAware`
+:class:`Symfony\\Component\\DependencyInjection\\ContainerAwareInterface` or
+extend :class:`Symfony\\Component\\DependencyInjection\\ContainerAware`
 instead.
 
 .. note::


### PR DESCRIPTION
These two classes seem to have moved from Foundation to Component. This commit should fix two dead hyperlinks in the docs.
