### PR TITLE
[WCM][TwigBundle] document new autoescape features

### DIFF
--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -31,14 +31,16 @@ TwigBundle Configuration Reference
                     # set to service or leave blank
                     type:                 ~
                     value:                ~
-            autoescape:           ~
-            base_template_class:  ~ # Example: Twig_Template
-            cache:                "%kernel.cache_dir%/twig"
-            charset:              "%kernel.charset%"
-            debug:                "%kernel.debug%"
-            strict_variables:     ~
-            auto_reload:          ~
-            optimizations:        ~
+            autoescape:                ~
+            autoescape_service:        ~ # Example: @my_service
+            autoescape_service_method: ~ # use in combination with autoescape_service option
+            base_template_class:       ~ # Example: Twig_Template
+            cache:                     "%kernel.cache_dir%/twig"
+            charset:                   "%kernel.charset%"
+            debug:                     "%kernel.debug%"
+            strict_variables:          ~
+            auto_reload:               ~
+            optimizations:             ~
 
     .. code-block:: xml
 


### PR DESCRIPTION
This is the documentation for symfony PR 7479 which adds new settings to the TwigBundle that allow to register a custom template escaping guesser

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes - https://github.com/symfony/symfony/pull/7479 |
| Applies to | master |
| Fixed tickets | - |
