### PR TITLE
Fix typos in /reference/forms/types/language.rst

### DIFF
--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -8,7 +8,7 @@ The ``language`` type is a subset of the ``ChoiceType`` that allows the user
 to select from a large list of languages. As an added bonus, the language names
 are displayed in the language of the user.
 
-The "value" for each locale is either the two letter ISO639-1 *language* code
+The "value" for each language is the two-letter ISO639-1 *language* code
 (e.g. ``fr``).
 
 .. note::


### PR DESCRIPTION
I think it's a bad copy/paste from locale.
I change "locale" to "language", delete the "either" word and add an hyphen as bonus.
