### PR TITLE
[book] Fixing missing render_template argument in "When Flat PHP meets Symfony" chapter

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -490,9 +490,7 @@ incidentally, acts quite a bit like the Symfony2 templating engine:
     function list_action()
     {
         $posts = get_all_posts();
-        $html = render_template('templates/list.php, array(
-	        'posts' => $posts,
-	');
+        $html = render_template('templates/list.php, array('posts' => $posts));
 
         return new Response($html);
     }
@@ -500,9 +498,7 @@ incidentally, acts quite a bit like the Symfony2 templating engine:
     function show_action($id)
     {
         $post = get_post_by_id($id);
-        $html = render_template('templates/show.php', array(
-            'post' => $post,
-        ));
+        $html = render_template('templates/show.php', array('post' => $post));
 
         return new Response($html);
     }

--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -492,7 +492,6 @@ incidentally, acts quite a bit like the Symfony2 templating engine:
         $posts = get_all_posts();
         $html = render_template('templates/list.php, array(
 	        'posts' => $posts,
-	
 	');
 
         return new Response($html);

--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -490,7 +490,10 @@ incidentally, acts quite a bit like the Symfony2 templating engine:
     function list_action()
     {
         $posts = get_all_posts();
-        $html = render_template('templates/list.php');
+        $html = render_template('templates/list.php, array(
+	        'posts' => $posts,
+	
+	');
 
         return new Response($html);
     }

--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -490,7 +490,7 @@ incidentally, acts quite a bit like the Symfony2 templating engine:
     function list_action()
     {
         $posts = get_all_posts();
-        $html = render_template('templates/list.php, array('posts' => $posts));
+        $html = render_template('templates/list.php', array('posts' => $posts));
 
         return new Response($html);
     }


### PR DESCRIPTION
Changed a call to the render_template function that lacked an argument.
