### PR TITLE
Added limitations in 'Managing Common Dependencies with Parent Services'...

### DIFF
--- a/components/dependency_injection/parentservices.rst
+++ b/components/dependency_injection/parentservices.rst
@@ -276,7 +276,7 @@ when the child services are instantiated.
    
 .. caution::
 
-   ``scope``, ``abstract``, ``abstract`` attributes are always taken from the child.
+   ``scope``, ``abstract``, ``tags`` attributes are always taken from the child.
 
 The parent service is abstract as it should not be directly retrieved from the
 container or passed into another service. It exists merely as a "template" that

--- a/components/dependency_injection/parentservices.rst
+++ b/components/dependency_injection/parentservices.rst
@@ -273,6 +273,10 @@ when the child services are instantiated.
    is that omitting the ``parent`` config key will mean that the ``calls``
    defined on the ``mail_manager`` service will not be executed when the
    child services are instantiated.
+   
+.. caution::
+
+   ``scope``, ``abstract``, ``abstract`` attributes are always taken from the child.
 
 The parent service is abstract as it should not be directly retrieved from the
 container or passed into another service. It exists merely as a "template" that


### PR DESCRIPTION
This PR adds a caution in 'Managing Common Dependencies with Parent Services' page.

| Q | A |
| --- | --- |
| Doc fix? | yes (Improvement on existing docs) |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

Ref: [Source code](https://github.com/symfony/DependencyInjection/blob/master/Compiler/ResolveDefinitionTemplatesPass.php#L79),   [Issue](https://github.com/symfony/symfony/issues/4620)

Note: In 2.0 branch, [commit](https://github.com/symfony/symfony-docs/commit/2e7d5aa1eee8b31cf0f6c98aca366aabdfd54ef1) (Fixing a bad merge conflict) hasn't been applied yet. As this PR was built on top of 2.0 branch, still this contains the conflicts text. I have another [PR](https://github.com/symfony/symfony-docs/pull/2501) in which I have applied that commit manually. 
