### PR TITLE
Remove references to verbose profiler option

### DIFF
--- a/book/internals.rst
+++ b/book/internals.rst
@@ -519,7 +519,6 @@ the configuration for the development environment:
         web_profiler:
             toolbar: true
             intercept_redirects: true
-            verbose: true
 
     .. code-block:: xml
 
@@ -558,10 +557,6 @@ when an exception is thrown by the application.
 When ``intercept-redirects`` is set to ``true``, the web profiler intercepts
 the redirects and gives you the opportunity to look at the collected data
 before following the redirect.
-
-When ``verbose`` is set to ``true``, the Web Debug Toolbar displays a lot of
-information. Setting ``verbose`` to ``false`` hides some secondary information
-to make the toolbar shorter.
 
 If you enable the web profiler, you also need to mount the profiler routes:
 


### PR DESCRIPTION
This option is deprecated in 2.1 version
