### PR TITLE
[Validation] fixed a link

### DIFF
--- a/book/validation.rst
+++ b/book/validation.rst
@@ -101,7 +101,7 @@ following:
 .. tip::
 
     Protected and private properties can also be validated, as well as "getter"
-    methods (see `validator-constraint-targets`).
+    methods (see :ref:`validator-constraint-targets`).
 
 .. index::
    single: Validation; Using the validator


### PR DESCRIPTION
The link doesn't show up on the documentation page (http://symfony.com/doc/current/book/validation.html).
