### PR TITLE
Add note about buffering in StreamedResponse.

### DIFF
--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -387,6 +387,18 @@ represented by a PHP callable instead of a string::
     });
     $response->send();
 
+.. note::
+
+    The ``flush()`` function does not flush bufferring. So if
+    ``ob_start()`` has been called before or php.ini option
+    ``output_buffering`` is not disabled (which is on some
+    installations by default), you have to call ``ob_flush()`` before
+    ``flush()``.
+
+    But not only php can buffer output. Your web-server can also do
+    it. Even more, if you use fastcgi, buffering can't be disabled at
+    all.
+
 Downloading Files
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes |
| Applies to | 2.1+ |
| Fixed tickets | #1668 |

As it's mentioned in #1668, there should be a note about buffering that will prevent flushing.
