### PR TITLE
Typo fix in reference/constraints/Collection.rst

### DIFF
--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -63,7 +63,7 @@ blank but is no longer than 100 characters in length, you would do the following
                             - MaxLength:
                                 limit:   100
                                 message: Your short bio is too long!
-                    allowMissingfields: true
+                    allowMissingFields: true
 
     .. code-block:: php-annotations
 


### PR DESCRIPTION
Typo fix: `f` ==> `F` in _allowMissingfields_

Copying bad code from this example caused:
`The options "allowMissingfields" do not exist in constraint Symfony\Component\Validator\Constraints\Collection`
