### PR TITLE
Adding link to how to render templates

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -14,6 +14,11 @@ used to return content to the user, populate email bodies, and more. You'll
 learn shortcuts, clever ways to extend templates and how to reuse template
 code.
 
+.. note::
+    How to render templates is covered in the :ref:`controller <controller-rendering-templates>`
+    page of the book.
+
+
 .. index::
    single: Templating; What is a template?
 


### PR DESCRIPTION
If you are not reading through page by page then it is not clear how templates are rendered reading the templating page.
