### PR TITLE
[Contributing] Migrated vendors installation instructions

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -31,22 +31,44 @@ The test suite needs the following third-party libraries:
 * Twig
 * Monolog
 
-To install them all, run the `vendors` script:
+To install them all, use `Composer`_:
+
+Step 1: Get `Composer`_
 
 .. code-block:: bash
 
-    $ php vendors.php install
+    curl -s http://getcomposer.org/installer | php
+
+Make sure you download ``composer.phar`` in the same folder where
+the ``composer.json`` file is located.
+
+Step 2: Install vendors
+
+.. code-block:: bash
+
+    $ php composer.phar --dev install
 
 .. note::
 
     Note that the script takes some time to finish.
+
+.. note::
+
+    If you don't have ``curl`` installed, you can also just download the ``installer``
+    file manually at http://getcomposer.org/installer. Place this file into your
+    project and then run:
+
+    .. code-block:: bash
+
+        $ php installer
+        $ php composer.phar --dev install
 
 After installation, you can update the vendors to their latest version with
 the follow command:
 
 .. code-block:: bash
 
-    $ php vendors.php update
+    $ php composer.phar --dev update
 
 Running
 -------
@@ -87,3 +109,4 @@ browser.
     dependencies installed.
 
 .. _install: http://www.phpunit.de/manual/current/en/installation.html
+.. _`Composer`: http://getcomposer.org/


### PR DESCRIPTION
The vendors instructions in contributing section had not been changed after the switch to composer and the removal of vendors.php .

Hope this would help some people who want to contribute.
