### PR TITLE
removed semicolon (typo).

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -102,7 +102,7 @@ from inside a controller::
 
             $form = $this->createFormBuilder($task)
                 ->add('task', 'text')
-                ->add('dueDate', 'date');
+                ->add('dueDate', 'date')
                 ->getForm();
 
             return $this->render('AcmeTaskBundle:Default:new.html.twig', array(


### PR DESCRIPTION
There was a typo in one of the code examples.
