### PR TITLE
Fixed bad example code in traversal section of testing.rst. [retry]

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -499,7 +499,7 @@ narrow down your node selection by chaining the method calls::
         ->filter('h1')
         ->reduce(function ($node, $i)
         {
-            if (!$node->attr('class')) {
+            if (!$node->getAttribute('class')) {
                 return false;
             }
         })


### PR DESCRIPTION
Since the actual node is passed to the closure attr() method does not work.
