### PR TITLE
    * added an example annotation for type constraint

### DIFF
--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -3,11 +3,21 @@ Type
 
 Validates that a value has a specific data type
 
-.. code-block:: yaml
+.. configuration-block::
 
-    properties:
-        age:
-            - Type: integer
+    .. code-block:: yaml
+
+        properties:
+            age:
+                - Type: integer
+
+    .. code-block:: php-annotations
+
+        /**
+         * @Assert\Type(type="integer")
+         */
+       protected $age;
+
 
 Options
 -------


### PR DESCRIPTION
added a sample annotation for type constraint,

sometimes to have things explicitly is more convenient, I say one should do all examples that way

I was thinking more like Type(boolean) or such but I had to repeat the type keyword moreover when adding more options like messages and group validators...
