### PR TITLE
Fixed a small typo in the form validation example

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -1384,7 +1384,7 @@ but here's a short example::
     ));
 
     // create a form, no default values, pass in the constraint option
-    $form = $this->createFormBuilder(null, , array(
+    $form = $this->createFormBuilder(null, array(
         'validation_constraint' => $collectionConstraint,
     ))->add('email', 'email')
         // ...


### PR DESCRIPTION
It's a very small typo, but i noticed it while studying the docs
