### PR TITLE
Update cookbook/form/data_transformers.rst

### DIFF
--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -125,6 +125,14 @@ issue field in some form.
                 );
             }
 
+            public function setDefaultOptions(OptionsResolverInterface $resolver)
+            {
+                $resolver->setDefaults(array(
+                    'data_class' => 'Acme\TaskBundle\Entity\Issue',
+                    'em'         => null,
+                ));
+            }
+
             // ...
         }
 


### PR DESCRIPTION
Hi,

I have followed this cookbook and got this error

``` bash
The option "em" does not exist. Known options are: "attr", ..., "widget_type"
```

It tooks me some hour to get this work. 

You should provide `'em'` in `setDefaultOptions` to avoid this error.

Thanks
