### PR TITLE
Part of issue 2378

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -681,7 +681,7 @@ be accomplished with the following route configuration:
 
         return $collection;
 
-.. versionadded::
+.. versionadded:: 2.2
     The ``methods`` option is added in Symfony2.2. Use the ``_method``
     requirement in older versions.
 


### PR DESCRIPTION
My first documentation commit.  Woot!

I found a VERY MINOR typo in the 2.2 documentation.  (I may actually get the award for "Smallest Commit" today.)
- Missing version number on "versionadded" function.
