### PR TITLE
Typo, grammar and GitHub UI description changes

### DIFF
--- a/contributing/code/bugs.rst
+++ b/contributing/code/bugs.rst
@@ -25,7 +25,7 @@ If your problem definitely looks like a bug, report it using the official bug
 * Describe the steps needed to reproduce the bug with short code examples
   (providing a unit test that illustrates the bug is best);
 
-* Give as much details as possible about your environment (OS, PHP version,
+* Give as much detail as possible about your environment (OS, PHP version,
   Symfony version, enabled extensions, ...);
 
 * *(optional)* Attach a :doc:`patch <patches>`.

--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -71,7 +71,7 @@ Get the Symfony2 source code:
 
 * Fork the `Symfony2 repository`_ (click on the "Fork" button);
 
-* After the "hardcore forking action" has completed, clone your fork locally
+* After the "forking action" has completed, clone your fork locally
   (this will create a `symfony` directory):
 
 .. code-block:: bash

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -97,7 +97,7 @@ trust_proxy_headers
 **type**: ``Boolean``
 
 Configures if HTTP headers (like ``HTTP_X_FORWARDED_FOR``, ``X_FORWARDED_PROTO``, and
-``X_FORWARDED_HOST``) are trusted as indication for an SSL connection. By default, it is
+``X_FORWARDED_HOST``) are trusted as an indication for an SSL connection. By default, it is
 set to ``false`` and only SSL_HTTPS connections are indicated as secure.
 
 You should enable this setting if your application is behind a reverse proxy.


### PR DESCRIPTION
- A couple of typo/grammar fixes
- Wording change when talking about GitHub forking action as it's no longer described as 'hardcore' 
