### PR TITLE
Changing the path of Form Class directory to match behaviour of CRUD generator

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -766,9 +766,9 @@ that will house the logic for building the task form:
 
 .. code-block:: php
 
-    // src/Acme/TaskBundle/Form/Type/TaskType.php
+    // src/Acme/TaskBundle/Form/TaskType.php
 
-    namespace Acme\TaskBundle\Form\Type;
+    namespace Acme\TaskBundle\Form;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilder;
@@ -796,7 +796,7 @@ form "type"). It can be used to quickly build a form object in the controller:
     // src/Acme/TaskBundle/Controller/DefaultController.php
 
     // add this new use statement at the top of the class
-    use Acme\TaskBundle\Form\Type\TaskType;
+    use Acme\TaskBundle\Form\TaskType;
 
     public function newAction()
     {


### PR DESCRIPTION
In docs, the Form class is placed in directory: Acme\TaskBundle\Form\Type
which is fine, but the CRUD generator is not following the same convention.
It places the form class directly in Form directory.
I think for consistency they should use the same directory.
