### PR TITLE
Added link to cookbook article

### DIFF
--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -164,8 +164,9 @@ lots of services. Services that are never used are never constructed.
 
 As an added bonus, the ``Mailer`` service is only created once and the same
 instance is returned each time you ask for the service. This is almost always
-the behavior you'll need (it's more flexible and powerful), but we'll learn
-later how you can configure a service that has multiple instances.
+the behavior you'll need (it's more flexible and powerful), but you learn how 
+to configure a service that has multiple instances in the
+":doc:`/cookbook/service_container/scopes`" cookbook article.
 
 .. _book-service-container-parameters:
 


### PR DESCRIPTION
It wasn't clear where you'll learn more about mulitple instances. I couldn't find it and after searching on google I found [others can't found it too](http://stackoverflow.com/questions/9869603/symfony-2-service-with-multiple-instances). So I added a link to the correct cookbook article.
