### PR TITLE
Changing the getVar method to get (only valid for 2.1)

### DIFF
--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -321,7 +321,7 @@ new "tag" forms. To render it, make the following change to your template:
 
     .. code-block:: html+php
 
-        <ul class="tags" data-prototype="<?php echo $view->escape($view['form']->row($form['tags']->getVar('prototype'))) ?>">
+        <ul class="tags" data-prototype="<?php echo $view->escape($view['form']->row($form['tags']->get('prototype'))) ?>">
             ...
         </ul>
 


### PR DESCRIPTION
As mentioned in #1906, in 2.1 the `getVar()` method is not available and `get()` must be used. This seems to be the case for only 2.1, so this PR should not be merged into master.
