### PR TITLE
[Console] Fix a typo in a method name

### DIFF
--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -416,7 +416,7 @@ progress bar::
     $progress->setBarCharacter('<comment>=</comment>');
     // the unfinished part of the bar
     $progress->setEmptyBarCharacter(' ');
-    $progress->setProgressChar('|');
+    $progress->setProgressCharacter('|');
     $progress->setBarWidth(50);
 
 To see other available options, check the API documentation for


### PR DESCRIPTION
See https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Helper/ProgressHelper.php#L142
