### PR TITLE
Remove reference to deprecated DataEvent and FilterDataEvent

### DIFF
--- a/cookbook/form/dynamic_form_generation.rst
+++ b/cookbook/form/dynamic_form_generation.rst
@@ -145,20 +145,16 @@ The ``FormEvents::PRE_SET_DATA`` line actually resolves to the string ``form.pre
 The `FormEvents class`_ serves an organizational purpose. It is a centralized location
 in which you can find all of the various form events available.
 
-While this example could have used the ``form.set_data`` event or even the ``form.post_set_data``
-events just as effectively, by using ``form.pre_set_data`` you guarantee that
+While this example could have used the ``form.post_set_data``
+event just as effectively, by using ``form.pre_set_data`` you guarantee that
 the data being retrieved from the ``Event`` object has in no way been modified
-by any other subscribers or listeners. This is because ``form.pre_set_data``
-passes a `DataEvent`_ object instead of the `FilterDataEvent`_ object passed
-by the ``form.set_data`` event. `DataEvent`_, unlike its child `FilterDataEvent`_,
-lacks a setData() method.
+by any other subscribers or listeners because ``form.pre_set_data`` is the
+first form event dispatched.
 
 .. note::
 
     You may view the full list of form events via the `FormEvents class`_,
     found in the form bundle.
 
-.. _`DataEvent`: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Event/DataEvent.php
 .. _`FormEvents class`: https://github.com/symfony/Form/blob/master/FormEvents.php
 .. _`Form class`: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Form.php
-.. _`FilterDataEvent`: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Event/FilterDataEvent.php

--- a/cookbook/form/dynamic_form_generation.rst
+++ b/cookbook/form/dynamic_form_generation.rst
@@ -91,10 +91,10 @@ might look like the following::
     // src/Acme/DemoBundle/Form/EventListener/AddNameFieldSubscriber.php
     namespace Acme\DemoBundle\Form\EventListener;
 
-    use Symfony\Component\Form\Event\DataEvent;
+    use Symfony\Component\Form\FormEvent;
+    use Symfony\Component\Form\FormEvents;
     use Symfony\Component\Form\FormFactoryInterface;
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-    use Symfony\Component\Form\FormEvents;
 
     class AddNameFieldSubscriber implements EventSubscriberInterface
     {


### PR DESCRIPTION
[`DataEvent`](https://github.com/symfony/symfony/blob/2.1/src/Symfony/Component/Form/Event/DataEvent.php) and [`FilterDataEvent`](https://github.com/symfony/symfony/blob/2.1/src/Symfony/Component/Form/Event/FilterDataEvent.php) have been deprecated as of 2.1 and will be removed in 2.3.

This PR removes references to them in the cookbook article "How to Dynamically Generate Forms Using Form Events", and also fixes a missing use statement relative to using the new `FormEvent` class that was merged in a recent change to the typehint.

Should be applied to docs branch 2.1 and master.

:rocket: 
