### PR TITLE
Remove min max length references 2.1

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -573,8 +573,9 @@ the correct values of a number of field options.
   validation will automatically match your validation rules.
 
 * ``max_length``: If the field is some sort of text field, then the ``max_length``
-  option can be guessed from the validation constraints (if ``MaxLength`` or ``Max``
-  is used) or from the Doctrine metadata (via the field's length).
+  option can be guessed from the validation constraints (if ``Length`` or
+  ``MaxLength`` or ``Max`` is used) or from the Doctrine metadata (via the
+  field's length).
   
 .. note::
 

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -563,7 +563,7 @@ the correct values of a number of field options.
 
     When these options are set, the field will be rendered with special HTML
     attributes that provide for HTML5 client-side validation. However, it
-    doesn't generate the equivalent server-side constraints (e.g. ``Assert\MaxLength``).
+    doesn't generate the equivalent server-side constraints (e.g. ``Assert\Length``).
     And though you'll need to manually add your server-side validation, these
     field type options can then be guessed from that information.
 

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -1533,11 +1533,11 @@ but here's a short example::
 
     // import the namespaces above your controller class
     use Symfony\Component\Validator\Constraints\Email;
-    use Symfony\Component\Validator\Constraints\MinLength;
+    use Symfony\Component\Validator\Constraints\Length;
     use Symfony\Component\Validator\Constraints\Collection;
 
     $collectionConstraint = new Collection(array(
-        'name' => new MinLength(5),
+        'name' => new Length(array("min" => 5)),
         'email' => new Email(array('message' => 'Invalid email address')),
     ));
 
@@ -1558,7 +1558,7 @@ method to specify the option::
     use Symfony\Component\Form\FormBuilder;
     use Symfony\Component\OptionsResolver\OptionsResolverInterface;
     use Symfony\Component\Validator\Constraints\Email;
-    use Symfony\Component\Validator\Constraints\MinLength;
+    use Symfony\Component\Validator\Constraints\Length;
     use Symfony\Component\Validator\Constraints\Collection;
 
     class ContactType extends AbstractType
@@ -1568,7 +1568,7 @@ method to specify the option::
         public function setDefaultOptions(OptionsResolverInterface $resolver)
         {
             $collectionConstraint = new Collection(array(
-                'name' => new MinLength(5),
+                'name' => new Length(array("min" => 5)),
                 'email' => new Email(array('message' => 'Invalid email address')),
             ));
 

--- a/book/validation.rst
+++ b/book/validation.rst
@@ -504,7 +504,8 @@ class to have at least 3 characters.
             properties:
                 firstName:
                     - NotBlank: ~
-                    - MinLength: 3
+                    - Length:
+                        min: 3
 
     .. code-block:: php-annotations
 
@@ -517,7 +518,7 @@ class to have at least 3 characters.
         {
             /**
              * @Assert\NotBlank()
-             * @Assert\MinLength(3)
+             * @Assert\Length(min = "3")
              */
             private $firstName;
         }
@@ -528,7 +529,9 @@ class to have at least 3 characters.
         <class name="Acme\BlogBundle\Entity\Author">
             <property name="firstName">
                 <constraint name="NotBlank" />
-                <constraint name="MinLength">3</constraint>
+                <constraint name="Length">
+                    <option name="min">3</option>
+                </constraint>
             </property>
         </class>
 
@@ -539,7 +542,7 @@ class to have at least 3 characters.
         // ...
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints\NotBlank;
-        use Symfony\Component\Validator\Constraints\MinLength;
+        use Symfony\Component\Validator\Constraints\Length;
 
         class Author
         {
@@ -548,7 +551,9 @@ class to have at least 3 characters.
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
                 $metadata->addPropertyConstraint('firstName', new NotBlank());
-                $metadata->addPropertyConstraint('firstName', new MinLength(3));
+                $metadata->addPropertyConstraint(
+                    'firstName',
+                    new Length(array("min" => 3)));
             }
         }
 
@@ -677,9 +682,10 @@ user registers and when a user updates his/her contact information later:
                     - Email: { groups: [registration] }
                 password:
                     - NotBlank: { groups: [registration] }
-                    - MinLength: { limit: 7, groups: [registration] }
+                    - Length: { min: 7, groups: [registration] }
                 city:
-                    - MinLength: 2
+                    - Length:
+                        min: 2
 
     .. code-block:: php-annotations
 
@@ -698,12 +704,12 @@ user registers and when a user updates his/her contact information later:
 
             /**
             * @Assert\NotBlank(groups={"registration"})
-            * @Assert\MinLength(limit=7, groups={"registration"})
+            * @Assert\Length(min=7, groups={"registration"})
             */
             private $password;
 
             /**
-            * @Assert\MinLength(2)
+            * @Assert\Length(min = "2")
             */
             private $city;
         }
@@ -725,15 +731,17 @@ user registers and when a user updates his/her contact information later:
                         <value>registration</value>
                     </option>
                 </constraint>
-                <constraint name="MinLength">
-                    <option name="limit">7</option>
+                <constraint name="Length">
+                    <option name="min">7</option>
                     <option name="groups">
                         <value>registration</value>
                     </option>
                 </constraint>
             </property>
             <property name="city">
-                <constraint name="MinLength">7</constraint>
+                <constraint name="Length">
+                    <option name="min">7</option>
+                </constraint>
             </property>
         </class>
 
@@ -745,7 +753,7 @@ user registers and when a user updates his/her contact information later:
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints\Email;
         use Symfony\Component\Validator\Constraints\NotBlank;
-        use Symfony\Component\Validator\Constraints\MinLength;
+        use Symfony\Component\Validator\Constraints\Length;
 
         class User
         {
@@ -758,12 +766,14 @@ user registers and when a user updates his/her contact information later:
                 $metadata->addPropertyConstraint('password', new NotBlank(array(
                     'groups' => array('registration')
                 )));
-                $metadata->addPropertyConstraint('password', new MinLength(array(
-                    'limit'  => 7,
+                $metadata->addPropertyConstraint('password', new Length(array(
+                    'min'  => 7,
                     'groups' => array('registration')
                 )));
 
-                $metadata->addPropertyConstraint('city', new MinLength(3));
+                $metadata->addPropertyConstraint(
+                    'city',
+                    Length(array("min" => 3)));
             }
         }
 

--- a/reference/constraints/All.rst
+++ b/reference/constraints/All.rst
@@ -30,7 +30,8 @@ entry in that array:
                 favoriteColors:
                     - All:
                         - NotBlank:  ~
-                        - MinLength: 5
+                        - Length:
+                            min: 5
 
     .. code-block:: php-annotations
 
@@ -44,7 +45,7 @@ entry in that array:
            /**
             * @Assert\All({
             *     @Assert\NotBlank
-            *     @Assert\MinLength(5),
+            *     @Assert\Length(min = "5"),
             * })
             */
             protected $favoriteColors = array();

--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -60,9 +60,9 @@ blank but is no longer than 100 characters in length, you would do the following
                         personal_email: Email
                         short_bio:
                             - NotBlank
-                            - MaxLength:
-                                limit:   100
-                                message: Your short bio is too long!
+                            - Length:
+                                max:   100
+                                maxMessage: Your short bio is too long!
                     allowMissingFields: true
 
     .. code-block:: php-annotations
@@ -78,9 +78,9 @@ blank but is no longer than 100 characters in length, you would do the following
              *         "personal_email" = @Assert\Email,
              *         "short_bio" = {
              *             @Assert\NotBlank(),
-             *             @Assert\MaxLength(
-             *                 limit = 100,
-             *                 message = "Your bio is too long!"
+             *             @Assert\Length(
+             *                 max = 100,
+             *                 maxMessage = "Your bio is too long!"
              *             )
              *         }
              *     },
@@ -105,9 +105,9 @@ blank but is no longer than 100 characters in length, you would do the following
                         </value>
                         <value key="short_bio">
                             <constraint name="NotBlank" />
-                            <constraint name="MaxLength">
-                                <option name="limit">100</option>
-                                <option name="message">Your bio is too long!</option>
+                            <constraint name="Length">
+                                <option name="max">100</option>
+                                <option name="maxMessage">Your bio is too long!</option>
                             </constraint>
                         </value>
                     </option>
@@ -122,7 +122,7 @@ blank but is no longer than 100 characters in length, you would do the following
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints\Collection;
         use Symfony\Component\Validator\Constraints\Email;
-        use Symfony\Component\Validator\Constraints\MaxLength;
+        use Symfony\Component\Validator\Constraints\Length;
 
         class Author
         {
@@ -133,7 +133,9 @@ blank but is no longer than 100 characters in length, you would do the following
                 $metadata->addPropertyConstraint('profileData', new Collection(array(
                     'fields' => array(
                         'personal_email' => new Email(),
-                        'lastName' => array(new NotBlank(), new MaxLength(100)),
+                        'lastName' => array(
+                            new NotBlank(),
+                            new Length(array("max" => 100)),
                     ),
                     'allowMissingFields' => true,
                 )));

--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -50,7 +50,8 @@ an ``Address`` instance in the ``$address`` property.
                     - NotBlank: ~
                 zipCode:
                     - NotBlank: ~
-                    - MaxLength: 5
+                    - Length:
+                        max: 5
 
         Acme\HelloBundle\Author:
             properties:
@@ -70,7 +71,9 @@ an ``Address`` instance in the ``$address`` property.
             </property>
             <property name="zipCode">
                 <constraint name="NotBlank" />
-                <constraint name="MaxLength">5</constraint>
+                <constraint name="Length">
+                    <option name="max">5</option>
+                </constraint>
             </property>
         </class>
 
@@ -100,7 +103,7 @@ an ``Address`` instance in the ``$address`` property.
 
             /**
              * @Assert\NotBlank
-             * @Assert\MaxLength(5)
+             * @Assert\MaxLength(max = "5")
              */
             protected $zipCode;
         }
@@ -127,7 +130,7 @@ an ``Address`` instance in the ``$address`` property.
         // src/Acme/HelloBundle/Address.php
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints\NotBlank;
-        use Symfony\Component\Validator\Constraints\MaxLength;
+        use Symfony\Component\Validator\Constraints\Length;
         
         class Address
         {
@@ -139,7 +142,9 @@ an ``Address`` instance in the ``$address`` property.
             {
                 $metadata->addPropertyConstraint('street', new NotBlank());
                 $metadata->addPropertyConstraint('zipCode', new NotBlank());
-                $metadata->addPropertyConstraint('zipCode', new MaxLength(5));
+                $metadata->addPropertyConstraint(
+                    'zipCode',
+                    new Length(array("max" => 5)));
             }
         }
 

--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -56,7 +56,8 @@ an ``Address`` instance in the ``$address`` property.
             properties:
                 firstName:
                     - NotBlank: ~
-                    - MinLength: 4
+                    - Length:
+                        min: 4
                 lastName:
                     - NotBlank: ~
 
@@ -76,7 +77,9 @@ an ``Address`` instance in the ``$address`` property.
         <class name="Acme\HelloBundle\Author">
             <property name="firstName">
                 <constraint name="NotBlank" />
-                <constraint name="MinLength">4</constraint>
+                <constraint name="Length">
+                    <option name="min">4</option>
+                </constraint>
             </property>
             <property name="lastName">
                 <constraint name="NotBlank" />
@@ -107,7 +110,7 @@ an ``Address`` instance in the ``$address`` property.
         {
             /**
              * @Assert\NotBlank
-             * @Assert\MinLength(4)
+             * @Assert\Length(min = "4")
              */
             protected $firstName;
 
@@ -143,7 +146,7 @@ an ``Address`` instance in the ``$address`` property.
         // src/Acme/HelloBundle/Author.php
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints\NotBlank;
-        use Symfony\Component\Validator\Constraints\MinLength;
+        use Symfony\Component\Validator\Constraints\Length;
         
         class Author
         {
@@ -156,7 +159,7 @@ an ``Address`` instance in the ``$address`` property.
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
                 $metadata->addPropertyConstraint('firstName', new NotBlank());
-                $metadata->addPropertyConstraint('firstName', new MinLength(4));
+                $metadata->addPropertyConstraint('firstName', new Length(array("min" => 4)));
                 $metadata->addPropertyConstraint('lastName', new NotBlank());
             }
         }


### PR DESCRIPTION
MinLength and MaxLength are deprecated. Do not use them as examples.
