### PR TITLE
Add info about security.firewall.context in pitfall

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -580,7 +580,7 @@ them for you. Here's the same sample application, now built in Symfony2::
         }
     }
 
-The two controllers are still lightweight. Each uses the Doctrine ORM library
+The two controllers are still lightweight. Each uses the :doc:`Doctrine ORM library</book/doctrine>`
 to retrieve objects from the database and the ``Templating`` component to
 render a template and return a ``Response`` object. The list template is
 now quite a bit simpler:

--- a/book/security.rst
+++ b/book/security.rst
@@ -655,7 +655,8 @@ see :doc:`/cookbook/security/form_login`.
 
     If you're using multiple firewalls and you authenticate against one firewall,
     you will *not* be authenticated against any other firewalls automatically.
-    Different firewalls are like different security systems. That's why,
+    Different firewalls are like different security systems. To do this you have
+    to explicitly specify the same context for different firewalls. But usually
     for most applications, having one main firewall is enough.
 
 Authorization

--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -72,6 +72,7 @@ method::
                     'The name of the bundle should be suffixed with \'Bundle\''
                 );
             }
+            return $answer;
         },
         false,
         'AcmeDemoBundle'
@@ -89,8 +90,8 @@ This methods has 2 new arguments, the full signature is::
 
 The ``$validator`` is a callback which handles the validation. It should
 throw an exception if there is something wrong. The exception message is displayed
-in the console, so it is a good practice to put some useful information 
-in it.
+in the console, so it is a good practice to put some useful information in it. The callback 
+function should also return the value of the user's input if the validatation was successfull.
 
 You can set the max number of times to ask in the ``$attempts`` argument.
 If you reach this max number it will use the default value, which is given

--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -91,7 +91,7 @@ This methods has 2 new arguments, the full signature is::
 The ``$validator`` is a callback which handles the validation. It should
 throw an exception if there is something wrong. The exception message is displayed
 in the console, so it is a good practice to put some useful information in it. The callback 
-function should also return the value of the user's input if the validatation was successfull.
+function should also return the value of the user's input if the validation was successful.
 
 You can set the max number of times to ask in the ``$attempts`` argument.
 If you reach this max number it will use the default value, which is given

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -214,7 +214,7 @@ benefit of merging multiple files and validation of the configuration::
         $processor = new Processor();
         $config = $processor->processConfiguration($configuration, $configs);
 
-        $container->setParameter('acme_demo.FOO', $config['foo'])
+        $container->setParameter('acme_demo.FOO', $config['foo']);
 
         // ...
     }

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -112,10 +112,11 @@ processed when the container is compiled at which point the Extensions are loade
     use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
     $container = new ContainerBuilder();
+    $container->registerExtension(new AcmeDemoExtension);
+
     $loader = new YamlFileLoader($container, new FileLocator(__DIR__));
     $loader->load('config.yml');
 
-    $container->registerExtension(new AcmeDemoExtension);
     // ...
     $container->compile();
 
@@ -213,7 +214,7 @@ benefit of merging multiple files and validation of the configuration::
         $processor = new Processor();
         $config = $processor->processConfiguration($configuration, $configs);
 
-        $container->setParameter('acme_demo.FOO', $config['foo']);
+        $container->setParameter('acme_demo.FOO', $config['foo'])
 
         // ...
     }

--- a/components/dependency_injection/definitions.rst
+++ b/components/dependency_injection/definitions.rst
@@ -28,7 +28,7 @@ Getting and Setting Service Definitions
 There are also some helpful methods for
 working with the service definitions.
 
-To find out if there is a definition for a service id:: 
+To find out if there is a definition for a service id::
 
     $container->hasDefinition($serviceId);
 
@@ -84,7 +84,7 @@ To get an array of the constructor arguments for a definition you can use::
 
 or to get a single argument by its position::
 
-    $definition->getArgument($index); 
+    $definition->getArgument($index);
     //e.g. $definition->getArguments(0) for the first argument
 
 You can add a new argument to the end of the arguments array using::
@@ -95,7 +95,7 @@ The argument can be a string, an array, a service parameter by using ``%paramete
 or a service id by using ::
 
     use Symfony\Component\DependencyInjection\Reference;
-  
+
     // ...
 
     $definition->addArgument(new Reference('service_id'));
@@ -131,3 +131,9 @@ You can also replace any existing method calls with an array of new ones with::
 
     $definition->setMethodCalls($methodCalls);
 
+.. tip::
+
+    There are more examples of specific ways of working with definitions
+    in the PHP code blocks of the configuration examples on pages such as
+    :doc:`/components/dependency_injection/factories` and
+    :doc:`/components/dependency_injection/parentservices`

--- a/components/dependency_injection/definitions.rst
+++ b/components/dependency_injection/definitions.rst
@@ -136,4 +136,4 @@ You can also replace any existing method calls with an array of new ones with::
     There are more examples of specific ways of working with definitions
     in the PHP code blocks of the configuration examples on pages such as
     :doc:`/components/dependency_injection/factories` and
-    :doc:`/components/dependency_injection/parentservices`
+    :doc:`/components/dependency_injection/parentservices`.

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -7,6 +7,11 @@ The DomCrawler Component
 
     The DomCrawler Component eases DOM navigation for HTML and XML documents.
 
+.. note::
+
+    While possible, the DomCrawler is not designed for manipulation of the
+    DOM or re-dumping HTML/XML.
+
 Installation
 ------------
 
@@ -171,6 +176,22 @@ and :phpclass:`DOMNode` objects:
     $crawler->addNodes(array($node));
     $crawler->addNode($node);
     $crawler->add($document);
+
+.. note::
+
+    These methods on the ``Crawler`` are intended to initially populate your
+    ``Crawler`` and aren't intended to be used to further manipulate a DOM
+    (though this is possible). However, since the ``Crawler`` is a set of
+    :phpclass:`DOMElement` objects, you can use any method or property available
+    on :phpclass:`DOMElement`, :phpclass:`DOMNode` or :phpclass:`DOMDocument`.
+    For example, you could get the HTML of a ``Crawler`` with something like
+    this::
+    
+        $html = '';
+
+        foreach ($crawler as $domElement) {
+            $html.= $domElement->ownerDocument->saveHTML();
+        }
 
 Form and Link support
 ~~~~~~~~~~~~~~~~~~~~~

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -9,8 +9,8 @@ The DomCrawler Component
 
 .. note::
 
-    While possible, the DomCrawler is not designed for manipulation of the
-    DOM or re-dumping HTML/XML.
+    While possible, the DomCrawler component is not designed for manipulation
+    of the DOM or re-dumping HTML/XML.
 
 Installation
 ------------
@@ -177,7 +177,7 @@ and :phpclass:`DOMNode` objects:
     $crawler->addNode($node);
     $crawler->add($document);
 
-.. note::
+.. sidebar:: Manipulating and Dumping a ``Crawler``
 
     These methods on the ``Crawler`` are intended to initially populate your
     ``Crawler`` and aren't intended to be used to further manipulate a DOM

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -133,7 +133,7 @@ how the behavior has changed.
         The ``include()`` function is a new Twig feature that's available in
         Symfony 2.2. Prior, the ``{% include %}`` tag was used.
 
-Whenever a new version of minor of Symfony2 is released (e.g. 2.3, 2.4, etc),
+Whenever a new minor version of Symfony2 is released (e.g. 2.3, 2.4, etc),
 a new branch of the documentation is created from the ``master`` branch.
 At this point, all the ``versionadded`` tags for Symfony2 versions that have
 reached end-of-life will be removed. For example, if Symfony 2.5 were released

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -78,6 +78,36 @@ GitHub covers the topic of `pull requests`_ in detail.
     by going to the `Documentation Build Errors`_ page (it is updated each French
     night at 3AM when the server rebuilds the documentation).
 
+Documenting new Features or Behavior Changes
+--------------------------------------------
+
+If you're documenting a brand new feature or a change that's been made in
+Symfony2, you should precede your description of the change with a ``.. versionadded:: 2.X``
+tag and a short description:
+
+.. code-block:: text
+
+    .. versionadded:: 2.2
+        The ``askHiddenResponse`` method was added in Symfony 2.2.
+
+    You can also ask a question and hide the response. This is particularly...
+
+If you're documenting a behavior change, it may be helpful to *briefly* describe
+how the behavior has changed.
+
+.. code-block:: text
+
+    .. versionadded:: 2.2
+        The ``include()`` function is a new Twig feature that's available in
+        Symfony 2.2. Prior, the ``{% include %}`` tag was used.
+
+Whenever a new version of minor of Symfony2 is released (e.g. 2.3, 2.4, etc),
+a new branch of the documentation is created from the ``master`` branch.
+At this point, all the ``versionadded`` tags for Symfony2 versions that have
+reached end-of-life will be removed. For example, if Symfony 2.5 were released
+today, and 2.2 had recently reached its end-of-life, the 2.2 ``versionadded``
+tags would be removed from the new 2.5 branch.
+
 Standards
 ---------
 

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -369,6 +369,10 @@ will be show next):
         // add the "add a tag" anchor and li to the tags ul
         collectionHolder.append($newLinkLi);
 
+        // count the current form inputs we have (e.g. 2), use that as the new
+        // index when inserting a new item (e.g. 2)
+        collectionHolder.data('index', collectionHolder.find(':input').length);
+
         $addTagLink.on('click', function(e) {
             // prevent the link from creating a "#" on the URL
             e.preventDefault();
@@ -393,12 +397,15 @@ one example:
         // Get the data-prototype explained earlier
         var prototype = collectionHolder.attr('data-prototype');
 
-        // count the current form inputs we have (e.g. 2), use that as the new index (e.g. 2)
-        var newIndex = collectionHolder.find(':input').length;
+        // get the new index
+        var index = collectionHolder.data('index');
 
         // Replace '$$name$$' in the prototype's HTML to
         // instead be a number based on how many items we have
-        var newForm = prototype.replace(/\$\$name\$\$/g, newIndex);
+        var newForm = prototype.replace(/\$\$name\$\$/g, index);
+
+        // increase the index with one for the next item
+        collectionHolder.attr('index', index + 1);
 
         // Display the form in the page in an li, before the "Add a tag" link li
         var $newFormLi = $('<li></li>').append(newForm);

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -405,7 +405,7 @@ one example:
         var newForm = prototype.replace(/\$\$name\$\$/g, index);
 
         // increase the index with one for the next item
-        collectionHolder.attr('index', index + 1);
+        collectionHolder.data('index', index + 1);
 
         // Display the form in the page in an li, before the "Add a tag" link li
         var $newFormLi = $('<li></li>').append(newForm);

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -395,7 +395,7 @@ one example:
 
     function addTagForm(collectionHolder, $newLinkLi) {
         // Get the data-prototype explained earlier
-        var prototype = collectionHolder.attr('data-prototype');
+        var prototype = collectionHolder.data('prototype');
 
         // get the new index
         var index = collectionHolder.data('index');

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -412,7 +412,7 @@ one example:
         $newLinkLi.before($newFormLi);
     }
 
-.. note:
+.. note::
 
     It is better to separate your javascript in real JavaScript files than
     to write it inside the HTML as is done here.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

I spent some time for looking into the source code to understand, what does the security/firewalls/{id}/context parameter do. The user guide for SonataUserBundle has an example with this parameter, but I did not found any information. The links in search results are all about the service "security.context".
