### PR TITLE
MongoDB installation and configuration updated to match BETA5 release

### DIFF
--- a/cookbook/doctrine/mongodb.rst
+++ b/cookbook/doctrine/mongodb.rst
@@ -32,7 +32,7 @@ one bundle that integrates them into Symfony. If you're using the Symfony
 Standard Distribution, add the following to the ``deps`` file at the root
 of your project:
 
-.. code-block:: text    
+.. code-block:: text
 
     [DoctrineMongoDBBundle]
         git=http://github.com/symfony/DoctrineMongoDBBundle.git
@@ -89,15 +89,15 @@ the MongoDB ODM across your application:
 
     # app/config/config.yml
     doctrine_mongodb:
-    connections:
-        default:
-            server: mongodb://localhost:27017
-            options:
-                connect: true
-    default_database: test_database
-    document_managers:
-        default:
-            auto_mapping: true
+        connections:
+            default:
+                server: mongodb://localhost:27017
+                options:
+                    connect: true
+        default_database: test_database
+        document_managers:
+            default:
+                auto_mapping: true
 
 .. note::
 

--- a/cookbook/doctrine/mongodb.rst
+++ b/cookbook/doctrine/mongodb.rst
@@ -35,7 +35,7 @@ of your project:
 .. code-block:: text    
 
     [DoctrineMongoDBBundle]
-        git=git://github.com/symfony/DoctrineMongoDBBundle.git
+        git=http://github.com/symfony/DoctrineMongoDBBundle.git
         target=/bundles/Symfony/Bundle/DoctrineMongoDBBundle
 
     [doctrine-mongodb-odm]

--- a/cookbook/doctrine/mongodb.rst
+++ b/cookbook/doctrine/mongodb.rst
@@ -36,13 +36,23 @@ of your project:
 
     DoctrineMongoDBBundle   /bundles/Symfony/Bundle git://github.com/symfony/DoctrineMongoDBBundle.git
     doctrine-mongodb-odm    /                       git://github.com/doctrine/mongodb-odm.git
-    doctrine-mongodb        /                       git://github.com/doctrine/mongodb.git
+    doctrine-mongodb        /                       git://github.com/doctrine/mongodb.git    
+
+    [DoctrineMongoDBBundle]
+        git=git://github.com/symfony/DoctrineMongoDBBundle.git
+        target=/bundles/Symfony/Bundle/DoctrineMongoDBBundle
+
+    [doctrine-mongodb-odm]
+        git=http://github.com/doctrine/mongodb-odm.git
+    
+    [doctrine-mongodb]
+        git=http://github.com/doctrine/mongodb.git
 
 Now, update the vendor libraries by running:
 
 .. code-block:: bash
 
-    $ ./bin/vendors
+    $ ./bin/vendors install
 
 Next, add the ``Doctrine\ODM\MongoDB`` and ``Doctrine\MongoDB`` namespaces
 to the ``app/autoload.php`` file so that these libraries can be autoloaded.
@@ -83,12 +93,15 @@ the MongoDB ODM across your application:
 
     # app/config/config.yml
     doctrine_mongodb:
-        document_managers:
-            default:
-                auto_mapping: true
-                database:     my_test_database
-        connections:
-            default:
+    connections:
+        default:
+            server: mongodb://localhost:27017
+            options:
+                connect: true
+    default_database: test_database
+    document_managers:
+        default:
+            auto_mapping: true
 
 .. note::
 

--- a/cookbook/doctrine/mongodb.rst
+++ b/cookbook/doctrine/mongodb.rst
@@ -32,11 +32,7 @@ one bundle that integrates them into Symfony. If you're using the Symfony
 Standard Distribution, add the following to the ``deps`` file at the root
 of your project:
 
-.. code-block:: text
-
-    DoctrineMongoDBBundle   /bundles/Symfony/Bundle git://github.com/symfony/DoctrineMongoDBBundle.git
-    doctrine-mongodb-odm    /                       git://github.com/doctrine/mongodb-odm.git
-    doctrine-mongodb        /                       git://github.com/doctrine/mongodb.git    
+.. code-block:: text    
 
     [DoctrineMongoDBBundle]
         git=git://github.com/symfony/DoctrineMongoDBBundle.git


### PR DESCRIPTION
Hey guys, 

I just updated the MongoDB cookbook installation and configuration section to match the latest Symfony BETA5 release. There were some changes in the "deps" file as well as the changed "$ ./bin/vendors" call to "$ ./bin/vendors install".

Hope this is useful.

Regards,
Herbert
