### PR TITLE
[2.0] Update all docs to not recommend invalid YAML.

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -67,11 +67,11 @@ information. By convention, this information is usually configured in an
         # app/config/config.yml
         doctrine:
             dbal:
-                driver:   %database_driver%
-                host:     %database_host%
-                dbname:   %database_name%
-                user:     %database_user%
-                password: %database_password%
+                driver:   "%database_driver%"
+                host:     "%database_host%"
+                dbname:   "%database_name%"
+                user:     "%database_user%"
+                password: "%database_password%"
     
     By separating the database information into a separate file, you can
     easily keep different versions of the file on each server. You can also

--- a/book/propel.rst
+++ b/book/propel.rst
@@ -52,10 +52,10 @@ information.  By convention, this information is usually configured in an
 
         propel:
             dbal:
-                driver:     %database_driver%
-                user:       %database_user%
-                password:   %database_password%
-                dsn:        %database_driver%:host=%database_host%;dbname=%database_name%;charset=%database_charset%
+                driver:     "%database_driver%"
+                user:       "%database_user%"
+                password:   "%database_password%"
+                dsn:        "%database_driver%:host=%database_host%;dbname=%database_name%;charset=%database_charset%"
 
 Now that Propel knows about your database, Symfony2 can create the database for
 you:

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -186,7 +186,7 @@ straightforward. Parameters make defining services more organized and flexible:
 
         services:
             my_mailer:
-                class:        %my_mailer.class%
+                class:        "%my_mailer.class%"
                 arguments:    [%my_mailer.transport%]
 
     .. code-block:: xml
@@ -358,7 +358,7 @@ directories don't exist, create them.
 
         services:
             my_mailer:
-                class:        %my_mailer.class%
+                class:        "%my_mailer.class%"
                 arguments:    [%my_mailer.transport%]
 
     .. code-block:: xml
@@ -594,7 +594,7 @@ the service container gives us a much more appealing option:
             my_mailer:
                 # ...
             newsletter_manager:
-                class:     %newsletter_manager.class%
+                class:     "%newsletter_manager.class%"
                 arguments: [@my_mailer]
 
     .. code-block:: xml
@@ -681,7 +681,7 @@ Injecting the dependency by the setter method just needs a change of syntax:
             my_mailer:
                 # ...
             newsletter_manager:
-                class:     %newsletter_manager.class%
+                class:     "%newsletter_manager.class%"
                 calls:
                     - [ setMailer, [ @my_mailer ] ]
 
@@ -746,7 +746,7 @@ it exists and do nothing if it doesn't:
 
         services:
             newsletter_manager:
-                class:     %newsletter_manager.class%
+                class:     "%newsletter_manager.class%"
                 arguments: [@?my_mailer]
 
     .. code-block:: xml
@@ -845,7 +845,7 @@ Configuring the service container is easy:
 
         services:
             newsletter_manager:
-                class:     %newsletter_manager.class%
+                class:     "%newsletter_manager.class%"
                 arguments: [@mailer, @templating]
 
     .. code-block:: xml

--- a/components/dependency_injection/advanced.rst
+++ b/components/dependency_injection/advanced.rst
@@ -107,7 +107,7 @@ the service itself gets loaded. To do so, you can use the ``file`` directive.
         services:
            foo:
              class: Example\Foo\Bar
-             file: %kernel.root_dir%/src/path/to/file/foo.php
+             file: "%kernel.root_dir%/src/path/to/file/foo.php"
 
     .. code-block:: xml
 

--- a/components/dependency_injection/factories.rst
+++ b/components/dependency_injection/factories.rst
@@ -41,8 +41,8 @@ class:
             newsletter_factory.class: NewsletterFactory
         services:
             newsletter_manager:
-                class:          %newsletter_manager.class%
-                factory_class:  %newsletter_factory.class%
+                class:          "%newsletter_manager.class%"
+                factory_class:  "%newsletter_factory.class%"
                 factory_method: get 
 
     .. code-block:: xml
@@ -92,9 +92,9 @@ factory itself as a service:
             newsletter_factory.class: NewsletterFactory
         services:
             newsletter_factory:
-                class:            %newsletter_factory.class%
+                class:            "%newsletter_factory.class%"
             newsletter_manager:
-                class:            %newsletter_manager.class%
+                class:            "%newsletter_manager.class%"
                 factory_service:  newsletter_factory
                 factory_method:   get 
 
@@ -156,9 +156,9 @@ in the previous example takes the ``templating`` service as an argument:
             newsletter_factory.class: NewsletterFactory
         services:
             newsletter_factory:
-                class:            %newsletter_factory.class%
+                class:            "%newsletter_factory.class%"
             newsletter_manager:
-                class:            %newsletter_manager.class%
+                class:            "%newsletter_manager.class%"
                 factory_service:  newsletter_factory
                 factory_method:   get
                 arguments:

--- a/components/dependency_injection/parentservices.rst
+++ b/components/dependency_injection/parentservices.rst
@@ -62,13 +62,13 @@ The service config for these classes would look something like this:
             my_email_formatter:
                 # ...
             newsletter_manager:
-                class:     %newsletter_manager.class%
+                class:     "%newsletter_manager.class%"
                 calls:
                     - [ setMailer, [ @my_mailer ] ]
                     - [ setEmailFormatter, [ @my_email_formatter] ]
 
             greeting_card_manager:
-                class:     %greeting_card_manager.class%
+                class:     "%greeting_card_manager.class%"
                 calls:
                     - [ setMailer, [ @my_mailer ] ]
                     - [ setEmailFormatter, [ @my_email_formatter] ]
@@ -191,18 +191,18 @@ a parent for a service.
             my_email_formatter:
                 # ...
             mail_manager:
-                class:     %mail_manager.class%
+                class:     "%mail_manager.class%"
                 abstract:  true
                 calls:
                     - [ setMailer, [ @my_mailer ] ]
                     - [ setEmailFormatter, [ @my_email_formatter] ]
             
             newsletter_manager:
-                class:     %newsletter_manager.class%
+                class:     "%newsletter_manager.class%"
                 parent: mail_manager
             
             greeting_card_manager:
-                class:     %greeting_card_manager.class%
+                class:     "%greeting_card_manager.class%"
                 parent: mail_manager
             
     .. code-block:: xml
@@ -317,20 +317,20 @@ to the ``NewsletterManager`` class, the config would look like this:
             my_email_formatter:
                 # ...
             mail_manager:
-                class:     %mail_manager.class%
+                class:     "%mail_manager.class%"
                 abstract:  true
                 calls:
                     - [ setMailer, [ @my_mailer ] ]
                     - [ setEmailFormatter, [ @my_email_formatter] ]
             
             newsletter_manager:
-                class:     %newsletter_manager.class%
+                class:     "%newsletter_manager.class%"
                 parent: mail_manager
                 calls:
                     - [ setMailer, [ @my_alternative_mailer ] ]
             
             greeting_card_manager:
-                class:     %greeting_card_manager.class%
+                class:     "%greeting_card_manager.class%"
                 parent: mail_manager
             
     .. code-block:: xml
@@ -449,13 +449,13 @@ If you had the following config:
             another_filter:
                 # ...
             mail_manager:
-                class:     %mail_manager.class%
+                class:     "%mail_manager.class%"
                 abstract:  true
                 calls:
                     - [ setFilter, [ @my_filter ] ]
                     
             newsletter_manager:
-                class:     %newsletter_manager.class%
+                class:     "%newsletter_manager.class%"
                 parent: mail_manager
                 calls:
                     - [ setFilter, [ @another_filter ] ]

--- a/components/dependency_injection/tags.rst
+++ b/components/dependency_injection/tags.rst
@@ -44,7 +44,7 @@ Then, define the chain as a service:
 
         services:
             acme_mailer.transport_chain:
-                class: %acme_mailer.transport_chain.class%
+                class: "%acme_mailer.transport_chain.class%"
 
     .. code-block:: xml
 

--- a/cookbook/configuration/external_parameters.rst
+++ b/cookbook/configuration/external_parameters.rst
@@ -66,8 +66,8 @@ You can now reference these parameters wherever you need them.
             dbal:
                 driver    pdo_mysql
                 dbname:   symfony2_project
-                user:     %database.user%
-                password: %database.password%
+                user:     "%database.user%"
+                password: "%database.password%"
 
     .. code-block:: xml
 

--- a/cookbook/configuration/override_dir_structure.rst
+++ b/cookbook/configuration/override_dir_structure.rst
@@ -108,7 +108,7 @@ may need to modify the paths inside these files::
         # ...
         assetic:
             # ...
-            read_from: %kernel.root_dir%/../../public_html
+            read_from: "%kernel.root_dir%/../../public_html"
 
     Now you just need to dump the assets again and your application should 
     work:

--- a/cookbook/security/custom_provider.rst
+++ b/cookbook/security/custom_provider.rst
@@ -170,7 +170,7 @@ Now we make the user provider available as a service.
             
         services:
             webservice_user_provider:
-                class: %webservice_user_provider.class%
+                class: "%webservice_user_provider.class%"
     
     .. code-block:: xml
 

--- a/cookbook/security/securing_services.rst
+++ b/cookbook/security/securing_services.rst
@@ -79,7 +79,7 @@ Then in your service configuration, you can inject the service:
 
         services:
             newsletter_manager:
-                class:     %newsletter_manager.class%
+                class:     "%newsletter_manager.class%"
                 arguments: [@security.context]
 
     .. code-block:: xml

--- a/cookbook/service_container/scopes.rst
+++ b/cookbook/service_container/scopes.rst
@@ -159,7 +159,7 @@ The service config for this class would look something like this:
             my_mailer.class: Acme\HelloBundle\Mail\Mailer
         services:
             my_mailer:
-                class:     %my_mailer.class%
+                class:     "%my_mailer.class%"
                 arguments:
                     - "@service_container"
                 # scope: container can be omitted as it is the default

--- a/cookbook/templating/global_variables.rst
+++ b/cookbook/templating/global_variables.rst
@@ -35,7 +35,7 @@ system, which lets you isolate or reuse the value:
     # app/config/config.yml
     twig:
         globals:
-            ga_tracking: %ga_tracking%
+            ga_tracking: "%ga_tracking%"
 
 The same variable is available exactly as before.
 

--- a/reference/configuration/assetic.rst
+++ b/reference/configuration/assetic.rst
@@ -14,8 +14,8 @@ Full Default Configuration
         assetic:
             debug:                true
             use_controller:       true
-            read_from:            %kernel.root_dir%/../web
-            write_to:             %assetic.read_from%
+            read_from:            "%kernel.root_dir%/../web"
+            write_to:             "%assetic.read_from%"
             java:                 /usr/bin/java
             node:                 /usr/bin/node
             sass:                 /usr/bin/sass

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -140,7 +140,7 @@ the ORM resolves to:
             # the standard distribution overrides this to be true in debug, false otherwise
             auto_generate_proxy_classes: false
             proxy_namespace: Proxies
-            proxy_dir: %kernel.cache_dir%/doctrine/orm/Proxies
+            proxy_dir: "%kernel.cache_dir%/doctrine/orm/Proxies"
             default_entity_manager: default
             metadata_cache_driver: array
             query_cache_driver: array
@@ -236,12 +236,12 @@ can configure. The following block shows all possible configuration keys:
                 driver_class:         MyNamespace\MyDriverImpl
                 options:
                     foo: bar
-                path:                 %kernel.data_dir%/data.sqlite
+                path:                 "%kernel.data_dir%/data.sqlite"
                 memory:               true
                 unix_socket:          /tmp/mysql.sock
                 wrapper_class:        MyDoctrineDbalConnectionWrapper
                 charset:              UTF8
-                logging:              %kernel.debug%
+                logging:              "%kernel.debug%"
                 platform_service:     MyOwnDatabasePlatformService
                 mapping_types:
                     enum: string


### PR DESCRIPTION
Updated the docs to make sure we don't have any instances of

``` yaml
key:    %value%
```

This invalid yaml mark up.
See: https://github.com/symfony/symfony-docs/pull/1770 #1770
See: https://github.com/symfony/symfony-standard/pull/427
