### PR TITLE
Fix console cookbook entry

### DIFF
--- a/cookbook/console.rst
+++ b/cookbook/console.rst
@@ -271,8 +271,9 @@ Calling a command from another one is straightforward::
         $command = $this->getApplication()->find('demo:greet');
 
         $arguments = array(
-            'name'   => 'Fabien',
-            '--yell' => true,
+            'command' => 'demo:greet',
+            'name'    => 'Fabien',
+            '--yell'  => true,
         );
 
         $input = new ArrayInput($arguments);


### PR DESCRIPTION
When you wan't call another command from a command you must provide the command argument.
