### PR TITLE
[Constraints] Fixed incosistenties and reordered config blocks

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -158,6 +158,18 @@ process. Each method can be one of the following formats:
             {
             }
 
+        .. code-block:: xml
+
+            <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
+            <class name="Acme\BlogBundle\Entity\Author">
+                <constraint name="Callback">
+                    <option name="methods">
+                        <value>Acme\BlogBundle\MyStaticValidatorClass</value>
+                        <value>isAuthorValid</value>
+                    </option>
+                </constraint>
+            </class>
+
         .. code-block:: php
 
             // src/Acme/BlogBundle/Entity/Author.php

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -46,21 +46,6 @@ If your valid choice list is simple, you can pass them in directly via the
                         choices:  [male, female]
                         message:  Choose a valid gender.
 
-    .. code-block:: xml
-
-        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
-        <class name="Acme\BlogBundle\Entity\Author">
-            <property name="gender">
-                <constraint name="Choice">
-                    <option name="choices">
-                        <value>male</value>
-                        <value>female</value>
-                    </option>
-                    <option name="message">Choose a valid gender.</option>
-                </constraint>
-            </property>
-        </class>
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -75,6 +60,21 @@ If your valid choice list is simple, you can pass them in directly via the
              */
             protected $gender;
         }
+
+    .. code-block:: xml
+
+        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
+        <class name="Acme\BlogBundle\Entity\Author">
+            <property name="gender">
+                <constraint name="Choice">
+                    <option name="choices">
+                        <value>male</value>
+                        <value>female</value>
+                    </option>
+                    <option name="message">Choose a valid gender.</option>
+                </constraint>
+            </property>
+        </class>
 
     .. code-block:: php
 
@@ -108,6 +108,8 @@ form element.
 .. code-block:: php
 
     // src/Acme/BlogBundle/Entity/Author.php
+    namespace Acme\BlogBundle\Entity;
+
     class Author
     {
         public static function getGenders()
@@ -132,6 +134,8 @@ constraint.
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
+        namespace Acme\BlogBundle\Entity;
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
@@ -153,6 +157,26 @@ constraint.
             </property>
         </class>
 
+    .. code-block:: php
+
+        // src/Acme/BlogBundle/EntityAuthor.php
+        namespace Acme\BlogBundle\Entity;
+
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints as Assert;
+        
+        class Author
+        {
+            protected $gender;
+            
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('gender', new Assert\Choice(array(
+                    'callback' => 'getGenders',
+                )));
+            }
+        }
+
 If the static callback is stored in a different class, for example ``Util``,
 you can pass the class name and the method as an array.
 
@@ -165,6 +189,21 @@ you can pass the class name and the method as an array.
             properties:
                 gender:
                     - Choice: { callback: [Util, getGenders] }
+
+    .. code-block:: php-annotations
+
+        // src/Acme/BlogBundle/Entity/Author.php
+        namespace Acme\BlogBundle\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            /**
+             * @Assert\Choice(callback = {"Util", "getGenders"})
+             */
+            protected $gender;
+        }
 
     .. code-block:: xml
 
@@ -180,17 +219,24 @@ you can pass the class name and the method as an array.
             </property>
         </class>
 
-    .. code-block:: php-annotations
+    .. code-block:: php
 
-        // src/Acme/BlogBundle/Entity/Author.php
+        // src/Acme/BlogBundle/EntityAuthor.php
+        namespace Acme\BlogBundle\Entity;
+
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
-
+        
         class Author
         {
-            /**
-             * @Assert\Choice(callback = {"Util", "getGenders"})
-             */
             protected $gender;
+            
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('gender', new Assert\Choice(array(
+                    'callback' => array('Util', 'getGenders'),
+                )));
+            }
         }
 
 Available Options

--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -30,6 +30,7 @@ Basic Usage
 The ``Collection`` constraint allows you to validate the different keys of
 a collection individually. Take the following example::
 
+    // src/Acme/BlogBundle/Entity/Author.php
     namespace Acme\BlogBundle\Entity;
 
     class Author
@@ -53,7 +54,7 @@ blank but is no longer than 100 characters in length, you would do the following
 
     .. code-block:: yaml
 
-        # src/BlogBundle/Resources/config/validation.yml
+        # src/Acme/BlogBundle/Resources/config/validation.yml
         Acme\BlogBundle\Entity\Author:
             properties:
                 profileData:

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -29,23 +29,6 @@ Basic Usage
                     - Email:
                         message: The email "{{ value }}" is not a valid email.
                         checkMX: true
-    .. code-block:: xml
-
-        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
-
-            <class name="Acme\BlogBundle\Entity\Author">
-                <property name="email">
-                    <constraint name="Email">
-                        <option name="message">The email "{{ value }}" is not a valid email.</option>
-                        <option name="checkMX">true</option>
-                    </constraint>
-                </property>
-            </class>
-        </constraint-mapping>
         
     .. code-block:: php-annotations
 
@@ -64,6 +47,24 @@ Basic Usage
              */
              protected $email;
         }
+
+    .. code-block:: xml
+
+        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\BlogBundle\Entity\Author">
+                <property name="email">
+                    <constraint name="Email">
+                        <option name="message">The email "{{ value }}" is not a valid email.</option>
+                        <option name="checkMX">true</option>
+                    </constraint>
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 

--- a/reference/constraints/False.rst
+++ b/reference/constraints/False.rst
@@ -48,17 +48,6 @@ method returns **false**:
                     - "False":
                         message: You've entered an invalid state.
 
-    .. code-block:: xml
-
-        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
-        <class name="Acme\BlogBundle\Entity\Author">
-            <getter property="stateInvalid">
-                <constraint name="False">
-                    <option name="message">You've entered an invalid state.</option>
-                </constraint>
-            </getter>
-        </class>
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -69,13 +58,26 @@ method returns **false**:
         class Author
         {
             /**
-             * @Assert\False()
+             * @Assert\False(
+             *     message = "You've entered an invalid state."
+             * )
              */
-             public function isStateInvalid($message = "You've entered an invalid state.")
+             public function isStateInvalid()
              {
                 // ...
              }
         }
+
+    .. code-block:: xml
+
+        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
+        <class name="Acme\BlogBundle\Entity\Author">
+            <getter property="stateInvalid">
+                <constraint name="False">
+                    <option name="message">You've entered an invalid state.</option>
+                </constraint>
+            </getter>
+        </class>
 
     .. code-block:: php
 

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -120,15 +120,14 @@ below a certain file size and a valid PDF, add the following:
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
 
-        // ...
         use Symfony\Component\Validator\Mapping\ClassMetadata;
-        use Symfony\Component\Validator\Constraints\File;
+        use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
         {
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
-                $metadata->addPropertyConstraint('bioFile', new File(array(
+                $metadata->addPropertyConstraint('bioFile', new Assert\File(array(
                     'maxSize' => '1024k',
                     'mimeTypes' => array(
                         'application/pdf',

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -27,6 +27,16 @@ table:
 
 .. configuration-block::
 
+    .. code-block:: yaml
+
+        # src/Acme/UserBundle/Resources/config/validation.yml
+        Acme\UserBundle\Entity\Author:
+            constraints:
+                - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity: email
+            properties:
+                email:
+                    - Email: ~
+
     .. code-block:: php-annotations
 
         // Acme/UserBundle/Entity/User.php
@@ -55,16 +65,6 @@ table:
             // ...
         }
 
-    .. code-block:: yaml
-
-        # src/Acme/UserBundle/Resources/config/validation.yml
-        Acme\UserBundle\Entity\Author:
-            constraints:
-                - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity: email
-            properties:
-                email:
-                    - Email: ~
-
     .. code-block:: xml
 
         <class name="Acme\UserBundle\Entity\Author">
@@ -72,10 +72,34 @@ table:
                 <option name="fields">email</option>
                 <option name="message">This email already exists.</option>
             </constraint>
-             <property name="email">
+            <property name="email">
                 <constraint name="Email" />
             </property>
         </class>
+
+    .. code-block:: php
+
+
+        // Acme/UserBundle/Entity/User.php
+        namespace Acme\UserBundle\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        // DON'T forget this use statement!!!
+        use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+        
+        class Author
+        {
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addConstraint(new UniqueEntity(array(
+                    'fields'  => 'email',
+                    'message' => 'This email already exists.',
+                )));
+
+                $metadata->addPropertyConstraint(new Assert\Email());
+            }
+        }
 
 Options
 -------

--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -22,7 +22,9 @@ an ``Address`` instance in the ``$address`` property.
 
 .. code-block:: php
 
-    // src/Acme/HelloBundle/Address.php
+    // src/Acme/HelloBundle/Entity/Address.php
+    namespace Amce\HelloBundle\Entity;
+
     class Address
     {
         protected $street;
@@ -31,7 +33,9 @@ an ``Address`` instance in the ``$address`` property.
 
 .. code-block:: php
 
-    // src/Acme/HelloBundle/Author.php
+    // src/Acme/HelloBundle/Entity/Author.php
+    namespace Amce\HelloBundle\Entity;
+
     class Author
     {
         protected $firstName;
@@ -44,7 +48,7 @@ an ``Address`` instance in the ``$address`` property.
     .. code-block:: yaml
 
         # src/Acme/HelloBundle/Resources/config/validation.yml
-        Acme\HelloBundle\Address:
+        Acme\HelloBundle\Entity\Address:
             properties:
                 street:
                     - NotBlank: ~
@@ -52,36 +56,13 @@ an ``Address`` instance in the ``$address`` property.
                     - NotBlank: ~
                     - MaxLength: 5
 
-        Acme\HelloBundle\Author:
+        Acme\HelloBundle\Entity\Author:
             properties:
                 firstName:
                     - NotBlank: ~
                     - MinLength: 4
                 lastName:
                     - NotBlank: ~
-
-    .. code-block:: xml
-
-        <!-- src/Acme/HelloBundle/Resources/config/validation.xml -->
-        <class name="Acme\HelloBundle\Address">
-            <property name="street">
-                <constraint name="NotBlank" />
-            </property>
-            <property name="zipCode">
-                <constraint name="NotBlank" />
-                <constraint name="MaxLength">5</constraint>
-            </property>
-        </class>
-
-        <class name="Acme\HelloBundle\Author">
-            <property name="firstName">
-                <constraint name="NotBlank" />
-                <constraint name="MinLength">4</constraint>
-            </property>
-            <property name="lastName">
-                <constraint name="NotBlank" />
-            </property>
-        </class>
 
     .. code-block:: php-annotations
 
@@ -123,26 +104,47 @@ an ``Address`` instance in the ``$address`` property.
             protected $address;
         }
 
+    .. code-block:: xml
+
+        <!-- src/Acme/HelloBundle/Resources/config/validation.xml -->
+        <class name="Acme\HelloBundle\Entity\Address">
+            <property name="street">
+                <constraint name="NotBlank" />
+            </property>
+            <property name="zipCode">
+                <constraint name="NotBlank" />
+                <constraint name="MaxLength">5</constraint>
+            </property>
+        </class>
+
+        <class name="Acme\HelloBundle\Entity\Author">
+            <property name="firstName">
+                <constraint name="NotBlank" />
+                <constraint name="MinLength">4</constraint>
+            </property>
+            <property name="lastName">
+                <constraint name="NotBlank" />
+            </property>
+        </class>
+
     .. code-block:: php
 
         // src/Acme/HelloBundle/Entity/Address.php
         namespace Acme\HelloBundle\Entity;
 
         use Symfony\Component\Validator\Mapping\ClassMetadata;
-        use Symfony\Component\Validator\Constraints\NotBlank;
-        use Symfony\Component\Validator\Constraints\MaxLength;
+        use Symfony\Component\Validator\Constraints as Assert;
 
         class Address
         {
             protected $street;
-
             protected $zipCode;
 
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
-                $metadata->addPropertyConstraint('street', new NotBlank());
-                $metadata->addPropertyConstraint('zipCode', new NotBlank());
-                $metadata->addPropertyConstraint('zipCode', new MaxLength(5));
+                $metadata->addPropertyConstraint('street', new Assert\NotBlank());
+                $metadata->addPropertyConstraint('zipCode', new Assert\NotBlank());
+                $metadata->addPropertyConstraint('zipCode', new Assert\MaxLength(5));
             }
         }
 
@@ -150,22 +152,19 @@ an ``Address`` instance in the ``$address`` property.
         namespace Acme\HelloBundle\Entity;
 
         use Symfony\Component\Validator\Mapping\ClassMetadata;
-        use Symfony\Component\Validator\Constraints\NotBlank;
-        use Symfony\Component\Validator\Constraints\MinLength;
+        use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
         {
             protected $firstName;
-
             protected $lastName;
-
             protected $address;
 
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
-                $metadata->addPropertyConstraint('firstName', new NotBlank());
-                $metadata->addPropertyConstraint('firstName', new MinLength(4));
-                $metadata->addPropertyConstraint('lastName', new NotBlank());
+                $metadata->addPropertyConstraint('firstName', new Assert\NotBlank());
+                $metadata->addPropertyConstraint('firstName', new Assert\MinLength(4));
+                $metadata->addPropertyConstraint('lastName', new Assert\NotBlank());
             }
         }
 
@@ -183,35 +182,37 @@ property.
                 address:
                     - Valid: ~
 
-    .. code-block:: xml
-
-        <!-- src/Acme/HelloBundle/Resources/config/validation.xml -->
-        <class name="Acme\HelloBundle\Author">
-            <property name="address">
-                <constraint name="Valid" />
-            </property>
-        </class>
-
     .. code-block:: php-annotations
 
-        // src/Acme/HelloBundle/Author.php
+        // src/Acme/HelloBundle/Entity/Author.php
+        namespace Acme\HelloBundle\Entity;
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
         {
-            /* ... */
-
             /**
              * @Assert\Valid
              */
             protected $address;
         }
 
+    .. code-block:: xml
+
+        <!-- src/Acme/HelloBundle/Resources/config/validation.xml -->
+        <class name="Acme\HelloBundle\Entity\Author">
+            <property name="address">
+                <constraint name="Valid" />
+            </property>
+        </class>
+
     .. code-block:: php
 
-        // src/Acme/HelloBundle/Author.php
+        // src/Acme/HelloBundle/Entity/Author.php
+        namespace Acme\HelloBundle\Entity;
+
         use Symfony\Component\Validator\Mapping\ClassMetadata;
-        use Symfony\Component\Validator\Constraints\Valid;
+        use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
         {
@@ -219,7 +220,7 @@ property.
 
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
-                $metadata->addPropertyConstraint('address', new Valid());
+                $metadata->addPropertyConstraint('address', new Assert\Valid());
             }
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

I planned to do a config block reorder PR, but before that, I just want to know what you think about this. This PR reordered the configuration blocks in the constraints reference and fixes some other issues with the examples.

If you think it is good to recheck the order of all configuration blocks in the docs, we should think of the best order. In general, it will be `yaml, [annotations,] xml, php`, but in the big bundles, you see that xml is used a lot for service configuration, we should maybe have a `xml, yaml, php` order there.

> PS: I don't start with the next PR about this topic soon, let's document important features first! :blue_book:
