### PR TITLE
Removed typo in the DBAL cookbook chapter

### DIFF
--- a/cookbook/doctrine/dbal.rst
+++ b/cookbook/doctrine/dbal.rst
@@ -148,7 +148,7 @@ mapping type:
         # app/config/config.yml
         doctrine:
             dbal:
-                connection:
+                connections:
                     default:
                         // Other connections parameters
                         mapping_types:


### PR DESCRIPTION
There is a missing 's' in the yaml code block of the last DBAL chapter.
