### PR TITLE
[Form] improve placement of timestamp limitation notices

### DIFF
--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -74,6 +74,8 @@ your underlying object. Valid values are:
 The value that comes back from the form will also be normalized back into
 this format.
 
+.. include:: /reference/forms/types/options/_date_limitation.rst.inc
+
 date_format
 ~~~~~~~~~~~
 

--- a/reference/forms/types/options/date_widget.rst.inc
+++ b/reference/forms/types/options/date_widget.rst.inc
@@ -12,5 +12,3 @@ The basic way in which this field should be rendered. Can be one of the followin
 
 * ``single_text``: renders a single input of type date (text in Symfony 2.0). User's 
   input is validated based on the `format`_ option.
-
-.. include:: /reference/forms/types/options/_date_limitation.rst.inc


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | rather an improvement |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets | none |
- Removes the notice for option `widget` on pages "`date` Field Type" and "`birthday` Field Type". It's already included by `date_input.rst.inc` and rendered for the `input` option.
- Adds the notice to the "`datetime` Field Type" page for the `input` option.
