### PR TITLE
Fix build errors

### DIFF
--- a/book/internals.rst
+++ b/book/internals.rst
@@ -208,7 +208,7 @@ each event has access to the same basic information:
 
 * :method:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent::getRequestType` 
   - returns the *type* of the request (``HttpKernelInterface::MASTER_REQUEST`` 
-    or ``HttpKernelInterface::SUB_REQUEST``);
+  or ``HttpKernelInterface::SUB_REQUEST``);
 
 * :method:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent::getKernel` 
   - returns the Kernel handling the request;

--- a/components/dependency_injection/workflow.rst
+++ b/components/dependency_injection/workflow.rst
@@ -51,7 +51,7 @@ Bundle-level Configuration with Extensions
 
 By convention, each bundle contains an Extension class which is in the bundle's
 ``DependencyInjection`` directory. These are registered with the ``ContainerBuilder``
-when the kernel is booted. When the ``ContainerBuilder`` is :doc:`compiled</components/dependency-injection/compilation>`,
+when the kernel is booted. When the ``ContainerBuilder`` is :doc:`compiled</components/dependency_injection/compilation>`,
 the application-level configuration relevant to the bundle's extension is
 passed to the Extension which also usually loads its own config file(s), typically from the bundle's
 ``Resources/config`` directory. The application-level config is usually processed


### PR DESCRIPTION
This PR fixs [the build errors](http://symfony.com/doc/build_errors) for the 2.0 branch. it also should be merged into the other branches.
