### PR TITLE
Routing working message period against dot

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -757,7 +757,7 @@ routing system can be:
 
 As you've seen, this route will only match if the ``{culture}`` portion of
 the URL is either ``en`` or ``fr`` and if the ``{year}`` is a number. This
-route also shows how you can use a period between placeholders instead of
+route also shows how you can use a dot between placeholders instead of
 a slash. URLs matching this route might look like:
 
 * ``/articles/en/2010/my-post``

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -131,7 +131,7 @@ configuration. The ``PhpDumper`` makes dumping the compiled container easy::
 
     if (file_exists($file)) {
         require_once $file;
-        $container = new ProjectServiceContiner();
+        $container = new ProjectServiceContainer();
     } else {
         $container = new ContainerBuilder();
         //--
@@ -141,7 +141,7 @@ configuration. The ``PhpDumper`` makes dumping the compiled container easy::
         file_put_contents($file, $dumper->dump());
     }
 
-``ProjectServiceContiner`` is the default name given to the dumped container
+``ProjectServiceContainer`` is the default name given to the dumped container
 class, you can change this though this with the ``class`` option when you dump
 it::
 


### PR DESCRIPTION
original:

> This route also shows how you can use a period between placeholders instead of a slash.

Shouldn't it be better to replace the word 'period' with the word 'dot'?

> This route also shows how you can use a dot between placeholders instead of a slash.

I got confused - for me the period symbol would be the same as the range symbol which in programming languages is usually '..'. I think that 'dot' makes it clear. Besides, until now I didn't know that 'dot' and 'period' are synonyms :/
