### PR TITLE
Use routes for security paths, instead of raw paths

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -313,7 +313,7 @@ First, enable form login under your firewall:
             <config>
                 <firewall name="secured_area" pattern="^/">
                     <anonymous />
-                    <form-login login_path="/login" check_path="/login_check" />
+                    <form-login login_path="login" check_path="login_check" />
                 </firewall>
             </config>
         </srv:container>
@@ -327,8 +327,8 @@ First, enable form login under your firewall:
                     'pattern' => '^/',
                     'anonymous' => array(),
                     'form_login' => array(
-                        'login_path' => '/login',
-                        'check_path' => '/login_check',
+                        'login_path' => 'login',
+                        'check_path' => 'login_check',
                     ),
                 ),
             ),
@@ -558,7 +558,7 @@ see :doc:`/cookbook/security/form_login`.
 
     **1. Create the correct routes**
 
-    First, be sure that you've defined the ``/login`` and ``/login_check``
+    First, be sure that you've defined the ``login`` and ``login_check``
     routes correctly and that they correspond to the ``login_path`` and
     ``check_path`` config values. A misconfiguration here can mean that you're
     redirected to a 404 page instead of the login page, or that submitting

--- a/book/security.rst
+++ b/book/security.rst
@@ -296,8 +296,8 @@ First, enable form login under your firewall:
                     pattern:    ^/
                     anonymous: ~
                     form_login:
-                        login_path:  /login
-                        check_path:  /login_check
+                        login_path:  login
+                        check_path:  login_check
 
     .. code-block:: xml
 
@@ -355,10 +355,11 @@ First, enable form login under your firewall:
             'form_login' => array(),
 
 Now, when the security system initiates the authentication process, it will
-redirect the user to the login form (``/login`` by default). Implementing
-this login form visually is your job. First, create two routes: one that
-will display the login form (i.e. ``/login``) and one that will handle the
-login form submission (i.e. ``/login_check``):
+redirect the user to the login form (``/login`` by default). Implementing this
+login form visually is your job. First, the create two routes we used in the
+security configuration: the ``login`` route will display the login form (i.e.
+``/login``) and the ``login_check`` route will handle the login form
+submission (i.e.  ``/login_check``):
 
 .. configuration-block::
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -218,16 +218,16 @@ The Login Form and Process
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 *   ``login_path`` (type: ``string``, default: ``/login``)
-    This is the URL that the user will be redirected to (unless ``use_forward``
+    This is the path that the user will be redirected to (unless ``use_forward``
     is set to ``true``) when he/she tries to access a protected resource
     but isn't fully authenticated.
 
-    This URL **must** be accessible by a normal, un-authenticated user, else
+    This path **must** be accessible by a normal, un-authenticated user, else
     you may create a redirect loop. For details, see
     ":ref:`Avoid Common Pitfalls<book-security-common-pitfalls>`".
 
 *   ``check_path`` (type: ``string``, default: ``/login_check``)
-    This is the URL that your login form must submit to. The firewall will
+    This is the path that your login form must submit to. The firewall will
     intercept any requests (``POST`` requests only, by default) to this URL
     and process the submitted login credentials.
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -218,18 +218,18 @@ The Login Form and Process
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 *   ``login_path`` (type: ``string``, default: ``/login``)
-    This is the path that the user will be redirected to (unless ``use_forward``
-    is set to ``true``) when he/she tries to access a protected resource
-    but isn't fully authenticated.
+    This is the route or path that the user will be redirected to (unless
+    ``use_forward`` is set to ``true``) when he/she tries to access a
+    protected resource but isn't fully authenticated.
 
     This path **must** be accessible by a normal, un-authenticated user, else
     you may create a redirect loop. For details, see
     ":ref:`Avoid Common Pitfalls<book-security-common-pitfalls>`".
 
 *   ``check_path`` (type: ``string``, default: ``/login_check``)
-    This is the path that your login form must submit to. The firewall will
-    intercept any requests (``POST`` requests only, by default) to this URL
-    and process the submitted login credentials.
+    This is the route or path that your login form must submit to. The
+    firewall will intercept any requests (``POST`` requests only, by default)
+    to this URL and process the submitted login credentials.
 
     Be sure that this URL is covered by your main firewall (i.e. don't create
     a separate firewall just for ``check_path`` URL).


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets | #2108 |

There where 3 articles where the old raw paths where used: `book/security`, `quick_tour/the_controller` and `reference/configuration/security` I haven't changed the quick tour article, because the SE still uses raw paths in their default security configuration file. However, I have updated the book article and the reference.
