### PR TITLE
Fixed console command example

### DIFF
--- a/cookbook/console.rst
+++ b/cookbook/console.rst
@@ -195,8 +195,8 @@ console.
 Getting Services from the Service Container
 -------------------------------------------
 
-By using ``Symfony\Bundle\FrameworkBundle\Command\Command`` as the base class
-for the command (instead of the more basic
+By using ``Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand`` as
+the base class for the command (instead of the more basic
 ``Symfony\Component\Console\Command\Command``), you have access to the service
 container. In other words, you have access to any configured service. For
 example, you could easily extend the task to be translatable::
@@ -204,7 +204,7 @@ example, you could easily extend the task to be translatable::
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $name = $input->getArgument('name');
-        $translator = $this->container->get('translator');
+        $translator = $this->getContainer()->get('translator');
         if ($name) {
             $output->writeln($translator->trans('Hello %name%!', array('%name%' => $name)));
         } else {

--- a/cookbook/console.rst
+++ b/cookbook/console.rst
@@ -195,11 +195,11 @@ console.
 Getting Services from the Service Container
 -------------------------------------------
 
-By using ``Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand`` as
-the base class for the command (instead of the more basic
-``Symfony\Component\Console\Command\Command``), you have access to the service
-container. In other words, you have access to any configured service. For
-example, you could easily extend the task to be translatable::
+By using :class:`Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand` 
+as the base class for the command (instead of the more basic 
+:class:`Symfony\Component\Console\Command\Command`), you have access to the 
+service container. In other words, you have access to any configured service.
+For example, you could easily extend the task to be translatable::
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/cookbook/console.rst
+++ b/cookbook/console.rst
@@ -18,7 +18,7 @@ add the following to it::
     // src/Acme/DemoBundle/Command/GreetCommand.php
     namespace Acme\DemoBundle\Command;
 
-    use Symfony\Bundle\FrameworkBundle\Command\Command;
+    use Symfony\Component\Console\Command\Command;
     use Symfony\Component\Console\Input\InputArgument;
     use Symfony\Component\Console\Input\InputInterface;
     use Symfony\Component\Console\Input\InputOption;

--- a/cookbook/console.rst
+++ b/cookbook/console.rst
@@ -18,13 +18,13 @@ add the following to it::
     // src/Acme/DemoBundle/Command/GreetCommand.php
     namespace Acme\DemoBundle\Command;
 
-    use Symfony\Component\Console\Command\Command;
+    use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
     use Symfony\Component\Console\Input\InputArgument;
     use Symfony\Component\Console\Input\InputInterface;
     use Symfony\Component\Console\Input\InputOption;
     use Symfony\Component\Console\Output\OutputInterface;
 
-    class GreetCommand extends Command
+    class GreetCommand extends ContainerAwareCommand
     {
         protected function configure()
         {


### PR DESCRIPTION
Namespace for Command is Symfony\Component\Console\Command
instead of Symfony\Bundle\FrameworkBundle\Command.
