### PR TITLE
Update reference/constraints/Image.rst

### DIFF
--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -91,7 +91,7 @@ it is between a certain size, add the following:
              *     minWidth = 200,
              *     maxWidth = 400,
              *     minHeight = 200,
-             *     maxHeight = 400,
+             *     maxHeight = 400
              * )
              */
             protected $headshot;


### PR DESCRIPTION
Seems that annotations do not support trailing commas in parameter lists like PHP arrays do.
