### PR TITLE
[Component][Finder] restrictions

### DIFF
--- a/components/finder.rst
+++ b/components/finder.rst
@@ -217,6 +217,28 @@ it is called with the file as a :class:`Symfony\\Component\\Finder\\SplFileInfo`
 instance. The file is excluded from the result set if the Closure returns
 ``false``.
 
+Restrictions
+------------
+
+Files and directories
+~~~~~~~~~~~~~~~~~~~~~
+
+The ``files()`` method excludes directories completely from other tests.
+Following code will not exclude files from ``Tests`` folders::
+
+    $finder->in('path/to/symfony')
+        ->notName('Tests')
+        ->files();
+
+The call ``notName('Tests')`` means: exclude files named ``Tests``.
+Custom filtering allows exclusion of files from directories:
+
+    $finder->in('path/to/symfony')
+        ->files()
+        ->filter(function(\SplFileInfo $file){
+            return !(preg_match('/Tests/', $file->getRealpath()));
+        });
+
 .. _strtotime:   http://www.php.net/manual/en/datetime.formats.php
 .. _Iterator:     http://www.php.net/manual/en/spl.iterators.php
 .. _protocol:     http://www.php.net/manual/en/wrappers.php


### PR DESCRIPTION
Fluent interface

```
$obj->a()->b()->c()->execute()
```

can work in two ways:
- as in jQuery: the set of included elements is modified according to a, then resulting set is modified according to b, etc.
- as in Finder: the set of matching files/directories is unmodified untill the final call

Maybe warning about the way

```
->notName()->files()
```

works will be helpful for someone?
