### PR TITLE
Add a tips about the Build-in web server included in PHP 5.4

### DIFF
--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -19,6 +19,16 @@ Downloading Symfony2
 First, check that you have installed and configured a Web server (such as
 Apache) with PHP 5.3.2 or higher.
 
+.. tips::
+   
+    Since PHP 5.4, you could use the Build-in web server:
+    
+    .. code-block:: bash
+
+        php -S localhost:80 -t www
+
+    For development purpose only, it can help you to start your project right now.
+
 Ready? Start by downloading the "`Symfony2 Standard Edition`_", a Symfony
 :term:`distribution` that is preconfigured for the most common use cases and
 also contains some code that demonstrates how to use Symfony2 (get the archive

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -21,13 +21,15 @@ Apache) with PHP 5.3.2 or higher.
 
 .. tips::
    
-    Since PHP 5.4, you could use the Build-in web server:
+    Since PHP 5.4, you could use the Build-in web server. For development purpose only, it can help you to start your project right now.
+    Just use this command to launch the server:
     
     .. code-block:: bash
 
-        php -S localhost:80 -t www
+        php -S localhost:80 -t /path/to/www
 
-    For development purpose only, it can help you to start your project right now.
+    Where "/path/to/www" is the path to some directory on your machine that you'll extract Symfony into so that the eventual URL to your application is "http://localhost/Symfony/app_dev.php".
+    You can also extract Symfony first and then start the web server in the Symfony "web" directory. If you do this, the URL to your application will be "http://localhost/app_dev.php".
 
 Ready? Start by downloading the "`Symfony2 Standard Edition`_", a Symfony
 :term:`distribution` that is preconfigured for the most common use cases and


### PR DESCRIPTION
Hi,

   When I start looking at the Symfony 2.0 quick tour, I find out that it was pretty difficult to bootstrap a simple project without having a whole http/php/fastcgi configuration.

   It can be somehow reluctant to new users not used to this kind of system management and who just want to start coding as fast as possible.

   So, as the new version of PHP provide a perfect way to avoid such boilerplate, I propose to add a small tip at the beginning of the quick tour to talk about this alternative.

   I though that the quick tour is the place where I wanted to find this information at my first visit. But if you think that a Cook Book would be better, I can change my Pull Request to reflect the change.

Thank you for, at least, looking at it.

Aurélien
