### PR TITLE
[Dependency Injection] small changes

### DIFF
--- a/components/dependency_injection/advanced.rst
+++ b/components/dependency_injection/advanced.rst
@@ -107,18 +107,18 @@ the service itself gets loaded. To do so, you can use the ``file`` directive.
         services:
            foo:
              class: Example\Foo\Bar
-             file: "%kernel.root_dir%/src/path/to/file/foo.php"
+             file: "%app.root_dir%/src/path/to/file/foo.php"
 
     .. code-block:: xml
 
         <service id="foo" class="Example\Foo\Bar">
-            <file>%kernel.root_dir%/src/path/to/file/foo.php</file>
+            <file>%app.root_dir%/src/path/to/file/foo.php</file>
         </service>
 
     .. code-block:: php
 
         $definition = new Definition('Example\Foo\Bar');
-        $definition->setFile('%kernel.root_dir%/src/path/to/file/foo.php');
+        $definition->setFile('%app.root_dir%/src/path/to/file/foo.php');
         $container->setDefinition('foo', $definition);
 
 Notice that symfony will internally call the PHP function require_once

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -334,7 +334,7 @@ worlds though by using configuration files and then dumping and caching the resu
 configuration. The ``PhpDumper`` makes dumping the compiled container easy::
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
-    use Symfony\Component\DependencyInjection\Dumper\PhpDumper
+    use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 
     $file = __DIR__ .'/cache/container.php';
 


### PR DESCRIPTION
Hello,

This adds a missing semicolon. And as it is the doc for the standalone component, I'm wondering if %kernel.root_dir% shouldn't be changed to something more generic? It's the only places I could find this parameter in this doc.
