### PR TITLE
using null in yaml

### DIFF
--- a/components/yaml/yaml_format.rst
+++ b/components/yaml/yaml_format.rst
@@ -114,7 +114,7 @@ Numbers
 Nulls
 ~~~~~
 
-Nulls in YAML can be expressed with ``null`` or ``-``.
+Nulls in YAML can be expressed with ``null`` or ``~``.
 
 Booleans
 ~~~~~~~~


### PR DESCRIPTION
I found that ~ is used for null instead of -,
when using mapped collection ~ can be used as value to represent null - (dash) did not work
