### PR TITLE
fixed example to check if the session exists when getting flash messages to avoid starting sessions when not needed

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -686,19 +686,23 @@ the ``notice`` message:
 
     .. code-block:: html+jinja
 
-        {% for flashMessage in app.session.flashbag.get('notice') %}
-            <div class="flash-notice">
-                {{ flashMessage }}
-            </div>
-        {% endfor %}
+        {% if app.session.started %}
+            {% for flashMessage in app.session.flashbag.get('notice') %}
+                <div class="flash-notice">
+                    {{ flashMessage }}
+                </div>
+            {% endfor %}
+        {% endif %}
 
     .. code-block:: html+php
 
-        <?php foreach ($view['session']->getFlashBag()->get('notice') as $message): ?>
-            <div class="flash-notice">
-                <?php echo "<div class='flash-error'>$message</div>" ?>
-            </div>
-        <?php endforeach; ?>
+        <?php if ($view['session']->isStarted()): ?>
+            <?php foreach ($view['session']->getFlashBag()->get('notice') as $message): ?>
+                <div class="flash-notice">
+                    <?php echo "<div class='flash-error'>$message</div>" ?>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
 
 By design, flash messages are meant to live for exactly one request (they're
 "gone in a flash"). They're designed to be used across redirects exactly as

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -333,3 +333,16 @@ Compact method to process display all flashes at once::
             echo "<div class='flash-$type'>$message</div>\n";
         }
     }
+
+.. caution::
+
+    As flash messages use a session to store the messages from one request to
+    the next one, a session will be automatically started when you read the
+    flash messages even if none already exists. To avoid that default
+    behavior, test if there is an existing session first::
+
+        if ($session->isStarted()) {
+            foreach ($session->getFlashBag()->get('warning', array()) as $message) {
+                echo "<div class='flash-warning'>$message</div>";
+            }
+        }

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -141,9 +141,11 @@ next request::
 
     // display any messages back in the next request (in a template)
 
-    {% for flashMessage in app.session.flashbag.get('notice') %}
-        <div>{{ flashMessage }}</div>
-    {% endfor %}
+    {% if app.session.started %}
+        {% for flashMessage in app.session.flashbag.get('notice') %}
+            <div>{{ flashMessage }}</div>
+        {% endfor %}
+    {% endif %}
 
 This is useful when you need to set a success message before redirecting
 the user to another page (which will then show the message). Please note that


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | symfony/symfony#6036 |
