### PR TITLE
Improved example for passing data to form_label

### DIFF
--- a/reference/forms/twig_reference.rst
+++ b/reference/forms/twig_reference.rst
@@ -37,8 +37,8 @@ label you want to display as the second argument.
     {{ form_label(form.name) }}
 
     {# The two following syntaxes are equivalent #}
-    {{ form_label(form.name, 'Your Name', { 'attr': {'class': 'foo'} }) }}
-    {{ form_label(form.name, null, { 'label': 'Your name', 'attr': {'class': 'foo'} }) }}
+    {{ form_label(form.name, 'Your Name', { 'label_attr': {'class': 'foo'} }) }}
+    {{ form_label(form.name, null, { 'label': 'Your name', 'label_attr': {'class': 'foo'} }) }}
 
 See ":ref:`twig-reference-form-variables`" to learn about the ``variables``
 argument.


### PR DESCRIPTION
Since, if passing a css class to form_label, 
the user usually wants to specify a class for the label, I changed 
'attr': {'class': 'foo'}
to
'label_attr': {'class': 'foo'}

Hopefully giving a more comfortable experience, when trying it first.
