### PR TITLE
[Cookbook] Constant fix

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -246,7 +246,7 @@ that serves to define and document your event:
          *
          * @var string
          */
-        const onStoreOrder = 'store.order';
+        const STORE_ORDER = 'store.order';
     }
 
 Notice that this class doesn't actually *do* anything. The purpose of the
@@ -314,7 +314,7 @@ listener of that event:
 
     // create the FilterOrderEvent and dispatch it
     $event = new FilterOrderEvent($order);
-    $dispatcher->dispatch(StoreEvents::onStoreOrder, $event);
+    $dispatcher->dispatch(StoreEvents::STORE_ORDER, $event);
 
 Notice that the special ``FilterOrderEvent`` object is created and passed to
 the ``dispatch`` method. Now, any listener to the ``store.order`` event will
@@ -323,7 +323,7 @@ the ``getOrder`` method:
 
 .. code-block:: php
 
-    // some listener class that's been registered for onStoreOrder
+    // some listener class that's been registered for "STORE_ORDER" event
     use Acme\StoreBundle\Event\FilterOrderEvent;
 
     public function onStoreOrder(FilterOrderEvent $event)

--- a/components/templating.rst
+++ b/components/templating.rst
@@ -31,6 +31,7 @@ convert a template name to a template reference and template loader
 (:class:`Symfony\\Component\\templating\\Loader\\LoaderInterface`) to find the
 template associated to a reference.
 
+.. code-block:: php
     use Symfony\Component\Templating\PhpEngine;
     use Symfony\Component\Templating\TemplateNameParser;
     use Symfony\Component\Templating\Loader\FilesystemLoader;
@@ -44,7 +45,7 @@ template associated to a reference.
 The :method:`Symfony\\Component\\Templating\\PhpEngine::render` method executes
 the file `views/hello.php` and returns the output text.
 
-.. code-block:: php
+.. code-block:: php+html
 
     <!-- views/hello.php -->
     Hello, <?php echo $firstname ?>!
@@ -54,7 +55,7 @@ Template Inheritance with Slots
 
 The template inheritance is designed to share layouts with many templates.
 
-.. code-block:: php
+.. code-block:: php+html
 
     <!-- views/layout.php -->
     <html>
@@ -69,7 +70,7 @@ The template inheritance is designed to share layouts with many templates.
 The :method:`Symfony\\Templating\\PhpEngine::extend` method is called in the
 sub-template to set its parent template.
 
-.. code-block:: php
+.. code-block:: php+html
 
     <!-- views/page.php -->
     <?php $view->extend('layout.php') ?>

--- a/components/templating.rst
+++ b/components/templating.rst
@@ -87,6 +87,7 @@ sub-template to set its parent template.
 To use template inheritance, the :class:`Symfony\\Templating\\Helper\\SlotsHelper`
 helper must be registered.
 
+.. code-block:: php
     use Symfony\Templating\Helper\SlotsHelper;
 
     $view->set(new SlotsHelper());


### PR DESCRIPTION
The class constants are in the current camelcase style. But the
symfony2 coding guidelines require that all constants must be written in capital letters.
