### PR TITLE
Update use of Twig filters to fit coding standards

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -90,7 +90,7 @@ it:
 
 .. code-block:: jinja
 
-    {{ title | upper }}
+    {{ title|upper }}
 
 Twig comes with a long list of `tags`_ and `filters`_ that are available
 by default. You can even `add your own extensions`_ to Twig as needed.
@@ -1120,7 +1120,7 @@ In some cases, you'll need to disable output escaping when you're rendering
 a variable that is trusted and contains markup that should not be escaped.
 Suppose that administrative users are able to write articles that contain
 HTML code. By default, Twig will escape the article body. To render it normally,
-add the ``raw`` filter: ``{{ article.body | raw }}``.
+add the ``raw`` filter: ``{{ article.body|raw }}``.
 
 You can also disable output escaping inside a ``{% block %}`` area or
 for an entire template. For more information, see `Output Escaping`_ in

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -767,13 +767,13 @@ texts* and complex expressions:
 
 .. code-block:: jinja
 
-    {{ message | trans }}
+    {{ message|trans }}
 
-    {{ message | transchoice(5) }}
+    {{ message|transchoice(5) }}
 
-    {{ message | trans({'%name%': 'Fabien'}, "app") }}
+    {{ message|trans({'%name%': 'Fabien'}, "app") }}
 
-    {{ message | transchoice(5, {'%name%': 'Fabien'}, 'app') }}
+    {{ message|transchoice(5, {'%name%': 'Fabien'}, 'app') }}
 
 .. tip::
 
@@ -793,10 +793,10 @@ texts* and complex expressions:
             {% set message = '<h3>foo</h3>' %}
 
             {# a variable translated via a filter is escaped by default #}
-            {{ message | trans | raw }}
+            {{ message|trans|raw }}
 
             {# but static strings are never escaped #}
-            {{ '<h3>foo</h3>' | trans }}
+            {{ '<h3>foo</h3>'|trans }}
 
 PHP Templates
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Nothing too exciting here ...

The goal is to follow the new Twig coding standards (http://twig.sensiolabs.org/doc/coding_standards.html).
