### PR TITLE
Document InputOptions

### DIFF
--- a/cookbook/console.rst
+++ b/cookbook/console.rst
@@ -179,14 +179,14 @@ will work:
 
 There are 4 option variants you can use:
 
-===========================  ===================================
+===========================  ==============================================================================
 Option                       Value
-===========================  ===================================
+===========================  ==============================================================================
 InputOption::VALUE_IS_ARRAY  This option accepts multiple values
 InputOption::VALUE_NONE      Do not accept input for this option
-InputOption::VALUE_REQUIRED  This option is required
+InputOption::VALUE_REQUIRED  The value for the option is required. The option itself will still be optional. 
 InputOption::VALUE_OPTIONAL  This option is optional
-===========================  ===================================
+===========================  ==============================================================================
 
 You can combine VALUE_IS_ARRAY with VALUE_REQUIRED or VALUE_OPTIONAL like this:
 

--- a/cookbook/console.rst
+++ b/cookbook/console.rst
@@ -1,3 +1,7 @@
+.. index::
+    single: Console; CLI
+
+
 How to create Console/Command-Line Commands
 ===========================================
 

--- a/cookbook/console.rst
+++ b/cookbook/console.rst
@@ -173,6 +173,27 @@ will work:
     app/console demo:greet Fabien --iterations=5 --yell
     app/console demo:greet Fabien --yell --iterations=5
 
+There are 4 option variants you can use:
+
+===========================  ===================================
+Option                       Value
+===========================  ===================================
+InputOption::VALUE_IS_ARRAY  This option accepts multiple values
+InputOption::VALUE_NONE      Do not accept input for this option
+InputOption::VALUE_REQUIRED  This option is required
+InputOption::VALUE_OPTIONAL  This option is optional
+===========================  ===================================
+
+You can combine VALUE_IS_ARRAY with VALUE_REQUIRED or VALUE_OPTIONAL like this:
+
+.. code-block:: php
+
+    $this
+        // ...
+        ->addOption('iterations', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'How many times should the message be printed?', 1)
+
+
+
 Asking the User for Information
 -------------------------------
 


### PR DESCRIPTION
Here's a quick extension to the docs as api.symfony.com does not show class constants. 

OT: Have you considered ways to improve api.symfony.com ?
