### PR TITLE
[Cookbook][Deployment] Correct parameters file name

### DIFF
--- a/cookbook/deployment-tools.rst
+++ b/cookbook/deployment-tools.rst
@@ -71,7 +71,7 @@ Common Post-Deployment Tasks
 After deploying your actual source code, there are a number of common things
 you'll need to do:
 
-A) Configure your ``app/config/parameters.ini`` file
+A) Configure your ``app/config/parameters.yml`` file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This file should be customized on each system. The method you use to


### PR DESCRIPTION
Updates references to `parameters.ini` which was used in Symfony SE 2.0 but was replaced with `parameters.yml` in >= 2.1.

This commit should also be merged into the 2.1 branch.

:rocket:
