### PR TITLE
[WIP] Add Twig Reference

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1545,6 +1545,8 @@ is defined by the ``target`` parameter above (e.g. the ``homepage``). For
 more information on configuring the logout, see the
 :doc:`Security Configuration Reference</reference/configuration/security>`.
 
+.. _book-security-template:
+
 Access Control in Templates
 ---------------------------
 

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -642,6 +642,8 @@ Controllers are fast to execute and promote good code organization and reuse.
 .. index::
    single: Templating; Linking to pages
 
+.. _book-templating-pages:
+
 Linking to Pages
 ~~~~~~~~~~~~~~~~
 
@@ -758,6 +760,8 @@ correctly:
 
 .. index::
    single: Templating; Linking to assets
+
+.. _book-templating-assets:
 
 Linking to Assets
 ~~~~~~~~~~~~~~~~~

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -703,6 +703,8 @@ Translations in Templates
 Most of the time, translation occurs in templates. Symfony2 provides native
 support for both Twig and PHP templates.
 
+.. _book-translation-twig:
+
 Twig Templates
 ~~~~~~~~~~~~~~
 

--- a/reference/forms/twig_reference.rst
+++ b/reference/forms/twig_reference.rst
@@ -9,6 +9,8 @@ rendering forms. There are several different functions available, and each
 is responsible for rendering a different part of a form (e.g. labels, errors,
 widgets, etc).
 
+.. _reference-forms-twig-label:
+
 form_label(form.name, label, variables)
 ---------------------------------------
 
@@ -26,6 +28,8 @@ label you want to display as the second argument.
 See ":ref:`twig-reference-form-variables`" to learn about the ``variables``
 argument.
 
+.. _reference-forms-twig-errors:
+
 form_errors(form.name)
 ----------------------
 
@@ -37,6 +41,8 @@ Renders any errors for the given field.
 
     {# render any "global" errors #}
     {{ form_errors(form) }}
+
+.. _reference-forms-twig-widget:
 
 form_widget(form.name, variables)
 ---------------------------------
@@ -59,6 +65,8 @@ rendering many fields at once (e.g. ``form_widget(form)``).
 See ":ref:`twig-reference-form-variables`" to learn more about the ``variables``
 argument.
 
+.. _reference-forms-twig-row:
+
 form_row(form.name, variables)
 ------------------------------
 
@@ -77,6 +85,8 @@ above.
 See ":ref:`twig-reference-form-variables`" to learn about the ``variables``
 argument.
 
+.. _reference-forms-twig-rest:
+
 form_rest(form, variables)
 --------------------------
 
@@ -88,6 +98,8 @@ obvious (since it'll render the field for you).
 .. code-block:: jinja
 
     {{ form_rest(form) }}
+
+.. _reference-forms-twig-enctype:
 
 form_enctype(form)
 ------------------

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -10,8 +10,7 @@ of Twig to integrate some components into the Twig templates.
 
 Below is information about all the custom functions, filters and tags
 that are defined by the Symfony2 Core Framework. There may also be tags
-in bundles that are included within the Symfony Standard Edition, or in
-bundles you use, that aren't listed here.
+in bundles you use that aren't listed here.
 
 Functions
 ---------
@@ -109,3 +108,18 @@ Tags
 | ``{% transchoice count with {variables}...        | This will translate and render the text with pluralization, more  |
 | {% endtranschoice %}``                            | information in :ref:`book-translation-twig`                       |
 +---------------------------------------------------+-------------------------------------------------------------------+
+
+Symfony Standard Edition Extensions
+-----------------------------------
+
+The Symfony Standard Edition adds some bundles to the Symfony2 Core Framework.
+Those bundles can have other Twig extensions:
+
+* **Twig Extension** includes all extensions that do not belong to the
+  Twig core but can be interesting. You can read more in 
+  `the official Twig Extensions documentation`_
+* **Assetic** adds the ``{% stylesheets %}``, ``{% javascripts %}`` and 
+  ``{% image %}`` tags. You can read more about them in 
+  :doc:`the Assetic Documentation<cookbook/assetic>`;
+
+.. _`the official Twig Extensions documentation`: http://twig.sensiolabs.org/doc/extensions/index.html

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -90,3 +90,22 @@ Filters
 +-------------------------------------------------+-------------------------------------------------------------------+
 | ``variable|yaml_dump``                          | This will render a yaml syntax with their type.                   |
 +-------------------------------------------------+-------------------------------------------------------------------+
+
+Tags
+----
+
++---------------------------------------------------+-------------------------------------------------------------------+
+| Tag Syntax                                        | Usage                                                             |
++===================================================+===================================================================+
+| ``{% render 'controller' with {parameters} %}``   | This will render the Response Content for the given controller,   |
+|                                                   | more information in :ref:`templating-embedding-controller`.       |
++---------------------------------------------------+-------------------------------------------------------------------+
+| ``{% form_theme form 'file' %}``                  | This will look inside the given file for overriden form blocks,   |
+|                                                   | more information in :doc:`cookbook/form/form_customization`.      |
++---------------------------------------------------+-------------------------------------------------------------------+
+| ``{% trans with {variables} %}...{% endtrans %}`` | This will translate and render the text, more information in      |
+|                                                   | :ref:`book-translation-twig`                                      |
++---------------------------------------------------+-------------------------------------------------------------------+
+| ``{% transchoice count with {variables}...        | This will translate and render the text with pluralization, more  |
+| {% endtranschoice %}``                            | information in :ref:`book-translation-twig`                       |
++---------------------------------------------------+-------------------------------------------------------------------+

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -1,0 +1,14 @@
+.. index::
+    single: Symfony2 Twig extensions
+
+Symfony2 Twig Extensions
+========================
+
+Twig is the default template engine for Symfony2. It contains a lot of build-in
+functions, filters and blocks. Symfony2 created some custom extension on
+top of Twig to integrate some components into the Twig templates.
+
+Below is information about all the custom functions, filters and blocks
+that are defined by the Symfony2 Core Framework. There may also be tags
+in bundles that are included within the Symfony Standard Edition, or in
+bundles you use, that aren't listed here.

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -12,3 +12,47 @@ Below is information about all the custom functions, filters and blocks
 that are defined by the Symfony2 Core Framework. There may also be tags
 in bundles that are included within the Symfony Standard Edition, or in
 bundles you use, that aren't listed here.
+
+Functions
+---------
+
++---------------------------------------------+---------------------------------------------------------------------------+
+| Function Syntax                             | Usage                                                                     |
++=============================================+===========================================================================+
+| ``asset(path, packageName)``                | Get the public path of the asset, more information in                     |
+|                                             | :ref:`book-templating-assets`.                                            |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``asset_version(packageName)``              | Get the current version of the package, more information in               |
+|                                             | :ref:`book-templating-assets`.                                            |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``form_encrypte(form)``                     | This will render the required ``enctype="multipart/form-data"`` attribute |
+|                                             | if the form contains at least one file upload field, more information in  |
+|                                             | :ref:`reference-forms-twig-enctype`.                                      |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``form_widget(form.name, variables)``       | This will render a complete form or a specific HTML widget of a field,    |
+|                                             | more information in :ref:`reference-forms-twig-widget`.                   |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``form_errors(form.name)``                  | This will render any errors for the given field or the "global" errors,   |
+|                                             | more information in :ref:`reference-forms-twig-errors`.                   |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``form_label(form.name, label, variables)`` | This will render the label for the given field, more information in       |
+|                                             | :ref:`reference-forms-twig-label`.                                        |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``form_row(form.name, variables)``          | This will render the row (the field's label, errors and widget) of the    |
+|                                             | given field, more information in :ref:`reference-forms-twig-row`.         |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``form_rest(form, variables)``              | This will render all fields that have not yet been rendered, more         |
+|                                             | information in :ref:`reference-forms-twig-rest`.                          |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``_form_is_choice_group(label)``            | This will return ``true`` if the label is a choice group.                 |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``_form_is_choice_selected(form, label)``   | This will return ``true`` if the given choice is selected.                |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``is_granted(role)``                        | This will return ``true`` if the current user has the required role, more |
+|                                             | information in :ref:`book-security-template`                              |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``path(name, parameters)``                  | Get a relative url for the given route, more information in               |
+|                                             | :ref:`book-templating-pages`.                                             |
++---------------------------------------------+---------------------------------------------------------------------------+
+| ``url(name, parameters)``                   | Equal to ``path(...)`` but it generates an absolute url                   |
++---------------------------------------------+---------------------------------------------------------------------------+

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -5,10 +5,10 @@ Symfony2 Twig Extensions
 ========================
 
 Twig is the default template engine for Symfony2. It contains a lot of build-in
-functions, filters and blocks. Symfony2 created some custom extension on
-top of Twig to integrate some components into the Twig templates.
+functions, filters and tags. Symfony2 created some custom extension on top 
+of Twig to integrate some components into the Twig templates.
 
-Below is information about all the custom functions, filters and blocks
+Below is information about all the custom functions, filters and tags
 that are defined by the Symfony2 Core Framework. There may also be tags
 in bundles that are included within the Symfony Standard Edition, or in
 bundles you use, that aren't listed here.
@@ -56,3 +56,37 @@ Functions
 +---------------------------------------------+---------------------------------------------------------------------------+
 | ``url(name, parameters)``                   | Equal to ``path(...)`` but it generates an absolute url                   |
 +---------------------------------------------+---------------------------------------------------------------------------+
+
+Filters
+-------
+
++-------------------------------------------------+-------------------------------------------------------------------+
+| Filter Syntax                                   | Usage                                                             |
++=================================================+===================================================================+
+| ``classname|abbr_class``                        | This will render an ``abbr`` element with the class short name.   |
++-------------------------------------------------+-------------------------------------------------------------------+
+| ``methodname|abbr_method``                      | This will render a method inside a ``abbr`` element.              |
++-------------------------------------------------+-------------------------------------------------------------------+
+| ``arguments|format_args``                       | This will render a string with the arguments and there types.     |
++-------------------------------------------------+-------------------------------------------------------------------+
+| ``arguments|format_args_as_text``               | Equal to ``[...]|format_args``, but it strips the tags.           |
++-------------------------------------------------+-------------------------------------------------------------------+
+| ``path|file_excerpt(line)``                     | This will render an excerpt of a code file around the given line. |
++-------------------------------------------------+-------------------------------------------------------------------+
+| ``path|format_file(line, text)``                | This will render a file path in a link.                           |
++-------------------------------------------------+-------------------------------------------------------------------+
+| ``exceptionMessage|format_file_from_text``      | Equal to ``format_file`` except it parsed the default PHP error   |
+|                                                 | string into a file path (i.e. 'in foo.php on line 45')            |
++-------------------------------------------------+-------------------------------------------------------------------+
+| ``path|file_link(line)``                        | This will render a path to the correct file (and line number)     |
++-------------------------------------------------+-------------------------------------------------------------------+
+| ``text|trans(parameters, domain)``              | This will translate the text into the current language, more      |
+|                                                 | information in :ref:`book-translation-twig`.                      |
++-------------------------------------------------+-------------------------------------------------------------------+
+| ``text|transchoice(count, parameters, domain)`` | This will translate the text with pluralization, more information |
+|                                                 | in :ref:`book-translation-twig`.                                  |
++-------------------------------------------------+-------------------------------------------------------------------+
+| ``variable|yaml_encode(inline)``                | This will transform the variable text into a YAML syntax.         |
++-------------------------------------------------+-------------------------------------------------------------------+
+| ``variable|yaml_dump``                          | This will render a yaml syntax with their type.                   |
++-------------------------------------------------+-------------------------------------------------------------------+


### PR DESCRIPTION
This is a work in progress. It's just a quick draw of what I think the Twig reference should look like.

It shows all Twig Extensions that Symfony2 includes in his templates. When I found a resource with a more detailed description about a tag/filter/function I linked it.

I have used [the list I posted earlier](https://github.com/symfony/symfony-docs/issues/494#issuecomment-9965754). I don't think I have missed an extension, but let me know if I did!

I'm not totally convient about the Rst syntax, but I think it is good (can someone give my a description/resource about the `.. index:` thing?). The document is currently not passed to the Sphinx parser, I will do it soon.
