### PR TITLE
Fix a few occurrences of Markdown links

### DIFF
--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -37,7 +37,7 @@ Set up your user information with your real name and a working email address:
     If your IDE creates configuration files inside project's directory,
     you can use global ``.gitignore`` file (for all projects) or
     ``.git/info/exclude`` file (per project) to ignore them. See
-    [Github's documentation](https://help.github.com/articles/ignoring-files)
+    `Github's documentation <https://help.github.com/articles/ignoring-files>`_.
 
 .. tip::
 
@@ -177,7 +177,8 @@ in mind the following:
 .. tip::
 
     You can check the coding standards of your patch by running the following
-    [script](http://cs.sensiolabs.org/get/php-cs-fixer.phar) [src](https://github.com/fabpot/PHP-CS-Fixer):
+    `script <http://cs.sensiolabs.org/get/php-cs-fixer.phar>`_
+    (`source <https://github.com/fabpot/PHP-CS-Fixer>`_):
 
     .. code-block:: bash
 


### PR DESCRIPTION
There are three instances of Markdown syntax used for links on http://symfony.com/doc/current/contributing/code/patches.html. The attached change switches these to ReST style.
