### PR TITLE
Added a link to Github on how to use .gitignore files

### DIFF
--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -35,6 +35,10 @@ git repository:
         /vendor/  
         /app/config/parameters.yml
 
+   You may also want to create a .gitignore file that can be used system-wide,
+   in which case, you can find more information here: `Github .gitignore`_
+   This way you can exclude files/folders often used by your IDE from all of your projects.
+
 4. Copy ``app/config/parameters.yml`` to ``app/config/parameters.yml.dist``.
    The ``parameters.yml`` file is ignored by git (see above) so that machine-specific
    settings like database passwords aren't committed. By creating the ``parameters.yml.dist``
@@ -111,3 +115,4 @@ manage this is `Gitolite`_.
 .. _`GitHub`: https://github.com/
 .. _`barebones repository`: http://progit.org/book/ch4-4.html
 .. _`Gitolite`: https://github.com/sitaramc/gitolite
+.. _`Github .gitignore`: http://help.github.com/ignore-files/

--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -39,7 +39,7 @@ git repository:
 
    You may also want to create a .gitignore file that can be used system-wide,
    in which case, you can find more information here: `Github .gitignore`_
-   This way you can exclude files/folders often used by your IDE from all of your projects.
+   This way you can exclude files/folders often used by your IDE for all of your projects.
 
 4. Copy ``app/config/parameters.yml`` to ``app/config/parameters.yml.dist``.
    The ``parameters.yml`` file is ignored by git (see above) so that machine-specific

--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -35,6 +35,8 @@ git repository:
         /vendor/  
         /app/config/parameters.yml
 
+.. tip::
+
    You may also want to create a .gitignore file that can be used system-wide,
    in which case, you can find more information here: `Github .gitignore`_
    This way you can exclude files/folders often used by your IDE from all of your projects.


### PR DESCRIPTION
Updated manual to include Github link on how to add a (system-wide) .gitignore file.

I've did this mainly because I didn't know about it and even if it's not really the place to learn people about how to use GIT a it would be great if other people that learn Symfony2 can also learn more about the tools they use if they want to follow a link (original PR for Symfony2 .gitignore: symfony/#3628 )
