### PR TITLE
Book/Doctrine: Minor typo fix

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -1462,7 +1462,7 @@ and ``nullable``. Take a few examples:
         <!--
             A string field length 255 that cannot be null
             (reflecting the default values for the "length" and *nullable* options)
-            type attribute is necessary in yaml definitions
+            type attribute is necessary in xml definitions
         -->
         <field name="name" type="string" />
         <field name="email"


### PR DESCRIPTION
Fixing bad copy/paste ("yaml" => "xml").
I'm checking/updating French doc so I see everything (or almost) ;)
