### PR TITLE
Fixed parameter type mismatch in addMethodCall example.

### DIFF
--- a/components/dependency_injection/introduction.rst
+++ b/components/dependency_injection/introduction.rst
@@ -147,7 +147,7 @@ If you do want to though then the container can call the setter method::
 
     $container
         ->register('newsletter_manager', 'NewsletterManager')
-        ->addMethodCall('setMailer', new Reference('mailer'));
+        ->addMethodCall('setMailer', array(new Reference('mailer')));
 
 You could then get your ``newsletter_manager`` service from the container
 like this::
@@ -259,6 +259,6 @@ The ``newsletter_manager`` and ``mailer`` services can be set up using config fi
 
         $container
             ->register('newsletter_manager', 'NewsletterManager')
-            ->addMethodCall('setMailer', new Reference('mailer'));
+            ->addMethodCall('setMailer', array(new Reference('mailer')));
 
 .. _Packagist: https://packagist.org/packages/symfony/dependency-injection


### PR DESCRIPTION
The example passes an object as the second parameter to addMethodCall. However, addMethodCall expects an array.

Fixed by wrapping the object in an array.
