### PR TITLE
Adding the mapped option to the form type references

### DIFF
--- a/reference/forms/types/birthday.rst
+++ b/reference/forms/types/birthday.rst
@@ -32,6 +32,7 @@ option defaults to 120 years ago to the current year.
 |                      | - `invalid_message_parameters`_                                                                                        |
 |                      | - `read_only`_                                                                                                         |
 |                      | - `disabled`_                                                                                                          |
+|                      | - `mapped`_                                                                                                            |
 |                      | - `virtual`_                                                                                                           |
 +----------------------+------------------------------------------------------------------------------------------------------------------------+
 | Parent type          | :doc:`date</reference/forms/types/date>`                                                                               |
@@ -80,5 +81,7 @@ These options inherit from the :doc:`date</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/virtual.rst.inc

--- a/reference/forms/types/checkbox.rst
+++ b/reference/forms/types/checkbox.rst
@@ -18,6 +18,7 @@ if the box is unchecked, the value will be set to false.
 |             | - `read_only`_                                                         |
 |             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
+|             | - `mapped`_                                                            |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                             |
 +-------------+------------------------------------------------------------------------+
@@ -59,3 +60,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -27,6 +27,7 @@ option.
 |             | - `read_only`_                                                              |
 |             | - `disabled`_                                                               |
 |             | - `error_bubbling`_                                                         |
+|             | - `mapped`_                                                                 |
 |             | - `virtual`_                                                                |
 +-------------+-----------------------------------------------------------------------------+
 | Parent type | :doc:`form</reference/forms/types/form>` (if expanded), ``field`` otherwise |
@@ -125,5 +126,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 
 These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/virtual.rst.inc

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -24,6 +24,7 @@ forms, which is useful when creating forms that expose one-to-many relationships
 | options     | - `error_bubbling`_                                                         |
 |             | - `by_reference`_                                                           |
 |             | - `empty_data`_                                                             |
+|             | - `mapped`_                                                                 |
 +-------------+-----------------------------------------------------------------------------+
 | Parent type | :doc:`form</reference/forms/types/form>`                                    |
 +-------------+-----------------------------------------------------------------------------+
@@ -341,6 +342,8 @@ These options inherit from the :doc:`field</reference/forms/types/form>` type.
 Not all options are listed here - only the most applicable to this type:
 
 .. include:: /reference/forms/types/options/label.rst.inc
+
+.. include:: /reference/forms/types/options/mapped.rst.inc
 
 error_bubbling
 ~~~~~~~~~~~~~~

--- a/reference/forms/types/country.rst
+++ b/reference/forms/types/country.rst
@@ -31,6 +31,7 @@ you should just use the ``choice`` type directly.
 |             | - `label`_                                                            |
 |             | - `read_only`_                                                        |
 |             | - `disabled`_                                                         |
+|             | - `mapped`_                                                           |
 +-------------+-----------------------------------------------------------------------+
 | Parent type | :doc:`choice</reference/forms/types/choice>`                          |
 +-------------+-----------------------------------------------------------------------+
@@ -61,3 +62,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/read_only.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -33,6 +33,7 @@ day, and year) or three select boxes (see the `widget_` option).
 | options              | - `invalid_message_parameters`_                                             |
 |                      | - `read_only`_                                                              |
 |                      | - `disabled`_                                                               |
+|                      | - `mapped`_                                                                 |
 |                      | - `virtual`_                                                                |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | ``field`` (if text), ``form`` otherwise                                     |
@@ -127,5 +128,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/virtual.rst.inc

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -33,6 +33,7 @@ data can be a ``DateTime`` object, a string, a timestamp or an array.
 | options              | - `invalid_message_parameters`_                                             |
 |                      | - `read_only`_                                                              |
 |                      | - `disabled`_                                                               |
+|                      | - `mapped`_                                                                 |
 |                      | - `virtual`_                                                                |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | :doc:`form</reference/forms/types/form>`                                    |
@@ -114,5 +115,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/virtual.rst.inc

--- a/reference/forms/types/email.rst
+++ b/reference/forms/types/email.rst
@@ -17,6 +17,7 @@ The ``email`` field is a text field that is rendered using the HTML5
 |             | - `read_only`_                                                      |
 |             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
+|             | - `mapped`_                                                         |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                          |
 +-------------+---------------------------------------------------------------------+
@@ -41,3 +42,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -27,6 +27,7 @@ objects from the database.
 |             | - `read_only`_                                                   |
 |             | - `disabled`_                                                    |
 |             | - `error_bubbling`_                                              |
+|             | - `mapped`_                                                      |
 +-------------+------------------------------------------------------------------+
 | Parent type | :doc:`choice</reference/forms/types/choice>`                     |
 +-------------+------------------------------------------------------------------+
@@ -152,3 +153,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -14,6 +14,7 @@ The ``file`` type represents a file input in your form.
 |             | - `read_only`_                                                      |
 |             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
+|             | - `mapped`_                                                         |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`form</reference/forms/types/form>`                            |
 +-------------+---------------------------------------------------------------------+
@@ -93,3 +94,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/hidden.rst
+++ b/reference/forms/types/hidden.rst
@@ -11,6 +11,7 @@ The hidden type represents a hidden input field.
 +-------------+----------------------------------------------------------------------+
 | Inherited   | - ``data``                                                           |
 | options     | - ``property_path``                                                  |
+|             | - `mapped`_                                                          |
 +-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                           |
 +-------------+----------------------------------------------------------------------+
@@ -25,3 +26,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/property_path.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -25,6 +25,7 @@ integers. By default, all non-integer values (e.g. 6.78) will round down (e.g. 6
 |             | - `error_bubbling`_                                                   |
 |             | - `invalid_message`_                                                  |
 |             | - `invalid_message_parameters`_                                       |
+|             | - `mapped`_                                                           |
 +-------------+-----------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                            |
 +-------------+-----------------------------------------------------------------------+
@@ -75,3 +76,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -32,6 +32,7 @@ you should just use the ``choice`` type directly.
 |             | - `label`_                                                             |
 |             | - `read_only`_                                                         |
 |             | - `disabled`_                                                          |
+|             | - `mapped`_                                                            |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`choice</reference/forms/types/choice>`                           |
 +-------------+------------------------------------------------------------------------+
@@ -62,3 +63,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/read_only.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -33,6 +33,7 @@ you should just use the ``choice`` type directly.
 |             | - `label`_                                                             |
 |             | - `read_only`_                                                         |
 |             | - `disabled`_                                                          |
+|             | - `mapped`_                                                            |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`choice</reference/forms/types/choice>`                           |
 +-------------+------------------------------------------------------------------------+
@@ -63,3 +64,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/read_only.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -26,6 +26,7 @@ how the input and output of the data is handled.
 |             | - `error_bubbling`_                                                 |
 |             | - `invalid_message`_                                                |
 |             | - `invalid_message_parameters`_                                     |
+|             | - `mapped`_                                                         |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                          |
 +-------------+---------------------------------------------------------------------+
@@ -96,5 +97,9 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. _`3 letter ISO 4217 code`: http://en.wikipedia.org/wiki/ISO_4217

--- a/reference/forms/types/number.rst
+++ b/reference/forms/types/number.rst
@@ -22,6 +22,7 @@ you want to use for your number.
 |             | - `error_bubbling`_                                                  |
 |             | - `invalid_message`_                                                 |
 |             | - `invalid_message_parameters`_                                      |
+|             | - `mapped`_                                                          |
 +-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                           |
 +-------------+----------------------------------------------------------------------+
@@ -94,3 +95,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/options/mapped.rst.inc
+++ b/reference/forms/types/options/mapped.rst.inc
@@ -4,4 +4,4 @@ mapped
 **type**: ``boolean``
 
 If you wish the field to be ignored when reading or writing to the object, you
-can set the ``mapped`` option to ``false``
+can set the ``mapped`` option to ``false``.

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -18,6 +18,7 @@ The ``password`` field renders an input password text box.
 |             | - `read_only`_                                                         |
 |             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
+|             | - `mapped`_                                                            |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`text</reference/forms/types/text>`                               |
 +-------------+------------------------------------------------------------------------+
@@ -57,3 +58,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/percent.rst
+++ b/reference/forms/types/percent.rst
@@ -25,6 +25,7 @@ This field adds a percentage sign "``%``" after the input box.
 |             | - `error_bubbling`_                                                   |
 |             | - `invalid_message`_                                                  |
 |             | - `invalid_message_parameters`_                                       |
+|             | - `mapped`_                                                           |
 +-------------+-----------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                            |
 +-------------+-----------------------------------------------------------------------+
@@ -80,3 +81,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -22,6 +22,7 @@ If you want to have a Boolean field, use :doc:`checkbox</reference/forms/types/c
 |             | - `read_only`_                                                      |
 |             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
+|             | - `mapped`_                                                         |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                          |
 +-------------+---------------------------------------------------------------------+
@@ -53,3 +54,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/repeated.rst
+++ b/reference/forms/types/repeated.rst
@@ -22,6 +22,7 @@ accuracy.
 | Inherited   | - `invalid_message`_                                                   |
 | options     | - `invalid_message_parameters`_                                        |
 |             | - `error_bubbling`_                                                    |
+|             | - `mapped`_                                                            |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/form>`                              |
 +-------------+------------------------------------------------------------------------+
@@ -178,3 +179,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/search.rst
+++ b/reference/forms/types/search.rst
@@ -19,6 +19,7 @@ Read about the input search field at `DiveIntoHTML5.info`_
 |             | - `read_only`_                                                       |
 |             | - `disabled`_                                                        |
 |             | - `error_bubbling`_                                                  |
+|             | - `mapped`_                                                          |
 +-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`text</reference/forms/types/text>`                             |
 +-------------+----------------------------------------------------------------------+
@@ -43,5 +44,9 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. _`DiveIntoHTML5.info`: http://diveintohtml5.info/forms.html#type-search

--- a/reference/forms/types/text.rst
+++ b/reference/forms/types/text.rst
@@ -16,6 +16,7 @@ The text field represents the most basic input text field.
 |             | - `read_only`_                                                     |
 |             | - `disabled`_                                                      |
 |             | - `error_bubbling`_                                                |
+|             | - `mapped`_                                                        |
 +-------------+--------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                         |
 +-------------+--------------------------------------------------------------------+
@@ -41,3 +42,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/textarea.rst
+++ b/reference/forms/types/textarea.rst
@@ -16,6 +16,7 @@ Renders a ``textarea`` HTML element.
 |             | - `read_only`_                                                         |
 |             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
+|             | - `mapped`_                                                            |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`field</reference/forms/types/field>`                             |
 +-------------+------------------------------------------------------------------------+
@@ -41,3 +42,6 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -28,6 +28,7 @@ as a ``DateTime`` object, a string, a timestamp or an array.
 | options              | - `invalid_message_parameters`_                                             |
 |                      | - `read_only`_                                                              |
 |                      | - `disabled`_                                                               |
+|                      | - `mapped`_                                                                 |
 |                      | - `virtual`_                                                                |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | form                                                                        |
@@ -125,5 +126,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/virtual.rst.inc

--- a/reference/forms/types/timezone.rst
+++ b/reference/forms/types/timezone.rst
@@ -27,6 +27,7 @@ you should just use the ``choice`` type directly.
 |             | - `read_only`_                                                         |
 |             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
+|             | - `mapped`_                                                            |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`choice</reference/forms/types/choice>`                           |
 +-------------+------------------------------------------------------------------------+
@@ -57,3 +58,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc

--- a/reference/forms/types/url.rst
+++ b/reference/forms/types/url.rst
@@ -20,6 +20,7 @@ have a protocol.
 |             | - `read_only`_                                                    |
 |             | - `disabled`_                                                     |
 |             | - `error_bubbling`_                                               |
+|             | - `mapped`_                                                       |
 +-------------+-------------------------------------------------------------------+
 | Parent type | :doc:`text</reference/forms/types/text>`                          |
 +-------------+-------------------------------------------------------------------+
@@ -56,3 +57,7 @@ These options inherit from the :doc:`field</reference/forms/types/field>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+These options inherit from the :doc:`date</reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/mapped.rst.inc


### PR DESCRIPTION
I ended up adding the mapped option to almost all types as they are usefull for almost all.

| Q | A |
| --- | --- |
| Doc fix? | yes (Improvement on existing docs) |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets | #1387 |
