### PR TITLE
switch to http authentication for tests

### DIFF
--- a/cookbook/testing/http_authentication.rst
+++ b/cookbook/testing/http_authentication.rst
@@ -28,7 +28,7 @@ the entity provider::
 
     .. code-block:: yaml
 
-	# app/config/config_test.yml
+        # app/config/config_test.yml
         security:
             firewalls:
                 secured_area:

--- a/cookbook/testing/http_authentication.rst
+++ b/cookbook/testing/http_authentication.rst
@@ -18,3 +18,21 @@ You can also override it on a per request basis::
         'PHP_AUTH_USER' => 'username',
         'PHP_AUTH_PW'   => 'pa$$word',
     ));
+
+When your application is using a form_login with an entity provider, you can
+simplify your tests by allowing your test configuration to make use of HTTP
+authentication. This way you can use the above to authenticate and still use
+the entity provider::
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+	# app/config/config_test.yml
+        security:
+            firewalls:
+                secured_area:
+                    http_basic:
+
+You do have to know the password for your users as this stored encrypted in
+the database. You can use fixtures to load test users into your database.


### PR DESCRIPTION
It was not clear to me how to switch to http authentication for the test environment. I want to do this because I don't know how to authenticate in an easy way with the form_login. Well, instead of actually going to /login, putting data in the fields and then login. But if you have a lot of functional tests, this is a lot of overhead.
