### PR TITLE
Fixing PHP functions when ending with () causes wrong link for locale co...

### DIFF
--- a/components/locale.rst
+++ b/components/locale.rst
@@ -9,9 +9,9 @@ The Locale Component
 
 Replacement for the following functions and classes is provided:
 
-* :phpfunction:`intl_is_failure()`
-* :phpfunction:`intl_get_error_code()`
-* :phpfunction:`intl_get_error_message()`
+* :phpfunction:`intl_is_failure`
+* :phpfunction:`intl_get_error_code`
+* :phpfunction:`intl_get_error_message`
 * :phpclass:`Collator`
 * :phpclass:`IntlDateFormatter`
 * :phpclass:`Locale`


### PR DESCRIPTION
Fixing PHP functions when ending with () causes wrong link for locale component. Thanks to remind me :) .

https://twitter.com/#!/igorwesome/status/173063963234418694
