### PR TITLE
Added Microsoft SQL Server Example to PDO session storage documentation

### DIFF
--- a/components/dependency_injection/advanced.rst
+++ b/components/dependency_injection/advanced.rst
@@ -107,18 +107,18 @@ the service itself gets loaded. To do so, you can use the ``file`` directive.
         services:
            foo:
              class: Example\Foo\Bar
-             file: "%kernel.root_dir%/src/path/to/file/foo.php"
+             file: "%app.root_dir%/src/path/to/file/foo.php"
 
     .. code-block:: xml
 
         <service id="foo" class="Example\Foo\Bar">
-            <file>%kernel.root_dir%/src/path/to/file/foo.php</file>
+            <file>%app.root_dir%/src/path/to/file/foo.php</file>
         </service>
 
     .. code-block:: php
 
         $definition = new Definition('Example\Foo\Bar');
-        $definition->setFile('%kernel.root_dir%/src/path/to/file/foo.php');
+        $definition->setFile('%app.root_dir%/src/path/to/file/foo.php');
         $container->setDefinition('foo', $definition);
 
 Notice that symfony will internally call the PHP function require_once

--- a/components/dependency_injection/advanced.rst
+++ b/components/dependency_injection/advanced.rst
@@ -107,18 +107,18 @@ the service itself gets loaded. To do so, you can use the ``file`` directive.
         services:
            foo:
              class: Example\Foo\Bar
-             file: "%app.root_dir%/src/path/to/file/foo.php"
+             file: "%kernel.root_dir%/src/path/to/file/foo.php"
 
     .. code-block:: xml
 
         <service id="foo" class="Example\Foo\Bar">
-            <file>%app.root_dir%/src/path/to/file/foo.php</file>
+            <file>%kernel.root_dir%/src/path/to/file/foo.php</file>
         </service>
 
     .. code-block:: php
 
         $definition = new Definition('Example\Foo\Bar');
-        $definition->setFile('%app.root_dir%/src/path/to/file/foo.php');
+        $definition->setFile('%kernel.root_dir%/src/path/to/file/foo.php');
         $container->setDefinition('foo', $definition);
 
 Notice that symfony will internally call the PHP function require_once

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -334,7 +334,7 @@ worlds though by using configuration files and then dumping and caching the resu
 configuration. The ``PhpDumper`` makes dumping the compiled container easy::
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
-    use Symfony\Component\DependencyInjection\Dumper\PhpDumper
+    use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 
     $file = __DIR__ .'/cache/container.php';
 

--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -182,3 +182,20 @@ For PostgreSQL, the statement should look like this:
         session_time integer NOT NULL,
         CONSTRAINT session_pkey PRIMARY KEY (session_id)
     );
+
+Microsoft SQL Server
+~~~~~~~~~~
+
+For MSSQL, the statement might look like the following:
+
+.. code-block:: sql
+
+   CREATE TABLE [dbo].[session](
+	[session_id] [nvarchar](255) NOT NULL,
+	[session_value] [ntext] NOT NULL,
+	[session_time] [int] NOT NULL,
+		PRIMARY KEY CLUSTERED 
+		(
+			[session_id] ASC
+		) WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON) ON [PRIMARY]
+		) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -303,4 +303,4 @@ which is the first one defined or the one configured via the
 Each connection is also accessible via the ``doctrine.dbal.[name]_connection``
 service where ``[name]`` if the name of the connection.
 
-.. _DBAL documentation: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/index.html
+.. _DBAL documentation: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -212,14 +212,10 @@ can control. The following configuration options exist for a mapping:
 Doctrine DBAL Configuration
 ---------------------------
 
-.. note::
-
-    DoctrineBundle supports all parameters that default Doctrine drivers
-    accept, converted to the XML or YAML naming standards that Symfony
-    enforces. See the Doctrine `DBAL documentation`_ for more information.
-
-Besides default Doctrine options, there are some Symfony-related ones that you
-can configure. The following block shows all possible configuration keys:
+DoctrineBundle supports all parameters that default Doctrine drivers
+accept, converted to the XML or YAML naming standards that Symfony
+enforces. See the Doctrine `DBAL documentation`_ for more information.
+The following block shows all possible configuration keys:
 
 .. configuration-block::
 
@@ -233,12 +229,15 @@ can configure. The following block shows all possible configuration keys:
                 user:                 user
                 password:             secret
                 driver:               pdo_mysql
+                # the DBAL driverClass option
                 driver_class:         MyNamespace\MyDriverImpl
+                # the DBAL driverOptions option
                 options:
                     foo: bar
                 path:                 "%kernel.data_dir%/data.sqlite"
                 memory:               true
                 unix_socket:          /tmp/mysql.sock
+                # the DBAL wrapperClass option
                 wrapper_class:        MyDoctrineDbalConnectionWrapper
                 charset:              UTF8
                 logging:              "%kernel.debug%"


### PR DESCRIPTION
Title pretty much says it all, and Microsoft's SQL dialect is naturally different than MySQL/PostgreSQL.
