### PR TITLE
[cookbook] [cache] updated Varnish configuration for Varnish 3.x as expla

### DIFF
--- a/cookbook/cache/varnish.rst
+++ b/cookbook/cache/varnish.rst
@@ -47,7 +47,7 @@ Symfony2 adds automatically:
     sub vcl_fetch {
         if (beresp.http.Surrogate-Control ~ "ESI/1.0") {
             unset beresp.http.Surrogate-Control;
-            esi;
+            set beresp.do_esi = true;
         }
     }
 


### PR DESCRIPTION
[cookbook] [cache] updated Varnish configuration for Varnish 3.x as explained in the following official documentation: https://www.varnish-cache.org/docs/3.0/installation/upgrade.html#esi-is-replaced-with-beresp-do-esi
