### PR TITLE
Added a note to the dom-crawler docs about character sets

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -160,6 +160,12 @@ The crawler supports multiple ways of adding the content::
     $crawler->add('<html><body /></html>');
     $crawler->add('<root><node /></root>');
 
+.. note::
+
+    When dealing with other character sets than ISO-8859-1, always add HTML content
+    using the addHTMLContent method where you can specify the second parameter
+    to be your target character set.
+
 As the Crawler's implementation is based on the DOM extension, it is also able
 to interact with native :phpclass:`DOMDocument`, :phpclass:`DOMNodeList`
 and :phpclass:`DOMNode` objects:


### PR DESCRIPTION
I added a note to the documentation to make it clear that when adding content using the default examples, the charset is assumed to be ISO-8859-1. If one wants to crawl/scrape UTF-8 documents, they should create a blank object and use addHTMLContent and specify the character set.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.0+ |
| Fixed tickets | n/a |
