### PR TITLE
[Book] change old "Demo" and "Blog" Bundle name to ProductBundle in forms

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -272,8 +272,8 @@ number:
 
     .. code-block:: yaml
 
-        # Acme/DemoBundle/Resources/config/validation.yml
-        Acme\DemoBundle\Entity\Product:
+        # Acme/StoreBundle/Resources/config/validation.yml
+        Acme\StoreBundle\Entity\Product:
             properties:
                 name:
                     - NotBlank: ~
@@ -283,8 +283,8 @@ number:
 
     .. code-block:: xml
 
-        <!-- Acme/BlogBundle/Resources/config/validation.xml -->
-        <class name="Acme\DemoBundle\Entity\Product">
+        <!-- Acme/StoreBundle/Resources/config/validation.xml -->
+        <class name="Acme\StoreBundle\Entity\Product">
             <property name="name">
                 <constraint name="NotBlank" />
             </property>


### PR DESCRIPTION
[Book] change old "Demo" and "Blog" Bundle name to ProductBundle in forms.

In http://symfony.com/doc/current/book/forms.html#form-validation , the config files with YAML and XML use "Blog" and "Demo" Bundle name.
