### PR TITLE
Fixed the YAML example in the scope cookboob article

### DIFF
--- a/cookbook/service_container/scopes.rst
+++ b/cookbook/service_container/scopes.rst
@@ -149,7 +149,7 @@ your code. This should also be taken into account when declaring your service:
             greeting_card_manager:
                 class: Acme\HelloBundle\Mail\GreetingCardManager
                 calls:
-                    - [setRequest, ['@?request']]
+                    - [setRequest, ['@?request=']]
 
     .. code-block:: xml
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | symfony/symfony#8307 |

The argument was missing the strict=false attribute to be consistent with the XML and PHP examples, and it is needed when using a synchronized service from a narrower scope.
