### PR TITLE
Correct input checkbox render type

### DIFF
--- a/reference/forms/types/checkbox.rst
+++ b/reference/forms/types/checkbox.rst
@@ -9,7 +9,7 @@ has a Boolean value: if the box is checked, the field will be set to true,
 if the box is unchecked, the value will be set to false.
 
 +-------------+------------------------------------------------------------------------+
-| Rendered as | ``input`` ``text`` field                                               |
+| Rendered as | ``input`` ``checkbox`` field                                           |
 +-------------+------------------------------------------------------------------------+
 | Options     | - `value`_                                                             |
 +-------------+------------------------------------------------------------------------+


### PR DESCRIPTION
Checkboxes render as `<input type="checkbox">` not `<input type="text">`

This typo exists in all versions of the docs 2.0, 2.1, master.

Thanks!
