### PR TITLE
git-ignore web/css and web/js (generated stuff)

### DIFF
--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -29,6 +29,8 @@ git repository:
     .. code-block:: text
 
         /web/bundles/
+        /web/css/
+        /web/js/
         /app/bootstrap*
         /app/cache/*
         /app/logs/*


### PR DESCRIPTION
Folks using assetic will appreciate this since assetic manages files in web/{css,js}.

Hopefully this makes sense for other folks, too... if not, please ignore the patch.
