### PR TITLE
DomCrawler\Form requires buttons to have names

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -319,4 +319,9 @@ directly::
     // submit that form
     $crawler = $client->submit($form);
 
+.. note::
+
+    Any fields without name attributes will be ignored when generating the form object.
+    This means that your form's submit buttons must have name attributes, else you won't be able to submit the form.
+
 .. _`Goutte`: https://github.com/fabpot/goutte


### PR DESCRIPTION
If a submit button doesn't have a name attribute then you won't be able to use it to submit the form.
