### PR TITLE
fixed namespace in form.type_extension code example

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -86,7 +86,7 @@ For simplicity, you'll often extend an
 the interface directly::
 
     // src/Acme/MainBundle/Form/Type/MyFormTypeExtension.php
-    namespace Acme\MainBundle\Form\Type\MyFormTypeExtension;
+    namespace Acme\MainBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractTypeExtension;
 


### PR DESCRIPTION
Hello. If file hosts in src/Acme/MainBundle/Form/Type/MyFormTypeExtension.php, namespace must be a Acme\MainBundle\Form\Type, not a Acme\MainBundle\Form\Type\MyFormTypeExtension

reference / dic_tags.rst 
