### PR TITLE
Clarify routing documentation on trailing optional parameters

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -420,7 +420,7 @@ match, giving the ``page`` parameter a value of ``2``. Perfect.
 .. tip::
 
     Routes with optional parameters at the end will not match on requests 
-    with a trailing slash (i.e. /blog/). In this case the slash is a separator and
+    with a trailing slash (i.e. ``/blog/``). In this case the slash is a separator and
     should not be used if the optional parameter isn't passed.
 
 .. index::

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -417,6 +417,12 @@ match, giving the ``page`` parameter a value of ``2``. Perfect.
 | /blog/2 | {page} = 2 |
 +---------+------------+
 
+.. tip::
+
+    Routes with optional parameters at the end will not match on requests 
+	with a trailing slash (i.e. /blog/). In this case the slash is a separator and
+	should not be used if the optional parameter isn't passed.
+
 .. index::
    single: Routing; Requirements
 

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -420,8 +420,8 @@ match, giving the ``page`` parameter a value of ``2``. Perfect.
 .. tip::
 
     Routes with optional parameters at the end will not match on requests 
-	with a trailing slash (i.e. /blog/). In this case the slash is a separator and
-	should not be used if the optional parameter isn't passed.
+    with a trailing slash (i.e. /blog/). In this case the slash is a separator and
+    should not be used if the optional parameter isn't passed.
 
 .. index::
    single: Routing; Requirements


### PR DESCRIPTION
As noted in issue https://github.com/symfony/symfony/issues/5869 the Routing documentation is a little unclear as to when routes with optional parameters at the end are matched.

```
my_test_homepage:
    pattern:  /hello/{name}
    defaults: { _controller: MyTestBundle:Default:index, name: DefaultName }
```

The above route will only match on /hello and /hello/name, it will not match /hello/. I would like to clarify this in the documentation to avoid any confusion in the future.
