### PR TITLE
Fix the namespace paths in reference/constraints/UserPassword.html

### DIFF
--- a/reference/constraints/UserPassword.rst
+++ b/reference/constraints/UserPassword.rst
@@ -7,10 +7,10 @@ UserPassword
 .. note::
 
     Since Symfony 2.2, the `UserPassword*` classes in the
-    `Symfony\Component\Security\Core\Validator\Constraint` namespace are
+    `Symfony\\Component\\Security\\Core\\Validator\\Constraint` namespace are
     deprecated and will be removed in Symfony 2.3. Please use the
     `UserPassword*` classes in the
-    `Symfony\Component\Security\Core\Validator\Constraints` namespace instead.
+    `Symfony\\Component\\Security\\Core\Validator\\Constraints` namespace instead.
 
 This validates that an input value is equal to the current authenticated
 user's password. This is useful in a form where a user can change his password,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | n/a |

The backslashes in the namespace were not escaped, and so did not show up in the generated output.
