### PR TITLE
Field reference attr option added

### DIFF
--- a/reference/forms/types/field.rst
+++ b/reference/forms/types/field.rst
@@ -18,3 +18,5 @@ The ``field`` type predefines a couple of options:
 .. include:: /reference/forms/types/options/trim.rst.inc
 
 .. include:: /reference/forms/types/options/property_path.rst.inc
+
+.. include:: /reference/forms/types/options/attr.rst.inc

--- a/reference/forms/types/options/attr.rst.inc
+++ b/reference/forms/types/options/attr.rst.inc
@@ -1,0 +1,15 @@
+attr
+~~~~
+
+**type**: array **default**: Empty array
+
+If you want to add extra attributes to HTML field representation
+you can use ``attr`` option. It's an associative array with HTML attribute
+as a key. This can be useful when you need to set a custom class for some widget.
+
+    $builder->add('body', 'textarea', array(
+        'attr' => array('class' => 'tinymce'),
+    ));
+
+
+


### PR DESCRIPTION
I've added this to docs, because it ain't documented at all, but is important IMHO. More about this problem here: http://blog.sznapka.pl/how-to-add-a-custom-class-to-form-field-in-symfony2/
