### PR TITLE
[Console] Improved coloring output section with OutputFormatterStyle and colors/options list

### DIFF
--- a/components/console.rst
+++ b/components/console.rst
@@ -118,7 +118,7 @@ output. For example::
     $output->writeln('<error>foo</error>');
 
 It is possible to define your own styles using the class 
-:class:`Symfony\\Component\\Console\\Formatter\\OutputFormatterStyle`:
+:class:`Symfony\\Component\\Console\\Formatter\\OutputFormatterStyle`::
 
     $style = new OutputFormatterStyle('red', 'yellow', array('bold', 'blink'));
     $output->getFormatter()->setStyle('fire', $style);
@@ -127,7 +127,7 @@ It is possible to define your own styles using the class
 Available foreground and background colors are: ``black``, ``red``, ``green``, 
 ``yellow``, ``blue``, ``magenta``, ``cyan`` and ``white``.
 
-And available options are: 'bold', 'underscore', 'blink', 'reverse' and 'conceal'.
+And available options are: ``bold``, ``underscore``, ``blink``, ``reverse`` and ``conceal``.
 
 Using Command Arguments
 -----------------------

--- a/components/console.rst
+++ b/components/console.rst
@@ -117,6 +117,18 @@ output. For example::
     // white text on a red background
     $output->writeln('<error>foo</error>');
 
+It is possible to define your own styles using the class 
+:class:`Symfony\\Component\\Console\\Formatter\\OutputFormatterStyle`:
+
+    $style = new OutputFormatterStyle('red', 'yellow', array('bold', 'blink'));
+    $output->getFormatter()->setStyle('fire', $style);
+    $output->writeln('<fire>foo</fire>');
+
+Available foreground and background colors are: ``black``, ``red``, ``green``, 
+``yellow``, ``blue``, ``magenta``, ``cyan`` and ``white``.
+
+And available options are: 'bold', 'underscore', 'blink', 'reverse' and 'conceal'.
+
 Using Command Arguments
 -----------------------
 


### PR DESCRIPTION
I just added some more info to the coloring output section of the Console component with an example of using OutputFormatterStyle to customize output and a list of available background/foreground colors and options.
