### PR TITLE
Updated "Load security users from database"

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -368,7 +368,7 @@ The code below shows the implementation of the
                 throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', $class));
             }
 
-            return $this->loadUserByUsername($user->getUsername());
+            return $this->findOneById($user->getId());
         }
 
         public function supportsClass($class)
@@ -456,11 +456,6 @@ returns the list of related groups::
         {
             return serialize(array(
                 $this->id,
-                $this->username,
-                $this->email,
-                $this->salt,
-                $this->password,
-                $this->isActive,
             ));
         }
 
@@ -471,11 +466,6 @@ returns the list of related groups::
         {
             list (
                 $this->id,
-                $this->username,
-                $this->email,
-                $this->salt,
-                $this->password,
-                $this->isActive,
             ) = unserialize($serialized);
         }
     }

--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -488,7 +488,7 @@ that forces it to have a ``getRole()`` method::
      * @ORM\Table(name="acme_groups")
      * @ORM\Entity()
      */
-    class Group implements RoleInterface, \Serializable
+    class Group implements RoleInterface
     {
         /**
          * @ORM\Column(name="id", type="integer")
@@ -525,30 +525,6 @@ that forces it to have a ``getRole()`` method::
         public function getRole()
         {
             return $this->role;
-        }
-    
-        /**
-         * @see \Serializable::serialize()
-         */
-        public function serialize()
-        {
-            return serialize(array(
-                $this->id,
-                $this->name,
-                $this->role,
-            ));
-        }
-
-        /**
-         * @see \Serializable::unserialize()
-         */
-        public function unserialize($serialized)
-        {
-            list(
-                $this->id,
-                $this->name,
-                $this->role,
-            ) = unserialize($serialized);
         }
     }
 

--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -454,13 +454,13 @@ returns the list of related groups::
          */
         public function serialize()
         {
-            return \serialize(array(
+            return serialize(array(
                 $this->id,
                 $this->username,
                 $this->email,
                 $this->salt,
                 $this->password,
-                $this->isActive
+                $this->isActive,
             ));
         }
 
@@ -475,8 +475,8 @@ returns the list of related groups::
                 $this->email,
                 $this->salt,
                 $this->password,
-                $this->isActive
-            ) = \unserialize($serialized);
+                $this->isActive,
+            ) = unserialize($serialized);
         }
     }
 
@@ -542,10 +542,10 @@ that forces it to have a ``getRole()`` method::
          */
         public function serialize()
         {
-            return \serialize(array(
+            return serialize(array(
                 $this->id,
                 $this->name,
-                $this->role
+                $this->role,
             ));
         }
 
@@ -557,8 +557,8 @@ that forces it to have a ``getRole()`` method::
             list(
                 $this->id,
                 $this->name,
-                $this->role
-            ) = \unserialize($serialized);
+                $this->role,
+            ) = unserialize($serialized);
         }
     }
 

--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -429,7 +429,7 @@ returns the list of related groups::
     use Doctrine\Common\Collections\ArrayCollection;
     // ...
 
-    class User implements AdvancedUserInterface
+    class User implements AdvancedUserInterface, \Serializable
     {
         /**
          * @ORM\ManyToMany(targetEntity="Group", inversedBy="users")
@@ -447,6 +447,36 @@ returns the list of related groups::
         public function getRoles()
         {
             return $this->groups->toArray();
+        }
+
+        /**
+         * @see \Serializable::serialize()
+         */
+        public function serialize()
+        {
+            return \serialize(array(
+                $this->id,
+                $this->username,
+                $this->email,
+                $this->salt,
+                $this->password,
+                $this->isActive
+            ));
+        }
+
+        /**
+         * @see \Serializable::unserialize()
+         */
+        public function unserialize($serialized)
+        {
+            list (
+                $this->id,
+                $this->username,
+                $this->email,
+                $this->salt,
+                $this->password,
+                $this->isActive
+            ) = \unserialize($serialized);
         }
     }
 
@@ -468,7 +498,7 @@ that forces it to have a ``getRole()`` method::
      * @ORM\Table(name="acme_groups")
      * @ORM\Entity()
      */
-    class Group implements RoleInterface
+    class Group implements RoleInterface, \Serializable
     {
         /**
          * @ORM\Column(name="id", type="integer")
@@ -505,6 +535,30 @@ that forces it to have a ``getRole()`` method::
         public function getRole()
         {
             return $this->role;
+        }
+    
+        /**
+         * @see \Serializable::serialize()
+         */
+        public function serialize()
+        {
+            return \serialize(array(
+                $this->id,
+                $this->name,
+                $this->role
+            ));
+        }
+
+        /**
+         * @see \Serializable::unserialize()
+         */
+        public function unserialize($serialized)
+        {
+            list(
+                $this->id,
+                $this->name,
+                $this->role
+            ) = \unserialize($serialized);
         }
     }
 


### PR DESCRIPTION
I've updated the "How to load Security Users from the Database" cookbook to include fix this error:

PHP Fatal error:  Call to a member function getRole() on a non-object in /vendor/symfony/symfony/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php on line 47

which is happening in PHP > 5.4.
The fix is taken by this issue: https://github.com/symfony/symfony/issues/3691#issuecomment-9831914
