### PR TITLE
Fix DomCrawler html dumping example.

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -190,7 +190,7 @@ and :phpclass:`DOMNode` objects:
         $html = '';
 
         foreach ($crawler as $domElement) {
-            $html.= $domElement->ownerDocument->saveHTML();
+            $html.= $domElement->ownerDocument->saveHTML($domElement);
         }
 
 Form and Link support

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -190,7 +190,7 @@ and :phpclass:`DOMNode` objects:
         $html = '';
 
         foreach ($crawler as $domElement) {
-            $html.= $domElement->ownerDocument->saveHTML($domElement);
+            $html .= $domElement->ownerDocument->saveHTML($domElement);
         }
 
 Form and Link support


### PR DESCRIPTION
Current example collects HTML of the whole documents instead of required nodes.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.0+ |
| Fixed tickets | - |
