### PR TITLE
Forms code block display error

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -1362,10 +1362,12 @@ no ``data_class`` option is set), ``$form->getData()`` ultimately returns
 an array.
 
 .. tip::
+
     You can also access POST values (in this case "name") directly through 
     the request object, like so:
 
     .. code-block:: php
+
         $this->get('request')->request->get('name');
 
     Be advised, however, that in most cases using the getData() method is 


### PR DESCRIPTION
@mikaelrandy reported that codeblock introduced in PR #758 wasn't showing up correctly, so I added some whitespace since that seemed to be how it differed from other examples of the use of `code-block::`
