### PR TITLE
[Cookbook] [Routing] Custom route loader

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -102,7 +102,7 @@ a controller object. Controllers are also called *actions*.
     {
         public function indexAction($name)
         {
-          return new Response('<html><body>Hello '.$name.'!</body></html>');
+            return new Response('<html><body>Hello '.$name.'!</body></html>');
         }
     }
 
@@ -687,7 +687,7 @@ the ``notice`` message:
             </div>
         {% endif %}
 
-    .. code-block:: php
+    .. code-block:: html+php
 
         <?php if ($view['session']->hasFlash('notice')): ?>
             <div class="flash-notice">

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -50,11 +50,11 @@ information. By convention, this information is usually configured in an
 
     ; app/config/parameters.ini
     [parameters]
-        database_driver   = pdo_mysql
-        database_host     = localhost
-        database_name     = test_project
-        database_user     = root
-        database_password = password
+    database_driver   = pdo_mysql
+    database_host     = localhost
+    database_name     = test_project
+    database_user     = root
+    database_password = password
 
 .. note::
 

--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -851,7 +851,7 @@ First, to use ESI, be sure to enable it in your application configuration:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
-            ...,
+            // ...
             'esi'    => array('enabled' => true),
         ));
 
@@ -884,7 +884,7 @@ matter), Symfony2 uses the standard ``render`` helper to configure ESI tags:
 
         {% render url('latest_news', { 'max': 5 }) with {}, {'standalone': true} %}
 
-    .. code-block:: php
+    .. code-block:: html+php
 
         <?php echo $view['actions']->render(
             $view['router']->generate('latest_news', array('max' => 5), true),

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -344,7 +344,7 @@ controller, and ``index.html.twig`` the template:
             Hello {{ name }}!
         {% endblock %}
 
-    .. code-block:: php
+    .. code-block:: html+php
 
         <!-- src/Acme/HelloBundle/Resources/views/Hello/index.html.php -->
         <?php $view->extend('::base.html.php') ?>
@@ -385,7 +385,7 @@ and in the ``app`` directory:
             </body>
         </html>
 
-    .. code-block:: php
+    .. code-block:: html+php
 
         <!-- app/Resources/views/base.html.php -->
         <!DOCTYPE html>

--- a/book/propel.rst
+++ b/book/propel.rst
@@ -35,12 +35,12 @@ information.  By convention, this information is usually configured in an
 
     ; app/config/parameters.ini
     [parameters]
-        database_driver   = mysql
-        database_host     = localhost
-        database_name     = test_project
-        database_user     = root
-        database_password = password
-        database_charset  = UTF8
+    database_driver   = mysql
+    database_host     = localhost
+    database_name     = test_project
+    database_user     = root
+    database_password = password
+    database_charset  = UTF8
 
 .. note::
 

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1169,7 +1169,7 @@ a template helper function:
           Read this blog post.
         </a>
 
-    .. code-block:: php
+    .. code-block:: html+php
 
         <a href="<?php echo $view['router']->generate('blog_show', array('slug' => 'my-blog-post')) ?>">
             Read this blog post.
@@ -1185,7 +1185,7 @@ Absolute URLs can also be generated.
           Read this blog post.
         </a>
 
-    .. code-block:: php
+    .. code-block:: html+php
 
         <a href="<?php echo $view['router']->generate('blog_show', array('slug' => 'my-blog-post'), true) ?>">
             Read this blog post.

--- a/book/security.rst
+++ b/book/security.rst
@@ -1799,7 +1799,7 @@ to show a link to exit impersonation:
     .. code-block:: html+jinja
 
         {% if is_granted('ROLE_PREVIOUS_ADMIN') %}
-            <a href="{{ path('homepage', { _switch_user: '_exit' }) }}">Exit impersonation</a>
+            <a href="{{ path('homepage', {_switch_user: '_exit'}) }}">Exit impersonation</a>
         {% endif %}
 
     .. code-block:: html+php

--- a/book/security.rst
+++ b/book/security.rst
@@ -484,7 +484,7 @@ Finally, create the corresponding template:
 
     .. code-block:: html+php
 
-        <?php // src/Acme/SecurityBundle/Resources/views/Security/login.html.php ?>
+        <!-- src/Acme/SecurityBundle/Resources/views/Security/login.html.php -->
         <?php if ($error): ?>
             <div><?php echo $error->getMessage() ?></div>
         <?php endif; ?>
@@ -723,7 +723,7 @@ You can define as many URL patterns as you need - each is a regular expression.
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
-            ...,
+            // ...
             'access_control' => array(
                 array('path' => '^/admin/users', 'role' => 'ROLE_SUPER_ADMIN'),
                 array('path' => '^/admin', 'role' => 'ROLE_ADMIN'),
@@ -1072,7 +1072,7 @@ In fact, you've seen this already in the example in this chapter.
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
-            ...,
+            // ...
             'providers' => array(
                 'default_provider' => array(
                     'users' => array(
@@ -1302,7 +1302,7 @@ configure the encoder for that user:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
-            ...,
+            // ...
             'encoders' => array(
                 'Acme\UserBundle\Entity\User' => 'sha512',
             ),
@@ -1502,10 +1502,10 @@ the first provider is always used:
         $container->loadFromExtension('security', array(
             'firewalls' => array(
                 'secured_area' => array(
-                    ...,
+                    // ...
                     'provider' => 'user_db',
                     'http_basic' => array(
-                        ...,
+                        // ...
                         'provider' => 'in_memory',
                     ),
                     'form_login' => array(),
@@ -1616,7 +1616,7 @@ the firewall can handle this automatically for you when you activate the
         $container->loadFromExtension('security', array(
             'firewalls' => array(
                 'secured_area' => array(
-                    ...,
+                    // ...
                     'logout' => array('path' => 'logout', 'target' => '/'),
                 ),
             ),
@@ -1771,7 +1771,7 @@ done by activating the ``switch_user`` firewall listener:
         $container->loadFromExtension('security', array(
             'firewalls' => array(
                 'main'=> array(
-                    ...,
+                    // ...
                     'switch_user' => true
                 ),
             ),
@@ -1799,7 +1799,7 @@ to show a link to exit impersonation:
     .. code-block:: html+jinja
 
         {% if is_granted('ROLE_PREVIOUS_ADMIN') %}
-            <a href="{{ path('homepage', {_switch_user: '_exit'}) }}">Exit impersonation</a>
+            <a href="{{ path('homepage', { _switch_user: '_exit' }) }}">Exit impersonation</a>
         {% endif %}
 
     .. code-block:: html+php

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1194,7 +1194,7 @@ this classic example:
 
 .. configuration-block::
 
-    .. code-block:: jinja
+    .. code-block:: html+jinja
 
         Hello {{ name }}
 
@@ -1202,12 +1202,16 @@ this classic example:
 
         Hello <?php echo $name ?>
 
-Imagine that the user enters the following code as his/her name::
+Imagine that the user enters the following code as his/her name:
+
+.. code-block:: text
 
     <script>alert('hello!')</script>
 
 Without any output escaping, the resulting template will cause a JavaScript
-alert box to pop up::
+alert box to pop up:
+
+.. code-block:: html
 
     Hello <script>alert('hello!')</script>
 
@@ -1217,7 +1221,9 @@ inside the secure area of an unknowing, legitimate user.
 
 The answer to the problem is output escaping. With output escaping on, the
 same template will render harmlessly, and literally print the ``script``
-tag to the screen::
+tag to the screen:
+
+.. code-block:: html
 
     Hello &lt;script&gt;alert(&#39;helloe&#39;)&lt;/script&gt;
 
@@ -1249,7 +1255,9 @@ Output Escaping in PHP
 
 Output escaping is not automatic when using PHP templates. This means that
 unless you explicitly choose to escape a variable, you're not protected. To
-use output escaping, use the special ``escape()`` view method::
+use output escaping, use the special ``escape()`` view method:
+
+.. code-block:: html+php
 
     Hello <?php echo $view->escape($name) ?>
 
@@ -1258,7 +1266,7 @@ within an HTML context (and thus the variable is escaped to be safe for HTML).
 The second argument lets you change the context. For example, to output something
 in a JavaScript string, use the ``js`` context:
 
-.. code-block:: js
+.. code-block:: html+php
 
     var myMsg = 'Hello <?php echo $view->escape($name, 'js') ?>';
 

--- a/book/testing.rst
+++ b/book/testing.rst
@@ -157,7 +157,9 @@ for its ``DemoController`` (`DemoControllerTest`_) that reads as follows::
     kernel of your application. In most cases, this happens automatically.
     However, if your kernel is in a non-standard directory, you'll need
     to modify your ``phpunit.xml.dist`` file to set the ``KERNEL_DIR`` environment
-    variable to the directory of your kernel::
+    variable to the directory of your kernel:
+
+    .. code-block:: xml
 
         <phpunit>
             <!-- ... -->

--- a/book/testing.rst
+++ b/book/testing.rst
@@ -353,14 +353,6 @@ or perform more complex requests::
         'image/jpeg',
         123
     );
-    // or
-    $photo = array(
-        'tmp_name' => '/path/to/photo.jpg',
-        'name'     => 'photo.jpg',
-        'type'     => 'image/jpeg',
-        'size'     => 123,
-        'error'    => UPLOAD_ERR_OK
-    );
     $client->request(
         'POST',
         '/submit',

--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -85,8 +85,8 @@ You also need to create the file to run at the command line which creates
 an ``Application`` and adds commands to it::
 
     #!/usr/bin/env php
-    # app/console
     <?php
+    // app/console
 
     use Acme\DemoBundle\Command\GreetCommand;
     use Symfony\Component\Console\Application;

--- a/components/console/single_command_tool.rst
+++ b/components/console/single_command_tool.rst
@@ -50,5 +50,5 @@ be used, without having to pass its name.
 
 .. note::
 
-  If your command accepts one or more arguments, you may also want to override
-  getDefinition() method.
+    If your command accepts one or more arguments, you may also want to override
+    the :method:`Symfony\\Component\\Console\\getDefaultInputDefinition` method.

--- a/components/console/single_command_tool.rst
+++ b/components/console/single_command_tool.rst
@@ -43,12 +43,32 @@ it is possible to remove this need by extending the application::
 
             return $defaultCommands;
         }
+
+        /**
+         * Overridden so that the application doesn't expect the command
+         * name to be the first argument.
+         */
+        public function getDefinition()
+        {
+            $inputDefinition = parent::getDefinition();
+            // clear out the normal first argument, which is the command name
+            $inputDefinition->setArguments();
+
+            return $inputDefinition;
+        }
     }
 
 When calling your console script, the command `MyCommand` will then always
 be used, without having to pass its name.
 
-.. note::
+You can also simplify how you execute the application::
 
-    If your command accepts one or more arguments, you may also want to override
-    the :method:`Symfony\\Component\\Console\\getDefaultInputDefinition` method.
+    #!/usr/bin/env php
+    <?php
+    // command.php
+
+    use Acme\Tool\MyApplication;
+
+    $application = new MyApplication();
+    $application->run();
+

--- a/components/console/single_command_tool.rst
+++ b/components/console/single_command_tool.rst
@@ -47,3 +47,8 @@ it is possible to remove this need by extending the application::
 
 When calling your console script, the command `MyCommand` will then always
 be used, without having to pass its name.
+
+.. note::
+
+  If your command accepts one or more arguments, you may also want to override
+  getDefinition() method.

--- a/components/event_dispatcher/introduction.rst
+++ b/components/event_dispatcher/introduction.rst
@@ -456,7 +456,7 @@ indexed by event names and whose values are either the method name to call or
 an array composed of the method name to call and a priority. The example
 above shows how to register several listener methods for the same event in
 subscriber and also shows how to pass the priority of each listener method.
-The higher the priority, the earlier the method is called, so in the above
+The higher the priority, the earlier the method is called. In the above
 example, when the ``kernel.response`` event is triggered, the methods
 ``onKernelResponsePre``, ``onKernelResponseMid``, and ``onKernelResponsePost``
 are called in that order.

--- a/components/event_dispatcher/introduction.rst
+++ b/components/event_dispatcher/introduction.rst
@@ -456,6 +456,10 @@ indexed by event names and whose values are either the method name to call or
 an array composed of the method name to call and a priority. The example
 above shows how to register several listener methods for the same event in
 subscriber and also shows how to pass the priority of each listener method.
+The higher the priority, the earlier the method is called, so in the above
+example, when the ``kernel.response`` event is triggered, the methods
+``onKernelResponsePre``, ``onKernelResponseMid``, and ``onKernelResponsePost``
+are called in that order.
 
 .. index::
    single: Event Dispatcher; Stopping event flow

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -26,13 +26,13 @@ then clone your fork:
     $ git clone git://github.com/YOURUSERNAME/symfony-docs.git
 
 Consistent with Symfony's source code, the documentation repository is split into
-three branches: ``2.0`` for the current Symfony 2.0.x release, ``2.1`` for the
-current Symfony 2.1.x release and ``master`` as the development branch for
-upcoming releases.
+multiple branches: ``2.0``, ``2.1``, ``2.2`` corresponding to the different
+versions of Symfony itself. The ``master`` branch holds the documentation
+for the development branch of the code.
 
-Unless you're documenting a feature that's new to Symfony 2.1, your changes
-should always be based on the 2.0 branch instead of the master branch. To do
-this checkout the 2.0 branch before the next step:
+Unless you're documenting a feature that was introduced *after* Symfony 2.0
+(e.g. in Symfony 2.1), your changes should always be based on the 2.0 branch.
+To do this checkout the 2.0 branch before the next step:
 
 .. code-block:: bash
 

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -38,6 +38,11 @@ To do this checkout the 2.0 branch before the next step:
 
     $ git checkout 2.0
 
+.. tip::
+
+    Your base branch (e.g. 2.0) will become the "Applies to" in the :ref:`doc-contributing-pr-format`
+    that you'll use later.
+
 Next, create a dedicated branch for your changes (for organization):
 
 .. code-block:: bash
@@ -73,6 +78,8 @@ GitHub covers the topic of `pull requests`_ in detail.
 
     The Symfony2 documentation is licensed under a Creative Commons
     Attribution-Share Alike 3.0 Unported :doc:`License <license>`.
+
+.. _doc-contributing-pr-format:
 
 Pull Request Format
 ~~~~~~~~~~~~~~~~~~~

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -74,10 +74,20 @@ GitHub covers the topic of `pull requests`_ in detail.
     The Symfony2 documentation is licensed under a Creative Commons
     Attribution-Share Alike 3.0 Unported :doc:`License <license>`.
 
+When you are not yet finished with your Pull Request, but you already want to
+review it, you should to prefix your Pull Request Title with ``[WIP]`` (Work In
+Progress). The Pull Request will not be merged until you say it is ready for
+merging.
+
+When you are documenting a new feature which you submitted to the core code, you
+should prefix your Pull Request Title with ``[WCM]`` (Waiting Code Merge). The Pull
+Request will not be merged until it is merged in the core code and the Pull Request
+will be closed when the Pull Request for the core code is reverted.
+
 Pull Request Format
 ~~~~~~~~~~~~~~~~~~~
 
-Unless you're fixing some minor typos, the pull request description must**
+Unless you're fixing some minor typos, the pull request description **must**
 include the following checklist to ensure that contributions may be reviewed
 without needless feedback loops and that your contributions can be included
 into the documentation as quickly as possible:

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -149,7 +149,7 @@ look and feel familiar, you should follow these rules:
 * The code follows the :doc:`Symfony Coding Standards</contributing/code/standards>`
   as well as the `Twig Coding Standards`_;
 * Each line should break approximately after the first word that crosses the
-  72nd character (so most lines end up being 72-78 lines);
+  72nd character (so most lines end up being 72-78 characters);
 * To avoid horizontal scrolling on code blocks, we prefer to break a line
   correctly if it crosses the 85th character;
 * When you fold one or more lines of code, place ``...`` in a comment at the point
@@ -197,7 +197,7 @@ Reporting an Issue
 ------------------
 
 The most easy contribution you can make is reporting issues: a typo, a grammar
-mistake, a bug in code example, a missing explanation, and so on.
+mistake, a bug in a code example, a missing explanation, and so on.
 
 Steps:
 

--- a/cookbook/form/use_virtuals_forms.rst
+++ b/cookbook/form/use_virtuals_forms.rst
@@ -49,6 +49,9 @@ Start by creating a very simple ``CompanyType`` and ``CustomerType``::
 
     // src/Acme/HelloBundle/Form/Type/CompanyType.php
     namespace Acme\HelloBundle\Form\Type;
+    
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\FormBuilder;
 
     class CompanyType extends AbstractType
     {
@@ -65,6 +68,9 @@ Start by creating a very simple ``CompanyType`` and ``CustomerType``::
     // src/Acme/HelloBundle/Form/Type/CustomerType.php
     namespace Acme\HelloBundle\Form\Type;
 
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\FormBuilder;
+
     class CustomerType extends AbstractType
     {
         public function buildForm(FormBuilder $builder, array $options)
@@ -80,6 +86,9 @@ location form type::
 
     // src/Acme/HelloBundle/Form/Type/LocationType.php
     namespace Acme\HelloBundle\Form\Type;
+
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\FormBuilder;
 
     class LocationType extends AbstractType
     {

--- a/cookbook/map.rst.inc
+++ b/cookbook/map.rst.inc
@@ -102,6 +102,7 @@
   * :doc:`/cookbook/routing/slash_in_parameter`
   * :doc:`/cookbook/routing/redirect_in_config`
   * :doc:`/cookbook/routing/method_parameters`
+  * :doc:`/cookbook/routing/custom_route_loader`
 
 * :doc:`/cookbook/security/index`
 

--- a/cookbook/routing/custom_route_loader.rst
+++ b/cookbook/routing/custom_route_loader.rst
@@ -1,0 +1,159 @@
+.. index::
+   single: Routing; Custom route loader
+
+How to Create a Custom Route Loader
+===================================
+
+Loading Routes
+--------------
+
+The routes in a Symfony application are loaded by the :class:`Symfony\\Bundle\\FrameworkBundle\\Routing\\DelegatingLoader`.
+This loader uses several other loaders (delegates) to load resources of
+different types, for instance Yaml files or ``@Route`` and ``@Method`` annotations
+in controller files. The specialized loaders implement :class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`
+and therefore have two important methods: :method:`Symfony\\Component\\Config\\Loader\\LoaderInterface::supports`
+and :method:`Symfony\\Component\\Config\\Loader\\LoaderInterface::load`.
+
+Take these lines from ``routing.yml``:
+
+.. code-block:: yaml
+
+    _demo:
+        resource: "@AcmeDemoBundle/Controller/DemoController.php"
+        type:     annotation
+        prefix:   /demo
+
+The main loader tries all the delegate loaders and calls their
+:method:`Symfony\\Component\\Config\\Loader\\LoaderInterface::supports`
+with the given resource ("@AcmeDemoBundle/Controller/DemoController.php")
+and type ("annotation") as arguments. When one of the loader returns ``true``,
+its method :method:`Symfony\\Component\\Config\\Loader\\LoaderInterface::load`
+will be called, and the loader returns a :class:`Symfony\\Component\\Routing\\RouteCollection`
+containing :class:`Symfony\\Component\\Routing\\Route` objects.
+
+Creating a Custom Loader
+------------------------
+
+To load routes in another way then using annotations, Yaml or XML files,
+you need to create a custom route loader. This loader should implement
+:class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`.
+
+The sample loader below supports resources of type "extra". The resource
+name itself is not used in the example::
+
+    namespace Acme\DemoBundleBundle\Routing;
+
+    use Symfony\Component\Config\Loader\LoaderInterface;
+    use Symfony\Component\Config\Loader\LoaderResolver;
+    use Symfony\Component\Routing\Route;
+    use Symfony\Component\Routing\RouteCollection;
+
+    class ExtraLoader implements LoaderInterface
+    {
+        private $loaded = false;
+
+        public function load($resource, $type = null)
+        {
+            if (true === $this->loaded) {
+                throw new \RuntimeException('Do not add the "extra" loader twice');
+            }
+
+            $routes = new RouteCollection();
+
+            // prepare a new route
+            $pattern = '/extra/{parameter}';
+            $defaults = array(
+                '_controller' => 'AcmeDemoBundle:Demo:extra',
+            );
+            $requirements = array(
+                'parameter' => '\d+',
+            );
+            $route = new Route($pattern, $defaults, $requirements);
+
+            // add the new route to the route collection:
+            $routeName = 'extraRoute';
+            $routes->add($routeName, $route);
+
+            return $routes;
+        }
+
+        public function supports($resource, $type = null)
+        {
+            return 'extra' === $type;
+        }
+
+        public function getResolver()
+        {
+            // irrelevant to us, since we don't use a loader resolver
+        }
+
+        public function setResolver(LoaderResolver $resolver)
+        {
+            // also irrelevant
+        }
+    }
+
+.. note::
+
+    Make sure the controller you specify really exists.
+
+Now define a service for the ``ExtraLoader``:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        services:
+            acme_demo.routing_loader:
+                class: Acme\DemoBundle\Routing\ExtraLoader
+                tags:
+                    - { name: routing.loader }
+
+    .. code-block:: xml
+
+        <?xml version="1.0" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service id="acme_demo.routing_loader" class="Acme\DemoBundle\Routing\ExtraLoader">
+                    <tag name="routing.loader"></tag>
+                </service>
+            </services>
+        </container>
+
+    .. code-block:: php
+
+        use Symfony\Component\DependencyInjection\Definition;
+
+        $container
+            ->setDefinition(
+                'acme_demo.routing_loader',
+                new Definition('Acme\DemoBundle\Routing\ExtraLoader')
+            )
+            ->addTag('routing.loader')
+        ;
+
+Notice the tag ``routing.loader``. All services with this tag will be marked
+as potential route loaders and added as specialized routers to the
+:class:`Symfony\\Bundle\\FrameworkBundle\\Routing\\DelegatingLoader`.
+
+Finally, we only need to add a few extra lines in ``routing.yml``:
+
+.. code-block:: yaml
+
+    AcmeDemoBundle_Extra:
+        resource: .
+        type: extra
+
+The ``resource`` key is irrelevant, but required. The important part here
+is the ``type`` key. Its value should be "extra". This is the type which
+our ``ExtraLoader`` supports and this will make sure its ``load()`` method
+is called.
+
+.. note::
+
+    The routes defined using the extra loader will be automatically cached
+    by the framework. So whenever you change something to the behavior of
+    the loader, don't forget to clear the cache.

--- a/cookbook/routing/index.rst
+++ b/cookbook/routing/index.rst
@@ -8,3 +8,4 @@ Routing
     slash_in_parameter
     redirect_in_config
     method_parameters
+    custom_route_loader

--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -469,7 +469,7 @@ The code below shows the implementation of the
 
 To finish the implementation, the configuration of the security layer must be
 changed to tell Symfony to use the new custom entity provider instead of the
-generic Doctrine entity provider. It's trival to achieve by removing the
+generic Doctrine entity provider. It's trivial to achieve by removing the
 ``property`` field in the ``security.providers.administrators.entity`` section
 of the ``security.yml`` file.
 

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -92,7 +92,7 @@ If your valid choice list is simple, you can pass them in directly via the
             {
                 $metadata->addPropertyConstraint('gender', new Assert\Choice(array(
                     'choices' => array('male', 'female'),
-                    'message' => 'Choose a valid gender',
+                    'message' => 'Choose a valid gender.',
                 )));
             }
         }

--- a/reference/constraints/Max.rst
+++ b/reference/constraints/Max.rst
@@ -72,7 +72,7 @@ add the following:
             {
                 $metadata->addPropertyConstraint('age', new Assert\Max(array(
                     'limit'   => 50,
-                    'message' => "You must be 50 or under to enter.",
+                    'message' => 'You must be 50 or under to enter.',
                 )));
             }
         }

--- a/reference/constraints/Min.rst
+++ b/reference/constraints/Min.rst
@@ -73,7 +73,7 @@ the following:
                 $metadata->addPropertyConstraint('age', new Assert\Min(array(
                     'limit'   => '18',
                     'message' => 'You must be 18 or older to enter.',
-                ));
+                )));
             }
         }
 

--- a/reference/constraints/True.rst
+++ b/reference/constraints/True.rst
@@ -50,7 +50,7 @@ Then you can constrain this method with ``True``.
         Acme\BlogBundle\Entity\Author:
             getters:
                 tokenValid:
-                    - "True": { message: "The token is invalid" }
+                    - "True": { message: "The token is invalid." }
 
     .. code-block:: php-annotations
 
@@ -78,7 +78,7 @@ Then you can constrain this method with ``True``.
         <class name="Acme\BlogBundle\Entity\Author">
             <getter property="tokenValid">
                 <constraint name="True">
-                    <option name="message">The token is invalid...</option>
+                    <option name="message">The token is invalid.</option>
                 </constraint>
             </getter>
         </class>
@@ -98,7 +98,7 @@ Then you can constrain this method with ``True``.
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
                 $metadata->addGetterConstraint('tokenValid', new True(array(
-                    'message' => 'The token is invalid',
+                    'message' => 'The token is invalid.',
                 )));
             }
 

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -44,7 +44,8 @@ the currency symbol that should be shown by the text box. Depending on
 the currency - the currency symbol may be shown before or after the input
 text field.
     
-This can also be set to false to hide the currency symbol.
+This can be any `3 letter ISO 4217 code`_. You can also set this to false to
+hide the currency symbol.
 
 divisor
 ~~~~~~~
@@ -92,3 +93,5 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
+
+.. _`3 letter ISO 4217 code`: http://en.wikipedia.org/wiki/ISO_4217

--- a/reference/forms/types/options/date_format.rst.inc
+++ b/reference/forms/types/options/date_format.rst.inc
@@ -11,7 +11,7 @@ that *the expected format will be different for different users*. You
 can override it by passing the format as a string.
 
 For more information on valid formats, see `Date/Time Format Syntax`_. For
-example, to render a single text box that expects the user to end ``yyyy-MM-dd``,
+example, to render a single text box that expects the user to enter ``yyyy-MM-dd``,
 use the following options::
 
     $builder->add('date_created', 'date', array(


### PR DESCRIPTION
I've created a new cookbook article about custom route loaders (see also #526). Feedback is much appreciated.

There is a small difference for version 2.1:

```
public function setResolver(LoaderResolver $resolver)
```

should be changed to 

```
public function setResolver(LoaderResolverInterface $resolver)
```

As well as the corresponding `use` at the top.

How should I add this to my pull request?
