### PR TITLE
Event dispatcher injection

### DIFF
--- a/book/internals.rst
+++ b/book/internals.rst
@@ -748,8 +748,16 @@ can be the way to go, especially for optional dependencies.
 
     If you use dependency injection like we did in the two examples above, you
     can then use the `Symfony2 Dependency Injection component`_ to elegantly
-    manage these objects.
+    manage the injection of the event_dispatcher service for these objects.
 
+        .. code-block:: yml
+
+            # src/Acme/HelloBundle/Resources/config/services.yml
+            services:
+                foo_service:
+                    class: Acme/HelloBundle/Foo/FooService
+                    arguments: [@event_dispatcher]
+            
 .. index::
    single: Event Dispatcher; Event subscribers
 


### PR DESCRIPTION
Since the internals doc already showed how to accept dispatcher object via getter/setters and constructor, I thought it also made sense to demonstrate the use of `arguments: [@event_dispatcher]` as well
