### PR TITLE
Correct little errors in cookbook/configuration/external_parameters.rst

### DIFF
--- a/cookbook/configuration/external_parameters.rst
+++ b/cookbook/configuration/external_parameters.rst
@@ -30,7 +30,7 @@ the following ``VirtualHost`` configuration:
         SetEnv          SYMFONY__DATABASE__USER user
         SetEnv          SYMFONY__DATABASE__PASSWORD secret
 
-        <Directory "/path/to/my_symfony_2_app/web">
+        <Directory "/path/to/symfony_2_app/web">
             AllowOverride All
             Allow from All
         </Directory>
@@ -77,7 +77,7 @@ You can now reference these parameters wherever you need them.
         <doctrine:config>
             <doctrine:dbal
                 driver="pdo_mysql"
-                dbname="symfony2_projet"
+                dbname="symfony2_project"
                 user="%database.user%"
                 password="%database.password%"
             />


### PR DESCRIPTION
It just corrects a typo and adds some coherence in the use
of the names
