### PR TITLE
Documenting the virtual option for types where it makes sense.

### DIFF
--- a/reference/forms/types/birthday.rst
+++ b/reference/forms/types/birthday.rst
@@ -31,6 +31,7 @@ option defaults to 120 years ago to the current year.
 |                      | - `user_timezone`_                                                                                                     |
 |                      | - `invalid_message`_                                                                                                   |
 |                      | - `invalid_message_parameters`_                                                                                        |
+|                      | - `virtual`_                                                                                                           |
 +----------------------+------------------------------------------------------------------------------------------------------------------------+
 | Parent type          | :doc:`date</reference/forms/types/date>`                                                                               |
 +----------------------+------------------------------------------------------------------------------------------------------------------------+
@@ -75,3 +76,6 @@ These options inherit from the :doc:`date</reference/forms/types/field>` type:
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/virtual.rst.inc

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -26,6 +26,7 @@ option.
 | options     | - `label`_                                                                  |
 |             | - `read_only`_                                                              |
 |             | - `error_bubbling`_                                                         |
+|             | - `virtual`_                                                                |
 +-------------+-----------------------------------------------------------------------------+
 | Parent type | :doc:`form</reference/forms/types/form>` (if expanded), ``field`` otherwise |
 +-------------+-----------------------------------------------------------------------------+
@@ -119,3 +120,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/read_only.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/virtual.rst.inc

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -32,6 +32,7 @@ day, and year) or three select boxes (see the `widget_` option).
 +----------------------+-----------------------------------------------------------------------------+
 | Inherited            | - `invalid_message`_                                                        |
 | options              | - `invalid_message_parameters`_                                             |
+|                      | - `virtual`_                                                                |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | ``field`` (if text), ``form`` otherwise                                     |
 +----------------------+-----------------------------------------------------------------------------+
@@ -121,3 +122,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/virtual.rst.inc

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -31,6 +31,7 @@ data can be a ``DateTime`` object, a string, a timestamp or an array.
 +----------------------+-----------------------------------------------------------------------------+
 | Inherited            | - `invalid_message`_                                                        |
 | options              | - `invalid_message_parameters`_                                             |
+|                      | - `virtual`_                                                                |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | :doc:`form</reference/forms/types/form>`                                    |
 +----------------------+-----------------------------------------------------------------------------+
@@ -105,3 +106,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/virtual.rst.inc

--- a/reference/forms/types/options/virtual.rst.inc
+++ b/reference/forms/types/options/virtual.rst.inc
@@ -1,0 +1,7 @@
+virtual
+~~~~~~~
+
+**type**: ``boolean`` **default**: ``false``
+
+This option determines if the form will be mapped with data. This can be usefull
+if you need a form to structure the view.

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -26,6 +26,7 @@ as a ``DateTime`` object, a string, a timestamp or an array.
 +----------------------+-----------------------------------------------------------------------------+
 | Inherited            | - `invalid_message`_                                                        |
 | options              | - `invalid_message_parameters`_                                             |
+|                      | - `virtual`_                                                                |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | form                                                                        |
 +----------------------+-----------------------------------------------------------------------------+
@@ -116,3 +117,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/virtual.rst.inc


### PR DESCRIPTION
This PR includes the documentation of the `virtual` option for those types which make sense to use with this option. When this is merged upstream, part two of #1387 can be appproached by adding the mapped documentation to the 2.1 branch.

| Q | A |
| --- | --- |
| Doc fix? | yes (Improvementt on existing docs) |
| New docs? | yes |
| Applies to | 2.0+ |
| Fixed tickets | #1387 (incomplete) |
