### PR TITLE
Added missing UniqueEntity ignoreNull documentation

### DIFF
--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -149,3 +149,15 @@ repositoryMethod
 The name of the repository method to use for making the query to determine the
 uniqueness. If it's left blank, the ``findBy`` method will be used. This
 method should return a countable result.
+
+ignoreNull
+~~~~~~~~~~
+
+**type**: ``Boolean`` **default**: ``true``
+
+.. versionadded:: 2.1
+    The ``ignoreNull`` option was added in Symfony 2.1.
+
+If this option is set to ``true``, it allows having multiple ``null`` values for
+the field(s) without failing the unique constraint. If set to ``false``, only one
+``null`` value is allowed.

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -12,6 +12,7 @@ using an email address that already exists in the system.
 |                | - `message`_                                                                        |
 |                | - `em`_                                                                             |
 |                | - `repositoryMethod`_                                                               |
+|                | - `ignoreNull`_                                                                     |
 +----------------+-------------------------------------------------------------------------------------+
 | Class          | :class:`Symfony\\Bridge\\Doctrine\\Validator\\Constraints\\UniqueEntity`            |
 +----------------+-------------------------------------------------------------------------------------+
@@ -150,13 +151,13 @@ The name of the repository method to use for making the query to determine the
 uniqueness. If it's left blank, the ``findBy`` method will be used. This
 method should return a countable result.
 
+.. versionadded:: 2.1
+    The ``ignoreNull`` option was added in Symfony 2.1.
+
 ignoreNull
 ~~~~~~~~~~
 
 **type**: ``Boolean`` **default**: ``true``
-
-.. versionadded:: 2.1
-    The ``ignoreNull`` option was added in Symfony 2.1.
 
 If this option is set to ``true``, it allows having multiple ``null`` values for
 the field(s) without failing the unique constraint. If set to ``false``, only one


### PR DESCRIPTION
The ignoreNull options was added to the UniqueEntity constraint on 6 Aug 2012, but there was no documentation created for it. The PR with the code changes was merged after the release of SF 2.0

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes (symfony/symfony#5015) |
| Applies to | 2.1+ |
| Fixed tickets | N/A |

Merge commit ref: symfony/symfony@0ccda3877538367c5aa73f7c0a557e643cfb2c70
