### PR TITLE
sf2.2 note: _method override disabled by default

### DIFF
--- a/cookbook/routing/method_parameters.rst
+++ b/cookbook/routing/method_parameters.rst
@@ -6,8 +6,8 @@ How to use HTTP Methods beyond GET and POST in Routes
 
 .. versionadded:: 2.2
     This functionality is disabled by default in Symfony 2.2. To enable it, 
-    you must call ``Request::enableHttpMethodParameterOverride()`` before you
-    handle the request.
+    you must call :method:`Request::enableHttpMethodParameterOverride <Symfony\\Component\\HttpFoundation\\Request::enableHttpMethodParameterOverride>` 
+    before you handle the request.
 
 The HTTP method of a request is one of the requirements that can be checked
 when seeing if it matches a route. This is introduced in the routing chapter

--- a/cookbook/routing/method_parameters.rst
+++ b/cookbook/routing/method_parameters.rst
@@ -4,6 +4,11 @@
 How to use HTTP Methods beyond GET and POST in Routes
 =====================================================
 
+.. versionadded:: 2.2
+    This functionality is disabled by default in Symfony 2.2. To enable it, 
+    you must call ``Request::enableHttpMethodParameterOverride()`` before you
+    handle the request.
+
 The HTTP method of a request is one of the requirements that can be checked
 when seeing if it matches a route. This is introduced in the routing chapter
 of the book ":doc:`/book/routing`" with examples using GET and POST. You can


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2 |
| Fixed tickets | n/a? |

Just added a short note explaining that the `_method` hidden field method of overriding the HTTP method (method method method) is now disabled by default in Symfony 2.2, and must be explicitly enabled.
