### PR TITLE
Removed deprecated 'security_factories' directive in security reference

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -69,9 +69,6 @@ Each part will be explained in the next section.
                 entity_provider_name:
                     entity: { class: SecurityBundle:User, property: username }
 
-            factories:
-                MyFactory: %kernel.root_dir%/../src/Acme/DemoBundle/Resources/config/security_factories.xml
-
             firewalls:
                 somename:
                     pattern: .*


### PR DESCRIPTION
This fixes #884
