### PR TITLE
[Console] Typo: $app->getHelperSet() instead of $this->getHelperSet()

### DIFF
--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -383,7 +383,7 @@ information, which updates as your command runs:
 To display progress details, use the :class:`Symfony\\Component\\Console\\Helper\\ProgressHelper`,
 pass it a total number of units, and advance the progress as your command executes::
 
-    $progress = $app->getHelperSet()->get('progress');
+    $progress = $this->getHelperSet()->get('progress');
 
     $progress->start($output, 50);
     $i = 0;


### PR DESCRIPTION
I'm not entirely sure but there seems to be a typo (in components/console/introduction.rst on line 386).

In my opinion

```
$progress = $app->getHelperSet()->get('progress');
```

should be

```
$progress = $this->getHelperSet()->get('progress');
```

$app is never instantiated, $this seems more consistent and less confusing.
