### PR TITLE
Shouldn't it be PreRemove?

### DIFF
--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -361,7 +361,7 @@ property, instead of the actual filename::
         }
 
         /**
-         * @ORM\PostRemove()
+         * @ORM\PreRemove()
          */
         public function removeUpload()
         {


### PR DESCRIPTION
In PostRemove  $this->id is empty and thus $this->getAbsolutePath() throws an Exception (Warning: file (..path..) does not exist).
