### PR TITLE
Typo in Console component cookbook

### DIFF
--- a/cookbook/console.rst
+++ b/cookbook/console.rst
@@ -207,7 +207,7 @@ console::
 
     use Symfony\Component\Console\Tester\CommandTester;
     use Symfony\Bundle\FrameworkBundle\Console\Application;
-    use Acme\DemoBundle\Command\GreetCommand.php;
+    use Acme\DemoBundle\Command\GreetCommand;
 
     class ListCommandTest extends \PHPUnit_Framework_TestCase
     {


### PR DESCRIPTION
I found a mistake here : http://symfony.com/doc/2.0/cookbook/console.html#testing-commands

`use Acme\DemoBundle\Command\GreetCommand.php;`should be `use Acme\DemoBundle\Command\GreetCommand`;
