### PR TITLE
Update reference/constraints/Callback.rst (dont use deprecated method)

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -105,7 +105,7 @@ those errors should be attributed::
         
             // check if the name is actually a fake name
             if (in_array($this->getFirstName(), $fakeNames)) {
-                $context->addViolationAtSubPath('firstname', 'This name sounds totally fake!', array(), null);
+                $context->addViolationAt('firstname', 'This name sounds totally fake!', array(), null);
             }
         }
     }


### PR DESCRIPTION
addViolationAtSubPath() is deprecated since version 2.2 and will be removed in 2.3. Use addViolationAt() instead.

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Validator/ExecutionContext.php#L150
