### PR TITLE
Fixed method call for rendering the label in twig

### DIFF
--- a/reference/forms/types/options/label.rst.inc
+++ b/reference/forms/types/options/label.rst.inc
@@ -8,4 +8,4 @@ also be directly set inside the template:
     
 .. code-block:: jinja
 
-    {{ render_label(form.name, 'Your name') }}
+    {{ form_label(form.name, 'Your name') }}


### PR DESCRIPTION
Found a small typo that seems to be referenced in the field type documentation.
