### PR TITLE
[Routing] remove wrong statement about unicode

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -105,10 +105,6 @@ This is the goal of the Symfony2 router: to map the URL of a request to a
 controller. Along the way, you'll learn all sorts of tricks that make mapping
 even the most complex URLs easy.
 
-.. versionadded:: 2.1
-    As of Symfony 2.1, the Routing component also accepts Unicode values
-    in routes like: /Жени/
-
 .. index::
    single: Routing; Under the hood
 

--- a/components/routing.rst
+++ b/components/routing.rst
@@ -301,10 +301,3 @@ automatically in the background if you want to use it. A basic example of the
     If you use caching, the Routing component will compile new classes which
     are saved in the ``cache_dir``. This means your script must have write
     permissions for that location.
-
-.. versionadded:: 2.1
-    As of Symfony 2.1, the Routing component also accepts Unicode values
-    in routes like this::
-
-        $routes->add('unicode_route', new Route('/Жени'));
-


### PR DESCRIPTION
The routing component doesn't fully handle unicode properly.
And without all my pending PRs, it's even worse and can mangle unicode strings.
See symfony/symfony#5236
