### PR TITLE
[Form] Adding disabled option docs

### DIFF
--- a/reference/forms/types/birthday.rst
+++ b/reference/forms/types/birthday.rst
@@ -31,6 +31,8 @@ option defaults to 120 years ago to the current year.
 |                      | - `user_timezone`_                                                                                                     |
 |                      | - `invalid_message`_                                                                                                   |
 |                      | - `invalid_message_parameters`_                                                                                        |
+|                      | - `read_only`_                                                                                                         |
+|                      | - `disabled`_                                                                                                          |
 +----------------------+------------------------------------------------------------------------------------------------------------------------+
 | Parent type          | :doc:`date</reference/forms/types/date>`                                                                               |
 +----------------------+------------------------------------------------------------------------------------------------------------------------+
@@ -75,3 +77,6 @@ These options inherit from the :doc:`date</reference/forms/types/field>` type:
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 
+.. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc

--- a/reference/forms/types/checkbox.rst
+++ b/reference/forms/types/checkbox.rst
@@ -16,6 +16,7 @@ if the box is unchecked, the value will be set to false.
 | Inherited   | - `required`_                                                          |
 | options     | - `label`_                                                             |
 |             | - `read_only`_                                                         |
+|             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                             |
@@ -54,5 +55,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -25,6 +25,7 @@ option.
 | Inherited   | - `required`_                                                               |
 | options     | - `label`_                                                                  |
 |             | - `read_only`_                                                              |
+|             | - `disabled`_                                                               |
 |             | - `error_bubbling`_                                                         |
 +-------------+-----------------------------------------------------------------------------+
 | Parent type | :doc:`form</reference/forms/types/form>` (if expanded), ``field`` otherwise |
@@ -117,5 +118,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc

--- a/reference/forms/types/country.rst
+++ b/reference/forms/types/country.rst
@@ -30,6 +30,7 @@ you should just use the ``choice`` type directly.
 |             | - `required`_                                                         |
 |             | - `label`_                                                            |
 |             | - `read_only`_                                                        |
+|             | - `disabled`_                                                         |
 +-------------+-----------------------------------------------------------------------+
 | Parent type | :doc:`choice</reference/forms/types/choice>`                          |
 +-------------+-----------------------------------------------------------------------+
@@ -58,3 +59,5 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -32,6 +32,8 @@ day, and year) or three select boxes (see the `widget_` option).
 +----------------------+-----------------------------------------------------------------------------+
 | Inherited            | - `invalid_message`_                                                        |
 | options              | - `invalid_message_parameters`_                                             |
+|                      | - `read_only`_                                                              |
+|                      | - `disabled`_                                                               |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | ``field`` (if text), ``form`` otherwise                                     |
 +----------------------+-----------------------------------------------------------------------------+
@@ -121,3 +123,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
+
+.. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -31,6 +31,8 @@ data can be a ``DateTime`` object, a string, a timestamp or an array.
 +----------------------+-----------------------------------------------------------------------------+
 | Inherited            | - `invalid_message`_                                                        |
 | options              | - `invalid_message_parameters`_                                             |
+|                      | - `read_only`_                                                              |
+|                      | - `disabled`_                                                               |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | :doc:`form</reference/forms/types/form>`                                    |
 +----------------------+-----------------------------------------------------------------------------+
@@ -105,3 +107,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
+
+.. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc

--- a/reference/forms/types/email.rst
+++ b/reference/forms/types/email.rst
@@ -15,6 +15,7 @@ The ``email`` field is a text field that is rendered using the HTML5
 |             | - `label`_                                                          |
 |             | - `trim`_                                                           |
 |             | - `read_only`_                                                      |
+|             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                          |
@@ -36,5 +37,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/trim.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -25,6 +25,7 @@ objects from the database.
 |             | - `preferred_choices`_                                           |
 |             | - `empty_value`_                                                 |
 |             | - `read_only`_                                                   |
+|             | - `disabled`_                                                    |
 |             | - `error_bubbling`_                                              |
 +-------------+------------------------------------------------------------------+
 | Parent type | :doc:`choice</reference/forms/types/choice>`                     |
@@ -140,5 +141,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc

--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -12,6 +12,7 @@ The ``file`` type represents a file input in your form.
 | Inherited   | - `required`_                                                       |
 | options     | - `label`_                                                          |
 |             | - `read_only`_                                                      |
+|             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`form</reference/forms/types/form>`                            |
@@ -88,5 +89,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc

--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -17,7 +17,7 @@ on all fields.
 
 .. include:: /reference/forms/types/options/cascade_validation.rst.inc
 
-.. include:: /reference/forms/types/options/disabled.rst.inc
+.. include:: /reference/forms/types/options/read_only.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
 

--- a/reference/forms/types/hidden.rst
+++ b/reference/forms/types/hidden.rst
@@ -11,6 +11,8 @@ The hidden type represents a hidden input field.
 +-------------+----------------------------------------------------------------------+
 | Inherited   | - ``data``                                                           |
 | options     | - ``property_path``                                                  |
+|             | - `read_only`_                                                       |
+|             | - `disabled`_                                                        |
 +-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                           |
 +-------------+----------------------------------------------------------------------+
@@ -25,3 +27,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/property_path.rst.inc
+
+.. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc

--- a/reference/forms/types/hidden.rst
+++ b/reference/forms/types/hidden.rst
@@ -11,8 +11,6 @@ The hidden type represents a hidden input field.
 +-------------+----------------------------------------------------------------------+
 | Inherited   | - ``data``                                                           |
 | options     | - ``property_path``                                                  |
-|             | - `read_only`_                                                       |
-|             | - `disabled`_                                                        |
 +-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                           |
 +-------------+----------------------------------------------------------------------+
@@ -27,7 +25,3 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/property_path.rst.inc
-
-.. include:: /reference/forms/types/options/read_only.rst.inc
-
-.. include:: /reference/forms/types/options/disabled.rst.inc

--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -21,6 +21,7 @@ integers. By default, all non-integer values (e.g. 6.78) will round down (e.g. 6
 | Inherited   | - `required`_                                                         |
 | options     | - `label`_                                                            |
 |             | - `read_only`_                                                        |
+|             | - `disabled`_                                                         |
 |             | - `error_bubbling`_                                                   |
 |             | - `invalid_message`_                                                  |
 |             | - `invalid_message_parameters`_                                       |
@@ -66,6 +67,8 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -31,6 +31,7 @@ you should just use the ``choice`` type directly.
 |             | - `required`_                                                          |
 |             | - `label`_                                                             |
 |             | - `read_only`_                                                         |
+|             | - `disabled`_                                                          |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`choice</reference/forms/types/choice>`                           |
 +-------------+------------------------------------------------------------------------+
@@ -59,3 +60,5 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -32,6 +32,7 @@ you should just use the ``choice`` type directly.
 |             | - `required`_                                                          |
 |             | - `label`_                                                             |
 |             | - `read_only`_                                                         |
+|             | - `disabled`_                                                          |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`choice</reference/forms/types/choice>`                           |
 +-------------+------------------------------------------------------------------------+
@@ -60,3 +61,5 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -22,6 +22,7 @@ how the input and output of the data is handled.
 | Inherited   | - `required`_                                                       |
 | options     | - `label`_                                                          |
 |             | - `read_only`_                                                      |
+|             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
 |             | - `invalid_message`_                                                |
 |             | - `invalid_message_parameters`_                                     |
@@ -86,6 +87,8 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 

--- a/reference/forms/types/number.rst
+++ b/reference/forms/types/number.rst
@@ -18,6 +18,7 @@ you want to use for your number.
 | Inherited   | - `required`_                                                        |
 | options     | - `label`_                                                           |
 |             | - `read_only`_                                                       |
+|             | - `disabled`_                                                        |
 |             | - `error_bubbling`_                                                  |
 |             | - `invalid_message`_                                                 |
 |             | - `invalid_message_parameters`_                                      |
@@ -85,6 +86,8 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 

--- a/reference/forms/types/options/disabled.rst.inc
+++ b/reference/forms/types/options/disabled.rst.inc
@@ -2,7 +2,7 @@ disabled
 ~~~~~~~~
 
 .. versionadded:: 2.1
-    The ``disabled`` option was added in 2.1
+    The ``disabled`` option is new in version 2.1
         
 **type**: ``boolean``  **default**: ``false``
 

--- a/reference/forms/types/options/disabled.rst.inc
+++ b/reference/forms/types/options/disabled.rst.inc
@@ -1,5 +1,9 @@
 disabled
 ~~~~~~~~
+
+.. versionadded:: 2.1
+    The ``disabled`` option was added in 2.1
+        
 **type**: ``boolean``  **default**: ``false``
 
 If you don't want a user to modify the value of a field, you can set 

--- a/reference/forms/types/options/read_only.rst.inc
+++ b/reference/forms/types/options/read_only.rst.inc
@@ -3,7 +3,7 @@ read_only
 
 .. versionadded:: 2.1
     The ``read_only`` option was changed in 2.1 to not render as ``disabled``
-    but as ``readonly`` attribute. Use the ``disabled`` option if you need
+    but as ``readonly`` attribute. Use the `disabled`_ option if you need
     the old behaviour.
 
 **type**: ``Boolean`` **default**: ``false``

--- a/reference/forms/types/options/read_only.rst.inc
+++ b/reference/forms/types/options/read_only.rst.inc
@@ -1,6 +1,11 @@
 read_only
 ~~~~~~~~~
 
+.. versionadded:: 2.1
+    The ``read_only`` option was changed in 2.1 to not render as ``disabled``
+    but as ``readonly`` attribute. Use the ``disabled`` option if you need
+    the old behaviour.
+
 **type**: ``Boolean`` **default**: ``false``
 
 If this option is true, the field will be rendered with the ``disabled``

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -16,6 +16,7 @@ The ``password`` field renders an input password text box.
 |             | - `label`_                                                             |
 |             | - `trim`_                                                              |
 |             | - `read_only`_                                                         |
+|             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`text</reference/forms/types/text>`                               |
@@ -52,5 +53,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/trim.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc

--- a/reference/forms/types/percent.rst
+++ b/reference/forms/types/percent.rst
@@ -21,6 +21,7 @@ This field adds a percentage sign "``%``" after the input box.
 | Inherited   | - `required`_                                                         |
 | options     | - `label`_                                                            |
 |             | - `read_only`_                                                        |
+|             | - `disabled`_                                                         |
 |             | - `error_bubbling`_                                                   |
 |             | - `invalid_message`_                                                  |
 |             | - `invalid_message_parameters`_                                       |
@@ -71,6 +72,8 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -20,6 +20,7 @@ If you want to have a Boolean field, use :doc:`checkbox</reference/forms/types/c
 | Inherited   | - `required`_                                                       |
 | options     | - `label`_                                                          |
 |             | - `read_only`_                                                      |
+|             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                          |
@@ -48,5 +49,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc

--- a/reference/forms/types/search.rst
+++ b/reference/forms/types/search.rst
@@ -17,6 +17,7 @@ Read about the input search field at `DiveIntoHTML5.info`_
 |             | - `label`_                                                           |
 |             | - `trim`_                                                            |
 |             | - `read_only`_                                                       |
+|             | - `disabled`_                                                        |
 |             | - `error_bubbling`_                                                  |
 +-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`text</reference/forms/types/text>`                             |
@@ -38,6 +39,8 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/trim.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 

--- a/reference/forms/types/text.rst
+++ b/reference/forms/types/text.rst
@@ -14,6 +14,7 @@ The text field represents the most basic input text field.
 |             | - `label`_                                                         |
 |             | - `trim`_                                                          |
 |             | - `read_only`_                                                     |
+|             | - `disabled`_                                                      |
 |             | - `error_bubbling`_                                                |
 +-------------+--------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                         |
@@ -36,5 +37,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/trim.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc

--- a/reference/forms/types/textarea.rst
+++ b/reference/forms/types/textarea.rst
@@ -14,6 +14,7 @@ Renders a ``textarea`` HTML element.
 |             | - `label`_                                                             |
 |             | - `trim`_                                                              |
 |             | - `read_only`_                                                         |
+|             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                             |
@@ -35,6 +36,8 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/trim.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -26,6 +26,8 @@ as a ``DateTime`` object, a string, a timestamp or an array.
 +----------------------+-----------------------------------------------------------------------------+
 | Inherited            | - `invalid_message`_                                                        |
 | options              | - `invalid_message_parameters`_                                             |
+|                      | - `read_only`_                                                              |
+|                      | - `disabled`_                                                               |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | form                                                                        |
 +----------------------+-----------------------------------------------------------------------------+
@@ -116,3 +118,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
+
+.. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc

--- a/reference/forms/types/timezone.rst
+++ b/reference/forms/types/timezone.rst
@@ -22,10 +22,11 @@ you should just use the ``choice`` type directly.
 | options     | - `expanded`_                                                          |
 |             | - `preferred_choices`_                                                 |
 |             | - `empty_value`_                                                       |
-|             | - `error_bubbling`_                                                    |
 |             | - `required`_                                                          |
 |             | - `label`_                                                             |
 |             | - `read_only`_                                                         |
+|             | - `disabled`_                                                          |
+|             | - `error_bubbling`_                                                    |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`choice</reference/forms/types/choice>`                           |
 +-------------+------------------------------------------------------------------------+
@@ -52,5 +53,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/label.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc

--- a/reference/forms/types/url.rst
+++ b/reference/forms/types/url.rst
@@ -18,6 +18,7 @@ have a protocol.
 |             | - `label`_                                                        |
 |             | - `trim`_                                                         |
 |             | - `read_only`_                                                    |
+|             | - `disabled`_                                                     |
 |             | - `error_bubbling`_                                               |
 +-------------+-------------------------------------------------------------------+
 | Parent type | :doc:`text</reference/forms/types/text>`                          |
@@ -51,5 +52,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/trim.rst.inc
 
 .. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc


### PR DESCRIPTION
As said in #2096, the docs are missing the `disabled` option which got introduced in 2.1.

I added the missing inheritance documentation and added a versionadd tag to both the `read_only` and the `disabled` option describing the change.
