### PR TITLE
Changed Twig tags link in templating book page

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1221,6 +1221,6 @@ Learn more from the Cookbook
 .. _`Symfony2Bundles.org`: http://symfony2bundles.org
 .. _`Cross Site Scripting`: http://en.wikipedia.org/wiki/Cross-site_scripting
 .. _`Output Escaping`: http://www.twig-project.org
-.. _`tags`: http://www.twig-project.org/doc/templates.html#comments
+.. _`tags`: http://www.twig-project.org/doc/templates.html#list-of-control-structures
 .. _`filters`: http://www.twig-project.org/doc/templates.html#list-of-built-in-filters
 .. _`add your own extensions`: http://www.twig-project.org/doc/advanced.html


### PR DESCRIPTION
Linking to the comments section does not seem right here. Not sure if linking to the control structures section is quite right either as it is not as clear cut as the link to the filters.
