### PR TITLE
Syntax error in code example corrected.

### DIFF
--- a/cookbook/form/create_custom_field_type.rst
+++ b/cookbook/form/create_custom_field_type.rst
@@ -247,7 +247,7 @@ argument to ``GenderType``, which receives the gender configuration::
         public function getDefaultOptions(array $options)
         {
             return array(
-                'choices' => $this->genderChoices;
+                'choices' => $this->genderChoices,
             );
         }
         


### PR DESCRIPTION
Semicolon inside array definition causes syntax error.
Already opened a ticket for this, but this might be better way to get the typo fixed.
