### PR TITLE
XML callback definition needs to define an array to work

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -162,8 +162,10 @@ process. Each method can be one of the following formats:
             <class name="Acme\BlogBundle\Entity\Author">
                 <constraint name="Callback">
                     <option name="methods">
-                        <value>Acme\BlogBundle\MyStaticValidatorClass</value>
-                        <value>isAuthorValid</value>
+                        <value>
+                            <value>Acme\BlogBundle\MyStaticValidatorClass</value>
+                            <value>isAuthorValid</value>
+                        </value>
                     </option>
                 </constraint>
             </class>


### PR DESCRIPTION
If it's not an array, it won't be considered a callable.
