### PR TITLE
the Filesystem component including a tagged API was added in Symfony 2.1

### DIFF
--- a/book/stable_api.rst
+++ b/book/stable_api.rst
@@ -31,6 +31,7 @@ As of Symfony 2.0, the following components have a public tagged API:
 * DependencyInjection
 * DomCrawler
 * EventDispatcher
+* Filesystem (as of Symfony 2.1)
 * Finder
 * HttpFoundation
 * HttpKernel


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets | #2391 |
