### PR TITLE
Update of Symfony standards

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -111,10 +111,8 @@ Structure
 Naming Conventions
 ------------------
 
-* Use camelCase, not underscores, for variable, function and method
+* Use camelCase, not underscores, for variable, option, argument, parameter names, function and method
   names;
-
-* Use underscores for option, argument, parameter names;
 
 * Use namespaces for all classes;
 

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -111,8 +111,10 @@ Structure
 Naming Conventions
 ------------------
 
-* Use camelCase, not underscores, for variable, option, argument, parameter names, function and method
+* Use camelCase, not underscores, for variable, argument, parameter names, function and method
   names;
+
+* Use underscores for option;
 
 * Use namespaces for all classes;
 


### PR DESCRIPTION
As we can see on each symfony class, **argument and parameter names** are camelized.
They are only options which keep "underscore"

Just an update.
