### PR TITLE
correction of wrong code example. 

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1129,7 +1129,7 @@ method:
 
     .. code-block:: php
 
-        $request->headers->set('HOST', 'www.example.com');
+        $router->getContext()->setHost('www.example.com');
 
 .. index::
    single: Routing; Generating URLs in a template

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1125,7 +1125,7 @@ method:
     the current ``Request`` object. This is detected automatically based
     on server information supplied by PHP. When generating absolute URLs for
     scripts run from the command line, you'll need to manually set the desired
-    host on the ``Request`` object:
+    host on the ``RequestContext`:
 
     .. code-block:: php
 


### PR DESCRIPTION
The request service is not available in Commandline (CLI) - You cannot create a service ("request") of an inactive scope
