### PR TITLE
Clearify the goal of Bundle::getParent()

### DIFF
--- a/cookbook/bundles/inheritance.rst
+++ b/cookbook/bundles/inheritance.rst
@@ -32,6 +32,11 @@ as the "parent" of your bundle::
 By making this simple change, you can now override several parts of the ``FOSUserBundle``
 simply by creating a file with the same name.
 
+.. note::
+
+    Despite the method name, there is no parent/child relationship between 
+    the bundles, it is just a way to extend and override an existing bundle.
+
 Overriding Controllers
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -295,14 +295,19 @@ Extending Bundles
 
 If you follow these conventions, then you can use :doc:`bundle inheritance</cookbook/bundles/inheritance>`
 to "override" files, controllers or templates. For example, you can create
-a bundle - ``AcmeNewBundle`` - and specify that its parent is ``AcmeDemoBundle``.
+a bundle - ``AcmeNewBundle`` - and specify that it overrides ``AcmeDemoBundle``.
 When Symfony loads the ``AcmeDemoBundle:Welcome:index`` controller, it will
-first look for the ``WelcomeController`` class in ``AcmeNewBundle`` and then
-look inside ``AcmeDemoBundle``. This means that one bundle can override almost
-any part of another bundle!
+first look for the ``WelcomeController`` class in ``AcmeNewBundle`` and, if it
+does not exists, then look inside ``AcmeDemoBundle``. This means that one bundle 
+can override almost any part of another bundle!
 
 Do you understand now why Symfony2 is so flexible? Share your bundles between
 applications, store them locally or globally, your choice.
+
+.. note::
+
+    Despite the method name, there is no parent/child relationship between 
+    the bundles, it is just a way to extend and override an existing bundle.
 
 .. _using-vendors:
 

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -297,8 +297,8 @@ If you follow these conventions, then you can use :doc:`bundle inheritance</cook
 to "override" files, controllers or templates. For example, you can create
 a bundle - ``AcmeNewBundle`` - and specify that it overrides ``AcmeDemoBundle``.
 When Symfony loads the ``AcmeDemoBundle:Welcome:index`` controller, it will
-first look for the ``WelcomeController`` class in ``AcmeNewBundle`` and, if it
-does not exists, then look inside ``AcmeDemoBundle``. This means that one bundle 
+first look for the ``WelcomeController`` class in ``AcmeNewBundle`` and, if 
+not exists, then look inside ``AcmeDemoBundle``. This means that one bundle 
 can override almost any part of another bundle!
 
 Do you understand now why Symfony2 is so flexible? Share your bundles between

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -304,11 +304,6 @@ can override almost any part of another bundle!
 Do you understand now why Symfony2 is so flexible? Share your bundles between
 applications, store them locally or globally, your choice.
 
-.. note::
-
-    Despite the method name, there is no parent/child relationship between 
-    the bundles, it is just a way to extend and override an existing bundle.
-
 .. _using-vendors:
 
 Using Vendors


### PR DESCRIPTION
The method getParent is confusing because there is no parent/child relation. This PR add a note to clearify this.

More information can be found at the [Symfony Issue](https://github.com/symfony/symfony/issues/4347)

Please note that English isn't my primary language, so please tell me if I have done something wrong.
