### PR TITLE
Add a tips about the Build-in server command included in PHP 5.4 / Symfony 2.1

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -141,7 +141,7 @@ to check your configuration:
 
 .. code-block:: text
 
-    http://localhost/web/config.php
+    http://localhost/config.php
 
 If there are any issues, correct them now before moving on.
 
@@ -209,7 +209,7 @@ first "real" Symfony2 webpage:
 
 .. code-block:: text
 
-    http://localhost/web/app_dev.php/
+    http://localhost/app_dev.php/
 
 Symfony2 should welcome and congratulate you for your hard work so far!
 

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -141,7 +141,7 @@ to check your configuration:
 
 .. code-block:: text
 
-    http://localhost/Symfony/web/config.php
+    http://localhost/web/config.php
 
 If there are any issues, correct them now before moving on.
 
@@ -209,7 +209,7 @@ first "real" Symfony2 webpage:
 
 .. code-block:: text
 
-    http://localhost/Symfony/web/app_dev.php/
+    http://localhost/web/app_dev.php/
 
 Symfony2 should welcome and congratulate you for your hard work so far!
 

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -25,17 +25,16 @@ Apache) with PHP 5.3.4 or higher.
     server should be used only for development purpose, but it can help you
     to start your project quickly and easily.
 
-    Just use this command to launch the server:
+    Just use this command in your Symfony directory to launch the server:
     
     .. code-block:: bash
 
-        php -S localhost:80 -t /path/to/www
+        ./app/console server:run localhost:8000
 
-    where "/path/to/www" is the path to some directory on your machine that
-    you'll extract Symfony into so that the eventual URL to your application
-    is "http://localhost/Symfony/app_dev.php". You can also extract Symfony
-    first and then start the web server in the Symfony "web" directory. If
-    you do this, the URL to your application will be "http://localhost/app_dev.php".
+    Then the URL to your application will be "http://localhost:8000/app_dev.php"
+
+    If you want to access your application via "http://localhost/app_dev.php",
+    you will need to launch the command with administrator rights.
 
 Ready? Start by downloading the "`Symfony2 Standard Edition`_", a Symfony
 :term:`distribution` that is preconfigured for the most common use cases and

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -97,7 +97,7 @@ URL to see the diagnostics for your machine:
 
 .. code-block:: text
 
-    http://localhost/Symfony/web/config.php
+    http://localhost/web/config.php
 
 If there are any outstanding issues listed, correct them. You might also tweak
 your configuration by following any given recommendations. When everything is
@@ -106,7 +106,7 @@ your first "real" Symfony2 webpage:
 
 .. code-block:: text
 
-    http://localhost/Symfony/web/app_dev.php/
+    http://localhost/web/app_dev.php/
 
 Symfony2 should welcome and congratulate you for your hard work so far!
 
@@ -134,7 +134,7 @@ Symfony2 (replace *Fabien* with your first name):
 
 .. code-block:: text
 
-    http://localhost/Symfony/web/app_dev.php/demo/hello/Fabien
+    http://localhost/web/app_dev.php/demo/hello/Fabien
 
 .. image:: /images/quick_tour/hello_fabien.png
    :align: center
@@ -391,14 +391,14 @@ to production. That's why you will find another front controller in the
 
 .. code-block:: text
 
-    http://localhost/Symfony/web/app.php/demo/hello/Fabien
+    http://localhost/web/app.php/demo/hello/Fabien
 
 And if you use Apache with ``mod_rewrite`` enabled, you can even omit the
 ``app.php`` part of the URL:
 
 .. code-block:: text
 
-    http://localhost/Symfony/web/demo/hello/Fabien
+    http://localhost/web/demo/hello/Fabien
 
 Last but not least, on the production servers, you should point your web root
 directory to the ``web/`` directory to secure your installation and have an

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -97,7 +97,7 @@ URL to see the diagnostics for your machine:
 
 .. code-block:: text
 
-    http://localhost/web/config.php
+    http://localhost/config.php
 
 If there are any outstanding issues listed, correct them. You might also tweak
 your configuration by following any given recommendations. When everything is
@@ -106,7 +106,7 @@ your first "real" Symfony2 webpage:
 
 .. code-block:: text
 
-    http://localhost/web/app_dev.php/
+    http://localhost/app_dev.php/
 
 Symfony2 should welcome and congratulate you for your hard work so far!
 
@@ -134,7 +134,7 @@ Symfony2 (replace *Fabien* with your first name):
 
 .. code-block:: text
 
-    http://localhost/web/app_dev.php/demo/hello/Fabien
+    http://localhost/app_dev.php/demo/hello/Fabien
 
 .. image:: /images/quick_tour/hello_fabien.png
    :align: center
@@ -391,14 +391,14 @@ to production. That's why you will find another front controller in the
 
 .. code-block:: text
 
-    http://localhost/web/app.php/demo/hello/Fabien
+    http://localhost/app.php/demo/hello/Fabien
 
 And if you use Apache with ``mod_rewrite`` enabled, you can even omit the
 ``app.php`` part of the URL:
 
 .. code-block:: text
 
-    http://localhost/web/demo/hello/Fabien
+    http://localhost/demo/hello/Fabien
 
 Last but not least, on the production servers, you should point your web root
 directory to the ``web/`` directory to secure your installation and have an

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -194,7 +194,7 @@ Moreover, the ``admin`` user has a ``ROLE_ADMIN`` role, which includes the
     configuration, but you can use any hashing algorithm by tweaking the
     ``encoders`` section.
 
-Going to the ``http://localhost/Symfony/web/app_dev.php/demo/secured/hello``
+Going to the ``http://localhost/web/app_dev.php/demo/secured/hello``
 URL will automatically redirect you to the login form because this resource is
 protected by a ``firewall``.
 

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -194,7 +194,7 @@ Moreover, the ``admin`` user has a ``ROLE_ADMIN`` role, which includes the
     configuration, but you can use any hashing algorithm by tweaking the
     ``encoders`` section.
 
-Going to the ``http://localhost/web/app_dev.php/demo/secured/hello``
+Going to the ``http://localhost/app_dev.php/demo/secured/hello``
 URL will automatically redirect you to the login form because this resource is
 protected by a ``firewall``.
 


### PR DESCRIPTION
Hi,

   Following this PR: https://github.com/symfony/symfony-docs/pull/1523

   I have change the tip in the quick tour to reflect the usage of the command "server:run" available in Symfony 2.1

Thank you.

Aurélien
