### PR TITLE
Added reference to the option 'empty_data' on the collection form type

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -22,6 +22,7 @@ forms, which is useful when creating forms that expose one-to-many relationships
 | Inherited   | - `label`_                                                                  |
 | options     | - `error_bubbling`_                                                         |
 |             | - `by_reference`_                                                           |
+|             | - `empty_data`_                                                             |
 +-------------+-----------------------------------------------------------------------------+
 | Parent type | :doc:`form</reference/forms/types/form>`                                    |
 +-------------+-----------------------------------------------------------------------------+
@@ -331,3 +332,5 @@ error_bubbling
 .. _reference-form-types-by-reference:
 
 .. include:: /reference/forms/types/options/by_reference.rst.inc
+
+.. include:: /reference/forms/types/options/empty_data.rst.inc


### PR DESCRIPTION
Didn't see this option on the reference page, though I had a feeling there had to be some way to customize the way newly added entities are created.
