### PR TITLE
Substituted word service for scope in scopes.rst

### DIFF
--- a/cookbook/service_container/scopes.rst
+++ b/cookbook/service_container/scopes.rst
@@ -108,7 +108,7 @@ Using a Service from a narrower Scope
 
 If your service depends on a scoped service, the best solution is to put
 it in the same scope (or a narrower one). Usually, this means putting your
-new service in the `request` service.
+new service in the `request` scope.
 
 But this is not always possible (for instance, a twig extension must be in
 the `container` scope as the Twig environment needs it as a dependency).


### PR DESCRIPTION
Pretty sure author meant "scope" in this particular sentence instead of "service". Excellent article, though. Very very clear.
