### PR TITLE
Add Previous session option to security configuration

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -147,6 +147,10 @@ Each part will be explained in the next section.
                         # by default, the login form *must* be a POST, not a GET
                         post_only:      true
                         remember_me:    false
+
+                        #by default, a session must exist before submitting an authentication request
+                        require_previous_session: true
+
                     remember_me:
                         token_provider: name
                         key: someS3cretKey


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony#4776) |
| Applies to | 2.2+ |

Added in the option for require_previous_session to form_login configuration.
