### PR TITLE
Fixed session table create statement for PGSQL

### DIFF
--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -188,5 +188,5 @@ For PostgreSQL, the statement should look like this:
         session_id character varying(255) NOT NULL,
         session_value text NOT NULL,
         session_time integer NOT NULL,
-        CONSTRAINT session_pkey PRIMARY KEY (session_id),
+        CONSTRAINT session_pkey PRIMARY KEY (session_id)
     );


### PR DESCRIPTION
In postgresql you cannot have a comma at the end of your db create statement or you get syntax error at or near ")"

Fix attached.
