### PR TITLE
added missing use statement on console tests

### DIFF
--- a/components/console.rst
+++ b/components/console.rst
@@ -261,6 +261,7 @@ console::
 
     use Symfony\Component\Console\Application;
     use Symfony\Component\Console\Tester\CommandTester;
+    use Acme\DemoBundle\Command\GreetCommand;
 
     class ListCommandTest extends \PHPUnit_Framework_TestCase
     {


### PR DESCRIPTION
I don't think this is important, but necessary if somebody is not using auto completion.
