### PR TITLE
[2.2] Fixed build errors

### DIFF
--- a/components/map.rst.inc
+++ b/components/map.rst.inc
@@ -26,7 +26,7 @@
 
   * :doc:`/components/dependency_injection/introduction`
   * :doc:`/components/dependency_injection/types`
-  * :doc:`/components/dependency_injection/parameter`
+  * :doc:`/components/dependency_injection/parameters`
   * :doc:`/components/dependency_injection/definitions`
   * :doc:`/components/dependency_injection/compilation`
   * :doc:`/components/dependency_injection/tags`


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |

There were a lot of build errors. Almost all of them are fixed by #2445 and 43d744461a4e22ad39cbef1afd74ebf7c6c4b8ed , this fixed the last build error.
