### PR TITLE
added 'data_class' option in examples

### DIFF
--- a/cookbook/form/use_virtuals_forms.rst
+++ b/cookbook/form/use_virtuals_forms.rst
@@ -118,7 +118,9 @@ Look at the result::
     // CompanyType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('foo', new LocationType());
+        $builder->add('foo', new LocationType(), array(
+            'data_class' => 'Acme\HelloBundle\Entity\Company'
+        ));
     }
 
 .. code-block:: php
@@ -126,7 +128,9 @@ Look at the result::
     // CustomerType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('bar', new LocationType());
+        $builder->add('bar', new LocationType(), array(
+            'data_class' => 'Acme\HelloBundle\Entity\Customer'
+        );
     }
 
 With the virtual option set to false (default behavior), the Form Component


### PR DESCRIPTION
The current examples for master are missing the "data_class" option in the examples. If someone is following the cookbook article like I did, he will face issue symfony/symfony#4405

This PR adds the data_class option.
