### PR TITLE
Broken git-scm.com links

### DIFF
--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -116,8 +116,8 @@ manage this is `Gitolite`_.
 .. _`git`: http://git-scm.com/
 .. _`Symfony2 Standard Edition`: http://symfony.com/download
 .. _`Standard Edition Readme`: https://github.com/symfony/symfony-standard/blob/master/README.md
-.. _`git submodules`: http://book.git-scm.com/5_submodules.html
+.. _`git submodules`: http://git-scm.com/book/en/Git-Tools-Submodules
 .. _`GitHub`: https://github.com/
-.. _`barebones repository`: http://progit.org/book/ch4-4.html
+.. _`barebones repository`: http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository
 .. _`Gitolite`: https://github.com/sitaramc/gitolite
 .. _`Github .gitignore`: http://help.github.com/ignore-files/


### PR DESCRIPTION
Updated the links to git-scm.com as they redesigned the page.
