### PR TITLE
Custom Authentication Provider update

### DIFF
--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -61,6 +61,14 @@ provider.
         public $created;
         public $digest;
         public $nonce;
+        
+        public function __construct(array $roles = array())
+        {
+            parent::__construct($roles);
+            
+            // If the user has roles, consider it authenticated
+            $this->setAuthenticated(count($roles) > 0);
+        }
 
         public function getCredentials()
         {


### PR DESCRIPTION
In the WsseUserToken example, the token is never set to authenticated. With the current setup, if an action required roles, authentication would be called twice and fail the second time, because the nonce is used at that point.
