### PR TITLE
Update default exception_controller in TwigBundle Configuration Reference

### DIFF
--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -9,7 +9,7 @@ TwigBundle Configuration Reference
     .. code-block:: yaml
 
         twig:
-            exception_controller:  Symfony\Bundle\TwigBundle\Controller\ExceptionController::showAction
+            exception_controller:  twig.controller.exception:showAction
             form:
                 resources:
 
@@ -86,7 +86,7 @@ Configuration
 exception_controller
 ....................
 
-**type**: ``string`` **default**: ``Symfony\\Bundle\\TwigBundle\\Controller\\ExceptionController::showAction``
+**type**: ``string`` **default**: ``twig.controller.exception:showAction``
 
 This is the controller that is activated after an exception is thrown anywhere
 in your application. The default controller


### PR DESCRIPTION
The default exception_controller value changed from `twig.controller.exception:showAction` to `Symfony\\Bundle\\TwigBundle\\Controller\\ExceptionController::showAction` in 2.2.

See commit https://github.com/symfony/symfony/commit/35d63df044cba20cdf441963ca85a7f4d51200cc.
