### PR TITLE
[book] Change "hello/config" to "app/config" in validation page

### DIFF
--- a/book/validation.rst
+++ b/book/validation.rst
@@ -221,7 +221,7 @@ configuration:
 
     .. code-block:: yaml
 
-        # hello/config/config.yml
+        # app/config/config.yml
         framework:
             validation: { enabled: true, enable_annotations: true }
 


### PR DESCRIPTION
It seems "app" should be used, as in XML and PHP examples
