### PR TITLE
Starting with symfony2 RC4 Annotations for the ORM have to be registered 

### DIFF
--- a/cookbook/doctrine/mongodb.rst
+++ b/cookbook/doctrine/mongodb.rst
@@ -64,7 +64,6 @@ Be sure to add them anywhere *above* the ``Doctrine`` namespace (shown here)::
     ));
 
 Register ODM Annotations::
-
     // app/autoload.php
 AnnotationRegistry::registerFile(__DIR__.'/../vendor/doctrine-mongodb-odm/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php');
 

--- a/cookbook/doctrine/mongodb.rst
+++ b/cookbook/doctrine/mongodb.rst
@@ -63,7 +63,12 @@ Be sure to add them anywhere *above* the ``Doctrine`` namespace (shown here)::
         // ...
     ));
 
-Enable the new bundle in the kernel::
+Register ODM Annotations::
+
+    // app/autoload.php
+AnnotationRegistry::registerFile(__DIR__.'/../vendor/doctrine-mongodb-odm/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php');
+
+Finally, enable the new bundle in the kernel::
 
     // app/AppKernel.php
     public function registerBundles()
@@ -76,9 +81,7 @@ Enable the new bundle in the kernel::
         // ...
     }
 
-Register ODM Annotations::
-    // app/AppKernel.php
-AnnotationRegistry::registerFile(__DIR__.'/../vendor/doctrine-mongodb-odm/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php');
+
 
 Congratulations! You're ready to get to work.
 

--- a/cookbook/doctrine/mongodb.rst
+++ b/cookbook/doctrine/mongodb.rst
@@ -63,7 +63,7 @@ Be sure to add them anywhere *above* the ``Doctrine`` namespace (shown here)::
         // ...
     ));
 
-Finally, enable the new bundle in the kernel::
+Enable the new bundle in the kernel::
 
     // app/AppKernel.php
     public function registerBundles()
@@ -75,6 +75,10 @@ Finally, enable the new bundle in the kernel::
 
         // ...
     }
+
+Register ODM Annotations::
+    // app/AppKernel.php
+AnnotationRegistry::registerFile(__DIR__.'/../vendor/doctrine-mongodb-odm/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php');
 
 Congratulations! You're ready to get to work.
 

--- a/cookbook/doctrine/mongodb.rst
+++ b/cookbook/doctrine/mongodb.rst
@@ -64,10 +64,11 @@ Be sure to add them anywhere *above* the ``Doctrine`` namespace (shown here)::
     ));
 
 Register ODM Annotations::
-    // app/autoload.php
-AnnotationRegistry::registerFile(__DIR__.'/../vendor/doctrine-mongodb-odm/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php');
 
+    // app/autoload.php
+    AnnotationRegistry::registerFile(__DIR__.'/../vendor/doctrine-mongodb-odm/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php');
 Finally, enable the new bundle in the kernel::
+
 
     // app/AppKernel.php
     public function registerBundles()


### PR DESCRIPTION
Starting with symfony2 RC4 Annotations for the ORM have to be registered (see http://symfony.com/blog/symfony2-2-0-rc4-released). This has to be done for the ODM, too.
