### PR TITLE
Changes to the standalone console testing section

### DIFF
--- a/components/console.rst
+++ b/components/console.rst
@@ -297,26 +297,6 @@ method::
     You can also test a whole console application by using
     :class:`Symfony\\Component\\Console\\Tester\\ApplicationTester`.
 
-Getting Services from the Service Container
--------------------------------------------
-
-By using :class:`Symfony\\Bundle\\FrameworkBundle\\Command\\ContainerAwareCommand` 
-as the base class for the command (instead of the more basic 
-:class:`Symfony\\Component\\Console\\Command\\Command`), you have access to the 
-service container. In other words, you have access to any configured service.
-For example, you could easily extend the task to be translatable::
-
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
-        $name = $input->getArgument('name');
-        $translator = $this->getContainer()->get('translator');
-        if ($name) {
-            $output->writeln($translator->trans('Hello %name%!', array('%name%' => $name)));
-        } else {
-            $output->writeln($translator->trans('Hello!'));
-        }
-    }
-
 Calling an existing Command
 ---------------------------
 

--- a/components/console.rst
+++ b/components/console.rst
@@ -247,9 +247,12 @@ console::
     {
         public function testExecute()
         {
-            $command = new GreetCommand();
+            $application = new Application();
+            $application->add(new GreetCommand());
+
+            $command = $application->find('demo:greet');
             $commandTester = new CommandTester($command);
-            $commandTester->execute();
+            $commandTester->execute(array('command' => $command->getName()));
 
             $this->assertRegExp('/.../', $commandTester->getDisplay());
 
@@ -276,9 +279,14 @@ method::
 
         public function testNameIsOutput()
         {
-            $command = new GreetCommand();
+            $application = new Application();
+            $application->add(new GreetCommand());
+
+            $command = $application->find('demo:greet');
             $commandTester = new CommandTester($command);
-            $commandTester->execute(array('name' => 'Fabien'));
+            $commandTester->execute(
+                array('command' => $command->getName(), 'name' => 'Fabien')
+            );
 
             $this->assertRegExp('/Fabien/', $commandTester->getDisplay());
         }

--- a/components/console.rst
+++ b/components/console.rst
@@ -247,13 +247,9 @@ console::
     {
         public function testExecute()
         {
-            // mock the Kernel or create one depending on your needs
-            $application = new Application($kernel);
-            $application->add(new GreetCommand());
-
-            $command = $application->find('demo:greet');
+            $command = new GreetCommand();
             $commandTester = new CommandTester($command);
-            $commandTester->execute(array('command' => $command->getName()));
+            $commandTester->execute();
 
             $this->assertRegExp('/.../', $commandTester->getDisplay());
 
@@ -264,6 +260,29 @@ console::
 The :method:`Symfony\\Component\\Console\\Tester\\CommandTester::getDisplay`
 method returns what would have been displayed during a normal call from the
 console.
+
+You can test sending arguments and options to the command by passing them
+as an array to the :method:`Symfony\\Component\\Console\\Tester\\CommandTester::getDisplay`
+method::
+
+    use Symfony\Component\Console\Tester\CommandTester;
+    use Symfony\Bundle\FrameworkBundle\Console\Application;
+    use Acme\DemoBundle\Command\GreetCommand;
+
+    class ListCommandTest extends \PHPUnit_Framework_TestCase
+    {
+
+        //--
+
+        public function testNameIsOutput()
+        {
+            $command = new GreetCommand();
+            $commandTester = new CommandTester($command);
+            $commandTester->execute(array('name' => 'Fabien'));
+
+            $this->assertRegExp('/Fabien/', $commandTester->getDisplay());
+        }
+    }
 
 .. tip::
 

--- a/components/console.rst
+++ b/components/console.rst
@@ -68,6 +68,22 @@ add the following to it::
         }
     }
 
+You also need to create the file to run at the command line which creates
+an ``Application`` and adds commands to it:
+
+.. code-block::php
+
+    #!/usr/bin/env php
+    # app/console
+    <?php 
+
+    use Acme\DemoBundle\Command\GreetCommand;
+    use Symfony\Component\Console\Application;
+
+    $application = new Application();
+    $application->add(new GreetCommand);
+    $application->run();
+
 Test the new console command by running the following
 
 .. code-block:: bash


### PR DESCRIPTION
Creating a new Application and passing it a kernel seem to me to be specific to using the console as part of the full stack and are unnecessary if the console component is being used on its own.
