### PR TITLE
[contributing/code/standards] Fixed wrong syntaxes

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -15,7 +15,7 @@ documents.
 Since a picture - or some code - is worth a thousand words, here's a short
 example containing most features described below:
 
-.. code-block:: php
+.. code-block:: php+html
 
     <?php
 
@@ -82,17 +82,17 @@ Structure
 
 * Add a single space after each comma delimiter;
 
-* Add a single space around operators (`==`, `&&`, ...);
+* Add a single space around operators (``==``, ``&&``, ...);
 
-* Add a blank line before `return` statements, unless the return is alone
-  inside a statement-group (like an `if` statement);
+* Add a blank line before ``return`` statements, unless the return is alone
+  inside a statement-group (like an ``if`` statement);
 
 * Use braces to indicate control structure body regardless of the number of
   statements it contains;
 
 * Define one class per file - this does not apply to private helper classes
   that are not intended to be instantiated from the outside and thus are not
-  concerned by the PSR-0 standard;
+  concerned by the `PSR-0`_ standard;
 
 * Declare class properties before methods;
 
@@ -108,9 +108,9 @@ Naming Conventions
 
 * Use namespaces for all classes;
 
-* Abstract classes are often prefixed with `Abstract`;
+* Abstract classes are often prefixed with ``Abstract``;
 
-* Suffix interfaces with `Interface`;
+* Suffix interfaces with ``Interface``;
 
 * Use alphanumeric characters and underscores for file names;
 
@@ -122,9 +122,9 @@ Documentation
 
 * Add PHPDoc blocks for all classes, methods, and functions;
 
-* Omit the `@return` tag if the method does not return anything;
+* Omit the ``@return`` tag if the method does not return anything;
 
-* The `@package` and `@subpackage` annotations are not used.
+* The ``@package`` and ``@subpackage`` annotations are not used.
 
 License
 -------


### PR DESCRIPTION
The markdown syntax was used for inline code blocks.
