### PR TITLE
Updated coding standard to specify using "sprintf" in Exception

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -72,6 +72,8 @@ example containing most features described below:
                 } else {
                     $dummy = ucwords($dummy);
                 }
+            } else {
+                throw new \RuntimeException(sprintf('Unrecognized dummy option "%s"', $dummy));
             }
 
             return $dummy;
@@ -100,10 +102,12 @@ Structure
 
 * Declare class properties before methods;
 
-* Declare public methods first, then protected ones and finally private ones.
+* Declare public methods first, then protected ones and finally private ones;
 
 * Use parentheses when instantiating classes regardless of the number of
-  arguments the constructor has.
+  arguments the constructor has;
+
+* Exception message strings should be concatenated using :phpfunction:`sprintf`.
 
 Naming Conventions
 ------------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | all |
| Fixed tickets | none |

Updated coding standard to specify using "sprintf" in Exception messages as per @fabpot's recommendation on the mailing list.

But I do wonder if this shouldn't apply to all concatenations.
