### PR TITLE
[book/security] Fix security filename typo 2.0

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -670,7 +670,7 @@ You can define as many URL patterns as you need - each is a regular expression.
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security:
             # ...
             access_control:
@@ -679,7 +679,7 @@ You can define as many URL patterns as you need - each is a regular expression.
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <!-- ... -->
             <rule path="^/admin/users" role="ROLE_SUPER_ADMIN" />
@@ -688,7 +688,7 @@ You can define as many URL patterns as you need - each is a regular expression.
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', array(
             // ...
             'access_control' => array(
@@ -887,7 +887,7 @@ In fact, you've seen this already in the example in this chapter.
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security:
             # ...
             providers:
@@ -898,7 +898,7 @@ In fact, you've seen this already in the example in this chapter.
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <!-- ... -->
             <provider name="default_provider">
@@ -909,7 +909,7 @@ In fact, you've seen this already in the example in this chapter.
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', array(
             // ...
             'providers' => array(
@@ -1056,7 +1056,7 @@ do the following:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security:
             # ...
             providers:
@@ -1073,7 +1073,7 @@ do the following:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <!-- ... -->
             <provider name="in_memory">
@@ -1086,7 +1086,7 @@ do the following:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', array(
             // ...
             'providers' => array(
@@ -1121,7 +1121,7 @@ configure the encoder for that user:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security:
             # ...
 
@@ -1130,7 +1130,7 @@ configure the encoder for that user:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <!-- ... -->
 
@@ -1139,7 +1139,7 @@ configure the encoder for that user:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', array(
             // ...
 
@@ -1216,7 +1216,7 @@ a new provider that chains the two together:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <provider name="chain_provider">
                 <provider>in_memory</provider>
@@ -1232,7 +1232,7 @@ a new provider that chains the two together:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', array(
             'providers' => array(
                 'chain_provider' => array(
@@ -1273,7 +1273,7 @@ the user from both the ``in_memory`` and ``user_db`` providers.
 
         .. code-block:: xml
 
-            <!-- app/config/config.xml -->
+            <!-- app/config/security.xml -->
             <config>
                 <provider name=="main_provider">
                     <user name="foo" password="test" />
@@ -1283,7 +1283,7 @@ the user from both the ``in_memory`` and ``user_db`` providers.
 
         .. code-block:: php
 
-            // app/config/config.php
+            // app/config/security.php
             $container->loadFromExtension('security', array(
                 'providers' => array(
                     'main_provider' => array(
@@ -1303,7 +1303,7 @@ the first provider is always used:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security:
             firewalls:
                 secured_area:
@@ -1316,7 +1316,7 @@ the first provider is always used:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall name="secured_area" pattern="^/" provider="user_db">
                 <!-- ... -->
@@ -1327,7 +1327,7 @@ the first provider is always used:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', array(
             'firewalls' => array(
                 'secured_area' => array(
@@ -1418,7 +1418,7 @@ the firewall can handle this automatically for you when you activate the
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/security.yml
         security:
             firewalls:
                 secured_area:
@@ -1430,7 +1430,7 @@ the firewall can handle this automatically for you when you activate the
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/security.xml -->
         <config>
             <firewall name="secured_area" pattern="^/">
                 <!-- ... -->
@@ -1441,7 +1441,7 @@ the firewall can handle this automatically for you when you activate the
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/security.php
         $container->loadFromExtension('security', array(
             'firewalls' => array(
                 'secured_area' => array(


### PR DESCRIPTION
change occurences of config.[yml,xml,php] by security.[yml,xml,php] for consistency (against 2.0)

Modifications made to ensure that beginners are not confused

Recreation of pull against symfony:2.0 as suggested in #937
