### PR TITLE
Fixed test suite dependencies

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -27,9 +27,9 @@ autoloaded from `vendor/` under the main root directory (see
 The test suite need the following third-party libraries:
 
 * Doctrine
-* Doctrine Migrations
 * Swiftmailer
 * Twig
+* Monolog
 
 To install them all, run the `vendors` script:
 

--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -24,7 +24,7 @@ dependencies, Symfony2 needs to be able to autoload them. By default, they are
 autoloaded from `vendor/` under the main root directory (see
 `autoload.php.dist`).
 
-The test suite need the following third-party libraries:
+The test suite needs the following third-party libraries:
 
 * Doctrine
 * Swiftmailer


### PR DESCRIPTION
Unless I'm missing something, Doctrine migrations is not used at all by Symfony so the test suite doesn't need it either.
On the other hand, Monolog is required for some tests.
