### PR TITLE
Fixed syntax

### DIFF
--- a/cookbook/doctrine/event_listeners_subscribers.rst
+++ b/cookbook/doctrine/event_listeners_subscribers.rst
@@ -92,7 +92,7 @@ a ``postPersist`` method, which will be called when the event is thrown::
         public function postPersist(LifecycleEventArgs $args)
         {
             $entity = $args->getEntity();
-            $entityManager = $args->getManager();
+            $entityManager = $args->getEntityManager();
             
             // perhaps you only want to act on some "Product" entity
             if ($entity instanceof Product) {


### PR DESCRIPTION
cookbook/doctrine/event_listeners_subscribers.rst

$entityManager = $args->getManager();
to
$entityManager = $args->getEntityManager();
