### PR TITLE
Fix session lifetime typo in FrameworkBundle Configuration reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -288,7 +288,7 @@ Full Default Configuration
                 auto_start:           ~
                 storage_id:           session.storage.native
                 name:                 ~
-                lifetime:             86400
+                lifetime:             0
                 path:                 ~
                 domain:               ~
                 secure:               ~


### PR DESCRIPTION
Should have been 0.

Follow-up to fa999f02d428cf32d3b3d4f70936f1bc817db633.
