### PR TITLE
[2.0] Edited JMSSecurityExtraBundle doc link

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1756,7 +1756,7 @@ Learn more from the Cookbook
 * :doc:`/cookbook/security/remember_me`
 
 .. _`security component`: https://github.com/symfony/Security
-.. _`JMSSecurityExtraBundle`: https://github.com/schmittjoh/JMSSecurityExtraBundle
+.. _`JMSSecurityExtraBundle`: http://jmsyst.com/bundles/JMSSecurityExtraBundle/1.0
 .. _`FOSUserBundle`: https://github.com/FriendsOfSymfony/FOSUserBundle
 .. _`implement the \Serializable interface`: http://php.net/manual/en/class.serializable.php
 .. _`functions-online.com`: http://www.functions-online.com/sha1.html


### PR DESCRIPTION
It now points to the real documentation of this bundle and the version used in Symfony2.0, which is 1.0.

This should be merged with `2.0` only, I create other PRs for the newer versions as the bundle version changes.
