### PR TITLE
[constraints] added link to mime-type reference

### DIFF
--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -171,6 +171,8 @@ If set, the validator will check that the mime type of the underlying file
 is equal to the given mime type (if a string) or exists in the collection
 of given mime types (if an array).
 
+You can find a list of existing mime types on the `IANA website`_
+
 maxSizeMessage
 ~~~~~~~~~~~~~~
 
@@ -227,3 +229,6 @@ uploadErrorMessage
 The message that is displayed if the uploaded file could not be uploaded
 for some unknown reason, such as the file upload failed or it couldn't be written
 to disk.
+
+
+.. _`IANA website`: http://www.iana.org/assignments/media-types/index.html

--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -19,7 +19,12 @@ mimeTypes
 
 **type**: ``array`` or ``string`` **default**: an array of jpg, gif and png image mime types
 
+You can find a list of existing image mime types on the `IANA website`_
+
 mimeTypesMessage
 ~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This file is not a valid image``
+
+
+.. _`IANA website`: http://www.iana.org/assignments/media-types/image/index.html


### PR DESCRIPTION
Added links to the IANA website for a reference of existing mime-types for the file and image constraints.

@weaverryan I have no clue why but it seems the 2.0 branch was nowhere to be found on my fork. I re-forked everything and based the changes on the 2.0 branch with this new PR.
