### PR TITLE
Added trans_default_domain tag to twig reference and some formatting

### DIFF
--- a/book/translation.rst
+++ b/book/translation.rst
@@ -741,7 +741,7 @@ Translations in Templates
 Most of the time, translation occurs in templates. Symfony2 provides native
 support for both Twig and PHP templates.
 
-.. _book-translation-twig:
+.. _book-translation-tags:
 
 Twig Templates
 ~~~~~~~~~~~~~~
@@ -777,6 +777,8 @@ You can also specify the message domain and pass some additional variables:
     {% transchoice count with {'%name%': 'Fabien'} from "app" %}
         {0} There is no apples|{1} There is one apple|]1,Inf] There are %count% apples
     {% endtranschoice %}
+
+.. _book-translation-filters:
 
 The ``trans`` and ``transchoice`` filters can be used to translate *variable
 texts* and complex expressions:

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -812,16 +812,19 @@ texts* and complex expressions:
             {{ message|trans|raw }}
             {{ '<h3>bar</h3>'|trans|raw }}
 
+.. tip::
+
+    You can set the translation domain for an entire Twig template with a single tag:
+
+    .. code-block:: jinja
+
+           {% trans_default_domain "app" %}
+
+    Note that this only influences the current template, not any "included"
+    templates (in order to avoid side effects).
+
 .. versionadded:: 2.1
-     You can now set the translation domain for an entire Twig template with a
-     single tag:
-
-     .. code-block:: jinja
-
-            {% trans_default_domain "app" %}
-
-     Note that this only influences the current template, not any "included"
-     templates (in order to avoid side effects).
+    The ``trans_default_domain`` tag is new in Symfony2.1
 
 PHP Templates
 ~~~~~~~~~~~~~

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -77,10 +77,10 @@ Filters
 |                                                                                 | spaces and capitalizes the string)                                |
 +---------------------------------------------------------------------------------+-------------------------------------------------------------------+
 | ``text|trans(arguments = {}, domain = 'messages', locale = null)``              | This will translate the text into the current language, more      |
-|                                                                                 | information in :ref:`book-translation-twig`.                      |
+|                                                                                 | information in :ref:`book-translation-filers`.                    |
 +---------------------------------------------------------------------------------+-------------------------------------------------------------------+
 | ``text|transchoice(count, arguments = {}, domain = 'messages', locale = null)`` | This will translate the text with pluralization, more information |
-|                                                                                 | in :ref:`book-translation-twig`.                                  |
+|                                                                                 | in :ref:`book-translation-filters`.                               |
 +---------------------------------------------------------------------------------+-------------------------------------------------------------------+
 | ``variable|yaml_encode(inline = 0)``                                            | This will transform the variable text into a YAML syntax.         |
 +---------------------------------------------------------------------------------+-------------------------------------------------------------------+
@@ -121,10 +121,10 @@ Tags
 |                                                   | more information in :doc:`/cookbook/form/form_customization`.      |
 +---------------------------------------------------+--------------------------------------------------------------------+
 | ``{% trans with {variables} %}...{% endtrans %}`` | This will translate and render the text, more information in       |
-|                                                   | :ref:`book-translation-twig`                                       |
+|                                                   | :ref:`book-translation-tags`                                       |
 +---------------------------------------------------+--------------------------------------------------------------------+
 | ``{% transchoice count with {variables} %}``      | This will translate and render the text with pluralization, more   |
-| ...                                               | information in :ref:`book-translation-twig`                        |
+| ...                                               | information in :ref:`book-translation-tags`                        |
 | ``{% endtranschoice %}``                          |                                                                    |
 +---------------------------------------------------+--------------------------------------------------------------------+
 | ``{% trans_default_domain language %}``           | This will set the default domain for message catalogues in the     |

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -110,23 +110,26 @@ Filters
 Tags
 ----
 
-+---------------------------------------------------+-------------------------------------------------------------------+
-| Tag Syntax                                        | Usage                                                             |
-+===================================================+===================================================================+
-| ``{% render url('route', {parameters}) %}``       | This will render the Response Content for the given controller    |
-|                                                   | that the URL points to. For more information,                     |
-|                                                   | see :ref:`templating-embedding-controller`.                       |
-+---------------------------------------------------+-------------------------------------------------------------------+
-| ``{% form_theme form 'file' %}``                  | This will look inside the given file for overridden form blocks,  |
-|                                                   | more information in :doc:`/cookbook/form/form_customization`.     |
-+---------------------------------------------------+-------------------------------------------------------------------+
-| ``{% trans with {variables} %}...{% endtrans %}`` | This will translate and render the text, more information in      |
-|                                                   | :ref:`book-translation-twig`                                      |
-+---------------------------------------------------+-------------------------------------------------------------------+
-| ``{% transchoice count with {variables} %}``      | This will translate and render the text with pluralization, more  |
-| ...                                               | information in :ref:`book-translation-twig`                       |
-| ``{% endtranschoice %}``                          |                                                                   |
-+---------------------------------------------------+-------------------------------------------------------------------+
++---------------------------------------------------+--------------------------------------------------------------------+
+| Tag Syntax                                        | Usage                                                              |
++===================================================+====================================================================+
+| ``{% render url('route', {parameters}) %}``       | This will render the Response Content for the given controller     |
+|                                                   | that the URL points to. For more information,                      |
+|                                                   | see :ref:`templating-embedding-controller`.                        |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``{% form_theme form 'file' %}``                  | This will look inside the given file for overridden form blocks,   |
+|                                                   | more information in :doc:`/cookbook/form/form_customization`.      |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``{% trans with {variables} %}...{% endtrans %}`` | This will translate and render the text, more information in       |
+|                                                   | :ref:`book-translation-twig`                                       |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``{% transchoice count with {variables} %}``      | This will translate and render the text with pluralization, more   |
+| ...                                               | information in :ref:`book-translation-twig`                        |
+| ``{% endtranschoice %}``                          |                                                                    |
++---------------------------------------------------+--------------------------------------------------------------------+
+| ``{% trans_default_domain language %}``           | This will set the default domain for message catalogues in the     |
+|                                                   | current template                                                   |
++---------------------------------------------------+--------------------------------------------------------------------+
 
 Tests
 -----


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes |
| Applies to | 2.1+ |
| Fixed tickets | #1569 |

This PR is splitted in 3 commits:
1. This adds the tag to the reference, this should be merged
2. This reformatted the text about this tag in `book/translation` to match the common style, this is in for discussion
3. This reformatted the reference links between the book article and the twig reference, I'm not sure of this
