### PR TITLE
Fix the "doctrine file uploads" cookbook examples, see symfony/symfony-d...

### DIFF
--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -133,7 +133,7 @@ rules::
         private $file;
 
         /**
-         * Sets file
+         * Sets file.
          *
          * @param UploadedFile $file
          */
@@ -143,7 +143,7 @@ rules::
         }
 
         /**
-         * Get file
+         * Get file.
          *
          * @return UploadedFile
          */
@@ -293,7 +293,7 @@ Next, refactor the ``Document`` class to take advantage of these callbacks::
         private $temp;
 
         /**
-         * Sets file
+         * Sets file.
          *
          * @param UploadedFile $file
          */
@@ -408,7 +408,7 @@ property, instead of the actual filename::
         private $temp;
 
         /**
-         * Sets file
+         * Sets file.
          *
          * @param UploadedFile $file
          */

--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -304,8 +304,10 @@ Next, refactor the ``Document`` class to take advantage of these callbacks::
             if (isset($this->path)) {
                 // store the old name to delete after the update
                 $this->temp = $this->path;
+                $this->path = null;
+            } else {
+                $this->path = 'initial';
             }
-            $this->path = null;
         }
 
         /**
@@ -419,6 +421,8 @@ property, instead of the actual filename::
             if (is_file($this->getAbsolutePath())) {
                 // store the old name to delete after the update
                 $this->temp = $this->getAbsolutePath();
+            } else {
+                $this->path = 'initial';
             }
         }
 

--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -443,6 +443,14 @@ property, instead of the actual filename::
                 return;
             }
 
+            // check if we have an old image
+            if (isset($this->temp)) {
+                // delete the old image
+                unlink($this->temp);
+                // clear the temp image path
+                $this->temp = null;
+            }
+
             // you must throw an exception here if the file cannot be moved
             // so that the entity is not persisted to the database
             // which the UploadedFile move() method does
@@ -452,14 +460,6 @@ property, instead of the actual filename::
             );
 
             unset($this->file);
-
-            // check if we have an old image
-            if (isset($this->temp)) {
-                // delete the old image
-                unlink($this->temp);
-                // clear the temp image path
-                $this->temp = null;
-            }
         }
 
         /**

--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -133,7 +133,7 @@ rules::
         private $file;
 
         /**
-         * Set file
+         * Sets file
          *
          * @param UploadedFile $file
          */
@@ -417,7 +417,7 @@ property, instead of the actual filename::
             $this->file = $file;
             // check if we have an old image path
             if (is_file($this->getAbsolutePath())) {
-                //store the old name to delete after the update
+                // store the old name to delete after the update
                 $this->temp = $this->getAbsolutePath();
             }
         }
@@ -453,7 +453,7 @@ property, instead of the actual filename::
 
             unset($this->file);
 
-            //check if we have an old image
+            // check if we have an old image
             if (isset($this->temp)) {
                 // delete the old image
                 unlink($this->temp);
@@ -475,7 +475,7 @@ property, instead of the actual filename::
          */
         public function removeUpload()
         {
-            if ($this->temp) {
+            if (isset($this->temp)) {
                 unlink($this->temp);
             }
         }

--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -293,7 +293,7 @@ Next, refactor the ``Document`` class to take advantage of these callbacks::
         private $temp;
 
         /**
-         * Set file
+         * Sets file
          *
          * @param UploadedFile $file
          */
@@ -408,7 +408,7 @@ property, instead of the actual filename::
         private $temp;
 
         /**
-         * Set file
+         * Sets file
          *
          * @param UploadedFile $file
          */

--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -338,7 +338,7 @@ Next, refactor the ``Document`` class to take advantage of these callbacks::
 
             unset($this->file);
 
-            //check if we have an old image
+            // check if we have an old image
             if (isset($this->temp)) {
                 // delete the old image
                 unlink($this->getUploadRootDir().'/'.$this->temp);


### PR DESCRIPTION
I did a rename on "filenameForRemove" to "temp" as it holds only the extension of the file in the "Using the id as the filename" section but I am ok with any other suggestions.
