### PR TITLE
Fixes doctrine migration cookbook article

### DIFF
--- a/cookbook/doctrine/migrations.rst
+++ b/cookbook/doctrine/migrations.rst
@@ -17,11 +17,12 @@ Installation
 ------------
 
 Doctrine migrations are maintained in the `DoctrineMigrationsBundle`_.
-If you don't have the library configured with Symfony2 yet, follow
-these steps to do so.
+Make sure you have the ``doctrine-migrations`` and ``DoctrineMigrationsBundle``
+libraries configured in your project.  Follow these steps to install the
+libraries in the Symfony Standard distribution.
 
 Add the following to ``bin/deps``.  This will register the Migrations Bundle
-and the doctrine-migrations library as dependencies in your application
+and the doctrine-migrations library as dependencies in your application:
 
 .. code-block:: text
 
@@ -32,7 +33,7 @@ Update the vendor libraries:
 
 .. code-block:: bash
 
-    $ bin/vendors.php
+    $ php bin/vendors.php
 
 Now ensure your libraries will be autoloaded in ``autoload.php`` and
 your bundle enabled in ``AppKernel.php`` by including the following:
@@ -42,8 +43,9 @@ your bundle enabled in ``AppKernel.php`` by including the following:
     // app/autoload.php
     $loader->registerNamespaces(array(
         //...
-        'Symfony'          => array(__DIR__.'/../vendor/symfony/src', __DIR__.'/../vendor/bundles'),
-        'Doctrine\\DBAL'   => array(__DIR__.'/../vendor/doctrine-dbal/lib', __DIR__.'/../vendor/doctrine-migrations/lib'),
+        'Symfony'                    => array(__DIR__.'/../vendor/symfony/src', __DIR__.'/../vendor/bundles'),
+        'Doctrine\\DBAL\\Migrations' => __DIR__.'/../vendor/doctrine-migrations/lib',
+        'Doctrine\\DBAL'             => __DIR__.'/../vendor/doctrine-dbal/lib',
     ));
 
 .. code-block:: php

--- a/cookbook/doctrine/migrations.rst
+++ b/cookbook/doctrine/migrations.rst
@@ -13,6 +13,53 @@ your database schema in a safe and standardized way.
     You can read more about the Doctrine Database Migrations on the projects
     `documentation`_.
 
+Installation
+------------
+
+Doctrine migrations are maintained in the `DoctrineMigrationsBundle`_.
+If you don't have the library configured with Symfony2 yet, follow
+these steps to do so.
+
+Add the following to ``bin/deps``.  This will register the Migrations Bundle
+and the doctrine-migrations library as dependencies in your application
+
+.. code-block:: text
+
+    /                       doctrine-migrations       https://github.com/doctrine/migrations.git
+    /bundles/Symfony/Bundle DoctrineMigrationsBundle  https://github.com/symfony/DoctrineMigrationsBundle.git
+
+Update the vendor libraries:
+
+.. code-block:: bash
+
+    $ bin/vendors.php
+
+Now ensure your libraries will be autoloaded in ``autoload.php`` and
+your bundle enabled in ``AppKernel.php`` by including the following:
+
+.. code-block:: php
+
+    // app/autoload.php
+    $loader->registerNamespaces(array(
+        //...
+        'Symfony'          => array(__DIR__.'/../vendor/symfony/src', __DIR__.'/../vendor/bundles'),
+        'Doctrine\\DBAL'   => array(__DIR__.'/../vendor/doctrine-dbal/lib', __DIR__.'/../vendor/doctrine-migrations/lib'),
+    ));
+
+.. code-block:: php
+
+    // app/AppKernel.php
+    public function registerBundles()
+    {
+        $bundles = array(
+            //...
+            new Symfony\Bundle\DoctrineMigrationsBundle\DoctrineMigrationsBundle(),
+        );
+    }
+
+Usage
+-----
+
 All of the migrations functionality is contained in a few console commands:
 
 .. code-block:: bash
@@ -112,3 +159,4 @@ migrate:
     $ php app/console doctrine:migrations:migrate
 
 .. _documentation: http://www.doctrine-project.org/docs/migrations/2.0/en
+.. _DoctrineMigrationsBundle: https://github.com/symfony/DoctrineMigrationsBundle

--- a/cookbook/map.rst.inc
+++ b/cookbook/map.rst.inc
@@ -24,6 +24,7 @@
 * :doc:`/cookbook/doctrine/reverse_engineering`
 * :doc:`/cookbook/doctrine/doctrine_fixtures`
 * :doc:`/cookbook/doctrine/mongodb`
+* :doc:`/cookbook/doctrine/migrations`
 * :doc:`/cookbook/routing/scheme`
 * :doc:`/cookbook/debugging`
 * :doc:`/cookbook/assetic/yuicompressor`


### PR DESCRIPTION
- Adds "How to use Doctrine Migrations" to Cookbook Index
- Adds "Installation" instructions to Doctrine Migrations cookbook article
