### PR TITLE
Rename Listener to EventListener #1924

### DIFF
--- a/cookbook/doctrine/event_listeners_subscribers.rst
+++ b/cookbook/doctrine/event_listeners_subscribers.rst
@@ -40,15 +40,15 @@ managers that use this connection.
 
         services:
             my.listener:
-                class: Acme\SearchBundle\Listener\SearchIndexer
+                class: Acme\SearchBundle\EventListener\SearchIndexer
                 tags:
                     - { name: doctrine.event_listener, event: postPersist }
             my.listener2:
-                class: Acme\SearchBundle\Listener\SearchIndexer2
+                class: Acme\SearchBundle\EventListener\SearchIndexer2
                 tags:
                     - { name: doctrine.event_listener, event: postPersist, connection: default }
             my.subscriber:
-                class: Acme\SearchBundle\Listener\SearchIndexerSubscriber
+                class: Acme\SearchBundle\EventListener\SearchIndexerSubscriber
                 tags:
                     - { name: doctrine.event_subscriber, connection: default }
 
@@ -65,13 +65,13 @@ managers that use this connection.
             </doctrine:config>
 
             <services>
-                <service id="my.listener" class="Acme\SearchBundle\Listener\SearchIndexer">
+                <service id="my.listener" class="Acme\SearchBundle\EventListener\SearchIndexer">
                     <tag name="doctrine.event_listener" event="postPersist" />
                 </service>
-                <service id="my.listener2" class="Acme\SearchBundle\Listener\SearchIndexer2">
+                <service id="my.listener2" class="Acme\SearchBundle\EventListener\SearchIndexer2">
                     <tag name="doctrine.event_listener" event="postPersist" connection="default" />
                 </service>
-                <service id="my.subscriber" class="Acme\SearchBundle\Listener\SearchIndexerSubscriber">
+                <service id="my.subscriber" class="Acme\SearchBundle\EventListener\SearchIndexerSubscriber">
                     <tag name="doctrine.event_subscriber" connection="default" />
                 </service>
             </services>
@@ -85,7 +85,7 @@ listener on the event ``postPersist``. That class behind that service must have
 a ``postPersist`` method, which will be called when the event is thrown::
 
     // src/Acme/SearchBundle/Listener/SearchIndexer.php
-    namespace Acme\SearchBundle\Listener;
+    namespace Acme\SearchBundle\EventListener;
 
     use Doctrine\ORM\Event\LifecycleEventArgs;
     use Acme\StoreBundle\Entity\Product;


### PR DESCRIPTION
Renamed the file structure to EventListener in accordance with http://symfony.com/doc/master/cookbook/bundles/best_practices.html.
This fixes #1924.
