### PR TITLE
fixed wrong lines number in book/doctrine/persisting objects to the database

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -421,17 +421,17 @@ of the bundle:
 
 Let's walk through this example:
 
-* **lines 8-11** In this section, you instantiate and work with the ``$product``
+* **lines 9-12** In this section, you instantiate and work with the ``$product``
   object like any other, normal PHP object;
 
-* **line 13** This line fetches Doctrine's *entity manager* object, which is
+* **line 14** This line fetches Doctrine's *entity manager* object, which is
   responsible for handling the process of persisting and fetching objects
   to and from the database;
 
-* **line 14** The ``persist()`` method tells Doctrine to "manage" the ``$product``
+* **line 15** The ``persist()`` method tells Doctrine to "manage" the ``$product``
   object. This does not actually cause a query to be made to the database (yet).
 
-* **line 15** When the ``flush()`` method is called, Doctrine looks through
+* **line 16** When the ``flush()`` method is called, Doctrine looks through
   all of the objects that it's managing to see if they need to be persisted
   to the database. In this example, the ``$product`` object has not been
   persisted yet, so the entity manager executes an ``INSERT`` query and a


### PR DESCRIPTION
Take a look at:
http://symfony.com/doc/2.0/book/doctrine.html#persisting-objects-to-the-database
http://symfony.com/doc/current/book/doctrine.html#persisting-objects-to-the-database
The line numbers are smaller than thay should be (I figured it out when reading printed version of docs).

By the way, I created a new branch just for this small issue. First, I created this new branch basing from 5fda74e commit, but when requesting a pull I saw two files being requested (and the first one was already accepted by you, https://github.com/symfony/symfony-docs/pull/1661). So I removed it, created a new branch from 7cc08f4 (lots of forks seem to start from there) and now there's just one file to be modified in this branch/single-commit. I hope it's ok - let me know if I should rework something.
