### PR TITLE
[2.2] Updated most routing changes

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -141,7 +141,7 @@ Mapping a URL to a Controller
 -----------------------------
 
 The new controller returns a simple HTML page. To actually view this page
-in your browser, you need to create a route, which maps a specific URL pattern
+in your browser, you need to create a route, which maps a specific URL path
 to the controller:
 
 .. configuration-block::
@@ -150,13 +150,13 @@ to the controller:
 
         # app/config/routing.yml
         hello:
-            pattern:      /hello/{name}
-            defaults:     { _controller: AcmeHelloBundle:Hello:index }
+            path:      /hello/{name}
+            defaults:  { _controller: AcmeHelloBundle:Hello:index }
 
     .. code-block:: xml
 
         <!-- app/config/routing.xml -->
-        <route id="hello" pattern="/hello/{name}">
+        <route id="hello" path="/hello/{name}">
             <default key="_controller">AcmeHelloBundle:Hello:index</default>
         </route>
 
@@ -229,13 +229,13 @@ example:
 
         # app/config/routing.yml
         hello:
-            pattern:      /hello/{first_name}/{last_name}
-            defaults:     { _controller: AcmeHelloBundle:Hello:index, color: green }
+            path:      /hello/{first_name}/{last_name}
+            defaults:  { _controller: AcmeHelloBundle:Hello:index, color: green }
 
     .. code-block:: xml
 
         <!-- app/config/routing.xml -->
-        <route id="hello" pattern="/hello/{first_name}/{last_name}">
+        <route id="hello" path="/hello/{first_name}/{last_name}">
             <default key="_controller">AcmeHelloBundle:Hello:index</default>
             <default key="color">green</default>
         </route>

--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -639,11 +639,11 @@ A routing configuration map provides this information in a readable format:
 
     # app/config/routing.yml
     blog_list:
-        pattern:  /blog
+        path:     /blog
         defaults: { _controller: AcmeBlogBundle:Blog:list }
 
     blog_show:
-        pattern:  /blog/show/{id}
+        path:     /blog/show/{id}
         defaults: { _controller: AcmeBlogBundle:Blog:show }
 
 Now that Symfony2 is handling all the mundane tasks, the front controller

--- a/book/http_fundamentals.rst
+++ b/book/http_fundamentals.rst
@@ -423,12 +423,12 @@ by adding an entry for ``/contact`` to your routing configuration file:
 
         # app/config/routing.yml
         contact:
-            pattern:  /contact
+            path:     /contact
             defaults: { _controller: AcmeDemoBundle:Main:contact }
 
     .. code-block:: xml
 
-        <route id="contact" pattern="/contact">
+        <route id="contact" path="/contact">
             <default key="_controller">AcmeBlogBundle:Main:contact</default>
         </route>
 

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -8,7 +8,7 @@ Creating a new page in Symfony2 is a simple two-step process:
 
 * *Create a route*: A route defines the URL (e.g. ``/about``) to your page
   and specifies a controller (which is a PHP function) that Symfony2 should
-  execute when the URL of an incoming request matches the route pattern;
+  execute when the URL of an incoming request matches the route path;
 
 * *Create a controller*: A controller is a PHP function that takes the incoming
   request and transforms it into the Symfony2 ``Response`` object that's
@@ -147,7 +147,7 @@ the new route that defines the URL of the page that you're about to create:
 
         # src/Acme/HelloBundle/Resources/config/routing.yml
         hello:
-            pattern:  /hello/{name}
+            path:     /hello/{name}
             defaults: { _controller: AcmeHelloBundle:Hello:index }
 
     .. code-block:: xml
@@ -159,7 +159,7 @@ the new route that defines the URL of the page that you're about to create:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="hello" pattern="/hello/{name}">
+            <route id="hello" path="/hello/{name}">
                 <default key="_controller">AcmeHelloBundle:Hello:index</default>
             </route>
         </routes>
@@ -177,9 +177,9 @@ the new route that defines the URL of the page that you're about to create:
 
         return $collection;
 
-The routing consists of two basic pieces: the ``pattern``, which is the URL
+The routing consists of two basic pieces: the ``path``, which is the URL
 that this route will match, and a ``defaults`` array, which specifies the
-controller that should be executed. The placeholder syntax in the pattern
+controller that should be executed. The placeholder syntax in the path
 (``{name}``) is a wildcard. It means that ``/hello/Ryan``, ``/hello/Fabien``
 or any other similar URL will match this route. The ``{name}`` placeholder
 parameter will also be passed to the controller so that you can use its value

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -67,6 +67,10 @@ The route is simple:
 
         return $collection;
 
+.. versionadded:: 2.2
+    The ``path`` option is new in Symfony2.2, ``pattern`` is used in older
+    versions.
+
 The path defined by the ``blog_show`` route acts like ``/blog/*`` where
 the wildcard is given the name ``slug``. For the URL ``/blog/my-blog-post``,
 the ``slug`` variable gets a value of ``my-blog-post``, which is available
@@ -677,6 +681,10 @@ be accomplished with the following route configuration:
 
         return $collection;
 
+.. versionadded::
+    The ``methods`` option is added in Symfony2.2. Use the ``_method``
+    requirement in older versions.
+
 Despite the fact that these two routes have identical paths (``/contact``),
 the first route will match only GET requests and the second route will match
 only POST requests. This means that you can display the form and submit the
@@ -686,8 +694,8 @@ form via the same URL, while using distinct controllers for the two actions.
 
     If no ``methods`` are specified, the route will match on *all* methods.
 
-Adding a Hostname Pattern
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Adding a Hostname
+~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.2
     Hostname matching support was added in Symfony 2.2

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -694,13 +694,13 @@ form via the same URL, while using distinct controllers for the two actions.
 
     If no ``methods`` are specified, the route will match on *all* methods.
 
-Adding a Hostname
-~~~~~~~~~~~~~~~~~
+Adding a Host
+~~~~~~~~~~~~~
 
 .. versionadded:: 2.2
-    Hostname matching support was added in Symfony 2.2
+    Host matching support was added in Symfony 2.2
 
-You can also match on the HTTP *hostname* of the incoming request. For more
+You can also match on the HTTP *host* of the incoming request. For more
 information, see :doc:`/components/routing/hostname_pattern` in the Routing
 component documentation.
 
@@ -1038,14 +1038,14 @@ from the new routing resource.
     :doc:`FrameworkExtraBundle documentation</bundles/SensioFrameworkExtraBundle/annotations/routing>`
     to see how.
 
-Adding a Hostname Pattern to Imported Routes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Adding a Host regex to Imported Routes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.2
-    Hostname matching support was added in Symfony 2.2
+    Host matching support was added in Symfony 2.2
 
-You can set the hostname on imported routes. For more information, see
-:ref:`component-routing-hostname-imported`.
+You can set the host regex on imported routes. For more information, see
+:ref:`component-routing-host-imported`.
 
 .. index::
    single: Routing; Debugging

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -27,7 +27,7 @@ areas of your application. By the end of this chapter, you'll be able to:
 Routing in Action
 -----------------
 
-A *route* is a map from a URL pattern to a controller. For example, suppose
+A *route* is a map from a URL path to a controller. For example, suppose
 you want to match any URL like ``/blog/my-post`` or ``/blog/all-about-symfony``
 and send it to a controller that can look up and render that blog entry.
 The route is simple:
@@ -38,7 +38,7 @@ The route is simple:
 
         # app/config/routing.yml
         blog_show:
-            pattern:   /blog/{slug}
+            path:      /blog/{slug}
             defaults:  { _controller: AcmeBlogBundle:Blog:show }
 
     .. code-block:: xml
@@ -49,7 +49,7 @@ The route is simple:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="blog_show" pattern="/blog/{slug}">
+            <route id="blog_show" path="/blog/{slug}">
                 <default key="_controller">AcmeBlogBundle:Blog:show</default>
             </route>
         </routes>
@@ -67,7 +67,7 @@ The route is simple:
 
         return $collection;
 
-The pattern defined by the ``blog_show`` route acts like ``/blog/*`` where
+The path defined by the ``blog_show`` route acts like ``/blog/*`` where
 the wildcard is given the name ``slug``. For the URL ``/blog/my-blog-post``,
 the ``slug`` variable gets a value of ``my-blog-post``, which is available
 for you to use in your controller (keep reading).
@@ -186,7 +186,7 @@ Basic Route Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Defining a route is easy, and a typical application will have lots of routes.
-A basic route consists of just two parts: the ``pattern`` to match and a
+A basic route consists of just two parts: the ``path`` to match and a
 ``defaults`` array:
 
 .. configuration-block::
@@ -194,7 +194,7 @@ A basic route consists of just two parts: the ``pattern`` to match and a
     .. code-block:: yaml
 
         _welcome:
-            pattern:   /
+            path:      /
             defaults:  { _controller: AcmeDemoBundle:Main:homepage }
 
     .. code-block:: xml
@@ -205,7 +205,7 @@ A basic route consists of just two parts: the ``pattern`` to match and a
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="_welcome" pattern="/">
+            <route id="_welcome" path="/">
                 <default key="_controller">AcmeDemoBundle:Main:homepage</default>
             </route>
 
@@ -242,7 +242,7 @@ routes will contain one or more named "wildcard" placeholders:
     .. code-block:: yaml
 
         blog_show:
-            pattern:   /blog/{slug}
+            path:      /blog/{slug}
             defaults:  { _controller: AcmeBlogBundle:Blog:show }
 
     .. code-block:: xml
@@ -253,7 +253,7 @@ routes will contain one or more named "wildcard" placeholders:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="blog_show" pattern="/blog/{slug}">
+            <route id="blog_show" path="/blog/{slug}">
                 <default key="_controller">AcmeBlogBundle:Blog:show</default>
             </route>
         </routes>
@@ -270,13 +270,13 @@ routes will contain one or more named "wildcard" placeholders:
 
         return $collection;
 
-The pattern will match anything that looks like ``/blog/*``. Even better,
+The path will match anything that looks like ``/blog/*``. Even better,
 the value matching the ``{slug}`` placeholder will be available inside your
 controller. In other words, if the URL is ``/blog/hello-world``, a ``$slug``
 variable, with a value of ``hello-world``, will be available in the controller.
 This can be used, for example, to load the blog post matching that string.
 
-The pattern will *not*, however, match simply ``/blog``. That's because,
+The path will *not*, however, match simply ``/blog``. That's because,
 by default, all placeholders are required. This can be changed by adding
 a placeholder value to the ``defaults`` array.
 
@@ -291,7 +291,7 @@ the available blog posts for this imaginary blog application:
     .. code-block:: yaml
 
         blog:
-            pattern:   /blog
+            path:      /blog
             defaults:  { _controller: AcmeBlogBundle:Blog:index }
 
     .. code-block:: xml
@@ -302,7 +302,7 @@ the available blog posts for this imaginary blog application:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="blog" pattern="/blog">
+            <route id="blog" path="/blog">
                 <default key="_controller">AcmeBlogBundle:Blog:index</default>
             </route>
         </routes>
@@ -329,7 +329,7 @@ entries? Update the route to have a new ``{page}`` placeholder:
     .. code-block:: yaml
 
         blog:
-            pattern:   /blog/{page}
+            path:      /blog/{page}
             defaults:  { _controller: AcmeBlogBundle:Blog:index }
 
     .. code-block:: xml
@@ -340,7 +340,7 @@ entries? Update the route to have a new ``{page}`` placeholder:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="blog" pattern="/blog/{page}">
+            <route id="blog" path="/blog/{page}">
                 <default key="_controller">AcmeBlogBundle:Blog:index</default>
             </route>
         </routes>
@@ -372,7 +372,7 @@ This is done by including it in the ``defaults`` collection:
     .. code-block:: yaml
 
         blog:
-            pattern:   /blog/{page}
+            path:      /blog/{page}
             defaults:  { _controller: AcmeBlogBundle:Blog:index, page: 1 }
 
     .. code-block:: xml
@@ -383,7 +383,7 @@ This is done by including it in the ``defaults`` collection:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="blog" pattern="/blog/{page}">
+            <route id="blog" path="/blog/{page}">
                 <default key="_controller">AcmeBlogBundle:Blog:index</default>
                 <default key="page">1</default>
             </route>
@@ -433,11 +433,11 @@ Take a quick look at the routes that have been created so far:
     .. code-block:: yaml
 
         blog:
-            pattern:   /blog/{page}
+            path:      /blog/{page}
             defaults:  { _controller: AcmeBlogBundle:Blog:index, page: 1 }
 
         blog_show:
-            pattern:   /blog/{slug}
+            path:      /blog/{slug}
             defaults:  { _controller: AcmeBlogBundle:Blog:show }
 
     .. code-block:: xml
@@ -448,12 +448,12 @@ Take a quick look at the routes that have been created so far:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="blog" pattern="/blog/{page}">
+            <route id="blog" path="/blog/{page}">
                 <default key="_controller">AcmeBlogBundle:Blog:index</default>
                 <default key="page">1</default>
             </route>
 
-            <route id="blog_show" pattern="/blog/{slug}">
+            <route id="blog_show" path="/blog/{slug}">
                 <default key="_controller">AcmeBlogBundle:Blog:show</default>
             </route>
         </routes>
@@ -475,7 +475,7 @@ Take a quick look at the routes that have been created so far:
 
         return $collection;
 
-Can you spot the problem? Notice that both routes have patterns that match
+Can you spot the problem? Notice that both routes have paths that match
 URL's that look like ``/blog/*``. The Symfony router will always choose the
 **first** matching route it finds. In other words, the ``blog_show`` route
 will *never* be matched. Instead, a URL like ``/blog/my-blog-post`` will match
@@ -491,7 +491,7 @@ to the ``{page}`` parameter.
 +--------------------+-------+-----------------------+
 
 The answer to the problem is to add route *requirements*. The routes in this
-example would work perfectly if the ``/blog/{page}`` pattern *only* matched
+example would work perfectly if the ``/blog/{page}`` path *only* matched
 URLs where the ``{page}`` portion is an integer. Fortunately, regular expression
 requirements can easily be added for each parameter. For example:
 
@@ -500,7 +500,7 @@ requirements can easily be added for each parameter. For example:
     .. code-block:: yaml
 
         blog:
-            pattern:   /blog/{page}
+            path:      /blog/{page}
             defaults:  { _controller: AcmeBlogBundle:Blog:index, page: 1 }
             requirements:
                 page:  \d+
@@ -513,7 +513,7 @@ requirements can easily be added for each parameter. For example:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="blog" pattern="/blog/{page}">
+            <route id="blog" path="/blog/{page}">
                 <default key="_controller">AcmeBlogBundle:Blog:index</default>
                 <default key="page">1</default>
                 <requirement key="page">\d+</requirement>
@@ -570,7 +570,7 @@ URL:
     .. code-block:: yaml
 
         homepage:
-            pattern:   /{culture}
+            path:      /{culture}
             defaults:  { _controller: AcmeDemoBundle:Main:homepage, culture: en }
             requirements:
                 culture:  en|fr
@@ -583,7 +583,7 @@ URL:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="homepage" pattern="/{culture}">
+            <route id="homepage" path="/{culture}">
                 <default key="_controller">AcmeDemoBundle:Main:homepage</default>
                 <default key="culture">en</default>
                 <requirement key="culture">en|fr</requirement>
@@ -635,16 +635,14 @@ be accomplished with the following route configuration:
     .. code-block:: yaml
 
         contact:
-            pattern:  /contact
+            path:     /contact
             defaults: { _controller: AcmeDemoBundle:Main:contact }
-            requirements:
-                _method:  GET
+            methods:  [GET]
 
         contact_process:
-            pattern:  /contact
+            path:     /contact
             defaults: { _controller: AcmeDemoBundle:Main:contactProcess }
-            requirements:
-                _method:  POST
+            methods:  [POST]
 
     .. code-block:: xml
 
@@ -654,14 +652,12 @@ be accomplished with the following route configuration:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="contact" pattern="/contact">
+            <route id="contact" path="/contact" methods="GET">
                 <default key="_controller">AcmeDemoBundle:Main:contact</default>
-                <requirement key="_method">GET</requirement>
             </route>
 
-            <route id="contact_process" pattern="/contact">
+            <route id="contact_process" path="/contact" methods="POST">
                 <default key="_controller">AcmeDemoBundle:Main:contactProcess</default>
-                <requirement key="_method">POST</requirement>
             </route>
         </routes>
 
@@ -673,29 +669,22 @@ be accomplished with the following route configuration:
         $collection = new RouteCollection();
         $collection->add('contact', new Route('/contact', array(
             '_controller' => 'AcmeDemoBundle:Main:contact',
-        ), array(
-            '_method' => 'GET',
-        )));
+        ), array(), array(), '', array(), array('GET')));
 
         $collection->add('contact_process', new Route('/contact', array(
             '_controller' => 'AcmeDemoBundle:Main:contactProcess',
-        ), array(
-            '_method' => 'POST',
-        )));
+        ), array(), array(), '', array(), array('POST')));
 
         return $collection;
 
-Despite the fact that these two routes have identical patterns (``/contact``),
+Despite the fact that these two routes have identical paths (``/contact``),
 the first route will match only GET requests and the second route will match
 only POST requests. This means that you can display the form and submit the
 form via the same URL, while using distinct controllers for the two actions.
 
 .. note::
-    If no ``_method`` requirement is specified, the route will match on
-    *all* methods.
 
-Like the other requirements, the ``_method`` requirement is parsed as a regular
-expression. To match ``GET`` *or* ``POST`` requests, you can use ``GET|POST``.
+    If no ``methods`` are specified, the route will match on *all* methods.
 
 Adding a Hostname Pattern
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -725,7 +714,7 @@ routing system can be:
     .. code-block:: yaml
 
         article_show:
-          pattern:  /articles/{culture}/{year}/{title}.{_format}
+          path:     /articles/{culture}/{year}/{title}.{_format}
           defaults: { _controller: AcmeDemoBundle:Article:show, _format: html }
           requirements:
               culture:  en|fr
@@ -740,7 +729,7 @@ routing system can be:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="article_show" pattern="/articles/{culture}/{year}/{title}.{_format}">
+            <route id="article_show" path="/articles/{culture}/{year}/{title}.{_format}">
                 <default key="_controller">AcmeDemoBundle:Article:show</default>
                 <default key="_format">html</default>
                 <requirement key="culture">en|fr</requirement>
@@ -961,7 +950,7 @@ like this:
 
         # src/Acme/HelloBundle/Resources/config/routing.yml
        acme_hello:
-            pattern:  /hello/{name}
+            path:     /hello/{name}
             defaults: { _controller: AcmeHelloBundle:Hello:index }
 
     .. code-block:: xml
@@ -973,7 +962,7 @@ like this:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="acme_hello" pattern="/hello/{name}">
+            <route id="acme_hello" path="/hello/{name}">
                 <default key="_controller">AcmeHelloBundle:Hello:index</default>
             </route>
         </routes>
@@ -998,7 +987,7 @@ Prefixing Imported Routes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can also choose to provide a "prefix" for the imported routes. For example,
-suppose you want the ``acme_hello`` route to have a final pattern of ``/admin/hello/{name}``
+suppose you want the ``acme_hello`` route to have a final path of ``/admin/hello/{name}``
 instead of simply ``/hello/{name}``:
 
 .. configuration-block::
@@ -1032,8 +1021,8 @@ instead of simply ``/hello/{name}``:
 
         return $collection;
 
-The string ``/admin`` will now be prepended to the pattern of each route
-loaded from the new routing resource.
+The string ``/admin`` will now be prepended to the path of each route loaded
+from the new routing resource.
 
 .. tip::
 
@@ -1047,8 +1036,8 @@ Adding a Hostname Pattern to Imported Routes
 .. versionadded:: 2.2
     Hostname matching support was added in Symfony 2.2
 
-You can set a hostname pattern on imported routes. For more information,
-see :ref:`component-routing-hostname-imported`.
+You can set the hostname on imported routes. For more information, see
+:ref:`component-routing-hostname-imported`.
 
 .. index::
    single: Routing; Debugging
@@ -1118,8 +1107,8 @@ system. Take the ``blog_show`` example route from earlier::
     // /blog/my-blog-post
 
 To generate a URL, you need to specify the name of the route (e.g. ``blog_show``)
-and any wildcards (e.g. ``slug = my-blog-post``) used in the pattern for
-that route. With this information, any URL can easily be generated::
+and any wildcards (e.g. ``slug = my-blog-post``) used in the path for that
+route. With this information, any URL can easily be generated::
 
     class MainController extends Controller
     {

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -781,12 +781,12 @@ configuration:
     .. code-block:: yaml
 
         _welcome:
-            pattern:  /
+            path:     /
             defaults: { _controller: AcmeDemoBundle:Welcome:index }
 
     .. code-block:: xml
 
-        <route id="_welcome" pattern="/">
+        <route id="_welcome" path="/">
             <default key="_controller">AcmeDemoBundle:Welcome:index</default>
         </route>
 
@@ -819,12 +819,12 @@ route:
     .. code-block:: yaml
 
         article_show:
-            pattern:  /article/{slug}
+            path:     /article/{slug}
             defaults: { _controller: AcmeArticleBundle:Article:show }
 
     .. code-block:: xml
 
-        <route id="article_show" pattern="/article/{slug}">
+        <route id="article_show" path="/article/{slug}">
             <default key="_controller">AcmeArticleBundle:Article:show</default>
         </route>
 

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -299,7 +299,7 @@ priority message files.
 
 The filename of the translations is also important as Symfony2 uses a convention
 to determine details about the translations. Each message file must be named
-according to the following pattern: ``domain.locale.loader``:
+according to the following path: ``domain.locale.loader``:
 
 * **domain**: An optional way to organize messages into groups (e.g. ``admin``,
   ``navigation`` or the default ``messages``) - see `Using Message Domains`_;
@@ -571,14 +571,14 @@ by the routing system using the special ``_locale`` parameter:
     .. code-block:: yaml
 
         contact:
-            pattern:   /{_locale}/contact
+            path:      /{_locale}/contact
             defaults:  { _controller: AcmeDemoBundle:Contact:index, _locale: en }
             requirements:
                 _locale: en|fr|de
 
     .. code-block:: xml
 
-        <route id="contact" pattern="/{_locale}/contact">
+        <route id="contact" path="/{_locale}/contact">
             <default key="_controller">AcmeDemoBundle:Contact:index</default>
             <default key="_locale">en</default>
             <requirement key="_locale">en|fr|de</requirement>

--- a/components/routing/hostname_pattern.rst
+++ b/components/routing/hostname_pattern.rst
@@ -14,12 +14,12 @@ You can also match on the HTTP *hostname* of the incoming request.
     .. code-block:: yaml
 
         mobile_homepage:
-            pattern:  /
-            hostname_pattern: m.example.com
+            path:     /
+            hostname: m.example.com
             defaults: { _controller: AcmeDemoBundle:Main:mobileHomepage }
 
         homepage:
-            pattern:  /
+            path:     /
             defaults: { _controller: AcmeDemoBundle:Main:homepage }
 
     .. code-block:: xml
@@ -32,11 +32,11 @@ You can also match on the HTTP *hostname* of the incoming request.
                 http://symfony.com/schema/routing/routing-1.0.xsd"
         >
 
-            <route id="mobile_homepage" pattern="/" hostname-pattern="m.example.com">
+            <route id="mobile_homepage" path="/" hostname="m.example.com">
                 <default key="_controller">AcmeDemoBundle:Main:mobileHomepage</default>
             </route>
 
-            <route id="homepage" pattern="/">
+            <route id="homepage" path="/">
                 <default key="_controller">AcmeDemoBundle:Main:homepage</default>
             </route>
         </routes>
@@ -57,7 +57,7 @@ You can also match on the HTTP *hostname* of the incoming request.
 
         return $collection;
 
-Both routes match the same pattern ``/``, however the first one will match
+Both routes match the same path ``/``, however the first one will match
 only if the hostname is ``m.example.com``.
 
 Placeholders and Requirements in Hostname Patterns
@@ -77,14 +77,14 @@ dependency injection container parameter.
     .. code-block:: yaml
 
         mobile_homepage:
-            pattern:  /
-            hostname_pattern: m.{domain}
+            path:     /
+            hostname: m.{domain}
             defaults: { _controller: AcmeDemoBundle:Main:mobileHomepage }
             requirements:
                 domain: %domain%
 
         homepage:
-            pattern:  /
+            path:  /
             defaults: { _controller: AcmeDemoBundle:Main:homepage }
 
     .. code-block:: xml
@@ -95,12 +95,12 @@ dependency injection container parameter.
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="mobile_homepage" pattern="/" hostname-pattern="m.example.com">
+            <route id="mobile_homepage" path="/" hostname="m.example.com">
                 <default key="_controller">AcmeDemoBundle:Main:mobileHomepage</default>
                 <requirement key="domain">%domain%</requirement>
             </route>
 
-            <route id="homepage" pattern="/">
+            <route id="homepage" path="/">
                 <default key="_controller">AcmeDemoBundle:Main:homepage</default>
             </route>
         </routes>
@@ -128,7 +128,7 @@ dependency injection container parameter.
 Adding a Hostname Pattern to Imported Routes
 --------------------------------------------
 
-You can set a hostname pattern on imported routes:
+You can set a hostname on imported routes:
 
 .. configuration-block::
 
@@ -137,7 +137,7 @@ You can set a hostname pattern on imported routes:
         # app/config/routing.yml
         acme_hello:
             resource: "@AcmeHelloBundle/Resources/config/routing.yml"
-            hostname_pattern: "hello.example.com"
+            hostname: "hello.example.com"
 
     .. code-block:: xml
 
@@ -148,7 +148,7 @@ You can set a hostname pattern on imported routes:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <import resource="@AcmeHelloBundle/Resources/config/routing.xml" hostname-pattern="hello.example.com" />
+            <import resource="@AcmeHelloBundle/Resources/config/routing.xml" hostname="hello.example.com" />
         </routes>
 
     .. code-block:: php
@@ -161,5 +161,5 @@ You can set a hostname pattern on imported routes:
 
         return $collection;
 
-The hostname pattern ``hello.example.com`` will be set on each route
-loaded from the new routing resource.
+The hostname ``hello.example.com`` will be set on each route loaded from the
+new routing resource.

--- a/components/routing/hostname_pattern.rst
+++ b/components/routing/hostname_pattern.rst
@@ -1,13 +1,13 @@
 .. index::
    single: Routing; Matching on Hostname
 
-How to match a route based on the Hostname
-==========================================
+How to match a route based on the Host
+======================================
 
 .. versionadded:: 2.2
-    Hostname matching support was added in Symfony 2.2
+    Host matching support was added in Symfony 2.2
 
-You can also match on the HTTP *hostname* of the incoming request.
+You can also match on the HTTP *host* of the incoming request.
 
 .. configuration-block::
 
@@ -15,7 +15,7 @@ You can also match on the HTTP *hostname* of the incoming request.
 
         mobile_homepage:
             path:     /
-            hostname: m.example.com
+            host:     m.example.com
             defaults: { _controller: AcmeDemoBundle:Main:mobileHomepage }
 
         homepage:
@@ -32,7 +32,7 @@ You can also match on the HTTP *hostname* of the incoming request.
                 http://symfony.com/schema/routing/routing-1.0.xsd"
         >
 
-            <route id="mobile_homepage" path="/" hostname="m.example.com">
+            <route id="mobile_homepage" path="/" host="m.example.com">
                 <default key="_controller">AcmeDemoBundle:Main:mobileHomepage</default>
             </route>
 
@@ -58,7 +58,7 @@ You can also match on the HTTP *hostname* of the incoming request.
         return $collection;
 
 Both routes match the same path ``/``, however the first one will match
-only if the hostname is ``m.example.com``.
+only if the host is ``m.example.com``.
 
 Placeholders and Requirements in Hostname Patterns
 --------------------------------------------------
@@ -78,7 +78,7 @@ dependency injection container parameter.
 
         mobile_homepage:
             path:     /
-            hostname: m.{domain}
+            host:     m.{domain}
             defaults: { _controller: AcmeDemoBundle:Main:mobileHomepage }
             requirements:
                 domain: %domain%
@@ -95,7 +95,7 @@ dependency injection container parameter.
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="mobile_homepage" path="/" hostname="m.example.com">
+            <route id="mobile_homepage" path="/" host="m.example.com">
                 <default key="_controller">AcmeDemoBundle:Main:mobileHomepage</default>
                 <requirement key="domain">%domain%</requirement>
             </route>
@@ -123,12 +123,12 @@ dependency injection container parameter.
 
         return $collection;
 
-.. _component-routing-hostname-imported:
+.. _component-routing-host-imported:
 
-Adding a Hostname Pattern to Imported Routes
+Adding a Host Regex to Imported Routes
 --------------------------------------------
 
-You can set a hostname on imported routes:
+You can set a host regex on imported routes:
 
 .. configuration-block::
 
@@ -137,7 +137,7 @@ You can set a hostname on imported routes:
         # app/config/routing.yml
         acme_hello:
             resource: "@AcmeHelloBundle/Resources/config/routing.yml"
-            hostname: "hello.example.com"
+            host:     "hello.example.com"
 
     .. code-block:: xml
 
@@ -148,7 +148,7 @@ You can set a hostname on imported routes:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <import resource="@AcmeHelloBundle/Resources/config/routing.xml" hostname="hello.example.com" />
+            <import resource="@AcmeHelloBundle/Resources/config/routing.xml" host="hello.example.com" />
         </routes>
 
     .. code-block:: php
@@ -161,5 +161,5 @@ You can set a hostname on imported routes:
 
         return $collection;
 
-The hostname ``hello.example.com`` will be set on each route loaded from the
-new routing resource.
+The host ``hello.example.com`` will be set on each route loaded from the new
+routing resource.

--- a/components/routing/introduction.rst
+++ b/components/routing/introduction.rst
@@ -161,7 +161,7 @@ the :method:`Symfony\\Component\\Routing\\RouteCollection::addPrefix` method::
     $rootCollection->addCollection($subCollection);
 
 .. versionadded:: 2.2
-    The ``addPrefixs`` method is added in Symfony2.2. This was part of the
+    The ``addPrefix`` method is added in Symfony2.2. This was part of the
     ``addCollection`` method in older versions.
 
 Set the Request Parameters

--- a/components/routing/introduction.rst
+++ b/components/routing/introduction.rst
@@ -85,7 +85,7 @@ placeholders as regular expressions.
 4. An array of options. These contain internal settings for the route and
 are the least commonly needed.
 
-5. A hostname. This is matched against the hostname of the request.  See
+5. A host. This is matched against the host of the request.  See
    :doc:`/components/routing/hostname_pattern` for more details.
 
 6. An array of schemes. These enforce a certain HTTP scheme (``http``, ``https``).
@@ -94,7 +94,7 @@ are the least commonly needed.
    ``GET``, ``POST``, ...).
 
 .. versionadded:: 2.2
-    The hostname was added in Symfony 2.2
+    Host matching support was added in Symfony 2.2
 
 Take the following route, which combines several of these ideas::
 
@@ -103,7 +103,7 @@ Take the following route, which combines several of these ideas::
        array('controller' => 'showArchive'), // default values
        array('month' => '[0-9]{4}-[0-9]{2}', 'subdomain' => 'www|m'), // requirements
        array(), // options
-       '{subdomain}.example.com', // hostname
+       '{subdomain}.example.com', // host
        array(), // schemes
        array() // methods
    );
@@ -142,9 +142,8 @@ Using Prefixes
 You can add routes or other instances of
 :class:`Symfony\\Component\\Routing\\RouteCollection` to *another* collection.
 This way you can build a tree of routes. Additionally you can define a prefix,
-default requirements, default options and hostname to all routes of a subtree
-with the :method:`Symfony\\Component\\Routing\\RouteCollection::addPrefix`
-method::
+default requirements, default options and host to all routes of a subtree with
+the :method:`Symfony\\Component\\Routing\\RouteCollection::addPrefix` method::
 
     $rootCollection = new RouteCollection();
 
@@ -155,7 +154,7 @@ method::
         '/prefix', // prefix
         array(), // requirements
         array(), // options
-        'admin.example.com', // hostname
+        'admin.example.com', // host
         array('https') // schemes
     );
 

--- a/components/routing/introduction.rst
+++ b/components/routing/introduction.rst
@@ -142,22 +142,28 @@ Using Prefixes
 You can add routes or other instances of
 :class:`Symfony\\Component\\Routing\\RouteCollection` to *another* collection.
 This way you can build a tree of routes. Additionally you can define a prefix,
-default requirements, default options and hostname to all routes of a subtree::
+default requirements, default options and hostname to all routes of a subtree
+with the :method:`Symfony\\Component\\Routing\\RouteCollection::addPrefix`
+method::
 
     $rootCollection = new RouteCollection();
 
     $subCollection = new RouteCollection();
     $subCollection->add(...);
     $subCollection->add(...);
-
-    $rootCollection->addCollection(
-        $subCollection,
+    $subCollection->addPrefix(
         '/prefix', // prefix
         array(), // requirements
         array(), // options
         'admin.example.com', // hostname
         array('https') // schemes
     );
+
+    $rootCollection->addCollection($subCollection);
+
+.. versionadded:: 2.2
+    The ``addPrefixs`` method is added in Symfony2.2. This was part of the
+    ``addCollection`` method in older versions.
 
 Set the Request Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/components/routing/introduction.rst
+++ b/components/routing/introduction.rst
@@ -70,9 +70,9 @@ which holds the name of the matched route.
 Defining routes
 ~~~~~~~~~~~~~~~
 
-A full route definition can contain up to five parts:
+A full route definition can contain up to seven parts:
 
-1. The URL pattern route. This is matched against the URL passed to the `RequestContext`,
+1. The URL path route. This is matched against the URL passed to the `RequestContext`,
 and can contain named wildcard placeholders (e.g. ``{placeholders}``)
 to match dynamic parts in the URL.
 
@@ -85,11 +85,16 @@ placeholders as regular expressions.
 4. An array of options. These contain internal settings for the route and
 are the least commonly needed.
 
-5. A hostname pattern. This is matched against the hostname of the request.
-See :doc:`/components/routing/hostname_pattern` for more details.
+5. A hostname. This is matched against the hostname of the request.  See
+   :doc:`/components/routing/hostname_pattern` for more details.
+
+6. An array of schemes. These enforce a certain HTTP scheme (``http``, ``https``).
+
+7. An array of methods. These enforce a certain HTTP request method (``HEAD``,
+   ``GET``, ``POST``, ...).
 
 .. versionadded:: 2.2
-    The hostname pattern was added in Symfony 2.2
+    The hostname was added in Symfony 2.2
 
 Take the following route, which combines several of these ideas::
 
@@ -98,7 +103,9 @@ Take the following route, which combines several of these ideas::
        array('controller' => 'showArchive'), // default values
        array('month' => '[0-9]{4}-[0-9]{2}', 'subdomain' => 'www|m'), // requirements
        array(), // options
-       '{subdomain}.example.com' // hostname
+       '{subdomain}.example.com', // hostname
+       array(), // schemes
+       array() // methods
    );
 
    // ...
@@ -118,21 +125,6 @@ In this case, the route is matched by ``/archive/2012-01``, because the ``{month
 wildcard matches the regular expression wildcard given. However, ``/archive/foo``
 does *not* match, because "foo" fails the month wildcard.
 
-Besides the regular expression constraints there are two special requirements
-you can define:
-
-* ``_method`` enforces a certain HTTP request method (``HEAD``, ``GET``, ``POST``, ...)
-* ``_scheme`` enforces a certain HTTP scheme (``http``, ``https``)
-
-For example, the following route would only accept requests to /foo with
-the POST method and a secure connection::
-
-   $route = new Route(
-       '/foo',
-       array(),
-       array('_method' => 'post', '_scheme' => 'https' )
-   );
-
 .. tip::
 
     If you want to match all urls which start with a certain path and end in an
@@ -150,8 +142,7 @@ Using Prefixes
 You can add routes or other instances of
 :class:`Symfony\\Component\\Routing\\RouteCollection` to *another* collection.
 This way you can build a tree of routes. Additionally you can define a prefix,
-default requirements, default options, and hostname pattern to all routes
-of a subtree::
+default requirements, default options and hostname to all routes of a subtree::
 
     $rootCollection = new RouteCollection();
 
@@ -162,10 +153,10 @@ of a subtree::
     $rootCollection->addCollection(
         $subCollection,
         '/prefix', // prefix
-        array('_scheme' => 'https'), // defaults
         array(), // requirements
         array(), // options
         'admin.example.com', // hostname
+        array('https') // schemes
     );
 
 Set the Request Parameters
@@ -220,9 +211,9 @@ a certain route::
 
 .. note::
 
-    If you have defined the ``_scheme`` requirement, an absolute URL is generated
-    if the scheme of the current :class:`Symfony\\Component\\Routing\\RequestContext`
-    does not match the requirement.
+    If you have defined a scheme, an absolute URL is generated if the scheme
+    of the current :class:`Symfony\\Component\\Routing\\RequestContext` does
+    not match the requirement.
 
 Load Routes from a File
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -244,11 +235,11 @@ If you're using the ``YamlFileLoader``, then route definitions look like this:
 
     # routes.yml
     route1:
-        pattern: /foo
+        path:     /foo
         defaults: { _controller: 'MyController::fooAction' }
 
     route2:
-        pattern: /foo/bar
+        path:     /foo/bar
         defaults: { _controller: 'MyController::foobarAction' }
 
 To load this file, you can use the following code. This assumes that your

--- a/cookbook/routing/method_parameters.rst
+++ b/cookbook/routing/method_parameters.rst
@@ -1,37 +1,34 @@
 .. index::
-   single: Routing; _method
+   single: Routing; methods
 
 How to use HTTP Methods beyond GET and POST in Routes
 =====================================================
 
 The HTTP method of a request is one of the requirements that can be checked
 when seeing if it matches a route. This is introduced in the routing chapter
-of the book ":doc:`/book/routing`" with examples using GET and POST. You
-can also use other HTTP verbs in this way. For example, if you have a blog
-post entry then you could use the same URL pattern to show it, make changes
-to it and delete it by matching on GET, PUT and DELETE.
+of the book ":doc:`/book/routing`" with examples using GET and POST. You can
+also use other HTTP verbs in this way. For example, if you have a blog post
+entry then you could use the same URL path to show it, make changes to it and
+delete it by matching on GET, PUT and DELETE.
 
 .. configuration-block::
 
     .. code-block:: yaml
 
         blog_show:
-            pattern:  /blog/{slug}
+            path:     /blog/{slug}
             defaults: { _controller: AcmeDemoBundle:Blog:show }
-            requirements:
-                _method:  GET
+            methods:   [GET]
 
         blog_update:
-            pattern:  /blog/{slug}
+            path:     /blog/{slug}
             defaults: { _controller: AcmeDemoBundle:Blog:update }
-            requirements:
-                _method:  PUT
+            methods:   [PUT]
 
         blog_delete:
-            pattern:  /blog/{slug}
+            path:     /blog/{slug}
             defaults: { _controller: AcmeDemoBundle:Blog:delete }
-            requirements:
-                _method:  DELETE
+            methods:   [DELETE]
 
     .. code-block:: xml
 
@@ -41,19 +38,16 @@ to it and delete it by matching on GET, PUT and DELETE.
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="blog_show" pattern="/blog/{slug}">
+            <route id="blog_show" path="/blog/{slug}" methods="GET">
                 <default key="_controller">AcmeDemoBundle:Blog:show</default>
-                <requirement key="_method">GET</requirement>
             </route>
 
-            <route id="blog_update" pattern="/blog/{slug}">
+            <route id="blog_update" path="/blog/{slug}" methods="PUT">
                 <default key="_controller">AcmeDemoBundle:Blog:update</default>
-                <requirement key="_method">PUT</requirement>
             </route>
 
-            <route id="blog_delete" pattern="/blog/{slug}">
+            <route id="blog_delete" path="/blog/{slug}" methods="DELETE">
                 <default key="_controller">AcmeDemoBundle:Blog:delete</default>
-                <requirement key="_method">DELETE</requirement>
             </route>
         </routes>
 
@@ -65,21 +59,15 @@ to it and delete it by matching on GET, PUT and DELETE.
         $collection = new RouteCollection();
         $collection->add('blog_show', new Route('/blog/{slug}', array(
             '_controller' => 'AcmeDemoBundle:Blog:show',
-        ), array(
-            '_method' => 'GET',
-        )));
+        ), array(), array(), '', array(), array('GET')));
 
         $collection->add('blog_update', new Route('/blog/{slug}', array(
             '_controller' => 'AcmeDemoBundle:Blog:update',
-        ), array(
-            '_method' => 'PUT',
-        )));
+        ), array(), array(), '', array(), array('PUT')));
 
         $collection->add('blog_delete', new Route('/blog/{slug}', array(
             '_controller' => 'AcmeDemoBundle:Blog:delete',
-        ), array(
-            '_method' => 'DELETE',
-        )));
+        ), array(), array(), '', array('DELETE')));
 
         return $collection;
 

--- a/cookbook/routing/redirect_in_config.rst
+++ b/cookbook/routing/redirect_in_config.rst
@@ -20,7 +20,7 @@ Your configuration will look like this:
         prefix:   /app
 
     root:
-        pattern: /
+        path:     /
         defaults:
             _controller: FrameworkBundle:Redirect:urlRedirect
             path: /app

--- a/cookbook/routing/scheme.rst
+++ b/cookbook/routing/scheme.rst
@@ -6,17 +6,16 @@ How to force routes to always use HTTPS or HTTP
 
 Sometimes, you want to secure some routes and be sure that they are always
 accessed via the HTTPS protocol. The Routing component allows you to enforce
-the URI scheme via the ``_scheme`` requirement:
+the URI scheme via schemes:
 
 .. configuration-block::
 
     .. code-block:: yaml
 
         secure:
-            pattern:  /secure
+            path:     /secure
             defaults: { _controller: AcmeDemoBundle:Main:secure }
-            requirements:
-                _scheme:  https
+            schemes:  [https]
 
     .. code-block:: xml
 
@@ -26,9 +25,8 @@ the URI scheme via the ``_scheme`` requirement:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="secure" pattern="/secure">
+            <route id="secure" path="/secure" schemes="http">
                 <default key="_controller">AcmeDemoBundle:Main:secure</default>
-                <requirement key="_scheme">https</requirement>
             </route>
         </routes>
 
@@ -40,9 +38,7 @@ the URI scheme via the ``_scheme`` requirement:
         $collection = new RouteCollection();
         $collection->add('secure', new Route('/secure', array(
             '_controller' => 'AcmeDemoBundle:Main:secure',
-        ), array(
-            '_scheme' => 'https',
-        )));
+        ), array(), array(), '', array('https')));
 
         return $collection;
 
@@ -65,8 +61,8 @@ The requirement is also enforced for incoming requests. If you try to access
 the ``/secure`` path with HTTP, you will automatically be redirected to the
 same URL, but with the HTTPS scheme.
 
-The above example uses ``https`` for the ``_scheme``, but you can also force a
-URL to always use ``http``.
+The above example uses ``https`` for the scheme, but you can also force a URL
+to always use ``http``.
 
 .. note::
 

--- a/cookbook/routing/service_container_parameters.rst
+++ b/cookbook/routing/service_container_parameters.rst
@@ -22,7 +22,7 @@ inside your routing configuration:
     .. code-block:: yaml
 
         contact:
-            pattern:  /{_locale}/contact
+            path:     /{_locale}/contact
             defaults: { _controller: AcmeDemoBundle:Main:contact }
             requirements:
                 _locale: %acme_demo.locales%
@@ -35,7 +35,7 @@ inside your routing configuration:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="contact" pattern="/{_locale}/contact">
+            <route id="contact" path="/{_locale}/contact">
                 <default key="_controller">AcmeDemoBundle:Main:contact</default>
                 <requirement key="_locale">%acme_demo.locales%</requirement>
             </route>
@@ -78,15 +78,15 @@ in your container:
         # app/config/config.php
         $container->setParameter('acme_demo.locales', 'en|es');
 
-You can also use a parameter to define your route pattern (or part of your
-pattern):
+You can also use a parameter to define your route path (or part of your
+path):
 
 .. configuration-block::
 
     .. code-block:: yaml
 
         some_route:
-            pattern:  /%acme_demo.route_prefix%/contact
+            path:     /%acme_demo.route_prefix%/contact
             defaults: { _controller: AcmeDemoBundle:Main:contact }
 
     .. code-block:: xml
@@ -97,7 +97,7 @@ pattern):
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="some_route" pattern="/%acme_demo.route_prefix%/contact">
+            <route id="some_route" path="/%acme_demo.route_prefix%/contact">
                 <default key="_controller">AcmeDemoBundle:Main:contact</default>
             </route>
         </routes>

--- a/cookbook/routing/slash_in_parameter.rst
+++ b/cookbook/routing/slash_in_parameter.rst
@@ -16,18 +16,18 @@ Configure the Route
 -------------------
 
 By default, the Symfony routing components requires that the parameters 
-match the following regex pattern: ``[^/]+``. This means that all characters 
+match the following regex path: ``[^/]+``. This means that all characters 
 are allowed except ``/``. 
 
 You must explicitly allow ``/`` to be part of your parameter by specifying 
-a more permissive regex pattern.
+a more permissive regex path.
 
 .. configuration-block::
 
     .. code-block:: yaml
 
         _hello:
-            pattern: /hello/{name}
+            path:     /hello/{name}
             defaults: { _controller: AcmeDemoBundle:Demo:hello }
             requirements:
                 name: ".+"
@@ -40,7 +40,7 @@ a more permissive regex pattern.
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="_hello" pattern="/hello/{name}">
+            <route id="_hello" path="/hello/{name}">
                 <default key="_controller">AcmeDemoBundle:Demo:hello</default>
                 <requirement key="name">.+</requirement>
             </route>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes (symfony/symfony#6738, symfony/symfony#6022, symfony/symfony#6825) |
| New docs? | no |
| Applies to | 2.2+ |
| Closes tickets | #2163 |

The Routing component has renamed some important options. This PR is fixes the most occurences of wrong Routing options in the documentation, I can't promise that every occurence is now fixed.

I marked this as a WIP because the `hostname` option is likely to be renamed to `host`, when that PR is created + merged I will change them and this PR can get merged.
