### PR TITLE
Updating Monolog Config

### DIFF
--- a/cookbook/logging/monolog.rst
+++ b/cookbook/logging/monolog.rst
@@ -54,7 +54,7 @@ allows you to log the messages in several ways easily.
 
         monolog:
             handlers:
-                syslog:
+                applog:
                     type: stream
                     path: /var/log/symfony.log
                     level: error
@@ -65,7 +65,9 @@ allows you to log the messages in several ways easily.
                 file:
                     type: stream
                     level: debug
-
+                syslog:
+                    type: syslog
+                    level: error
     .. code-block:: xml
 
         <container xmlns="http://symfony.com/schema/dic/services"
@@ -76,7 +78,7 @@ allows you to log the messages in several ways easily.
 
             <monolog:config>
                 <monolog:handler
-                    name="syslog"
+                    name="applog"
                     type="stream"
                     path="/var/log/symfony.log"
                     level="error"
@@ -91,6 +93,11 @@ allows you to log the messages in several ways easily.
                     name="file"
                     type="stream"
                     level="debug"
+                />
+                <monolog:handler
+                    name="syslog"
+                    type="syslog"
+                    level="error"
                 />
             </monolog:config>
         </container>


### PR DESCRIPTION
Updating a misleading `syslog` entry that actually used a stream and added a true `syslogHandler` example so its clearer to people using it.

This should be ported to all versions as its valid for all of them. Is there a procedure for that? open a separate PR?
