### PR TITLE
Adding collection field type documentation

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -948,12 +948,146 @@ are used to construct an instance of ``Category``, which is then set on the
 
 The ``Category`` instance is accessible naturally via ``$task->getCategory()``
 and can be persisted to the database or used however you need.
-
 Embedding a Collection of Forms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can also embed a collection of forms into one form. This is done by
-using the ``collection`` field type. For more information, see the
+using the ``collection`` field type. 
+
+Suppose that each ``Task`` belongs to multiple ``Tags`` objects. Start,
+of course, by creating the ``Tag`` object::
+
+    // src/Acme/TaskBundle/Entity/Tag.php
+    namespace Acme\TaskBundle\Entity;
+
+    use Symfony\Component\Validator\Constraints as Assert;
+
+    class Tag
+    {
+        /**
+         * @Assert\NotBlank()
+         */
+        public $name;
+    }
+
+Next, add a new ``tags`` property to the ``Task`` class::
+
+    // ...
+
+    class Task
+    {
+        // ...
+
+        /**
+         * @ORM\ManyToMany(entityName="Tag")
+         */
+        protected $tags;
+
+        // ...
+
+        public function getTags()
+        {
+            return $this->tags;
+        }
+
+        public function setTags(ArrayCollection $tags)
+        {
+            $this->tags = $tags;
+        }
+    }
+
+Now that your application has been updated to reflect the new requirements,
+create a form class so that a ``Tag`` object can be modified by the user::
+
+    // src/Acme/TaskBundle/Form/Type/TagType.php
+    namespace Acme\TaskBundle\Form\Type;
+
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\FormBuilder;
+
+    class TagType extends AbstractType
+    {
+        public function buildForm(FormBuilder $builder, array $options)
+        {
+            $builder->add('name');
+        }
+
+        public function getDefaultOptions(array $options)
+        {
+            return array(
+                'data_class' => 'Acme\TaskBundle\Entity\Tag',
+            );
+        }
+
+        public function getName()
+        {
+            return 'tag';
+        }
+    }
+
+The end goal is to allow the ``Tags`` of a ``Task`` to be modified right
+inside the task form itself. To accomplish this, add a ``tags`` field
+to the ``TaskType`` object whose type is a ``collection`` and the options describe the type in the collection which is an instance of the new ``TagType``
+class:
+
+.. code-block:: php
+
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        // ...
+
+        $builder->add('tags', 'collection', array('type' => new TagType()));
+    }
+
+Other options can be passed to the collection which are 
+
+* ``options`` - normal options sent to the ``TagType`` form.
+* ``prototype`` - (default: true) add extra html attribute ``data-prototype`` if ``allow_add`` is set to true
+* ``allow_add`` - (default: false) add the prototype of the form in the ``data-prototype`` html attribute, which makes it easy to use with javascript to add new form fields dynamically
+* ``allow_delete`` - (default: false) to be defined
+
+The fields from ``TagType`` can now be rendered alongside those from
+the ``TaskType`` class multiple times. Render the ``Tags`` fields in a loop the same way
+as the original ``Task`` fields:
+
+.. configuration-block::
+
+    .. code-block:: html+jinja
+
+        {# ... #}
+
+        <h3>Tags</h3>
+        <ul class="tags">
+			{% for tag in form.tags %}
+            	<li>{{ form_row(tag.name) }}</li>
+			{% endfor %}
+        </ul>
+
+        {{ form_rest(form) }}
+        {# ... #}
+
+    .. code-block:: html+php
+
+        <!-- ... -->
+
+        <h3>Tags</h3>
+        <ul class="tags">
+			<?php foreach($form['tags'] as $tag): ?>
+            	<li><?php echo $view['form']->row($tag['name']) ?></li>
+			<?php endforeach; ?>
+        </ul>
+
+        <?php echo $view['form']->rest($form) ?>
+        <!-- ... -->
+
+When the user submits the form, the submitted data for the ``Tags`` fields
+are used to construct an ArrayCollection of ``Tag`` objects, which is then set on the
+``tag`` field of the ``Task`` instance.
+
+The ``Tags`` collection is accessible naturally via ``$task->getTags()``
+and can be persisted to the database or used however you need.
+
+For more information, see the
 :doc:`collection field type reference</reference/forms/types/collection>`.
 
 .. index::

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -948,6 +948,7 @@ are used to construct an instance of ``Category``, which is then set on the
 
 The ``Category`` instance is accessible naturally via ``$task->getCategory()``
 and can be persisted to the database or used however you need.
+
 Embedding a Collection of Forms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Hi, after this great #sfdaycgn and the conference about "Catching Opportunities with Open Source", I decided to add my first little contribution to the symfony-docs. I added pretty much the same documentation as "Embedding a Single Object" for the "Collection" type.

I saw that someone is already working on "prototype" option documentation, so I didn't get further on this, but I can if you need it.

I would like to add a full example like on http://www.siteduzero.com/tutoriel-3-523899-creer-des-formulaires-avec-symfony2.html#ss_part_2 which is pretty great, but I don't know if I can and where I should put this (In cookbook I guess ?)
