### PR TITLE
During String to Object transform, addModelTransformer should be used instead 

### DIFF
--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -65,6 +65,35 @@ was entered::
         }
     }
 
+.. tip::
+
+    You can also use transformers without creating a new custom form type
+    by calling ``addModelTransformer`` on any field builder::
+
+        use Symfony\Component\Form\FormBuilderInterface;
+        use Acme\TaskBundle\Form\DataTransformer\IssueToNumberTransformer;
+
+        class TaskType extends AbstractType
+        {
+            public function buildForm(FormBuilderInterface $builder, array $options)
+            {
+                // ...
+
+                // this assumes that the entity manager was passed in as an option
+                $entityManager = $options['em'];
+                $transformer = new IssueToNumberTransformer($entityManager);
+
+                // use a normal text field, but transform the text into an issue object
+                $builder
+                    ->add(
+                        $builder->create('issue', 'text')
+                            ->addModelTransformer($transformer)
+                );
+            }
+
+            // ...
+        }
+
 Next, we create the data transformer, which does the actual conversion::
 
     // src/Acme/TaskBundle/Form/DataTransformer/IssueToNumberTransformer.php

--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -51,7 +51,7 @@ was entered::
         public function buildForm(FormBuilderInterface $builder, array $options)
         {
             $transformer = new IssueToNumberTransformer($this->om);
-            $builder->addViewTransformer($transformer);
+            $builder->addModelTransformer($transformer);
         }
 
         public function getParent()
@@ -64,34 +64,6 @@ was entered::
             return 'issue_selector';
         }
     }
-
-.. tip::
-
-    You can also use transformers without creating a new custom form type
-    by calling ``appendClientTransformer`` on any field builder::
-
-        use Symfony\Component\Form\FormBuilderInterface;
-        use Acme\TaskBundle\Form\DataTransformer\IssueToNumberTransformer;
-
-        class TaskType extends AbstractType
-        {
-            public function buildForm(FormBuilderInterface $builder, array $options)
-            {
-                // ...
-
-                // this assumes that the entity manager was passed in as an option
-                $entityManager = $options['em'];
-                $transformer = new IssueToNumberTransformer($entityManager);
-
-                // use a normal text field, but transform the text into an issue object
-                $builder
-                    ->add('issue', 'text')
-                    ->addViewTransformer($transformer)
-                ;
-            }
-
-            // ...
-        }
 
 Next, we create the data transformer, which does the actual conversion::
 


### PR DESCRIPTION
In the docs' example, it is doing a transform form String to Object. While suppose `addViewTransformers` is for Form to View. 

_suggested by merk on IRC_
- the tips is removed, since it doesn't work for current master version (not so sure is it a bug or deprecated behavior)
