### PR TITLE
Fixing indentation issue in components map page

### DIFF
--- a/components/map.rst.inc
+++ b/components/map.rst.inc
@@ -31,7 +31,7 @@
 
 * **DOM Crawler**
 
-* :doc:`/components/dom_crawler`
+  * :doc:`/components/dom_crawler`
 
 * :doc:`/components/event_dispatcher/index`
 


### PR DESCRIPTION
I think I may have introduced this reordering the map page.
