### PR TITLE
Update monolog.rst

### DIFF
--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -56,9 +56,6 @@ Monolog Configuration Reference
                     email_prototype:
                         id:                   ~ # Required (when the email_prototype is used)
                         method:               ~
-                    channels:
-                        type:                 ~
-                        elements:             []
                     formatter:            ~
 
     .. code-block:: xml


### PR DESCRIPTION
'channels' key was specified twice in default options, removed one.
