### PR TITLE
[cookbook][autoloader] Add explicit register()

### DIFF
--- a/cookbook/tools/autoloader.rst
+++ b/cookbook/tools/autoloader.rst
@@ -69,6 +69,8 @@ methods::
         'Monolog' => __DIR__.'/../vendor/monolog/src',
     ));
 
+    $loader->register();
+
 For classes that follow the PEAR naming convention, use the
 :method:`Symfony\\Component\\ClassLoader\\UniversalClassLoader::registerPrefix`
 or
@@ -81,6 +83,8 @@ methods::
         'Swift_' => __DIR__.'/vendor/swiftmailer/lib/classes',
         'Twig_'  => __DIR__.'/vendor/twig/lib',
     ));
+
+    $loader->register();
 
 .. note::
 
@@ -97,6 +101,8 @@ projects::
         'Doctrine\\DBAL'             => __DIR__.'/vendor/doctrine-dbal/lib',
         'Doctrine'                   => __DIR__.'/vendor/doctrine/lib',
     ));
+
+    $loader->register();
 
 In this example, if you try to use a class in the ``Doctrine\Common`` namespace
 or one of its children, the autoloader will first look for the class under the


### PR DESCRIPTION
Someone asked me for help figuring out why their UniversalAutoloader wasn't picking up their class in a new non-framework project they were just starting. They had checked and double-checked their folder hierarchy, class namespaces, etc. They said that after an hour they had given up and asked me out of frustration. Turns out, this was their `bootstrap.php` code:

```
<?php
require_once __DIR__ . '/../vendor/Symfony/Component/ClassLoader/UniversalClassLoader.php';

use Symfony\Component\ClassLoader\UniversalClassLoader;

$loader = new UniversalClassLoader();
$loader->registerNamespace('Aquia', __DIR__ . '/src');
```

They were missing `$loader->register()`. Even though it's in the top two examples on the docs page they were following at http://symfony.com/doc/current/cookbook/tools/autoloader.html , they didn't realize it was required when registering a namespace because it wasn't included in the code sample.

This change adds `$loader->register()` to all subsequent examples on the docs page.
