### PR TITLE
typo yaml error message should have quote 

### DIFF
--- a/reference/constraints/MinLength.rst
+++ b/reference/constraints/MinLength.rst
@@ -26,7 +26,7 @@ Basic Usage
         Acme\BlogBundle\Entity\Blog:
             properties:
                 firstName:
-                    - MinLength: { limit: 3, message: Your name must have at least {{ limit}} characters. }
+                    - MinLength: { limit: 3, message: "Your name must have at least {{ limit}} characters." }
 
     .. code-block:: php-annotations
 


### PR DESCRIPTION
there is a typo in the error message.
