### PR TITLE
removed unneeded block

### DIFF
--- a/reference/forms/types/options/property_path.rst.inc
+++ b/reference/forms/types/options/property_path.rst.inc
@@ -9,8 +9,3 @@ the form is submitted, the submitted value is written back into the object.
 If you want to override the property that a field reads from and writes to, 
 you can set the ``property_path`` option. Its default value is the field's
 name.
-
-If you wish the field to be ignored when reading or writing to the object 
-you can set the ``property_path`` option to ``false``, but using
-``property_path`` for this purpose is deprecated, you should do it the way
-described below:


### PR DESCRIPTION
Since the block below has been removed (@4346f75f05a5ee010d0148ea251e99c7f6a02c38).
