### PR TITLE
Assetic fixes

### DIFF
--- a/cookbook/assetic/asset_management.rst
+++ b/cookbook/assetic/asset_management.rst
@@ -104,10 +104,42 @@ The actual rendered tag might simply look like:
 .. note::
 
     This is a key point: once you let Assetic handle your assets, the files are
-    served from a different location. This *can* cause problems with CSS files
+    served from a different location. This *will* cause problems with CSS files
     that reference images by their relative path. However, this can be fixed
     by using the ``cssrewrite`` filter, which updates paths in CSS files
     to reflect their new location.
+    
+    Unfortunately, the ``cssrewrite`` filter does not work when using the
+    ``@AcmeFooBundle`` syntax to reference the assets. This is a known
+    limitation. A workaround is to use the ``output`` option to change the
+    location the files are served from to a path from which the relative paths
+    work, e.g.: 
+
+    .. configuration-block::
+
+        .. code-block:: html+jinja
+
+            {% stylesheets
+                output='bundles/acmefoo/css/compiled.css'
+                '@AcmeFooBundle/Resources/public/css/*'
+            %}
+                <link rel="stylesheet" href="{{ asset_url }}" />
+            {% endstylesheets %}
+
+        .. code-block:: html+php
+
+            <?php foreach ($view['assetic']->stylesheets(
+                array('@AcmeFooBundle/Resources/public/css/*'),
+                array(),
+                array('output' => 'bundles/acmefoo/css/compiled.css')
+            ) as $url): ?>
+                <link rel="stylesheet" href="<?php echo $view->escape($url) ?>" />
+            <?php endforeach; ?>
+    
+    Of course, this assumes that all the CSS files you serve in this block use
+    relative paths that start from the same location, which is not always
+    convenient. This is the reason this is called a *workaround* and not a
+    *solution*.
 
 Combining Assets
 ~~~~~~~~~~~~~~~~

--- a/cookbook/assetic/asset_management.rst
+++ b/cookbook/assetic/asset_management.rst
@@ -78,10 +78,8 @@ drawn from various sources such as from within a bundle:
 
 .. tip::
 
-    For the above example to work, you must either add your bundle to the list
-    of bundles that Assetic is allowed to handle (which is *none* in a default
-    Symfony installation), or remove the bundle list from the configuration
-    altogether:
+    For the above example to work, you must also add your bundle to the list
+    of bundles that Assetic handles, which is empty by default:
 
     .. code-block:: yaml
 
@@ -89,7 +87,7 @@ drawn from various sources such as from within a bundle:
         assetic:
             debug:          "%kernel.debug%"
             use_controller: false
-            #bundles:       [ ]
+            bundles:       [ AcmeFooBundle ]
             filters:
                 # ...
 

--- a/cookbook/assetic/asset_management.rst
+++ b/cookbook/assetic/asset_management.rst
@@ -76,6 +76,23 @@ drawn from various sources such as from within a bundle:
                 <link rel="stylesheet" href="<?php echo $view->escape($url) ?>" />
             <?php endforeach; ?>
 
+.. tip::
+
+    For the above example to work, you must either add your bundle to the list
+    of bundles that Assetic is allowed to handle (which is *none* in a default
+    Symfony installation), or remove the bundle list from the configuration
+    altogether:
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        assetic:
+            debug:          "%kernel.debug%"
+            use_controller: false
+            #bundles:       [ ]
+            filters:
+                # ...
+
 In this example, all of the files in the ``Resources/public/js/`` directory
 of the ``AcmeFooBundle`` will be loaded and served from a different location.
 The actual rendered tag might simply look like:


### PR DESCRIPTION
Two additions to hopefully help newcomers:
- The `bundles` option in the Assetic configuration defaults to `[]`, it must be changed, one way or another;
- Relative paths in CSS files don’t work anymore and the `cssrewrite` filter [does not work with the `@AsseticFooBundle` syntax](https://github.com/kriswallsmith/assetic/issues/53#issuecomment-2976018), so a workaround is proposed.

I have not included the other formats besides YAML for the config file because I’m not comfortable enough with them and the AsseticBundle Configuration Reference only includes YAML. I have not tested the PHP version of the example for the output parameter.

Of course, I will gladly update this based on suggestions.
