### PR TITLE
Add some xml and php formats

### DIFF
--- a/reference/configuration/assetic.rst
+++ b/reference/configuration/assetic.rst
@@ -50,3 +50,52 @@ Full Default Configuration
 
                     # Prototype
                     name:                 []
+
+    .. code-block:: xml
+
+        <assetic:config
+            debug="%kernel.debug%"
+            use-controller="%kernel.debug%"
+            read-from="%kernel.root_dir%/../web"
+            write-to="%assetic.read_from%"
+            java="/usr/bin/java"
+            node="/usr/bin/node"
+            sass="/usr/bin/sass"
+        >
+            <!-- Defaults (all currently registered bundles) -->
+            <assetic:bundle>FrameworkBundle</assetic:bundle>
+            <assetic:bundle>SecurityBundle</assetic:bundle>
+            <assetic:bundle>TwigBundle</assetic:bundle>
+            <assetic:bundle>MonologBundle</assetic:bundle>
+            <assetic:bundle>SwiftmailerBundle</assetic:bundle>
+            <assetic:bundle>DoctrineBundle</assetic:bundle>
+            <assetic:bundle>AsseticBundle</assetic:bundle>
+            <assetic:bundle>...</assetic:bundle>
+
+            <assetic:asset>
+                <!-- prototype -->
+                <assetic:name>
+                    <assetic:input />
+
+                    <assetic:filter />
+
+                    <assetic:option>
+                        <!-- prototype -->
+                        <assetic:name />
+                    </assetic:option>
+                </assetic:name>
+            </assetic:asset>
+
+            <assetic:filter>
+                <!-- prototype -->
+                <assetic:name />
+            </assetic:filter>
+
+            <assetic:twig>
+                <assetic:functions>
+                    <!-- prototype -->
+                    <assetic:name />
+                </assetic:functions>
+            </assetic:twig>
+
+        </assetic:config>

--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -194,3 +194,29 @@ Full Default Configuration
             delivery_address:     ~
             disable_delivery:     ~
             logging:              "%kernel.debug%"
+
+    .. code-block:: xml
+
+        <swiftmailer:config
+            transport="smtp"
+            username=""
+            password=""
+            host="localhost"
+            port="false"
+            encryption=""
+            auth_mode=""
+            sender_address=""
+            delivery_address=""
+            disable_delivery=""
+            logging="%kernel.debug%"
+        >
+            <swiftmailer:spool
+                path="%kernel.cache_dir%/swiftmailer/spool"
+                type="file"
+            />
+
+            <swiftmailer:antiflood
+                sleep="0"
+                threshold="99"
+            />
+        </swiftmailer:config>

--- a/reference/configuration/web_profiler.rst
+++ b/reference/configuration/web_profiler.rst
@@ -21,3 +21,11 @@ Full Default Configuration
 
             # gives you the opportunity to look at the collected data before following the redirect
             intercept_redirects: false
+
+    .. code-block:: xml
+
+        <web-profiler:config
+            toolbar="false"
+            verbose="true"
+            intercept_redirects="false"
+        />


### PR DESCRIPTION
This PR added XML formats in the `reference/configuration` section for the AsseticBundle, WebProfilerBundle and SwiftMailerBundle. It also adds the XML and PHP formats for the `Min` constraint.

It's my first time that I use xml or PHP for configuration, so I'm not sure about all of them. Please check the examples before merging.<br>
I don't know the schema location and how this should be registered, this should be added before merging.

If this PR is correct and gets merged, I will create the other missing formats in the reference section too.
