### PR TITLE
[HttpFoundation] [Request] add attributes property of Symfony\Component\HttpFoundation\Request object

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -52,7 +52,7 @@ can be accessed via several public properties:
 
 * ``cookies``: equivalent of ``$_COOKIE``;
 
-* ``attributes``: router parameters (``_controller``, ``_route`` and any placeholder used);
+* ``attributes``: ``HttpKernel`` uses it to store parameters like routing (``_controller``, ``_route`` and any placeholder used) for example;
 
 * ``files``: equivalent of ``$_FILE``;
 

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -52,7 +52,7 @@ can be accessed via several public properties:
 
 * ``cookies``: equivalent of ``$_COOKIE``;
 
-* ``attributes``: ``HttpKernel`` uses it to store parameters like routing (``_controller``, ``_route`` and any placeholder used) for example;
+* ``attributes``: information about the Request that is not directly related to the HTTP data. For example, ``HttpKernel`` uses it to store parameters about routing (``_controller``, ``_route`` and any placeholder used);
 
 * ``files``: equivalent of ``$_FILE``;
 

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -52,6 +52,8 @@ can be accessed via several public properties:
 
 * ``cookies``: equivalent of ``$_COOKIE``;
 
+* ``attributes``: router parameters (``_controller``, ``_route`` and any placeholder used);
+
 * ``files``: equivalent of ``$_FILE``;
 
 * ``server``: equivalent of ``$_SERVER``;
@@ -67,6 +69,8 @@ instance (or a sub-class of), which is a data holder class:
 * ``query``:   :class:`Symfony\\Component\\HttpFoundation\\ParameterBag`;
 
 * ``cookies``: :class:`Symfony\\Component\\HttpFoundation\\ParameterBag`;
+
+* ``attributes``: :class:`Symfony\\Component\\HttpFoundation\\ParameterBag`;
 
 * ``files``:   :class:`Symfony\\Component\\HttpFoundation\\FileBag`;
 


### PR DESCRIPTION
The documentation was missing this property in Symfony\Component\HttpFoundation\Request.
I found it while debugging (print_r()-of-hell) and found out that it was not in the documentation.
