### PR TITLE
[Contributing] Improved CS

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -58,7 +58,7 @@ example containing most features described below:
                 return;
             }
             if ('string' === $dummy) {
-                if (mergedOptions['some_default'] === 'values') {
+                if ('values' === $mergedOptions['some_default']) {
                     $dummy = substr($dummy, 0, 5);
                 } else {
                     $dummy = ucwords($dummy);

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -57,9 +57,13 @@ example containing most features described below:
             if (true === $dummy) {
                 return;
             }
-            if ('string' === $dummy && mergedOptions['some_default'] === 'values') {
-                $dummy = substr($dummy, 0, 5);
-            }
+            if ('string' === $dummy) {
+                if (mergedOptions['some_default'] === 'values') {
+                    $dummy = substr($dummy, 0, 5);
+                } else {
+                    $dummy = ucwords($dummy);
+                }
+            } 
 
             return $dummy;
         }

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -30,30 +30,34 @@ example containing most features described below:
 
     namespace Acme;
 
-    class Foo
+    class FooBar
     {
         const SOME_CONST = 42;
 
-        private $foo;
+        private $fooBar;
 
         /**
          * @param string $dummy Some argument description
          */
         public function __construct($dummy)
         {
-            $this->foo = $this->transform($dummy);
+            $this->fooBar = $this->transform($dummy);
         }
 
         /**
          * @param string $dummy Some argument description
          * @return string|null Transformed input
          */
-        private function transform($dummy)
+        private function transformText($dummy, $options = array())
         {
+            $mergedOptions = array_merge($options, array(
+                'some_default' => 'values',
+            ));
+
             if (true === $dummy) {
                 return;
             }
-            if ('string' === $dummy) {
+            if ('string' === $dummy && mergedOptions['some_default'] === 'values') {
                 $dummy = substr($dummy, 0, 5);
             }
 

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -82,9 +82,6 @@ Structure
 * Use braces to indicate control structure body regardless of the number of
   statements it contains;
 
-* Declare visibility explicitly for class, methods, and properties (usage of
-  `var` is prohibited);
-
 * Define one class per file - this does not apply to private helper classes
   that are not intended to be instantiated from the outside and thus are not
   concerned by the PSR-0 standard;


### PR DESCRIPTION
I have done some code improvements to the coding standards:
- Added camelCase, StudlyCase and underscores in the example (as requested in [this PR comment](https://github.com/symfony/symfony-docs/pull/1126#issuecomment-5397514))
- Added example with `if ... else` statements, because it is not clear if the `else` needs to be on a new line or not
- Removed the visibility rules, because it is in the PSR-2 rules ([4.2](https://github.com/pmjones/fig-standards/blob/psr-1-style-guide/proposed/PSR-2-advanced.md#42-properties) and [4.3](https://github.com/pmjones/fig-standards/blob/psr-1-style-guide/proposed/PSR-2-advanced.md#43-methods))
