### PR TITLE
[cookbook] Fix example config in XML

### DIFF
--- a/cookbook/bundles/extension.rst
+++ b/cookbook/bundles/extension.rst
@@ -136,7 +136,7 @@ So, given the following configuration:
             xsi:schemaLocation="http://www.example.com/symfony/schema/ http://www.example.com/symfony/schema/hello-1.0.xsd">
 
             <hello:config foo="foo">
-                <hello:bar>foo</hello:bar>
+                <hello:bar>bar</hello:bar>
             </hello:config>
 
         </container>


### PR DESCRIPTION
Not sure for this one, but in http://symfony.com/doc/current/cookbook/bundles/extension.html ,  the example config in YAML is

``` yaml
# app/config/config.yml
hello:
    foo: foo
    bar: bar
```

and in XML

``` xml
[...]
    <hello:config foo="foo">
        <hello:bar>foo</hello:bar>
    </hello:config>
[...]
```

I don't get the "foo" between the `bar`
