### PR TITLE
[Book] [Templating] Added app global variable section

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -889,17 +889,18 @@ give you access to some application specific variables automatically:
 
     .. code-block:: html+jinja
 
+        <p>Username: {{ app.user.username }}</p>
         {% if app.debug %}
-            <p>Username: {{ app.user.username }}</p>
             <p>Request method: {{ app.request.method }}</p>
             <p>Application Environment: {{ app.environment }}</p>
         {% endif %}
 
     .. code-block:: html+php
+
+        <p>Username: <?php echo $app->getUser()->getUsername() ?></p>
         <?php if ($app->getDebug()): ?>
-            <p>Username: <?php echo $app->getUser()->getUsername() ?></p>
             <p>Request method: <?php echo $app->getRequest()->getMethod() ?></p>
-        <p>Application Environment: <?php echo $app->getEnvironment() ?></p>
+            <p>Application Environment: <?php echo $app->getEnvironment() ?></p>
         <?php endif; ?>
 
 .. index::

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -876,14 +876,14 @@ Global Template Variables
 
 During each request, Symfony2 will set a global template variable ``app``
 in both Twig and PHP template engines by default.  The ``app`` variable
-is a :class:`<Symfony\\Bundle\\FrameworkBundle\\Templating\\GlobalVariables>`
-object which will give you access to some application specific variables
+is a :class:`Symfony\\Bundle\\FrameworkBundle\\Templating\\GlobalVariables`
+instance which will give you access to some application specific variables
 automatically:
 
-* ``app.security`` - The security context service.
+* ``app.security`` - The security context.
 * ``app.user`` - The current user object.
 * ``app.request`` - The request object.
-* ``app.session`` - The session object. Equivalent to ``app.request.session``.
+* ``app.session`` - The session object.
 * ``app.environment`` - The current environment (dev, prod, etc).
 * ``app.debug`` - True if in debug mode. False otherwise.
 
@@ -907,7 +907,7 @@ automatically:
 
 .. tip::
 
-    You can set your own global template variables. See the cookbook example
+    You can add your own global template variables. See the cookbook example
     on :doc:`Global Variables</cookbook/templating/global_variables>`.
 
 .. index::

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -871,6 +871,37 @@ is by default "web").
 The end result is a page that includes both the ``main.css`` and ``contact.css``
 stylesheets.
 
+The ``app`` Global Variable
+---------------------------
+
+Symfony2 will set a global template variable ``app`` on every request in
+both Twig and PHP template engines by default.  The ``app`` variable will
+give you access to some application specific variables automatically:
+
+* ``app.security`` - The security context service.
+* ``app.user`` - The current user object. Equivalent to ``app.security.token.user``.
+* ``app.request`` - The request object.
+* ``app.session`` - The session object. Equivalent to ``app.request.session``.
+* ``app.environment`` - The current environment (dev, prod, etc)
+* ``app.debug`` - True if in debug mode. False otherwise.
+
+.. configuration-block::
+
+    .. code-block:: html+jinja
+
+        {% if app.debug %}
+            <p>Username: {{ app.user.username }}</p>
+            <p>Request method: {{ app.request.method }}</p>
+            <p>Application Environment: {{ app.environment }}</p>
+        {% endif %}
+
+    .. code-block:: html+php
+        <?php if ($app->getDebug()): ?>
+            <p>Username: <?php echo $app->getUser()->getUsername() ?></p>
+            <p>Request method: <?php echo $app->getRequest()->getMethod() ?></p>
+        <p>Application Environment: <?php echo $app->getEnvironment() ?></p>
+        <?php endif; ?>
+
 .. index::
    single: Templating; The templating service
 

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -871,18 +871,20 @@ is by default "web").
 The end result is a page that includes both the ``main.css`` and ``contact.css``
 stylesheets.
 
-The ``app`` Global Variable
----------------------------
+Global Template Variables
+-------------------------
 
-Symfony2 will set a global template variable ``app`` on every request in
-both Twig and PHP template engines by default.  The ``app`` variable will
-give you access to some application specific variables automatically:
+During each request, Symfony2 will set a global template variable ``app``
+in both Twig and PHP template engines by default.  The ``app`` variable
+is a :class:`<Symfony\\Bundle\\FrameworkBundle\\Templating\\GlobalVariables>`
+object which will give you access to some application specific variables
+automatically:
 
 * ``app.security`` - The security context service.
-* ``app.user`` - The current user object. Equivalent to ``app.security.token.user``.
+* ``app.user`` - The current user object.
 * ``app.request`` - The request object.
 * ``app.session`` - The session object. Equivalent to ``app.request.session``.
-* ``app.environment`` - The current environment (dev, prod, etc)
+* ``app.environment`` - The current environment (dev, prod, etc).
 * ``app.debug`` - True if in debug mode. False otherwise.
 
 .. configuration-block::
@@ -902,6 +904,11 @@ give you access to some application specific variables automatically:
             <p>Request method: <?php echo $app->getRequest()->getMethod() ?></p>
             <p>Application Environment: <?php echo $app->getEnvironment() ?></p>
         <?php endif; ?>
+
+.. tip::
+
+    You can set your own global template variables. See the cookbook example
+    on :doc:`Global Variables</cookbook/templating/global_variables>`.
 
 .. index::
    single: Templating; The templating service


### PR DESCRIPTION
Added a brief section on the "app" global template variable.  This was inspired by issue 675: https://github.com/symfony/symfony-docs/issues/675

There was already some information on app.user in security.  However, there is no information in the book on any of the other methods available in app.  

Feedback on the content of the section or on the placement of the section in the chapter?  Let me know what you think.
