### PR TITLE
Remove parameters in the signature of the getDefaultOptions method.

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -393,7 +393,7 @@ If you're creating :ref:`form classes<book-form-creating-form-classes>` (a
 good practice), then you'll need to add the following to the ``getDefaultOptions()``
 method::
 
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         return array(
             'validation_groups' => array('registration')
@@ -414,7 +414,7 @@ If you need some advanced logic to determine the validation groups (e.g.
 based on submitted data), you can set the ``validation_groups`` option
 to an array callback, or a ``Closure``::
 
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         return array(
             'validation_groups' => array('Acme\\AcmeBundle\\Entity\\Client', 'determineValidationGroups'),
@@ -426,7 +426,7 @@ This will call the static method ``determineValidationGroups()`` on the
 The Form object is passed as an argument to that method (see next example).
 You can also define whole logic inline by using a Closure::
 
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         return array(
             'validation_groups' => function(FormInterface $form) {
@@ -846,7 +846,7 @@ the choice is ultimately up to you.
     good idea to explicitly specify the ``data_class`` option by adding the
     following to your form type class::
 
-        public function getDefaultOptions(array $options)
+        public function getDefaultOptions()
         {
             return array(
                 'data_class' => 'Acme\TaskBundle\Entity\Task',
@@ -978,7 +978,7 @@ create a form class so that a ``Category`` object can be modified by the user::
             $builder->add('name');
         }
 
-        public function getDefaultOptions(array $options)
+        public function getDefaultOptions()
         {
             return array(
                 'data_class' => 'Acme\TaskBundle\Entity\Category',
@@ -1407,7 +1407,7 @@ The CSRF token can be customized on a form-by-form basis. For example::
     {
         // ...
 
-        public function getDefaultOptions(array $options)
+        public function getDefaultOptions()
         {
             return array(
                 'data_class'      => 'Acme\TaskBundle\Entity\Task',
@@ -1539,7 +1539,7 @@ method to specify the option::
     {
         // ...
 
-        public function getDefaultOptions(array $options)
+        public function getDefaultOptions()
         {
             $collectionConstraint = new Collection(array(
                 'name' => new MinLength(5),


### PR DESCRIPTION
The getDefaultOptions method does not take any parameters in the master branch of the Symfony repository.

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/AbstractType.php#L97
