### PR TITLE
removed extra "the" in text

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -1221,13 +1221,13 @@ rendered (e.g. ``label``, ``widget``, ``errors``, etc). By default, there
 are 4 possible *parts* of a form that can be rendered:
 
 +-------------+--------------------------+---------------------------------------------------------+
-| ``label``   | (e.g. ``field_label``)   | renders the field's label                               |
+| ``label``   | (e.g. ``form_label``)   | renders the field's label                               |
 +-------------+--------------------------+---------------------------------------------------------+
-| ``widget``  | (e.g. ``field_widget``)  | renders the field's HTML representation                 |
+| ``widget``  | (e.g. ``form_widget``)  | renders the field's HTML representation                 |
 +-------------+--------------------------+---------------------------------------------------------+
-| ``errors``  | (e.g. ``field_errors``)  | renders the field's errors                              |
+| ``errors``  | (e.g. ``form_errors``)  | renders the field's errors                              |
 +-------------+--------------------------+---------------------------------------------------------+
-| ``row``     | (e.g. ``field_row``)     | renders the field's entire row (label, widget & errors) |
+| ``row``     | (e.g. ``form_row``)     | renders the field's entire row (label, widget & errors) |
 +-------------+--------------------------+---------------------------------------------------------+
 
 .. note::

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -200,7 +200,7 @@ the array::
     $tokens['c'] = $value;
     $session->set('tokens', $tokens);
 
-With structured namespacing, the the key can be translated to the array
+With structured namespacing, the key can be translated to the array
 structure like this using a namespace character (defaults to `/`)::
 
     $session->set('tokens/c', $value);


### PR DESCRIPTION
Update block name, field_\* are deprecated in sf2.1
