### PR TITLE
Change Size constraint to the new Length and Count constraints

### DIFF
--- a/reference/constraints.rst
+++ b/reference/constraints.rst
@@ -16,7 +16,7 @@ Validation Constraints Reference
    constraints/Email
    constraints/MinLength
    constraints/MaxLength
-   constraints/Size
+   constraints/Length
    constraints/Url
    constraints/Regex
    constraints/Ip

--- a/reference/constraints.rst
+++ b/reference/constraints.rst
@@ -35,6 +35,7 @@ Validation Constraints Reference
    constraints/Language
    constraints/Locale
    constraints/Country
+   constraints/Count
 
    constraints/File
    constraints/Image

--- a/reference/constraints/Count.rst
+++ b/reference/constraints/Count.rst
@@ -1,0 +1,101 @@
+Count
+=====
+
+Validates that a given collection (i.e. an array or an object that implements Countable) elements count is *between*
+some minimum and maximum value.
+
+.. versionadded:: 2.1
+    The Count constraint was added in Symfony 2.1.
+
++----------------+---------------------------------------------------------------------+
+| Applies to     | :ref:`property or method<validation-property-target>`               |
++----------------+---------------------------------------------------------------------+
+| Options        | - `min`_                                                            |
+|                | - `max`_                                                            |
+|                | - `minMessage`_                                                     |
+|                | - `maxMessage`_                                                     |
+|                | - `exactMessage`_                                                   |
++----------------+---------------------------------------------------------------------+
+| Class          | :class:`Symfony\\Component\\Validator\\Constraints\\Count`          |
++----------------+---------------------------------------------------------------------+
+| Validator      | :class:`Symfony\\Component\\Validator\\Constraints\\CountValidator` |
++----------------+---------------------------------------------------------------------+
+
+Basic Usage
+-----------
+
+To verify that the ``emails`` array field contains between 1 and 5 elements
+you might add the following:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # src/Acme/EventBundle/Resources/config/validation.yml
+        Acme\EventBundle\Entity\Participant:
+            properties:
+                emails:
+                    - Count:
+                        min: 1
+                        max: 5
+                        minMessage: You must specify at least one email
+                        maxMessage: You cannot specify more than 5 emails
+
+    .. code-block:: php-annotations
+
+        // src/Acme/EventBundle/Entity/Participant.php
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Participant
+        {
+            /**
+             * @Assert\Count(
+             *      min = "1",
+             *      max = "5",
+             *      minMessage = "You must specify at least one email",
+             *      maxMessage = "You cannot specify more than 5 emails"
+             * )
+             */
+             protected $emails = array();
+        }
+
+Options
+-------
+
+min
+~~~
+
+**type**: ``integer`` [:ref:`default option<validation-default-option>`]
+
+This required option is the "min" count value. Validation will fail if the given
+collection elements count is **less** than this min value.
+
+max
+~~~
+
+**type**: ``integer`` [:ref:`default option<validation-default-option>`]
+
+This required option is the "max" count value. Validation will fail if the given
+collection elements count is **greater** than this max value.
+
+minMessage
+~~~~~~~~~~
+
+**type**: ``string`` **default**: ``This collection should contain {{ limit }} elements or more.``.
+
+The message that will be shown if the underlying collection elements count is less than the `min`_ option.
+
+maxMessage
+~~~~~~~~~~
+
+**type**: ``string`` **default**: ``This collection should contain {{ limit }} elements or less.``.
+
+The message that will be shown if the underlying collection elements count is more than the `max`_ option.
+
+exactMessage
+~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``This collection should contain exactly {{ limit }} elements.``.
+
+The message that will be shown if min and max values are equal and the underlying collection elements 
+count is not exactly this value.

--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -1,27 +1,25 @@
 Length
-====
+======
 
-Validates that a given string length or collection elements count is *between*
-some minimum and maximum value.
+Validates that a given string length is *between* some minimum and maximum value.
 
 .. versionadded:: 2.1
     The Length constraint was added in Symfony 2.1.
 
-+----------------+--------------------------------------------------------------------+
-| Applies to     | :ref:`property or method<validation-property-target>`              |
-+----------------+--------------------------------------------------------------------+
-| Options        | - `min`_                                                           |
-|                | - `max`_                                                           |
-|                | - `type`_                                                          |
-|                | - `charset`_                                                       |
-|                | - `minMessage`_                                                    |
-|                | - `maxMessage`_                                                    |
-|                | - `exactMessage`_                                                  |
-+----------------+--------------------------------------------------------------------+
++----------------+----------------------------------------------------------------------+
+| Applies to     | :ref:`property or method<validation-property-target>`                |
++----------------+----------------------------------------------------------------------+
+| Options        | - `min`_                                                             |
+|                | - `max`_                                                             |
+|                | - `charset`_                                                         |
+|                | - `minMessage`_                                                      |
+|                | - `maxMessage`_                                                      |
+|                | - `exactMessage`_                                                    |
++----------------+----------------------------------------------------------------------+
 | Class          | :class:`Symfony\\Component\\Validator\\Constraints\\Length`          |
-+----------------+--------------------------------------------------------------------+
++----------------+----------------------------------------------------------------------+
 | Validator      | :class:`Symfony\\Component\\Validator\\Constraints\\LengthValidator` |
-+----------------+--------------------------------------------------------------------+
++----------------+----------------------------------------------------------------------+
 
 Basic Usage
 -----------
@@ -61,44 +59,6 @@ To verify that the ``firstName`` field length of a class is between "2" and
              protected $firstName;
         }
 
-Basic Usage - Collections
--------------------------
-
-To verify that the ``emails`` array field contains between 1 and 5 elements
-you might add the following:
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # src/Acme/EventBundle/Resources/config/validation.yml
-        Acme\EventBundle\Entity\Participant:
-            properties:
-                emails:
-                    - Length:
-                        min: 1
-                        max: 5
-                        minMessage: You must specify at least one email
-                        maxMessage: You cannot specify more than 5 emails
-
-    .. code-block:: php-annotations
-
-        // src/Acme/EventBundle/Entity/Participant.php
-        use Symfony\Component\Validator\Constraints as Assert;
-
-        class Participant
-        {
-            /**
-             * @Assert\Length(
-             *      min = "1",
-             *      max = "5",
-             *      minMessage = "You must specify at least one email",
-             *      maxMessage = "You cannot specify more than 5 emails"
-             * )
-             */
-             protected $emails = array();
-        }
-
 Options
 -------
 
@@ -118,15 +78,6 @@ max
 This required option is the "max" length value. Validation will fail if the given
 value's length is **greater** than this max value.
 
-type
-~~~~
-
-**type**: ``string``
-
-The type of value to validate. It can be either ``string`` or ``collection``. If
-not specified, the validator will try the correct type based on the underlying
-data being validated.
-
 charset
 ~~~~~~~
 
@@ -140,23 +91,21 @@ is used.
 minMessage
 ~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This value is too short. It should have {{ limit }} characters or more.`` when validating a string, or ``This collection should contain {{ limit }} elements or more.`` when validating a collection.
+**type**: ``string`` **default**: ``This value is too short. It should have {{ limit }} characters or more.``.
 
-The message that will be shown if the underlying value's length or collection elements
-count is less than the `min`_ option.
+The message that will be shown if the underlying value's length is less than the `min`_ option.
 
 maxMessage
 ~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This value is too long. It should have {{ limit }} characters or less.`` when validating a string, or ``This collection should contain {{ limit }} elements or less.`` when validating a collection.
+**type**: ``string`` **default**: ``This value is too long. It should have {{ limit }} characters or less.``.
 
-The message that will be shown if the underlying value's length or collection elements
-count is more than the `max`_ option.
+The message that will be shown if the underlying value's length is more than the `max`_ option.
 
 exactMessage
 ~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This value should have exactly {{ limit }} characters.`` when validating a string, or ``This collection should contain exactly {{ limit }} elements.`` when validating a collection.
+**type**: ``string`` **default**: ``This value should have exactly {{ limit }} characters.``.
 
 The message that will be shown if min and max values are equal and the underlying
-value's length or collection elements count is not exactly this value.
+value's length is not exactly this value.

--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -1,11 +1,11 @@
-Size
+Length
 ====
 
 Validates that a given string length or collection elements count is *between*
 some minimum and maximum value.
 
 .. versionadded:: 2.1
-    The Size constraint was added in Symfony 2.1.
+    The Length constraint was added in Symfony 2.1.
 
 +----------------+--------------------------------------------------------------------+
 | Applies to     | :ref:`property or method<validation-property-target>`              |
@@ -18,9 +18,9 @@ some minimum and maximum value.
 |                | - `maxMessage`_                                                    |
 |                | - `exactMessage`_                                                  |
 +----------------+--------------------------------------------------------------------+
-| Class          | :class:`Symfony\\Component\\Validator\\Constraints\\Size`          |
+| Class          | :class:`Symfony\\Component\\Validator\\Constraints\\Length`          |
 +----------------+--------------------------------------------------------------------+
-| Validator      | :class:`Symfony\\Component\\Validator\\Constraints\\SizeValidator` |
+| Validator      | :class:`Symfony\\Component\\Validator\\Constraints\\LengthValidator` |
 +----------------+--------------------------------------------------------------------+
 
 Basic Usage
@@ -37,7 +37,7 @@ To verify that the ``firstName`` field length of a class is between "2" and
         Acme\EventBundle\Entity\Participant:
             properties:
                 firstName:
-                    - Size:
+                    - Length:
                         min: 2
                         max: 50
                         minMessage: Your first name must be at least 2 characters length
@@ -51,7 +51,7 @@ To verify that the ``firstName`` field length of a class is between "2" and
         class Participant
         {
             /**
-             * @Assert\Size(
+             * @Assert\Length(
              *      min = "2",
              *      max = "50",
              *      minMessage = "Your first name must be at least 2 characters length",
@@ -75,7 +75,7 @@ you might add the following:
         Acme\EventBundle\Entity\Participant:
             properties:
                 emails:
-                    - Size:
+                    - Length:
                         min: 1
                         max: 5
                         minMessage: You must specify at least one email
@@ -89,7 +89,7 @@ you might add the following:
         class Participant
         {
             /**
-             * @Assert\Size(
+             * @Assert\Length(
              *      min = "1",
              *      max = "5",
              *      minMessage = "You must specify at least one email",

--- a/reference/constraints/map.rst.inc
+++ b/reference/constraints/map.rst.inc
@@ -46,7 +46,7 @@ Collection Constraints
 * :doc:`Language </reference/constraints/Language>`
 * :doc:`Locale </reference/constraints/Locale>`
 * :doc:`Country </reference/constraints/Country>`
-* :doc:`Size </reference/constraints/Size>`
+* :doc:`Count </reference/constraints/Count>`
 
 File Constraints
 ~~~~~~~~~~~~~~~~

--- a/reference/constraints/map.rst.inc
+++ b/reference/constraints/map.rst.inc
@@ -18,7 +18,7 @@ String Constraints
 * :doc:`Email </reference/constraints/Email>`
 * :doc:`MinLength </reference/constraints/MinLength>`
 * :doc:`MaxLength </reference/constraints/MaxLength>`
-* :doc:`Size </reference/constraints/Size>`
+* :doc:`Length </reference/constraints/Length>`
 * :doc:`Url </reference/constraints/Url>`
 * :doc:`Regex </reference/constraints/Regex>`
 * :doc:`Ip </reference/constraints/Ip>`


### PR DESCRIPTION
The `Size` constraint is actually a deprecated form of the `Range` constraint and what is now called `Size` is in fact the `Length` constraint.
