### PR TITLE
Updated the doc for symfony/symfony#4497

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -275,7 +275,7 @@ document::
         // Assert that the response status code is 404
         $this->assertTrue($client->getResponse()->isNotFound());
         // Assert a specific 200 status code
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertEquals(200, $client->getResponse()->getStatus());
 
         // Assert that the response is a redirect to /demo/contact
         $this->assertTrue($client->getResponse()->isRedirect('/demo/contact'));

--- a/cookbook/testing/insulating_clients.rst
+++ b/cookbook/testing/insulating_clients.rst
@@ -13,7 +13,7 @@ chat for instance), create several Clients::
     $harry->request('POST', '/say/sally/Hello');
     $sally->request('GET', '/messages');
 
-    $this->assertEquals(201, $harry->getResponse()->getStatusCode());
+    $this->assertEquals(201, $harry->getResponse()->getStatus());
     $this->assertRegExp('/Hello/', $sally->getResponse()->getContent());
 
 This works except when your code maintains a global state or if it depends on
@@ -29,7 +29,7 @@ can insulate your clients::
     $harry->request('POST', '/say/sally/Hello');
     $sally->request('GET', '/messages');
 
-    $this->assertEquals(201, $harry->getResponse()->getStatusCode());
+    $this->assertEquals(201, $harry->getResponse()->getStatus());
     $this->assertRegExp('/Hello/', $sally->getResponse()->getContent());
 
 Insulated clients transparently execute their requests in a dedicated and


### PR DESCRIPTION
The response returned by `getResponse` is now the BrowserKit Response (as specified in the phpdoc) instead of the HttpFoundation Response.
