### PR TITLE
Extra piece of code was deleted.

### DIFF
--- a/components/dependency_injection/introduction.rst
+++ b/components/dependency_injection/introduction.rst
@@ -294,10 +294,6 @@ configuration. The ``PhpDumper`` makes dumping the compiled container easy::
     use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
     use Symfony\Component\DependencyInjection\Dumper\PhpDumper
 
-    $container = new ContainerBuilder();
-    $loader = new XmlFileLoader($container, new FileLocator(__DIR__));
-    $loader->load('services.xml');
-
     $file = __DIR__ .'/cache/container.php';
 
     if (file_exists($file)) {


### PR DESCRIPTION
Piece of code:

$container = new ContainerBuilder();
$loader = new XmlFileLoader($container, new FileLocator(**DIR**));
$loader->load('services.xml');

is extra. It should be deleted.
