### PR TITLE
Added example of non standard 'X-Requested-With' HTTP header.

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -235,8 +235,9 @@ document::
         )
 
     The ``server`` array is the raw values that you'd expect to normally
-    find in the PHP `$_SERVER`_ superglobal. For example, to set the `Content-Type`
-    and `Referer` HTTP headers, you'd pass the following::
+    find in the PHP `$_SERVER`_ superglobal. For example, to set the `Content-Type`,
+    `Referer` and `X-Requested-With' HTTP headers, you'd pass the following (mind
+    the `HTTP_` prefix for non standard headers)::
 
         $client->request(
             'GET',
@@ -244,8 +245,9 @@ document::
             array(),
             array(),
             array(
-                'CONTENT_TYPE' => 'application/json',
-                'HTTP_REFERER' => '/foo/bar',
+                'CONTENT_TYPE'          => 'application/json',
+                'HTTP_REFERER'          => '/foo/bar',
+                'HTTP_X-Requested-With' => 'XMLHttpRequest'
             )
         );
 

--- a/book/testing.rst
+++ b/book/testing.rst
@@ -247,7 +247,7 @@ document::
             array(
                 'CONTENT_TYPE'          => 'application/json',
                 'HTTP_REFERER'          => '/foo/bar',
-                'HTTP_X-Requested-With' => 'XMLHttpRequest'
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
             )
         );
 


### PR DESCRIPTION
This example is giving an example on how to add a non standard header, and as well reminding the user to add a 'HTTP_' prefix, so the custom header gets sent when doing the request.
