### PR TITLE
Fix how to safely use is_granted in error pages

### DIFF
--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -56,7 +56,7 @@ end-user, create a new template located at
     by your error pages), because the router runs before the firewall. If
     the router throws an exception (for instance, when the route does not
     match), then using ``is_granted`` will throw a further exception. You
-    can use ``is_granted`` safely by saying ``{% if app.security and is_granted('...') %}``.
+    can use ``is_granted`` safely by saying ``{% if app.user and is_granted('...') %}``.
 
 .. tip::
 

--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -56,7 +56,7 @@ end-user, create a new template located at
     by your error pages), because the router runs before the firewall. If
     the router throws an exception (for instance, when the route does not
     match), then using ``is_granted`` will throw a further exception. You
-    can use ``is_granted`` safely by saying ``{% if app.user and is_granted('...') %}``.
+    can use ``is_granted`` safely by saying ``{% if app.user is not null and is_granted('...') %}``.
 
 .. tip::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets | #2078 |

See https://github.com/symfony/symfony-docs/commit/df85a35e69707a34a63f5cf0ff85c4cc5cf1eab1#L0R59
