### PR TITLE
fixed typo

### DIFF
--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -32,7 +32,8 @@ First, create a simple Doctrine Entity class to work with::
     class Document
     {
         /**
-         * @ORM\Id @ORM\Column(type="integer")
+         * @ORM\Id
+         * @ORM\Column(type="integer")
          * @ORM\GeneratedValue(strategy="AUTO")
          */
         public $id;


### PR DESCRIPTION
Fixed typo in the doctrine cookbook where two annotations was in the same line
