### PR TITLE
[Book][HTTP Cache] added example of render() with existing Response

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -649,14 +649,14 @@ exposing a simple and efficient pattern::
         } else {
             // Do some more heavy stuff here
             // like getting more stuff from the DB
-	    $article->getMoreHeavyStuff();
+            $article->getMoreHeavyStuff();
             // and rendering a template 
-	    // with the $response you've already started.
-	    return $this->render(
-		'MyBundle:MyController:article.html.twig',
-		array('article' => $article),
-		$response
-	    );
+            // with the $response you've already started.
+            return $this->render(
+                'MyBundle:MyController:article.html.twig',
+                array('article' => $article),
+                $response
+            );
 
         }
     }

--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -647,9 +647,17 @@ exposing a simple and efficient pattern::
             // return the 304 Response immediately
             return $response;
         } else {
-            // do some more heavy stuff here
+            // Do some more heavy stuff here
             // like getting more stuff from the DB
-            // and rendering a template
+	    $article->getMoreHeavyStuff();
+            // and rendering a template 
+	    // with the $response you've already started.
+	    return $this->render(
+		'MyBundle:MyController:article.html.twig',
+		array('article' => $article),
+		$response
+	    );
+
         }
     }
 


### PR DESCRIPTION
I was so pleased when I dug in and found `Controller::render()` takes a `Response` as the third param so I thought I'd leave a clue for the next person.
