### PR TITLE
Reference to validation in previous section

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -246,7 +246,7 @@ possible paths:
    and the form is simply created and rendered;
 
 #. When the user submits the form (i.e. the method is ``POST``) with invalid
-   data (validation is covered in the next section), the form is bound and
+   data (:doc:`validation</book/validation>` was covered in the previous section), the form is bound and
    then rendered, this time displaying all validation errors;
 
 #. When the user submits the form with valid data, the form is bound and


### PR DESCRIPTION
Added link to validation and corrected "next section" to say "previous section", since validation is ordered before forms.
