### PR TITLE
Added initial backslash to example in Web Services cookbook recipe in response to comments in Issue #567.

### DIFF
--- a/cookbook/web_services/php_soap_extension.rst
+++ b/cookbook/web_services/php_soap_extension.rst
@@ -111,7 +111,7 @@ assumes indexAction in our controller above is accessible via the route "/soap".
 
 .. code-block:: php
 
-    $client = new soapclient('http://example.com/app.php/soap?wsdl', true);
+    $client = new \soapclient('http://example.com/app.php/soap?wsdl', true);
     
     $result = $client->call('hello', array('name' => 'Scott'));
 


### PR DESCRIPTION
Added initial backslash to example in Web Services cookbook recipe in response to comments in Issue #567.  The initial backslash is used for classes that are not in a namespace.
