### PR TITLE
Added link to ubuntus docs on adding ACL support in installation.rst

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -120,9 +120,9 @@ If there are any issues, correct them now before moving on.
 
     **2. Using Acl on a system that does not support chmod +a**
 
-    Some systems, like Ubuntu, don't support ``chmod +a``, but do support
-    another utility called ``setfacl``. On some systems, this will need to
-    be installed before using it:
+    Some systems don't support ``chmod +a``, but do support another utility 
+    called ``setfacl``. On some systems, like Ubuntu, you will need to `enable 
+    ACL support`_ on your partition and install setfacl before using it:
 
     .. code-block:: bash
 
@@ -204,6 +204,7 @@ Now, the vendor directory won't be committed to source control. This is fine
 project, he/she can simply run the ``php bin/vendors install`` script to
 download all the necessary vendor libraries.
 
+.. _`enable ACL support`: https://help.ubuntu.com/community/FilePermissions#ACLs
 .. _`http://symfony.com/download`: http://symfony.com/download
 .. _`Git`: http://git-scm.com/
 .. _`GitHub Bootcamp`: http://help.github.com/set-up-git-redirect


### PR DESCRIPTION
I happen to run Ubuntu and was having issues with permissions on app/cache and app/logs. Sorted it out with the help of Stof and lee on IRC. Ubuntu has a very concise and to the point couple of steps on how to turn on ACL which allowed me to be able to use setfacl. I added this link in an appropriate place in installation.rst.
