### PR TITLE
Coding standard example

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -49,7 +49,8 @@ example containing most features described below:
         {
             if (true === $dummy) {
                 return;
-            } elseif ('string' === $dummy) {
+            }
+            if ('string' === $dummy) {
                 $dummy = substr($dummy, 0, 5);
             }
 


### PR DESCRIPTION
The discussion about Propel coding standards pointed that the example of the Sf2 coding standards is not correct as the `if` returns.

Another point that could need to be changed is the sentence `Use Symfony as the first namespace level`. This is true for the Sf2 code itself but is wrong for all bundles that decide to follow the Sf2 CS (it should even be forbidden to use Symfony in this case. They should use their own vendor). What do you think about removing the sentence ?
