### PR TITLE
update default regex for parameters

### DIFF
--- a/cookbook/routing/slash_in_parameter.rst
+++ b/cookbook/routing/slash_in_parameter.rst
@@ -16,8 +16,8 @@ Configure the Route
 -------------------
 
 By default, the Symfony routing components requires that the parameters 
-match the following regex path: ``[^/]+``. This means that all characters 
-are allowed except ``/``. 
+match the following regex path: ``[^/\-]++``. This means that all characters 
+are allowed except ``/`` and ``-``. 
 
 You must explicitly allow ``/`` to be part of your parameter by specifying 
 a more permissive regex path.


### PR DESCRIPTION
I didn't find the commit or the point in the code but the exception says

```
An exception has been thrown during the rendering of a template ("Parameter "slug" for route "de__RG__frontend_show" must match "[^/\-]++" ("Fuss-ball" given) to generate a corresponding URL.") in ... show.html.twig at line 24. 
```
