### PR TITLE
[Cookbook][Security] Form login _target_path example fix

### DIFF
--- a/cookbook/security/form_login.rst
+++ b/cookbook/security/form_login.rst
@@ -261,7 +261,7 @@ redirect to the URL defined by some ``acount`` route, use the following:
             <label for="password">Password:</label>
             <input type="password" id="password" name="_password" />
 
-            <input type="hidden" name="_target_path" value="{{ path('account') }}" />
+            <input type="hidden" name="_target_path" value="account" />
 
             <input type="submit" name="login" />
         </form>
@@ -280,13 +280,14 @@ redirect to the URL defined by some ``acount`` route, use the following:
             <label for="password">Password:</label>
             <input type="password" id="password" name="_password" />
 
-            <input type="hidden" name="_target_path" value="<?php echo $view['router']->generate('account') ?>" />
+            <input type="hidden" name="_target_path" value="account" />
             
             <input type="submit" name="login" />
         </form>
 
-Now, the user will be redirected to the value of the hidden form field. You
-can even change the name of the hidden form field by changing the ``target_path_parameter``
+Now, the user will be redirected to the value of the hidden form field. The
+value attribute can be a relative path, absolute URL, or a route name. You 
+can even change the name of the hidden form field by changing the ``target_path_parameter`` 
 option to another value.
 
 .. configuration-block::


### PR DESCRIPTION
The current custom _target_path examples suggest generating a route in the value attribute of the hidden input, but the method that ends up being called is `HttpUtils::createRedirectResponse` which expects (taken from the PHPDoc):

 "A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))"

Thus, generating the route in the form can lead to redirects to `/app_dev.php/app_dev.php/foo` when hitting the dev controller.
