### PR TITLE
Added change that brought me in doubt while doing this in my code

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -650,6 +650,9 @@ exposing a simple and efficient pattern::
         $response = new Response();
         $response->setETag($article->computeETag());
         $response->setLastModified($article->getPublishedAt());
+        
+        // Set response as public. Otherwise it will be private by default.
+        $response->setPublic();
 
         // Check that the Response is not modified for the given Request
         if ($response->isNotModified($this->getRequest())) {


### PR DESCRIPTION
Was wondering why my cache will not work if just setting last-modified header. Found that Symfony set private must-revalidate header by default. Hope this will help other people to understand this better.
