### PR TITLE
Fixed nonce expiry example

### DIFF
--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -226,7 +226,7 @@ the ``PasswordDigest`` header value matches with the user's password.
             }
 
             // Validate nonce is unique within 5 minutes
-            if (file_exists($this->cacheDir.'/'.$nonce) && file_get_contents($this->cacheDir.'/'.$nonce) + 300 < time()) {
+            if (file_exists($this->cacheDir.'/'.$nonce) && file_get_contents($this->cacheDir.'/'.$nonce) + 300 > time()) {
                 throw new NonceExpiredException('Previously used nonce detected');
             }
             file_put_contents($this->cacheDir.'/'.$nonce, time());


### PR DESCRIPTION
With the existing example, nonces can be re-used for five minutes and then expire, which is the reverse of the desired effect.
