### PR TITLE
Changed the namespaces of form related classes in the bundle

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -629,9 +629,9 @@ that will house the logic for building the product form:
 
 .. code-block:: php
 
-    // src/Acme/StoreBundle/Form/ProductType.php
+    // src/Acme/StoreBundle/Form/Type/ProductType.php
 
-    namespace Acme\StoreBundle\Form;
+    namespace Acme\StoreBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilder;
@@ -653,7 +653,7 @@ It can be used to quickly build a form object in the controller:
     // src/Acme/StoreBundle/Controller/DefaultController.php
 
     // add this new use statement at the top of the class
-    use Acme\StoreBundle\Form\ProductType;
+    use Acme\StoreBundle\Form\Type\ProductType;
 
     public function indexAction()
     {
@@ -796,8 +796,8 @@ create a form class so that a ``Category`` object can be modified by the user:
 
 .. code-block:: php
 
-    // src/Acme/StoreBundle/Form/CategoryType.php
-    namespace Acme\StoreBundle\Form;
+    // src/Acme/StoreBundle/Form/Type/CategoryType.php
+    namespace Acme\StoreBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilder;

--- a/cookbook/form/simple_signup_form_with_mongodb.rst
+++ b/cookbook/form/simple_signup_form_with_mongodb.rst
@@ -4,12 +4,12 @@ How to implement a simple Registration Form with MongoDB
 Some forms have extra fields whose values don't need to be stored in the
 database. In this example, we'll create a registration form with some extra
 fields and (like a "terms accepted" checkbox field) and embed the form that
-actually stores the account information. We'll use MongoDB for storing the data. 
+actually stores the account information. We'll use MongoDB for storing the data.
 
 .. tip::
 
     If you are not familiar with Doctrine's MongoDB library, read
-    ":doc:`/cookbook/doctrine/mongodb`" cookbook entry first to learn 
+    ":doc:`/cookbook/doctrine/mongodb`" cookbook entry first to learn
     how to setup and work with MongoDB inside Symfony.
 
 The simple User model
@@ -40,44 +40,44 @@ So, in this tutorial we begin with the model for a ``User`` document::
          * @Assert\NotBlank()
          * @Assert\Email()
          */
-        protected $email; 
-    
+        protected $email;
+
         /**
          * @MongoDB\Field(type="string")
          * @Assert\NotBlank()
          */
-        protected $password; 
-    
+        protected $password;
+
         public function getId()
         {
-            return $this->id; 
+            return $this->id;
         }
-    
+
         public function getEmail()
         {
-            return $this->email; 
+            return $this->email;
         }
-    
+
         public function setEmail($email)
         {
-            $this->email = $email; 
+            $this->email = $email;
         }
-    
+
         public function getPassword()
         {
-            return $this->password; 
+            return $this->password;
         }
-    
+
         // stupid simple encryption (please don't copy it!)
         public function setPassword($password)
         {
-            $this->password = sha1($password); 
+            $this->password = sha1($password);
         }
     }
 
 This ``User`` document contains three fields and two of them (email and
-password) should display on the form. The email property must be unique 
-on the database, so we've added this validation at the top of the class. 
+password) should display on the form. The email property must be unique
+on the database, so we've added this validation at the top of the class.
 
 .. note::
 
@@ -90,38 +90,38 @@ Create a Form for the Model
 
 Next, create the form for the ``User`` model::
 
-    // src/Acme/AccountBundle/Form/UserType.php
-    namespace Acme\AccountBundle\Form; 
+    // src/Acme/AccountBundle/Form/Type/UserType.php
+    namespace Acme\AccountBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
-    use Symfony\Component\Form\Extension\Core\Type\RepeatedType; 
-    use Symfony\Component\Form\FormBuilder; 
+    use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+    use Symfony\Component\Form\FormBuilder;
 
     class UserType extends AbstractType
     {
         public function buildForm(FormBuilder $builder, array $options)
         {
-            $builder->add('email', 'email'); 
+            $builder->add('email', 'email');
             $builder->add('password', 'repeated', array(
-               'first_name' => 'password', 
-               'second_name' => 'confirm', 
+               'first_name' => 'password',
+               'second_name' => 'confirm',
                'type' => 'password'
-            ));        
+            ));
         }
-    
+
         public function getDefaultOptions(array $options)
         {
             return array('data_class' => 'Acme\AccountBundle\Document\User');
         }
     }
 
-We just added two fields: email and password (repeated to confirm the entered 
+We just added two fields: email and password (repeated to confirm the entered
 password). The ``data_class`` option tells the form the name of data class
 (i.e. your ``User`` document).
 
 .. tip::
 
-    To explore more things about form component, read this documentation :doc:`file</book/forms>`. 
+    To explore more things about form component, read this documentation :doc:`file</book/forms>`.
 
 Embedding the User form into a Registration Form
 ------------------------------------------------
@@ -135,55 +135,55 @@ In other words, create a second form for registration, which embeds the ``User``
 form and adds the extra field needed. Start by creating a simple class which
 represents the "registration"::
 
-    // src/Acme/AccountBundle/Form/Registration.php
-    namespace Acme\AccountBundle\Form;
+    // src/Acme/AccountBundle/Form/Model/Registration.php
+    namespace Acme\AccountBundle\Form\Model;
 
     use Symfony\Component\Validator\Constraints as Assert;
 
     use Acme\AccountBundle\Document\User;
 
     class Registration
-    {    
+    {
         /**
          * @Assert\Type(type="Acme\AccountBundle\Document\User")
          */
-        protected $user; 
-    
+        protected $user;
+
         /**
          * @Assert\NotBlank()
          * @Assert\True()
          */
         protected $termsAccepted;
-    
+
         public function setUser(User $user)
         {
-            $this->user = $user; 
+            $this->user = $user;
         }
-    
+
         public function getUser()
         {
-            return $this->user; 
+            return $this->user;
         }
-    
+
         public function getTermsAccepted()
         {
             return $this->termsAccepted;
         }
-    
+
         public function setTermsAccepted($termsAccepted)
         {
-            $this->termsAccepted = (boolean)$termsAccepted; 
+            $this->termsAccepted = (boolean)$termsAccepted;
         }
     }
 
 Next, create the form for this ``Registration`` model::
 
-    // src/Acme/AccountBundle/Form/RegistrationType.php
-    namespace Acme\AccountBundle\Form; 
+    // src/Acme/AccountBundle/Form/Type/RegistrationType.php
+    namespace Acme\AccountBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
-    use Symfony\Component\Form\Extension\Core\Type\RepeatedType; 
-    use Symfony\Component\Form\FormBuilder; 
+    use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+    use Symfony\Component\Form\FormBuilder;
 
     class RegistrationType extends AbstractType
     {
@@ -209,21 +209,24 @@ controller for displaying the registration form::
     namespace Acme\AccountBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-    use Symfony\Component\HttpFoundation\Response; 
+    use Symfony\Component\HttpFoundation\Response;
 
-    use Acme\AccountBundle\Form; 
+    use Acme\AccountBundle\Form\Type\RegistrationType;
+    use Acme\AccountBundle\Form\Model\Registration;
 
     class AccountController extends Controller
     {
         public function registerAction()
         {
-            $form = $this->createForm(new Form\RegistrationType(), new Form\Registration());
-        
+            $form = $this->createForm(new RegistrationType(), new Registration());
+
             return $this->render('AcmeAccountBundle:Account:register.html.twig', array('form' => $form->createView()));
         }
     }
 
-and it's template:: 
+and it's template:
+
+.. code-block:: html+jinja
 
     {# src/Acme/AccountBundle/Resources/views/Account/register.html.twig #}
 
@@ -231,7 +234,7 @@ and it's template::
         {{ form_widget(form) }}
 
         <input type="submit" />
-    </form>        
+    </form>
 
 Finally, create the controller which handles the form submission.  This performs
 the validation and saves the data into MongoDB::
@@ -239,20 +242,20 @@ the validation and saves the data into MongoDB::
     public function createAction()
     {
         $dm = $this->get('doctrine.odm.mongodb.default_document_manager');
-    
-        $form = $this->createForm(new Form\RegistrationType(), new Form\Registration());
-    
-        $form->bindRequest($this->get('request')); 
-    
+
+        $form = $this->createForm(new RegistrationType(), new Registration());
+
+        $form->bindRequest($this->get('request'));
+
         if ($form->isValid()) {
             $registration = $form->getData();
-        
-            $dm->persist($registration->getUser()); 
+
+            $dm->persist($registration->getUser());
             $dm->flush();
-        
+
             return $this->redirect(...);
         }
-    
+
         return $this->render('AcmeAccountBundle:Account:register.html.twig', array('form' => $form->createView()));
     }
 


### PR DESCRIPTION
The types are now placed in Form\Type and the form-specific non-persisted
models in Form\Model to keep the namespace organized.

This is related to the discussion on #433 and @weaverryan agreed that Form\Model is a good idea.

I add the fact that many people are asking where they should place them so providing such a convention would be good. Once we agree on the naming, I will do the change in FOSUserBundle.
