### PR TITLE
Add deprecations to PR summary

### DIFF
--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -279,6 +279,7 @@ your contributions can be included into Symfony2 as quickly as possible:
     Bug fix: [yes|no]
     Feature addition: [yes|no]
     Backwards compatibility break: [yes|no]
+    Deprecations: [what, when|no]
     Symfony2 tests pass: [yes|no]
     Fixes the following tickets: [comma separated list of tickets fixed by the PR]
     Todo: [list of todos pending]


### PR DESCRIPTION
Recently we have received at lot of PRs (especially in the Form component) that have a `Backwards compatibility break: no` only because they provide a "legacy layer" which is intended to be deprecated in 2.3 or 3.0.

This means that merging those PRs will ultimately cause BCs and that there is no other way than looking at the code in order to know what they will be. I think this is not fair.

Adding the `deprecations` header would allow indicating those BC breaks in advance and help users sreach the issue tracker when they will hit errors.

/cc @bschussek
