### PR TITLE
Added by reference option to choice type

### DIFF
--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -20,6 +20,7 @@ option.
 |             | - `preferred_choices`_                                                      |
 |             | - `empty_value`_                                                            |
 |             | - `empty_data`_                                                             |
+|             | - `by_reference`_                                                           |
 +-------------+-----------------------------------------------------------------------------+
 | Inherited   | - `required`_                                                               |
 | options     | - `label`_                                                                  |
@@ -103,6 +104,8 @@ can be created to supply the choices.
 .. include:: /reference/forms/types/options/empty_value.rst.inc
 
 .. include:: /reference/forms/types/options/empty_data.rst.inc
+
+.. include:: /reference/forms/types/options/by_reference.rst.inc
 
 Inherited options
 -----------------


### PR DESCRIPTION
Hi,

The choice type has supported `by_reference` as an option since 2.1, so that when using this type to manage related entities, setXXX methods relating to the options can be called accordingly when the form is bound.

This option is missing from the docs; I've linked to the common document for that option but I'm not sure if it is 100% accurate since that was written, I believe, with the Collection type in mind. If that's the case let me know and I'll write something specific.

Cheers,
Craig
