### PR TITLE
Added tip for those using other programs (like Doxygen) that use annotati

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -230,6 +230,14 @@ in a number of different formats including YAML, XML or directly inside the
     The table name is optional and if omitted, will be determined automatically
     based on the name of the entity class.
 
+.. tip::
+
+    When using another library or program (ie. Doxygen) that uses annotations, 
+    you must use the @IgnoreAnnotation annotation to indicate which annotations 
+    Symfony and Doctrine should ignore.  Failing to do so may result in an 
+    Exception being thrown.
+    Example:  @IgnoreAnnotation("param") will prevent "@param ..." from throwing an Exception.
+
 Doctrine allows you to choose from a wide variety of different field types,
 each with their own options. For information on the available field types,
 see the :ref:`book-doctrine-field-types` section.

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -234,9 +234,10 @@ in a number of different formats including YAML, XML or directly inside the
 
     When using another library or program (ie. Doxygen) that uses annotations, 
     you must use the @IgnoreAnnotation annotation to indicate which annotations 
-    Symfony and Doctrine should ignore.  Failing to do so may result in an 
+    Symfony and Doctrine should ignore.  This annotation should be placed in the 
+    comment block of the class it applies to.  Failing to do so may result in an 
     Exception being thrown.
-    Example:  @IgnoreAnnotation("param") will prevent "@param ..." from throwing an Exception.
+    Example:  @IgnoreAnnotation("fn") will prevent "@fn ..." from throwing an Exception.
 
 Doctrine allows you to choose from a wide variety of different field types,
 each with their own options. For information on the available field types,


### PR DESCRIPTION
Added tip for those using other programs (like Doxygen) that use annotations letting the user know that the @IgnoreAnnotation annotation is necessary to prevent an Exception from being thrown.
