### PR TITLE
ROLE_ADMIN instead of ADMIN in "Access Control in Controllers"

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1592,7 +1592,7 @@ the ``isGranted`` method of the security context:
     public function indexAction()
     {
         // show different content to admin users
-        if ($this->get('security.context')->isGranted('ADMIN')) {
+        if ($this->get('security.context')->isGranted('ROLE_ADMIN')) {
             // Load admin content here
         }
         // load other regular content here


### PR DESCRIPTION
Using "ROLE_ADMIN" instead of "ADMIN" in the "Access Control in Controllers" part's example makes more sense.
