### PR TITLE
[Coookbook] - EventListener exception method error

### DIFF
--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -26,12 +26,12 @@ event is just one of the core kernel events::
         {
             // We get the exception object from the received event
             $exception = $event->getException();
-            $message = 'My Error says: ' . $exception->getMessage();
+            $message = 'My Error says: ' . $exception->getMessage() . ' with code: ' . $exception->getCode();
 
             // Customize our response object to display our exception details
             $response = new Response();
             $response->setContent($message);
-            $response->setStatusCode($exception->getStatusCode());
+            $response->setStatusCode(500);
 
             // Send our modified response object to the event
             $event->setResponse($response);


### PR DESCRIPTION
\Exception does not have a "getCodeStatus" method, but a"getCode". Apart from that, this code is related to the exception not to the Response status code.
Therefore I've adapted the $message to have the exception code via getCode and added a 500 HTTP Status Code.
