### PR TITLE
restructured text (rst) format optimizations

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -546,8 +546,8 @@ The ``NotFoundHttpException`` will return a 404 HTTP response back to the
 browser. When viewing a page in debug mode, a full exception with stacktrace
 is displayed so that the cause of the exception can be easily tracked down.
 
-Of course, you're free to throw any ``Exception`` class in your controller
-- Symfony2 will automatically return a 500 HTTP response code.
+Of course, you're free to throw any ``Exception`` class in your controller -
+Symfony2 will automatically return a 500 HTTP response code.
 
 .. code-block:: php
 

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -117,8 +117,8 @@ inside the ``Entity`` directory of your ``AcmeStoreBundle``::
         protected $description;
     }
 
-The class - often called an "entity", meaning *a basic class that holds data*
-- is simple and helps fulfill the business requirement of needing products
+The class - often called an "entity", meaning *a basic class that holds data* -
+is simple and helps fulfill the business requirement of needing products
 in your application. This class can't be persisted to a database yet - it's
 just a simple PHP class.
 

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -938,8 +938,8 @@ portions of a form. For a more extensive discussion, see :doc:`/cookbook/form/tw
 Form Template Blocks
 ~~~~~~~~~~~~~~~~~~~~
 
-Every part of a form that is rendered - HTML form elements, errors, labels, etc
-- is defined in a base template as individual Twig blocks. By default, every
+Every part of a form that is rendered - HTML form elements, errors, labels, etc -
+is defined in a base template as individual Twig blocks. By default, every
 block needed is defined in the `div_layout.html.twig`_ file that lives inside
 the `Twig Bridge`_. Inside this file, you can see every block needed
 to render a form and every default field type.

--- a/book/index.rst
+++ b/book/index.rst
@@ -23,4 +23,4 @@ Book
     internals
     stable_api
 
-.. include:: map.rst.inc
+.. include:: /book/map.rst.inc

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -282,8 +282,8 @@ return that ``Response`` object.
 
 Notice that there are two different examples for rendering the template.
 By default, Symfony2 supports two different templating languages: classic
-PHP templates and the succinct but powerful `Twig`_ templates. Don't be alarmed
-- you're free to choose either or even both in the same project.
+PHP templates and the succinct but powerful `Twig`_ templates. Don't be
+alarmed - you're free to choose either or even both in the same project.
 
 The controller renders the ``AcmeHelloBundle:Hello:index.html.twig`` template,
 which uses the following naming convention:

--- a/contributing/index.rst
+++ b/contributing/index.rst
@@ -8,4 +8,4 @@ Contributing
     documentation/index
     community/index
 
-.. include:: map.rst.inc
+.. include:: /contributing/map.rst.inc

--- a/cookbook/doctrine/mongodb.rst
+++ b/cookbook/doctrine/mongodb.rst
@@ -141,10 +141,10 @@ inside the ``Document`` directory of your ``AcmeStoreBundle``::
         protected $price;
     }
 
-The class - often called a "document", meaning *a basic class that holds data*
-- is simple and helps fulfill the business requirement of needing products
-in your application. This class can't be persisted to Doctrine MongoDB yet
-- it's just a simple PHP class.
+The class - often called a "document", meaning *a basic class that holds data* -
+is simple and helps fulfill the business requirement of needing products
+in your application. This class can't be persisted to Doctrine MongoDB yet -
+it's just a simple PHP class.
 
 Add Mapping Information
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/cookbook/doctrine/mongodb.rst
+++ b/cookbook/doctrine/mongodb.rst
@@ -106,15 +106,15 @@ documents to and from MongoDB.
 
     If you want to follow along with the example in this chapter, create
     an ``AcmeStoreBundle`` via:
-    
+
     .. code-block:: bash
-    
+
         php app/console init:bundle Acme/StoreBundle src/
 
     Next, be sure that the new bundle is enabled in the kernel::
-    
+
         // app/AppKernel.php
-        
+
         public function registerBundles()
         {
             $bundles = array(
@@ -131,7 +131,7 @@ Without even thinking about Doctrine or MongoDB, you already know that you
 need a ``Product`` object to represent those products. Create this class
 inside the ``Document`` directory of your ``AcmeStoreBundle``::
 
-    // src/Acme/StoreBundle/Document/Product.php    
+    // src/Acme/StoreBundle/Document/Product.php
     namespace Acme\StoreBundle\Document;
 
     class Product
@@ -551,7 +551,7 @@ You can use this new method just like the default finder methods of the reposito
     $product = $this->get('doctrine.odm.mongodb.document_manager')
         ->getRepository('AcmeStoreBundle:Product')
         ->findAllOrderedByName();
-                
+
 
 .. note::
 
@@ -638,16 +638,16 @@ see Doctrine's `Event Documentation`_.
 In Symfony, you can register a listener or subscriber by creating a :term:`service`
 and then :ref:`tagging<book-service-container-tags>` it with a specific tag.
 
-* **event listener**: Use the ``doctrine.odm.mongodb.<connection>_event_listener``
+*   **event listener**: Use the ``doctrine.odm.mongodb.<connection>_event_listener``
     tag, where ``<connection>`` name is replaced by the name of your connection
     (usually ``default``). Also, be sure to add an ``event`` key to the tag
     specifying which event to listen to. Assuming your connection is called
     ``default``, then:
 
     .. configuration-block::
-    
+
         .. code-block:: yaml
-        
+
             services:
                 my_doctrine_listener:
                     class:   Acme\HelloBundle\Listener\MyDoctrineListener
@@ -656,7 +656,7 @@ and then :ref:`tagging<book-service-container-tags>` it with a specific tag.
                         -  { name: doctrine.odm.mongodb.default_event_listener, event: postPersist }
 
         .. code-block:: xml
-        
+
             <service id="my_doctrine_listener" class="Acme\HelloBundle\Listener\MyDoctrineListener">
                 <!-- ... -->
                 <tag name="doctrine.odm.mongodb.default_event_listener" event="postPersist" />
@@ -669,7 +669,7 @@ and then :ref:`tagging<book-service-container-tags>` it with a specific tag.
             $definition->addTag('doctrine.odm.mongodb.default_event_listener');
             $container->setDefinition('my_doctrine_listener', $definition);
 
-* **event subscriber**: Use the ``doctrine.odm.mongodb.<connection>_event_subscriber``
+*   **event subscriber**: Use the ``doctrine.odm.mongodb.<connection>_event_subscriber``
     tag. No other keys are needed in the tag.
 
 Summary

--- a/cookbook/index.rst
+++ b/cookbook/index.rst
@@ -66,4 +66,4 @@ Cookbook
 
     symfony1
 
-.. include:: map.rst.inc
+.. include:: /cookbook/map.rst.inc

--- a/glossary.rst
+++ b/glossary.rst
@@ -1,4 +1,4 @@
-:orphan:``
+:orphan:
 
 Glossary
 ========

--- a/glossary.rst
+++ b/glossary.rst
@@ -1,4 +1,4 @@
-:orphan:
+:orphan:``
 
 Glossary
 ========

--- a/index.rst
+++ b/index.rst
@@ -26,7 +26,7 @@ Dive into Symfony2 with the topical guides:
 
     book/index
 
-.. include:: book/map.rst.inc
+.. include:: /book/map.rst.inc
 
 Cookbook
 --------
@@ -48,7 +48,7 @@ Get answers quickly with reference documents:
 
     reference/index
 
-.. include:: reference/map.rst.inc
+.. include:: /reference/map.rst.inc
 
 Contributing
 ------------
@@ -60,4 +60,4 @@ Contribute to Symfony2:
 
     contributing/index
 
-.. include:: contributing/map.rst.inc
+.. include:: /contributing/map.rst.inc

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -151,7 +151,7 @@ there are several common options for configuring the "form login" experience:
 The Login Form and Process
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ``login_path`` (type: ``string``, default: ``/login``)
+*   ``login_path`` (type: ``string``, default: ``/login``)
     This is the URL that the user will be redirected to (unless ``use_forward``
     is set to ``true``) when he/she tries to access a protected resource
     but isn't fully authenticated.
@@ -160,7 +160,7 @@ The Login Form and Process
     you may create a redirect loop. For details, see
     ":ref:`Avoid Common Pitfalls<book-security-common-pitfalls>`".
 
-* ``check_path`` (type: ``string``, default: ``/login_check``)
+*   ``check_path`` (type: ``string``, default: ``/login_check``)
     This is the URL that your login form must submit to. The firewall will
     intercept any requests (``POST`` requests only, be default) to this URL
     and process the submitted login credentials.
@@ -168,21 +168,21 @@ The Login Form and Process
     Be sure that this URL is covered by your main firewall (i.e. don't create
     a separate firewall just for ``check_path`` URL).
 
-* ``use_forward`` (type: ``Boolean``, default: ``false``)
+*   ``use_forward`` (type: ``Boolean``, default: ``false``)
     If you'd like the user to be forwarded to the login form instead of being
     redirected, set this option to ``true``.
 
-* ``username_parameter`` (type: ``string``, default: ``_username``)
+*   ``username_parameter`` (type: ``string``, default: ``_username``)
     This is the field name that you should give to the username field of
     your login form. When you submit the form to ``check_path``, the security
     system will look for a POST parameter with this name.
 
-* ``password_parameter`` (type: ``string``, default: ``_password``)
+*   ``password_parameter`` (type: ``string``, default: ``_password``)
     This is the field name that you should give to the password field of
     your login form. When you submit the form to ``check_path``, the security
     system will look for a POST parameter with this name.
 
-* ``post_only`` (type: ``Boolean``, default: ``true``)
+*   ``post_only`` (type: ``Boolean``, default: ``true``)
     By default, you must submit your login form to the ``check_path`` URL
     as a POST request. By setting this option to ``true``, you can send a
     GET request to the ``check_path`` URL.

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -24,12 +24,12 @@ a list of given choices.
 Available Options
 -----------------
 
-* ``choices`` (**default**) [type: array]
+*   ``choices`` (**default**) [type: array]
     A required option (unless ``callback`` is specified) - this is the array
     of options that should be considered in the valid set. The input value
     will be matched against this array.
 
-* ``callback``: [type: string|array]
+*   ``callback``: [type: string|array]
     This is a static callback method that can be used instead of the ``choices``
     option to return the choices array.
     
@@ -40,33 +40,33 @@ Available Options
     the normal callable syntax where the first argument is the class name
     and the second argument is the method name.
 
-* ``multiple``: [type: Boolean, default: false]
+*   ``multiple``: [type: Boolean, default: false]
     If this option is true, the input value is expected to be an array instead
     of a single, scalar value. The constraint will check that each value of
     the input array can be found in the array of valid choices. If even one
     of the input values cannot be found, the validation will fail.
 
-* ``min``: [type: integer]
+*   ``min``: [type: integer]
     If the ``multiple`` option is true, then you can use the ``min`` option
     to force at least XX number of values to be selected. For example, if
     ``min`` is 3, but the input array only contains 2 valid items, the
     validation will fail.
 
-* ``max``: [type: integer]
+*   ``max``: [type: integer]
     If the ``multiple`` option is true, then you can use the ``max`` option
     to force no more than XX number of values to be selected. For example, if
     ``max`` is 3, but the input array contains 4 valid items, the validation
     will fail.
 
-* ``message``: [type: string, default: `This value should be one of the given choices`]
+*   ``message``: [type: string, default: `This value should be one of the given choices`]
     This is the validation error message that's displayed when the input
     value is invalid.
 
-* ``minMessage``: [type: string, default: `You should select at least {{ limit }} choices`]
+*   ``minMessage``: [type: string, default: `You should select at least {{ limit }} choices`]
     This is the validation error message that's displayed when the user chooses
     too few options per the ``min`` option.
 
-* ``maxMessage``: [type: string, default: `You should select at most {{ limit }} choices`]
+*   ``maxMessage``: [type: string, default: `You should select at most {{ limit }} choices`]
     This is the validation error message that's displayed when the user chooses
     too many options per the ``max`` option.
 

--- a/reference/constraints/MaxLength.rst
+++ b/reference/constraints/MaxLength.rst
@@ -18,11 +18,11 @@ Validates that the string length of a value is not larger than the given limit.
 Options
 -------
 
-* ``limit`` (**default**, required) [type: integer]
+*   ``limit`` (**default**, required) [type: integer]
     This is the maximum length of the string. If set to 10, the string must
     be no more than 10 characters in length.
 
-* ``message`` [type: string, default: ``This value is too long. It should have {{ limit }} characters or less``]
+*   ``message`` [type: string, default: ``This value is too long. It should have {{ limit }} characters or less``]
     This is the validation error message when the validation fails.
 
 Basic Usage

--- a/reference/constraints/MinLength.rst
+++ b/reference/constraints/MinLength.rst
@@ -18,11 +18,11 @@ Validates that the string length of a value is not smaller than the given limit.
 Options
 -------
 
-* ``limit`` (**default**, required) [type: integer]
+*   ``limit`` (**default**, required) [type: integer]
     This is the minimum length of the string. If set to 3, the string must
     be at least 3 characters in length.
 
-* ``message`` [type: string, default: ``This value is too short. It should have {{ limit }} characters or more``]
+*   ``message`` [type: string, default: ``This value is too short. It should have {{ limit }} characters or more``]
     This is the validation error message when the validation fails.
 
 Basic Usage

--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -216,4 +216,4 @@ If you validate an author with an invalid address now, you can see that the
 validation of the ``Address`` fields failed.
 
     Acme\HelloBundle\Author.address.zipCode:
-        This value is too long. It should have 5 characters or less
+    This value is too long. It should have 5 characters or less

--- a/reference/forms/types/birthday.rst
+++ b/reference/forms/types/birthday.rst
@@ -37,7 +37,7 @@ years ago to the current year.
 Options
 -------
 
-* ``years`` [type: ``array``, default: 120 years ago to the current year ]
+*   ``years`` [type: ``array``, default: 120 years ago to the current year ]
     List of years available to the year field type.  This option is only
     relevant when the ``widget`` option is set to ``choice``.
 

--- a/reference/forms/types/checkbox.rst
+++ b/reference/forms/types/checkbox.rst
@@ -36,7 +36,7 @@ Example Usage
 Options
 -------
 
-* ``value`` [type: mixed, default: 1]
+*   ``value`` [type: mixed, default: 1]
     The value that's actually used as the value for the checkbox. This does
     not affect the value that's set on your object.
 

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -71,7 +71,7 @@ specify the choices for your widget.
 Options
 -------
 
-* ``choices`` [type: array]
+*   ``choices`` [type: array]
     This is the most basic way to specify the choices that should be used
     by this field. The ``choices`` option is an array, where the array key
     is the item value and the array value is the item's label:
@@ -82,7 +82,7 @@ Options
             'choices' => array('m' => 'Male', 'f' => 'Female')
         ));
 
-* ``choice_list`` [type: ``Symfony\Component\Form\ChoiceList\ChoiceListInterface``]
+*   ``choice_list`` [type: ``Symfony\Component\Form\ChoiceList\ChoiceListInterface``]
     This is one way of specifying the options to be used for this field.
     The ``choice_list`` option must be an instance of the ``ChoiceListInterface``.
     For more advanced cases, a custom class that implements the interface

--- a/reference/forms/types/csrf.rst
+++ b/reference/forms/types/csrf.rst
@@ -39,5 +39,6 @@ Inherited options
 These options inherit from the :doc:`field</reference/forms/types/field>` type:
 
 * ``error_bubbling`` [type: Boolean, default: true]
+
   .. include:: /reference/forms/types/options/error_bubbling.rst.inc
      :start-line: 1

--- a/reference/forms/types/csrf.rst
+++ b/reference/forms/types/csrf.rst
@@ -39,6 +39,5 @@ Inherited options
 These options inherit from the :doc:`field</reference/forms/types/field>` type:
 
 * ``error_bubbling`` [type: Boolean, default: true]
-
-.. include:: /reference/forms/types/options/error_bubbling.rst.inc
-   :start-line: 1
+  .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+     :start-line: 1

--- a/reference/forms/types/csrf.rst
+++ b/reference/forms/types/csrf.rst
@@ -24,11 +24,11 @@ The ``csrf`` type is a hidden input field containing a CSRF token.
 Options
 -------
 
-* ``csrf_provider`` [type: ``Symfony\Component\Form\CsrfProvider\CsrfProviderInterface``]
+*   ``csrf_provider`` [type: ``Symfony\Component\Form\CsrfProvider\CsrfProviderInterface``]
     The ``CsrfProviderInterface`` object that should generate the CSRF token.
     If not set, this defaults to the default provider.
 
-* ``page_id`` [type: string]
+*   ``page_id`` [type: string]
     An optional page identifier used to generate the CSRF token.
 
 .. include:: /reference/forms/types/options/property_path.rst.inc
@@ -39,5 +39,6 @@ Inherited options
 These options inherit from the :doc:`field</reference/forms/types/field>` type:
 
 * ``error_bubbling`` [type: Boolean, default: true]
-   .. include:: /reference/forms/types/options/error_bubbling.rst.inc
-      :start-line: 1
+
+.. include:: /reference/forms/types/options/error_bubbling.rst.inc
+   :start-line: 1

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -34,13 +34,13 @@ data can be a ``DateTime`` object, a string, a timestamp or an array.
 Options
 -------
 
-* ``date_widget`` [type: string, default: choice]
+*   ``date_widget`` [type: string, default: choice]
     Defines the ``widget`` option for the :doc:`date</reference/forms/types/date>` type
 
-* ``time_widget`` [type: string, default: choice]
+*   ``time_widget`` [type: string, default: choice]
     Defines the ``widget`` option for the :doc:`time</reference/forms/types/time>` type
 
-* ``input`` [type: string, default: ``datetime``]
+*   ``input`` [type: string, default: ``datetime``]
     The value of the input for the widget.  Can be ``string``, ``datetime``
     or ``array``.  The form type input value will be returned in the format
     specified.  The input of ``April 21th, 2011 18:15:30`` as an array would return:

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -69,15 +69,15 @@ option. The easiest way to use the option is as follows::
 Options
 -------
 
-* ``class`` **required** [type: string]
+*   ``class`` **required** [type: string]
     The class of your entity (e.g. ``Acme\StoreBundle\Entity\Category``).
 
-* ``property`` [type: string]
+*   ``property`` [type: string]
     This is the property that should be used for displaying the entities
     as text in the HTML element. If left blank, the entity object will be
     cast into a string and so must have a ``__toString()`` method.
 
-* ``query_builder`` [type: ``Doctrine\ORM\QueryBuilder`` or a Closure]
+*   ``query_builder`` [type: ``Doctrine\ORM\QueryBuilder`` or a Closure]
     If specified, this is used to query the subset of options (and their
     order) that should be used for the field. The value of this option can
     either be a ``QueryBuilder`` object or a Closure. If using a Closure,

--- a/reference/forms/types/hidden.rst
+++ b/reference/forms/types/hidden.rst
@@ -20,6 +20,5 @@ Options
 -------
 
 * ``error_bubbling`` [type: Boolean, default: true]
-
-.. include:: /reference/forms/types/options/error_bubbling.rst.inc
-   :start-line: 1
+  .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+     :start-line: 1

--- a/reference/forms/types/hidden.rst
+++ b/reference/forms/types/hidden.rst
@@ -20,5 +20,6 @@ Options
 -------
 
 * ``error_bubbling`` [type: Boolean, default: true]
-   .. include:: /reference/forms/types/options/error_bubbling.rst.inc
-      :start-line: 1
+
+.. include:: /reference/forms/types/options/error_bubbling.rst.inc
+   :start-line: 1

--- a/reference/forms/types/hidden.rst
+++ b/reference/forms/types/hidden.rst
@@ -20,5 +20,6 @@ Options
 -------
 
 * ``error_bubbling`` [type: Boolean, default: true]
+
   .. include:: /reference/forms/types/options/error_bubbling.rst.inc
      :start-line: 1

--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -30,18 +30,18 @@ integers. By default, all non-integer values (e.g. 6.78) will round down (e.g. 6
 Options
 -------
 
-* ``rounding_mode`` [type: integer, default: ``IntegerToLocalizedStringTransformer::ROUND_DOWN``]
+*   ``rounding_mode`` [type: integer, default: ``IntegerToLocalizedStringTransformer::ROUND_DOWN``]
     By default, if the user enters a non-integer number, it will be rounded
     down. There are several other rounding methods, and each is a constant
     on the :class:`Symfony\\Component\\Form\\DataTransformer\\IntegerToLocalizedStringTransformer`:
     
-    * ``IntegerToLocalizedStringTransformer::ROUND_DOWN``
+    *   ``IntegerToLocalizedStringTransformer::ROUND_DOWN``
         Rounding mode to round towards zero.
-    * ``IntegerToLocalizedStringTransformer::ROUND_FLOOR``
+    *   ``IntegerToLocalizedStringTransformer::ROUND_FLOOR``
         Rounding mode to round towards negative infinity.
-    * ``IntegerToLocalizedStringTransformer::ROUND_UP``
+    *   ``IntegerToLocalizedStringTransformer::ROUND_UP``
         Rounding mode to round away from zero.
-    * ``IntegerToLocalizedStringTransformer::ROUND_CEILING``
+    *   ``IntegerToLocalizedStringTransformer::ROUND_CEILING``
         Rounding mode to round towards positive infinity.
 
 Inherited options

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -32,7 +32,7 @@ how the input and output of the data is handled.
 Options
 -------
 
-* ``currency`` [type: string, default ``EUR``]
+*   ``currency`` [type: string, default ``EUR``]
     Specifies the currency that the money is being specified in. This determines
     the currency symbol that should be shown by the text box. Depending on
     the currency - the currency symbol may be shown before or after the input
@@ -40,7 +40,7 @@ Options
     
     This can also be set to false to hide the currency symbol.
 
-* ``divisor`` [type: integer, default: ``1``]
+*   ``divisor`` [type: integer, default: ``1``]
     If, for some reason, you need to divide your starting value by a number
     before rendering it to the user, you can use the ``divisor`` option.
     For example:
@@ -56,7 +56,7 @@ Options
     value ``99``, it will be multiplied by ``100`` and ``9900`` will ultimately
     be set back on your object.
 
-* ``precision`` [type: integer, default: 2]
+*   ``precision`` [type: integer, default: 2]
     For some reason, if you need some precision other than 2 decimal places,
     you can modify this value. You probably won't need to do this unless,
     for example, you want to round to the nearest dollar (set the precision

--- a/reference/forms/types/number.rst
+++ b/reference/forms/types/number.rst
@@ -28,33 +28,33 @@ you want to use for your number.
 Options
 -------
 
-* ``precision`` [type: integer, default: Locale-specific (usually around ``3``)]
+*   ``precision`` [type: integer, default: Locale-specific (usually around ``3``)]
     This specifies how many decimals will be allowed until the field rounds
     the submitted value (via ``rounding_mode``). For example, if ``precision``
     is set to ``2``, a submitted value of ``20.123`` will be rounded to,
     for example, ``20.12`` (depending on your ``rounding_mode``).
 
-* ``rounding_mode`` [type: integer, default: ``IntegerToLocalizedStringTransformer::ROUND_DOWN``]
+*   ``rounding_mode`` [type: integer, default: ``IntegerToLocalizedStringTransformer::ROUND_DOWN``]
     If a submitted number needs to be rounded (based on the ``precision``
     option), you have several configurable options for that rounding. Each
     option is a constant on the :class:`Symfony\\Component\\Form\\DataTransformer\\IntegerToLocalizedStringTransformer`:
-    
-    * ``IntegerToLocalizedStringTransformer::ROUND_DOWN``
+
+    *   ``IntegerToLocalizedStringTransformer::ROUND_DOWN``
         Rounding mode to round towards zero.
-    * ``IntegerToLocalizedStringTransformer::ROUND_FLOOR``
+    *   ``IntegerToLocalizedStringTransformer::ROUND_FLOOR``
         Rounding mode to round towards negative infinity.
-    * ``IntegerToLocalizedStringTransformer::ROUND_UP``
+    *   ``IntegerToLocalizedStringTransformer::ROUND_UP``
         Rounding mode to round away from zero.
-    * ``IntegerToLocalizedStringTransformer::ROUND_CEILING``
+    *   ``IntegerToLocalizedStringTransformer::ROUND_CEILING``
         Rounding mode to round towards positive infinity.
-    * ``IntegerToLocalizedStringTransformer::ROUND_HALFDOWN``
+    *   ``IntegerToLocalizedStringTransformer::ROUND_HALFDOWN``
         Rounding mode to round towards "nearest neighbor" unless both neighbors
         are equidistant, in which case round down.
-    * ``IntegerToLocalizedStringTransformer::ROUND_HALFEVEN``
+    *   ``IntegerToLocalizedStringTransformer::ROUND_HALFEVEN``
         Rounding mode to round towards the "nearest neighbor" unless both
-    	neighbors are equidistant, in which case, round towards the even
-    	neighbor.
-    * ``IntegerToLocalizedStringTransformer::ROUND_HALFUP``
+        neighbors are equidistant, in which case, round towards the even
+        neighbor.
+    *   ``IntegerToLocalizedStringTransformer::ROUND_HALFUP``
         Rounding mode to round towards "nearest neighbor" unless both neighbors
         are equidistant, in which case round up.
 

--- a/reference/forms/types/options/data.rst.inc
+++ b/reference/forms/types/options/data.rst.inc
@@ -1,4 +1,4 @@
-* ``data`` [type: any, default: the field's initial value]
+*   ``data`` [type: any, default: the field's initial value]
     When you create a form, each field initially displays the value of the 
     corresponding property of the form's domain object. If you want to override 
     this initial value, you can set it in the data option.

--- a/reference/forms/types/options/data_timezone.rst.inc
+++ b/reference/forms/types/options/data_timezone.rst.inc
@@ -1,4 +1,4 @@
-* ``data_timezone`` [type: string, default: system default timezone]
+*   ``data_timezone`` [type: string, default: system default timezone]
     Timezone for the data being stored.  This must be one of the `PHP supported timezones`__
 
 .. _PhpTimezones: http://php.net/manual/en/timezones.php

--- a/reference/forms/types/options/date_format.rst.inc
+++ b/reference/forms/types/options/date_format.rst.inc
@@ -1,4 +1,4 @@
-* ``format`` [type: integer, default: IntlDateFormatter::MEDIUM]
+*   ``format`` [type: integer, default: IntlDateFormatter::MEDIUM]
     Option passed to the IntlDateFormatter class, used to transform user input
     into the proper format. This is critical when the ``widget`` option is
     set to ``text``, and will define how to transform the input.

--- a/reference/forms/types/options/date_input.rst.inc
+++ b/reference/forms/types/options/date_input.rst.inc
@@ -1,4 +1,4 @@
-* ``input`` [type: string, default: ``datetime``]
+*   ``input`` [type: string, default: ``datetime``]
     The value of the input for the widget.  Can be ``string``, ``datetime``
     or ``array``.  The form type input value will be returned  in the format
     specified.  The input of ``April 21th, 2011`` as an array would return:

--- a/reference/forms/types/options/date_pattern.rst.inc
+++ b/reference/forms/types/options/date_pattern.rst.inc
@@ -1,4 +1,4 @@
-* ``pattern`` [type: string, default: null]
+*   ``pattern`` [type: string, default: null]
     This option is only relevant when the ``widget`` is set to ``choice``.
     The default pattern is based off the ``format`` option, and tries to
     match the characters ``M``, ``d``, and ``y`` in the format pattern. If

--- a/reference/forms/types/options/date_widget.rst.inc
+++ b/reference/forms/types/options/date_widget.rst.inc
@@ -1,4 +1,4 @@
-* ``widget`` [type: string, default: ``choice``]
+*   ``widget`` [type: string, default: ``choice``]
     Type of widget used for this form type.  Can be ``text`` or ``single_text`` or ``choice``.
 
       * ``text``: renders a three field input of type text (month, day, year).

--- a/reference/forms/types/options/days.rst.inc
+++ b/reference/forms/types/options/days.rst.inc
@@ -1,4 +1,4 @@
-* ``days`` [type: array, default: 1 to 31 ]
+*   ``days`` [type: array, default: 1 to 31 ]
     List of days available to the day field type.  This option is only relevant when the ``widget`` option is set to ``choice``.
 
     .. code-block:: php

--- a/reference/forms/types/options/disabled.rst.inc
+++ b/reference/forms/types/options/disabled.rst.inc
@@ -1,4 +1,4 @@
-* ``disabled`` [type: Boolean, default: false]
+*   ``disabled`` [type: Boolean, default: false]
     If you don't want a user to modify the value of a field, you can set 
     the disabled option to true. Any submitted value will be ignored.
 

--- a/reference/forms/types/options/error_bubbling.rst.inc
+++ b/reference/forms/types/options/error_bubbling.rst.inc
@@ -1,4 +1,4 @@
-* ``error_bubbling`` [type: Boolean, default: false]
+*   ``error_bubbling`` [type: Boolean, default: false]
     If true, any errors for this field will be passed to the parent field
     or form. For example, if set to true on a normal field, any errors for
     that field will be attached to the main form, not to the specific field.

--- a/reference/forms/types/options/expanded.rst.inc
+++ b/reference/forms/types/options/expanded.rst.inc
@@ -1,3 +1,3 @@
-* ``expanded`` [type: Boolean, default: false]
+*   ``expanded`` [type: Boolean, default: false]
     If set to true, radio buttons or checkboxes will be rendered (depending
     on the ``multiple`` value). If false, a select element will be rendered.

--- a/reference/forms/types/options/hours.rst.inc
+++ b/reference/forms/types/options/hours.rst.inc
@@ -1,2 +1,2 @@
-* ``hours`` [type: integer, default: 1 to 23 ]
+*   ``hours`` [type: integer, default: 1 to 23 ]
     List of hours available to the hours field type.  This option is only relevant when the ``widget`` option is set to ``choice``.

--- a/reference/forms/types/options/label.rst.inc
+++ b/reference/forms/types/options/label.rst.inc
@@ -1,4 +1,4 @@
-* ``label`` [type: string]
+*   ``label`` [type: string]
     Sets the label that will be used when rendering the field. If blank,
     the label will be auto-generated based on the name of the field. The label
     can also be directly set inside the template:

--- a/reference/forms/types/options/max_length.rst.inc
+++ b/reference/forms/types/options/max_length.rst.inc
@@ -1,3 +1,3 @@
-* ``max_length`` [type: integer]
+*   ``max_length`` [type: integer]
     This option is used to add a ``max_length`` attribute, which is used by
     some browsers to limit the amount of text in a field.

--- a/reference/forms/types/options/minutes.rst.inc
+++ b/reference/forms/types/options/minutes.rst.inc
@@ -1,2 +1,2 @@
-* ``minutes`` [type: integer, default: 1 to 59 ]
+*   ``minutes`` [type: integer, default: 1 to 59 ]
     List of minutes available to the minutes field type.  This option is only relevant when the ``widget`` option is set to ``choice``.

--- a/reference/forms/types/options/months.rst.inc
+++ b/reference/forms/types/options/months.rst.inc
@@ -1,2 +1,2 @@
-* ``months`` [type: array, default: 1 to 12 ]
+*   ``months`` [type: array, default: 1 to 12 ]
     List of months available to the month field type. This option is only relevant when the ``widget`` option is set to ``choice``.

--- a/reference/forms/types/options/multiple.rst.inc
+++ b/reference/forms/types/options/multiple.rst.inc
@@ -1,4 +1,4 @@
-* ``multiple`` [type: Boolean, default: false]
+*   ``multiple`` [type: Boolean, default: false]
     If true, the user will be able to select multiple options (as opposed
     to choosing just one option). Depending on the value of the ``expanded``
     option, this will render either a select tag or checkboxes if true and

--- a/reference/forms/types/options/preferred_choices.rst.inc
+++ b/reference/forms/types/options/preferred_choices.rst.inc
@@ -1,4 +1,4 @@
-* ``preferred_choices`` [type: array]
+*   ``preferred_choices`` [type: array]
     If this option is specified, then a sub-set of the total number of options
     will be moved to the top of the select menu. The following would move
     the "Baz" option to the top, with a visual separator between it and the

--- a/reference/forms/types/options/property_path.rst.inc
+++ b/reference/forms/types/options/property_path.rst.inc
@@ -1,4 +1,4 @@
-* ``property_path`` [type: any, default: the field's value]
+*   ``property_path`` [type: any, default: the field's value]
     Fields display a property value of the form's domain object by default. When
     the form is submitted, the submitted value is written back into the object.
 

--- a/reference/forms/types/options/read_only.rst.inc
+++ b/reference/forms/types/options/read_only.rst.inc
@@ -1,3 +1,3 @@
-* ``read_only`` [type: Boolean, default: false]
+*   ``read_only`` [type: Boolean, default: false]
     If this option is true, the field will be rendered with the ``disabled``
     attribute so that the field is not editable.

--- a/reference/forms/types/options/required.rst.inc
+++ b/reference/forms/types/options/required.rst.inc
@@ -1,4 +1,4 @@
-* ``required`` [type: Boolean, default: true]
+*   ``required`` [type: Boolean, default: true]
     The ``required`` option can be used to render an `HTML5 required attribute`_.
     Note that this is independent from validation: if you include the required
     attribute on the field type but omit any required validation, the object

--- a/reference/forms/types/options/seconds.rst.inc
+++ b/reference/forms/types/options/seconds.rst.inc
@@ -1,2 +1,2 @@
-* ``seconds`` [type: integer, default: 1 to 59 ]
+*   ``seconds`` [type: integer, default: 1 to 59 ]
     List of seconds available to the seconds field type.  This option is only relevant when the ``widget`` option is set to ``choice``.

--- a/reference/forms/types/options/trim.rst.inc
+++ b/reference/forms/types/options/trim.rst.inc
@@ -1,4 +1,4 @@
-* ``trim`` [type: Boolean, default: true]
+*   ``trim`` [type: Boolean, default: true]
     If true, the whitespace of the submitted string value will be stripped
     via the ``trim()`` function when the data is bound. This guarantees that
     if a value is submitted with extra whitespace, it will be removed before

--- a/reference/forms/types/options/user_timezone.rst.inc
+++ b/reference/forms/types/options/user_timezone.rst.inc
@@ -1,4 +1,4 @@
-* ``user_timezone`` [type: string, default: system default timezone]
+*   ``user_timezone`` [type: string, default: system default timezone]
     Timezone for the data being submitted by the user.  This must be one of the `PHP supported timezones`__
 
 .. _PhpTimezones: http://php.net/manual/en/timezones.php

--- a/reference/forms/types/options/with_seconds.rst.inc
+++ b/reference/forms/types/options/with_seconds.rst.inc
@@ -1,2 +1,2 @@
-* ``with_seconds`` [type: Boolean, default: false]
+*   ``with_seconds`` [type: Boolean, default: false]
     Whether or not to include seconds in the input. This will result in an additional input to capture seconds.

--- a/reference/forms/types/options/years.rst.inc
+++ b/reference/forms/types/options/years.rst.inc
@@ -1,3 +1,3 @@
-* ``years`` [type: array, default: five years before to five years after the current year ]
+*   ``years`` [type: array, default: five years before to five years after the current year ]
     List of years available to the year field type.  This option is only
     relevant when the ``widget`` option is set to ``choice``.

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -26,7 +26,7 @@ The ``password`` field renders an input password text box.
 Options
 -------
 
-* ``always_empty`` [type: Boolean, default: true]
+*   ``always_empty`` [type: Boolean, default: true]
     If set to true, the field will *always* render blank, even if the corresponding
     field has a value. When set to false, the password field will be rendered
     with the ``value`` attribute set to its true value.

--- a/reference/forms/types/percent.rst
+++ b/reference/forms/types/percent.rst
@@ -30,17 +30,17 @@ This field adds a percentage sign "``%``" after the input box.
 Options
 -------
 
-* ``type`` [type: string, default: ``fractional``]
+*   ``type`` [type: string, default: ``fractional``]
     This controls how your data is stored on your object. For example, a percentage
     corresponding to "55%", might be stored as ``.55`` or ``55`` on your
     object. The two "types" handle these two cases:
     
-    * ``fractional``
+    *   ``fractional``
         If your data is stored as a decimal (e.g. ``.55``), use this type.
         The data will be multiplied by ``100`` before being shown to the
         user (e.g. ``55``). The submitted data will be divided by ``100``
         on form submit so that the decimal value is stored (``.55``);
-    * ``integer``
+    *   ``integer``
         If your data is stored as an integer (e.g. 55), then use this option.
         The raw value (``55``) is shown to the user and stored on your object.
         Note that this only works for integer values.

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -30,7 +30,7 @@ If you want to have a Boolean field, use :doc:`checkbox</reference/forms/types/c
 Options
 -------
 
-* ``value`` [type: mixed, default: 1]
+*   ``value`` [type: mixed, default: 1]
     The value that's actually used as the value for the radio button. This does
     not affect the value that's set on your object.
 

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -63,13 +63,13 @@ values.
 Options
 -------
 
-* ``widget`` [type: string, default: ``choice``]
+*   ``widget`` [type: string, default: ``choice``]
     Type of widget used for this form type.  Can be ``text`` or ``choice``.  
     
       * ``text``: renders a single input of type text.  User's input is validated based on the ``format`` option.
       * ``choice``: renders two select inputs (three select inputs if ``with_seconds`` is set to ``true``).
 
-* ``input`` [type: string, default: ``datetime``]
+*   ``input`` [type: string, default: ``datetime``]
     The value of the input for the widget.  Can be ``string``, ``datetime`` or ``array``.  The form type input value will be returned 
     in the format specified.  The value "12:30" with the ``input`` option set to ``array`` would return:
     

--- a/reference/forms/types/url.rst
+++ b/reference/forms/types/url.rst
@@ -27,7 +27,7 @@ have a protocol.
 Options
 -------
 
-* ``default_protocol`` [type: string, default: ``http``]
+*   ``default_protocol`` [type: string, default: ``http``]
 
     If a value is submitted that doesn't begin with some protocol (e.g. ``http://``,
     ``ftp://``, etc), this protocol will be prepended to the string when

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -23,4 +23,4 @@ Reference Documents
     requirements
     model
 
-.. include:: map.rst.inc
+.. include:: /reference/map.rst.inc


### PR DESCRIPTION
These changes are made to make the rst valid for restructured text parser.
- fixed wrong indention of list items
- fixed some leading dashes in string (moved the dash to the line before)
- changed some include paths to paths starting from root folder (e.g. changed map.rst.inc - to /book/map.rst.inc)
