### PR TITLE
Describing memory spooling in combination with console command

### DIFF
--- a/cookbook/email/spool.rst
+++ b/cookbook/email/spool.rst
@@ -53,6 +53,24 @@ swiftmailer with the memory option, use the following configuration:
             'spool' => array('type' => 'memory')
         ));
         
+.. note::
+
+    If you are trying to sent emails from within a console command, you must
+    trigger the sending of all spooled messages by yourself as the kernel 
+    terminate event doesn't get called. Use the following code to sent
+    emails inside your console command::
+
+        $container = $this->getContainer();
+        $mailer = $container->get('mailer');
+        $spool = $mailer->getTransport()->getSpool();
+        $transport = $container->get('swiftmailer.transport.real');
+
+        $spool->flushQueue($transport);
+        
+    Another option is to create an environment which is only used by console
+    commands and either deactivate spooling, thus sending messages directly, or
+    use file spooling and then send spooled emails as described below.
+        
 Spool using a file
 ------------------
 


### PR DESCRIPTION
As discussed (https://github.com/symfony/SwiftmailerBundle/issues/23), when memory spooling is active and one tries to sent mails from a console command, nothing happens because the kernel terminate doesn't get called.

I tried to find a good place and think the email cookbooks are ok. I didn't want to put it with the console documentation as the console is a stand alone component and the docs are written in a general way. The behaviour described above on the other hand is related to how symfony works with the events.
