### PR TITLE
[WCM] Documented that the Optional and Required constraints were moved

### DIFF
--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -166,6 +166,10 @@ from the ``$personalData`` property, no validation error would occur.
 .. versionadded:: 2.1
     The ``Required`` and ``Optional`` constraints are new to Symfony 2.1.
 
+.. versionadded:: 2.3
+    The ``Required`` and ``Optional`` constraints were moved to the namespace
+    ``Symfony\Component\Validator\Constraints\`` in Symfony 2.3.
+
 Required and Optional Field Constraints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -191,8 +195,8 @@ field is optional but must be a valid email if supplied, you can do the followin
             /**
              * @Assert\Collection(
              *     fields={
-             *         "personal_email"  = @Assert\Collection\Required({@Assert\NotBlank, @Assert\Email}),
-             *         "alternate_email" = @Assert\Collection\Optional({@Assert\Email}),
+             *         "personal_email"  = @Assert\Required({@Assert\NotBlank, @Assert\Email}),
+             *         "alternate_email" = @Assert\Optional(@Assert\Email),
              *     }
              * )
              */
@@ -217,8 +221,8 @@ field is optional but must be a valid email if supplied, you can do the followin
             {
                 $metadata->addPropertyConstraint('profileData', new Assert\Collection(array(
                     'fields' => array(
-                        'personal_email'  => new Assert\Collection\Required(array(new Assert\NotBlank(), new Assert\Email())),
-                        'alternate_email' => new Assert\Collection\Optional(array(new Assert\Email())),
+                        'personal_email'  => new Assert\Required(array(new Assert\NotBlank(), new Assert\Email())),
+                        'alternate_email' => new Assert\Optional(new Assert\Email()),
                     ),
                 )));
             }


### PR DESCRIPTION
... to the Symfony\Component\Validator\Constraints\ namespace

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony#7701) |
| Applies to | 2.3 |
| Fixed tickets | - |
