### PR TITLE
Adding console usage cookbook page

### DIFF
--- a/cookbook/console/index.rst
+++ b/cookbook/console/index.rst
@@ -5,3 +5,4 @@ Console
     :maxdepth: 2
 
     console_command
+    usage

--- a/cookbook/console/usage.rst
+++ b/cookbook/console/usage.rst
@@ -1,0 +1,54 @@
+.. index::
+    single: Console; Usage
+
+How to use the Console
+======================
+
+The :doc:`/components/console/usage` page of the components documentation looks
+at the global console options. When you use the console as part of the full
+stack framework some additional global options are available as well.
+
+By default console commands run in the ``dev`` environment, you may want
+to change this for some commands. For example, you may want to run some commands
+in the ``prod`` environment for performance reasons. The result of some commands
+will be different depending on the environment, for example, the ``cache:clear``
+command will clear and warm the cache for the specified environment only so to
+clear and warm the ``prod`` cache you need to run:
+
+.. code-block:: bash
+
+    $ php app/console cache:clear --env=prod
+    $ php app/console cache:clear -e=prod
+
+As well as changing the environment you can also choose to disable debug mode.
+This can be useful where you want to run commands in the ``dev`` environment
+but avoid the performance hit of collecting debug data:
+
+.. code-block:: bash
+
+    $ php app/console list --no-debug
+
+There is an interactive shell which allows you to enter commands without having to
+specify ``php app/console`` each time, which is useful if you need to run several
+commands. To enter the shell run:
+
+.. code-block:: bash
+
+    $ php app/console --shell
+    $ php app/console -s
+
+You can now just run commands with the command name:
+
+.. code-block:: bash
+
+    Symfony > list
+
+When using the shell you can choose to run each command in a separate process:
+
+.. code-block:: bash
+
+    $ php app/console --shell --process-isolation
+    $ php app/console -s --process-isolation
+
+When you do this the output will not be colorized and interactivity is not
+supported so you will need to pass all command params explicitly.

--- a/cookbook/console/usage.rst
+++ b/cookbook/console/usage.rst
@@ -52,3 +52,9 @@ When using the shell you can choose to run each command in a separate process:
 
 When you do this the output will not be colorized and interactivity is not
 supported so you will need to pass all command params explicitly.
+
+.. note::
+
+    Unless you are using isolated processes, clearing the cache in the shell
+    will not have an effect on subsequent commands you run. This is because
+    the original cached files will still be being used.


### PR DESCRIPTION
Adding a cookbook page about the extra global console options  when using the framework.
