### PR TITLE
Fixed typo in cookbook/event_dispatcher/class_extension.rst

### DIFF
--- a/cookbook/event_dispatcher/class_extension.rst
+++ b/cookbook/event_dispatcher/class_extension.rst
@@ -122,4 +122,4 @@ instance of ``Bar`` with the ``foo.method_is_not_found`` event:
 .. code-block:: php
 
     $bar = new Bar();
-    $dispatcher->addListener('foo.method_is_not_found', $bar);
+    $dispatcher->addListener('foo.method_is_not_found', array($bar, 'onFooMethodIsNotFound'));


### PR DESCRIPTION
see https://github.com/symfony/symfony/blob/master/src/Symfony/Component/EventDispatcher/EventDispatcher.php#L164

the second argument of `$dispatcher->addListener` must be callabled. so I think it is a typo.
