### PR TITLE
added a paragraph about experimental features

### DIFF
--- a/book/api.rst
+++ b/book/api.rst
@@ -1,8 +1,11 @@
 .. index::
-   single: Stable API
+   single: API
 
-The Symfony2 Stable API
-=======================
+The Symfony2 API
+================
+
+The Stable API
+--------------
 
 The Symfony2 stable API is a subset of all Symfony2 published public methods
 (components and core bundles) that share the following properties:
@@ -42,3 +45,11 @@ As of Symfony 2.0, the following components have a public tagged API:
 * Translation
 * Validator
 * Yaml
+
+The Experimental API
+--------------------
+
+Some Symfony features are marked as being experimental (tagged with
+``@experimental``). Experimental features are not stable yet and they might
+change **drastically** in subsequent versions. These features were added early
+to Symfony to gather feedback from Symfony developers.

--- a/book/index.rst
+++ b/book/index.rst
@@ -22,6 +22,6 @@ The Book
     service_container
     performance
     internals
-    stable_api
+    api
 
 .. include:: /book/map.rst.inc

--- a/book/map.rst.inc
+++ b/book/map.rst.inc
@@ -16,4 +16,4 @@
 * :doc:`/book/service_container`
 * :doc:`/book/performance`
 * :doc:`/book/internals`
-* :doc:`/book/stable_api`
+* :doc:`/book/api`


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.3+ |
| Fixed tickets | n/a |

As Symfony 2.3 will freeze most of its API, we need a way to explicitly mark things as being experimental.

The goal of experimental features is to be able to gather feedback from our users as early as possible, by keeping the possibility to change things based on this feedback.

The first feature that will be marked as experimental in 2.3 is the simplification of the security customization (see symfony/symfony#6069 -- and Seldaek/symfony#3).
