### PR TITLE
Fix versionadded

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1006,7 +1006,6 @@ interface. This means that your concept of a "user" can be anything, as long
 as it implements this interface.
 
 .. versionadded:: 2.1
-
     In Symfony 2.1, the ``equals`` method was removed from ``UserInterface``.
     If you need to override the default implementation of comparison logic,
     implement the new :class:`Symfony\\Component\\Security\\Core\\User\\EquatableInterface`

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -544,7 +544,6 @@ by defining a ``default_locale`` for the framework:
         ));
 
 .. versionadded:: 2.1
-
      The ``default_locale`` parameter was defined under the session key
      originally, however, as of 2.1 this has been moved. This is because the 
      locale is now set on the request instead of the session.
@@ -797,7 +796,6 @@ texts* and complex expressions:
             {{ '<h3>foo</h3>'|trans }}
 
 .. versionadded:: 2.1
-
      You can now set the translation domain for an entire Twig template with a
      single tag:
 

--- a/components/console.rst
+++ b/components/console.rst
@@ -62,9 +62,7 @@ and add the following to it::
     }
 
 You also need to create the file to run at the command line which creates
-an ``Application`` and adds commands to it:
-
-.. code-block::php
+an ``Application`` and adds commands to it::
 
     #!/usr/bin/env php
     # app/console

--- a/components/templating.rst
+++ b/components/templating.rst
@@ -44,7 +44,7 @@ template associated to a reference.
 The :method:`Symfony\\Component\\Templating\\PhpEngine::render` method executes
 the file `views/hello.php` and returns the output text.
 
-.. code-block::php
+.. code-block:: php
 
     <!-- views/hello.php -->
     Hello, <?php echo $firstname ?>!
@@ -54,7 +54,7 @@ Template Inheritance with Slots
 
 The template inheritance is designed to share layouts with many templates.
 
-.. code-block::php
+.. code-block:: php
 
     <!-- views/layout.php -->
     <html>
@@ -69,7 +69,7 @@ The template inheritance is designed to share layouts with many templates.
 The :method:`Symfony\\Templating\\PhpEngine::extend` method is called in the
 sub-template to set its parent template.
 
-.. code-block::php
+.. code-block:: php
 
     <!-- views/page.php -->
     <?php $view->extend('layout.php') ?>


### PR DESCRIPTION
There must be no blank line between the directive head and the explanation; this is to make these blocks visually continuous in the markup.
