### PR TITLE
2 0 remove  git lock caution

### DIFF
--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -85,7 +85,13 @@ changes to your git repository.
 
     your project will contain complete the git history of all the bundles
     and libraries defined in the ``deps`` file. It can be as much as 100 MB!
-    You can remove the git history directories with the following command:
+    If you save current versions of all depencencies with command:
+
+    .. code-block:: bash
+
+        $ php bin/vendors lock
+
+    then you can remove the git history directories with the following command:
 
     .. code-block:: bash
 


### PR DESCRIPTION
I think that before removing `.git` directories we should update `deps.lock`.
