### PR TITLE
Make clear that form needs to be validated before an UploadedFile instance is available.

### DIFF
--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -30,7 +30,7 @@ Let's say you have this form definition:
     Don't forget to add the ``enctype`` attribute in the form tag: ``<form
     action="#" method="post" {{ form_enctype(form) }}>``.
 
-When the form is submitted, the ``attachment`` field will be an instance of
+When the form is submitted and validated, the ``attachment`` field will be an instance of
 :class:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile`. It can be
 used to move the ``attachment`` file to a permanent location:
 


### PR DESCRIPTION
Updated the form `file` type documentation to make clear that the form needs to be validated before an `UploadedFile` instance is available for manipulation.
