### PR TITLE
Fix cache invalidate signature method on ApiCache.

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -1017,10 +1017,10 @@ Here is how you can configure the Symfony2 reverse proxy to support the
 
     class AppCache extends HttpCache
     {
-        protected function invalidate(Request $request)
+        protected function invalidate(Request $request, $catch = false)
         {
             if ('PURGE' !== $request->getMethod()) {
-                return parent::invalidate($request);
+                return parent::invalidate($request, $catch);
             }
 
             $response = new Response();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | n/a |

Look at HttpKernel\HttpCache::invalidate signature:

https://github.com/symfony/HttpKernel/blob/2.0/HttpCache/HttpCache.php#L243
https://github.com/symfony/HttpKernel/blob/2.1/HttpCache/HttpCache.php#L256
https://github.com/symfony/HttpKernel/blob/2.2/HttpCache/HttpCache.php#L259
https://github.com/symfony/HttpKernel/blob/master/HttpCache/HttpCache.php#L259
