### PR TITLE
Adding a note describing the configuration of SQLite with doctrine

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -117,36 +117,38 @@ for you:
     If you want to use SQLite as your database, you need to set the path
     where your database file should be stored:
     
-    .. code-block:: yaml
+    .. configuration-block::
+    
+        .. code-block:: yaml
 
-        # app/config/config.yml
-        doctrine:
-            dbal:
-                driver: pdo_sqlite
-                path: "%kernel.root_dir%/sqlite.db"
-                charset: UTF8
-                
-    .. code-block:: xml
-    
-        <!-- app/config/config.xml -->
-        <doctrine:config
-            driver="pdo_sqlite"
-            path="%kernel.root_dir%/sqlite.db"
-            charset="UTF-8"
-        >
-            <!-- ... -->
-        </doctrine:config>
+            # app/config/config.yml
+            doctrine:
+                dbal:
+                    driver: pdo_sqlite
+                    path: "%kernel.root_dir%/sqlite.db"
+                    charset: UTF8
+                    
+        .. code-block:: xml
         
-    .. code-block:: php
-    
-        // app/config/config.php
-        $container->loadFromExtension('doctrine', array(
-            'dbal' => array(
-                'driver'  => 'pdo_sqlite',
-                'path'    => '%kernel.root_dir%/sqlite.db',
-                'charset' => 'UTF-8',
-            ),
-        ));
+            <!-- app/config/config.xml -->
+            <doctrine:config
+                driver="pdo_sqlite"
+                path="%kernel.root_dir%/sqlite.db"
+                charset="UTF-8"
+            >
+                <!-- ... -->
+            </doctrine:config>
+            
+        .. code-block:: php
+        
+            // app/config/config.php
+            $container->loadFromExtension('doctrine', array(
+                'dbal' => array(
+                    'driver'  => 'pdo_sqlite',
+                    'path'    => '%kernel.root_dir%/sqlite.db',
+                    'charset' => 'UTF-8',
+                ),
+            ));
 
 Creating an Entity Class
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -114,8 +114,8 @@ for you:
         
 .. note::
     
-    If you want to use SQLite as your database, you need to set the path where
-    your database file should be stored:
+    If you want to use SQLite as your database, you need to set the path
+    where your database file should be stored:
     
     .. code-block:: yaml
 
@@ -123,8 +123,30 @@ for you:
         doctrine:
             dbal:
                 driver: pdo_sqlite
-                path: %kernel.root_dir%/sqlite.db
+                path: "%kernel.root_dir%/sqlite.db"
                 charset: UTF8
+                
+    .. code-block: xml
+    
+        <!-- app/config/config.xml -->
+        <doctrine:config
+            driver="pdo_sqlite"
+            path="%kernel.root_dir%/sqlite.db"
+            charset="UTF-8"
+        >
+            <!-- ... -->
+        </doctrine:config>
+        
+    .. code-block: php
+    
+        // app/config/config.php
+        $container->loadFromExtension('doctrine', array(
+            'dbal' => array(
+                'driver'  => 'pdo_sqlite',
+                'path'    => '%kernel.root_dir%/sqlite.db',
+                'charset' => 'UTF-8',
+            ),
+        ));
 
 Creating an Entity Class
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -111,6 +111,20 @@ for you:
         [mysqld]
         collation-server = utf8_general_ci
         character-set-server = utf8
+        
+.. note::
+    
+    If you want to use SQLite as your database, you need to set the path where
+    your database file should be stored:
+    
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        doctrine:
+            dbal:
+                driver: pdo_sqlite
+                path: %kernel.root_dir%/sqlite.db
+                charset: UTF8
 
 Creating an Entity Class
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -126,7 +126,7 @@ for you:
                 path: "%kernel.root_dir%/sqlite.db"
                 charset: UTF8
                 
-    .. code-block: xml
+    .. code-block:: xml
     
         <!-- app/config/config.xml -->
         <doctrine:config
@@ -137,7 +137,7 @@ for you:
             <!-- ... -->
         </doctrine:config>
         
-    .. code-block: php
+    .. code-block:: php
     
         // app/config/config.php
         $container->loadFromExtension('doctrine', array(


### PR DESCRIPTION
As discussed in #1638, the doctrine configuration option for SQLite was added as a note (including the correct configuration for the driver and the encoding setting).

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | 2.0+ |
| Fixed tickets | #1638 |
