### PR TITLE
Templating: code example highlighting error

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -854,7 +854,7 @@ independent of the rest of the page.
     public function indexAction()
     {
         $response = $this->render('MyBundle:MyController:index.html.twig');
-        // set the shared max age - the also marks the response as public
+        // set the shared max age - which also marks the response as public
         $response->setSharedMaxAge(600);
 
         return $response;

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -927,7 +927,7 @@ you're actually using the templating engine service. For example::
 
     return $this->render('AcmeArticleBundle:Article:index.html.twig');
 
-is equivalent to:
+is equivalent to::
 
     $engine = $this->container->get('templating');
     $content = $engine->render('AcmeArticleBundle:Article:index.html.twig');


### PR DESCRIPTION
Missed a ':'
