### PR TITLE
New requirements PHP 5.3.3

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -20,7 +20,7 @@ Downloading a Symfony2 Distribution
 .. tip::
 
     First, check that you have installed and configured a Web server (such
-    as Apache) with PHP 5.3.2 or higher. For more information on Symfony2
+    as Apache) with PHP 5.3.3 or higher. For more information on Symfony2
     requirements, see the :doc:`requirements reference</reference/requirements>`.
     For information on configuring your specific web server document root, see the
     following documentation: `Apache`_ | `Nginx`_ .

--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -14,7 +14,7 @@ Before working on Symfony2, setup a friendly environment with the following
 software:
 
 * Git;
-* PHP version 5.3.2 or above;
+* PHP version 5.3.3 or above;
 * PHPUnit 3.6.4 or above.
 
 Configure Git

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -17,7 +17,7 @@ Downloading Symfony2
 --------------------
 
 First, check that you have installed and configured a Web server (such as
-Apache) with PHP 5.3.2 or higher.
+Apache) with PHP 5.3.3 or higher.
 
 Ready? Start by downloading the "`Symfony2 Standard Edition`_", a Symfony
 :term:`distribution` that is preconfigured for the most common use cases and

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -19,7 +19,7 @@ Below is the list of required and optional requirements.
 Required
 --------
 
-* PHP needs to be a minimum version of PHP 5.3.2
+* PHP needs to be a minimum version of PHP 5.3.3
 * JSON needs to be enabled
 * ctype needs to be enabled
 * Your PHP.ini needs to have the date.timezone setting


### PR DESCRIPTION
Symfony 2.1 updated its minimum required PHP version to 5.3.3.
http://symfony.com/blog/a-week-of-symfony-280-7-13-may-2012

My Community Account: sfcoder
