### PR TITLE
Fixed wrong makePathRelative example in Filesystem component

### DIFF
--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -204,7 +204,7 @@ Return the relative path of a directory given another one::
         '/var/lib/symfony/src/Symfony/Component'
     );
     // returns 'videos'
-    $fs->makePathRelative('/tmp', '/tmp/videos');
+    $fs->makePathRelative('/tmp/videos', '/tmp')
 
 mirror
 ~~~~~~


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets | n/a |
