### PR TITLE
Created information for framework session.name reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -27,6 +27,7 @@ Configuration
     * enabled
     * field_name
 * `session`_
+    * `name`_
     * `lifetime`_
 * `templating`_
     * `assets_base_urls`_
@@ -146,6 +147,14 @@ csrf_protection
 
 session
 ~~~~~~~
+
+name
+....
+
+**type**: ``string`` **default**: ``null``
+
+This specifies the name of the session cookie. By default it will use the cookie
+name which is defined in the ``php.ini`` with the ``session.name`` directive.
 
 lifetime
 ........


### PR DESCRIPTION
Since the documentation has no information about framework.session.name. I want to add some.
