### PR TITLE
Changed options table to match descriptions below.

### DIFF
--- a/reference/forms/types/csrf.rst
+++ b/reference/forms/types/csrf.rst
@@ -10,7 +10,7 @@ The ``csrf`` type is a hidden input field containing a CSRF token.
 | Rendered as | ``input`` ``hidden`` field                                         |
 +-------------+--------------------------------------------------------------------+
 | Options     | - ``csrf_provider``                                                |
-|             | - ``page_id``                                                      |
+|             | - ``intention``                                                    |
 |             | - ``property_path``                                                |
 +-------------+--------------------------------------------------------------------+
 | Parent type | ``hidden``                                                         |


### PR DESCRIPTION
There's no reference to `page_id` in the Csrf field type.
