### PR TITLE
property will disappear on class level if done with unset!

### DIFF
--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -217,7 +217,7 @@ object, which is what's returned after a ``file`` field is submitted::
         $this->setPath($this->file->getClientOriginalName());
 
         // clean up the file property as you won't need it anymore
-        unset($this->file);
+        $this->file = null;
     }
 
 Using Lifecycle Callbacks


### PR DESCRIPTION
If using unset the property will be removed from the class, so if you are adding e.g. in a loop a lot of entities in fixtures you will get a notice that the property doesnt exists in the second time you try to set or get it!
