### PR TITLE
Fixed the location of find method

### DIFF
--- a/components/console.rst
+++ b/components/console.rst
@@ -345,7 +345,7 @@ Calling a command from another one is straightforward::
         // ...
     }
 
-First, you :method:`Symfony\\Component\\Console\\Command\\Command::find` the
+First, you :method:`Symfony\\Component\\Console\\Application::find` the
 command you want to execute by passing the command name.
 
 Then, you need to create a new


### PR DESCRIPTION
The location of Application's find method was wrong. Fixed it.

I have also noticed that method links to API are not being generated properly, for example:

`http://api.symfony.com/2.0/Symfony/Component/Console/Application.html#find()`

should be as follows:

`http://api.symfony.com/2.0/Symfony/Component/Console/Application.html#method_find`

Maybe @fabpot can do something on this.
