### PR TITLE
Fixed error in securing services cookbook recipe

### DIFF
--- a/cookbook/security/securing_services.rst
+++ b/cookbook/security/securing_services.rst
@@ -234,7 +234,7 @@ documentation.
             # app/config/config.yml
             jms_security_extra:
                 # ...
-                secure_all_services: false
+                secure_all_services: true
     
         .. code-block:: xml
 
@@ -253,7 +253,7 @@ documentation.
             // app/config/config.php
             $container->loadFromExtension('jms_security_extra', array(            
                 // ...
-                'secure_all_services' => false,
+                'secure_all_services' => true,
             ));
 
     The disadvantage of this method is that, if activated, the initial page


### PR DESCRIPTION
Settings in the secure all services config example were false when they should have been true
