### PR TITLE
Better doc when using GMail transport

### DIFF
--- a/cookbook/email/gmail.rst
+++ b/cookbook/email/gmail.rst
@@ -51,6 +51,23 @@ In the development configuration file, change the ``transport`` setting to
 
 You're done!
 
+.. tip::
+
+If you are using Symfony Standard Edition, configure the parameters at ``parameters.yml``:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/parameters.yml
+        parameters:
+            ...
+            mailer_transport: gmail
+            mailer_host:      ~
+            mailer_user:      your_gmail_username
+            mailer_password:  your_gmail_password
+
+
 .. note::
 
     The ``gmail`` transport is simply a shortcut that uses the ``smtp`` transport

--- a/cookbook/email/gmail.rst
+++ b/cookbook/email/gmail.rst
@@ -53,7 +53,7 @@ You're done!
 
 .. tip::
 
-If you are using Symfony Standard Edition, configure the parameters at ``parameters.yml``:
+    If you are using Symfony Standard Edition, configure the parameters at ``parameters.yml``:
 
 .. configuration-block::
 


### PR DESCRIPTION
If your are using Symfony Standard Edition, there is a way to configure the GMail transport from parameters.yml without change the config files.
