### PR TITLE
[WCM][SwiftMailerHandler] Fixed 'method' option name

### DIFF
--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -54,7 +54,7 @@ Monolog Configuration Reference
                     subject:              ~
                     email_prototype:
                         id:                   ~ # Required (when the email_prototype is used)
-                        factory-method:       ~
+                        method:               ~
                     channels:
                         type:                 ~
                         elements:             []


### PR DESCRIPTION
Related PR : symfony/MonologBundle#38
