### PR TITLE
Fix for #2485

### DIFF
--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -123,6 +123,7 @@ before creating the parent form::
     namespace Acme\TestBundle\Tests\Form\Type;
 
     use Acme\TestBundle\Form\Type\TestedType;
+    use Acme\TestBundle\Form\Forms;
     use Acme\TestBundle\Model\TestObject;
     use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
 
@@ -130,10 +131,12 @@ before creating the parent form::
     {
         public function testBindValidData()
         {
-            $this->factory->addType(new TestChildType());
-
             $type = new TestedType();
-            $form = $this->factory->create($type);
+
+            $form = Forms::createFormFactoryBuilder()
+                ->addType(new TestChildType())
+                ->getFormFactory()
+                ->create($type);
 
             // ... your test
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets | #2485 |

Fixes the documented example of how to test forms with custom types,
as there was no better suggestions than the one put forward by
@chrisburgess7 I implemented that in my test case & it worked so
I've updated the documentation to match.

(Resubmitted against the proper branch)
