### PR TITLE
Cleaned up typos in chapter comparing Sf2 and sf1

### DIFF
--- a/cookbook/symfony1.rst
+++ b/cookbook/symfony1.rst
@@ -20,7 +20,7 @@ So, sit back and relax as you travel from "then" to "now".
 Directory Structure
 -------------------
 
-When looking at a Symfony2 project - for example, the `Symfony2 Standard`_ -
+When looking at a Symfony2 project - for example, the `Symfony2 Standard Edition`_ -
 you'll notice a very different directory structure than in symfony1. The
 differences, however, are somewhat superficial.
 
@@ -133,13 +133,13 @@ example::
     }
 
 The file itself lives at
-``vendor/bundle/Sensio/Bundle/FrameworkExtraBundle/SensioFrameworkExtraBundle.php``.
+``vendor/bundles/Sensio/Bundle/FrameworkExtraBundle/SensioFrameworkExtraBundle.php``.
 As you can see, the location of the file follows the namespace of the class.
 Specifically, the namespace, ``Sensio\Bundle\FrameworkExtraBundle``, spells out
 the directory that the file should live in
-(``vendor/bundle/Sensio/Bundle/FrameworkExtraBundle``). This is because, in the
+(``vendor/bundles/Sensio/Bundle/FrameworkExtraBundle``). This is because, in the
 ``app/autoload.php`` file, you'll configure Symfony to look for the ``Sensio``
-namespace in the ``vendor/bundle`` directory:
+namespace in the ``vendor/bundles`` directory:
 
 .. code-block:: php
 

--- a/cookbook/symfony1.rst
+++ b/cookbook/symfony1.rst
@@ -367,4 +367,4 @@ In reality, the Symfony2 configuration is much more powerful and is used
 primarily to configure objects that you can use. For more information, see
 the chapter titled ":doc:`/book/service_container`".
 
-.. _`Symfony2 Standard`: https://github.com/symfony/symfony-standard
+.. _`Symfony2 Standard Edition`: https://github.com/symfony/symfony-standard


### PR DESCRIPTION
Fixed name of Symfony Standard Edition and bundle/bundles typos.

Note: however in 2.1.x onwards vendor/bundles is not used any more (and default app/autoload.php doesn't look like this), so might be better to rewrite the autoloader section completely with an Acme example - or explain the new vendor autoloader.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.0 |
| Fixed tickets | N/A |
