### PR TITLE
[cookbook][pdo_session_storage] Fixed argument to session storage

### DIFF
--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -26,15 +26,15 @@ configuration format of your choice).
             
         parameters:
             pdo.db_options:
-                db_table: session
-                db_id_col: session_id
+                db_table:    session
+                db_id_col:   session_id
                 db_data_col: session_value
                 db_time_col: session_time
 		
         services:
             session.storage.pdo:
                 class:     Symfony\Component\HttpFoundation\SessionStorage\PdoSessionStorage
-                arguments: [@pdo, {}, %pdo.db_options%]
+                arguments: [@pdo, %session.storage.options%, %pdo.db_options%]
 					
             pdo:
                 class: PDO


### PR DESCRIPTION
This patch fixes a typo in service arguments for session storage. The current example does not import session parameters (like lifetime, name, etc)..
