### PR TITLE
[Book/Validation] Removed namespace at creating new instance

### DIFF
--- a/book/validation.rst
+++ b/book/validation.rst
@@ -221,7 +221,7 @@ workflow looks like the following from inside a controller::
 
     public function updateAction(Request $request)
     {
-        $author = new Acme\BlogBundle\Entity\Author();
+        $author = new Author();
         $form = $this->createForm(new AuthorType(), $author);
 
         if ($request->getMethod() == 'POST') {


### PR DESCRIPTION
I have removed the namespace in the section where a new instance is created, because it is already in a use statement at te top of the code example.
