### PR TITLE
Changing the description of the Radio Form Type

### DIFF
--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -5,8 +5,8 @@ radio Field Type
 ================
 
 Creates a single radio button. If the radio button is selected, the field will
-be set to the specified value. Radio buttons cannot be unchecked - The value only
-changes when another radio button with the same gets checked.
+be set to the specified value. Radio buttons cannot be unchecked - the value only
+changes when another radio button with the same name gets checked.
 
 The ``radio`` type isn't usually used directly. More commonly it's used
 internally by other types such as :doc:`choice</reference/forms/types/choice>`.

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -4,9 +4,9 @@
 radio Field Type
 ================
 
-Creates a single radio button. This should always be used for a field that
-has a Boolean value: if the radio button is selected, the field will be set
-to true, if the button is not selected, the value will be set to false.
+Creates a single radio button. If the radio button is selected, the field will
+be set to the specified value. Radio buttons cannot be unchecked - The value only
+changes when another radio button with the same gets checked.
 
 The ``radio`` type isn't usually used directly. More commonly it's used
 internally by other types such as :doc:`choice</reference/forms/types/choice>`.


### PR DESCRIPTION
As described in #1130, the description of the radio form type was not correct. I changed it to better reflect the actual behaviour of the radio button in HTML web forms.

This PR needs to be merged in 2.1 and master as well.
