### PR TITLE
Fixed indention issues in configuration blocks

### DIFF
--- a/reference/constraints/All.rst
+++ b/reference/constraints/All.rst
@@ -50,21 +50,21 @@ entry in that array:
             protected $favoriteColors = array();
        }
 
-   .. code-block:: xml
+    .. code-block:: xml
 
-       <!-- src/Acme/UserBundle/Resources/config/validation.xml -->
-       <class name="Acme\UserBundle\Entity\User">
-           <property name="favoriteColors">
-               <constraint name="All">
-                   <option name="constraints">
-                       <constraint name="NotBlank" />
-                       <constraint name="Length">
-                           <option name="min">5</option>
-                       </constraint>
-                   </option>
-               </constraint>
-           </property>
-       </class>
+        <!-- src/Acme/UserBundle/Resources/config/validation.xml -->
+        <class name="Acme\UserBundle\Entity\User">
+            <property name="favoriteColors">
+                <constraint name="All">
+                    <option name="constraints">
+                        <constraint name="NotBlank" />
+                        <constraint name="Length">
+                            <option name="min">5</option>
+                        </constraint>
+                    </option>
+                </constraint>
+            </property>
+        </class>
 
 Now, each entry in the ``favoriteColors`` array will be validated to not
 be blank and to be at least 5 characters long.

--- a/reference/constraints/Country.rst
+++ b/reference/constraints/Country.rst
@@ -41,14 +41,14 @@ Basic Usage
             protected $country;
        }
 
-   .. code-block:: xml
+    .. code-block:: xml
 
-       <!-- src/Acme/UserBundle/Resources/config/validation.xml -->
-       <class name="Acme\UserBundle\Entity\User">
-           <property name="country">
-               <constraint name="Country" />
-           </property>
-       </class>
+        <!-- src/Acme/UserBundle/Resources/config/validation.xml -->
+        <class name="Acme\UserBundle\Entity\User">
+            <property name="country">
+                <constraint name="Country" />
+            </property>
+        </class>
 
 Options
 -------

--- a/reference/constraints/Ip.rst
+++ b/reference/constraints/Ip.rst
@@ -44,14 +44,14 @@ Basic Usage
             protected $ipAddress;
        }
 
-   .. code-block:: xml
+    .. code-block:: xml
 
-       <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
-       <class name="Acme\BlogBundle\Entity\Author">
-           <property name="ipAddress">
-               <constraint name="Ip" />
-           </property>
-       </class>
+        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
+        <class name="Acme\BlogBundle\Entity\Author">
+            <property name="ipAddress">
+                <constraint name="Ip" />
+            </property>
+        </class>
 
 Options
 -------

--- a/reference/constraints/Language.rst
+++ b/reference/constraints/Language.rst
@@ -41,14 +41,14 @@ Basic Usage
             protected $preferredLanguage;
        }
 
-   .. code-block:: xml
+    .. code-block:: xml
 
-       <!-- src/Acme/UserBundle/Resources/config/validation.xml -->
-       <class name="Acme\UserBundle\Entity\User">
-           <property name="preferredLanguage">
-               <constraint name="Language" />
-           </property>
-       </class>
+        <!-- src/Acme/UserBundle/Resources/config/validation.xml -->
+        <class name="Acme\UserBundle\Entity\User">
+            <property name="preferredLanguage">
+                <constraint name="Language" />
+            </property>
+        </class>
 
 Options
 -------

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -45,14 +45,14 @@ Basic Usage
             protected $locale;
        }
 
-   .. code-block:: xml
+    .. code-block:: xml
 
-       <!-- src/Acme/UserBundle/Resources/config/validation.xml -->
-       <class name="Acme\UserBundle\Entity\User">
-           <property name="locale">
-               <constraint name="Locale" />
-           </property>
-       </class>
+        <!-- src/Acme/UserBundle/Resources/config/validation.xml -->
+        <class name="Acme\UserBundle\Entity\User">
+            <property name="locale">
+                <constraint name="Locale" />
+            </property>
+        </class>
 
 Options
 -------

--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -42,14 +42,14 @@ Basic Usage
             protected $bioUrl;
        }
 
-   .. code-block:: xml
+    .. code-block:: xml
 
-       <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
-       <class name="Acme\BlogBundle\Entity\Author">
-           <property name="bioUrl">
-               <constraint name="Url" />
-           </property>
-       </class>
+        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
+        <class name="Acme\BlogBundle\Entity\Author">
+            <property name="bioUrl">
+                <constraint name="Url" />
+            </property>
+        </class>
 
 Options
 -------


### PR DESCRIPTION
As mentioned in #2071 the tabs aren't rendering correctly when the indention is incosistent, I find that there were some problems with indenting at the recently added XML formats in #2053. This PR fix all rendering issues with configuration blocks in the _constraint reference_.
