### PR TITLE
[Components][DomCrawler] Remove protected method getRawUri()

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -192,17 +192,16 @@ instance with just the selected link(s). Calling ``link()`` gives us a special
 The :class:`Symfony\\Component\\DomCrawler\\Link` object has several useful
 methods to get more information about the selected link itself::
 
-    // return the raw href value
-    $href = $link->getRawUri();
-
     // return the proper URI that can be used to make another request
     $uri = $link->getUri();
 
-The ``getUri()`` is especially useful as it cleans the ``href`` value and
-transforms it into how it should really be processed. For example, for a
-link with ``href="#foo"``, this would return the full URI of the current
-page suffixed with ``#foo``. The return from ``getUri()`` is always a full
-URI that you can act on.
+.. note::
+
+    The ``getUri()`` is especially useful as it cleans the ``href`` value and
+    transforms it into how it should really be processed. For example, for a
+    link with ``href="#foo"``, this would return the full URI of the current
+    page suffixed with ``#foo``. The return from ``getUri()`` is always a full
+    URI that you can act on.
 
 Forms
 .....


### PR DESCRIPTION
getRawUri() is a protected method, so it's not accesible and shouldn't be listed on the docs

https://github.com/symfony/symfony/blob/2.0/src/Symfony/Component/DomCrawler/Link.php#L137

The method it's still protected on master, so it applies to all doc branches:
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DomCrawler/Link.php#L137

Also moved brief explanation of the method from the block to a "note" block so it's a bit more prominent 
