### PR TITLE
Fix reference to $session->set/get typo on p.21

### DIFF
--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -131,7 +131,7 @@ from any controller::
     $foo = $session->get('foo');
 
     // use a default value if the key doesn't exist
-    $filters = $session->set('filters', array());
+    $filters = $session->get('filters', array());
 
 You can also store small messages that will only be available for the very
 next request::


### PR DESCRIPTION
On page 21 of the PDF it reads:

``` php
// use a default value if the key doesn't exist
$filters = $session->set('filters', array());
```

It appears that the `$session->set` here should be a `$session->get`.  This PR would change it to read:

``` php
// use a default value if the key doesn't exist
$filters = $session->get('filters', array());
```
