### PR TITLE
Adding description of how to test a command which expects user input

### DIFF
--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -109,12 +109,9 @@ from the command line, you need to overwrite the HelperSet used by the command::
     use Symfony\Component\Console\Helper\HelperSet;
     
     // ...
-    
     public function testExecute()
     {
-    
-        // ..
-
+        // ...
         $commandTester = new CommandTester($command);
         
         $dialog = new DialogHelper();
@@ -126,8 +123,7 @@ from the command line, you need to overwrite the HelperSet used by the command::
         
         $commandTester->execute(array('command' => $command->getName()));
     
-        // assert
-        
+        // $this->assertRegExp('/.../', $commandTester->getDisplay());
     }
     
     protected function getInputStream($input)

--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -98,3 +98,48 @@ If you reach this max number it will use the default value, which is given
 in the last argument. Using ``false`` means the amount of attempts is infinite.
 The user will be asked as long as he provides an invalid answer and will only
 be able to proceed if her input is valid.
+
+Testing a command which expects input
+-------------------------------------
+
+If you want to write a unit test for a command which expects some kind of input
+from the command line, you need to overwrite the HelperSet used by the command::
+
+    use Symfony\Component\Console\Helper\DialogHelper;
+    use Symfony\Component\Console\Helper\HelperSet;
+    
+    // ...
+    
+    public function testExecute()
+    {
+    
+        // ..
+
+        $commandTester = new CommandTester($command);
+        
+        $dialog = new DialogHelper();
+        $dialog->setInputStream($this->getInputStream('Test\n')); 
+        // Equals to a user inputing "Test" and hitting ENTER
+        // If you need to enter a confirmation, "yes\n" will work
+        
+        $command->setHelperSet(new HelperSet(array($dialog)));
+        
+        $commandTester->execute(array('command' => $command->getName()));
+    
+        // assert
+        
+    }
+    
+    protected function getInputStream($input)
+    {
+        $stream = fopen('php://memory', 'r+', false);
+        fputs($stream, $input);
+        rewind($stream);
+
+        return $stream;
+    }
+    
+By setting the inputStream of the `DialogHelper`, you do the same the
+console would do internally with all user input through the cli. This way
+you can test any user interaction (even complex ones) by passing an appropriate
+input stream.

--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -114,12 +114,10 @@ from the command line, you need to overwrite the HelperSet used by the command::
         // ...
         $commandTester = new CommandTester($command);
         
-        $dialog = new DialogHelper();
+        $dialog = $command->getHelper('dialog');
         $dialog->setInputStream($this->getInputStream('Test\n')); 
         // Equals to a user inputing "Test" and hitting ENTER
         // If you need to enter a confirmation, "yes\n" will work
-        
-        $command->setHelperSet(new HelperSet(array($dialog)));
         
         $commandTester->execute(array('command' => $command->getName()));
     


### PR DESCRIPTION
This PR adds a description on testing a command which uses the `DialogHelper` and expects some user input.

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.0+ |
| Fixed tickets | #2351 |

One thing I'm not sure about is if I should add a link to the section about command testing. If so, where should I add it?
