### PR TITLE
date Field type: date format example is invalid

### DIFF
--- a/reference/forms/types/options/date_format.rst.inc
+++ b/reference/forms/types/options/date_format.rst.inc
@@ -10,12 +10,12 @@ By default, the format is determined based on the current user locale; you
 can override it by passing the format as a string.
 
 For more information on valid formats, see `Date/Time Format Syntax`_. For
-example, to render a single text box that expects the user to end ``YYYY-MM-dd``,
+example, to render a single text box that expects the user to end ``yyyy-MM-dd``,
 use the following options::
 
     $builder->add('date_created', 'date', array(
         'widget' => 'single_text',
-        'format' => 'YYYY-MM-dd',
+        'format' => 'yyyy-MM-dd',
     ));
 
 .. _`Date/Time Format Syntax`: http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax


### PR DESCRIPTION
It is actually a documentation bug but I haven't found where to file them. So:

http://symfony.com/doc/current/reference/forms/types/date.html -- here it is specified that 

> For more information on valid formats, see Date/Time Format Syntax. For example, to render a single text box that expects the user to end YYYY-MM-dd, use the following options:

and the issue is that according specification http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax (which php's IntlDateFormatter follows) `YYYY` is **not a valid year format** and `yyyy` should be used instead.

If you specify the format as specified in documentation you'll always get `1970` as year fraction.

Reated: https://bugs.php.net/bug.php?id=52283
