### PR TITLE
Fixed the way to set the charset to UTF8 for the dbal connection

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -27,7 +27,7 @@ Configuration Reference
                         memory:               true
                         unix_socket:          /tmp/mysql.sock
                         wrapper_class:        MyDoctrineDbalConnectionWrapper
-                        charset:              UTF-8
+                        charset:              UTF8
                         logging:              %kernel.debug%
                         platform_service:     MyOwnDatabasePlatformService
                     conn1:
@@ -88,7 +88,7 @@ Configuration Reference
                         memory="true"
                         unix-socket="/tmp/mysql.sock"
                         wrapper-class="MyDoctrineDbalConnectionWrapper"
-                        charset="UTF-8"
+                        charset="UTF8"
                         logging="%kernel.debug%"
                         platform-service="MyOwnDatabasePlatformService"
                     />


### PR DESCRIPTION
Using UTF-8 will lead to a PDOException because `SET NAMES UTF-8` is invalid.
