### PR TITLE
[WIP] Add missing formats

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -62,16 +62,44 @@ information. By convention, this information is usually configured in an
     The parameters defined in that file are referenced by the main configuration
     file when setting up Doctrine:
 
-    .. code-block:: yaml
+    .. configuration-block::
 
-        # app/config/config.yml
-        doctrine:
-            dbal:
-                driver:   "%database_driver%"
-                host:     "%database_host%"
-                dbname:   "%database_name%"
-                user:     "%database_user%"
-                password: "%database_password%"
+        .. code-block:: yaml
+
+            # app/config/config.yml
+            doctrine:
+                dbal:
+                    driver:   "%database_driver%"
+                    host:     "%database_host%"
+                    dbname:   "%database_name%"
+                    user:     "%database_user%"
+                    password: "%database_password%"
+
+        .. code-block:: xml
+
+            <!-- app/config/config.xml -->
+            <doctrine:config>
+                <doctrine:dbal
+                    driver="%database_driver%"
+                    host="%database_host%"
+                    dbname="%database_name%"
+                    user="%database_user%"
+                    password="%database_password%"
+                >
+            </doctrine:config>
+
+        .. code-block:: php
+        
+            // app/config/config.php
+            $configuration->loadFromExtension('doctrine', array(
+                'dbal' => array(
+                    'driver'   => '%database_driver%',
+                    'host'     => '%database_host%',
+                    'dbname'   => '%database_name%',
+                    'user'     => '%database_user%',
+                    'password' => '%database_password%',
+                ),
+            ));
 
     By separating the database information into a separate file, you can
     easily keep different versions of the file on each server. You can also
@@ -909,6 +937,24 @@ To relate the ``Category`` and ``Product`` entities, start by creating a
                     mappedBy: category
             # don't forget to init the collection in entity __construct() method
 
+    .. code-block:: xml
+
+        <!-- src/Acme/StoreBundle/Resources/config/doctrine/Category.orm.xml -->
+        <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+            <entity name="Acme\StoreBundle\Entity\Category">
+                <!-- ... -->
+                <one-to-many field="products"
+                    target-entity="product"
+                    mapped-by="category"
+                />
+
+                <!-- don't forget to init the collection in entity __construct() method -->
+            </entity>
+        </doctrine-mapping>
 
 First, since a ``Category`` object will relate to many ``Product`` objects,
 a ``products`` array property is added to hold those ``Product`` objects.
@@ -965,6 +1011,28 @@ object, you'll want to add a ``$category`` property to the ``Product`` class:
                     joinColumn:
                         name: category_id
                         referencedColumnName: id
+
+    .. code-block:: xml
+
+        <!-- src/Acme/StoreBundle/Resources/config/doctrine/Product.orm.xml -->
+        <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+            <entity name="Acme\StoreBundle\Entity\Product">
+                <!-- ... -->
+                <many-to-one field="category"
+                    target-entity="products"
+                    join-column="category"
+                >
+                    <join-column
+                        name="category_id"
+                        referenced-column-name="id"
+                    />
+                </many-to-one>
+            </entity>
+        </doctrine-mapping>
 
 Finally, now that you've added a new property to both the ``Category`` and
 ``Product`` classes, tell Doctrine to generate the missing getter and setter
@@ -1386,6 +1454,21 @@ and ``nullable``. Take a few examples:
                 column: email_address
                 length: 150
                 unique: true
+
+    .. code-block:: xml
+
+        <!--
+            A string field length 255 that cannot be null
+            (reflecting the default values for the "length" and *nullable* options)
+            type attribute is necessary in yaml definitions
+        -->
+        <field name="name" type="string" />
+        <field name="email"
+            type="string"
+            column="email_address"
+            length="150"
+            unique="true"
+        />
 
 .. note::
 

--- a/cookbook/configuration/apache_router.rst
+++ b/cookbook/configuration/apache_router.rst
@@ -13,12 +13,33 @@ Change Router Configuration Parameters
 To dump Apache routes you must first tweak some configuration parameters to tell
 Symfony2 to use the ``ApacheUrlMatcher`` instead of the default one:
 
-.. code-block:: yaml
+.. configuration-block::
 
-    # app/config/config_prod.yml
-    parameters:
-        router.options.matcher.cache_class: ~ # disable router cache
-        router.options.matcher_class: Symfony\Component\Routing\Matcher\ApacheUrlMatcher
+    .. code-block:: yaml
+
+        # app/config/config_prod.yml
+        parameters:
+            router.options.matcher.cache_class: ~ # disable router cache
+            router.options.matcher_class: Symfony\Component\Routing\Matcher\ApacheUrlMatcher
+
+    .. code-block:: xml
+
+        <!-- app/config/config_prod.xml -->
+        <parameters>
+            <parameter key="router.options.matcher.cache_class">null</parameter> <!-- disable router cache -->
+            <parameter key="router.options.matcher_class">
+                Symfony\Component\Routing\Matcher\ApacheUrlMatcher
+            </parameter>
+        </parameters>
+
+    .. code-block:: php
+
+        // app/config/config_prod.php
+        $container->setParameter('router.options.matcher.cache_class', null); // disable router cache
+        $container->setParameter(
+            'router.options.matcher_class',
+            'Symfony\Component\Routing\Matcher\ApacheUrlMatcher'
+        );
 
 .. tip::
 
@@ -33,13 +54,28 @@ Generating mod_rewrite rules
 
 To test that it's working, let's create a very basic route for demo bundle:
 
-.. code-block:: yaml
+.. configuration-block::
 
-    # app/config/routing.yml
-    hello:
-        pattern:  /hello/{name}
-        defaults: { _controller: AcmeDemoBundle:Demo:hello }
+    .. code-block:: yaml
 
+        # app/config/routing.yml
+        hello:
+            pattern:  /hello/{name}
+            defaults: { _controller: AcmeDemoBundle:Demo:hello }
+
+    .. code-block:: xml
+
+        <!-- app/config/routing.xml -->
+        <route id="hello" pattern="/hello/{name}">
+            <default key="_controller">AcmeDemoBundle:Demo:hello</default>
+        </route>
+
+    .. code-block:: php
+
+        // app/config/routing.php
+        $collection->add('hello', new Route('/hello/{name}', array(
+            '_controller' => 'AcmeDemoBundle:Demo:hello',
+        )));
 
 Now generate **url_rewrite** rules:
 

--- a/cookbook/configuration/external_parameters.rst
+++ b/cookbook/configuration/external_parameters.rst
@@ -117,11 +117,19 @@ key, and define the type as ``constant``.
     This only works for XML configuration. If you're *not* using XML, simply
     import an XML file to take advantage of this functionality:
 
-    .. code-block:: yaml
+    .. configuration-block::
 
-        # app/config/config.yml
-        imports:
-            - { resource: parameters.xml }
+        .. code-block:: yaml
+
+            # app/config/config.yml
+            imports:
+                - { resource: parameters.xml }
+
+        .. code-block:: php
+
+            // app/config/config.php
+            $loader->import('parameters.xml');
+
 
 Miscellaneous Configuration
 ---------------------------

--- a/cookbook/configuration/override_dir_structure.rst
+++ b/cookbook/configuration/override_dir_structure.rst
@@ -117,7 +117,7 @@ may need to modify the paths inside these files::
             <!-- app/config/config.xml -->
 
             <!-- ... -->
-            <assetic:config read_from="%kernel.root_dir%/../../public_html" />
+            <assetic:config read-from="%kernel.root_dir%/../../public_html" />
 
         .. code-block:: php
 

--- a/cookbook/configuration/override_dir_structure.rst
+++ b/cookbook/configuration/override_dir_structure.rst
@@ -101,14 +101,33 @@ may need to modify the paths inside these files::
     If you use the AsseticBundle you need to configure this, so it can use
     the correct ``web`` directory:
 
-    .. code-block:: yaml
+    .. configuration-block::
 
-        # app/config/config.yml
+        .. code-block:: yaml
 
-        # ...
-        assetic:
+            # app/config/config.yml
+
             # ...
-            read_from: "%kernel.root_dir%/../../public_html"
+            assetic:
+                # ...
+                read_from: "%kernel.root_dir%/../../public_html"
+
+        .. code-block:: xml
+
+            <!-- app/config/config.xml -->
+
+            <!-- ... -->
+            <assetic:config read_from="%kernel.root_dir%/../../public_html" />
+
+        .. code-block:: php
+
+            // app/config/config.php
+
+            // ...
+            $container->loadFromExtension('assetic', array(
+                // ...
+                'read_from' => '%kernel.root_dir%/../../public_html',
+            ));
 
     Now you just need to dump the assets again and your application should
     work:

--- a/cookbook/doctrine/dbal.rst
+++ b/cookbook/doctrine/dbal.rst
@@ -38,7 +38,7 @@ To get started, configure the database connection parameters:
 
     .. code-block:: xml
 
-        // app/config/config.xml
+        <!-- app/config/config.xml -->
         <doctrine:config>
             <doctrine:dbal
                 name="default"
@@ -64,9 +64,7 @@ To get started, configure the database connection parameters:
 For full DBAL configuration options, see :ref:`reference-dbal-configuration`.
 
 You can then access the Doctrine DBAL connection by accessing the
-``database_connection`` service:
-
-.. code-block:: php
+``database_connection`` service::
 
     class UserController extends Controller
     {

--- a/cookbook/doctrine/event_listeners_subscribers.rst
+++ b/cookbook/doctrine/event_listeners_subscribers.rst
@@ -77,6 +77,44 @@ managers that use this connection.
             </services>
         </container>
 
+    .. code-block:: php
+
+        use Symfony\Component\DependencyInjection\Definition;
+
+        $container->loadFromExtension('doctrine', array(
+            'dbal' => array(
+                'default_connection' => 'default',
+                'connections' => array(
+                    'default' => array(
+                        'driver' => 'pdo_sqlite',
+                        'memory' => true,
+                    ),
+                ),
+            ),
+        ));
+
+        $container
+            ->setDefinition(
+                'my.listener',
+                new Definition('Acme\SearchBundle\EventListener\SearchIndexer')
+            )
+            ->addTag('doctrine.event_listener', array('event' => 'postPersist'))
+        ;
+        $container
+            ->setDefinition(
+                'my.listener2',
+                new Definition('Acme\SearchBundle\EventListener\SearchIndexer2')
+            )
+            ->addTag('doctrine.event_listener', array('event' => 'postPersist', 'connection' => 'default'))
+        ;
+        $container
+            ->setDefinition(
+                'my.subscriber',
+                new Definition('Acme\SearchBundle\EventListener\SearchIndexerSubscriber')
+            )
+            ->addTag('doctrine.event_subscriber', array('connection' => 'default'))
+        ;
+
 Creating the Listener Class
 ---------------------------
 
@@ -99,7 +137,7 @@ a ``postPersist`` method, which will be called when the event is thrown::
 
             // perhaps you only want to act on some "Product" entity
             if ($entity instanceof Product) {
-                // do something with the Product
+                // ... do something with the Product
             }
         }
     }

--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -22,7 +22,7 @@ will be covered in this cookbook entry.
 Basic Setup
 -----------
 
-First, create a simple Doctrine Entity class to work with::
+First, create a simple ``Doctrine`` Entity class to work with::
 
     // src/Acme/DemoBundle/Entity/Document.php
     namespace Acme\DemoBundle\Entity;
@@ -118,20 +118,68 @@ look like this::
     }
 
 Next, create this property on your ``Document`` class and add some validation
-rules::
+rules:
 
-    // src/Acme/DemoBundle/Entity/Document.php
+.. configuration-block::
 
-    // ...
-    class Document
-    {
-        /**
-         * @Assert\File(maxSize="6000000")
-         */
-        public $file;
+    .. code-block:: yaml
+
+        # src/Acme/DemoBundle/Resources/config/validation.yml
+        Acme\DemoBundle\Entity\Document:
+            properties:
+                file:
+                    - File:
+                        maxSize: 6000000
+
+    .. code-block:: php-annotations
+
+        // src/Acme/DemoBundle/Entity/Document.php
+        namespace Acme\DemoBundle\Entity;
 
         // ...
-    }
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Document
+        {
+            /**
+             * @Assert\File(maxSize="6000000")
+             */
+            public $file;
+
+            // ...
+        }
+
+    .. code-block:: xml
+
+        <!-- src/Acme/DemoBundle/Resources/config/validation.yml -->
+        <class name="Acme\DemoBundle\Entity\Document">
+            <property name="file">
+                <constraint name="File">
+                    <option name="maxSize">6000000</option>
+                </constraint>
+            </property>
+        </class>
+
+    .. code-block:: php
+
+        // src/Acme/DemoBundle/Entity/Document.php
+        namespace Acme\DemoBundle\Entity;
+
+        // ...
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Document
+        {
+            // ...
+            
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('file', new Assert\File(array(
+                    'maxSize' => 6000000,
+                )));
+            }
+        }
 
 .. note::
 
@@ -141,6 +189,7 @@ rules::
 
 The following controller shows you how to handle the entire process::
 
+    // ...
     use Acme\DemoBundle\Entity\Document;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
     // ...
@@ -176,15 +225,27 @@ The following controller shows you how to handle the entire process::
 
     When writing the template, don't forget to set the ``enctype`` attribute:
 
-    .. code-block:: html+jinja
+    .. configuration-block::
 
-        <h1>Upload File</h1>
+        .. code-block:: html+jinja
 
-        <form action="#" method="post" {{ form_enctype(form) }}>
-            {{ form_widget(form) }}
+            <h1>Upload File</h1>
 
-            <input type="submit" value="Upload Document" />
-        </form>
+            <form action="#" method="post" {{ form_enctype(form) }}>
+                {{ form_widget(form) }}
+
+                <input type="submit" value="Upload Document" />
+            </form>
+
+        .. code-block:: html+php
+
+            <h1>Upload File</h1>
+
+            <form action="#" method="post" <?php echo $view['form']->enctype($form) ?>>
+                <?php echo $view['form']->widget($form) ?>
+
+                <input type="submit" value="Upload Document" />
+            </form>
 
 The previous controller will automatically persist the ``Document`` entity
 with the submitted name, but it will do nothing about the file and the ``path``

--- a/cookbook/doctrine/multiple_entity_managers.rst
+++ b/cookbook/doctrine/multiple_entity_managers.rst
@@ -56,6 +56,99 @@ The following configuration code shows how you can configure two entity managers
                         mappings:
                             AcmeCustomerBundle: ~
 
+    .. code-block:: xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <srv:container xmlns="http://symfony.com/schema/dic/doctrine"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:srv="http://symfony.com/schema/dic/services"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                                http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+            <config>
+                <dbal default-connection="default">
+                    <connection name="default"
+                        driver="%database_driver%"
+                        host="%database_host%"
+                        port="%database_port%"
+                        dbname="%database_name%"
+                        user="%database_user%"
+                        password="%database_password%"
+                        charset="UTF8"
+                    />
+
+                    <connection name="customer"
+                        driver="%database_driver2%"
+                        host="%database_host2%"
+                        port="%database_port2%"
+                        dbname="%database_name2%"
+                        user="%database_user2%"
+                        password="%database_password2%"
+                        charset="UTF8"
+                    />
+                </dbal>
+
+                <orm default-entity-manager="default">
+                    <entity-manager name="default" connection="default">
+                        <mapping name="AcmeDemoBundle" />
+                        <mapping name="AcmeStoreBundle" />
+                    </entity-manager>
+
+                    <entity-manager name="customer" connection="customer">
+                        <mapping name="AcmeCustomerBundle" />
+                    </entity-manager>
+                </orm>
+            </config>
+        </srv:container>
+
+    .. code-block:: php
+
+        $container->loadFromExtension('doctrine', array(
+            'dbal' => array(
+                'default_connection' => 'default',
+                'connections' => array(
+                    'default' => array(
+                        'driver'   => '%database_driver%',
+                        'host'     => '%database_host%',
+                        'port'     => '%database_port%',
+                        'dbname'   => '%database_name%',
+                        'user'     => '%database_user%',
+                        'password' => '%database_password%',
+                        'charset'  => 'UTF8',
+                    ),
+                    'customer' => array(
+                        'driver'   => '%database_driver2%',
+                        'host'     => '%database_host2%',
+                        'port'     => '%database_port2%',
+                        'dbname'   => '%database_name2%',
+                        'user'     => '%database_user2%',
+                        'password' => '%database_password2%',
+                        'charset'  => 'UTF8',
+                    ),
+                ),
+            ),
+
+            'orm' => array(
+                'default_entity_manager' => 'default',
+                'entity_managers' => array(
+                    'default' => array(
+                        'connection' => 'default',
+                        'mappings'   => array(
+                            'AcmeDemoBundle'  => null,
+                            'AcmeStoreBundle' => null,
+                        ),
+                    ),
+                    'customer' => array(
+                        'connection' => 'customer',
+                        'mappings'   => array(
+                            'AcmeCustomerBundle' => null,
+                        ),
+                    ),
+                ),
+            ),
+        ));
+
 In this case, you've defined two entity managers and called them ``default``
 and ``customer``. The ``default`` entity manager manages entities in the
 ``AcmeDemoBundle`` and ``AcmeStoreBundle``, while the ``customer`` entity

--- a/cookbook/form/create_custom_field_type.rst
+++ b/cookbook/form/create_custom_field_type.rst
@@ -131,7 +131,7 @@ you want to always render it in a ``ul`` element. In your form theme template
 
         <!-- src/Acme/DemoBundle/Resources/views/Form/gender_widget.html.twig -->
         <?php if ($expanded) : ?>
-            <ul <?php $view['slots']->output('widget_container_attributes') ?>>
+            <ul <?php $view['form']->block($form, 'widget_container_attributes') ?>>
             <?php foreach ($form as $child) : ?>
                 <li>
                     <?php echo $view['form']->widget($child) ?>

--- a/cookbook/form/create_form_type_extension.rst
+++ b/cookbook/form/create_form_type_extension.rst
@@ -112,14 +112,19 @@ tag:
 
     .. code-block:: xml
 
-        <service id="acme_demo_bundle.image_type_extension" class="Acme\DemoBundle\Form\Extension\ImageTypeExtension">
+        <service id="acme_demo_bundle.image_type_extension"
+            class="Acme\DemoBundle\Form\Extension\ImageTypeExtension"
+        >
             <tag name="form.type_extension" alias="file" />
         </service>
 
     .. code-block:: php
 
         $container
-            ->register('acme_demo_bundle.image_type_extension', 'Acme\DemoBundle\Form\Extension\ImageTypeExtension')
+            ->register(
+                'acme_demo_bundle.image_type_extension',
+                'Acme\DemoBundle\Form\Extension\ImageTypeExtension'
+            )
             ->addTag('form.type_extension', array('alias' => 'file'));
 
 The ``alias`` key of the tag is the type of field that this extension should
@@ -219,8 +224,8 @@ it in the view::
         /**
          * Store the image_path option as a builder attribute
          *
-         * @param \Symfony\Component\Form\FormBuilder $builder
-         * @param array $options
+         * @param FormBuilder $builder
+         * @param array       $options
          */
         public function buildForm(FormBuilder $builder, array $options)
         {
@@ -232,8 +237,8 @@ it in the view::
         /**
          * Pass the image url to the view
          *
-         * @param \Symfony\Component\Form\FormView $view
-         * @param \Symfony\Component\Form\FormInterface $form
+         * @param FormView      $view
+         * @param FormInterface $form
          */
         public function buildView(FormView $view, FormInterface $form)
         {

--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -293,7 +293,7 @@ it's recognized as a custom field type:
 
         $container
             ->setDefinition('acme_demo.type.issue_selector', array(
-                '@doctrine.orm.entity_manager'
+                new Reference('doctrine.orm.entity_manager'),
             ))
             ->addTag('form.type', array(
                 'alias' => 'issue_selector',

--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -65,7 +65,9 @@ for converting to and from the issue number and the Issue object::
          * Transforms a string (number) to an object (issue).
          *
          * @param  string $number
+         *
          * @return Issue|null
+         *
          * @throws TransformationFailedException if object (issue) is not found.
          */
         public function reverseTransform($number)
@@ -287,6 +289,17 @@ it's recognized as a custom field type:
             <tag name="form.type" alias="issue_selector" />
         </service>
 
+    .. code-block:: php
+
+        $container
+            ->setDefinition('acme_demo.type.issue_selector', array(
+                '@doctrine.orm.entity_manager'
+            ))
+            ->addTag('form.type', array(
+                'alias' => 'issue_selector',
+            ))
+        ;
+
 Now, whenever you need to use your special ``issue_selector`` field type,
 it's quite easy::
 
@@ -311,4 +324,3 @@ it's quite easy::
             return 'task';
         }
     }
-

--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -39,7 +39,8 @@ from this class will look the exact same regardless if a new Product is being cr
 or if an existing product is being edited (e.g. a product fetched from the database).
 
 Suppose now, that you don't want the user to be able to change the ``name`` value
-once the object has been created. To do this, you can rely on Symfony's :doc:`Event Dispatcher </components/event_dispatcher/introduction>`
+once the object has been created. To do this, you can rely on Symfony's
+:doc:`Event Dispatcher </components/event_dispatcher/introduction>`
 system to analyze the data on the object and modify the form based on the
 Product object's data. In this entry, you'll learn how to add this level of
 flexibility to your forms.

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -471,7 +471,7 @@ into new ``Tag`` objects and added to the ``tags`` property of the ``Task`` obje
                     <!-- ... -->
                     <one-to-many field="tags" target-entity="Tag">
                         <cascade>
-                            <cascade-persists />
+                            <cascade-persist />
                         </cascade>
                     </one-to-many>
                 </entity>

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -179,7 +179,7 @@ In your controller, you'll now initialize a new instance of ``TaskType``::
             if ('POST' === $request->getMethod()) {
                 $form->bindRequest($request);
                 if ($form->isValid()) {
-                    // maybe do some form processing, like saving the Task and Tag objects
+                    // ... maybe do some form processing, like saving the Task and Tag objects
                 }
             }
 
@@ -458,6 +458,24 @@ into new ``Tag`` objects and added to the ``tags`` property of the ``Task`` obje
                     tags:
                         targetEntity: Tag
                         cascade:      [persist]
+
+        .. code-block:: xml
+
+            <!-- src/Acme/TaskBundle/Resources/config/doctrine/Task.orm.xml -->
+            <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+                <entity name="Acme\TaskBundle\Entity\Task" ...>
+                    <!-- ... -->
+                    <one-to-many field="tags" target-entity="Tag">
+                        <cascade>
+                            <cascade-persists />
+                        </cascade>
+                    </one-to-many>
+                </entity>
+            </doctrine-mapping>
 
     A second potential issue deals with the `Owning Side and Inverse Side`_
     of Doctrine relationships. In this example, if the "owning" side of the

--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -733,6 +733,7 @@ and customize the ``field_errors`` fragment.
         <?php endif ?>
 
 .. tip::
+
     See :ref:`cookbook-form-theming-methods` for how to apply this customization.
 
 You can also customize the error output for just one specific field type.
@@ -786,6 +787,7 @@ class to the ``div`` element around each row:
         </div>
 
 .. tip::
+
     See :ref:`cookbook-form-theming-methods` for how to apply this customization.
 
 Adding a "Required" Asterisk to Field Labels
@@ -840,6 +842,7 @@ original template:
     <?php endif ?>
 
 .. tip::
+
     See :ref:`cookbook-form-theming-methods` for how to apply this customization.
 
 Adding "help" messages
@@ -909,6 +912,7 @@ To render a help message below a field, pass in a ``help`` variable:
         <?php echo $view['form']->widget($form['title'], array('help' => 'foobar')) ?>
 
 .. tip::
+
     See :ref:`cookbook-form-theming-methods` for how to apply this customization.
 
 Using Form Variables

--- a/cookbook/logging/monolog.rst
+++ b/cookbook/logging/monolog.rst
@@ -59,6 +59,7 @@ allows you to log the messages in several ways easily.
 
     .. code-block:: yaml
 
+        # app/config/config.yml
         monolog:
             handlers:
                 applog:
@@ -75,8 +76,10 @@ allows you to log the messages in several ways easily.
                 syslog:
                     type: syslog
                     level: error
+
     .. code-block:: xml
 
+        <!-- app/config/config.xml -->
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:monolog="http://symfony.com/schema/dic/monolog"
@@ -109,6 +112,32 @@ allows you to log the messages in several ways easily.
             </monolog:config>
         </container>
 
+    .. code-block:: php
+        
+        // app/config/config.php
+        $container->loadFromExtension('monolog', array(
+            'handlers' => array(
+                'applog' => array(
+                    'type'  => 'stream',
+                    'path'  => '/var/log/symfony.log',
+                    'level' => 'error',
+                ),    
+                'main' => array(
+                    'type'         => 'fingers_crossed',
+                    'action_level' => 'warning',
+                    'handler'      => 'file',
+                ),    
+                'file' => array(
+                    'type'  => 'stream',
+                    'level' => 'debug',
+                ),   
+                'syslog' => array(
+                    'type'  => 'syslog',
+                    'level' => 'error',
+                ),    
+            ),
+        ));        
+
 The above configuration defines a stack of handlers which will be called
 in the order where they are defined.
 
@@ -137,6 +166,7 @@ easily. Your formatter must implement
 
     .. code-block:: yaml
 
+        # app/config/config.yml
         services:
             my_formatter:
                 class: Monolog\Formatter\JsonFormatter
@@ -149,6 +179,7 @@ easily. Your formatter must implement
 
     .. code-block:: xml
 
+        <!-- app/config/config.xml -->
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:monolog="http://symfony.com/schema/dic/monolog"
@@ -158,6 +189,7 @@ easily. Your formatter must implement
             <services>
                 <service id="my_formatter" class="Monolog\Formatter\JsonFormatter" />
             </services>
+
             <monolog:config>
                 <monolog:handler
                     name="file"
@@ -167,6 +199,22 @@ easily. Your formatter must implement
                 />
             </monolog:config>
         </container>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container
+            ->register('my_formatter', 'Monolog\Formatter\JsonFormatter');
+
+        $container->loadFromExtension('monolog', array(
+            'handlers' => array(
+                'file' => array(
+                    'type'      => 'stream',
+                    'level'     => 'debug',
+                    'formatter' => 'my_formatter',
+                ),
+            ),
+        ));
 
 Adding some extra data in the log messages
 ------------------------------------------
@@ -242,6 +290,59 @@ using a processor.
                     path: "%kernel.logs_dir%/%kernel.environment%.log"
                     level: debug
                     formatter: monolog.formatter.session_request
+
+    .. code-block:: xml
+
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:monolog="http://symfony.com/schema/dic/monolog"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                                http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+            <services>
+                <service id="monolog.formatter.session_request" class="Monolog\Formatter\LineFormatter">
+                    <argument>[%%datetime%%] [%%extra.token%%] %%channel%%.%%level_name%%: %%message%%\n</argument>
+                </service>
+
+                <service id="monolog.processor.session_request" class="Acme\MyBundle\SessionRequestProcessor">
+                    <argument type="service" id="session" />
+                    <tag name="monolog.processor" method="processRecord" />
+                </service>
+            </services>
+
+            <monolog:config>
+                <monolog:handler
+                    name="main"
+                    type="stream"
+                    path="%kernel.logs_dir%/%kernel.environment%.log"
+                    level="debug"
+                    formatter="monolog.formatter.session_request"
+                />
+            </monolog:config>
+        </container>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container
+            ->register('monolog.formatter.session_request', 'Monolog\Formatter\LineFormatter')
+            ->addArgument('[%%datetime%%] [%%extra.token%%] %%channel%%.%%level_name%%: %%message%%\n');
+
+        $container
+            ->register('monolog.processor.session_request', 'Acme\MyBundle\SessionRequestProcessor')
+            ->addArgument(new Reference('session'))
+            ->addTag('monolog.processor', array('method' => 'processRecord'));
+
+        $container->loadFromExtension('monolog', array(
+            'handlers' => array(
+                'main' => array(
+                    'type'      => 'stream',
+                    'path'      => '%kernel.logs_dir%/%kernel.environment%.log',
+                    'level'     => 'debug',
+                    'formatter' => 'monolog.formatter.session_request',
+                ),
+            ),
+        ));
 
 .. note::
 

--- a/cookbook/logging/monolog_email.rst
+++ b/cookbook/logging/monolog_email.rst
@@ -61,6 +61,31 @@ it is broken down.
                 />
             </monolog:config>
         </container>
+        
+    .. code-block:: php
+            
+        // app/config/config.php
+        $container->loadFromExtension('monolog', array(
+            'handlers' => array(
+                'mail' => array(
+                    'type'         => 'fingers_crossed',
+                    'action_level' => 'critical',
+                    'handler'      => 'buffered',
+                ),    
+                'buffered' => array(
+                    'type'    => 'buffer',
+                    'handler' => 'swift',
+                ),    
+                'swift' => array(
+                    'type'       => 'swift_mailer',
+                    'from_email' => 'error@example.com',
+                    'to_email'   => 'error@example.com',
+                    'subject'    => 'An Error Occurred!',
+                    'level'      => 'debug',
+                ),    
+            ),
+        ));    
+        
 
 The ``mail`` handler is a ``fingers_crossed`` handler which means that
 it is only triggered when the action level, in this case ``critical`` is reached.
@@ -153,6 +178,40 @@ get logged on the server as well as the emails being sent:
                 />
             </monolog:config>
         </container>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container->loadFromExtension('monolog', array(
+            'handlers' => array(
+                'main' => array(
+                    'type'         => 'fingers_crossed',
+                    'action_level' => 'critical',
+                    'handler'      => 'grouped',
+                ),    
+                'grouped' => array(
+                    'type'    => 'group',
+                    'members' => array('streamed', 'buffered'),
+                ),    
+                'streamed'  => array(
+                    'type'  => 'stream',
+                    'path'  => '%kernel.logs_dir%/%kernel.environment%.log',
+                    'level' => 'debug',
+                ),    
+                'buffered'    => array(
+                    'type'    => 'buffer',
+                    'handler' => 'swift',
+                ),    
+                'swift' => array(
+                    'type'       => 'swift_mailer',
+                    'from_email' => 'error@example.com',
+                    'to_email'   => 'error@example.com',
+                    'subject'    => 'An Error Occurred!',
+                    'level'      => 'debug',
+                ),    
+            ),
+        ));
+
 
 This uses the ``group`` handler to send the messages to the two
 group members, the ``buffered`` and the ``stream`` handlers. The messages will

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -499,10 +499,9 @@ You are finished! You can now define parts of your app as under WSSE protection.
     .. code-block:: xml
 
         <config>
-            <firewall name="wsse_secured"
-                pattern="/api/.*"
-                wsse="true"
-            />
+            <firewall name="wsse_secured" pattern="/api/.*">
+                <wsse />
+            </firewall>
         </config>
 
     .. code-block:: php

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -354,13 +354,13 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
 
         # src/Acme/DemoBundle/Resources/config/services.yml
         services:
-          wsse.security.authentication.provider:
-            class:  Acme\DemoBundle\Security\Authentication\Provider\WsseProvider
-            arguments: ['', %kernel.cache_dir%/security/nonces]
+            wsse.security.authentication.provider:
+                class:  Acme\DemoBundle\Security\Authentication\Provider\WsseProvider
+                arguments: ['', %kernel.cache_dir%/security/nonces]
 
-          wsse.security.authentication.listener:
-            class:  Acme\DemoBundle\Security\Firewall\WsseListener
-            arguments: [@security.context, @security.authentication.manager]
+            wsse.security.authentication.listener:
+                class:  Acme\DemoBundle\Security\Firewall\WsseListener
+                arguments: [@security.context, @security.authentication.manager]
 
 
     .. code-block:: xml
@@ -370,19 +370,19 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-           <services>
-               <service id="wsse.security.authentication.provider"
-                 class="Acme\DemoBundle\Security\Authentication\Provider\WsseProvider" public="false">
-                   <argument /> <!-- User Provider -->
-                   <argument>%kernel.cache_dir%/security/nonces</argument>
-               </service>
+            <services>
+                <service id="wsse.security.authentication.provider"
+                    class="Acme\DemoBundle\Security\Authentication\Provider\WsseProvider" public="false">
+                    <argument /> <!-- User Provider -->
+                    <argument>%kernel.cache_dir%/security/nonces</argument>
+                </service>
 
-               <service id="wsse.security.authentication.listener"
-                 class="Acme\DemoBundle\Security\Firewall\WsseListener" public="false">
-                   <argument type="service" id="security.context"/>
-                   <argument type="service" id="security.authentication.manager" />
-               </service>
-           </services>
+                <service id="wsse.security.authentication.listener"
+                    class="Acme\DemoBundle\Security\Firewall\WsseListener" public="false">
+                    <argument type="service" id="security.context"/>
+                    <argument type="service" id="security.authentication.manager" />
+                </service>
+            </services>
         </container>
 
     .. code-block:: php
@@ -392,17 +392,22 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
         use Symfony\Component\DependencyInjection\Reference;
 
         $container->setDefinition('wsse.security.authentication.provider',
-          new Definition(
-            'Acme\DemoBundle\Security\Authentication\Provider\WsseProvider',
-            array('', '%kernel.cache_dir%/security/nonces')
-        ));
+            new Definition(
+                'Acme\DemoBundle\Security\Authentication\Provider\WsseProvider', array(
+                    '',
+                    '%kernel.cache_dir%/security/nonces',
+                )
+            )
+        );
 
         $container->setDefinition('wsse.security.authentication.listener',
-          new Definition(
-            'Acme\DemoBundle\Security\Firewall\WsseListener', array(
-              new Reference('security.context'),
-              new Reference('security.authentication.manager'))
-        ));
+            new Definition(
+                'Acme\DemoBundle\Security\Firewall\WsseListener', array(
+                    new Reference('security.context'),
+                    new Reference('security.authentication.manager'),
+                )
+            )
+        );
 
 Now that your services are defined, tell your security context about your
 factory. Factories must be included in an individual configuration file,
@@ -434,6 +439,20 @@ factory service, tagged as ``security.listener.factory``:
                 </service>
             </services>
         </container>
+
+    .. code-block:: php
+
+        // src/Acme/DemoBundle/Resources/config/security_factories.php
+        use Symfony\Component\DependencyInjection\Definition;
+        use Symfony\Component\DependencyInjection\Reference;
+
+        $definition = new Definition('Acme\DemoBundle\DependencyInjection\Security\Factory\WsseFactory', array(
+            '',
+            '%kernel.cache_dir%/security/nonces',
+        ));
+        $definition->addTag('security.listener.factory');
+
+        $container->setDefinition('security.authentication.factory.wsse', $definition);
 
 Now, import the factory configuration via the the ``factories`` key in your
 security configuration:
@@ -467,13 +486,36 @@ security configuration:
 
 You are finished! You can now define parts of your app as under WSSE protection.
 
-.. code-block:: yaml
+.. configuration-block::
 
-    security:
-        firewalls:
-            wsse_secured:
-                pattern:   /api/.*
-                wsse:      true
+    .. code-block:: yaml
+
+        security:
+            firewalls:
+                wsse_secured:
+                    pattern:   /api/.*
+                    wsse:      true
+
+    .. code-block:: xml
+
+        <config>
+            <firewall name="wsse_secured"
+                pattern="/api/.*"
+                wsse="true"
+            />
+        </config>
+
+    .. code-block:: php
+
+        $container->loadFromExtension('security', array(
+            'firewalls' => array(
+                'wsse_secured' => array(
+                    'pattern' => '/api/.*',
+                    'wsse'    => true,
+                ),
+            ),
+        ));
+    
 
 Congratulations!  You have written your very own custom security authentication
 provider!
@@ -546,13 +588,38 @@ in order to put it to use.
 The lifetime of each wsse request is now configurable, and can be
 set to any desirable value per firewall.
 
-.. code-block:: yaml
+.. configuration-block::
 
-    security:
-        firewalls:
-            wsse_secured:
-                pattern:   /api/.*
-                wsse:      { lifetime: 30 }
+    .. code-block:: yaml
+
+        security:
+            firewalls:
+                wsse_secured:
+                    pattern:   /api/.*
+                    wsse:      { lifetime: 30 }
+
+    .. code-block:: xml
+
+        <config>
+            <firewall name="wsse_secured"
+                pattern="/api/.*"
+            >
+                <wsse lifetime="30" />
+            </firewall>
+        </config>
+
+    .. code-block:: php
+
+        $container->loadFromExtension('security', array(
+            'firewalls' => array(
+                'wsse_secured' => array(
+                    'pattern' => '/api/.*',
+                    'wsse'    => array(
+                        'lifetime' => 30,
+                    ),
+                ),
+            ),
+        ));
 
 The rest is up to you! Any relevant configuration items can be defined
 in the factory and consumed or passed to the other classes in the container.

--- a/cookbook/security/custom_provider.rst
+++ b/cookbook/security/custom_provider.rst
@@ -206,26 +206,66 @@ Now you make the user provider available as a service:
 Modify ``security.yml``
 -----------------------
 
-In ``/app/config/security.yml`` everything comes together. Add the user provider
+Everything comes together in your security configuration. Add the user provider
 to the list of providers in the "security" section. Choose a name for the user provider
 (e.g. "webservice") and mention the id of the service you just defined.
 
-.. code-block:: yaml
+.. configuration-block::
 
-    security:
-        providers:
-            webservice:
-                id: webservice_user_provider
+    .. code-block:: yaml
+
+        // app/config/security.yml
+        security:
+            providers:
+                webservice:
+                    id: webservice_user_provider
+
+    .. code-block:: xml
+
+        <!-- app/config/security.xml -->
+        <config>
+            <provider name="webservice" id="webservice_user_provider" />
+        </config>
+
+    .. code-block:: php
+
+        // app/config/security.php
+        $container->loadFromExtension('security', array(
+            'providers' => array(
+                'webservice' => array(
+                    'id' => 'webservice_user_provider',
+                ),
+            ),
+        ));
 
 Symfony also needs to know how to encode passwords that are supplied by website
 users, e.g. by filling in a login form. You can do this by adding a line to the
-"encoders" section in ``/app/config/security.yml``.
+"encoders" section in your security configuration:
 
-.. code-block:: yaml
+.. configuration-block::
 
-    security:
-        encoders:
-            Acme\WebserviceUserBundle\Security\User\WebserviceUser: sha512
+    .. code-block:: yaml
+
+        # app/config/security.yml
+        security:
+            encoders:
+                Acme\WebserviceUserBundle\Security\User\WebserviceUser: sha512
+
+    .. code-block:: xml
+
+        <!-- app/config/security.xml -->
+        <config>
+            <encoder class="Acme\WebserviceUserBundle\Security\User\WebserviceUser">sha512</encoder>
+        </config>
+
+    .. code-block:: php
+
+        // app/config/security.php
+        $container->loadFromExtension('security', array(
+            'encoders' => array(
+                'Acme\WebserviceUserBundle\Security\User\WebserviceUser' => 'sha512',
+            ),
+        ));
 
 The value here should correspond with however the passwords were originally
 encoded when creating your users (however those users were created). When
@@ -252,15 +292,42 @@ options, the password may be encoded multiple times and encoded to base64.
 
     Additionally, the hash, by default, is encoded multiple times and encoded
     to base64. For specific details, see `MessageDigestPasswordEncoder`_.
-    To prevent this, configure it in ``security.yml``:
+    To prevent this, configure it in your configuration file:
 
-    .. code-block:: yaml
+    .. configuration-block::
 
-        security:
-            encoders:
-                Acme\WebserviceUserBundle\Security\User\WebserviceUser:
-                    algorithm: sha512
-                    encode_as_base64: false
-                    iterations: 1
+        .. code-block:: yaml
+
+            # app/config/security.yml
+            security:
+                encoders:
+                    Acme\WebserviceUserBundle\Security\User\WebserviceUser:
+                        algorithm: sha512
+                        encode_as_base64: false
+                        iterations: 1
+
+        .. code-block:: xml
+
+            <!-- app/config/security.xml -->
+            <config>
+                <encoder class="Acme\WebserviceUserBundle\Security\User\WebserviceUser"
+                    algorithm="sha512"
+                    encode-as-base64="false"
+                    iterations="1"
+                />
+            </config>
+
+        .. code-block:: php
+
+            // app/config/security.php
+            $container->loadFromExtension('security', array(
+                'encoders' => array(
+                    'Acme\WebserviceUserBundle\Security\User\WebserviceUser' => array(
+                        'algorithm'         => 'sha512',
+                        'encode_as_base64'  => false,
+                        'iterations'        => 1,
+                    ),
+                ),
+            ));
 
 .. _MessageDigestPasswordEncoder: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php

--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -251,6 +251,65 @@ then be checked against your User entity records in the database:
             access_control:
                 - { path: ^/admin, roles: ROLE_ADMIN }
 
+    .. code-block:: xml
+
+        <!-- app/config/security.xml -->
+        <config>
+            <encoder class="Acme\UserBundle\Entity\User"
+                algorithm="sha1"
+                encode-as-base64="false"
+                iterations="1"
+            />
+
+            <role id="ROLE_ADMIN">ROLE_USER</role>
+            <role id="ROLE_SUPER_ADMIN">ROLE_USER, ROLE_ADMIN, ROLE_ALLOWED_TO_SWITCH</role>
+
+            <provider name="administrators">
+                <entity class="AcmeUserBundle:User" property="username" />
+            </provider>
+
+            <firewall name="admin_area"
+                pattern="^/admin"
+                http_basic
+            />
+
+            <rule path="^/admin" role="ROLE_ADMIN" />
+        </config>
+
+    .. code-block:: php
+
+        // app/config/security.php
+        $container->loadFromExtension('security', array(
+            'encoders' => array(
+                'Acme\UserBundle\Entity\User' => array(
+                    'algorithm'         => 'sha1',
+                    'encode_as_base64'  => false,
+                    'iterations'        => 1,
+                ),
+            ),
+            'role_hierarchy' => array(
+                'ROLE_ADMIN'       => 'ROLE_USER',
+                'ROLE_SUPER_ADMIN' => array('ROLE_USER', 'ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'),
+            ),
+            'providers' => array(
+                'administrator' => array(
+                    'entity' => array(
+                        'class'    => 'AcmeUserBundle:User',
+                        'property' => 'username',
+                    ),
+                ),
+            ),
+            'firewalls' => array(
+                'admin_area' => array(
+                    'pattern' => '^/admin',
+                    'http_basic' => null,
+                ),
+            ),
+            'access_control' => array(
+                array('path' => '^/admin', 'role' => 'ROLE_ADMIN'),
+            ),
+        ));
+
 The ``encoders`` section associates the ``sha1`` password encoder to the entity
 class. This means that Symfony will expect the password that's stored in
 the database to be encoded using this algorithm. For details on how to create
@@ -416,6 +475,34 @@ of the ``security.yml`` file.
                 administrators:
                     entity: { class: AcmeUserBundle:User }
             # ...
+    
+    .. code-block:: xml
+
+        <!-- app/config/security.xml -->
+        <config>
+            <!-- ... -->
+
+            <provider name="administrator">
+                <entity class="AcmeUserBundle:User" />
+            </provider>
+
+            <!-- ... -->
+        </config>
+
+    .. code-block:: php
+
+        // app/config/security.php
+        $container->loadFromExtension('security', array(
+            ...,
+            'providers' => array(
+                'administrator' => array(
+                    'entity' => array(
+                        'class' => 'AcmeUserBundle:User',
+                    ),
+                ),
+            ),
+            ...,
+        ));
 
 By doing this, the security layer will use an instance of ``UserRepository`` and
 call its ``loadUserByUsername()`` method to fetch a user from the database

--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -268,10 +268,9 @@ then be checked against your User entity records in the database:
                 <entity class="AcmeUserBundle:User" property="username" />
             </provider>
 
-            <firewall name="admin_area"
-                pattern="^/admin"
-                http_basic
-            />
+            <firewall name="admin_area" pattern="^/admin">
+                <http-basic />
+            </firewall>
 
             <rule path="^/admin" role="ROLE_ADMIN" />
         </config>

--- a/cookbook/security/voters.rst
+++ b/cookbook/security/voters.rst
@@ -179,8 +179,26 @@ application configuration file with the following code.
         # app/config/security.yml
         security:
             access_decision_manager:
-                # Strategy can be: affirmative, unanimous or consensus
+                # strategy can be: affirmative, unanimous or consensus
                 strategy: unanimous
+
+    .. code-block:: xml
+
+        <!-- app/config/security.xml -->
+        <config>
+            <!-- strategy can be: affirmative, unanimous or consensus -->
+            <access-decision-manager strategy="unanimous">
+        </config>
+
+    .. code-block:: php
+
+        // app/config/security.xml
+        $container->loadFromExtension('security', array(
+            // strategy can be: affirmative, unanimous or consensus
+            'access_decision_manager' => array(
+                'strategy' => 'unanimous',
+            ),
+        ));
 
 That's it! Now, when deciding whether or not a user should have access,
 the new voter will deny access to any user in the list of blacklisted IPs.

--- a/cookbook/symfony1.rst
+++ b/cookbook/symfony1.rst
@@ -267,11 +267,35 @@ configuration inside a bundle must be included manually. For example, to
 include a routing resource from a bundle called ``AcmeDemoBundle``, you can
 do the following:
 
-.. code-block:: yaml
+.. configuration-block::
 
-    # app/config/routing.yml
-    _hello:
-        resource: "@AcmeDemoBundle/Resources/config/routing.yml"
+    .. code-block:: yaml
+
+        # app/config/routing.yml
+        _hello:
+            resource: "@AcmeDemoBundle/Resources/config/routing.yml"
+
+    .. code-block:: xml
+
+        <!-- app/config/routing.yml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+
+        <routes xmlns="http://symfony.com/schema/routing"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+            <import resource="@AcmeDemoBundle/Resources/config/routing.xml" />
+        </routes>
+
+    .. code-block:: php
+
+        // app/config/routing.php
+        use Symfony\Component\Routing\RouteCollection;
+
+        $collection = new RouteCollection();
+        $collection->addCollection($loader->import("@AcmeHelloBundle/Resources/config/routing.php"));
+
+        return $collection;
 
 This will load the routes found in the ``Resources/config/routing.yml`` file
 of the ``AcmeDemoBundle``. The special ``@AcmeDemoBundle`` is a shortcut syntax
@@ -279,11 +303,25 @@ that, internally, resolves to the full path to that bundle.
 
 You can use this same strategy to bring in configuration from a bundle:
 
-.. code-block:: yaml
+.. configuration-block::
 
-    # app/config/config.yml
-    imports:
-        - { resource: "@AcmeDemoBundle/Resources/config/config.yml" }
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        imports:
+            - { resource: "@AcmeDemoBundle/Resources/config/config.yml" }
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+        <imports>
+            <import resource="@AcmeDemoBundle/Resources/config/config.xml" />
+        </imports>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $this->import('@AcmeDemoBundle/Resources/config/config.php')
 
 In Symfony2, configuration is a bit like ``app.yml`` in symfony1, except much
 more systematic. With ``app.yml``, you could simply create any keys you wanted.
@@ -300,10 +338,22 @@ used them in your application:
 In Symfony2, you can also create arbitrary entries under the ``parameters``
 key of your configuration:
 
-.. code-block:: yaml
+.. configuration-block::
 
-    parameters:
-        email.from_address: foo.bar@example.com
+    .. code-block:: yaml
+
+        parameters:
+            email.from_address: foo.bar@example.com
+
+    .. code-block:: xml
+
+        <parameters>
+            <parameter key="email.from_address">foo.bar@example.com</parameter>
+        </parameters>
+
+    .. code-block:: php
+
+        $container->setParameter('email.from_address', 'foo.bar@example.com');
 
 You can now access this from a controller, for example::
 

--- a/cookbook/templating/global_variables.rst
+++ b/cookbook/templating/global_variables.rst
@@ -29,7 +29,7 @@ This is possible inside your ``app/config/config.yml`` file:
 
         // app/config/config.php
         $container->loadFromExtension('twig', array(
-             ...,
+             // ...
              'globals' => array(
                  'ga_tracking' => 'UA-xxxxx-x',
              ),
@@ -37,15 +37,9 @@ This is possible inside your ``app/config/config.yml`` file:
 
 Now, the variable ``ga_tracking`` is available in all Twig templates:
 
-.. configuration-block::
+.. code-block:: html+jinja
 
-    .. code-block:: html+jinja
-
-        <p>The google tracking code is: {{ ga_tracking }}</p>
-
-    .. code-block:: html+php
-
-        <p>The google tracking code is: <?php echo $ga_tracking; ?></p>
+    <p>The google tracking code is: {{ ga_tracking }}</p>
 
 It's that easy! You can also take advantage of the built-in :ref:`book-service-container-parameters`
 system, which lets you isolate or reuse the value:

--- a/cookbook/templating/global_variables.rst
+++ b/cookbook/templating/global_variables.rst
@@ -7,19 +7,45 @@ How to Inject Variables into all Templates (i.e. Global Variables)
 Sometimes you want a variable to be accessible to all the templates you use.
 This is possible inside your ``app/config/config.yml`` file:
 
-.. code-block:: yaml
+.. configuration-block::
 
-    # app/config/config.yml
-    twig:
-        # ...
-        globals:
-            ga_tracking: UA-xxxxx-x
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        twig:
+            # ...
+            globals:
+                ga_tracking: UA-xxxxx-x
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+        <twig:config ...>
+            <!-- ... -->
+            <twig:global key="ga_tracking">UA-xxxxx-x</twig:global>
+        </twig:config>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container->loadFromExtension('twig', array(
+             ...,
+             'globals' => array(
+                 'ga_tracking' => 'UA-xxxxx-x',
+             ),
+        ));
 
 Now, the variable ``ga_tracking`` is available in all Twig templates:
 
-.. code-block:: html+jinja
+.. configuration-block::
 
-    <p>The google tracking code is: {{ ga_tracking }} </p>
+    .. code-block:: html+jinja
+
+        <p>The google tracking code is: {{ ga_tracking }}</p>
+
+    .. code-block:: html+php
+
+        <p>The google tracking code is: <?php echo $ga_tracking; ?></p>
 
 It's that easy! You can also take advantage of the built-in :ref:`book-service-container-parameters`
 system, which lets you isolate or reuse the value:
@@ -30,12 +56,30 @@ system, which lets you isolate or reuse the value:
     [parameters]
         ga_tracking: UA-xxxxx-x
 
-.. code-block:: yaml
+.. configuration-block::
 
-    # app/config/config.yml
-    twig:
-        globals:
-            ga_tracking: "%ga_tracking%"
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        twig:
+            globals:
+                ga_tracking: "%ga_tracking%"
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+        <twig:config ...>
+            <twig:global key="ga_tracking">%ga_tracking%</twig:global>
+        </twig:config>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container->loadFromExtension('twig', array(
+             'globals' => array(
+                 'ga_tracking' => '%ga_tracking%',
+             ),
+        ));
 
 The same variable is available exactly as before.
 

--- a/cookbook/testing/http_authentication.rst
+++ b/cookbook/testing/http_authentication.rst
@@ -39,9 +39,9 @@ key in your firewall, along with the ``form_login`` key:
 
         <!-- app/config/config_test.xml -->
         <security:config>
-            <firewall name="your_firewall_name">
-              <http-basic />
-           </firewall>
+            <security:firewall name="your_firewall_name">
+              <security:http-basic />
+           </security:firewall>
         </security:config>
 
     .. code-block:: php
@@ -50,7 +50,7 @@ key in your firewall, along with the ``form_login`` key:
         $container->loadFromExtension('security', array(
             'firewalls' => array(
                 'your_firewall_name' => array(
-                    'http-basic' => array(),
+                    'http_basic' => array(),
                 ),
             ),
         ));

--- a/cookbook/testing/http_authentication.rst
+++ b/cookbook/testing/http_authentication.rst
@@ -34,3 +34,23 @@ key in your firewall, along with the ``form_login`` key:
             firewalls:
                 your_firewall_name:
                     http_basic:
+
+    .. code-block:: xml
+
+        <!-- app/config/config_test.xml -->
+        <security:config>
+            <firewall name="your_firewall_name">
+              <http-basic />
+           </firewall>
+        </security:config>
+
+    .. code-block:: php
+
+        // app/config/config_test.php
+        $container->loadFromExtension('security', array(
+            'firewalls' => array(
+                'your_firewall_name' => array(
+                    'http-basic' => array(),
+                ),
+            ),
+        ));

--- a/cookbook/web_services/php_soap_extension.rst
+++ b/cookbook/web_services/php_soap_extension.rst
@@ -68,10 +68,18 @@ a ``HelloService`` object properly:
 
         <!-- app/config/config.xml -->
         <services>
-         <service id="hello_service" class="Acme\SoapBundle\Services\HelloService">
-          <argument type="service" id="mailer"/>
-         </service>
+            <service id="hello_service" class="Acme\SoapBundle\Services\HelloService">
+                <argument type="service" id="mailer"/>
+            </service>
         </services>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container
+            ->register('hello_service', 'Acme\SoapBundle\Services\HelloService')
+            ->addArgument(new Reference('mailer'));
+
 
 Below is an example of a controller that is capable of handling a SOAP
 request. If ``indexAction()`` is accessible via the route ``/soap``, then the
@@ -125,53 +133,61 @@ An example WSDL is below.
 .. code-block:: xml
 
     <?xml version="1.0" encoding="ISO-8859-1"?>
-     <definitions xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
-         xmlns:tns="urn:arnleadservicewsdl"
-         xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
-         xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-         xmlns="http://schemas.xmlsoap.org/wsdl/"
-         targetNamespace="urn:helloservicewsdl">
-      <types>
-       <xsd:schema targetNamespace="urn:hellowsdl">
-        <xsd:import namespace="http://schemas.xmlsoap.org/soap/encoding/" />
-        <xsd:import namespace="http://schemas.xmlsoap.org/wsdl/" />
-       </xsd:schema>
-      </types>
-      <message name="helloRequest">
-       <part name="name" type="xsd:string" />
-      </message>
-      <message name="helloResponse">
-       <part name="return" type="xsd:string" />
-      </message>
-      <portType name="hellowsdlPortType">
-       <operation name="hello">
-        <documentation>Hello World</documentation>
-        <input message="tns:helloRequest"/>
-        <output message="tns:helloResponse"/>
-       </operation>
-      </portType>
-      <binding name="hellowsdlBinding" type="tns:hellowsdlPortType">
-      <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
-      <operation name="hello">
-       <soap:operation soapAction="urn:arnleadservicewsdl#hello" style="rpc"/>
-       <input>
-        <soap:body use="encoded" namespace="urn:hellowsdl"
-            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-       </input>
-       <output>
-        <soap:body use="encoded" namespace="urn:hellowsdl"
-            encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
-       </output>
-      </operation>
-     </binding>
-     <service name="hellowsdl">
-      <port name="hellowsdlPort" binding="tns:hellowsdlBinding">
-       <soap:address location="http://example.com/app.php/soap" />
-      </port>
-     </service>
+    <definitions xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+        xmlns:tns="urn:arnleadservicewsdl"
+        xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+        xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+        xmlns="http://schemas.xmlsoap.org/wsdl/"
+        targetNamespace="urn:helloservicewsdl">
+
+        <types>
+            <xsd:schema targetNamespace="urn:hellowsdl">
+                <xsd:import namespace="http://schemas.xmlsoap.org/soap/encoding/" />
+                <xsd:import namespace="http://schemas.xmlsoap.org/wsdl/" />
+            </xsd:schema>
+        </types>
+
+        <message name="helloRequest">
+            <part name="name" type="xsd:string" />
+        </message>
+
+        <message name="helloResponse">
+            <part name="return" type="xsd:string" />
+        </message>
+
+        <portType name="hellowsdlPortType">
+            <operation name="hello">
+                <documentation>Hello World</documentation>
+                <input message="tns:helloRequest"/>
+                <output message="tns:helloResponse"/>
+            </operation>
+        </portType>
+
+        <binding name="hellowsdlBinding" type="tns:hellowsdlPortType">
+            <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+            <operation name="hello">
+                <soap:operation soapAction="urn:arnleadservicewsdl#hello" style="rpc"/>
+                
+                <input>
+                    <soap:body use="encoded" namespace="urn:hellowsdl"
+                        encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                </input>
+
+                <output>
+                    <soap:body use="encoded" namespace="urn:hellowsdl"
+                        encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+                </output>
+            </operation>
+        </binding>
+
+        <service name="hellowsdl">
+            <port name="hellowsdlPort" binding="tns:hellowsdlBinding">
+                <soap:address location="http://example.com/app.php/soap" />
+            </port>
+        </service>
     </definitions>
 
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #2042 |

Thanks to the great work of @ricardclau, we have almost documented each format where we can in the documentation.

We just need to do the `cookbook/doctrine` chapters and we are ready for merging.
### Questions

While working on this, we had a discussion about the security configuration in xml. In `book/security`, we use this:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<srv:container ...>
    <config>
```

But in the reference, we use this:

``` xml
<security:config>
```

I think we use `config` because we put this in `config.xml` and we use `security:config` because we use it in the `config.xml` file? Can some developer explain the difference between these?
### Todo
- [x] Add formats in `cookbook/doctrine`
- [x] Add formats in `book/doctrine`
- [x] Recheck all formats
### Merge instructions

You should pay attention to the routing example (in `cookbook/configuration/apache_router.rst`). The `pattern` option should be changed to `path` while mering into `2.2`/`master`.
