### PR TITLE
Remove unused code in the last code sample

### DIFF
--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -613,7 +613,6 @@ your form::
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         // ...
-        $subscriber = new AddNameFieldSubscriber($builder->getFormFactory());
         $builder->addEventSubscriber($this->registrationSportListener);
     }
 


### PR DESCRIPTION
This PR only removes a line in the last code sample of the dynamic_form_modification.rst page. The line does not make sense in the sample and has been removed to avoid confusing the reader.
