### PR TITLE
Document how to override log/cache dir

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -76,7 +76,7 @@ something like this:
 .. tip::
 
     You can change the default location of the ``cache`` and ``log`` directories
-    by creating a ``getCacheDir()`` and ``getLogDir()`` methods in the ``AppKernel``
+    by creating a ``getCacheDir()`` or ``getLogDir()`` method in the ``AppKernel``
     class::
 
         // app/AppKernel.php

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -73,6 +73,26 @@ something like this:
                 app.php
                 ...
 
+.. tip::
+
+    You can change the default location of the ``cache`` and ``log`` directories
+    by creating a ``getCacheDir()`` and ``getLogDir()`` methods in the ``AppKernel``
+    class::
+
+        // app/AppKernel.php
+
+        // ...
+        class AppKernel extends Kernel
+        {
+            // ...
+
+            public function getCacheDir()
+            {
+                // rootDir is the path to the app directory
+                return $this->rootDir.'/../cache/'.$this->environment;
+            }
+        }
+
 Updating Vendors
 ~~~~~~~~~~~~~~~~
 

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -77,7 +77,8 @@ something like this:
 
     You can change the default location of the ``cache`` and ``log`` directories
     by creating a ``getCacheDir()`` or ``getLogDir()`` method in the ``AppKernel``
-    class::
+    class. The following example set the ``cache`` directory to the root of your
+    project::
 
         // app/AppKernel.php
 
@@ -88,7 +89,7 @@ something like this:
 
             public function getCacheDir()
             {
-                // rootDir is the path to the app directory
+                // $this->rootDir is the path to the app directory
                 return $this->rootDir.'/../cache/'.$this->environment;
             }
         }

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -981,7 +981,7 @@ in mind:
 * the **configuration** for each bundle lives in the ``Resources/config``
   directory of the bundle and can be specified in YAML, XML or PHP;
 
-* the global **application configuration** lives in the ``app/Resources/config``
+* the global **application configuration** lives in the ``app/config``
   directory;
 
 * each **environment** is accessible via a different front controller (e.g.


### PR DESCRIPTION
This PR closes #1519

When this is correct I will create a new note for the `charset` option, which is added in `2.1`. Where should I place that note, or do I need to create a new cookbook article which documents both 3 options (and remove this one)?
