### PR TITLE
Fix minor typo in Routing chapter of the Book

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -88,7 +88,7 @@ pattern that points to a specific PHP class and method:
     {
         public function showAction($slug)
         {
-            $blog = // use the $slug varible to query the database
+            $blog = // use the $slug variable to query the database
             
             return $this->render('AcmeBlogBundle:Blog:show.html.twig', array(
                 'blog' => $blog,


### PR DESCRIPTION
"varible" has been changed to "variable".
This is by the way my first pull request on the Symfony2 documentation, I hope everything's allright!
