### PR TITLE
Fixed plural version of URLs where it was referred to as "URL's"

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -476,7 +476,7 @@ Take a quick look at the routes that have been created so far:
         return $collection;
 
 Can you spot the problem? Notice that both routes have patterns that match
-URL's that look like ``/blog/*``. The Symfony router will always choose the
+URLs that look like ``/blog/*``. The Symfony router will always choose the
 **first** matching route it finds. In other words, the ``blog_show`` route
 will *never* be matched. Instead, a URL like ``/blog/my-blog-post`` will match
 the first route (``blog``) and return a nonsense value of ``my-blog-post``

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -162,16 +162,16 @@ assets_base_urls
 
 **default**: ``{ http: [], ssl: [] }``
 
-This option allows you to define base URL's to be used for assets referenced
+This option allows you to define base URLs to be used for assets referenced
 from ``http`` and ``ssl`` (``https``) pages. A string value may be provided in
-lieu of a single-element array. If multiple base URL's are provided, Symfony2
+lieu of a single-element array. If multiple base URLs are provided, Symfony2
 will select one from the collection each time it generates an asset's path.
 
 For your convenience, ``assets_base_urls`` can be set directly with a string or
 array of strings, which will be automatically organized into collections of base
-URL's for ``http`` and ``https`` requests. If a URL starts with ``https://`` or
+URLs for ``http`` and ``https`` requests. If a URL starts with ``https://`` or
 is `protocol-relative`_ (i.e. starts with `//`) it will be added to both
-collections. URL's starting with ``http://`` will only be added to the
+collections. URLs starting with ``http://`` will only be added to the
 ``http`` collection.
 
 .. _ref-framework-assets-version:


### PR DESCRIPTION
A simple fix to a couple of typos in the documentation. It's my first time sending a pull request to a github repo so I hope I've done it right. If all ok there are lots more typos/grammar bits I can update.

| Q | A |
| --- | --- |
| Doc fix? | yes ? (Fixes typos, not sure if this is the meaning of "Doc fix") |
| New docs? | no |
| Applies to | all |
| Fixed tickets | none |
