### PR TITLE
[Reference/Validation Constraints] Add some missing xml reference examples.

### DIFF
--- a/reference/constraints/Blank.rst
+++ b/reference/constraints/Blank.rst
@@ -43,6 +43,15 @@ of an ``Author`` class were blank, you could do the following:
             protected $firstName;
         }
 
+    .. code-block:: xml
+
+        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
+        <class name="Acme\BlogBundle\Entity\Author">
+            <property name="firstName">
+                <constraint name="Blank" />
+            </property>
+        </class>
+
 Options
 -------
 

--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -38,8 +38,8 @@ To verify that the ``firstName`` field length of a class is between "2" and
                     - Length:
                         min: 2
                         max: 50
-                        minMessage: Your first name must be at least 2 characters length
-                        maxMessage: Your first name cannot be longer than than 50 characters length
+                        minMessage: "Your first name must be at least {{ limit }} characters length"
+                        maxMessage: "Your first name cannot be longer than than {{ limit }} characters length"
 
     .. code-block:: php-annotations
 
@@ -52,12 +52,26 @@ To verify that the ``firstName`` field length of a class is between "2" and
              * @Assert\Length(
              *      min = "2",
              *      max = "50",
-             *      minMessage = "Your first name must be at least 2 characters length",
-             *      maxMessage = "Your first name cannot be longer than than 50 characters length"
+             *      minMessage = "Your first name must be at least {{ limit }} characters length",
+             *      maxMessage = "Your first name cannot be longer than than {{ limit }} characters length"
              * )
              */
              protected $firstName;
         }
+
+    .. code-block:: xml
+
+        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
+        <class name="Acme\EventBundle\Entity\Participant">
+            <property name="firstName">
+                <constraint name="Length">
+                    <option name="min">2</option>
+                    <option name="max">50</option>
+                    <option name="minMessage">Your first name must be at least {{ limit }} characters length</option>
+                    <option name="maxMessage">Your first name cannot be longer than than {{ limit }} characters length</option>
+                </constraint>
+            </property>
+        </class>
 
 Options
 -------

--- a/reference/constraints/MaxLength.rst
+++ b/reference/constraints/MaxLength.rst
@@ -53,7 +53,7 @@ Basic Usage
         <class name="Acme\BlogBundle\Entity\Blog">
             <property name="summary">
                 <constraint name="MaxLength">
-                    <value>100</value>
+                    <option name="limit">100</option>
                 </constraint>
             </property>
         </class>

--- a/reference/constraints/NotBlank.rst
+++ b/reference/constraints/NotBlank.rst
@@ -42,6 +42,15 @@ were not blank, you could do the following:
             protected $firstName;
         }
 
+    .. code-block:: xml
+
+        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
+        <class name="Acme\BlogBundle\Entity\Author">
+            <property name="firstName">
+                <constraint name="NotBlank" />
+            </property>
+        </class>
+
 Options
 -------
 

--- a/reference/constraints/NotNull.rst
+++ b/reference/constraints/NotNull.rst
@@ -42,6 +42,15 @@ were not strictly equal to ``null``, you would:
             protected $firstName;
         }
 
+    .. code-block:: xml
+
+        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
+        <class name="Acme\BlogBundle\Entity\Author">
+            <property name="firstName">
+                <constraint name="NotNull" />
+            </property>
+        </class>
+
 Options
 -------
 

--- a/reference/constraints/Null.rst
+++ b/reference/constraints/Null.rst
@@ -46,6 +46,15 @@ of an ``Author`` class exactly equal to ``null``, you could do the following:
             protected $firstName;
         }
 
+    .. code-block:: xml
+
+        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
+        <class name="Acme\BlogBundle\Entity\Author">
+            <property name="firstName">
+                <constraint name="Null" />
+            </property>
+        </class>
+
 Options
 -------
 


### PR DESCRIPTION
- Added missing xml examples for: Blank, Length, NotBlank, NotNull, Null
- Fix MinLength xml example
