### PR TITLE
routing/working with message obj/dot instead of period

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -757,7 +757,7 @@ routing system can be:
 
 As you've seen, this route will only match if the ``{culture}`` portion of
 the URL is either ``en`` or ``fr`` and if the ``{year}`` is a number. This
-route also shows how you can use a period between placeholders instead of
+route also shows how you can use a dot between placeholders instead of
 a slash. URLs matching this route might look like:
 
 * ``/articles/en/2010/my-post``


### PR DESCRIPTION
original:

> This route also shows how you can use a period between placeholders instead of a slash.

Shouldn't it be better to replace the word 'period' with the word 'dot'?

> This route also shows how you can use a dot between placeholders instead of a slash.

I got confused - for me the period symbol would be the same as the range symbol which in programming languages is usually '..'. I think that 'dot' makes it clear. Besides, until now I didn't know that 'dot' and 'period' are synonyms :/
