### PR TITLE
[Book/Propel] Add codeblock in 'code along with the example'

### DIFF
--- a/book/propel.rst
+++ b/book/propel.rst
@@ -18,8 +18,11 @@ persist it to the database and fetch it back out.
 .. sidebar:: Code along with the example
 
     If you want to follow along with the example in this chapter, create an
-    ``AcmeStoreBundle`` via: ``php app/console generate:bundle
-    --namespace=Acme/StoreBundle``.
+    ``AcmeStoreBundle`` via: 
+    
+    .. code-block:: bash
+
+        php app/console generate:bundle --namespace=Acme/StoreBundle
 
 Configuring the Database
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I have added a codeblock in the propel documentation like the Doctrine documentation.
