### PR TITLE
Revert "fixed example to check if the session exists when getting flash ...

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -686,23 +686,19 @@ the ``notice`` message:
 
     .. code-block:: html+jinja
 
-        {% if app.session.started %}
-            {% for flashMessage in app.session.flashbag.get('notice') %}
-                <div class="flash-notice">
-                    {{ flashMessage }}
-                </div>
-            {% endfor %}
-        {% endif %}
+        {% for flashMessage in app.session.flashbag.get('notice') %}
+            <div class="flash-notice">
+                {{ flashMessage }}
+            </div>
+        {% endfor %}
 
     .. code-block:: html+php
 
-        <?php if ($view['session']->isStarted()): ?>
-            <?php foreach ($view['session']->getFlashBag()->get('notice') as $message): ?>
-                <div class="flash-notice">
-                    <?php echo "<div class='flash-error'>$message</div>" ?>
-                </div>
-            <?php endforeach; ?>
-        <?php endif; ?>
+        <?php foreach ($view['session']->getFlashBag()->get('notice') as $message): ?>
+            <div class="flash-notice">
+                <?php echo "<div class='flash-error'>$message</div>" ?>
+            </div>
+        <?php endforeach; ?>
 
 By design, flash messages are meant to live for exactly one request (they're
 "gone in a flash"). They're designed to be used across redirects exactly as

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -333,16 +333,3 @@ Compact method to process display all flashes at once::
             echo "<div class='flash-$type'>$message</div>\n";
         }
     }
-
-.. caution::
-
-    As flash messages use a session to store the messages from one request to
-    the next one, a session will be automatically started when you read the
-    flash messages even if none already exists. To avoid that default
-    behavior, test if there is an existing session first::
-
-        if ($session->isStarted()) {
-            foreach ($session->getFlashBag()->get('warning', array()) as $message) {
-                echo "<div class='flash-warning'>$message</div>";
-            }
-        }

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -141,11 +141,9 @@ next request::
 
     // display any messages back in the next request (in a template)
 
-    {% if app.session.started %}
-        {% for flashMessage in app.session.flashbag.get('notice') %}
-            <div>{{ flashMessage }}</div>
-        {% endfor %}
-    {% endif %}
+    {% for flashMessage in app.session.flashbag.get('notice') %}
+        <div>{{ flashMessage }}</div>
+    {% endfor %}
 
 This is useful when you need to set a success message before redirecting
 the user to another page (which will then show the message). Please note that


### PR DESCRIPTION
Hi guys!

This reverts #2564. In that issue, I made a comment:

> Before I merge this, I want to make sure I'm not missing something. Why would the following situation not cause a problem:
> 
> 1) On one request, you set a value in the flashbag and redirect
> 2) On the next request, you check for app.session.started in Twig. There is a flash message in the session, but the session hasn't been started yet, so the message is not displayed.

I apologize if I'm missing something, but it seems that this _is_ a problem. I've tested locally (and had a training group that hit this) and with the new `if` statement, the flash messages don't print unless you've explicitly started the session earlier in the request (e.g. by accessing the session in the controller).

Can someone verify one way or another? I don't think it's possible to lazily ask "is there something in the flashbag?" without actually starting the session to be sure.

Thanks!
