### PR TITLE
fixed misspelling

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -634,8 +634,8 @@ Whenever you find that you need a variable or a piece of information that
 you don't have access to in a template, consider rendering a controller.
 Controllers are fast to execute and promote good code organization and reuse.
 
-Asyncronous Content with hinclude.js
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Asynchronous Content with hinclude.js
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.1
     hinclude.js support was added in Symfony 2.1


### PR DESCRIPTION
"Asyncronous" => "Asynchronous"
