### PR TITLE
[2.2] Updating some URLs from 2.1/master to 2.2

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -1603,7 +1603,7 @@ Learn more from the Cookbook
 
 .. _`Symfony2 Form Component`: https://github.com/symfony/Form
 .. _`DateTime`: http://php.net/manual/en/class.datetime.php
-.. _`Twig Bridge`: https://github.com/symfony/symfony/tree/master/src/Symfony/Bridge/Twig
-.. _`form_div_layout.html.twig`: https://github.com/symfony/symfony/blob/2.1/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+.. _`Twig Bridge`: https://github.com/symfony/symfony/tree/2.2/src/Symfony/Bridge/Twig
+.. _`form_div_layout.html.twig`: https://github.com/symfony/symfony/blob/2.2/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
 .. _`Cross-site request forgery`: http://en.wikipedia.org/wiki/Cross-site_request_forgery
-.. _`view on GitHub`: https://github.com/symfony/symfony/tree/master/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form
+.. _`view on GitHub`: https://github.com/symfony/symfony/tree/2.2/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form

--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -433,7 +433,7 @@ content:
 
     {
         "require": {
-            "symfony/symfony": "2.1.*"
+            "symfony/symfony": "2.2.*"
         },
         "autoload": {
             "files": ["model.php","controllers.php"]

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -57,12 +57,12 @@ Distribution:
 
 .. code-block:: bash
 
-    php composer.phar create-project symfony/framework-standard-edition /path/to/webroot/Symfony dev-master
+    php composer.phar create-project symfony/framework-standard-edition /path/to/webroot/Symfony 2.2.0
 
 .. tip::
 
-    For an exact version, replace `dev-master` with the latest Symfony version
-    (e.g. 2.1.1). For details, see the `Symfony Installation Page`_
+    For an exact version, replace `2.2.0` with the latest Symfony version
+    (e.g. 2.2.1). For details, see the `Symfony Installation Page`_
 
 .. tip::
 
@@ -110,10 +110,10 @@ one of the following commands (replacing ``###`` with your actual filename):
 .. code-block:: bash
 
     # for .tgz file
-    $ tar zxvf Symfony_Standard_Vendors_2.1.###.tgz
+    $ tar zxvf Symfony_Standard_Vendors_2.2.###.tgz
 
     # for a .zip file
-    $ unzip Symfony_Standard_Vendors_2.1.###.zip
+    $ unzip Symfony_Standard_Vendors_2.2.###.zip
 
 If you've downloaded "without vendors", you'll definitely need to read the
 next section.

--- a/components/using_components.rst
+++ b/components/using_components.rst
@@ -24,7 +24,7 @@ Using the Finder Component
 
     {
         "require": {
-            "symfony/finder": "2.1.*"
+            "symfony/finder": "2.2.*"
         }
     }
 
@@ -69,9 +69,9 @@ immediately::
 
             {
                 "require": {
-                    "symfony/finder": "2.1.*",
-                    "symfony/dom-crawler": "2.1.*",
-                    "symfony/css-selector": "2.1.*"
+                    "symfony/finder": "2.2.*",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/css-selector": "2.2.*"
                 }
             }
 
@@ -81,7 +81,7 @@ immediately::
 
             {
                 "require": {
-                    "symfony/symfony": "2.1.*"
+                    "symfony/symfony": "2.2.*"
                 }
             }
 

--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -965,4 +965,4 @@ customizations directly. Look at the following example:
 The array passed as the second argument contains form "variables". For
 more details about this concept in Twig, see :ref:`twig-reference-form-variables`.
 
-.. _`form_div_layout.html.twig`: https://github.com/symfony/symfony/blob/2.1/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+.. _`form_div_layout.html.twig`: https://github.com/symfony/symfony/blob/2.2/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -76,12 +76,12 @@ have a ``Symfony/`` directory that looks like this:
 
     .. code-block:: bash
 
-        $ composer.phar create-project symfony/framework-standard-edition path/to/install dev-master
+        $ composer.phar create-project symfony/framework-standard-edition path/to/install 2.2.0
 
         # remove the Git history
         $ rm -rf .git
     
-    For an exact version, replace `dev-master` with the latest Symfony version
+    For an exact version, replace `2.2.0` with the latest Symfony version
     (e.g. 2.1.1). For details, see the `Symfony Installation Page`_
 
 .. tip::

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -808,6 +808,6 @@ For an example, see the ``EntityInitializer`` class inside the Doctrine Bridge.
 
 .. _`Twig's documentation`: http://twig.sensiolabs.org/doc/advanced.html#creating-an-extension
 .. _`Twig official extension repository`: https://github.com/fabpot/Twig-extensions
-.. _`KernelEvents`: https://github.com/symfony/symfony/blob/2.1/src/Symfony/Component/HttpKernel/KernelEvents.php
+.. _`KernelEvents`: https://github.com/symfony/symfony/blob/2.2/src/Symfony/Component/HttpKernel/KernelEvents.php
 .. _`SwiftMailer's Plugin Documentation`: http://swiftmailer.org/docs/plugins.html
 .. _`Twig Loader`: http://twig.sensiolabs.org/doc/api.html#loaders


### PR DESCRIPTION
Hi guys!

On a few places, we mention the specific current version for one reason or another. This replaces old 2.1 or master references with "2.2".

After merge, I'll also update a few of the "2.1" references on the master branch to say "master". The idea is that master is always master, and when we create new release branches, we change master to whatever the current version is in these places.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | no |

Thanks!
