### PR TITLE
Voters should refer to authorization, not authentication.

### DIFF
--- a/cookbook/security/voters.rst
+++ b/cookbook/security/voters.rst
@@ -4,10 +4,10 @@
 How to implement your own Voter to blacklist IP Addresses
 =========================================================
 
-The Symfony2 security component provides several layers to authenticate users.
+The Symfony2 security component provides several layers to authorize users.
 One of the layers is called a `voter`. A voter is a dedicated class that checks
 if the user has the rights to be connected to the application. For instance,
-Symfony2 provides a layer that checks if the user is fully authenticated or if
+Symfony2 provides a layer that checks if the user is fully authorized or if
 it has some expected roles.
 
 It is sometimes useful to create a custom voter to handle a specific case not


### PR DESCRIPTION
Voters have nothing to do with authentication, only authorization.  I have updated the terminology as such.  I was caught by this when trying to build custom authentication due to the terminology of this page.
