### PR TITLE
Fix generation error

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -768,7 +768,7 @@ Relationship Mapping Metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To relate the ``Category`` and ``Product`` entities, start by creating a
-``products`` property on the ``Category`` class::
+``products`` property on the ``Category`` class:
 
 .. configuration-block::
 
@@ -828,7 +828,7 @@ makes sense in the application for each ``Category`` to hold an array of
    namespace as the targetEntity.
 
 Next, since each ``Product`` class can relate to exactly one ``Category``
-object, you'll want to add a ``$category`` property to the ``Product`` class::
+object, you'll want to add a ``$category`` property to the ``Product`` class:
 
 .. configuration-block::
 


### PR DESCRIPTION
Fix a doc generation error, caused by, what I believe, using `::` before a `.. configuration-block::`, as it tries to put the `.. configuration-block::` directive inside a block itself.

I did a search in all the project, and only found it happening on this file.

The error happens here:
http://symfony.com/doc/current/book/doctrine.html#entity-relationships-associations
