### PR TITLE
simplified code sample for semantic configuration

### DIFF
--- a/cookbook/bundles/extension.rst
+++ b/cookbook/bundles/extension.rst
@@ -462,15 +462,11 @@ method to merge your configuration and force validation. If any options other
 than ``my_type`` are passed, the user will be notified with an exception
 that an unsupported option was passed::
 
-    use Symfony\Component\Config\Definition\Processor;
-    // ...
-
     public function load(array $configs, ContainerBuilder $container)
     {
-        $processor = new Processor();
         $configuration = new Configuration();
-        $config = $processor->processConfiguration($configuration, $configs);
-    
+        $config = $this->processConfiguration($configuration, $configs);
+
         // ...
     }
 


### PR DESCRIPTION
Simplified a code example to use the available processConfiguration() method from within a DependencyInjection extension class (rather than explicitly instantiating a Processor). Now fits better with the explanation, and matches the code the Sensio generator bundle would generate.

This is a re-submission of #1241 but against the 2.0 branch instead of master this time.
