### PR TITLE
Remove SQLi vulnerability from a 'flat PHP' example

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -263,7 +263,7 @@ an individual blog result based on a given id::
     {
         $link = open_database_connection();
 
-        $id = mysql_real_escape_string($id);
+        $id = intval($id);
         $query = 'SELECT date, title, body FROM post WHERE id = '.$id;
         $result = mysql_query($query);
         $row = mysql_fetch_assoc($result);
@@ -308,7 +308,7 @@ this page introduces even more lingering problems that a framework can solve
 for you. For example, a missing or invalid ``id`` query parameter will cause
 the page to crash. It would be better if this caused a 404 page to be rendered,
 but this can't really be done easily yet. Worse, had you forgotten to clean
-the ``id`` parameter via the ``mysql_real_escape_string()`` function, your
+the ``id`` parameter via the ``intval()`` function, your
 entire database would be at risk for an SQL injection attack.
 
 Another major problem is that each individual controller file must include


### PR DESCRIPTION
On http://symfony.com/doc/current/book/from_flat_php_to_symfony2.html#adding-a-blog-show-page one of the examples for the flat PHP blog has an SQL injection vulnerability.

The $id parameter isn't being used in a string context so escaping it as such doesn't help! Instead it should be treated as an integer.

Maybe a little could be added to the "Worse, had you forgotten ..." line saying something like "or incorrectly used mysql_real_escape()" too :)
