### PR TITLE
[Reference] Fixed typo in Collection constraint reference

### DIFF
--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -132,7 +132,7 @@ blank but is no longer than 100 characters in length, you would do the following
             {
                 $metadata->addPropertyConstraint('profileData', new Collection(array(
                     'fields' => array(
-                        'personal_email' => arraynew Email(),
+                        'personal_email' => new Email(),
                         'lastName' => array(new NotBlank(), new MaxLength(100)),
                     ),
                     'allowMissingFields' => true,


### PR DESCRIPTION
The alternative is to include the parentheses for `array`, but in my opinion this way makes more clear that the `Collection` constraint accepts either an array or a single constraint for each of its sub-properties.
