### PR TITLE
fixed typo in autoload config for issue #904

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -438,7 +438,7 @@ files in the application and to configure the autoloader:
 
     $loader = new Symfony\Component\ClassLoader\UniversalClassLoader();
     $loader->registerNamespaces(array(
-        'Symfony' => __DIR__.'/vendor/symfony/src',
+        'Symfony' => __DIR__.'/../vendor/symfony/src',
     ));
 
     $loader->register();


### PR DESCRIPTION
Fixed the autoloader config. Can't access /vendor folder from /app otherwise.

P.S. Not sure what @ienzam meant by 'This is not at all clear. We just need to extract it somewhere.' in second part of the issue.
