### PR TITLE
[Reference] Document AppKernel config settings

### DIFF
--- a/cookbook/configuration/override_dir_structure.rst
+++ b/cookbook/configuration/override_dir_structure.rst
@@ -23,6 +23,8 @@ directory structure is:
         app.php
         ...
 
+.. _override-cache-dir:
+
 Override the ``cache`` directory
 --------------------------------
 
@@ -52,6 +54,8 @@ the location of the cache directory to ``app/{environment}/cache``.
     otherwise some unexpected behaviour may happen. Each environment generates
     its own cached config files, and so each needs its own directory to store
     those cache files.
+
+.. _override-logs-dir:
 
 Override the ``logs`` directory
 -------------------------------

--- a/reference/configuration/kernel.rst
+++ b/reference/configuration/kernel.rst
@@ -1,0 +1,68 @@
+.. index::
+    single: Configuration reference; Kernel class
+
+Configuration in the ``AppKernel``
+==================================
+
+Some configuration can be done in the ``AppKernel`` class (which is located in
+``app/AppKernel.php``. You can do this by overriding the method of the
+:class:`Symfony\\Component\\HttpKernel\\Kernel` class, which is extended by
+the ``AppKernel`` class.
+
+Configuration
+-------------
+
+* `kernel name`_
+* `root directory`_
+* `cache directory`_
+* `log directory`_
+
+kernel name
+~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``$this->name``
+
+To change this setting, override the
+:method:`Symfony\\Component\\HttpKernel\\Kernel::getName` method.
+
+root directory
+~~~~~~~~~~~~~~
+
+**type**: ``string`` **default**: the directory of ``AppKernel``
+
+This returns the root directory of you Symfony2 application. If you use the
+Symfony Standard edition, the root directory refers to the ``app`` directory.
+
+To change this setting, override the
+:method:`Symfony\\Component\\HttpKernel\\Kernel::getRootDir` method::
+
+    // app/AppKernel.php
+
+    // ...
+    class AppKernel extends Kernel
+    {
+        // ...
+
+        public function getRootDir()
+        {
+            return realpath(parent::getRootDir().'/../');
+        }
+    }
+
+cache directory
+~~~~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``$this->rootDir/cache/$this->environment``
+
+This returns the cache directory. You need to override the
+:method:`Symfony\\Component\\HttpKernel\\Kernel::getCacheDir` method. Read
+":ref:`override-cache-dir`" for more information.
+
+log directory
+~~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``$this->rootDir/logs``
+
+This returns the log directory. You need to override the
+:method:`Symfony\\Component\\HttpKernel\\Kernel::getLogDir` method. Read
+":ref:`override-logs-dir`" for more information.

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -12,6 +12,7 @@ Reference Documents
     configuration/twig
     configuration/monolog
     configuration/web_profiler
+    configuration/kernel
 
     forms/types
     forms/twig_reference

--- a/reference/map.rst.inc
+++ b/reference/map.rst.inc
@@ -9,10 +9,12 @@
   * :doc:`doctrine </reference/configuration/doctrine>`
   * :doc:`security </reference/configuration/security>`
   * :doc:`assetic </reference/configuration/assetic>`
-  * :doc:`swiftmailer </reference/configuration/swiftmailer>`
+  * :doc:`swiftMailer </reference/configuration/swiftmailer>`
   * :doc:`twig </reference/configuration/twig>`
   * :doc:`monolog </reference/configuration/monolog>`
   * :doc:`web_profiler </reference/configuration/web_profiler>`
+
+* :doc:`Configuration in the Kernel </reference/configuration/kernel>`
 
 * **Forms and Validation**
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | all |
| Fixed tickets | - |
### Todo
- [ ] Document the Kernel name setting

We can configure some things by overriding methods of the `Kernel` in the `AppKernel`, I think we should document those. This way, we can document how to set the charset in Symfony2.1 (see #1519).

I don't understand where the name of the Kernel is used for, so I didn't include a description for that currently. Can someone (@stof ?) tell me where this is used?
