### PR TITLE
form_theme form _self not for parentless templates

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -1275,6 +1275,17 @@ to define form output.
     this method to quickly make form output customizations that will only
     ever be needed in a single template.
 
+    .. caution::
+
+        Templates that do not make use of the extends tag and thereby become 
+        a child of another template will have all of their blocks executed 
+        the moment they are rendered. This has the side-effect of preventing 
+        form_theme from having access to blocks you may be attempting to use 
+        when overriding the default form blocks.
+        
+        In practice, {% form_theme form _self %} should only be used by templates 
+        that do extend a base template.
+
 PHP
 ...
 


### PR DESCRIPTION
Addressing issue brought up as pull request #1044
