### PR TITLE
Added namespace declaration to MainController.php.

### DIFF
--- a/book/http_fundamentals.rst
+++ b/book/http_fundamentals.rst
@@ -459,6 +459,8 @@ the ``AcmeDemoBundle:Main:contact`` string is a short syntax that points to a
 specific PHP method ``contactAction`` inside a class called ``MainController``::
 
     // src/Acme/DemoBundle/Controller/MainController.php
+    namespace Acme\DemoBundle\Controller;
+
     use Symfony\Component\HttpFoundation\Response;
 
     class MainController

--- a/book/http_fundamentals.rst
+++ b/book/http_fundamentals.rst
@@ -449,7 +449,7 @@ by adding an entry for ``/contact`` to your routing configuration file:
 
 .. note::
 
-   This example uses :doc:`YAML</components/yaml/introduction>` to define the routing
+   This example uses :doc:`YAML</components/yaml/format>` to define the routing
    configuration. Routing configuration can also be written in other formats
    such as XML or PHP.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets |  |

My first experience with Symfony so I'm going through the docs and entering the code snippets. I got an exception when trying to view the newly-created contact page in HTTP Fundamentals - saying that it found the MainController file but couldn't find the class. I added a missing namespace declaration and that fixed the problem.
