### PR TITLE
[Installation] Improve setfacl options

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -156,7 +156,7 @@ If there are any issues, correct them now before moving on.
 
     .. code-block:: bash
 
-        $ sudo setfacl -R -m u:www-data:rwx -m u:`whoami`:rwx app/cache app/logs
+        $ sudo setfacl -R -m u:www-data:rwX -m u:`whoami`:rwX app/cache app/logs
         $ sudo setfacl -dR -m u:www-data:rwx -m u:`whoami`:rwx app/cache app/logs
 
     **3. Without using ACL**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | No Symfony involved |
| Fixed tickets | - |

Improve setfacl options to avoid existing files gaining unwanted x-bit permission.

When setting the ACL for all existing files and directory recursivly, an uppercase "X" should be used in the permission options. It means granting the x-bit only to those files which already have it. Otherwise existing files like .gitkeep or existing cache and log files are provided with the x-bit.

See setfacl man page for more details (section "ACL ENTRIES"): 
http://manpages.ubuntu.com/manpages/precise/en/man1/setfacl.1.html
