### PR TITLE
[TheBook][Testing] - Fixed example, wrong access to header property on Client object

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -279,7 +279,7 @@ document::
 
         // Assert that the "Content-Type" header is "application/json"
         $this->assertTrue(
-            $client->getResponse()->headers->contains(
+            $client->getResponse()->getHeaders()->contains(
                 'Content-Type',
                 'application/json'
             )


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | NA |

In the example on how to validate headers $client tries to access Symfony\Bundle\FrameworkBundle\Client::headers directly this property is protected. The correct way is Symfony\Bundle\FrameworkBundle\Client::getHeaders()
