### PR TITLE
Minor improvement: Cleaned up the WsseListener example

### DIFF
--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -106,7 +106,6 @@ set an authenticated token in the security context if successful.
     use Symfony\Component\Security\Core\Exception\AuthenticationException;
     use Symfony\Component\Security\Core\SecurityContextInterface;
     use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
-    use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
     use Acme\DemoBundle\Security\Authentication\Token\WsseUserToken;
 
     class WsseListener implements ListenerInterface
@@ -124,35 +123,35 @@ set an authenticated token in the security context if successful.
         {
             $request = $event->getRequest();
 
-            if ($request->headers->has('x-wsse')) {
-
-                $wsseRegex = '/UsernameToken Username="([^"]+)", PasswordDigest="([^"]+)", Nonce="([^"]+)", Created="([^"]+)"/';
-
-                if (preg_match($wsseRegex, $request->headers->get('x-wsse'), $matches)) {
-                    $token = new WsseUserToken();
-                    $token->setUser($matches[1]);
-
-                    $token->digest   = $matches[2];
-                    $token->nonce    = $matches[3];
-                    $token->created  = $matches[4];
-
-                    try {
-                        $returnValue = $this->authenticationManager->authenticate($token);
-
-                        if ($returnValue instanceof TokenInterface) {
-                            return $this->securityContext->setToken($returnValue);
-                        } elseif ($returnValue instanceof Response) {
-                            return $event->setResponse($returnValue);
-                        }
-                    } catch (AuthenticationException $e) {
-                        // you might log something here
-                    }
-                }
+            $wsseRegex = '/UsernameToken Username="([^"]+)", PasswordDigest="([^"]+)", Nonce="([^"]+)", Created="([^"]+)"/';
+            if (!$request->headers->has('x-wsse') || 1 !== preg_match($wsseRegex, $request->headers->get('x-wsse'), $matches)) {
+                return;
             }
 
-            $response = new Response();
-            $response->setStatusCode(403);
-            $event->setResponse($response);
+            $token = new WsseUserToken();
+            $token->setUser($matches[1]);
+
+            $token->digest   = $matches[2];
+            $token->nonce    = $matches[3];
+            $token->created  = $matches[4];
+
+            try {
+                $authToken = $this->authenticationManager->authenticate($token);
+
+                $this->securityContext->setToken($authToken);
+            } catch (AuthenticationException $failed) {
+                // you might log something here
+
+                // To deny the authentication clear the token. This will redirect to the login page.
+                // $this->securityContext->setToken(null);
+                // return;
+
+                // Deny authentication with a '403 Forbidden' HTTP response
+                $response = new Response();
+                $response->setStatusCode(403);
+                $event->setResponse($response);
+
+            }
         }
     }
 


### PR DESCRIPTION
Refactoring the WsseListener
- AuthenticationManagerInterface will never return a Response, instanceof check is obsolete
- Added option to redirect to the login page by clear the token of the securityContext
