### PR TITLE
Update reference/forms/types/repeated.rst

### DIFF
--- a/reference/forms/types/repeated.rst
+++ b/reference/forms/types/repeated.rst
@@ -36,7 +36,7 @@ Example Usage
     $builder->add('password', 'repeated', array(
         'type' => 'password',
         'invalid_message' => 'The password fields must match.',
-        'options' => array('required' => true),
+        'required' => true,
         'first_options'  => array('label' => 'Password'),
         'second_options' => array('label' => 'Repeat Password'),
     ));


### PR DESCRIPTION
Removed a superfluous reference to "options" in the example options array of the repeated field documentation.

This one had me stumped for a while, changing the example to this seemed to work.
