### PR TITLE
[Cookbook/Form] Fixed jQuery bug

### DIFF
--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -369,6 +369,10 @@ will be show next):
         // add the "add a tag" anchor and li to the tags ul
         collectionHolder.append($newLinkLi);
 
+        // count the current form inputs we have (e.g. 2), use that as the new
+        // index when inserting a new item (e.g. 2)
+        collectionHolder.data('index', collectionHolder.find(':input').length);
+
         $addTagLink.on('click', function(e) {
             // prevent the link from creating a "#" on the URL
             e.preventDefault();
@@ -393,12 +397,15 @@ one example:
         // Get the data-prototype explained earlier
         var prototype = collectionHolder.attr('data-prototype');
 
-        // count the current form inputs we have (e.g. 2), use that as the new index (e.g. 2)
-        var newIndex = collectionHolder.find(':input').length;
+        // get the new index
+        var index = collectionHolder.data('index');
 
         // Replace '$$name$$' in the prototype's HTML to
         // instead be a number based on how many items we have
-        var newForm = prototype.replace(/\$\$name\$\$/g, newIndex);
+        var newForm = prototype.replace(/\$\$name\$\$/g, index);
+
+        // increase the index with one for the next item
+        collectionHolder.attr('index', index + 1);
 
         // Display the form in the page in an li, before the "Add a tag" link li
         var $newFormLi = $('<li></li>').append(newForm);

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -405,7 +405,7 @@ one example:
         var newForm = prototype.replace(/\$\$name\$\$/g, index);
 
         // increase the index with one for the next item
-        collectionHolder.attr('index', index + 1);
+        collectionHolder.data('index', index + 1);
 
         // Display the form in the page in an li, before the "Add a tag" link li
         var $newFormLi = $('<li></li>').append(newForm);

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -395,7 +395,7 @@ one example:
 
     function addTagForm(collectionHolder, $newLinkLi) {
         // Get the data-prototype explained earlier
-        var prototype = collectionHolder.attr('data-prototype');
+        var prototype = collectionHolder.data('prototype');
 
         // get the new index
         var index = collectionHolder.data('index');

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -412,7 +412,7 @@ one example:
         $newLinkLi.before($newFormLi);
     }
 
-.. note:
+.. note::
 
     It is better to separate your javascript in real JavaScript files than
     to write it inside the HTML as is done here.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.0 |
| Fixed tickets | #1382 |
### Description

This PR fixes the old bug while adding new items. If you press the 'add a tag' button 4 times you get the indexes `0, 1, 2, 3`. If you remove 1 and 2, you have the indexes `0, 3`. If you press the 'add a tag' button twice after this, you expect to get `0, 3, 4, 5`, but you got `0, 3, 2, 3`.

This PR saves the index in a `data-index` attribute on the `$collectionHolder`.
### Live examples

Before: http://jsfiddle.net/WouterJ/847Kf/
After: http://jsfiddle.net/WouterJ/847Kf/1/
### Side fixes

This PR also improves the jQuery code by adding support of `e.preventDefault()` for old browsers and by using the `data` method to get `data-*` attributes.

At least, this PR fixes a Sphinx syntax bug (`.. index:` instead of `.. index::`)
### Merge instructions

Because the placeholder changed from `$$name$$` to `__name__`, line 408 should be changed when merging this to `2.1` and `master`.
