### PR TITLE
Clarified the use of the validatedBy method for custom contraint validators

### DIFF
--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -98,10 +98,17 @@ tag and an ``alias`` attribute:
             ->addTag('validator.constraint_validator', array('alias' => 'alias_name'))
         ;
 
-Your constraint class may now use this alias to reference the appropriate
+Your constraint class should now use this alias to reference the appropriate
 validator::
 
     public function validatedBy()
     {
         return 'alias_name';
     }
+
+As mentioned above, Symfony2 will automatically look for a class named after
+the constraint, with ``Validator`` appended.  If your constraint validator
+is defined as a service, it's important that you override the
+``validatedBy()`` method to return the alias used when defining your service,
+otherwise Symfony2 won't use the constraint validator service, and will
+instantiate the class instead, without any dependencies injected.


### PR DESCRIPTION
I've added a bit of blurb to clarify the need to override the `validatedBy` method when using a custom constraint validator that is defined as a service.  Without returning the alias used when defining the service, the class is just instantiated as normal without any dependencies.  The use of the word "may" in the existing documentation implies that it's not strictly necessary to override, but it is when other dependencies need injecting in.
