### PR TITLE
SQL reserved words section.

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -249,7 +249,9 @@ see the :ref:`book-doctrine-field-types` section.
     class name is ``Group``, then, by default, your table name will be ``group``,
     which will cause an SQL error in some engines. See Doctrine's
     `Reserved SQL keywords documentation`_ on how to properly escape these
-    names.
+    names. Alternatively, if you're free to choose your database schema,
+    simply map to a different table name or column name. See Doctrines 
+    `Persistent classes`_ and `Property Mapping`_ documentation.
 
 .. note::
 
@@ -1384,3 +1386,5 @@ For more information about Doctrine, see the *Doctrine* section of the
 .. _`Property Mapping documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/basic-mapping.html#property-mapping
 .. _`Lifecycle Events documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/events.html#lifecycle-events
 .. _`Reserved SQL keywords documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/basic-mapping.html#quoting-reserved-words
+.. _`Persistent classes`: http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/basic-mapping.html#persistent-classes
+.. _`Property Mapping`: http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/basic-mapping.html#property-mapping

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -250,7 +250,7 @@ see the :ref:`book-doctrine-field-types` section.
     which will cause an SQL error in some engines. See Doctrine's
     `Reserved SQL keywords documentation`_ on how to properly escape these
     names. Alternatively, if you're free to choose your database schema,
-    simply map to a different table name or column name. See Doctrines 
+    simply map to a different table name or column name. See Doctrine's 
     `Persistent classes`_ and `Property Mapping`_ documentation.
 
 .. note::

--- a/components/event_dispatcher/container_aware_dispatcher.rst
+++ b/components/event_dispatcher/container_aware_dispatcher.rst
@@ -1,0 +1,98 @@
+.. index::
+   single: Event Dispatcher; Container Aware; Dependency Injection; DIC
+
+The Container Aware Event Dispatcher
+====================================
+
+.. versionadded:: 2.1
+    This feature was moved into the EventDispatcher component in Symfony 2.1.
+
+Introduction
+------------
+
+The :class:`Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher` is
+a special event dispatcher implementation which is coupled to the Symfony2
+Dependency Injection Container Component (DIC). It allows DIC services to be
+specified as event listeners making the event dispatcher extremely powerful.
+
+Services are lazy loaded meaning the services attached as listeners will only be
+created if an event is dispatched that requires those listeners.
+
+Setup
+-----
+
+Setup is straightforward by injecting a :class:`Symfony\\Component\\DependencyInjection\\ContainerInterface`
+into the :class:`Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher`::
+
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
+    use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
+
+    $container = new ContainerBuilder();
+    $dispatcher = new ContainerAwareEventDispatcher($container);
+
+Adding Listeners
+----------------
+
+The *Container Aware Event Dispatcher* can either load specified services
+directly, or services that implement :class:`Symfony\\Component\\EventDispatcher\\EventSubscriberInterface`.
+
+The following examples assume the DIC has been loaded with any services that
+are mentioned.
+
+.. note::
+
+    Services must be marked as public in the DIC.
+
+Adding Services
+~~~~~~~~~~~~~~~
+
+To connect existing service definitions, use the
+:method:`Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher::addListenerService`
+method where the ``$callback`` is an array of ``array($serviceId, $methodName)``::
+
+    $dispatcher->addListenerService($eventName, array('foo', 'logListener'));
+
+Adding Subscriber Services
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``EventSubscribers`` can be added using the
+:method:`Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher::addSubscriberService`
+method where the first argument is the service ID of the subscriber service,
+and the second argument is the the service's class name (which must implement
+:class:`Symfony\\Component\\EventDispatcher\\EventSubscriberInterface`) as follows::
+
+    $dispatcher->addSubscriberService('kernel.store_subscriber', 'StoreSubscriber');
+
+The ``EventSubscriberInterface`` will be exactly as you would expect::
+
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    // ...
+
+    class StoreSubscriber implements EventSubscriberInterface
+    {
+        static public function getSubscribedEvents()
+        {
+            return array(
+                'kernel.response' => array(
+                    array('onKernelResponsePre', 10),
+                    array('onKernelResponsePost', 0),
+                ),
+                'store.order'     => array('onStoreOrder', 0),
+            );
+        }
+
+        public function onKernelResponsePre(FilterResponseEvent $event)
+        {
+            // ...
+        }
+
+        public function onKernelResponsePost(FilterResponseEvent $event)
+        {
+            // ...
+        }
+
+        public function onStoreOrder(FilterOrderEvent $event)
+        {
+            // ...
+        }
+    }

--- a/components/event_dispatcher/generic_event.rst
+++ b/components/event_dispatcher/generic_event.rst
@@ -1,0 +1,107 @@
+.. index::
+   single: Event Dispatcher
+
+The Generic Event Object
+========================
+
+.. versionadded:: 2.1
+    The ``GenericEvent`` event class was added in Symfony 2.1
+
+The base :class:`Symfony\\Component\\EventDispatcher\\Event` class provided by the
+``Event Dispatcher`` component is deliberately sparse to allow the creation of
+API specific event objects by inheritance using OOP. This allow for elegant and
+readable code in complex applications.
+
+The :class:`Symfony\\Component\\EventDispatcher\\GenericEvent` is available
+for convenience for those who wish to use just one event object throughout their
+application. It is suitable for most purposes straight out of the box, because
+it follows the standard observer pattern where the event object
+encapsulates an event 'subject', but has the addition of optional extra
+arguments.
+
+:class:`Symfony\\Component\\EventDispatcher\\GenericEvent` has a simple API in
+addition to the base class :class:`Symfony\\Component\\EventDispatcher\\Event`
+
+* :method:`Symfony\\Component\\EventDispatcher\\GenericEvent::__construct`:
+  Constructor takes the event subject and any arguments;
+
+* :method:`Symfony\\Component\\EventDispatcher\\GenericEvent::getSubject`:
+  Get the subject;
+
+* :method:`Symfony\\Component\\EventDispatcher\\GenericEvent::setArg`:
+  Sets an argument by key;
+
+* :method:`Symfony\\Component\\EventDispatcher\\GenericEvent::setArgs`:
+  Sets arguments array;
+
+* :method:`Symfony\\Component\\EventDispatcher\\GenericEvent::getArg`:
+  Gets an argument by key;
+
+* :method:`Symfony\\Component\\EventDispatcher\\GenericEvent::getArgs`:
+  Gets an array of argument;
+
+* :method:`Symfony\\Component\\EventDispatcher\\GenericEvent::hasArg`:
+  Returns true if the argument key exists;
+
+The ``GenericEvent`` also implements :phpclass:`ArrayAccess` on the event
+arguments which makes it very convenient to pass extra arguments regarding the
+event subject.
+
+The following examples show use-cases to give a general idea of the flexibility.
+The examples assume event listeners have been added to the dispatcher.
+
+Simply passing a subject::
+
+    use Symfony\Component\EventDispatcher\GenericEvent;
+
+    $event = GenericEvent($subject);
+    $dispatcher->dispatch('foo', $event);
+
+    class FooListener
+    {
+        public function handler(GenericEvent $event)
+        {
+            if ($event->getSubject() instanceof Foo) {
+                // ...
+            }
+        }
+    }
+
+Passing and processing arguments using the :phpclass:`ArrayAccess` API to access
+the event arguments::
+
+    use Symfony\Component\EventDispatcher\GenericEvent;
+
+    $event = new GenericEvent($subject, array('type' => 'foo', 'counter' => 0)));
+    $dispatcher->dispatch('foo', $event);
+
+    echo $event['counter'];
+
+    class FooListener
+    {
+        public function handler(GenericEvent $event)
+        {
+            if (isset($event['type']) && $event['type'] === 'foo') {
+                // ... do something
+            }
+
+            $event['counter']++;
+        }
+    }
+
+Filtering data::
+
+    use Symfony\Component\EventDispatcher\GenericEvent;
+
+    $event = new GenericEvent($subject, array('data' => 'foo'));
+    $dispatcher->dispatch('foo', $event);
+
+    echo $event['data'];
+
+    class FooListener
+    {
+        public function filter(GenericEvent $event)
+        {
+            strtolower($event['data']);
+        }
+    }

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -1,0 +1,604 @@
+.. index::
+   single: HTTP
+   single: HttpFoundation, Sessions
+
+Sessions
+========
+
+The Symfony2 HttpFoundation Component has a very powerful and flexible session
+subsystem which is designed to provide session management through a simple
+object-oriented interface using a variety of session storage drivers.
+
+.. versionadded:: 2.1
+    The :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionInterface` interface,
+    as well as a number of other changes, are new as of Symfony 2.1.
+
+Sessions are used via the simple :class:`Symfony\\Component\\HttpFoundation\\Session\\Session`
+implementation of :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionInterface` interface.
+
+Quick example::
+
+    use Symfony\Component\HttpFoundation\Session\Session;
+
+    $session = new Session();
+    $session->start();
+
+    // set and get session attributes
+    $session->set('name', 'Drak');
+    $session->get('name');
+
+    // set flash messages
+    $session->getFlashBag()->add('notice', 'Profile updated');
+
+    // retrieve messages
+    foreach ($session->getFlashBag()->get('notice', array()) as $message) {
+        echo "<div class='flash-notice'>$message</div>";
+    }
+
+Session API
+~~~~~~~~~~~
+
+The :class:`Symfony\\Component\\HttpFoundation\\Session\\Session` class implements
+:class:`Symfony\\Component\\HttpFoundation\\Session\\SessionInterface`.
+
+The :class:`Symfony\\Component\\HttpFoundation\\Session\\Session` has a simple API
+as follows divided into a couple of groups.
+
+Session workflow
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::start`:
+  Starts the session - do not use ``session_start()``.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::migrate`:
+  Regenerates the session id - do not use ``session_regenerate_id()``.
+  This method can optionally change the lifetime of the new cookie that will
+  be emitted by calling this method.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::invalidate`:
+  Clears the session data and regenerates the session id do not use ``session_destroy()``.
+  This is basically a shortcut for ``clear()`` and ``migrate()``.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::getId`: Gets the
+  session ID.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::setId`: Sets the
+  session ID.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::getName`: Gets the
+  session name.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::setName`: Sets the
+  session name.
+
+Session attributes
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::set`:
+  Sets an attribute by key;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::get`:
+  Gets an attribute by key;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::all`:
+  Gets all attributes as an array of key => value;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::has`:
+  Returns true if the attribute exists;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::keys`:
+  Returns an array of stored attribute keys;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::replace`:
+  Sets multiple attributes at once: takes a keyed array and sets each key => value pair.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::remove`:
+  Deletes an attribute by key;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::clear`:
+  Clear all attributes;
+
+The attributes are stored internally in an "Bag", a PHP object that acts like
+an array. A few methods exist for "Bag" management:
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::registerBag`:
+  Registers a :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionBagInterface`
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::getBag`:
+  Gets a :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionBagInterface` by
+  bag name.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::getFlashBag`:
+  Gets the :class:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface`.
+  This is just a shortcut for convenience.
+
+Session meta-data
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::getMetadataBag`:
+  Gets the :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\MetadataBag`
+  which contains information about the session.
+
+Save Handlers
+~~~~~~~~~~~~~
+
+The PHP session workflow has 6 possible operations that may occur.  The normal
+session follows `open`, `read`, `write` and `close`, with the possibility of
+`destroy` and `gc` (garbage collection which will expire any old sessions: `gc`
+is called randomly according to PHP's configuration and if called, it is invoked
+after the `open` operation).  You can read more about this at
+`php.net/session.customhandler`_
+
+
+Native PHP Save Handlers
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+So-called 'native' handlers, are session handlers which are either compiled into
+PHP or provided by PHP extensions, such as PHP-Sqlite, PHP-Memcached and so on.
+The handlers are compiled and can be activated directly in PHP using
+`ini_set('session.save_handler', $name);` and are usually configured with
+`ini_set('session.save_path', $path);` and sometimes, a variety of other PHP
+`ini` directives.
+
+Symfony2 provides drivers for native handlers which are easy to configure, these are:
+
+  * :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\NativeFileSessionHandler`;
+  * :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\NativeSqliteSessionHandler`;
+  * :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\NativeMemcacheSessionHandler`;
+  * :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\NativeMemcachedSessionHandler`;
+  * :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\NativeRedisSessionHandler`;
+
+Example of use::
+
+    use Symfony\Component\HttpFoundation\Session\Session;
+    use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+    use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeMemcachedSessionHandler;
+
+    $storage = new NativeSessionStorage(array(), new NativeMemcachedSessionHandler());
+    $session = new Session($storage);
+
+Custom Save Handlers
+~~~~~~~~~~~~~~~~~~~~
+
+Custom handlers are those which completely replace PHP's built in session save
+handlers by providing six callback functions which PHP calls internally at
+various points in the session workflow.
+
+Symfony2 HttpFoundation provides some by default and these can easily serve as
+examples if you wish to write your own.
+
+  * :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\PdoSessionHandler`;
+  * :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\MemcacheSessionHandler`;
+  * :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\MemcachedSessionHandler`;
+  * :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\NullSessionHandler`;
+
+Example::
+
+    use Symfony\Component\HttpFoundation\Session\Session;
+    use Symfony\Component\HttpFoundation\Session\Storage\SessionStorage;
+    use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
+
+    $storage = new NativeSessionStorage(array(), new PdoSessionHandler());
+    $session = new Session($storage);
+
+Session Bags
+------------
+
+PHP's session management requires the use of the `$_SESSION` super-global,
+however, this interferes somewhat with code testability and encapsulation in a
+OOP paradigm. To help overcome this, Symfony2 uses 'session bags' linked to the
+session to encapsulate a specific dataset of 'attributes' or 'flash messages'.
+
+This approach also mitigates namespace pollution within the `$_SESSION`
+super-global because each bag stores all its data under a unique namespace.
+This allows Symfony2 to peacefully co-exist with other applications or libraries
+that might use the `$_SESSION` super-global and all data remains completely
+compatible with Symfony2's session management.
+
+Symfony2 provides 2 kinds of bags, with two separate implementations.
+Everything is written against interfaces so you may extend or create your own
+bag types if necessary.
+
+:class:`Symfony\\Component\\HttpFoundation\\Session\\SessionBagInterface` has
+the following API which is intended mainly for internal purposes:
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\SessionBagInterface::getStorageKey`:
+  Returns the key which the bag will ultimately store its array under in `$_SESSION`.
+  Generally this value can be left at its default and is for internal use.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\SessionBagInterface::initialize`:
+  This is called internally by Symfony2 session storage classes to link bag data
+  to the session.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\SessionBagInterface::getName`:
+  Returns the name of the session bag.
+
+Attributes
+~~~~~~~~~~
+
+The purpose of the bags implementing the :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface`
+is to handle session attribute storage. This might include things like user ID,
+and remember me login settings or other user based state information.
+
+* :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBag`
+  This is the standard default implementation.
+
+* :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\NamespacedAttributeBag`
+  This implementation allows for attributes to be stored in a structured namespace.
+
+Any plain `key => value` storage system is limited in the extent to which
+complex data can be stored since each key must be unique. You can achieve
+namespacing by introducing a naming convention to the keys so different parts of
+your application could operate without clashing. For example, `module1.foo` and
+`module2.foo`. However, sometimes this is not very practical when the attributes
+data is an array, for example a set of tokens. In this case, managing the array
+becomes a burden because you have to retrieve the array then process it and
+store it again::
+
+    $tokens = array('tokens' => array('a' => 'a6c1e0b6',
+                                      'b' => 'f4a7b1f3'));
+
+So any processing of this might quickly get ugly, even simply adding a token to
+the array::
+
+    $tokens = $session->get('tokens');
+    $tokens['c'] = $value;
+    $session->set('tokens', $tokens);
+
+With structured namespacing, the the key can be translated to the array
+structure like this using a namespace character (defaults to `/`)::
+
+    $session->set('tokens/c', $value);
+
+This way you can easily access a key within the stored array directly and easily.
+
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface`
+has a simple API
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::set`:
+  Sets an attribute by key;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::get`:
+  Gets an attribute by key;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::all`:
+  Gets all attributes as an array of key => value;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::has`:
+  Returns true if the attribute exists;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::keys`:
+  Returns an array of stored attribute keys;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::replace`:
+  Sets multiple attributes at once: takes a keyed array and sets each key => value pair.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::remove`:
+  Deletes an attribute by key;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::clear`:
+  Clear the bag;
+
+Flash messages
+~~~~~~~~~~~~~~
+
+The purpose of the :class:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface`
+is to provide a way of settings and retrieving messages on a per session basis.
+The usual workflow for flash messages would be set in an request, and displayed
+after a page redirect. For example, a user submits a form which hits an update
+controller, and after processing the controller redirects the page to either the
+updated page or an error page. Flash messages set in the previous page request
+would be displayed immediately on the subsequent page load for that session.
+This is however just one application for flash messages.
+
+* :class:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\AutoExpireFlashBag`
+   This implementation messages set in one page-load will
+   be available for display only on the next page load. These messages will auto
+   expire regardless of if they are retrieved or not.
+
+* :class:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBag`
+   In this implementation, messages will remain in the session until
+   they are explicitly retrieved or cleared. This makes it possible to use ESI
+   caching.
+
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface`
+has a simple API
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface::add`:
+  Adds a flash message to the stack of specified type;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface::set`:
+  Sets flashes by type;  This method conveniently takes both singles messages as
+  a ``string`` or multiple messages in an ``array``.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface::get`:
+  Gets flashes by type and clears those flashes from the bag;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface::setAll`:
+  Sets all flashes, accepts a keyed array of arrays ``type => array(messages)``;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface::all`:
+  Gets all flashes (as a keyed array of arrays) and clears the flashes from the bag;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface::peek`:
+  Gets flashes by type (read only);
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface::peekAll`:
+  Gets all flashes (read only) as keyed array of arrays;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface::has`:
+  Returns true if the type exists, false if not;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface::keys`:
+  Returns an array of the stored flash types;
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface::clear`:
+  Clears the bag;
+
+For simple applications it is usually sufficient to have one flash message per
+type, for example a confirmation notice after a form is submitted. However,
+flash messages are stored in a keyed array by flash ``$type`` which means your
+application can issue multiple messages for a given type. This allows the API
+to be used for more complex messaging in your application.
+
+Examples of setting multiple flashes::
+
+    use Symfony\Component\HttpFoundation\Session\Session;
+
+    $session = new Session();
+    $session->start();
+
+    // add flash messages
+    $session->getFlashBag()->add('warning', 'Your config file is writable, it should be set read-only');
+    $session->getFlashBag()->add('error', 'Failed to update name');
+    $session->getFlashBag()->add('error', 'Another error');
+
+Displaying the flash messages might look like this:
+
+Simple, display one type of message::
+
+    // display warnings
+    foreach ($session->getFlashBag()->get('warning', array()) as $message) {
+        echo "<div class='flash-warning'>$message</div>";
+    }
+
+    // display errors
+    foreach ($session->getFlashBag()->get('error', array()) as $message) {
+        echo "<div class='flash-error'>$message</div>";
+    }
+
+Compact method to process display all flashes at once::
+
+    foreach ($session->getFlashBag()->all() as $type => $messages) {
+        foreach ($messages as $message) {
+            echo "<div class='flash-$type'>$message</div>\n";
+        }
+    }
+
+Testability
+-----------
+
+Symfony2 is designed from the ground up with code-testability in mind. In order
+to make your code which utilizes session easily testable we provide two separate
+mock storage mechanisms for both unit testing and functional testing.
+
+Testing code using real sessions is tricky because PHP's workflow state is global
+and it is not possible to have multiple concurrent sessions in the same PHP
+process.
+
+The mock storage engines simulate the PHP session workflow without actually
+starting one allowing you to test your code without complications. You may also
+run multiple instances in the same PHP process.
+
+The mock storage drivers do not read or write the system globals
+`session_id()` or `session_name()`. Methods are provided to simulate this if
+required:
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\SessionStorageInterface::getId`: Gets the
+  session ID.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\SessionStorageInterface::setId`: Sets the
+  session ID.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\SessionStorageInterface::getName`: Gets the
+  session name.
+
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\SessionStorageInterface::setName`: Sets the
+  session name.
+
+Unit Testing
+~~~~~~~~~~~~
+
+For unit testing where it is not necessary to persist the session, you should
+simply swap out the default storage engine with
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\MockArraySessionStorage`::
+
+    use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+    use Symfony\Component\HttpFoundation\Session\Session;
+
+    $session = new Session(new MockArraySessionStorage());
+
+Functional Testing
+~~~~~~~~~~~~~~~~~~
+
+For functional testing where you may need to persist session data across
+separate PHP processes, simply change the storage engine to
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\MockFileSessionStorage`::
+
+    use Symfony\Component\HttpFoundation\Session\Session;
+    use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
+
+    $session = new Session(new MockFileSessionStorage());
+
+PHP 5.4 compatibility
+~~~~~~~~~~~~~~~~~~~~~
+
+Since PHP 5.4.0, :phpclass:`SessionHandler` and :phpclass:`SessionHandlerInterface`
+are available. Symfony 2.1 provides forward compatibility for the :phpclass:`SessionHandlerInterface`
+so it can be used under PHP 5.3. This greatly improves inter-operability with other
+libraries.
+
+:phpclass:`SessionHandler` is a special PHP internal class which exposes native save
+handlers to PHP user-space.
+
+In order to provide a solution for those using PHP 5.4, Symfony2 has a special
+class called :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\NativeSessionHandler`
+which under PHP 5.4, extends from `\SessionHandler` and under PHP 5.3 is just a
+empty base class. This provides some interesting opportunities to leverage
+PHP 5.4 functionality if it is available.
+
+Save Handler Proxy
+~~~~~~~~~~~~~~~~~~
+
+There are two kinds of save handler class proxies which inherit from
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\AbstractProxy`:
+they are :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\NativeProxy`
+and :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\SessionHandlerProxy`.
+
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage`
+automatically injects storage handlers into a save handler proxy unless already
+wrapped by one.
+
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\NativeProxy`
+is used automatically under PHP 5.3 when internal PHP save handlers are specified
+using the `Native*SessionHandler` classes, while
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\SessionHandlerProxy`
+will be used to wrap any custom save handlers, that implement :phpclass:`SessionHandlerInterface`.
+
+Under PHP 5.4 and above, all session handlers implement :phpclass:`SessionHandlerInterface`
+including `Native*SessionHandler` classes which inherit from :phpclass:`SessionHandler`.
+
+The proxy mechanism allow you to get more deeply involved in session save handler
+classes. A proxy for example could be used to encrypt any session transaction
+without knowledge of the specific save handler.
+
+Configuring PHP Sessions
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage`
+can configure most of the PHP ini configuration directives which are documented
+at `php.net/session.configuration`_.
+
+To configure these setting, pass the keys (omitting the initial ``session.`` part
+of the key) as a key-value array to the ``$options`` constructor argument.
+Or set them via the
+:method:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage::setOptions`
+method.
+
+For the sake of clarity, some key options are explained in this documentation.
+
+Session Cookie Lifetime
+~~~~~~~~~~~~~~~~~~~~~~~
+
+For security, session tokens are generally recommended to be sent as session cookies.
+You can configure the lifetime of session cookies by specifying the lifetime
+(in seconds) using the ``cookie_lifetime`` key in the constructor's ``$options``
+argument in :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage`.
+
+Setting a ``cookie_lifetime`` to ``0`` will cause the cookie to live only as
+long as the browser remains open. Generally, ``cookie_lifetime`` would be set to
+a relatively large number of days, weeks or months. It is not uncommon to set
+cookies for a year or more depending on the application.
+
+Since session cookies are just a client-side token, they are less important in
+controlling the fine details of your security settings which ultimately can only
+be securely controlled from the server side.
+
+.. note::
+
+    The ``cookie_lifetime`` setting is the number of seconds the cookie should live
+    for, it is not a Unix timestamp. The resulting session cookie will be stamped
+    with an expiry time of ``time()``+``cookie_lifetime`` where the time is taken
+    from the server.
+
+Configuring Garbage Collection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a session opens, PHP will call the ``gc`` handler randomly according to the
+probability set by ``session.gc_probability`` / ``session.gc_divisor``. For
+example if these were set to ``5/100`` respectively, it would mean a probability
+of 5%. Similarly, ``3/4`` would mean a 3 in 4 chance of being called, i.e. 75%.
+
+If the garbage collection handler is invoked, PHP will pass the value stored in
+the PHP ini directive ``session.gc_maxlifetime`. The meaning in this context is
+that any stored session that was saved more than ``maxlifetime`` ago should be
+deleted. This allows one to expire records based on idle time.
+
+You can configure these settings by passing ``gc_probability``, ``gc_divisor``
+and ``gc_maxlifetime`` in an array to the constructor of
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage`
+or to the :method:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage::setOptions()`
+method.
+
+Session Lifetime
+~~~~~~~~~~~~~~~~
+
+When a new session is created, meaning Symfony2 issues a new session cookie
+to the client, the cookie will be stamped with an expiry time. This is
+calculated by adding the PHP runtime configuration value in
+``session.cookie_lifetime`` with the current server time.
+
+.. note::
+
+    PHP will only issue a cookie once. The client is expected to store that cookie
+    for the entire lifetime. A new cookie will only be issued when the session is
+    destroyed, the browser cookie is deleted, or the session ID is regenerated
+    using the ``migrate()`` or ``invalidate()`` methods of the ``Session`` class.
+
+    The initial cookie lifetime can be set by configuring ``NativeSessionStorage``
+    using the ``setOptions(array('cookie_lifetime' => 1234))`` method.
+
+.. note::
+
+    A cookie lifetime of ``0`` means the cookie expire when the browser is closed.
+
+Session Idle Time/Keep Alive
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are often circumstances where you may want to protect, or minimize
+unauthorized use of a session when a user steps away from their terminal while
+logged in by destroying the session after a certain period of idle time. For
+example, it is common for banking applications to log the user out after just
+5 to 10 minutes of inactivity. Setting the cookie lifetime here is not
+appropriate because that can be manipulated by the client, so we must do the expiry
+on the server side. The easiest way is to implement this via garbage collection
+which runs reasonably frequently. The cookie ``lifetime`` would be set to a
+relatively high value, and the garbage collection ``maxlifetime`` would be set
+to destroy sessions at whatever the desired idle period is.
+
+The other option is to specifically checking if a session has expired after the
+session is started. The session can be destroyed as required. This method of
+processing can allow the expiry of sessions to be integrated into the user
+experience, for example, by displaying a message.
+
+Symfony2 records some basic meta-data about each session to give you complete
+freedom in this area.
+
+Session meta-data
+~~~~~~~~~~~~~~~~~
+
+Sessions are decorated with some basic meta-data to enable fine control over the
+security settings. The session object has a getter for the meta-data,
+:method:`Symfony\\Component\\HttpFoundation\\Session\\Session::getMetadataBag` which
+exposes an instance of :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\MetadataBag`::
+
+    $session->getMetadataBag()->getCreated();
+    $session->getMetadataBag()->getLastUsed();
+
+Both methods return a Unix timestamp (relative to the server).
+
+This meta-data can be used to explicitly expire a session on access, e.g.::
+
+    $session->start();
+    if (time() - $session->getMetadataBag()->getLastUpdate() > $maxIdleTime) {
+        $session->invalidate();
+        throw new SessionExpired(); // redirect to expired session page
+    }
+
+It is also possible to tell what the ``cookie_lifetime`` was set to for a
+particular cookie by reading the ``getLifetime()`` method::
+
+    $session->getMetadataBag()->getLifetime();
+
+The expiry time of the cookie can be determined by adding the created
+timestamp and the lifetime.
+
+.. _`php.net/session.customhandler`: http://php.net/session.customhandler
+.. _`php.net/session.configuration`: http://php.net/session.configuration

--- a/cookbook/logging/channels_handlers.rst
+++ b/cookbook/logging/channels_handlers.rst
@@ -1,0 +1,88 @@
+.. index::
+   single: Logging
+
+How to log Messages to different Files
+======================================
+
+.. versionadded:: 2.1
+    The ability to specify channels for a specific handler was added to
+    the MonologBundle for Symfony 2.1.
+
+The Symfony Standard Edition contains a bunch of channels for logging: ``doctrine``,
+``event``, ``security`` and ``request``. Each channel corresponds to a logger
+service (``monolog.logger.XXX``) in the container and is injected to the
+concerned service. The purpose of channels is to be able to organize different
+types of log messages.
+
+By default, Symfony2 logs every messages into a single file (regardless of
+the channel).
+
+Switching a Channel to a different Handler
+------------------------------------------
+
+Now, suppose you want to log the ``doctrine`` channel to a different file.
+
+To do so, just create a new handler and configure it like this:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        monolog:
+            handlers:
+                main:
+                    type: stream
+                    path: /var/log/symfony.log
+                    channels: !doctrine
+                doctrine:
+                    type: stream
+                    path: /var/log/doctrine.log
+                    channels: doctrine
+
+    .. code-block:: xml
+
+        <monolog:config>
+            <monolog:handlers>
+                <monolog:handler name="main" type="stream" path="/var/log/symfony.log">
+                    <monolog:channels>
+                        <type>exclusive</type>
+                        <channel>doctrine</channel>
+                    </monolog:channels>
+                </monolog:handler>
+
+                <monolog:handler name="doctrine" type="stream" path="/var/log/doctrine.log" />
+                    <monolog:channels>
+                        <type>inclusive</type>
+                        <channel>doctrine</channel>
+                    </monolog:channels>
+                </monolog:handler>
+            </monolog:handlers>
+        </monolog:config>
+
+Yaml specification
+------------------
+
+You can specify the configuration by many forms:
+
+.. code-block:: yaml
+
+    channels: ~    # Include all the channels
+
+    channels: foo  # Include only channel "foo"
+    channels: !foo # Include all channels, except "foo"
+
+    channels: [foo, bar]   # Include only channels "foo" and "bar"
+    channels: [!foo, !bar] # Include all channels, except "foo" and "bar"
+
+    channels:
+        type:     inclusive # Include only those listed below
+        elements: [ foo, bar ]
+    channels:
+        type:     exclusive # Include all, except those listed below
+        elements: [ foo, bar ]
+
+
+Learn more from the Cookbook
+----------------------------
+
+* :doc:`/cookbook/logging/monolog`

--- a/cookbook/security/target_path.rst
+++ b/cookbook/security/target_path.rst
@@ -1,0 +1,68 @@
+.. index::
+   single: Security; Target redirect path
+
+How to change the Default Target Path Behavior
+==============================================
+
+By default, the security component retains the information of the last request
+URI in a session variable named ``_security.target_path``. Upon a successful
+login, the user is redirected to this path, as to help her continue from
+the last known page she visited.
+
+On some occasions, this is unexpected. For example when the last request
+URI was an HTTP POST against a route which is configured to allow only a POST
+method, the user is redirected to this route only to get a 404 error.
+
+To get around this behavior, you would simply need to extend the ``ExceptionListener``
+class and override the default method named ``setTargetPath()``.
+
+First, override the ``security.exception_listener.class`` parameter in your
+configuration file. This can be done from your main configuration file (in
+`app/config`) or from a configuration file being imported from a bundle:
+
+.. configuration-block::
+
+        .. code-block:: yaml
+
+            # src/Acme/HelloBundle/Resources/config/services.yml
+            parameters:
+                # ...
+                security.exception_listener.class: Acme\HelloBundle\Security\Firewall\ExceptionListener
+
+        .. code-block:: xml
+
+            <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
+            <parameters>
+                <!-- ... -->
+                <parameter key="security.exception_listener.class">Acme\HelloBundle\Security\Firewall\ExceptionListener</parameter>
+            </parameters>
+
+        .. code-block:: php
+
+            // src/Acme/HelloBundle/Resources/config/services.php
+            // ...
+            $container->setParameter('security.exception_listener.class', 'Acme\HelloBundle\Security\Firewall\ExceptionListener');
+
+Next, create your own ``ExceptionListener``::
+
+    // src/Acme/HelloBundle/Security/Firewall/ExceptionListener.php
+    namespace Acme\HelloBundle\Security\Firewall;
+
+    use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\Security\Http\Firewall\ExceptionListener as BaseExceptionListener;
+
+    class ExceptionListener extends BaseExceptionListener
+    {
+        protected function setTargetPath(Request $request)
+        {
+            // Do not save target path for XHR and non-GET requests
+            // You can add any more logic here you want
+            if ($request->isXmlHttpRequest() || 'GET' !== $request->getMethod()) {
+                return;
+            }
+
+            $request->getSession()->set('_security.target_path', $request->getUri());
+        }
+    }
+
+Add as much or few logic here as required for your scenario!

--- a/reference/constraints/Size.rst
+++ b/reference/constraints/Size.rst
@@ -1,0 +1,101 @@
+Size
+====
+
+Validates that a given number is *between* some minimum and maximum number.
+
++----------------+--------------------------------------------------------------------+
+| Applies to     | :ref:`property or method<validation-property-target>`              |
++----------------+--------------------------------------------------------------------+
+| Options        | - `min`_                                                           |
+|                | - `max`_                                                           |
+|                | - `minMessage`_                                                    |
+|                | - `maxMessage`_                                                    |
+|                | - `invalidMessage`_                                                |
++----------------+--------------------------------------------------------------------+
+| Class          | :class:`Symfony\\Component\\Validator\\Constraints\\Size`          |
++----------------+--------------------------------------------------------------------+
+| Validator      | :class:`Symfony\\Component\\Validator\\Constraints\\SizeValidator` |
++----------------+--------------------------------------------------------------------+
+
+Basic Usage
+-----------
+
+To verify that the "height" field of a class is between "120" and "180", you might add
+the following:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # src/Acme/EventBundle/Resources/config/validation.yml
+        Acme\EventBundle\Entity\Participant:
+            properties:
+                height:
+                    - Size:
+                        min: 120
+                        max: 180
+                        minMessage: You must be at least 120cm tall to enter
+                        maxMessage: You cannot be taller than 180cm to enter
+
+    .. code-block:: php-annotations
+
+        // src/Acme/EventBundle/Entity/Participant.php
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Participant
+        {
+            /**
+             * @Assert\Size(
+             *      min = "120",
+             *      max = "180",
+             *      minMessage = "You must be at least 120cm tall to enter",
+             *      maxMessage="You cannot be taller than 180cm to enter"
+             * )
+             */
+             protected $height;
+        }
+
+Options
+-------
+
+min
+~~~
+
+**type**: ``integer`` [:ref:`default option<validation-default-option>`]
+
+This required option is the "min" value. Validation will fail if the given
+value is **less** than this min value.
+
+max
+~~~
+
+**type**: ``integer`` [:ref:`default option<validation-default-option>`]
+
+This required option is the "max" value. Validation will fail if the given
+value is **greater** than this max value.
+
+minMessage
+~~~~~~~~~~
+
+**type**: ``string`` **default**: ``This value should be {{ limit }} or more.``
+
+The message that will be shown if the underlying value is less than the `min`_
+option.
+
+maxMessage
+~~~~~~~~~~
+
+**type**: ``string`` **default**: ``This value should be {{ limit }} or less.``
+
+The message that will be shown if the underlying value is more than the `max`_
+option.
+
+invalidMessage
+~~~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``This value should be a valid number.``
+
+The message that will be shown if the underlying value is not a number (per
+the `is_numeric`_ PHP function).
+
+.. _`is_numeric`: http://www.php.net/manual/en/function.is-numeric.php

--- a/reference/constraints/SizeLength.rst
+++ b/reference/constraints/SizeLength.rst
@@ -1,0 +1,114 @@
+SizeLength
+==========
+
+Validates that a given string length is *between* some minimum and maximum value according to the provided charset.
+
++----------------+--------------------------------------------------------------------------+
+| Applies to     | :ref:`property or method<validation-property-target>`                    |
++----------------+--------------------------------------------------------------------------+
+| Options        | - `min`_                                                                 |
+|                | - `max`_                                                                 |
+|                | - `charset`_                                                             |
+|                | - `minMessage`_                                                          |
+|                | - `maxMessage`_                                                          |
+|                | - `exactMessage`_                                                        |
++----------------+--------------------------------------------------------------------------+
+| Class          | :class:`Symfony\\Component\\Validator\\Constraints\\SizeLength`          |
++----------------+--------------------------------------------------------------------------+
+| Validator      | :class:`Symfony\\Component\\Validator\\Constraints\\SizeLengthValidator` |
++----------------+--------------------------------------------------------------------------+
+
+Basic Usage
+-----------
+
+To verify that the ``firstName`` field length of a class is between "2" and
+"50", you might add the following:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # src/Acme/EventBundle/Resources/config/validation.yml
+        Acme\EventBundle\Entity\Height:
+            properties:
+                firstName:
+                    - SizeLength:
+                        min: 2
+                        max: 50
+                        minMessage: Your first name must be at least 2 characters length
+                        maxMessage: Your first name cannot be longer than than 50 characters length
+
+    .. code-block:: php-annotations
+
+        // src/Acme/EventBundle/Entity/Participant.php
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Participant
+        {
+            /**
+             * @Assert\SizeLength(
+             *      min = "2",
+             *      max = "50",
+             *      minMessage = "Your first name must be at least 2 characters length",
+             *      maxMessage="Your first name cannot be longer than than 50 characters length"
+             * )
+             */
+             protected $firstName;
+        }
+
+Options
+-------
+
+min
+~~~
+
+**type**: ``integer`` [:ref:`default option<validation-default-option>`]
+
+This required option is the "min" length value. Validation will fail if the given
+value's length is **less** than this min value.
+
+max
+~~~
+
+**type**: ``integer`` [:ref:`default option<validation-default-option>`]
+
+This required option is the "max" length value. Validation will fail if the given
+value's length is **greater** than this max value.
+
+charset
+~~~~~~~
+
+**type**: ``string``  **default**: ``UTF-8``
+
+The charset to be used when computing value's length. The `grapheme_strlen`_ PHP
+function is used if available. If not, the the `mb_strlen`_ PHP function
+is used if available. If neither are available, the `strlen`_ PHP function
+is used.
+
+.. _`grapheme_strlen`: http://www.php.net/manual/en/function.grapheme_strlen.php
+.. _`mb_strlen`: http://www.php.net/manual/en/function.mb_strlen.php
+.. _`strlen`: http://www.php.net/manual/en/function.strlen.php
+
+minMessage
+~~~~~~~~~~
+
+**type**: ``string`` **default**: ``This value is too short. It should have {{ limit }} characters or more.``
+
+The message that will be shown if the underlying value's length is less than the `min`_
+option.
+
+maxMessage
+~~~~~~~~~~
+
+**type**: ``string`` **default**: ``This value is too long. It should have {{ limit }} characters or less.``
+
+The message that will be shown if the underlying value's length is more than the `max`_
+option.
+
+exactMessage
+~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``This value should have exactly {{ limit }} characters.``
+
+The message that will be shown if min and max values are equal and the underlying
+value's length is not exactly this value.

--- a/reference/constraints/UserPassword.rst
+++ b/reference/constraints/UserPassword.rst
@@ -1,0 +1,75 @@
+UserPassword
+============
+
+.. versionadded:: 2.1
+
+   This constraint is new in version 2.1.
+
+This validates that an input value is equal to the current authenticated
+user's password. This is useful in a form where a user can change his password,
+but needs to enter his old password for security.
+
+.. note::
+
+    This should **not** be used validate a login form, since this is done
+    automatically by the security system.
+
+When applied to an array (or Traversable object), this constraint allows
+you to apply a collection of constraints to each element of the array.
+
++----------------+----------------------------------------------------------------------------------------+
+| Applies to     | :ref:`property or method<validation-property-target>`                                  |
++----------------+----------------------------------------------------------------------------------------+
+| Options        | - `message`_                                                                           |
++----------------+----------------------------------------------------------------------------------------+
+| Class          | :class:`Symfony\\Component\\Validator\\Constraints\\UserPassword`                      |
++----------------+----------------------------------------------------------------------------------------+
+| Validator      | :class:`Symfony\\Bundle\\SecurityBundle\\Validator\\Constraint\\UserPasswordValidator` |
++----------------+----------------------------------------------------------------------------------------+
+
+Basic Usage
+-----------
+
+Suppose you have a `PasswordChange` class, that's used in a form where the
+user can change his password by entering his old password and a new password.
+This constraint will validate that the old password matches the user's current
+password:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # src/UserBundle/Resources/config/validation.yml
+        Acme\UserBundle\Form\Model\ChangePassword:
+            properties:
+                oldPassword:
+                    - UserPassword:
+                        message: "Wrong value for your current password"
+
+    .. code-block:: php-annotations
+
+       // src/Acme/UserBundle/Form/Model/ChangePassword.php
+       namespace Acme\UserBundle\Form\Model;
+       
+       use Symfony\Component\Validator\Constraints as Assert;
+
+       class ChangePassword
+       {
+           /**
+            * @Assert\UserPassword(
+            *     message = "Wrong value for your current password"
+            * )
+            */
+            protected $oldPassword;
+       }
+
+Options
+-------
+
+message
+~~~~~~~
+
+**type**: ``message`` **default**: ``This value should be the user current password``
+
+This is the message that's displayed when the underlying string does *not*
+match the current user's password.

--- a/reference/forms/types/options/translation_domain.rst.inc
+++ b/reference/forms/types/options/translation_domain.rst.inc
@@ -1,0 +1,7 @@
+translation_domain
+~~~~~~~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``messages``
+
+This is the translation domain that will be used for any labels or options
+that are rendered for this field.


### PR DESCRIPTION
Added information on how to prevent using reserved sql words while keeping your model the same.

This was solution didn't appear to me when I was initally reading the docs, so I think it should be mentioned, since it is in my view a much better solution than escaping reserved words, which is [discouraged](http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/basic-mapping.html#quoting-reserved-words).
