### PR TITLE
Documented simulating an authentication by manual token creation.

### DIFF
--- a/cookbook/testing/index.rst
+++ b/cookbook/testing/index.rst
@@ -5,6 +5,7 @@ Testing
     :maxdepth: 2
 
     http_authentication
+    simulating_authentication
     insulating_clients
     profiling
     doctrine

--- a/cookbook/testing/simulating_authentication.rst
+++ b/cookbook/testing/simulating_authentication.rst
@@ -1,0 +1,61 @@
+.. index::
+   single: Tests; Simulating authentication
+
+How to simulate Authentication with a token in a Functional Test
+================================================================
+
+Authenticating requests in functional tests might slow down the suite.
+It could become an issue especially when ``form_login`` is used, since
+it requires additional requests to fill in and submit the form.
+
+One of the solutions is to configure your firewall to use ``http_basic`` in
+the test environment as explained in
+:doc:`/cookbook/testing/http_authentication`.
+Another way would be creating a token yourself and storing it in a session.
+While doing this you have to make sure that appropriate cookie is sent
+with a request. Following example demonstrates this technique::
+
+    // src/Acme/DemoBundle/Tests/Controller/DemoControllerTest.php
+    namespace Acme\DemoBundle\Tests\Controller;
+
+    use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+    use Symfony\Component\BrowserKit\Cookie;
+    use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+    class DemoControllerTest extends WebTestCase
+    {
+        private $client = null;
+
+        public function setUp()
+        {
+            $this->client = static::createClient();
+        }
+
+        public function testSecuredHello()
+        {
+            $this->logIn();
+
+            $this->client->request('GET', '/demo/secured/hello/Fabien');
+
+            $this->assertTrue($this->client->getResponse()->isSuccessful());
+            $this->assertGreaterThan(0, $crawler->filter('html:contains("Hello Fabien")')->count());
+        }
+
+        private function logIn()
+        {
+            $session = $this->client->getContainer()->get('session');
+
+            $firewall = 'secured_area';
+            $token = new UsernamePasswordToken('admin', null, $firewall, array('ROLE_ADMIN'));
+            $session->set('_security_'.$firewall, serialize($token));
+            $session->save();
+
+            $cookie = new Cookie($session->getName(), $session->getId());
+            $this->client->getCookieJar()->set($cookie);
+        }
+    }
+
+.. note::
+
+    Technique described in :doc:`/cookbook/testing/http_authentication`.
+    is cleaner and therefore preferred way.


### PR DESCRIPTION
Even though there are better ways of doing the same thing (like alternative authentication strategy for test environment), we're getting lots of questions on how to properly authenticate a user in a functional test by creating a token manually (see https://github.com/symfony/symfony/issues/5161).

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | >=2.0 |
| Fixed tickets | - |
