### PR TITLE
Fixes security authentication provider cookbook article

### DIFF
--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -116,30 +116,29 @@ set an authenticated token in the security context if successful.
         {
             $request = $event->getRequest();
 
-            if (!$request->headers->has('x-wsse')) {
-                return;
-            }
+            if ($request->headers->has('x-wsse')) {
 
-            $wsseRegex = '/UsernameToken Username="([^"]+)", PasswordDigest="([^"]+)", Nonce="([^"]+)", Created="([^"]+)"/';
+                $wsseRegex = '/UsernameToken Username="([^"]+)", PasswordDigest="([^"]+)", Nonce="([^"]+)", Created="([^"]+)"/';
 
-            if (preg_match($wsseRegex, $request->headers->get('x-wsse'), $matches)) {
-                $token = new WsseUserToken();
-                $token->setUser($matches[1]);
+                if (preg_match($wsseRegex, $request->headers->get('x-wsse'), $matches)) {
+                    $token = new WsseUserToken();
+                    $token->setUser($matches[1]);
 
-                $token->digest   = $matches[2];
-                $token->nonce    = $matches[3];
-                $token->created  = $matches[4];
+                    $token->digest   = $matches[2];
+                    $token->nonce    = $matches[3];
+                    $token->created  = $matches[4];
 
-                try {
-                    $returnValue = $this->authenticationManager->authenticate($token);
+                    try {
+                        $returnValue = $this->authenticationManager->authenticate($token);
 
-                    if ($returnValue instanceof TokenInterface) {
-                        return $this->securityContext->setToken($returnValue);
-                    } else if ($returnValue instanceof Response) {
-                        return $event->setResponse($returnValue);
+                        if ($returnValue instanceof TokenInterface) {
+                            return $this->securityContext->setToken($returnValue);
+                        } else if ($returnValue instanceof Response) {
+                            return $event->setResponse($returnValue);
+                        }
+                    } catch (AuthenticationException $e) {
+                        // you might log something here
                     }
-                } catch (AuthenticationException $e) {
-                    // you might log something here
                 }
             }
 

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -427,35 +427,27 @@ factory service, tagged as ``security.listener.factory``:
             </services>
         </container>
 
-Now, import the factory configuration via the the ``factories`` key in your
-security configuration:
+As a final step, add the factory to the security extension in your bundle class.
 
-.. configuration-block::
+.. code-block:: php
 
-    .. code-block:: yaml
+    // src/Acme/DemoBundle/AcmeDemoBundle.php
+    namespace Acme\DemoBundle;
 
-        # app/config/security.yml
-        security:
-          factories:
-            - "%kernel.root_dir%/../src/Acme/DemoBundle/Resources/config/security_factories.yml"
+    use Acme\DemoBundle\DependencyInjection\Security\Factory\WsseFactory;
+    use Symfony\Component\HttpKernel\Bundle\Bundle;
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-    .. code-block:: xml
+    class AcmeDemoBundle extends Bundle
+    {
+        public function build(ContainerBuilder $container)
+        {
+            parent::build($container);
 
-        <!-- app/config/security.xml -->
-        <config>
-            <factories>
-              "%kernel.root_dir%/../src/Acme/DemoBundle/Resources/config/security_factories.xml
-            </factories>
-        </config>
-
-    .. code-block:: php
-
-        // app/config/security.php
-        $container->loadFromExtension('security', array(
-            'factories' => array(
-              "%kernel.root_dir%/../src/Acme/DemoBundle/Resources/config/security_factories.php"
-            ),
-        ));
+            $extension = $container->getExtension('security');
+            $extension->addSecurityListenerFactory(new WsseFactory());
+        }
+    }
 
 You are finished! You can now define parts of your app as under WSSE protection.
 


### PR DESCRIPTION
Addresses this issue:

   https://github.com/symfony/symfony-docs/issues/1033

This fixes the listener to always return a 403 when the request is not WSSE.  This was previously cause for much confusion.

Also, it seems the `security_factories` configuration key is no longer valid, so we are now initializing the security factory as part of the `AcmeDemoBundle`.   This is how it's done in core, but if there's a better way I will change it.

The diffs are confusing as hell for some reason.  The listener is changed now so the logic is wrapped in a conditional, and the security_factories portion is replaced by a code sample from AcmeDemoBundle.

Let me know if you have any questions!
