### PR TITLE
Change confusing part in ex. of class validator

### DIFF
--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -236,7 +236,7 @@ not to the property:
         # src/Acme/BlogBundle/Resources/config/validation.yml
         Acme\DemoBundle\Entity\AcmeEntity:
             constraints:
-                - ContainsAlphanumeric
+                - Acme\DemoBundle\Validator\Constraints\ContainsAlphanumeric: ~
 
     .. code-block:: php-annotations
 
@@ -252,5 +252,5 @@ not to the property:
 
         <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
         <class name="Acme\DemoBundle\Entity\AcmeEntity">
-            <constraint name="ContainsAlphanumeric" />
+            <constraint name="Acme\DemoBundle\Validator\Constraints\ContainsAlphanumeric" />
         </class>


### PR DESCRIPTION
Change confusing part in examples of class custom validator in YML and XML.
