### PR TITLE
Fix typo in Forms chapter

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -439,7 +439,7 @@ You can also define whole logic inline by using a Closure::
             'validation_groups' => function(FormInterface $form) {
                 $data = $form->getData();
                 if (Entity\Client::TYPE_PERSON == $data->getType()) {
-                    return array('person')
+                    return array('person');
                 } else {
                     return array('company');
                 }


### PR DESCRIPTION
Fix typo (missing ";") in source code sample for dynamic validation groups
