### PR TITLE
Added a slash to some links

### DIFF
--- a/glossary.rst
+++ b/glossary.rst
@@ -100,19 +100,19 @@ Glossary
         The *Kernel* is the core of Symfony2. The Kernel object handles HTTP
         requests using all the bundles and libraries registered to it. See
         :ref:`The Architecture: The Application Directory <the-app-dir>` and the
-        :doc:`book/internals/kernel` chapter.
+        :doc:`/book/internals/kernel` chapter.
 
    Firewall
         In Symfony2, a *Firewall* doesn't have to do with networking. Instead,
         it defines the authentication mechanisms (i.e. it handles the process
         of determining the identity of your users), either for the whole
         application or for just a part of it. See the
-        :doc:`book/security/overview` chapters.
+        :doc:`/book/security/overview` chapters.
 
    YAML 
         *YAML* is a recursive acronym for "YAML Ain't a Markup Language". It's a
         lightweight, humane data serialization language used extensively in
-        Symfony2's configuration files.  See the :doc:`reference/YAML` reference
+        Symfony2's configuration files.  See the :doc:`/reference/YAML` reference
         chapter.
 
 


### PR DESCRIPTION
All links from the glossary page to the book are broken (Error 404). Compare these urls:

http://symfony.com/doc/current/glossary/quick_tour/the_architecture.html#the-app-dir
http://symfony.com/doc/current/quick_tour/the_architecture.html#the-app-dir

http://symfony.com/doc/current/glossary/quick_tour/the_architecture.html#using-vendors
http://symfony.com/doc/current/quick_tour/the_architecture.html#using-vendors

http://symfony.com/doc/current/glossary/reference/YAML.html
http://symfony.com/doc/current/reference/YAML.html

There's always an extra "glossary" which leads to the 404 page. I'm not sure how to fix this, but I tried prefixing a slash to the links. Is there a page explaining the syntax of the symfony documentation? I'll gladly follow any advise given there but I wasn't able to find such a page.
