### PR TITLE
[#1708] Fixed description of single_text date widget

### DIFF
--- a/reference/forms/types/options/date_widget.rst.inc
+++ b/reference/forms/types/options/date_widget.rst.inc
@@ -10,5 +10,5 @@ The basic way in which this field should be rendered. Can be one of the followin
 
 * ``text``: renders a three field input of type text (month, day, year).
 
-* ``single_text``: renders a single input of type text. User's input is validated
-  based on the `format`_ option.
+* ``single_text``: renders a single input of type date (text in Symfony 2.0). User's 
+  input is validated based on the `format`_ option.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets | #1708 |

I'm not sure about the part between parantheses, we should maybe remove this or create a `.. versionadded:: 2.1` block.
