### PR TITLE
[book/doctrine] Transform parameters file to yml

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -48,13 +48,15 @@ information. By convention, this information is usually configured in an
 
 .. code-block:: yaml
 
-    ; app/config/parameters.ini
-    [parameters]
-        database_driver   = pdo_mysql
-        database_host     = localhost
-        database_name     = test_project
-        database_user     = root
-        database_password = password
+    # app/config/parameters.yml
+    parameters:
+        database_driver:    pdo_mysql
+        database_host:      localhost
+        database_name:      test_project
+        database_user:      root
+        database_password:  password
+
+    # ...
 
 .. note::
 


### PR DESCRIPTION
The `book/doctrine` file was using the old `ini` syntax instead of the newer `yml` syntax (which is new in Symfony2.1 issue: symfony/symfony#178). This PR fix this.
