### PR TITLE
Fix an incorrect configuration snippet in the cookbook about scopes

### DIFF
--- a/cookbook/service_container/scopes.rst
+++ b/cookbook/service_container/scopes.rst
@@ -149,7 +149,7 @@ your code. This should also be taken into account when declaring your service:
             greeting_card_manager:
                 class: Acme\HelloBundle\Mail\GreetingCardManager
                 calls:
-                    - [setRequest, ['@?request']]
+                    - [setRequest, ['@?request=']]
 
     .. code-block:: xml
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets |  |

Pointed out by stof [here](https://github.com/symfony/symfony-docs/pull/2343#discussion_r3536554).
When using `['@?request']]` the synchronized service does not work and I get a `ScopeWideningInjectionException`. Using `['@?request=']]` fixes that issue.
