### PR TITLE
Cookbook: How to create an Event Listener - Fix $response not initialized

### DIFF
--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -17,7 +17,8 @@ event is just one of the core kernel events::
     // src/Acme/DemoBundle/Listener/AcmeExceptionListener.php
     namespace Acme\DemoBundle\Listener;
 
-    use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+    use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent,
+        Symfony\Component\HttpFoundation\Response;
 
     class AcmeExceptionListener
     {
@@ -28,6 +29,7 @@ event is just one of the core kernel events::
             $message = 'My Error says: ' . $exception->getMessage();
             
             // Customize our response object to display our exception details
+            $response = new Response();
             $response->setContent($message);
             $response->setStatusCode($exception->getStatusCode());
             

--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -17,8 +17,8 @@ event is just one of the core kernel events::
     // src/Acme/DemoBundle/Listener/AcmeExceptionListener.php
     namespace Acme\DemoBundle\Listener;
 
-    use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent,
-        Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+    use Symfony\Component\HttpFoundation\Response;
 
     class AcmeExceptionListener
     {


### PR DESCRIPTION
Fixed the example code for creating an exception listener: the $response was never initialized.
