### PR TITLE
Adding two use statements to virtual form cookbook page

### DIFF
--- a/cookbook/form/use_virtuals_forms.rst
+++ b/cookbook/form/use_virtuals_forms.rst
@@ -50,6 +50,7 @@ Start by creating a very simple ``CompanyType`` and ``CustomerType``::
     // src/Acme/HelloBundle/Form/Type/CompanyType.php
     namespace Acme\HelloBundle\Form\Type;
 
+    use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
 
     class CompanyType extends AbstractType
@@ -85,6 +86,7 @@ location form type::
     // src/Acme/HelloBundle/Form/Type/LocationType.php
     namespace Acme\HelloBundle\Form\Type;
 
+    use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
     use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 


### PR DESCRIPTION
These two examples are missing the use statement for the `AbstractType` class.

Once fixed in master, this should probably also be backported to the 2.1 docs as well (it's missing there).
