### PR TITLE
Cookbook/ServiceFactories: Small typo in namespace declaration

### DIFF
--- a/cookbook/service_container/factories.rst
+++ b/cookbook/service_container/factories.rst
@@ -12,7 +12,7 @@ the object.
 Suppose you have a factory that configures and returns a new NewsletterManager
 object::
 
-    namespace Acme\HelloBundle\Newletter;
+    namespace Acme\HelloBundle\Newsletter;
 
     class NewsletterFactory
     {


### PR DESCRIPTION
Missing s in Newsletter
