### PR TITLE
[book] New Installation Chapter

### DIFF
--- a/book/index.rst
+++ b/book/index.rst
@@ -6,6 +6,7 @@ Book
 
     http_fundamentals
     from_flat_php_to_symfony2
+    installation
     page_creation
     doctrine/index
     controller

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -79,8 +79,9 @@ by running the following command from the command line:
 .. tip::
 
     You can call ``php bin/vendors.php --min`` if you don't want all of the
-    Git history for your vendor libraries. This also makes the installation
-    much faster.
+    Git history for your vendor libraries. This makes the installation much
+    faster, but you can't "freeze" your vendor libraries later at an arbitrary
+    point.
 
 This command downloads all of the necessary vendor libraries - including Symfony
 itself - into the ``vendor/`` directory.

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -1,0 +1,158 @@
+.. index::
+   single: Installation
+
+Installing and Configuring Symfony
+==================================
+
+The goal of this chapter is to get you up-and-running with a working application
+built on top of Symfony. Fortunately, Symfony offers "distributions", which
+are functional Symfony "starter" projects that you can download and begin
+developing in immediately.
+
+Downloading a Symfony2 Distribution
+-----------------------------------
+
+Symfony2 packages "distributions", which are fully-functional applications
+that include the Symfony2 core libraries, a selection of useful bundles, a
+sensible directory structure and some default configuration. When you download
+a Symfony2 distribution, you're downloading a functional application skeleton
+that can be used immediately to begin developing your application.
+
+Start by visiting the Symfony2 download page at `http://symfony.com/download`_.
+On this page, you'll see the *Symfony Standard Edition*, which is the main
+Symfony2 distribution. Here, you'll need to make two choices:
+
+* Download either a ``.tgz`` or ``.zip`` archive - both are equivalent, download
+  whatever you're more comfortable using;
+
+* Download the distribution with or without vendors. If you have `Git`_ installed
+  on your computer, you should download Symfony2 "without vendors", as it
+  adds a bit more flexibility when including third-party/vendor libraries.
+
+Download one of the archives somewhere under your local web server/s root
+directory and unpack it. From a UNIX command line, this can be done with
+one of the following commands (replacing ``###`` with your actual filename):
+
+.. code-block:: bash
+
+    # for .tgz file
+    tar zxvf Symfony_Standard_Vendors_2.0.###.tgz
+    
+    # for a .zip file
+    unzip Symfony_Standard_Vendors_2.0.###.tgz
+
+When you're finished, you should have a ``Symfony/`` directory that looks
+something like this:
+
+.. code-block:: text
+
+    www/ <- your web root directory
+        Symfony/ <- the unpacked archive
+            app/
+                cache/
+                config/
+                logs/
+            src/
+                ...
+            vendor/
+                ...
+            web/
+                app.php
+                ...
+
+Updating Vendors
+~~~~~~~~~~~~~~~~
+
+Finally, if you downloaded the archive "without vendors", install the vendors
+by running the following command from the command line:
+
+.. code-block:: bash
+
+    php bin/vendors.php
+
+.. tip::
+
+    You can call ``php bin/vendors.php --min`` if you don't want all of the
+    Git history for your vendor libraries. This also makes the installation
+    much faster.
+
+This command downloads all of the necessary vendor libraries - including Symfony
+itself - into the ``vendor/`` directory.
+
+Configuration and Setup
+~~~~~~~~~~~~~~~~~~~~~~~
+
+At this point, all of the needed third-party libraries now live in the ``vendor/``
+directory. You also have a default application setup in ``app/`` and some
+sample code inside the ``src/`` directory.
+
+Symfony2 comes with a visual server configuration tester to help make sure
+your Web server and PHP are configured to use Symfony. Use the following URL
+URL to check your configuration:
+
+.. code-block:: text
+
+    http://localhost/Symfony/web/config.php
+
+If there are any issues, correct them now before moving on.
+
+.. sidebar:: Setting up Permissions
+
+    One common issue is that the ``app/cache`` and ``app/log`` directories
+    must be writable both by the web server and the command line user. On
+    a UNIX system, if your web server user is different from your command
+    line user, you can run the following commands just once in your project
+    to ensure that permissions will be setup properly. Change ``www-data``
+    to the web server user and ``yourname`` to your command line user:
+
+    .. code-block:: bash
+
+        rm -rf app/cache/*
+        rm -rf app/log/*
+
+        sudo chmod +a "www-data allow delete,write,append,file_inherit,directory_inherit" app/cache
+        sudo chmod +a "www-data allow delete,write,append,file_inherit,directory_inherit" app/logs
+
+        sudo chmod +a "yourname allow delete,write,append,file_inherit,directory_inherit" app/cache
+        sudo chmod +a "yourname allow delete,write,append,file_inherit,directory_inherit" app/logs
+
+When everything is fine, click on "Go to the Welcome page" to request your
+first "real" Symfony2 webpage:
+
+.. code-block:: text
+
+    http://localhost/Symfony/web/app_dev.php/
+
+Symfony2 should welcome and congratulate you for your hard work so far!
+
+.. image:: /images/quick_tour/welcome.jpg
+
+Beginning Development
+---------------------
+
+Now that you have a fully-functional Symfony2 application, you can begin
+development! Your distribution may contain some sample code - check the
+``README.rst`` file included with the distribution (open it as a text file)
+to learn about what sample code was included with your distribution and how
+you can remove it later.
+
+Using Source Control
+~~~~~~~~~~~~~~~~~~~~
+
+If you're using a version control system like ``Git`` or ``Subversion``, you
+can begin committing your project as normal. If you've downloaded the archive
+*without vendors*, you can safely ignore the entire ``vendors/`` directory
+and not commit it to source control. With ``Git``, this is done by creating
+and adding the following to a ``.gitignore`` file:
+
+.. code-block:: text
+
+    vendor/
+
+Now, the vendor directory won't be committed to source control. This is fine
+(actually, it's great!) because when someone else clones our checks out the
+project, he/she can simply run the ``php bin/vendors.php`` script to download
+all the necessary vendor libraries.
+
+.. _`http://symfony.com/download`: http://symfony.com/download
+.. _`Git`: http://git-scm.com/

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -4,7 +4,7 @@
 Installing and Configuring Symfony
 ==================================
 
-The goal of this chapter is to get you up-and-running with a working application
+The goal of this chapter is to get you up and running with a working application
 built on top of Symfony. Fortunately, Symfony offers "distributions", which
 are functional Symfony "starter" projects that you can download and begin
 developing in immediately.
@@ -35,7 +35,7 @@ Symfony2 distribution. Here, you'll need to make two choices:
   on your computer, you should download Symfony2 "without vendors", as it
   adds a bit more flexibility when including third-party/vendor libraries.
 
-Download one of the archives somewhere under your local web server/s root
+Download one of the archives somewhere under your local web server's root
 directory and unpack it. From a UNIX command line, this can be done with
 one of the following commands (replacing ``###`` with your actual filename):
 
@@ -94,7 +94,7 @@ sample code inside the ``src/`` directory.
 
 Symfony2 comes with a visual server configuration tester to help make sure
 your Web server and PHP are configured to use Symfony. Use the following URL
-URL to check your configuration:
+to check your configuration:
 
 .. code-block:: text
 
@@ -142,23 +142,41 @@ development! Your distribution may contain some sample code - check the
 to learn about what sample code was included with your distribution and how
 you can remove it later.
 
+If you're new to Symfony, join us in the ":doc:`page_creation`", where you'll
+learn how to create pages, change configuration, and do everything else you'll
+need in your new application.
+
 Using Source Control
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 If you're using a version control system like ``Git`` or ``Subversion``, you
-can begin committing your project as normal. If you've downloaded the archive
-*without vendors*, you can safely ignore the entire ``vendors/`` directory
-and not commit it to source control. With ``Git``, this is done by creating
-and adding the following to a ``.gitignore`` file:
+can setup your version control system and begin committing your project to
+it as normal. For ``Git``, this can be done easily with the following command:
+
+.. code-block:: bash
+
+    git init
+
+For more information on setting up and using Git, check out the `GitHub Bootcamp`_
+tutorials.
+
+Ignoring the ``vendor/`` Directory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you've downloaded the archive *without vendors*, you can safely ignore
+the entire ``vendors/`` directory and not commit it to source control. With
+``Git``, this is done by creating and adding the following to a ``.gitignore``
+file:
 
 .. code-block:: text
 
     vendor/
 
 Now, the vendor directory won't be committed to source control. This is fine
-(actually, it's great!) because when someone else clones our checks out the
+(actually, it's great!) because when someone else clones or checks out the
 project, he/she can simply run the ``php bin/vendors.php`` script to download
 all the necessary vendor libraries.
 
 .. _`http://symfony.com/download`: http://symfony.com/download
 .. _`Git`: http://git-scm.com/
+.. _`GitHub Bootcamp`: http://help.github.com/set-up-git-redirect

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -12,6 +12,12 @@ developing in immediately.
 Downloading a Symfony2 Distribution
 -----------------------------------
 
+.. tip::
+
+    First, check that you have installed and configured a Web server (such
+    as Apache) with PHP 5.3.2 or higher. For more information on Symfony2
+    requirements, see the :doc:`requirements reference</reference/requirements>`.
+
 Symfony2 packages "distributions", which are fully-functional applications
 that include the Symfony2 core libraries, a selection of useful bundles, a
 sensible directory structure and some default configuration. When you download

--- a/book/map.rst.inc
+++ b/book/map.rst.inc
@@ -1,5 +1,7 @@
 * :doc:`Symfony2 Fundamentals </book/http_fundamentals>`
 * :doc:`When flat PHP meets Symfony </book/from_flat_php_to_symfony2>`
+
+* :doc:`Installing and Configuring Symfony </book/installation>`
 * :doc:`The Basics of Page Creation </book/page_creation>`
 
 * :doc:`Controllers </book/controller>`

--- a/book/map.rst.inc
+++ b/book/map.rst.inc
@@ -1,3 +1,5 @@
+* :doc:`Symfony2 Requirements </book/requirements>`
+
 * :doc:`Introduction to Symfony2 and HTTP </book/http_fundamentals>`
 * :doc:`From flat PHP to Symfony2 </book/from_flat_php_to_symfony2>`
 * :doc:`The Basics of Page Creation </book/page_creation>`

--- a/book/requirements.rst
+++ b/book/requirements.rst
@@ -1,0 +1,37 @@
+.. index::
+   single: Requirements
+   
+Requirements for running Symfony2
+=================================
+
+To run Symfony2, your system needs to adhere to a list of requirements. You can easily see if your system passes all requirements by running the web/check.php in your symfony distribution. Below is the list of required and optional requirements.
+
+Required
+--------
+
+* PHP needs to be a minimum version of PHP 5.3.2
+* Your PHP.ini needs to have the date.timezone setting
+* The app/cache and app/logs directories need to be writable
+
+Optional
+--------
+
+* You need to have the PHP-XML module installed
+* You need to have at least version 2.6.21 of libxml
+* PHP tokenizer needs to be enabled
+* mbstring functions need to be enabled
+* iconv needs to be enabled
+* POSIX needs to be enabled
+* Intl needs to be installed
+* APC (or another opcode cache needs to be installed)
+* PHP.ini recommended settings
+
+    * short_open_tags: off
+    * magic_quotes_gpc: off
+    * register_globals: off
+    * session.autostart: off
+    
+Doctrine
+--------
+
+If you want to use Doctrine, you will need to have PDO installed. Additionally, you need to have the PDO driver installed for the database server you want to use.

--- a/book/requirements.rst
+++ b/book/requirements.rst
@@ -4,7 +4,10 @@
 Requirements for running Symfony2
 =================================
 
-To run Symfony2, your system needs to adhere to a list of requirements. You can easily see if your system passes all requirements by running the web/check.php in your symfony distribution. Below is the list of required and optional requirements.
+To run Symfony2, your system needs to adhere to a list of requirements. You can
+easily see if your system passes all requirements by running the web/check.php
+in your symfony distribution. Below is the list of required and optional
+requirements.
 
 Required
 --------
@@ -34,4 +37,6 @@ Optional
 Doctrine
 --------
 
-If you want to use Doctrine, you will need to have PDO installed. Additionally, you need to have the PDO driver installed for the database server you want to use.
+If you want to use Doctrine, you will need to have PDO installed. Additionally,
+you need to have the PDO driver installed for the database server you want
+to use.

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -14,5 +14,6 @@ Reference Documents
     constraints
     forms/types
     forms/twig_reference
+    requirements
 
 .. include:: map.rst.inc

--- a/reference/map.rst.inc
+++ b/reference/map.rst.inc
@@ -19,3 +19,4 @@
   * :doc:`/reference/constraints`
   * :doc:`/reference/dic_tags`
   * :doc:`/reference/YAML`
+  * :doc:`/reference/requirements`

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -6,8 +6,9 @@ Requirements for running Symfony2
 
 To run Symfony2, your system needs to adhere to a list of requirements. You can
 easily see if your system passes all requirements by running the ``web/config.php``
-in your symfony distribution. To check your requirements from the command
-line, run:
+in your symfony distribution. Since the CLI often uses a different ``php.ini``
+configuration file, it's also a good idea to check your requirements from
+the command line via:
 
 .. code-block:: bash
 

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -5,16 +5,21 @@ Requirements for running Symfony2
 =================================
 
 To run Symfony2, your system needs to adhere to a list of requirements. You can
-easily see if your system passes all requirements by running the web/check.php
-in your symfony distribution. Below is the list of required and optional
-requirements.
+easily see if your system passes all requirements by running the ``web/config.php``
+in your symfony distribution. To check your requirements from the command
+line, run:
+
+.. code-block:: bash
+
+    php app/check.php
+
+Below is the list of required and optional requirements.
 
 Required
 --------
 
 * PHP needs to be a minimum version of PHP 5.3.2
 * Your PHP.ini needs to have the date.timezone setting
-* The app/cache and app/logs directories need to be writable
 
 Optional
 --------


### PR DESCRIPTION
Hey guys-

This is a first pass at a basic "installation" chapter, which was covered briefly in the quick tour, but not anyone in the core docs.

I think we need to figure out what's missing and what common pain points are. We're not really responsible for teaching people how to install Apache, PHP, Virtual Hosts, etc, but perhaps we can add a few cookbook articles that give even more information (and links to other good resources) specific to installing to Unix, Windows, nginx, etc. Via feedback from the user board/forum, we might also consider a "troubleshooting" cookbook.

So, thoughts on this PR? Please check out my "sidebar" solution for handling permissions on the `logs` and `cache` dirs.
