### PR TITLE
For BCrypt password encoder indicated PHP 5.5 is required

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -303,6 +303,9 @@ for the hash algorithm.
 Using the BCrypt Password Encoder
 ---------------------------------
 
+.. caution::
+	PHP Version 5.5 is required or install the "ircmaxell/password-compat" via composer.
+
 .. versionadded:: 2.2
     The BCrypt password encoder was added in Symfony 2.2.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets |  |

Should indicate that PHP 5.5 is required for Bcrypt password encoding
