### PR TITLE
Fixed the serializer initialization for 2.0

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -42,7 +42,7 @@ which Encoders and Normalizer are going to be available::
     use Symfony\Component\Serializer\Encoder\JsonEncoder;
     use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 
-    $encoders = array(new XmlEncoder(), new JsonEncoder());
+    $encoders = array('xml' => new XmlEncoder(), 'json' => new JsonEncoder());
     $normalizers = array(new GetSetMethodNormalizer());
 
     $serializer = new Serializer($normalizers, $encoders);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.0 only |
| Fixed tickets | symfony/symfony#7145 |

Symfony 2.0 was using an associative array to associate encoders to formats. So the code was wrong.

This change should then be reverted when merging into the 2.1 branch as 2.1 does not bother about the key. The format support is handled by each encoder (which allows splitting the encoder and the decoder into 2 different classes for the same format for instance, or to use the same encoder for several formats)
