### PR TITLE
Document new framework option http_method_override

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -16,6 +16,7 @@ Configuration
 -------------
 
 * `secret`_
+* `http_method_override`_
 * `ide`_
 * `test`_
 * `trust_proxy_headers`_
@@ -48,6 +49,21 @@ This is a string that should be unique to your application. In practice,
 it's used for generating the CSRF tokens, but it could be used in any other
 context where having a unique string is useful. It becomes the service container
 parameter named ``kernel.secret``.
+
+http_method_override
+~~~~~~
+
+.. versionadded:: 2.3
+    The ``http_method_override`` option is new in version 2.3
+
+**type**: ``Boolean`` **default**: ``true``
+
+This determines whether the '_method' request parameter is used as the intended
+HTTP method on POST requests. If enabled, the
+:method:`Request::enableHttpMethodParameterOverride <Symfony\\Component\\HttpFoundation\\Request::enableHttpMethodParameterOverride>`
+gets called automatically. It becomes the service container parameter named
+``kernel.http_method_override``. For more information, see
+:doc:`/cookbook/routing/method_parameters`.
 
 ide
 ~~~
@@ -379,6 +395,7 @@ Full Default Configuration
         framework:
             charset:              ~
             secret:               ~
+            http_method_override: true
             trust_proxy_headers:  false
             trusted_proxies:      []
             ide:                  ~
@@ -405,7 +422,7 @@ Full Default Configuration
             profiler:
                 enabled:              false
                 only_exceptions:      false
-                only_master_requests:  false
+                only_master_requests: false
                 dsn:                  file:%kernel.cache_dir%/profiler
                 username:
                 password:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes (symfony/symfony#7202) |
| Applies to | master (2.3+) |
| Fixed tickets |  |

If `http_method_override` is set to `true` (default value), the method
[Request::enableHttpMethodParameterOverride()](http://api.symfony.com/master/Symfony/Component/HttpFoundation/Request.html#method_enableHttpMethodParameterOverride) is called before the Request is handled.

Please note that this means it is enabled by default when using the FrameworkBundle and disabled when using HttpFoundation as a standalone component (2.3).
