### PR TITLE
Event dispatcher injection

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -846,7 +846,7 @@ independent of the rest of the page.
 
 In this example, we've given the full-page cache a lifetime of ten minutes.
 Next, let's include the news ticker in the template by embedding an action.
-This is done via the ``render`` helper (See `templating-embedding-controller`
+This is done via the ``render`` helper (See :ref:`templating-embedding-controller`
 for more details).
 
 As the embedded content comes from another page (or controller for that

--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -396,7 +396,7 @@ The HTTP specification defines two caching models:
   until the cached version reaches its expiration time and becomes "stale".
 
 * When pages are really dynamic (i.e. their representation changes often),
-  the `validation model`_ model is often necessary. With this model, the
+  the `validation model`_ is often necessary. With this model, the
   cache stores the response, but asks the server on each request whether
   or not the cached response is still valid. The application uses a unique
   response identifier (the ``Etag`` header) and/or a timestamp (the ``Last-Modified``

--- a/book/internals.rst
+++ b/book/internals.rst
@@ -748,8 +748,16 @@ can be the way to go, especially for optional dependencies.
 
     If you use dependency injection like we did in the two examples above, you
     can then use the `Symfony2 Dependency Injection component`_ to elegantly
-    manage these objects.
+    manage the injection of the event_dispatcher service for these objects.
 
+        .. code-block:: yml
+
+            # src/Acme/HelloBundle/Resources/config/services.yml
+            services:
+                foo_service:
+                    class: Acme/HelloBundle/Foo/FooService
+                    arguments: [@event_dispatcher]
+            
 .. index::
    single: Event Dispatcher; Event subscribers
 

--- a/book/testing.rst
+++ b/book/testing.rst
@@ -26,7 +26,7 @@ sub-directory of your bundles:
 
     <!-- app/phpunit.xml.dist -->
 
-    <phpunit bootstrap="../src/autoload.php">
+    <phpunit bootstrap="bootstrap.php.cache">
         <testsuites>
             <testsuite name="Project Test Suite">
                 <directory>../src/*/*Bundle/Tests</directory>
@@ -64,7 +64,7 @@ structure under its ``Tests/`` sub-directory. So, write tests for the
 ``Acme/HelloBundle/Tests/Model/ArticleTest.php`` file.
 
 In a unit test, autoloading is automatically enabled via the
-``src/autoload.php`` file (as configured by default in the ``phpunit.xml.dist``
+``bootstrap.php.cache`` file (as configured by default in the ``phpunit.xml.dist``
 file).
 
 Running tests for a given file or directory is also very easy:

--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -8,7 +8,7 @@ Check List
 ----------
 
 The purpose of the check list is to ensure that contributions may be reviewed
-with needless feedback loops to ensure that your contributions can be included
+without needless feedback loops to ensure that your contributions can be included
 into Symfony2 as quickly as possible.
 
 All pull requests should include the following template in the request


### PR DESCRIPTION
Since the internals doc already showed how to accept dispatcher object via getter/setters and constructor, I thought it also made sense to demonstrate the use of `arguments: [@event_dispatcher]` as well
