### PR TITLE
very simple grammar change

### DIFF
--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -724,7 +724,7 @@ Core Symfony and Third-Party Bundle Services
 
 Since Symfony2 and all third-party bundles configure and retrieve their services
 via the container, you can easily access them or even use them in your own
-services. To keep things simple, Symfony2 by defaults does not require that
+services. To keep things simple, Symfony2 by default does not require that
 controllers be defined as services. Furthermore Symfony2 injects the entire
 service container into your controller. For example, to handle the storage of
 information on a user's session, Symfony2 provides a ``session`` service,

--- a/cookbook/doctrine/multiple_entity_managers.rst
+++ b/cookbook/doctrine/multiple_entity_managers.rst
@@ -34,11 +34,11 @@ The following configuration code shows how you can configure two entity managers
                             AcmeCustomerBundle: ~
 
 In this case, you've defined two entity managers and called them ``default``
-and ``customer``. The ``default`` entity managers managers any entities in
-the ``AcmeDemoBundle`` and ``AcmeStoreBundle``, while the ``customer`` entity
-manager manages any bundle in the ``AcmeCustomerBundle``.
+and ``customer``. The ``default`` entity manager manages entities of in the
+``AcmeDemoBundle`` and ``AcmeStoreBundle``, while the ``customer`` entity
+manager manages entities in the ``AcmeCustomerBundle``.
 
-When working with your entity managers, you should now be explicit about which
+When working with multiple entity managers, you should be explicit about which
 entity manager you want. If you *do* omit the entity manager's name when
 asking for it, the default entity manager (i.e. ``default``) is returned::
 


### PR DESCRIPTION
changed "Symfony2 by defaults" to "Symfony2 by default"
