### PR TITLE
Update the service container core symfony services tip

### DIFF
--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -848,8 +848,8 @@ the framework.
 
 .. tip::
 
-    Be sure that ``swiftmailer`` entry appears in your application
-    configuration. As you mentioned in :ref:`service-container-extension-configuration`,
+    Be sure that the ``swiftmailer`` entry appears in your application
+    configuration. As was mentioned in :ref:`service-container-extension-configuration`,
     the ``swiftmailer`` key invokes the service extension from the
     ``SwiftmailerBundle``, which registers the ``mailer`` service.
 


### PR DESCRIPTION
I felt the tip was a little clumsy. It appeared to be missing some
words and referenced the reader as if they were the person writing
the documentation.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | none |
