### PR TITLE
fixed logical error, hould be "outside" instead of "inside"

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -183,7 +183,7 @@ file:
 .. tip::
 
     Even though all routes are loaded from a single file, it's common practice
-    to include additional routing resources from inside the file. See the
+    to include additional routing resources from outside the file. See the
     :ref:`routing-include-external-resources` section for more information.
 
 Basic Route Configuration

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -183,8 +183,10 @@ file:
 .. tip::
 
     Even though all routes are loaded from a single file, it's common practice
-    to include additional routing resources from outside the file. See the
-    :ref:`routing-include-external-resources` section for more information.
+    to include additional routing resources. To do so, just point out in the
+    main routing configuration file which external files should be included.
+    See the :ref:`routing-include-external-resources` section for more
+    information.
 
 Basic Route Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
There seems to be a logical error in this sentence:
if all routing is loaded from a single file and this includes loading external resources (= external files), including those additional resources is from external files, so it's from outside the main routing file. At least the actual meaning seems illogical to me... ;)
