### PR TITLE
add notes on collection and entity field types

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -29,6 +29,13 @@ forms, which is useful when creating forms that expose one-to-many relationships
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType`    |
 +-------------+-----------------------------------------------------------------------------+
 
+.. note::
+
+    If you are working with a collection of Doctrine entities, pay special 
+    attention to the `allow_add`_, `allow_delete`_ and `by_reference`_ options.
+    You can also see a complete example in the cookbook article 
+    :doc:`/cookbook/form/form_collections`.
+
 Basic Usage
 -----------
 

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -115,6 +115,13 @@ These options inherit from the :doc:`choice</reference/forms/types/choice>` type
 
 .. include:: /reference/forms/types/options/multiple.rst.inc
 
+.. note::
+    
+    If you are working with a collection of Doctrine entities, it will be helpful
+    to read the documention for the :doc:`/reference/forms/types/collection`
+    as well. In addition, there is a complete example in the cookbook article
+    :doc:`/cookbook/form/form_collections`.
+    
 .. include:: /reference/forms/types/options/expanded.rst.inc
 
 .. include:: /reference/forms/types/options/preferred_choices.rst.inc


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes |
| Applies to | all |
| Fixed tickets | #1566 |

I added notes at the top of the collection and entity field types, directing the user to more specific documentation (and the cookbook article) if they are working with collections of Doctrine entities. Hopefully, this will point people in the right direction.
