### PR TITLE
[Constraints] Added missing formats

### DIFF
--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -120,6 +120,7 @@ below a certain file size and a valid PDF, add the following:
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
 
+        // ...
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints\File;
 

--- a/reference/constraints/Min.rst
+++ b/reference/constraints/Min.rst
@@ -41,7 +41,7 @@ the following:
         class Participant
         {
             /**
-             * @Assert\Min(limit = "18", message = "You must be 18 or older to enter")
+             * @Assert\Min(limit = "18", message = "You must be 18 or older to enter.")
              */
              protected $age;
         }
@@ -53,7 +53,7 @@ the following:
             <property name="age">
                 <constraint name="Min">
                     <option name="limit">18</option>
-                    <option name="message">You must be 18 or older to enter</option>
+                    <option name="message">You must be 18 or older to enter.</option>
                 </constraint>
             </property>
         </class>
@@ -72,7 +72,7 @@ the following:
             {
                 $metadata->addPropertyConstraint('age', new Assert\Min(array(
                     'limit'   => '18',
-                    'message' => 'You must be 18 or older to enter',
+                    'message' => 'You must be 18 or older to enter.',
                 ));
             }
         }

--- a/reference/constraints/Min.rst
+++ b/reference/constraints/Min.rst
@@ -46,6 +46,37 @@ the following:
              protected $age;
         }
 
+    .. code-block:: xml
+
+        <!-- src/Acme/EventBundle/Resources/config/validation.yml -->
+        <class name="Acme\EventBundle\Entity\Participant">
+            <property name="age">
+                <constraint name="Min">
+                    <option name="limit">18</option>
+                    <option name="message">You must be 18 or older to enter</option>
+                </constraint>
+            </property>
+        </class>
+
+    .. code-block:: php
+
+        // src/Acme/EventBundle/Entity/Participant.php
+        namespace Acme\EventBundle\Entity\Participant;
+
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Participant
+        {
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('age', new Assert\Min(array(
+                    'limit'   => '18',
+                    'message' => 'You must be 18 or older to enter',
+                ));
+            }
+        }
+
 Options
 -------
 

--- a/reference/constraints/Regex.rst
+++ b/reference/constraints/Regex.rst
@@ -127,6 +127,26 @@ message:
             </property>
         </class>
 
+    .. code-block:: php
+
+        // src/Acme/BlogBundle/Entity/Author.php
+        namespace Acme\BlogBundle\Entity;
+
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('firstName', new Assert\Regex(array(
+                    'pattern' => '/\d/',
+                    'match'   => false,
+                    'message' => 'Your name cannot contain a number',
+                )));
+            }
+        }
+
 Options
 -------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Related tickets | #2042 |

After this PR, all formats are documented for the constraints in the reference section. This PR adds the XML format for the Regex constraint and cherry picks the XML and PHP config formats for the Min constraint from #2076
