### PR TITLE
Fix method name typos in TableHelper cookbook entry

### DIFF
--- a/components/console/helpers/tablehelper.rst
+++ b/components/console/helpers/tablehelper.rst
@@ -48,8 +48,8 @@ You can also control table rendering by setting custom rendering option values:
 *  :method:`Symfony\\Component\\Console\\Helper\\TableHelper::setPaddingChar`
 *  :method:`Symfony\\Component\\Console\\Helper\\TableHelper::setHorizontalBorderChar`
 *  :method:`Symfony\\Component\\Console\\Helper\\TableHelper::setVerticalBorderChar`
-*  :method:`Symfony\\Component\\Console\\Helper\\TableHelper::setVrossingChar`
-*  :method:`Symfony\\Component\\Console\\Helper\\TableHelper::setVellHeaderFormat`
-*  :method:`Symfony\\Component\\Console\\Helper\\TableHelper::setVellRowFormat`
+*  :method:`Symfony\\Component\\Console\\Helper\\TableHelper::setCrossingChar`
+*  :method:`Symfony\\Component\\Console\\Helper\\TableHelper::setCellHeaderFormat`
+*  :method:`Symfony\\Component\\Console\\Helper\\TableHelper::setCellRowFormat`
 *  :method:`Symfony\\Component\\Console\\Helper\\TableHelper::setBorderFormat`
 *  :method:`Symfony\\Component\\Console\\Helper\\TableHelper::setPadType`


### PR DESCRIPTION
There were a few method name typos in the TableHelper cookbook entry.
