### PR TITLE
Fixing minor rst errors

### DIFF
--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -360,7 +360,7 @@ The previous YAML file is equivalent to the following PHP code:
 
     array('PHP', 'Perl', 'Python');
 
-Mappings use a colon followed by a space (``: ``) to mark each key/value pair:
+Mappings use a colon followed by a space (``:`` ) to mark each key/value pair:
 
 .. code-block:: yaml
 
@@ -438,7 +438,7 @@ A sequence can be written as a comma separated list within square brackets
     [PHP, Perl, Python]
 
 A mapping can be written as a comma separated list of key/values within curly
-braces (`{}`):
+braces (``{}``):
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Should fix warning about Inline literal start-string without end-string by moving the space from just before the closing string to afterwards but should not make any difference to how it displays.
