### PR TITLE
LoadDataFixturesDoctrineCommand seems to not support file path as fixtures option

### DIFF
--- a/cookbook/doctrine/doctrine_fixtures.rst
+++ b/cookbook/doctrine/doctrine_fixtures.rst
@@ -139,7 +139,7 @@ the ``FixtureInterface``.
 Both commands come with a few options:
 
 * ``--fixtures=/path/to/fixture`` - Use this option to manually specify the
-  directory or file where the fixtures classes should be loaded;
+  directory where the fixtures classes should be loaded;
 
 * ``--append`` - Use this flag to append data instead of deleting data before
   loading it (deleting first is the default behavior);


### PR DESCRIPTION
It is very confusing.

The code from command class:

``` php
        foreach ($paths as $path) {
            if (is_dir($path)) {
                $loader->loadFromDirectory($path);
            }
        }
```
