### PR TITLE
[book] php app/console doctrine:generate:entities requires 1 argument : add the namespace

### DIFF
--- a/book/doctrine/orm.rst
+++ b/book/doctrine/orm.rst
@@ -359,7 +359,7 @@ add the name of the repository class to your mapping definition.
 The repository class is created for you if you run the following command
 to generate your entities.
 
-    $ php app/console doctrine:generate:entities
+    $ php app/console doctrine:generate:entities Acme\HelloBundle
 
 If you have already generated your entity class before adding the ``repositoryClass``
 mapping, you have to create the class on your own. Fortunately, it's pretty


### PR DESCRIPTION
In the book, doctrine/orm page :

`php app/console doctrine:generate:entities` requires 1 argument : add the `Acme\HelloBundle` namespace to the command.
