### PR TITLE
Clean the way the validation group is set in the Form data types

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -356,8 +356,9 @@ Validation Groups
 If your object takes advantage of :ref:`validation groups <book-validation-validation-groups>`,
 you'll need to specify which validation group(s) your form should use::
 
-    $form = $this->createFormBuilder($users)
-        ->setAttribute('validation_groups', array('registration'))
+    $form = $this->createFormBuilder($users, array(
+            'validation_groups' => array('registration')
+        )
         // ...
     ;
 

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -362,12 +362,12 @@ you'll need to specify which validation group(s) your form should use::
     ;
 
 If you're creating :ref:`form classes<book-form-creating-form-classes>` (a good
-practice), then you'll need to add the following to the ``buildForm()`` method::
+practice), then you'll need to add the following to the ``getDefaultOptions()`` method::
 
-    public function buildForm(FormBuilder $builder, array $options)
-    {
-        // Restrict the constraints to the 'registration' group
-        $builder->setAttribute('validation_groups', array('registration'));
+    public function getDefaultOptions(array $options) {
+        return array(
+            'validation_groups' => array('registration')
+        );
     }
 
 In both of these cases, *only* the ``registration`` validation group will


### PR DESCRIPTION
I find it better to set the validation group in the `getDefaultOptions()` rather than in the `buildForm()` function.
IMO `buildForm()` should only concern the fields definition while `getDefaultOptions()` should concern the configuration of the form (data class, validation group...).
