### PR TITLE
ignore composer.phar

### DIFF
--- a/book/propel.rst
+++ b/book/propel.rst
@@ -32,7 +32,7 @@ information.  By convention, this information is usually configured in an
 
     # app/config/parameters.yml
     parameters:
-        database_driver:   mysql
+        database_driver:   pdo_mysql
         database_host:     localhost
         database_name:     test_project
         database_user:     root

--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -37,6 +37,7 @@ git repository:
         /app/logs/*
         /vendor/  
         /app/config/parameters.yml
+        /composer.phar
 
 .. tip::
 

--- a/cookbook/workflow/new_project_svn.rst
+++ b/cookbook/workflow/new_project_svn.rst
@@ -81,6 +81,7 @@ To get started, you'll need to download Symfony2 and get the basic Subversion se
         $ svn propset svn:ignore "parameters.yml" app/config/
         $ svn propset svn:ignore "*" app/cache/
         $ svn propset svn:ignore "*" app/logs/
+        $ svn propset svn:ignore "composer.phar" .
 
         $ svn propset svn:ignore "bundles" web
 


### PR DESCRIPTION
when we use composer to update or install a symfony project it shouldnt be added to the git repository
