### PR TITLE
setContainer method signature is now the same as that of ContainerAwareIn

### DIFF
--- a/cookbook/doctrine/doctrine_fixtures.rst
+++ b/cookbook/doctrine/doctrine_fixtures.rst
@@ -296,7 +296,7 @@ component when checking it:
     {
         private $container;
 
-        public function setContainer(ContainerInterface $container)
+        public function setContainer(ContainerInterface $container = null)
         {
             $this->container = $container;
         }


### PR DESCRIPTION
setContainer method signature is now the same as that of ContainerAwareInterface
