### PR TITLE
Spelling tweak, use the word "if" not "of"

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -616,7 +616,7 @@ from any controller::
     // in another controller for another request
     $foo = $session->get('foo');
 
-    // use a default value of the key doesn't exist
+    // use a default value if the key doesn't exist
     $filters = $session->set('filters', array());
 
 These attributes will remain on the user for the remainder of that user's

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -126,7 +126,7 @@ from any controller::
     // in another controller for another request
     $foo = $session->get('foo');
 
-    // use a default value of the key doesn't exist
+    // use a default value if the key doesn't exist
     $filters = $session->set('filters', array());
 
 You can also store small messages that will only be available for the very


### PR DESCRIPTION
There is a small spelling error in the controller documentation.

Original:

```
// use a default value of the key doesn't exist
$filters = $session->set('filters', array());
```

Patched:

```
// use a default value if the key doesn't exist
$filters = $session->set('filters', array());
```
