### PR TITLE
[Reference] [Form types] Link to the non-deprecated form parent type

### DIFF
--- a/reference/forms/types/checkbox.rst
+++ b/reference/forms/types/checkbox.rst
@@ -19,7 +19,7 @@ if the box is unchecked, the value will be set to false.
 |             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
 +-------------+------------------------------------------------------------------------+
-| Parent type | :doc:`field</reference/forms/types/field>`                             |
+| Parent type | :doc:`form</reference/forms/types/form>`                               |
 +-------------+------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CheckboxType` |
 +-------------+------------------------------------------------------------------------+
@@ -48,7 +48,7 @@ not affect the value that's set on your object.
 Inherited options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -28,7 +28,7 @@ option.
 |             | - `disabled`_                                                               |
 |             | - `error_bubbling`_                                                         |
 +-------------+-----------------------------------------------------------------------------+
-| Parent type | :doc:`form</reference/forms/types/form>` (if expanded), ``field`` otherwise |
+| Parent type | :doc:`form</reference/forms/types/form>`                                    |
 +-------------+-----------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\ChoiceType`        |
 +-------------+-----------------------------------------------------------------------------+
@@ -111,7 +111,7 @@ can be created to supply the choices.
 Inherited options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/country.rst
+++ b/reference/forms/types/country.rst
@@ -52,7 +52,7 @@ These options inherit from the :doc:`choice</reference/forms/types/choice>` type
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -118,7 +118,7 @@ Alternatively, you can specify a string to be displayed for the "blank" value::
 Inherited options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -102,7 +102,7 @@ for more details.
 Inherited options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 

--- a/reference/forms/types/email.rst
+++ b/reference/forms/types/email.rst
@@ -18,7 +18,7 @@ The ``email`` field is a text field that is rendered using the HTML5
 |             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
 +-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`field</reference/forms/types/field>`                          |
+| Parent type | :doc:`form</reference/forms/types/form>`                            |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\EmailType` |
 +-------------+---------------------------------------------------------------------+
@@ -26,7 +26,7 @@ The ``email`` field is a text field that is rendered using the HTML5
 Inherited Options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/max_length.rst.inc
 

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -96,7 +96,7 @@ group_by
 
 **type**: ``string``
 
-This is a property path (e.g. ``author.name``) used to organize the 
+This is a property path (e.g. ``author.name``) used to organize the
 available choices in groups. It only works when rendered as a select tag
 and does so by adding optgroup tags around options. Choices that do not
 return a value for this property path are rendered directly under the
@@ -134,7 +134,7 @@ These options inherit from the :doc:`choice</reference/forms/types/choice>` type
 
 .. include:: /reference/forms/types/options/empty_value.rst.inc
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -82,7 +82,7 @@ how to manage a file upload associated with a Doctrine entity.
 Inherited options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/hidden.rst
+++ b/reference/forms/types/hidden.rst
@@ -12,7 +12,7 @@ The hidden type represents a hidden input field.
 | Inherited   | - ``data``                                                           |
 | options     | - ``property_path``                                                  |
 +-------------+----------------------------------------------------------------------+
-| Parent type | :doc:`field</reference/forms/types/field>`                           |
+| Parent type | :doc:`form</reference/forms/types/form>`                             |
 +-------------+----------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\HiddenType` |
 +-------------+----------------------------------------------------------------------+
@@ -20,7 +20,7 @@ The hidden type represents a hidden input field.
 Inherited Options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/data.rst.inc
 

--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -26,7 +26,7 @@ integers. By default, all non-integer values (e.g. 6.78) will round down (e.g. 6
 |             | - `invalid_message`_                                                  |
 |             | - `invalid_message_parameters`_                                       |
 +-------------+-----------------------------------------------------------------------+
-| Parent type | :doc:`field</reference/forms/types/field>`                            |
+| Parent type | :doc:`form</reference/forms/types/form>`                              |
 +-------------+-----------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\IntegerType` |
 +-------------+-----------------------------------------------------------------------+
@@ -49,7 +49,7 @@ on the :class:`Symfony\\Component\\Form\\Extension\\Core\\DataTransformer\\Integ
 *   ``IntegerToLocalizedStringTransformer::ROUND_FLOOR`` Rounding mode to
     round towards negative infinity.
 
-*   ``IntegerToLocalizedStringTransformer::ROUND_UP`` Rounding mode to round 
+*   ``IntegerToLocalizedStringTransformer::ROUND_UP`` Rounding mode to round
     away from zero.
 
 *   ``IntegerToLocalizedStringTransformer::ROUND_CEILING`` Rounding mode
@@ -60,7 +60,7 @@ on the :class:`Symfony\\Component\\Form\\Extension\\Core\\DataTransformer\\Integ
 Inherited options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -53,7 +53,7 @@ These options inherit from the :doc:`choice</reference/forms/types/choice>` type
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -54,7 +54,7 @@ These options inherit from the :doc:`choice</reference/forms/types/choice>` type
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/map.rst.inc
+++ b/reference/forms/types/map.rst.inc
@@ -52,5 +52,5 @@ Hidden Fields
 Base Fields
 ~~~~~~~~~~~
 
-* :doc:`field</reference/forms/types/field>`
+* :doc:`form</reference/forms/types/form>`
 * :doc:`form</reference/forms/types/form>`

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -27,7 +27,7 @@ how the input and output of the data is handled.
 |             | - `invalid_message`_                                                |
 |             | - `invalid_message_parameters`_                                     |
 +-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`field</reference/forms/types/field>`                          |
+| Parent type | :doc:`form</reference/forms/types/form>`                            |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\MoneyType` |
 +-------------+---------------------------------------------------------------------+
@@ -44,7 +44,7 @@ Specifies the currency that the money is being specified in. This determines
 the currency symbol that should be shown by the text box. Depending on
 the currency - the currency symbol may be shown before or after the input
 text field.
-    
+
 This can also be set to false to hide the currency symbol.
 
 divisor
@@ -80,7 +80,7 @@ to ``0``).
 Inherited Options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/number.rst
+++ b/reference/forms/types/number.rst
@@ -23,7 +23,7 @@ you want to use for your number.
 |             | - `invalid_message`_                                                 |
 |             | - `invalid_message_parameters`_                                      |
 +-------------+----------------------------------------------------------------------+
-| Parent type | :doc:`field</reference/forms/types/field>`                           |
+| Parent type | :doc:`form</reference/forms/types/form>`                             |
 +-------------+----------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\NumberType` |
 +-------------+----------------------------------------------------------------------+
@@ -49,14 +49,14 @@ rounding_mode
 If a submitted number needs to be rounded (based on the ``precision``
 option), you have several configurable options for that rounding. Each
 option is a constant on the :class:`Symfony\\Component\\Form\\Extension\\Core\\DataTransformer\\IntegerToLocalizedStringTransformer`:
-    
+
 *   ``IntegerToLocalizedStringTransformer::ROUND_DOWN`` Rounding mode to
     round towards zero.
 
 *   ``IntegerToLocalizedStringTransformer::ROUND_FLOOR`` Rounding mode to
     round towards negative infinity.
 
-*   ``IntegerToLocalizedStringTransformer::ROUND_UP`` Rounding mode to round 
+*   ``IntegerToLocalizedStringTransformer::ROUND_UP`` Rounding mode to round
     away from zero.
 
 *   ``IntegerToLocalizedStringTransformer::ROUND_CEILING`` Rounding mode
@@ -79,7 +79,7 @@ option is a constant on the :class:`Symfony\\Component\\Form\\Extension\\Core\\D
 Inherited Options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -42,7 +42,7 @@ Put simply, if for some reason you want to render your password field
 Inherited Options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/max_length.rst.inc
 

--- a/reference/forms/types/percent.rst
+++ b/reference/forms/types/percent.rst
@@ -26,7 +26,7 @@ This field adds a percentage sign "``%``" after the input box.
 |             | - `invalid_message`_                                                  |
 |             | - `invalid_message_parameters`_                                       |
 +-------------+-----------------------------------------------------------------------+
-| Parent type | :doc:`field</reference/forms/types/field>`                            |
+| Parent type | :doc:`form</reference/forms/types/form>`                              |
 +-------------+-----------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\PercentType` |
 +-------------+-----------------------------------------------------------------------+
@@ -42,7 +42,7 @@ type
 This controls how your data is stored on your object. For example, a percentage
 corresponding to "55%", might be stored as ``.55`` or ``55`` on your
 object. The two "types" handle these two cases:
-    
+
 *   ``fractional``
     If your data is stored as a decimal (e.g. ``.55``), use this type.
     The data will be multiplied by ``100`` before being shown to the
@@ -65,7 +65,7 @@ places, use this option.
 Inherited Options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -23,7 +23,7 @@ If you want to have a Boolean field, use :doc:`checkbox</reference/forms/types/c
 |             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
 +-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`field</reference/forms/types/field>`                          |
+| Parent type | :doc:`form</reference/forms/types/form>`                            |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType` |
 +-------------+---------------------------------------------------------------------+
@@ -42,7 +42,7 @@ not affect the value that's set on your object.
 Inherited Options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/repeated.rst
+++ b/reference/forms/types/repeated.rst
@@ -171,7 +171,7 @@ The same as ``first_name``, but for the second field.
 Inherited options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 

--- a/reference/forms/types/search.rst
+++ b/reference/forms/types/search.rst
@@ -28,7 +28,7 @@ Read about the input search field at `DiveIntoHTML5.info`_
 Inherited Options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/max_length.rst.inc
 

--- a/reference/forms/types/text.rst
+++ b/reference/forms/types/text.rst
@@ -17,7 +17,7 @@ The text field represents the most basic input text field.
 |             | - `disabled`_                                                      |
 |             | - `error_bubbling`_                                                |
 +-------------+--------------------------------------------------------------------+
-| Parent type | :doc:`field</reference/forms/types/field>`                         |
+| Parent type | :doc:`form</reference/forms/types/form>`                           |
 +-------------+--------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TextType` |
 +-------------+--------------------------------------------------------------------+
@@ -26,7 +26,7 @@ The text field represents the most basic input text field.
 Inherited Options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/max_length.rst.inc
 

--- a/reference/forms/types/textarea.rst
+++ b/reference/forms/types/textarea.rst
@@ -4,7 +4,7 @@
 textarea Field Type
 ===================
 
-Renders a ``textarea`` HTML element. 
+Renders a ``textarea`` HTML element.
 
 +-------------+------------------------------------------------------------------------+
 | Rendered as | ``textarea`` tag                                                       |
@@ -17,7 +17,7 @@ Renders a ``textarea`` HTML element.
 |             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
 +-------------+------------------------------------------------------------------------+
-| Parent type | :doc:`field</reference/forms/types/field>`                             |
+| Parent type | :doc:`form</reference/forms/types/form>`                               |
 +-------------+------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TextareaType` |
 +-------------+------------------------------------------------------------------------+
@@ -25,7 +25,7 @@ Renders a ``textarea`` HTML element.
 Inherited Options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/max_length.rst.inc
 

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -29,7 +29,7 @@ as a ``DateTime`` object, a string, a timestamp or an array.
 |                      | - `read_only`_                                                              |
 |                      | - `disabled`_                                                               |
 +----------------------+-----------------------------------------------------------------------------+
-| Parent type          | form                                                                        |
+| Parent type          | :doc:`form</reference/forms/types/form>`                                    |
 +----------------------+-----------------------------------------------------------------------------+
 | Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TimeType`          |
 +----------------------+-----------------------------------------------------------------------------+
@@ -113,7 +113,7 @@ this format.
 Inherited options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 

--- a/reference/forms/types/timezone.rst
+++ b/reference/forms/types/timezone.rst
@@ -46,7 +46,7 @@ These options inherit from the :doc:`choice</reference/forms/types/choice>` type
 
 .. include:: /reference/forms/types/options/empty_value.rst.inc
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/url.rst
+++ b/reference/forms/types/url.rst
@@ -41,7 +41,7 @@ the data is bound to the form.
 Inherited Options
 -----------------
 
-These options inherit from the :doc:`field</reference/forms/types/field>` type:
+These options inherit from the :doc:`form</reference/forms/types/form>` type:
 
 .. include:: /reference/forms/types/options/max_length.rst.inc
 


### PR DESCRIPTION
I changed all the links to the deprecated (since Symfony 2.1) `field` form type to the `form` type.

This way, there's no need to click a second time to get the documentation of the parent form type, and we are ready for the Symfony 2.3 documentation which probably remove the `field` documentation entry.

A few trailing spaces have been accidentally removed as well, but I guess that's alright not to make a second PR just for a few white spaces.
