### PR TITLE
Typo: Use PHP docblock instead of XML

### DIFF
--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -143,7 +143,7 @@ parameter.ini by referencing the database-related parameters defined there:
             <argument>%database_password%</argument>
         </service>
 
-    .. code-block:: xml
+    .. code-block:: php
 
         $pdoDefinition = new Definition('PDO', array(
             'mysql:dbname=%database_name%',


### PR DESCRIPTION
The second code example at http://symfony.com/doc/current/cookbook/configuration/pdo_session_storage.html uses XML docblock instead of PHP as third code snippet. The code itself is PHP, only the docblock type is wrong.
