### PR TITLE
[2.2] add explicit profiler enabling, necessary on 2.2

### DIFF
--- a/cookbook/email/testing.rst
+++ b/cookbook/email/testing.rst
@@ -41,6 +41,10 @@ to get information about the messages send on the previous request::
         public function testMailIsSentAndContentIsOk()
         {
             $client = static::createClient();
+
+            // Enable the profiler for the next request (it does nothing if the profiler is not available)
+            $client->enableProfiler();
+
             $crawler = $client->request('POST', '/path/to/above/action');
 
             $mailCollector = $client->getProfile()->getCollector('swiftmailer');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | None |

In Symfony 2.2 you have to explicitly enable profiler in functional testing to inspect collected data.

This is covered in http://symfony.com/doc/current/cookbook/testing/profiling.html but I thought it would be better to have it documented also in this cookbook
