### PR TITLE
[DependencyInjection] Added section about extending Definitions.

### DIFF
--- a/components/dependency_injection/definitions.rst
+++ b/components/dependency_injection/definitions.rst
@@ -134,20 +134,4 @@ You can also replace any existing method calls with an array of new ones with::
 Extending Definitions
 ~~~~~~~~~~~~~~~~~~~~~
 
-Sometimes you might need to extend i.e. an abstract service definition. In this
-case you can use a :class:`Symfony\\Component\\DependencyInjection\\DefinitionDecorator`.
-
-Pass in the id of the service you want to extend as constructor argument::
-
-    use Symfony\Component\DependencyInjection\DefinitionDecorator;
-
-    // ...
-
-    $decorator = new DefinitionDecorator('abstract_service_id');
-
-    // ... add arguments or method calls to the Definition
-
-    $container->setDefinition('concrete_service_id', $decorator);
-
-You don't need to worry about setting ``$decorator->setAbstract(false)``, the
-container will take care of that.
+See :doc:`/components/dependency_injection/parentservices`

--- a/components/dependency_injection/definitions.rst
+++ b/components/dependency_injection/definitions.rst
@@ -28,7 +28,7 @@ Getting and Setting Service Definitions
 There are also some helpful methods for
 working with the service definitions.
 
-To find out if there is a definition for a service id:: 
+To find out if there is a definition for a service id::
 
     $container->hasDefinition($serviceId);
 
@@ -84,7 +84,7 @@ To get an array of the constructor arguments for a definition you can use::
 
 or to get a single argument by its position::
 
-    $definition->getArgument($index); 
+    $definition->getArgument($index);
     //e.g. $definition->getArguments(0) for the first argument
 
 You can add a new argument to the end of the arguments array using::
@@ -95,7 +95,7 @@ The argument can be a string, an array, a service parameter by using ``%paramete
 or a service id by using ::
 
     use Symfony\Component\DependencyInjection\Reference;
-  
+
     // ...
 
     $definition->addArgument(new Reference('service_id'));
@@ -131,3 +131,23 @@ You can also replace any existing method calls with an array of new ones with::
 
     $definition->setMethodCalls($methodCalls);
 
+Extending Definitions
+~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes you might need to extend i.e. an abstract service definition. In this
+case you can use a :class:`Symfony\\Component\\DependencyInjection\\DefinitionDecorator`.
+
+Pass in the id of the service you want to extend as constructor argument::
+
+    use Symfony\Component\DependencyInjection\DefinitionDecorator;
+
+    // ...
+
+    $decorator = new DefinitionDecorator('abstract_service_id');
+
+    // ... add arguments or method calls to the Definition
+
+    $container->setDefinition('concrete_service_id', $decorator);
+
+You don't need to worry about setting ``$decorator->setAbstract(false)``, the
+container will take care of that.


### PR DESCRIPTION
I was fighting with extending an abstract service definition inside a CompilerPass and there is absolutely _no_ documentation on this, so I thought adding at least a small section about  it would be nice.
