### PR TITLE
[Locale] Removed unavailable methods

### DIFF
--- a/components/locale.rst
+++ b/components/locale.rst
@@ -65,8 +65,4 @@ When using the ClassLoader component following code is sufficient to supplement 
     $locales = Locale::getDisplayLocales('en');
     $localeCodes = Locale::getLocales();
 
-    // Get ICU versions
-    $icuVersion = Locale::getIcuVersion();
-    $icuDataVersion = Locale::getIcuDataVersion();
-
 .. _Packagist: https://packagist.org/packages/symfony/locale


### PR DESCRIPTION
The methods `Locale::getIcuVersion();` and `Locale::getIcuDataVersion();` isn't available in 2.0
