### PR TITLE
Fixed formatting

### DIFF
--- a/cookbook/cache/varnish.rst
+++ b/cookbook/cache/varnish.rst
@@ -128,6 +128,7 @@ that will invalidate the cache for a given resource:
     purging your cached data. You can do this by setting up an access list: 
 
 .. code-block:: text
+
     /* 
      Connect to the backend server 
      on the local machine on port 8080


### PR DESCRIPTION
I believe this missing newline is causing symfony.com to end on the following note.

```
You can do this by setting up an access list:
```

Quite a cliffhanger! ;)
