### PR TITLE
Improving reserved sql words section part 2

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -251,7 +251,7 @@ see the :ref:`book-doctrine-field-types` section.
     `Reserved SQL keywords documentation`_ on how to properly escape these
     names. Alternatively, if you're free to choose your database schema,
     simply map to a different table name or column name. See Doctrine's
-    `Persistent classes`_ and `Property Mapping`_ documentation. test
+    `Persistent classes`_ and `Property Mapping`_ documentation.
 
 .. note::
 

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -249,7 +249,9 @@ see the :ref:`book-doctrine-field-types` section.
     class name is ``Group``, then, by default, your table name will be ``group``,
     which will cause an SQL error in some engines. See Doctrine's
     `Reserved SQL keywords documentation`_ on how to properly escape these
-    names.
+    names. Alternatively, if you're free to choose your database schema,
+    simply map to a different table name or column name. See Doctrine's 
+    `Persistent classes`_ and `Property Mapping`_ documentation.
 
 .. note::
 
@@ -1384,3 +1386,5 @@ For more information about Doctrine, see the *Doctrine* section of the
 .. _`Property Mapping documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/basic-mapping.html#property-mapping
 .. _`Lifecycle Events documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/events.html#lifecycle-events
 .. _`Reserved SQL keywords documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/basic-mapping.html#quoting-reserved-words
+.. _`Persistent classes`: http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/basic-mapping.html#persistent-classes
+.. _`Property Mapping`: http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/basic-mapping.html#property-mapping

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -250,8 +250,8 @@ see the :ref:`book-doctrine-field-types` section.
     which will cause an SQL error in some engines. See Doctrine's
     `Reserved SQL keywords documentation`_ on how to properly escape these
     names. Alternatively, if you're free to choose your database schema,
-    simply map to a different table name or column name. See Doctrine's 
-    `Persistent classes`_ and `Property Mapping`_ documentation.
+    simply map to a different table name or column name. See Doctrine's
+    `Persistent classes`_ and `Property Mapping`_ documentation. test
 
 .. note::
 


### PR DESCRIPTION
Retry:

Added information on how to prevent using reserved sql words while keeping your model the same.

This was solution didn't appear to me when I was initally reading the docs, so I think it should be mentioned, since it is in my view a much better solution than escaping reserved words, which is [discouraged](http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/basic-mapping.html#quoting-reserved-words).

Original pull request: https://github.com/symfony/symfony-docs/pull/1361
