### PR TITLE
[Config] Fix missing argument

### DIFF
--- a/components/config/resources.rst
+++ b/components/config/resources.rst
@@ -71,7 +71,7 @@ has found a suitable loader, this loader will be asked to load the resource::
     use Symfony\Component\Config\Loader\LoaderResolver;
     use Symfony\Component\Config\Loader\DelegatingLoader;
 
-    $loaderResolver = new LoaderResolver(array(new YamlUserLoader));
+    $loaderResolver = new LoaderResolver(array(new YamlUserLoader($locator)));
     $delegatingLoader = new DelegatingLoader($loaderResolver);
 
     $delegatingLoader->load(__DIR__.'/users.yml');


### PR DESCRIPTION
If `YamlUserLoader` corresponds to the definition above (which extends `FileLocator`), then it should receive a `FileLocatorInterface` for the first argument of its constructor.

The `$locator` variable here is the one defined above in the page.
