### PR TITLE
Codeblock indent fix

### DIFF
--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -120,7 +120,7 @@ look like this::
 Next, create this property on your ``Document`` class and add some validation
 rules::
 
-use Symfony\Component\HttpFoundation\File\UploadedFile;
+    use Symfony\Component\HttpFoundation\File\UploadedFile;
 
     // ...
     class Document


### PR DESCRIPTION
First line of codeblock wasn't indented resulting in terribly ugly output.
