### PR TITLE
Code example fix: invalid second argument used on QueryBuilder::where()

### DIFF
--- a/cookbook/testing/doctrine.rst
+++ b/cookbook/testing/doctrine.rst
@@ -117,7 +117,8 @@ the following example::
         public function createSearchByNameQueryBuilder($name)
         {
             return $this->createQueryBuilder('p')
-                ->where('p.name LIKE :name', $name)
+                ->where('p.name LIKE :name')
+                ->setParameter('name', $name);
         }
     }
 


### PR DESCRIPTION
Should use `setParameter()` since the second argument of `where()` is never used.
