### PR TITLE
Fixed typo in cookbook / event_dispatcher / class_extension.rst

### DIFF
--- a/cookbook/event_dispatcher/class_extension.rst
+++ b/cookbook/event_dispatcher/class_extension.rst
@@ -17,7 +17,7 @@ magic ``__call()`` method in the class you want to be extended like this:
         {
             // create an event named 'foo.method_is_not_found'
             $event = new HandleUndefinedMethodEvent($this, $method, $arguments);
-            $this->dispatcher->dispatch($this, 'foo.method_is_not_found', $event);
+            $this->dispatcher->dispatch('foo.method_is_not_found', $event);
 
             // no listener was able to process the event? The method does not exist
             if (!$event->isProcessed()) {


### PR DESCRIPTION
See : https://github.com/symfony/symfony/blob/master/src/Symfony/Component/EventDispatcher/EventDispatcher.php#L40
