### PR TITLE
Reformatted security cookbook examples to avoid horizontal scrolling

### DIFF
--- a/cookbook/security/force_https.rst
+++ b/cookbook/security/force_https.rst
@@ -11,7 +11,9 @@ to use ``HTTPS`` then you could use the following config:
         .. code-block:: yaml
 
             access_control:
-                - { path: ^/secure, roles: ROLE_ADMIN, requires_channel: https }
+                - path: ^/secure
+                  roles: ROLE_ADMIN
+                  requires_channel: https
 
         .. code-block:: xml
 
@@ -22,7 +24,10 @@ to use ``HTTPS`` then you could use the following config:
         .. code-block:: php
 
             'access_control' => array(
-                array('path' => '^/secure', 'role' => 'ROLE_ADMIN', 'requires_channel' => 'https'),
+                array('path' => '^/secure', 
+                      'role' => 'ROLE_ADMIN', 
+                      'requires_channel' => 'https'
+                ),
             ),
 
 The login form itself needs to allow anonymous access otherwise users will
@@ -35,18 +40,25 @@ role:
         .. code-block:: yaml
 
             access_control:
-                - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https  }
+                - path: ^/login
+                  roles: IS_AUTHENTICATED_ANONYMOUSLY
+                  requires_channel: https
 
         .. code-block:: xml
 
             <access-control>
-                <rule path="^/login" role="IS_AUTHENTICATED_ANONYMOUSLY" requires_channel="https" />
+                <rule path="^/login" 
+                      role="IS_AUTHENTICATED_ANONYMOUSLY" 
+                      requires_channel="https" />
             </access-control>
 
         .. code-block:: php
 
             'access_control' => array(
-                array('path' => '^/login', 'role' => 'IS_AUTHENTICATED_ANONYMOUSLY', 'requires_channel' => 'https'),
+                array('path' => '^/login', 
+                      'role' => 'IS_AUTHENTICATED_ANONYMOUSLY', 
+                      'requires_channel' => 'https'
+                ),
             ),
 
 It is also possible to specify using ``HTTPS`` in the routing configuration

--- a/cookbook/security/remember_me.rst
+++ b/cookbook/security/remember_me.rst
@@ -89,7 +89,8 @@ might ultimately look like this:
 
         <form action="<?php echo $view['router']->generate('login_check') ?>" method="post">
             <label for="username">Username:</label>
-            <input type="text" id="username" name="_username" value="<?php echo $last_username ?>" />
+            <input type="text" id="username" 
+                   name="_username" value="<?php echo $last_username ?>" />
 
             <label for="password">Password:</label>
             <input type="password" id="password" name="_password" />
@@ -156,7 +157,9 @@ In the following example, the action is only allowed if the user has the
 
     public function editAction()
     {
-        if (false === $this->get('security.context')->isGranted('IS_AUTHENTICATED_FULLY')) {
+        if (false === $this->get('security.context')->isGranted(
+            'IS_AUTHENTICATED_FULLY'
+        )) {
             throw new AccessDeniedException();
         }
 


### PR DESCRIPTION
Not sure if you are concerned about it or not but there is what seems like unnecessary horizontal scrolling in some of the example code and config blocks. I have reformatted them to avoid it. 
