### PR TITLE
Update components/http_foundation/introduction.rst

### DIFF
--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -431,7 +431,7 @@ class, which can make this even easier::
     use Symfony\Component\HttpFoundation\JsonResponse;
 
     $response = new JsonResponse();
-    $response->setContent(array(
+    $response->setData(array(
         'data' => 123
     ));
 


### PR DESCRIPTION
Typo in documentation that would cause an exception. setContent can not accept array. Assuming documentation meant setData.
