### PR TITLE
fixed YAML syntax for True validator

### DIFF
--- a/book/validation.rst
+++ b/book/validation.rst
@@ -553,7 +553,7 @@ this method must return ``true``:
         Acme\BlogBundle\Entity\Author:
             getters:
                 passwordLegal:
-                    - True: { message: "The password cannot match your first name" }
+                    - "True": { message: "The password cannot match your first name" }
 
     .. code-block:: xml
 


### PR DESCRIPTION
The YAML syntax for the `getters` property is incorrect. If you do not quote True then it will look for the following constraint: `Symfony\Component\Validator\Constraints\1`
