### PR TITLE
Adding link to using annotations from routing book page

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1017,7 +1017,8 @@ loaded from the new routing resource.
 
 .. tip::
 
-    You can also define routes using annotations. See the :doc:`FrameworkExtraBundle documentation<bundles/SensioFrameworkExtraBundle/annotations/routing>`
+    You can also define routes using annotations. See the
+    :doc:`FrameworkExtraBundle documentation<bundles/SensioFrameworkExtraBundle/annotations/routing>`
     to see how to.
 
 .. index::

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -18,7 +18,7 @@ areas of your application. By the end of this chapter, you'll be able to:
 
 * Create complex routes that map to controllers
 * Generate URLs inside templates and controllers
-* Load routing resources from bundles (or anywhere else) 
+* Load routing resources from bundles (or anywhere else)
 * Debug your routes
 
 .. index::
@@ -90,7 +90,7 @@ pattern that points to a specific PHP class and method:
         {
             // use the $slug variable to query the database
             $blog = ...;
-            
+
             return $this->render('AcmeBlogBundle:Blog:show.html.twig', array(
                 'blog' => $blog,
             ));
@@ -103,7 +103,7 @@ will be executed and the ``$slug`` variable will be equal to ``my-post``.
 
 This is the goal of the Symfony2 router: to map the URL of a request to a
 controller. Along the way, you'll learn all sorts of tricks that make mapping
-even the most complex URLs easy. 
+even the most complex URLs easy.
 
 .. index::
    single: Routing; Under the hood
@@ -821,7 +821,7 @@ The controller might look like this:
     namespace Acme\BlogBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-    
+
     class BlogController extends Controller
     {
         public function showAction($slug)
@@ -1015,6 +1015,11 @@ instead of simply ``/hello/{name}``:
 The string ``/admin`` will now be prepended to the pattern of each route
 loaded from the new routing resource.
 
+.. tip::
+
+    You can also define routes using annotations. See the :doc:`FrameworkExtraBundle documentation<bundles/SensioFrameworkExtraBundle/annotations/routing>`
+    to see how to.
+
 .. index::
    single: Routing; Debugging
 
@@ -1091,9 +1096,9 @@ In an upcoming section, you'll learn how to generate URLs from inside templates.
     If the frontend of your application uses AJAX requests, you might want
     to be able to generate URLs in JavaScript based on your routing configuration.
     By using the `FOSJsRoutingBundle`_, you can do exactly that:
-    
+
     .. code-block:: javascript
-    
+
         var url = Routing.generate('blog_show', { "slug": 'my-blog-post'});
 
     For more information, see the documentation for that bundle.
@@ -1120,9 +1125,9 @@ method:
     on server information supplied by PHP. When generating absolute URLs for
     scripts run from the command line, you'll need to manually set the desired
     host on the ``RequestContext`` object:
-    
+
     .. code-block:: php
-    
+
         $router->getContext()->setHost('www.example.com');
 
 .. index::


### PR DESCRIPTION
I appreciate that the FrameworkExtraBundle annotations are not included in the main book but it is quite hidden away so it would possibly be useful to link through to it.
