### PR TITLE
[book/translation] fix typo (directory name 'vendors' is wrong)

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -194,7 +194,7 @@ Ignoring the ``vendor/`` Directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you've downloaded the archive *without vendors*, you can safely ignore
-the entire ``vendors/`` directory and not commit it to source control. With
+the entire ``vendor/`` directory and not commit it to source control. With
 ``Git``, this is done by creating and adding the following to a ``.gitignore``
 file:
 


### PR DESCRIPTION
fixed directory name 'vendors' to 'vendor'
