### PR TITLE
fixed file property accessibility

### DIFF
--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -122,9 +122,14 @@ rules::
         /**
          * @Assert\File(maxSize="6000000")
          */
-        public $file;
+        private $file;
 
         // ...
+
+        public function setFile($file)
+        {
+            $this->file = $file;
+        }
     }
 
 .. note::


### PR DESCRIPTION
The file property should be private and there should be a setter for the property (so the form can save it).
Otherwise doctrine complains about the public property: Field 'file' in class 'Acme\DemoBundle\Entity\Document' must be private or protected. Public fields may break lazy-loading.
