### PR TITLE
Fixing description of default behaviour of testclient on redirects, see #1254

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -429,16 +429,16 @@ For specific details on using the profiler inside a test, see the
 Redirecting
 ~~~~~~~~~~~
 
-When a request returns a redirect response, the client automatically follows
-it. If you want to examine the Response before redirecting, you can force
-the client to not follow redirects with the  ``followRedirects()`` method::
-
-    $client->followRedirects(false);
-
-When the client does not follow redirects, you can force the redirection with
-the ``followRedirect()`` method::
+When a request returns a redirect response, the client does not follow
+it automatically. You can examine the response and force a redirection
+afterwards  with the ``followRedirect()`` method::
 
     $crawler = $client->followRedirect();
+    
+If you want the client to automatically follow all redirects, you can 
+force him with the ``followRedirects()`` method::
+
+    $client->followRedirects();
 
 .. index::
    single: Tests; Crawler


### PR DESCRIPTION
As said in issue #1254, the client does not follow redirects automatically. I changed the text to point out this behaviour and show a way to both follow one redirect at a time and to follow all redirects.
