### PR TITLE
Removed get('response') because the response is not available as a service

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -530,8 +530,6 @@ via the ``get()`` method. Here are several common services you might need::
 
     $request = $this->getRequest();
 
-    $response = $this->get('response');
-
     $templating = $this->get('templating');
 
     $router = $this->get('router');


### PR DESCRIPTION
In the controller chapter, it says you can do $this->get('response') to get the response, however, the response is not available as a service. In this pull request, I've simply removed this get() example for the response.
