### PR TITLE
Added more sections to the container page

### DIFF
--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -747,7 +747,7 @@ Marking services as public / private
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When defining your services, you most of the time want to be able to use
-these definitions within your application code. We call these services
+these definitions within your application code. These services are called
 ``public``. For example, the ``doctrine`` service registered with the
 container when using the DoctrineBundle is a public service as you can
 access it via
@@ -776,12 +776,11 @@ Here is an example:
 
     .. code-block:: xml
 
-        <service id="foo" class="Acme\HelloBundle\Extension\RadiusExtension" public="false">
-        </service>
+        <service id="foo" class="Acme\HelloBundle\Foo\Bar" public="false" />
 
     .. code-block:: php
 
-        $definition = new Definition('Acme\HelloBundle\Extension\RadiusExtension');
+        $definition = new Definition('Acme\HelloBundle\Foo\Bar');
         $definition->setPublic(false);
         $container->setDefinition('foo', $definition);
 
@@ -793,6 +792,10 @@ as the service ``foo`` is marked as private.
 
 However, if a service has been marked as private, you can still alias it (see below)
 to access this service (via the alias).
+
+.. note::
+
+   Services are by default public.
 
 Aliasing
 ~~~~~~~~
@@ -813,29 +816,23 @@ furthermore, you can even alias non-public services.
 
     .. code-block:: xml
 
-        <service id="foo" class="Acme\HelloBundle\Extension\RadiusExtension">
-        </service>
+        <service id="foo" class="Acme\HelloBundle\Foo\Bar"/>
 
-        <service id="bar" alias="foo">
-        </service>
+        <service id="bar" alias="foo" />
 
     .. code-block:: php
 
-        $definition = new Definition('Acme\HelloBundle\Extension\RadiusExtension');
+        $definition = new Definition('Acme\HelloBundle\Foo\Bar');
         $container->setDefinition('foo', $definition);
 
         $containerBuilder->setAlias('bar', 'foo');
 
-You could now access the service ``foo`` within your configuration by referencing
-the service ``bar``. Of course, when using the container directly, you could type
-
+This means that when using the container directly, you can access the ``foo`` service by asking for the ``bar`` service like this
 .. configuration-block::
 
     .. code-block:: php
 
        $container->get('bar'); // Would return the foo service
-
-as well.
 
 Requiring files
 ~~~~~~~~~~~~~~~
@@ -850,18 +847,18 @@ the service itself gets loaded. To do so, you can use the ``file`` directive.
         services:
            foo:
              class: Acme\HelloBundle\Foo\Bar
-             file: /full/path/to/your/file/foo.php
+             file: %kernel.root_dir%/src/path/to/file/foo.php
 
     .. code-block:: xml
 
-        <service id="foo" class="Acme\HelloBundle\Extension\RadiusExtension">
-            <file name="/full/path/to/your/file/foo.php" />
+        <service id="foo" class="Acme\HelloBundle\Foo\Bar">
+            <file name="%kernel.root_dir%/src/path/to/file/foo.php" />
         </service>
 
     .. code-block:: php
 
-        $definition = new Definition('Acme\HelloBundle\Extension\RadiusExtension');
-        $definition->setFile('/full/path/to/your/file/foo.php');
+        $definition = new Definition('Acme\HelloBundle\Foo\Bar');
+        $definition->setFile('%kernel.root_dir%/src/path/to/file/foo.php');
         $container->setDefinition('foo', $definition);
 
 Notice that symfony will internally call the PHP function require_once

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -752,6 +752,8 @@ these definitions within your application code. These services are called
 container when using the DoctrineBundle is a public service as you can
 access it via
 
+.. codeblock::php
+
    $doctrine = $container->get('doctrine');
 
 and then operate on it, like calling methods et cetera.
@@ -759,6 +761,10 @@ and then operate on it, like calling methods et cetera.
 However, there are use-cases when you don't want a service to be public, for
 example when a service is only defined because it could be used as an
 argument for another service.
+
+You should note, however, that using a private service twice as an argument
+will result in two different instances being used as the instantiation is
+inlined.
 
 Simply said: A service will be private when you do not want to access it
 directly from your code.
@@ -786,12 +792,14 @@ Here is an example:
 
 You are now not able to call
 
+.. code-block::php
+
     $container->get('foo');
 
 as the service ``foo`` is marked as private.
 
-However, if a service has been marked as private, you can still alias it (see below)
-to access this service (via the alias).
+However, if a service has been marked as private, you can still alias it (see
+below) to access this service (via the alias).
 
 .. note::
 
@@ -827,8 +835,8 @@ furthermore, you can even alias non-public services.
 
         $containerBuilder->setAlias('bar', 'foo');
 
-This means that when using the container directly, you can access the ``foo`` service by asking for the ``bar`` service like this
-.. configuration-block::
+This means that when using the container directly, you can access the ``foo``
+service by asking for the ``bar`` service like this
 
     .. code-block:: php
 

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -743,6 +743,36 @@ the container has several other tools available that help to *tag* services
 for special functionality, create more complex services, and perform operations
 after the container is built.
 
+Requiring files
+~~~~~~~~~~~~~~~
+
+There might be use cases when you need to include another file just before
+the service itself gets loaded. To do so, you can use the ``file`` directive.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        services:
+           foo:
+             class: Acme\HelloBundle\Foo\Bar
+             file: /full/path/to/your/file/foo.php
+
+    .. code-block:: xml
+
+        <service id="foo" class="Acme\HelloBundle\Extension\RadiusExtension">
+            <file name="/full/path/to/your/file/foo.php" />
+        </service>
+
+    .. code-block:: php
+
+        $definition = new Definition('Acme\HelloBundle\Extension\RadiusExtension');
+        $definition->setFile('/full/path/to/your/file/foo.php');
+        $container->setDefinition('foo', $definition);
+
+Notice that symfony will internally call the PHP function require_once
+which means that your file will be included only once per request.
+
 Tags (``tags``)
 ~~~~~~~~~~~~~~~
 

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -743,6 +743,49 @@ the container has several other tools available that help to *tag* services
 for special functionality, create more complex services, and perform operations
 after the container is built.
 
+Aliasing
+~~~~~~~~
+
+When using core or third party bundles within your application, you may want
+to use shortcuts to access some services. You can do so by aliasing them and,
+furthermore, you can even alias non-public services.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        services:
+           foo:
+             class: Acme\HelloBundle\Foo\Bar
+           bar:
+             alias: foo
+
+    .. code-block:: xml
+
+        <service id="foo" class="Acme\HelloBundle\Extension\RadiusExtension">
+        </service>
+
+        <service id="bar" alias="foo">
+        </service>
+
+    .. code-block:: php
+
+        $definition = new Definition('Acme\HelloBundle\Extension\RadiusExtension');
+        $container->setDefinition('foo', $definition);
+
+        $containerBuilder->setAlias('bar', 'foo');
+
+You could now access the service ``foo`` within your configuration by referencing
+the service ``bar``. Of course, when using the container directly, you could type
+
+.. configuration-block::
+
+    .. code-block:: php
+
+       $container->get('bar'); // Would return the foo service
+
+as well.
+
 Requiring files
 ~~~~~~~~~~~~~~~
 

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -743,6 +743,57 @@ the container has several other tools available that help to *tag* services
 for special functionality, create more complex services, and perform operations
 after the container is built.
 
+Marking services as public / private
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When defining your services, you most of the time want to be able to use
+these definitions within your application code. We call these services
+``public``. For example, the ``doctrine`` service registered with the
+container when using the DoctrineBundle is a public service as you can
+access it via
+
+   $doctrine = $container->get('doctrine');
+
+and then operate on it, like calling methods et cetera.
+
+However, there are use-cases when you don't want a service to be public, for
+example when a service is only defined because it could be used as an
+argument for another service.
+
+Simply said: A service will be private when you do not want to access it
+directly from your code.
+
+Here is an example:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        services:
+           foo:
+             class: Acme\HelloBundle\Foo\Bar
+             public: false
+
+    .. code-block:: xml
+
+        <service id="foo" class="Acme\HelloBundle\Extension\RadiusExtension" public="false">
+        </service>
+
+    .. code-block:: php
+
+        $definition = new Definition('Acme\HelloBundle\Extension\RadiusExtension');
+        $definition->setPublic(false);
+        $container->setDefinition('foo', $definition);
+
+You are now not able to call
+
+    $container->get('foo');
+
+as the service ``foo`` is marked as private.
+
+However, if a service has been marked as private, you can still alias it (see below)
+to access this service (via the alias).
+
 Aliasing
 ~~~~~~~~
 


### PR DESCRIPTION
I did several sections as these were still missing - see https://gist.github.com/968411

It might be a good thing to restructure the whole page and maybe divide it into different pages (similar to the doctrine chapter); however, I do not think that putting these chapters into the cookbook would be a good idea as @weaverryan mentioned in the forementioned gist; I believe that this is core functionality and thus belongs into the book.

Note: Please check the code examples. I admit that I have not tested xml / php and therefore there might be errors!
