### PR TITLE
Fixes to the code in __Using Lifecycle Callbacks__

### DIFF
--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -268,8 +268,8 @@ Next, refactor the ``Document`` class to take advantage of these callbacks::
         }
 
         /**
-         * @ORM\PostPersist()
-         * @ORM\PostUpdate()
+         * @ORM\PrePersist()
+         * @ORM\PreUpdate()
          */
         public function upload()
         {
@@ -290,8 +290,8 @@ Next, refactor the ``Document`` class to take advantage of these callbacks::
          */
         public function removeUpload()
         {
-            if ($file = $this->getAbsolutePath()) {
-                unlink($file);
+            if ($this->$file = $this->getAbsolutePath()) {
+                unlink($this->$file);
             }
         }
     }


### PR DESCRIPTION
- When persisting an entity with a file, the Upload event must be triggered before persisting.
- In the @ORM\PostRemove function $file was not known (the correct var is actually $this->file).
