### PR TITLE
Corrected place where persist method was referred, when flush was meant.

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -394,10 +394,11 @@ Let's walk through this example:
 
   In fact, since Doctrine is aware of all your managed entities, when you
   call the ``flush()`` method, it calculates an overall changeset and executes
-  the most efficient query/queries possible. For example, if you're persist
-  100 ``Product`` objects and then call ``persist()``, Doctrine will create
-  a *single* prepared statement and re-use it for each insert. This pattern
-  is called *Unit of Work*, and it's used because it's fast and efficient.
+  the most efficient query/queries possible. For example, if you persist a
+  total of 100 ``Product`` objects and then subsequently call ``flush()``, 
+  Doctrine will create a *single* prepared statement and re-use it for each 
+  insert. This pattern is called *Unit of Work*, and it's used because it's 
+  fast and efficient.
 
 When creating or updating objects, the workflow is always the same. In the
 next section, you'll see how Doctrine is smart enough to automatically issue


### PR DESCRIPTION
Corrects this issue https://github.com/symfony/symfony-docs/issues/633
