### PR TITLE
Remove "s" from constraint as it's wrong path

### DIFF
--- a/reference/constraints/UserPassword.rst
+++ b/reference/constraints/UserPassword.rst
@@ -50,7 +50,7 @@ password:
        // src/Acme/UserBundle/Form/Model/ChangePassword.php
        namespace Acme\UserBundle\Form\Model;
        
-       use Symfony\Component\Security\Core\Validator\Constraints as SecurityAssert;
+       use Symfony\Component\Security\Core\Validator\Constraint as SecurityAssert;
 
        class ChangePassword
        {


### PR DESCRIPTION
Changes from 
   `use Symfony\Component\Security\Core\Validator\Constraints as SecurityAssert;`
to 
    `use Symfony\Component\Security\Core\Validator\Constraint as SecurityAssert;`
