### PR TITLE
Cookbook: Doctrine fixtures odm path fix

### DIFF
--- a/cookbook/doctrine/doctrine_fixtures.rst
+++ b/cookbook/doctrine/doctrine_fixtures.rst
@@ -81,7 +81,7 @@ one of your application bundles.
 
 For a bundle located at ``src/Acme/HelloBundle``, the fixture classes
 should live inside ``src/Acme/HelloBundle/DataFixtures/ORM`` or
-``src/Acme/HelloBundle/DataFixtures/ODM`` respectively for the ORM and ODM,
+``src/Acme/HelloBundle/DataFixtures/MongoDB`` respectively for the ORM and ODM,
 This tutorial assumes that you are using the ORM - but fixtures can be added
 just as easily if you're using the ODM.
 
@@ -132,7 +132,7 @@ If you're using the ODM, use the ``doctrine:mongodb:fixtures:load`` command inst
 
     php app/console doctrine:mongodb:fixtures:load
 
-The task will look inside the ``DataFixtures/ORM`` (or ``DataFixtures/ODM``
+The task will look inside the ``DataFixtures/ORM`` (or ``DataFixtures/MongoDB``
 for the ODM) directory of each bundle and execute each class that implements
 the ``FixtureInterface``.
 


### PR DESCRIPTION
The load data command search in */DataFixtures/MongoDB.

The couchdb bundle has no load data command.
