### PR TITLE
Update yaml component docs to reflect Yaml::parse(filename) deprecation

### DIFF
--- a/components/yaml/introduction.rst
+++ b/components/yaml/introduction.rst
@@ -134,13 +134,11 @@ string or a file containing YAML. Internally, it calls the
 :method:`Symfony\\Component\\Yaml\\Parser::parse` method, but enhances the
 error if something goes wrong by adding the filename to the message.
 
-.. note::
+.. caution::
 
-    Although it is currently possible to pass the
-    :method:`Symfony\\Component\\Yaml\\Yaml::parse` static method a
-    filename, this functionality is deprecated in Symfony 2.3, and will be
-    removed in Symfony 3.0. Because it is possible to pass a filename, if
-    you use this method, you must validate the input first.
+    Because it is currently possible to pass a filename to this method, you
+    must validate the input first. Passing a filename is deprecated in
+    Symfony 2.2, and will be removed in Symfony 3.0.
 
 Executing PHP Inside YAML Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/components/yaml/introduction.rst
+++ b/components/yaml/introduction.rst
@@ -120,19 +120,27 @@ error occurred:
     As the parser is re-entrant, you can use the same parser object to load
     different YAML strings.
 
-When loading a YAML file, it is sometimes better to use the
+It may also be convenient to use the
 :method:`Symfony\\Component\\Yaml\\Yaml::parse` wrapper method:
 
 .. code-block:: php
 
     use Symfony\Component\Yaml\Yaml;
 
-    $yaml = Yaml::parse('/path/to/file.yml');
+    $yaml = Yaml::parse(file_get_contents('/path/to/file.yml'));
 
 The :method:`Symfony\\Component\\Yaml\\Yaml::parse` static method takes a YAML
 string or a file containing YAML. Internally, it calls the
 :method:`Symfony\\Component\\Yaml\\Parser::parse` method, but enhances the
 error if something goes wrong by adding the filename to the message.
+
+.. note::
+
+    Although it is currently possible to pass the
+    :method:`Symfony\\Component\\Yaml\\Yaml::parse` static method a
+    filename, this functionality is deprecated in Symfony 2.3, and will be
+    removed in Symfony 3.0. Because it is possible to pass a filename, if
+    you use this method, you must validate the input first.
 
 Executing PHP Inside YAML Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | #2570 |

Using a filename as argument to Yaml::parse is deprecated as of 2.2 (according to the sources) and will be removed from sf 3.0. Updated the documentation to indicate this, and include the warning from the source about the need to validate the input first.

Obsoletes PR #2620.
