### PR TITLE
"New in 2.1" description was not being rendered

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -105,7 +105,6 @@ controller. Along the way, you'll learn all sorts of tricks that make mapping
 even the most complex URLs easy.
 
 .. versionadded:: 2.1
-
     As of Symfony 2.1, the Routing component also accepts Unicode values
     in routes like: /Жени/
 


### PR DESCRIPTION
In the routing chapter http://symfony.com/doc/master/book/routing.html there is a "New in version 2.1." block but it has no descriptive text showing.

I don't know the doc format very well but comparing it to other similar sections it appears to have an extra newline between the block declaration and the text, so I've removed it.
