### PR TITLE
Reordered two code blocks so that YML appears before XML

### DIFF
--- a/cookbook/request/mime_type.rst
+++ b/cookbook/request/mime_type.rst
@@ -43,10 +43,19 @@ project::
 Registering your Listener
 -------------------------
 
-As for any other listener, you need to add it in one of your configuration
-file and register it as a listener by adding the ``kernel.event_listener`` tag:
+As with any other listener, you need to add it in one of your configuration
+files and register it as a listener by adding the ``kernel.event_listener`` tag:
 
 .. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        services:
+            acme.demobundle.listener.request:
+                class: Acme\DemoBundle\RequestListener
+                tags:
+                    - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
     .. code-block:: xml
 
@@ -62,15 +71,6 @@ file and register it as a listener by adding the ``kernel.event_listener`` tag:
             </service>
             </services>
         </container>
-
-    .. code-block:: yaml
-
-        # app/config/config.yml
-        services:
-            acme.demobundle.listener.request:
-                class: Acme\DemoBundle\RequestListener
-                tags:
-                    - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
     .. code-block:: php
 

--- a/cookbook/templating/twig_extension.rst
+++ b/cookbook/templating/twig_extension.rst
@@ -56,18 +56,9 @@ As an example you'll create a price filter to format a given number into price::
 Register an Extension as a Service
 ----------------------------------
 
-Now you must let Service Container know about your newly created Twig Extension:
+Now you must let the Service Container know about your newly created Twig Extension:
 
 .. configuration-block::
-
-    .. code-block:: xml
-
-        <!-- src/Acme/DemoBundle/Resources/config/services.xml -->
-        <services>
-            <service id="acme.twig.acme_extension" class="Acme\DemoBundle\Twig\AcmeExtension">
-                <tag name="twig.extension" />
-            </service>
-        </services>
 
     .. code-block:: yaml
 
@@ -77,6 +68,15 @@ Now you must let Service Container know about your newly created Twig Extension:
                 class: Acme\DemoBundle\Twig\AcmeExtension
                 tags:
                     - { name: twig.extension }
+
+    .. code-block:: xml
+
+        <!-- src/Acme/DemoBundle/Resources/config/services.xml -->
+        <services>
+            <service id="acme.twig.acme_extension" class="Acme\DemoBundle\Twig\AcmeExtension">
+                <tag name="twig.extension" />
+            </service>
+        </services>
 
     .. code-block:: php
 


### PR DESCRIPTION
This matches the style used everywhere else in the docs except for translations (where XLIFF is the recommended format so it makes sense for XML to come first). This is particularly noticable when reading the PDF versions of the docs since only the first code block is rendered in the PDF.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.0+ |
| Fixed tickets | N/A |
