### PR TITLE
Fixed missing versionadded descriptions

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1021,7 +1021,6 @@ interface. This means that your concept of a "user" can be anything, as long
 as it implements this interface.
 
 .. versionadded:: 2.1
-
     In Symfony 2.1, the ``equals`` method was removed from ``UserInterface``.
     If you need to override the default implementation of comparison logic,
     implement the new :class:`Symfony\\Component\\Security\\Core\\User\\EquatableInterface`

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -552,7 +552,6 @@ by defining a ``default_locale`` for the framework:
         ));
 
 .. versionadded:: 2.1
-
      The ``default_locale`` parameter was defined under the session key
      originally, however, as of 2.1 this has been moved. This is because the 
      locale is now set on the request instead of the session.
@@ -805,7 +804,6 @@ texts* and complex expressions:
             {{ '<h3>foo</h3>'|trans }}
 
 .. versionadded:: 2.1
-
      You can now set the translation domain for an entire Twig template with a
      single tag:
 

--- a/components/routing.rst
+++ b/components/routing.rst
@@ -303,7 +303,6 @@ automatically in the background if you want to use it. A basic example of the
     permissions for that location.
 
 .. versionadded:: 2.1
-
     As of Symfony 2.1, the Routing component also accepts Unicode values
     in routes like this::
 

--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -149,7 +149,6 @@ interface forces the class to implement the five following methods:
 For more details on each of these, see :class:`Symfony\\Component\\Security\\Core\\User\\UserInterface`.
 
 .. versionadded:: 2.1
-
     In Symfony 2.1, the ``equals`` method was removed from ``UserInterface``.
     If you need to override the default implementation of comparison logic,
     implement the new :class:`Symfony\\Component\\Security\\Core\\User\\EquatableInterface`

--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -78,7 +78,6 @@ The validator class is also simple, and only has one required method: ``validate
     use for that violation.
 
 .. versionadded:: 2.1
-
     The ``isValid`` method was renamed to ``validate`` in Symfony 2.1. The
     ``setMessage`` method was also deprecated, in favor of calling ``addViolation``
     on the context.

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -121,7 +121,6 @@ collections. URL's starting with ``http://`` will only be added to the
 ``http`` collection.
 
 .. versionadded:: 2.1
-
     Unlike most configuration blocks, successive values for ``assets_base_urls``
     will overwrite each other instead of being merged. This behavior was chosen
     because developers will typically define base URL's for each environment.

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -228,7 +228,6 @@ kernel.event_subscriber
 **Purpose**: To subscribe to a set of different events/hooks in Symfony
 
 .. versionadded:: 2.1
-
    The ability to add kernel event subscribers is new to 2.1.
 
 To enable a custom subscriber, add it as a regular service in one of your


### PR DESCRIPTION
If there is an empty line after the versionadded heading then the block does not render correctly in the HTML docs - it just shows the "New in version 2.1." heading with no description.

See http://symfony.com/doc/master/book/security.html#loading-users-from-the-database for an example.
