### PR TITLE
Extend the example to include the `Constraint::setMessage()` call.

### DIFF
--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -62,6 +62,7 @@ Furthering our example, take a look at the ``ProtocolValidator`` as an example:
         public function isValid($value, Constraint $constraint)
         {
             if (in_array($value, $constraint->protocols));
+                $this->setMessage($constraint->message, array('%protocols%' => $constraint->protocols));
 
                 return true;
             }
@@ -69,6 +70,11 @@ Furthering our example, take a look at the ``ProtocolValidator`` as an example:
             return false;
         }
     }
+
+.. note::
+
+    Don't forget to call ``setMessage`` to construct an error message when the
+    value is invalid.
 
 Constraint Validators with Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Without invoking this method, the object might be perceived valid.
