### PR TITLE
[Coding Standards] Add psr links

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -9,7 +9,7 @@ follow the same guidelines, and you should too.
 Remember that the main advantage of standards is that every piece of code
 looks and feels familiar, it's not about this or that being more readable.
 
-Symfony follows the standards defined in the PSR-0, PSR-1, and PSR-2
+Symfony follows the standards defined in the `PSR-0`_, `PSR-1`_, and `PSR-2`_
 documents.
 
 Since a picture - or some code - is worth a thousand words, here's a short
@@ -121,3 +121,7 @@ License
 
 * Symfony is released under the MIT license, and the license block has to be
   present at the top of every PHP file, before the namespace.
+
+.. `PSR-0`: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
+.. `PSR-1`: https://github.com/pmjones/fig-standards/blob/psr-1-style-guide/proposed/PSR-1-basic.md
+.. `PSR-2`: https://github.com/pmjones/fig-standards/blob/psr-1-style-guide/proposed/PSR-2-advanced.md

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -123,5 +123,5 @@ License
   present at the top of every PHP file, before the namespace.
 
 .. _`PSR-0`: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
-.. _`PSR-1`: https://github.com/pmjones/fig-standards/blob/psr-1-style-guide/proposed/PSR-1-basic.md
-.. _`PSR-2`: https://github.com/pmjones/fig-standards/blob/psr-1-style-guide/proposed/PSR-2-advanced.md
+.. _`PSR-1`: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
+.. _`PSR-2`: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -122,6 +122,6 @@ License
 * Symfony is released under the MIT license, and the license block has to be
   present at the top of every PHP file, before the namespace.
 
-.. `PSR-0`: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
-.. `PSR-1`: https://github.com/pmjones/fig-standards/blob/psr-1-style-guide/proposed/PSR-1-basic.md
-.. `PSR-2`: https://github.com/pmjones/fig-standards/blob/psr-1-style-guide/proposed/PSR-2-advanced.md
+.. _`PSR-0`: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
+.. _`PSR-1`: https://github.com/pmjones/fig-standards/blob/psr-1-style-guide/proposed/PSR-1-basic.md
+.. _`PSR-2`: https://github.com/pmjones/fig-standards/blob/psr-1-style-guide/proposed/PSR-2-advanced.md


### PR DESCRIPTION
I have added PSR links in the coding standards. This makes it a lot easier for beginner to find, and follow, the PSR-0, PSR-1 and PSR-2 standards.
