### PR TITLE
removed references to the PEAR channel

### DIFF
--- a/components/class_loader.rst
+++ b/components/class_loader.rst
@@ -28,7 +28,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/ClassLoader);
-* Install it via PEAR ( `pear.symfony.com/ClassLoader`);
 * Install it via Composer (`symfony/class-loader` on Packagist).
 
 Usage

--- a/components/config/introduction.rst
+++ b/components/config/introduction.rst
@@ -18,7 +18,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/Config);
-* Install it via PEAR ( `pear.symfony.com/Config`);
 * Install it via Composer (`symfony/config` on Packagist).
 
 Sections

--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -18,7 +18,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/Console);
-* Install it via PEAR ( `pear.symfony.com/Console`);
 * Install it via Composer (`symfony/console` on Packagist).
 
 Creating a basic Command

--- a/components/css_selector.rst
+++ b/components/css_selector.rst
@@ -13,7 +13,6 @@ Installation
 You can install the component in several different ways:
 
 * Use the official Git repository (https://github.com/symfony/CssSelector);
-* Install it via PEAR ( `pear.symfony.com/CssSelector`);
 * Install it via Composer (`symfony/css-selector` on Packagist).
 
 Usage

--- a/components/dependency_injection/introduction.rst
+++ b/components/dependency_injection/introduction.rst
@@ -17,7 +17,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/DependencyInjection);
-* Install it via PEAR ( `pear.symfony.com/DependencyInjection`);
 * Install it via Composer (`symfony/dependency-injection` on Packagist).
 
 Basic Usage

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -13,7 +13,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/DomCrawler);
-* Install it via PEAR ( `pear.symfony.com/DomCrawler`);
 * Install it via Composer (`symfony/dom-crawler` on Packagist).
 
 Usage

--- a/components/event_dispatcher/introduction.rst
+++ b/components/event_dispatcher/introduction.rst
@@ -50,7 +50,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/EventDispatcher);
-* Install it via PEAR ( `pear.symfony.com/EventDispatcher`);
 * Install it via Composer (`symfony/event-dispatcher` on Packagist).
 
 Usage

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -14,7 +14,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/Finder);
-* Install it via PEAR ( `pear.symfony.com/Finder`);
 * Install it via Composer (`symfony/finder` on Packagist).
 
 Usage

--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -22,7 +22,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/HttpFoundation);
-* Install it via PEAR ( `pear.symfony.com/HttpFoundation`);
 * Install it via Composer (`symfony/http-foundation` on Packagist).
 
 Request

--- a/components/locale.rst
+++ b/components/locale.rst
@@ -28,7 +28,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/Locale);
-* Install it via PEAR ( `pear.symfony.com/Locale`);
 * Install it via Composer (`symfony/locale` on Packagist).
 
 Usage

--- a/components/process.rst
+++ b/components/process.rst
@@ -13,7 +13,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/Process);
-* Install it via PEAR ( `pear.symfony.com/Process`);
 * Install it via Composer (`symfony/process` on Packagist).
 
 Usage

--- a/components/routing.rst
+++ b/components/routing.rst
@@ -14,7 +14,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/Routing);
-* Install it via PEAR (`pear.symfony.com/Routing`);
 * Install it via Composer (`symfony/routing` on Packagist)
 
 Usage

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -28,7 +28,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/Serializer);
-* Install it via PEAR ( `pear.symfony.com/Serializer`);
 * Install it via Composer (`symfony/serializer` on Packagist).
 
 Usage

--- a/components/templating.rst
+++ b/components/templating.rst
@@ -19,7 +19,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/Templating);
-* Install it via PEAR (`pear.symfony.com/Templating`);
 * Install it via Composer (`symfony/templating` on Packagist).
 
 Usage

--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -27,7 +27,6 @@ Installation
 You can install the component in many different ways:
 
 * Use the official Git repository (https://github.com/symfony/Yaml);
-* Install it via PEAR ( `pear.symfony.com/Yaml`);
 * Install it via Composer (`symfony/yaml` on Packagist).
 
 Why?


### PR DESCRIPTION
The PEAR channel should be considered deprecated as Composer is now the de-facto much better standard to manage dependencies.
