### PR TITLE
Added array for Choice validator options in PHP code block.

### DIFF
--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -86,10 +86,10 @@ If your valid choice list is simple, you can pass them in directly via the
             
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
-                $metadata->addPropertyConstraint('gender', new Choice(
+                $metadata->addPropertyConstraint('gender', new Choice(array(
                     'choices' => array('male', 'female'),
                     'message' => 'Choose a valid gender',
-                ));
+                )));
             }
         }
 


### PR DESCRIPTION
The Choice constraint expects an options array in PHP. array() was missing for the options. 
