### PR TITLE
[book] Fixing name variables that extract data from the model in "When Flat PHP meets Symfony" chapter

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -551,26 +551,26 @@ them for you. Here's the same sample application, now built in Symfony2:
     {
         public function listAction()
         {
-            $blogs = $this->get('doctrine')->getEntityManager()
-                ->createQuery('SELECT b FROM AcmeBlogBundle:Blog b')
+            $posts = $this->get('doctrine')->getEntityManager()
+                ->createQuery('SELECT p FROM AcmeBlogBundle:Post p')
                 ->execute();
 
-            return $this->render('AcmeBlogBundle:Blog:list.html.php', array('blogs' => $blogs));
+            return $this->render('AcmeBlogBundle:Post:list.html.php', array('posts' => $posts));
         }
 
         public function showAction($id)
         {
-            $blog = $this->get('doctrine')
+            $post = $this->get('doctrine')
                 ->getEntityManager()
-                ->getRepository('AcmeBlogBundle:Blog')
+                ->getRepository('AcmeBlogBundle:Post')
                 ->find($id);
             
-            if (!$blog) {
+            if (!$post) {
                 // cause the 404 page not found to be displayed
                 throw $this->createNotFoundException();
             }
 
-            return $this->render('AcmeBlogBundle:Blog:show.html.php', array('blog' => $blog));
+            return $this->render('AcmeBlogBundle:Post:show.html.php', array('post' => $post));
         }
     }
 


### PR DESCRIPTION
Later on in the chapter, the templates use $post and $posts as the objects' name, so I assume these ones ($blog and $blogs), are typos.

Hopefully I got the commit right this time. 
