### PR TITLE
Added 'single-text' option.

### DIFF
--- a/reference/forms/types/options/date_widget.rst.inc
+++ b/reference/forms/types/options/date_widget.rst.inc
@@ -1,8 +1,11 @@
 * ``widget`` [type: string, default: ``choice``]
     Type of widget used for this form type.  Can be ``text`` or ``choice``.  
     
-      * ``text``: renders a single input of type text. User's input is validated
+      * ``text``: renders a three field input of type text (month, day, year). 
+
+      * ``single-text``: renders a single input of type text. User's input is validated
         based on the ``format`` option.
+
 
       * ``choice``: renders three select inputs.  The order of the selects
         is defined in the ``pattern`` option.


### PR DESCRIPTION
single-text option was in update doc but not in master documentation.  I copied the old 'text' option and slightly modified the new 'text' option.  I haven't used 'text' (ie. the new 3 field version), so someone else may want to modify that.
