### PR TITLE
Wrong default value in docs ?

### DIFF
--- a/reference/forms/types/options/grouping.rst.inc
+++ b/reference/forms/types/options/grouping.rst.inc
@@ -1,6 +1,6 @@
 grouping
 ~~~~~~~~
 
-**type**: ``integer`` **default**: ``false``
+**type**: ``integer`` **default**: ``true``
 
 This value is used internally as the ``NumberFormatter::GROUPING_USED`` value when using PHP's ``NumberFormatter`` class. Its documentation is non-existent, but it appears that if you set this to ``true``, numbers will be grouped with a comma or period (depending on your locale): ``12345.123`` would display as ``12,345.123``.


### PR DESCRIPTION
If I'm not mistaken, `money` grouping is by default TRUE [see code](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php#L30)
