### PR TITLE
Added documentation for the Config Component

### DIFF
--- a/components/config/caching.rst
+++ b/components/config/caching.rst
@@ -1,0 +1,54 @@
+.. index::
+   single: Config; Caching based on resources
+
+Caching based on resources
+==========================
+
+When all configuration resources are loaded, you may want to process the configuration values and
+combine them all in one file. This file acts like a cache. It’s contents don’t have to be
+regenerated every time the application runs – only when the configuration resources are modified.
+
+For example, the Symfony Routing component allows you to load all routes, and then dump a URL
+matcher or a URL generator based on these routes. In this case, when one of the resources is
+modified (and you are working in a development environment), the generated file should be
+invalidated and regenerated. This can be accomplished by making use of the
+:class:`Symfony\\Component\\Config\\ConfigCache` class.
+
+The example below shows you how to collect resources, then generate some code based on the
+resources that were loaded, and write this code to the cache. The cache also receives the
+collection of resources that were used for generating the code. By looking at the “last modified”
+timestamp of these resources, the cache can tell if it is still fresh or that it’s contents should
+be regenerated.
+
+.. code-block:: php
+
+    use Symfony\Component\Config\ConfigCache;
+
+    // $yamlUserFiles is filled before with an array of 'users.yml' file paths
+
+    $resources = array();
+
+    foreach ($yamlUserFiles as $yamlUserFile) {
+        $resources[] = new FileResource($yamlUserFile);
+    }
+
+    $cachePath = __DIR__ . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'appUserMatcher.php';
+
+    $userMatcherCache = new ConfigCache($cachePath, true);
+    // the second constructor argument indicates whether or not we are in debug mode
+
+    if (!$userMatcherCache->isFresh()) {
+        foreach ($resources as $resource) {
+            $delegatingLoader->load($resource->getResource());
+        }
+
+        // The code for the UserMatcher is generated elsewhere
+        // $code = ...;
+        $userMatcherCache->write($code, $resources);
+    }
+
+    // you may want to require the cached code:
+    require $cachePath;
+
+A ``.meta`` file is created in the same directory as the cache file itself. This ``.meta`` file
+contains the serialized resources, for later reference.

--- a/components/config/caching.rst
+++ b/components/config/caching.rst
@@ -27,8 +27,8 @@ be regenerated.
 
     $cachePath = __DIR__.'/cache/appUserMatcher.php';
 
+    // the second argument indicates whether or not we are in debug mode
     $userMatcherCache = new ConfigCache($cachePath, true);
-    // the second constructor argument indicates whether or not we are in debug mode
 
     if (!$userMatcherCache->isFresh()) {
         // fill this with an array of 'users.yml' file paths
@@ -41,7 +41,7 @@ be regenerated.
             $resources[] = new FileResource($yamlUserFile);
         }
 
-        // The code for the UserMatcher is generated elsewhere
+        // the code for the UserMatcher is generated elsewhere
         $code = ...;
 
         $userMatcherCache->write($code, $resources);

--- a/components/config/caching.rst
+++ b/components/config/caching.rst
@@ -5,7 +5,7 @@ Caching based on resources
 ==========================
 
 When all configuration resources are loaded, you may want to process the configuration values and
-combine them all in one file. This file acts like a cache. It’s contents don’t have to be
+combine them all in one file. This file acts like a cache. Its contents don’t have to be
 regenerated every time the application runs – only when the configuration resources are modified.
 
 For example, the Symfony Routing component allows you to load all routes, and then dump a URL
@@ -16,39 +16,41 @@ invalidated and regenerated. This can be accomplished by making use of the
 
 The example below shows you how to collect resources, then generate some code based on the
 resources that were loaded, and write this code to the cache. The cache also receives the
-collection of resources that were used for generating the code. By looking at the “last modified”
-timestamp of these resources, the cache can tell if it is still fresh or that it’s contents should
+collection of resources that were used for generating the code. By looking at the "last modified"
+timestamp of these resources, the cache can tell if it is still fresh or that its contents should
 be regenerated.
 
 .. code-block:: php
 
     use Symfony\Component\Config\ConfigCache;
+    use Symfony\Component\Config\Resource\FileResource;
 
-    // $yamlUserFiles is filled before with an array of 'users.yml' file paths
-
-    $resources = array();
-
-    foreach ($yamlUserFiles as $yamlUserFile) {
-        $resources[] = new FileResource($yamlUserFile);
-    }
-
-    $cachePath = __DIR__ . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'appUserMatcher.php';
+    $cachePath = __DIR__.'/cache/appUserMatcher.php';
 
     $userMatcherCache = new ConfigCache($cachePath, true);
     // the second constructor argument indicates whether or not we are in debug mode
 
     if (!$userMatcherCache->isFresh()) {
-        foreach ($resources as $resource) {
-            $delegatingLoader->load($resource->getResource());
+        // fill this with an array of 'users.yml' file paths
+        $yamlUserFiles = ...;
+
+        $resources = array();
+
+        foreach ($yamlUserFiles as $yamlUserFile) {
+            $delegatingLoader->load($yamlUserFile);
+            $resources[] = new FileResource($yamlUserFile);
         }
 
         // The code for the UserMatcher is generated elsewhere
-        // $code = ...;
+        $code = ...;
+
         $userMatcherCache->write($code, $resources);
     }
 
     // you may want to require the cached code:
     require $cachePath;
 
-A ``.meta`` file is created in the same directory as the cache file itself. This ``.meta`` file
-contains the serialized resources, for later reference.
+In debug mode, a ``.meta`` file will be created in the same directory as the cache file itself.
+This ``.meta`` file contains the serialized resources, whose timestamps are used to determine if
+the cache is still fresh. When not in debug mode, the cache is considered to be "fresh" as soon
+as it exists, and therefore no ``.meta`` file will be generated.

--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -171,7 +171,7 @@ has a certain value:
 ``isRequired()``
     Must be defined (but may be empty)
 ``cannotBeEmpty()``
-    may not contain an empty value
+    May not contain an empty value
 ``default*()``
     (``Null``, ``True``, ``False``), shortcut for ``defaultValue()``
 ``treat*Like()``

--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -1,0 +1,284 @@
+.. index::
+   single: Config; Define and process configuration values
+
+Define and process configuration values
+=======================================
+
+Validate configuration values
+-----------------------------
+
+After loading configuration values from all kinds of resources, the values and their structure can
+be validated using the "Definition" part of the Config Component. Configuration values are usually
+expected to show some kind of hierarchy. Also, values should be of a certain type, be restricted in
+number or be one of a given set of values. For example, the following configuration (in Yaml) shows
+a clear hierarchy and some validation rules that should be applied to it (like: "the value for
+'auto_connect' must be a boolean value"):
+
+.. code-block:: yaml
+
+    auto_connect: true
+    default_connection: mysql
+    connections:
+        mysql:
+            host: localhost
+            driver: mysql
+            username: user
+            password: pass
+        sqlite:
+            host: localhost
+            driver: sqlite
+            memory: true
+            username: user
+            password: pass
+
+When loading multiple configuration files, it should be possible to merge and overwrite some
+values. Other values should not be merged and stay as they are when first encountered. Also,
+some keys are only available, when another key has a specific value (in the sample configuration
+above: the "memory" key only makes sense when the "driver" is "sqlite").
+
+Define a hierarchy of configuration values using the TreeBuilder
+----------------------------------------------------------------
+
+All the rules concerning configuration values can be defined using the
+:class:`Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder`.
+
+A :class:`Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder` instance should be returned
+from a custom ``Configuration`` class which implements the
+:class:`Symfony\\Component\\Config\\Definition\\ConfigurationInterface`:
+
+.. code-block:: php
+
+    namespace Acme\DatabaseConfiguration;
+
+    use Symfony\Component\Config\Definition\ConfigurationInterface;
+    use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+    class DatabaseConfiguration implements ConfigurationInterface
+    {
+        public function getConfigTreeBuilder()
+        {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('database');
+
+            // add node definitions to the root of the tree
+
+            return $treeBuilder;
+        }
+    }
+
+Add node definitions to the tree
+--------------------------------
+
+Variable nodes
+~~~~~~~~~~~~~~
+
+A tree contains node definitions which can be layed out in a semantic way. This means, using
+indentation and the fluent notation, it is possible to reflect the real structure of the
+configuration values:
+
+.. code-block:: php
+
+    $rootNode
+        ->children()
+            ->booleanNode('auto_connect')
+                ->defaultTrue()
+            ->end()
+            ->scalarNode('default_connection')
+                ->defaultValue('default')
+            ->end()
+        ->end()
+    ;
+
+The root node itself is an array node, and has children, like the boolean node "auto_connect"
+and the scalar node "default_connection". In general: after defining a node, a call to ``end()``
+takes you one step up in the hierarchy.
+
+Array nodes
+~~~~~~~~~~~
+
+It is possible to add a deeper level to the hierarchy, by adding an array node. The array node
+itself, may have a pre-defined set of variable nodes:
+
+.. code-block:: php
+
+    $rootNode
+        ->arrayNode('connection')
+            ->scalarNode('driver')->end()
+            ->scalarNode('host')->end()
+            ->scalarNode('username')->end()
+            ->scalarNode('password')->end()
+        ->end()
+    ;
+
+Or you may define a prototype for each node inside an array node:
+
+.. code-block:: php
+
+    $rootNode
+        ->arrayNode('connections')
+            ->prototype('array)
+                ->children()
+                    ->scalarNode('driver')->end()
+                    ->scalarNode('host')->end()
+                    ->scalarNode('username')->end()
+                    ->scalarNode('password')->end()
+                ->end()
+            ->end()
+        ->end()
+    ;
+
+A prototype can be used to add a definition which may be repeated many times inside the current
+node. According to the prototype definition in the example above, it is possible to have multiple
+connection arrays (containing a "driver", "host", etc.).
+
+Array node options
+~~~~~~~~~~~~~~~~~~
+
+Before defining the children of an array node, you can provide options like:
+
+``useAttributeAsKey()``
+    Provide the name of a childnode, whose value should be used as the key in the resulting array
+``requiresAtLeastOneElement()``
+    There should be at least one element in the array (works only when ``isRequired()`` is also
+    called).
+
+An example of this:
+
+.. code-block:: php
+
+    $rootNode
+        ->arrayNode('parameters')
+            ->isRequired()
+            ->requiresAtLeastOneElement()
+            ->prototype('array')
+                ->useAttributeAsKey('name')
+                ->children()
+                    ->scalarNode('name')->isRequired()->end()
+                    ->scalarNode('value')->isRequired()->end()
+                ->end()
+            ->end()
+        ->end()
+    ;
+
+Default and required values
+---------------------------
+
+For all node types, it is possible to define default values and replacement values in case a node
+has a certain value:
+
+``defaultValue()``
+    Set a default value
+``isRequired()``
+    Must be defined (but may be empty)
+``cannotBeEmpty()``
+    may not contain an empty value
+``default*()``
+    (``Null``, ``True``, ``False``), shortcut for ``defaultValue()``
+``treat*Like()``
+    (``Null``, ``True``, ``False``), provide a replacement value in case the value is *.
+
+.. code-block:: php
+
+    $rootNode
+        ->arrayNode('connection')
+            ->children()
+                ->scalarNode('driver')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('host')
+                    ->defaultValue('localhost')
+                ->end()
+                ->scalarNode('username')->end()
+                ->scalarNode('password')->end()
+                ->booleanNode('memory')
+                    ->defaultFalse()
+                ->end()
+            ->end()
+        ->end()
+    ;
+
+Merging options
+---------------
+
+Extra options concerning the merge process may be provided. For arrays:
+
+``performNoDeepMerging()``
+    When the value is also defined in a second configuration array, don’t try to merge an array,
+    but overwrite it entirely
+
+For all nodes:
+
+``cannotBeOverwritten()``
+    don’t let other configuration arrays overwrite an existing value for this node
+
+Validation rules
+----------------
+
+More advanced validation rules can be provided using the
+:class:`Symfony\\Component\\Config\\Definition\\Builder\\ExprBuilder`. This builder implements a
+fluent interface for a well-known control structure. The builder is used for adding advanced
+validation rules to node definitions, like:
+
+.. code-block:: php
+
+    $rootNode
+        ->arrayNode('connection')
+            ->children()
+                ->scalarNode('driver')
+                    ->isRequired()
+                    ->validate()
+                        ->ifNotInArray(array('mysql', 'sqlite', 'mssql'))
+                        ->thenInvalid('Invalid database driver "%s"')
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+    ;
+
+A validation rule always has an "if" part. You can specify this part in the following ways:
+
+- ``ifTrue()``
+- ``ifString()``
+- ``ifNull()``
+- ``ifArray()``
+- ``ifInArray()``
+- ``ifNotInArray()``
+
+A validation rule also requires a "then" part:
+
+- ``then()``
+- ``thenEmptyArray()``
+- ``thenInvalid()``
+- ``thenUnset()``
+
+The only exception is of course:
+
+- ``always()``
+
+Usually, “then” is a closure. It’s return value will be used as a new value for the node, instead
+of the node’s original value.
+
+Processing configuration values
+-------------------------------
+
+The :class:`Symfony\\Component\\Config\\Definition\\Processor` uses the tree as it was built
+using the :class:`Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder` to process
+multiple arrays of configuration values that should be merged. If any value is not of the
+expected type, is mandatory and yet undefined, or could not be validated in some other way,
+an exception will be thrown. Otherwise the result is a clean array of configuration values.
+
+.. code-block:: php
+
+    use Symfony\Component\Yaml\Yaml;
+    use Symfony\Component\Config\Definition\Processor;
+    use Acme\DatabaseConfiguration;
+
+    $config1 = Yaml::parse(__DIR__.'/src/Matthias/config/config.yml');
+    $config2 = Yaml::parse(__DIR__.'/src/Matthias/config/config_extra.yml');
+
+    $configs = array($config1, $config2);
+
+    $processor = new Processor;
+    $configuration = new DatabaseConfiguration;
+    $processedConfiguration = $processor->processConfiguration($configuration, $configs);

--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -60,7 +60,7 @@ from a custom ``Configuration`` class which implements the
             $treeBuilder = new TreeBuilder();
             $rootNode = $treeBuilder->root('database');
 
-            // add node definitions to the root of the tree
+            // ... add node definitions to the root of the tree
 
             return $treeBuilder;
         }
@@ -244,6 +244,7 @@ A validation rule always has an "if" part. You can specify this part in the foll
 - ``ifArray()``
 - ``ifInArray()``
 - ``ifNotInArray()``
+- ``always()``
 
 A validation rule also requires a "then" part:
 
@@ -252,12 +253,8 @@ A validation rule also requires a "then" part:
 - ``thenInvalid()``
 - ``thenUnset()``
 
-The only exception is of course:
-
-- ``always()``
-
-Usually, “then” is a closure. It’s return value will be used as a new value for the node, instead
-of the node’s original value.
+Usually, "then" is a closure. Its return value will be used as a new value for the node, instead
+of the node's original value.
 
 Processing configuration values
 -------------------------------
@@ -279,6 +276,6 @@ an exception will be thrown. Otherwise the result is a clean array of configurat
 
     $configs = array($config1, $config2);
 
-    $processor = new Processor;
+    $processor = new Processor();
     $configuration = new DatabaseConfiguration;
     $processedConfiguration = $processor->processConfiguration($configuration, $configs);

--- a/components/config/index.rst
+++ b/components/config/index.rst
@@ -1,0 +1,10 @@
+Config
+======
+
+.. toctree::
+    :maxdepth: 2
+
+    introduction
+    resources
+    caching
+    definition

--- a/components/config/introduction.rst
+++ b/components/config/introduction.rst
@@ -1,0 +1,21 @@
+.. index::
+   single: Config
+
+The Config Component
+====================
+
+Introduction
+------------
+
+The Config Component provides several classes to help you find, load, combine, autofill and
+validate configuration values of any kind, whatever their source may be (Yaml, XML, INI files, or
+for instance a database).
+
+Installation
+------------
+
+You can install the component in many different ways:
+
+* Use the official Git repository (https://github.com/symfony/Config);
+* Install it via PEAR ( `pear.symfony.com/Config`);
+* Install it via Composer (`symfony/config` on Packagist).

--- a/components/config/resources.rst
+++ b/components/config/resources.rst
@@ -14,7 +14,7 @@ can be done with the :class:`Symfony\\Component\\Config\\FileLocator`:
 
     use Symfony\Component\Config\FileLocator;
 
-    $configDirectories = array(__DIR__ . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'config');
+    $configDirectories = array(__DIR__.'/app/config');
 
     $locator = new FileLocator($configDirectories);
     $yamlUserFiles = $locator->locate('users.yml', null, false);
@@ -44,7 +44,7 @@ importing other resources.
         {
             $configValues = Yaml::parse($resource);
 
-            // handle the config values
+            // ... handle the config values
 
             // maybe import some other resource:
 
@@ -60,7 +60,7 @@ importing other resources.
 Finding the right loader
 ------------------------
 
-The :class:`Symfony\\Component\\Config\\Loader\\LoaderResolver` receives as it’s first constructor
+The :class:`Symfony\\Component\\Config\\Loader\\LoaderResolver` receives as its first constructor
 argument a collection of loaders. When a resource (for instance an XML file) should be loaded,
 it loops through this collection of loaders and returns the loader which supports this
 particular resource type.
@@ -77,7 +77,7 @@ In case the resolver has found a suitable loader, this loader will be asked to l
     $loaderResolver = new LoaderResolver(array(new YamlUserLoader));
     $delegatingLoader = new DelegatingLoader($loaderResolver);
 
-    $delegatingLoader->load(__DIR__ . DIRECTORY_SEPARATOR . '/users.yml');
+    $delegatingLoader->load(__DIR__.'/users.yml');
     /*
     The YamlUserLoader will be used to load this resource,
     since it supports files with a "yml" extension

--- a/components/config/resources.rst
+++ b/components/config/resources.rst
@@ -1,0 +1,84 @@
+.. index::
+   single: Config; Loading resources
+
+Loading resources
+=================
+
+Locating resources
+------------------
+
+Loading the configuration normally starts with a search for resources – in most cases: files. This
+can be done with the :class:`Symfony\\Component\\Config\\FileLocator`:
+
+.. code-block:: php
+
+    use Symfony\Component\Config\FileLocator;
+
+    $configDirectories = array(__DIR__ . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'config');
+
+    $locator = new FileLocator($configDirectories);
+    $yamlUserFiles = $locator->locate('users.yml', null, false);
+
+The locator receives a collection of locations where it should look for files. The first argument of
+``locate()`` is the name of the file to look for. The second argument may be the current path and
+when supplied, the locator will look in this directory first.
+The third argument indicates whether or not the locator should return the first file it has found,
+or an array containing all matches.
+
+Resource loaders
+----------------
+
+For each type of resource (Yaml, XML, annotation, etc.) a loader must be defined. Each loader should
+implement :class:`Symfony\\Component\\Config\\Loader\\LoaderInterface` or extend the abstract
+:class:`Symfony\\Component\\Config\\Loader\\FileLoader` class, which allows for recursively
+importing other resources.
+
+.. code-block:: php
+
+    use Symfony\Component\Config\Loader\FileLoader;
+    use Symfony\Component\Yaml\Yaml;
+
+    class YamlUserLoader extends FileLoader
+    {
+        public function load($resource, $type = null)
+        {
+            $configValues = Yaml::parse($resource);
+
+            // handle the config values
+
+            // maybe import some other resource:
+
+            // $this->import('extra_users.yml');
+        }
+
+        public function supports($resource, $type = null)
+        {
+            return is_string($resource) && 'yml' === pathinfo($resource, PATHINFO_EXTENSION);
+        }
+    }
+
+Finding the right loader
+------------------------
+
+The :class:`Symfony\\Component\\Config\\Loader\\LoaderResolver` receives as it’s first constructor
+argument a collection of loaders. When a resource (for instance an XML file) should be loaded,
+it loops through this collection of loaders and returns the loader which supports this
+particular resource type.
+
+The :class:`Symfony\\Component\\Config\\Loader\\DelegatingLoader` makes use of the :class:`Symfony\\Component\\Config\\Loader\\LoaderResolver`. When it is asked to load a resource,
+it delegates this question to the :class:`Symfony\\Component\\Config\\Loader\\LoaderResolver`.
+In case the resolver has found a suitable loader, this loader will be asked to load the resource.
+
+.. code-block:: php
+
+    use Symfony\Component\Config\Loader\LoaderResolver;
+    use Symfony\Component\Config\Loader\DelegatingLoader;
+
+    $loaderResolver = new LoaderResolver(array(new YamlUserLoader));
+    $delegatingLoader = new DelegatingLoader($loaderResolver);
+
+    $delegatingLoader->load(__DIR__ . DIRECTORY_SEPARATOR . '/users.yml');
+    /*
+    The YamlUserLoader will be used to load this resource,
+    since it supports files with a "yml" extension
+    */

--- a/components/index.rst
+++ b/components/index.rst
@@ -5,6 +5,7 @@ The Components
     :hidden:
 
     class_loader
+    config/index
     console
     css_selector
     dom_crawler

--- a/components/map.rst.inc
+++ b/components/map.rst.inc
@@ -2,6 +2,13 @@
 
   * :doc:`/components/class_loader`
 
+* :doc:`/components/config/index`
+
+  * :doc:`/components/config/introduction`
+  * :doc:`/components/config/resources`
+  * :doc:`/components/config/caching`
+  * :doc:`/components/config/definition`
+
 * **The Console Component**
 
   * :doc:`/components/console`


### PR DESCRIPTION
I took the time to reshape my blog posts about the Config Component (http://php-and-symfony.matthiasnoback.nl/2012/05/symfony2-config-component-using-filelocator-loaders-and-loaderresolver/ and http://php-and-symfony.matthiasnoback.nl/2012/05/symfony2-config-component-config-definition-and-processing/). I have added some chapters about it to the Components documentation.

There should probably be links to these chapters from several other parts of the Symfony Documentation (like  http://symfony.com/doc/current/cookbook/bundles/extension.html).

But first: any feedback is welcome!

Note: something is wrong with my "fork" and I don't know how to fix it... If anyone could help me: thanks!
