### PR TITLE
Fixed documentation of collection prototype

### DIFF
--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -311,13 +311,13 @@ new "tag" forms. To render it, make the following change to your template:
 
     .. code-block:: html+jinja
     
-        <ul class="tags" data-prototype="{{ form_widget(form.tags.get('prototype')) | e }}">
+        <ul class="tags" data-prototype="{{ form_widget(form.tags.getVar('prototype')) | e }}">
             ...
         </ul>
     
     .. code-block:: html+php
     
-        <ul class="tags" data-prototype="<?php echo $view->escape($view['form']->row($form['tags']->get('prototype'))) ?>">
+        <ul class="tags" data-prototype="<?php echo $view->escape($view['form']->row($form['tags']->getVar('prototype'))) ?>">
             ...
         </ul>
 
@@ -329,7 +329,7 @@ new "tag" forms. To render it, make the following change to your template:
 
 .. tip::
 
-    The ``form.tags.get('prototype')`` is form element that looks and feels just
+    The ``form.tags.getVar('prototype')`` is form element that looks and feels just
     like the individual ``form_widget(tag)`` elements inside our ``for`` loop.
     This means that you can call ``form_widget``, ``form_row``, or ``form_label``
     on it. You could even choose to render only one of its fields (e.g. the
@@ -337,7 +337,11 @@ new "tag" forms. To render it, make the following change to your template:
     
     .. code-block:: html+jinja
     
-        {{ form_widget(form.tags.get('prototype').name) | e }}
+        {{ form_widget(form.tags.getVar('prototype').name) | e }}
+
+    .. versionadded:: 2.1
+        Prototype is accessed as ``form.tags.getVar('prototype')`` instead of ``form.tags.get('prototype')`` in Symfony 2.1
+
 
 On the rendered page, the result will look something like this:
 

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -146,7 +146,7 @@ you need is the JavaScript:
             {# ... #}
 
             {# store the prototype on the data-prototype attribute #}
-            <ul id="email-fields-list" data-prototype="{{ form_widget(form.emails.get('prototype')) | e }}">
+            <ul id="email-fields-list" data-prototype="{{ form_widget(form.emails.getVar('prototype')) | e }}">
             {% for emailField in form.emails %}
                 <li>
                     {{ form_errors(emailField) }}
@@ -295,11 +295,11 @@ collection field:
 
     .. code-block:: jinja
     
-        {{ form_row(form.emails.get('prototype')) }}
+        {{ form_row(form.emails.getVar('prototype')) }}
 
     .. code-block:: php
     
-        <?php echo $view['form']->row($form['emails']->get('prototype')) ?>
+        <?php echo $view['form']->row($form['emails']->getVar('prototype')) ?>
 
 Note that all you really need is the "widget", but depending on how you're
 rendering your form, having the entire "form row" may be easier for you.


### PR DESCRIPTION
Since symfony/symfony@98a7c0cf5f6ad34092f4c7eed90775889ed18f5b, collection prototypes are accessed as `form.tags.getVar('prototype')` instead of `form.tags.get('prototype')`.
