### PR TITLE
[Cookbook] New article "How to Override Symfony's Default Directory Structure"

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -73,6 +73,12 @@ something like this:
                 app.php
                 ...
 
+.. note::
+
+    You can easily override the default directory structure. See 
+    :doc:`/cookbook/configuration/override_dir_structure` for more 
+    information.
+
 Updating Vendors
 ~~~~~~~~~~~~~~~~
 

--- a/cookbook/configuration/environments.rst
+++ b/cookbook/configuration/environments.rst
@@ -338,6 +338,11 @@ includes the following:
 
 * ``twig/`` - this directory contains all the cached Twig templates.
 
+.. note::
+
+    You can easilly change the directory location and name, for more information
+    read the article :doc:`/cookbook/configuration/override_dir_structure`.
+
 
 Going Further
 -------------

--- a/cookbook/configuration/index.rst
+++ b/cookbook/configuration/index.rst
@@ -5,6 +5,7 @@ Configuration
     :maxdepth: 2
 
     environments
+    override_dir_structure
     external_parameters
     pdo_session_storage
     apache_router

--- a/cookbook/configuration/override_dir_structure.rst
+++ b/cookbook/configuration/override_dir_structure.rst
@@ -1,0 +1,110 @@
+.. index::
+   single: Override Symfony
+
+How to override Symfony's Default Directory Structure
+=====================================================
+
+Symfony automatically ships with a default directory structure. You can 
+easily override this directory structure to create your own. The default 
+directory structure is:
+
+.. code-block:: text
+
+    app/
+        cache/
+        config/
+        logs/
+        ...
+    src/
+        ...
+    vendor/
+        ...
+    web/
+        app.php
+        ...
+
+Override the ``cache`` directory
+--------------------------------
+
+You can override the cache directory by overriding the ``getCacheDir`` method 
+in the ``AppKernel`` class of you application::
+
+    // app/AppKernel.php
+
+    // ...
+    class AppKernel extends Kernel
+    {
+        // ...
+
+        public function getCacheDir()
+        {
+            return $this->rootDir.'/'.$this->environment.'/cache/';
+        }
+    }
+
+``$this->rootDir`` is the absolute path to the ``app`` directory and ``$this->environment``
+is the current environment (i.e. ``dev``). In this case we have changed 
+the location of the cache directory to ``app/{environment}/cache``.
+
+.. warning::
+
+    You should keep the ``cache`` directory different for each environment, 
+    otherwise some unexpected behaviour can happen as a different environment
+    means different config files and those are cached, so the cached data
+    is different.
+
+Override the ``logs`` directory
+-------------------------------
+
+Overriding the ``logs`` directory is the same as overriding the ``cache`` 
+directory, the only difference is that you need to override the ``getLogDir`` 
+method::
+
+    // app/AppKernel.php
+
+    // ...
+    class AppKernel extends Kernel
+    {
+        // ...
+
+        public function getLogDir()
+        {
+            return $this->rootDir.'/'.$this->environment.'/logs/';
+        }
+    }
+
+We have changed location of the directory to ``app/{environment}/logs``.
+
+Override the ``web`` directory
+------------------------------
+
+Some shared hosting require to rename the ``web`` directory to ``public_html``
+and move this directory to the apache root. You can simply rename the directory: 
+The only thing you need to check is if the path to the ``app`` directory 
+is still right in ``app.php`` or ``app_dev.php``. For instance: If we move 
+the ``web`` directory one map up we need to add ``Symfony`` (the name of 
+your Symfony installation directory) to the path::
+
+    require_once __DIR__.'/../Symfony/app/bootstrap.php.cache';
+    require_once __DIR__.'/../Symfony/app/AppKernel.php';
+    
+.. note::
+    
+    If you use the AsseticBundle you need to configure this, so it can use 
+    the correct ``web`` directory:
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+
+        # ...
+        assetic:
+            # ...
+            read_from: %kernel.root_dir%/../../public_html
+
+    Now you just need to dump the assets again and your application should 
+    work:
+
+    .. code-block:: bash
+
+        $ php app/console assetic:dump --env=prod --no-debug

--- a/cookbook/map.rst.inc
+++ b/cookbook/map.rst.inc
@@ -19,6 +19,7 @@
 * :doc:`/cookbook/configuration/index`
 
   * :doc:`/cookbook/configuration/environments`
+  * :doc:`/cookbook/configuration/override_dir_structure`
   * :doc:`/cookbook/configuration/external_parameters`
   * :doc:`/cookbook/configuration/pdo_session_storage`
   * :doc:`/cookbook/configuration/apache_router`


### PR DESCRIPTION
This PR adds a new cookbook article which explains how to override the default directory structure. This closes 2 of the 3 issues, mentioned by @fabpot in #1519

If this is correct I will go further with an article about setting the charset and at some text about composer (changing the web directory needs some setting in composer.json) for the master branch.

Please note I'm relative new to Restructered Text, it's my first article from scratch. So I maybe have done something wrong, for instance I don't understand the ``.. index::`.

> Note: I did something completely wrong with GIT, this is a new PR that solves the catches by @stof in the first version of this PR (#1677)
