### PR TITLE
    * fix specificity in regards to Default constraint group

### DIFF
--- a/book/validation.rst
+++ b/book/validation.rst
@@ -634,7 +634,7 @@ user registers and when a user updates his/her contact information later::
 
 With this configuration, there are two validation groups:
 
-* ``Default`` - contains *all* of the constraints;
+* ``Default`` - contains the constraints not assigned to any other group;
 
 * ``registration`` - contains the constraints on the ``email`` and ``password``
   fields only.


### PR DESCRIPTION
Default group is not all constraints applied
but rather the rest of constraints not grouped into specific groups named
