### PR TITLE
() missing

### DIFF
--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -37,7 +37,7 @@ Basic Usage
        class Author
        {
            /**
-            * @Assert\Url
+            * @Assert\Url()
             */
             protected $bioUrl;
        }


### PR DESCRIPTION
I don't know if it's mandatory or not on @Assert\Url() to have "()" but on Date constraint, there're "()" so either we have to add it here either we have to remove it on Date.
