### PR TITLE
Made Drupal settings.php path more kosher.

### DIFF
--- a/cookbook/configuration/external_parameters.rst
+++ b/cookbook/configuration/external_parameters.rst
@@ -156,7 +156,7 @@ the symfony service container.
 
     // app/config/parameters.php
 
-    include_once('/path/to/drupal/sites/all/default/settings.php');
+    include_once('/path/to/drupal/sites/default/settings.php');
     $container->setParameter('drupal.database.url', $db_url);
 
 .. _`SetEnv`: http://httpd.apache.org/docs/current/env.html


### PR DESCRIPTION
Drupal's settings file is per standard located at sites/default/settings.php.
