### PR TITLE
Unified the two parts of a custom validator Constraint and Validator be more clear.

### DIFF
--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -48,9 +48,14 @@ Symfony2 will automatically look for another class, ``MyConstraintValidator``
 when actually performing the validation.
 
 The validator class is also simple, and only has one required method: ``isValid``.
-Take the ``NotBlankValidator`` as an example:
+Furthering our example, take a look at the ``ProtocolValidator`` as an example:
 
 .. code-block:: php
+
+    namespace Symfony\Component\Validator\Constraints;
+    
+    use Symfony\Component\Validator\Constraint;
+    use Symfony\Component\Validator\ConstraintValidator;
 
     class ProtocolValidator extends ConstraintValidator
     {

--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -19,9 +19,9 @@ the ``message`` and ``protocols`` properties:
     /**
      * @Annotation
      */
-    class Url extends Constraint
+    class Protocol extends Constraint
     {
-        public $message = 'This value is not a valid URL';
+        public $message = 'This value is not a valid protocol';
         public $protocols = array('http', 'https', 'ftp', 'ftps');
     }
 
@@ -52,17 +52,16 @@ Take the ``NotBlankValidator`` as an example:
 
 .. code-block:: php
 
-    class NotBlankValidator extends ConstraintValidator
+    class ProtocolValidator extends ConstraintValidator
     {
         public function isValid($value, Constraint $constraint)
         {
-            if (null === $value || '' === $value) {
-                $this->setMessage($constraint->message);
+            if (in_array($value, $constraint->protocols));
 
-                return false;
+                return true;
             }
 
-            return true;
+            return false;
         }
     }
 


### PR DESCRIPTION
Before the documentation for this seemed strange because you introduce a new Constraint (URL) but then you showed a Validator for something completely different (NotBlankValidator). With this commit, the Constraint and the Validator match in the documentation, which I feel is more clear.
