### PR TITLE
Tip: how to remove .git directories

### DIFF
--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -69,6 +69,32 @@ At this point, you have a fully-functional Symfony2 project that's correctly
 committed to git. You can immediately begin development, committing the new
 changes to your git repository.
 
+.. tip::
+
+    After execution of the command:
+
+        $ php bin/vendors install
+
+    your project will contain complete git history of all the bundles defined
+    in ``deps`` file. It can be as much as 100 MB! You can remove git history
+    directories with following command:
+
+    .. code-block:: bash
+
+        $ find vendor -name .git -type d | xargs rm -rf
+
+    The command removes all ``.git`` directoreis contained inside 
+    ``vendor`` directory.
+
+    After this command your project will be similar to 
+    ``Symfony_Standard_Vendors_2.0.x.zip`` archive.
+    If you want to update bundles defined in ``deps`` file you will
+    have to reinstall them:
+
+    .. code-block:: bash
+
+        $ php bin/vendors install --reinstall
+
 You can continue to follow along with the :doc:`/book/page_creation` chapter
 to learn more about how to configure and develop inside your application.
 


### PR DESCRIPTION
It can be embarassing for newcommers that a new project with additional bundles (e.g. data fixtures, migrations or sluggable behaviour) after execution of 

```
$ php bin/vendors install
```

is as large as 100 MB.

Maybe they will find this tip helpful?

Best regards,
gajdaw
