### PR TITLE
[Component][Finder][NumberComparator] notEqual operator

### DIFF
--- a/components/finder.rst
+++ b/components/finder.rst
@@ -168,7 +168,10 @@ Restrict by a size range by chaining calls::
     $finder->files()->size('>= 1K')->size('<= 2K');
 
 The comparison operator can be any of the following: ``>``, ``>=``, ``<``, '<=',
-'=='.
+'==', '!='.
+
+.. versionadded:: 2.1
+   The operator '!=' has been added is version 2.1.
 
 The target value may use magnitudes of kilobytes (``k``, ``ki``), megabytes
 (``m``, ``mi``), or gigabytes (``g``, ``gi``). Those suffixed with an ``i`` use


### PR DESCRIPTION
New operator `!=` in the class `Component\Finder\NumberComparator`.

[PR 3974](https://github.com/symfony/symfony/pull/3974)
