### PR TITLE
add note on service parameters regarding ScopeWideningInjectionException

### DIFF
--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -231,6 +231,15 @@ looks up the value of each parameter and uses it in the service definition.
 
         <argument type="string">http://symfony.com/?foo=%%s&bar=%%d</argument>
 
+.. note::
+
+    It can be useful to pass other services in as arguments to your custom service.
+    For example, you may want to pass in the `request` service as an argument.
+    In these cases, you may receive a `ScopeWideningInjectionException`.
+    To understand this problem better and learn how to solve it, refer to
+    the cookbook article :doc:`/cookbook/service_container/scopes` for a
+    few solutions.
+
 The purpose of parameters is to feed information into services. Of course
 there was nothing wrong with defining the service without using any parameters.
 Parameters, however, have several advantages:

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -234,8 +234,8 @@ looks up the value of each parameter and uses it in the service definition.
 .. note::
 
     It can be useful to pass other services in as arguments to your custom service.
-    For example, you may want to pass in the `request` service as an argument.
-    In these cases, you may receive a `ScopeWideningInjectionException`.
+    For example, you may want to pass in the ``request`` service as an argument.
+    In these cases, you may receive a ``ScopeWideningInjectionException``.
     To understand this problem better and learn how to solve it, refer to
     the cookbook article :doc:`/cookbook/service_container/scopes` for a
     few solutions.

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -231,13 +231,13 @@ looks up the value of each parameter and uses it in the service definition.
 
         <argument type="string">http://symfony.com/?foo=%%s&bar=%%d</argument>
 
-.. note::
+.. caution::
 
-    It can be useful to pass other services in as arguments to your custom service.
-    For example, you may want to pass in the ``request`` service as an argument.
-    In these cases, you may receive a ``ScopeWideningInjectionException``.
-    To understand this problem better and learn how to solve it, refer to
-    the cookbook article :doc:`/cookbook/service_container/scopes`.
+    You may receive a 
+    :class:`Symfony\\Component\\DependencyInjection\\Exception\\ScopeWideningInjectionException`
+    when passing the ``request`` service as an argument. To understand this
+    problem better and learn how to solve it, refer to the cookbook article
+    :doc:`/cookbook/service_container/scopes`.
 
 The purpose of parameters is to feed information into services. Of course
 there was nothing wrong with defining the service without using any parameters.

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -237,8 +237,7 @@ looks up the value of each parameter and uses it in the service definition.
     For example, you may want to pass in the ``request`` service as an argument.
     In these cases, you may receive a ``ScopeWideningInjectionException``.
     To understand this problem better and learn how to solve it, refer to
-    the cookbook article :doc:`/cookbook/service_container/scopes` for a
-    few solutions.
+    the cookbook article :doc:`/cookbook/service_container/scopes`.
 
 The purpose of parameters is to feed information into services. Of course
 there was nothing wrong with defining the service without using any parameters.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes |
| Applies to | all |
| Fixed tickets | #1707 |

Based on our discussion in IRC, instead of describing how to use `strict=false`, I linked to the cookbook article on Scopes for the recommended solutions.
