### PR TITLE
Fixed image/document not being displayed because of the __DIR__ option in the path.

### DIFF
--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -50,13 +50,19 @@ First, create a simple Doctrine Entity class to work with::
 
         public function getFullPath()
         {
-            return null === $this->path ? null : $this->getUploadRootDir().'/'.$this->path;
+            return null === $this->path ? null : $this->getRealLocation().'/'.$this->path;
         }
 
         protected function getUploadRootDir()
         {
             // the absolute directory path where uploaded documents should be saved
-            return __DIR__.'/../../../../web/uploads/documents';
+            return __DIR__.'/../../../../web'.$this->getRealLocation();
+        }
+
+        protected function getRealLocation()
+        {
+            // get rid of the __DIR__ so it doesn't screw when displaying uploaded doc/image in the view.
+            return '/uploads/documents';
         }
     }
 


### PR DESCRIPTION
Added another method in order to prevent the document/image not being displayed because of the rendered path with DIR. I tryed to make it as clean as possible.
