### PR TITLE
Fix custom Roles in entity_provider cookbook.

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -592,13 +592,12 @@ The ``AcmeUserBundle:Group`` entity class defines three table fields (``id``,
 ``name`` and ``role``). The unique ``role`` field contains the role name used by
 the Symfony security layer to secure parts of the application. The most
 important thing to notice is that the ``AcmeUserBundle:Group`` entity class
-implements the :class:`Symfony\\Component\\Security\\Core\\Role\\RoleInterface`
-that forces it to have a ``getRole()`` method::
+extends the :class:`Symfony\\Component\\Security\\Core\\Role\\Role`::
 
     // src/Acme/Bundle/UserBundle/Entity/Group.php
     namespace Acme\UserBundle\Entity;
 
-    use Symfony\Component\Security\Core\Role\RoleInterface;
+    use Symfony\Component\Security\Core\Role\Role;
     use Doctrine\Common\Collections\ArrayCollection;
     use Doctrine\ORM\Mapping as ORM;
 
@@ -606,7 +605,7 @@ that forces it to have a ``getRole()`` method::
      * @ORM\Table(name="acme_groups")
      * @ORM\Entity()
      */
-    class Group implements RoleInterface
+    class Group extends Role
     {
         /**
          * @ORM\Column(name="id", type="integer")


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | Symfony version 2.0 |
| Fixed tickets | I don't believe this fixes any PR's, but does relate to many rejected PR's on symfony/symfony (listed below) |

The current documentation seems to assume the implementation present in commit
https://github.com/symfony/symfony/pull/1673, which was reverted soon after its addition due to a potential, but undisclosed security hole (citation @schmittjoh in https://github.com/symfony/symfony/commit/af70ac8d777873c49347ac828a817a400006cbea).

This incorrect documentation has likely been the source of many
of the following issues:
- symfony/symfony#1538 - [ACL RoleSecurityIdentity] check if instance of Role
- symfony/symfony#1748 - Replace Role to RoleInterface for RoleSecurityIdentity
- symfony/symfony#4309 - Issue related to custom group (role) and ACL/ACE
- symfony/symfony#5026 - potential bug in Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity
- symfony/symfony#5076 - [Acl] altered the behaviour of RoleSecurityIdentity
- symfony/symfony#5171 - Fix/role security identity
- symfony/symfony#5303 - [Security] Check for RoleInterface instead of Role object in RoleSecurityIdentity
- symfony/symfony#5909 - Allow Custom Roles to implement the RoleInterface
- symfony/symfony#6012 - Securityidentity fix
