### PR TITLE
Updated link to correct twig docs

### DIFF
--- a/cookbook/templating/twig_extension.rst
+++ b/cookbook/templating/twig_extension.rst
@@ -118,6 +118,6 @@ Learning further
 For a more in-depth look into Twig Extensions, please take a look at the `Twig extensions documentation`_.
 
 .. _`Twig official extension repository`: https://github.com/fabpot/Twig-extensions
-.. _`Twig extensions documentation`: http://twig.sensiolabs.org/doc/advanced.html#creating-an-extension
+.. _`Twig extensions documentation`: http://twig.sensiolabs.org/doc/advanced_legacy.html#creating-an-extension
 .. _`global variables`: http://twig.sensiolabs.org/doc/advanced.html#id1
 .. _`functions`: http://twig.sensiolabs.org/doc/advanced.html#id2


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.1- |
| Fixed tickets | - |

Creating extensions had a big change in Twig 1.12. That means they completely rewritten that chapter. We should update the docs to link to the correct article (Sf2.1- should get a link to the old article, while 2.2+ should use the current article).

**Please note that this should not be merged in 2.2, as that comes with Twig 1.12**
