### PR TITLE
Extra info for property_path

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -792,6 +792,22 @@ the choice is ultimately up to you.
             );
         }
 
+.. tip::
+	
+	When mapping forms to objects, all fields are mapped, any fields on the 
+	form that do not exist on the mapped object will cause an exception to
+	be thrown.
+	
+	In cases where you need extra fields in the form (for example: a "do you
+	agree with these terms" checkbox) that will not be mapped to the undelying
+	object, you need to set the property_path setting to ``false``.
+	
+        public function buildForm(FormBuilder $builder, array $options)
+        {
+            $builder->add('task');
+            $builder->add('dueDate', null, array('property_path' => false));
+        }
+
 .. index::
    pair: Forms; Doctrine
 

--- a/reference/forms/types/options/property_path.rst.inc
+++ b/reference/forms/types/options/property_path.rst.inc
@@ -9,3 +9,6 @@ the form is submitted, the submitted value is written back into the object.
 If you want to override the property that a field reads from and writes to, 
 you can set the ``property_path`` option. Its default value is the field's
 name.
+
+If you wish the field to be ignored when reading or writing to the object 
+you can set the ``property_path`` option to ``false``


### PR DESCRIPTION
Added notes to inform users that in case a field is not present in the mapped class, the property_path can be set to false and thus avoiding the exceptions thrown by symfony.

This is useful for example in forms where an extra field is needed, like in registration where the "i agree to these terms" will not be persisted in the underlying user object.

This was discussed here: https://github.com/symfony/symfony/issues/1960#issuecomment-3774169
