### PR TITLE
Adding an official format to be used for documentation pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,6 @@ Contributing
 ------------
 
 We love contributors! For more information on how you can contribute to the
-Symfony documentation, please read [Contributing to the Documentation](http://symfony.com/doc/current/contributing/documentation/overview.html) 
+Symfony documentation, please read [Contributing to the Documentation](http://symfony.com/doc/current/contributing/documentation/overview.html)
+and notice the [Pull Request Format](http://symfony.com/doc/current/contributing/documentation/overview.html#pull-request-format)
+that helps us merge your pull requests faster!

--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -264,7 +264,7 @@ pull request message, like in:
     [Yaml] fixed something
     [Form] [Validator] [FrameworkBundle] added something
 
-The pull request description must include the following check list at the top
+The pull request description must include the following checklist at the top
 to ensure that contributions may be reviewed without needless feedback
 loops and that your contributions can be included into Symfony2 as quickly as
 possible:

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -87,7 +87,7 @@ the documentation as quickly as possible:
     | Q             | A
     | ------------- | ---
     | Doc fix?      | [yes|no]
-    | New docs?     | [yes|no]
+    | New docs?     | [yes|no] (PR # on symfony/symfony if applicable)
     | Applies to    | [Symfony version numbers this applies to]
     | Fixed tickets | [comma separated list of tickets fixed by the PR]
 
@@ -98,7 +98,7 @@ An example submission could now look as follows:
     | Q             | A
     | ------------- | ---
     | Doc fix?      | yes
-    | New docs?     | no
+    | New docs?     | yes (symfony/symfony#2500)
     | Applies to    | all (or 2.1+)
     | Fixed tickets | #1075
 

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -50,8 +50,8 @@ you're done, push this branch to *your* GitHub fork and initiate a pull request.
 Creating a Pull Request
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Following the example, create a pull request will be between your ``improving_foo_and_bar``
-branch and the ``symfony-docs`` ``master`` branch.
+Following the example, the pull request will default to be between your
+``improving_foo_and_bar`` branch and the ``symfony-docs`` ``master`` branch.
 
 .. image:: /images/docs-pull-request.png
    :align: center
@@ -77,10 +77,10 @@ GitHub covers the topic of `pull requests`_ in detail.
 Pull Request Format
 ~~~~~~~~~~~~~~~~~~~
 
-To ease the core team's work, the pull request description must include the
-following checklist to ensure that contributions may be reviewed without
-needless feedback loops and that your contributions can be included into
-the documentation as quickly as possible:
+Unless you're fixing some minor typos, the pull request description must**
+include the following checklist to ensure that contributions may be reviewed
+without needless feedback loops and that your contributions can be included
+into the documentation as quickly as possible:
 
 .. code-block:: text
 

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -46,8 +46,12 @@ Next, create a dedicated branch for your changes (for organization):
 
 You can now make your changes directly to this branch and commit them. When
 you're done, push this branch to *your* GitHub fork and initiate a pull request.
-The pull request will be between your ``improving_foo_and_bar`` branch and
-the ``symfony-docs`` ``master`` branch.
+
+Creating a Pull Request
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Following the example, create a pull request will be between your ``improving_foo_and_bar``
+branch and the ``symfony-docs`` ``master`` branch.
 
 .. image:: /images/docs-pull-request.png
    :align: center
@@ -60,8 +64,8 @@ the base branch to be 2.0 on the preview page:
 
 .. note::
 
-  All changes made to the 2.0 branch will be merged into 2.1 which in turn will be
-  merged into the master branch for the next release on a weekly basis.
+  All changes made to a branch (e.g. 2.0) will be merged up to each "newer"
+  branch (e.g. 2.1, master, etc) for the next release on a weekly basis.
 
 GitHub covers the topic of `pull requests`_ in detail.
 
@@ -69,6 +73,34 @@ GitHub covers the topic of `pull requests`_ in detail.
 
     The Symfony2 documentation is licensed under a Creative Commons
     Attribution-Share Alike 3.0 Unported :doc:`License <license>`.
+
+Pull Request Format
+~~~~~~~~~~~~~~~~~~~
+
+To ease the core team's work, the pull request description must include the
+following checklist to ensure that contributions may be reviewed without
+needless feedback loops and that your contributions can be included into
+the documentation as quickly as possible:
+
+.. code-block:: text
+
+    | Q             | A
+    | ------------- | ---
+    | Doc fix?      | [yes|no]
+    | New docs?     | [yes|no]
+    | Applies to    | [Symfony version numbers this applies to]
+    | Fixed tickets | [comma separated list of tickets fixed by the PR]
+
+An example submission could now look as follows:
+
+.. code-block:: text
+
+    | Q             | A
+    | ------------- | ---
+    | Doc fix?      | yes
+    | New docs?     | no
+    | Applies to    | all (or 2.1+)
+    | Fixed tickets | #1075
 
 .. tip::
 


### PR DESCRIPTION
Hi guys!

This introduces a new PR format for the documentation, similar to what was
just introduced for the core repo and as recommended by @WouterJ in our ongoing
conversation at https://groups.google.com/forum/#!msg/symfony-devs/-6HAQgAB2LY/uBSx8uYJQdQJ.

There are 2 parts of the PR process that this doesn't cover:

1) **Code Accuracy Review** This is something that the community can help
with, and which increases our speed and accuracy. Having a :thumbsup: or
comments from people on a ticket is a _huge_ help. It's something that happens
already, but it's not part of any formal process.

2) **English Review** Also something the community can help with. Even if
you don't understand the code, if your English is good, proofreading for
English accuracy is great. I also proofread things, but I don't catch everything :).

While formalizing things, I want to keep the barrier to entry low. If someone
finds a small typo and creates a PR to the wrong branch and without this
format, I think that's still great!

If you have any feedback specifically about this PR and what we can add to
help document the process, please let me know!

Thanks!
