### PR TITLE
[book] Avoid scrollbars in code examples

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -667,7 +667,10 @@ For example, imagine you're processing a form submit::
         if ($form->isValid()) {
             // do some sort of processing
 
-            $this->get('session')->getFlashBag()->add('notice', 'Your changes were saved!');
+            $this->get('session')->getFlashBag()->add(
+                'notice',
+                'Your changes were saved!'
+            );
 
             return $this->redirect($this->generateUrl(...));
         }

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -212,7 +212,9 @@ just a simple PHP class.
 
     .. code-block:: bash
 
-        $ php app/console doctrine:generate:entity --entity="AcmeStoreBundle:Product" --fields="name:string(255) price:float description:text"
+        $ php app/console doctrine:generate:entity \
+          --entity="AcmeStoreBundle:Product" \
+          --fields="name:string(255) price:float description:text"
 
 .. index::
     single: Doctrine; Adding mapping metadata
@@ -696,7 +698,10 @@ a controller, do the following::
 
     $em = $this->getDoctrine()->getManager();
     $query = $em->createQuery(
-        'SELECT p FROM AcmeStoreBundle:Product p WHERE p.price > :price ORDER BY p.price ASC'
+        'SELECT p
+        FROM AcmeStoreBundle:Product p
+        WHERE p.price > :price
+        ORDER BY p.price ASC'
     )->setParameter('price', '19.99');
 
     $products = $query->getResult();
@@ -858,7 +863,9 @@ ordered alphabetically.
         public function findAllOrderedByName()
         {
             return $this->getEntityManager()
-                ->createQuery('SELECT p FROM AcmeStoreBundle:Product p ORDER BY p.name ASC')
+                ->createQuery(
+                    'SELECT p FROM AcmeStoreBundle:Product p ORDER BY p.name ASC'
+                )
                 ->getResult();
         }
     }
@@ -892,7 +899,8 @@ you can let Doctrine create the class for you.
 
 .. code-block:: bash
 
-    $ php app/console doctrine:generate:entity --entity="AcmeStoreBundle:Category" --fields="name:string(255)"
+    $ php app/console doctrine:generate:entity --entity="AcmeStoreBundle:Category" \ 
+      --fields="name:string(255)"
 
 This task generates the ``Category`` entity for you, with an ``id`` field,
 a ``name`` field and the associated getter and setter functions.
@@ -937,7 +945,7 @@ To relate the ``Category`` and ``Product`` entities, start by creating a
                 products:
                     targetEntity: Product
                     mappedBy: category
-            # don't forget to init the collection in entity __construct() method
+            # don't forget to init the collection in the __construct() method of the entity
 
     .. code-block:: xml
 
@@ -954,7 +962,10 @@ To relate the ``Category`` and ``Product`` entities, start by creating a
                     mapped-by="category"
                 />
 
-                <!-- don't forget to init the collection in entity __construct() method -->
+                <!--
+                    don't forget to init the collection in
+                    the __construct() method of the entity
+                -->
             </entity>
         </doctrine-mapping>
 
@@ -1325,7 +1336,8 @@ the current date, only when the entity is first persisted (i.e. inserted):
             <entity name="Acme\StoreBundle\Entity\Product">
                     <!-- ... -->
                     <lifecycle-callbacks>
-                        <lifecycle-callback type="prePersist" method="setCreatedValue" />
+                        <lifecycle-callback type="prePersist"
+                            method="setCreatedValue" />
                     </lifecycle-callbacks>
             </entity>
         </doctrine-mapping>

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -344,7 +344,10 @@ object.
                 $metadata->addPropertyConstraint('task', new NotBlank());
 
                 $metadata->addPropertyConstraint('dueDate', new NotBlank());
-                $metadata->addPropertyConstraint('dueDate', new Type('\DateTime'));
+                $metadata->addPropertyConstraint(
+                    'dueDate',
+                    new Type('\DateTime')
+                );
             }
         }
 
@@ -424,7 +427,10 @@ to an array callback, or a ``Closure``::
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'validation_groups' => array('Acme\\AcmeBundle\\Entity\\Client', 'determineValidationGroups'),
+            'validation_groups' => array(
+                'Acme\AcmeBundle\Entity\Client',
+                'determineValidationGroups',
+            ),
         ));
     }
 
@@ -903,7 +909,8 @@ easy to use in your application.
     .. code-block:: xml
 
         <!-- src/Acme/TaskBundle/Resources/config/services.xml -->
-        <service id="acme_demo.form.type.task" class="Acme\TaskBundle\Form\Type\TaskType">
+        <service id="acme_demo.form.type.task"
+            class="Acme\TaskBundle\Form\Type\TaskType">
             <tag name="form.type" alias="task" />
         </service>
 
@@ -913,7 +920,10 @@ easy to use in your application.
         use Symfony\Component\DependencyInjection\Definition;
 
         $container
-            ->register('acme_demo.form.type.task', 'Acme\TaskBundle\Form\Type\TaskType')
+            ->register(
+                'acme_demo.form.type.task',
+                'Acme\TaskBundle\Form\Type\TaskType'
+            )
             ->addTag('form.type', array(
                 'alias' => 'task',
             ))
@@ -1286,13 +1296,13 @@ rendered (e.g. ``label``, ``widget``, ``errors``, etc). By default, there
 are 4 possible *parts* of a form that can be rendered:
 
 +-------------+--------------------------+---------------------------------------------------------+
-| ``label``   | (e.g. ``form_label``)   | renders the field's label                                |
+| ``label``   | (e.g. ``form_label``)    | renders the field's label                               |
 +-------------+--------------------------+---------------------------------------------------------+
-| ``widget``  | (e.g. ``form_widget``)  | renders the field's HTML representation                  |
+| ``widget``  | (e.g. ``form_widget``)   | renders the field's HTML representation                 |
 +-------------+--------------------------+---------------------------------------------------------+
-| ``errors``  | (e.g. ``form_errors``)  | renders the field's errors                               |
+| ``errors``  | (e.g. ``form_errors``)   | renders the field's errors                              |
 +-------------+--------------------------+---------------------------------------------------------+
-| ``row``     | (e.g. ``form_row``)     | renders the field's entire row (label, widget & errors)  |
+| ``row``     | (e.g. ``form_row``)      | renders the field's entire row (label, widget & errors) |
 +-------------+--------------------------+---------------------------------------------------------+
 
 .. note::

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -57,7 +57,8 @@ Distribution:
 
 .. code-block:: bash
 
-    php composer.phar create-project symfony/framework-standard-edition /path/to/webroot/Symfony 2.2.0
+    $ php composer.phar create-project \
+      symfony/framework-standard-edition /path/to/webroot/Symfony 2.2.0
 
 .. tip::
 

--- a/book/internals.rst
+++ b/book/internals.rst
@@ -418,7 +418,11 @@ and set a new ``Exception`` object, or do nothing::
     response won't work. If you want to overwrite the status code (which you
     should not without a good reason), set the ``X-Status-Code`` header::
 
-        return new Response('Error', 404 /* ignored */, array('X-Status-Code' => 200));
+        return new Response(
+            'Error',
+            404 // ignored,
+            array('X-Status-Code' => 200)
+        );
 
 .. index::
    single: Event Dispatcher
@@ -610,11 +614,19 @@ If you enable the web profiler, you also need to mount the profiler routes:
 
     .. code-block:: xml
 
-        <import resource="@WebProfilerBundle/Resources/config/routing/profiler.xml" prefix="/_profiler" />
+        <import
+            resource="@WebProfilerBundle/Resources/config/routing/profiler.xml"
+            prefix="/_profiler"
+        />
 
     .. code-block:: php
 
-        $collection->addCollection($loader->import("@WebProfilerBundle/Resources/config/routing/profiler.xml"), '/_profiler');
+        $collection->addCollection(
+            $loader->import(
+                "@WebProfilerBundle/Resources/config/routing/profiler.xml"
+            ),
+            '/_profiler'
+        );
 
 As the profiler adds some overhead, you might want to enable it only under
 certain circumstances in the production environment. The ``only-exceptions``
@@ -626,7 +638,8 @@ portion of the website? You can use a request matcher:
 
     .. code-block:: yaml
 
-        # enables the profiler only for request coming for the 192.168.0.0 network
+        # enables the profiler only for request coming
+        # for the 192.168.0.0 network
         framework:
             profiler:
                 matcher: { ip: 192.168.0.0/24 }
@@ -641,14 +654,18 @@ portion of the website? You can use a request matcher:
             profiler:
                 matcher: { ip: 192.168.0.0/24, path: "^/admin/" }
 
-        # use a custom matcher instance defined in the "custom_matcher" service
+        # use a custom matcher instance defined in
+        # the "custom_matcher" service
         framework:
             profiler:
                 matcher: { service: custom_matcher }
 
     .. code-block:: xml
 
-        <!-- enables the profiler only for request coming for the 192.168.0.0 network -->
+        <!--
+            enables the profiler only for request coming
+            for the 192.168.0.0 network
+        -->
         <framework:config>
             <framework:profiler>
                 <framework:matcher ip="192.168.0.0/24" />
@@ -669,7 +686,10 @@ portion of the website? You can use a request matcher:
             </framework:profiler>
         </framework:config>
 
-        <!-- use a custom matcher instance defined in the "custom_matcher" service -->
+        <!--
+            use a custom matcher instance defined in
+            the "custom_matcher" service
+        -->
         <framework:config>
             <framework:profiler>
                 <framework:matcher service="custom_matcher" />
@@ -678,7 +698,8 @@ portion of the website? You can use a request matcher:
 
     .. code-block:: php
 
-        // enables the profiler only for request coming for the 192.168.0.0 network
+        // enables the profiler only for request coming
+        // for the 192.168.0.0 network
         $container->loadFromExtension('framework', array(
             'profiler' => array(
                 'matcher' => array('ip' => '192.168.0.0/24'),
@@ -695,11 +716,15 @@ portion of the website? You can use a request matcher:
         // combine rules
         $container->loadFromExtension('framework', array(
             'profiler' => array(
-                'matcher' => array('ip' => '192.168.0.0/24', 'path' => '^/admin/'),
+                'matcher' => array(
+                    'ip' => '192.168.0.0/24',
+                    'path' => '^/admin/',
+                ),
             ),
         ));
 
-        # use a custom matcher instance defined in the "custom_matcher" service
+        // use a custom matcher instance defined in
+        // the "custom_matcher" service
         $container->loadFromExtension('framework', array(
             'profiler' => array(
                 'matcher' => array('service' => 'custom_matcher'),

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -114,9 +114,11 @@ an entry when you generated the ``AcmeHelloBundle``:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <import resource="@AcmeHelloBundle/Resources/config/routing.xml" prefix="/" />
+            <import resource="@AcmeHelloBundle/Resources/config/routing.xml"
+                prefix="/" />
         </routes>
 
     .. code-block:: php
@@ -157,7 +159,8 @@ the new route that defines the URL of the page that you're about to create:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="hello" path="/hello/{name}">
                 <default key="_controller">AcmeHelloBundle:Hello:index</default>
@@ -771,7 +774,9 @@ format you prefer:
 
         $container->loadFromExtension('framework', array(
             'secret'          => '%secret%',
-            'router'          => array('resource' => '%kernel.root_dir%/config/routing.php'),
+            'router'          => array(
+                'resource' => '%kernel.root_dir%/config/routing.php',
+            ),
             // ...
             ),
         ));
@@ -940,7 +945,9 @@ the configuration file for the ``dev`` environment.
         </imports>
 
         <framework:config>
-            <framework:router resource="%kernel.root_dir%/config/routing_dev.xml" />
+            <framework:router
+                resource="%kernel.root_dir%/config/routing_dev.xml"
+            />
             <framework:profiler only-exceptions="false" />
         </framework:config>
 
@@ -952,7 +959,9 @@ the configuration file for the ``dev`` environment.
         $loader->import('config.php');
 
         $container->loadFromExtension('framework', array(
-            'router'   => array('resource' => '%kernel.root_dir%/config/routing_dev.php'),
+            'router'   => array(
+                'resource' => '%kernel.root_dir%/config/routing_dev.php',
+            ),
             'profiler' => array('only-exceptions' => false),
         ));
 

--- a/book/performance.rst
+++ b/book/performance.rst
@@ -79,7 +79,8 @@ as comments in this file::
     $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
 
     // Use APC for autoloading to improve performance
-    // Change 'sf2' by the prefix you want in order to prevent key conflict with another application
+    // Change 'sf2' by the prefix you want in order
+    // to prevent key conflict with another application
     /*
     $loader = new ApcClassLoader('sf2', $loader);
     $loader->register(true);

--- a/book/propel.rst
+++ b/book/propel.rst
@@ -304,22 +304,46 @@ Start by adding the ``category`` definition in your ``schema.xml``:
 
 .. code-block:: xml
 
-    <database name="default" namespace="Acme\StoreBundle\Model" defaultIdMethod="native">
+    <database name="default"
+        namespace="Acme\StoreBundle\Model"
+        defaultIdMethod="native">
         <table name="product">
-            <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true" />
-            <column name="name" type="varchar" primaryString="true" size="100" />
-            <column name="price" type="decimal" />
-            <column name="description" type="longvarchar" />
+            <column name="id"
+                type="integer"
+                required="true"
+                primaryKey="true"
+                autoIncrement="true" />
 
-            <column name="category_id" type="integer" />
+            <column name="name"
+                type="varchar"
+                primaryString="true"
+                size="100" />
+
+            <column name="price"
+                type="decimal" />
+
+            <column name="description"
+                type="longvarchar" />
+
+            <column name="category_id"
+                type="integer" />
+
             <foreign-key foreignTable="category">
                 <reference local="category_id" foreign="id" />
             </foreign-key>
         </table>
 
         <table name="category">
-            <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true" />
-            <column name="name" type="varchar" primaryString="true" size="100" />
+            <column name="id"
+                type="integer"
+                required="true"
+                primaryKey="true"
+                autoIncrement="true" />
+
+            <column name="name"
+                type="varchar"
+                primaryString="true"
+                size="100" />
        </table>
     </database>
 

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -47,7 +47,8 @@ The route is simple:
         <?xml version="1.0" encoding="UTF-8" ?>
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="blog_show" path="/blog/{slug}">
                 <default key="_controller">AcmeBlogBundle:Blog:show</default>
@@ -175,7 +176,9 @@ file:
         // app/config/config.php
         $container->loadFromExtension('framework', array(
             // ...
-            'router' => array('resource' => '%kernel.root_dir%/config/routing.php'),
+            'router' => array(
+                'resource' => '%kernel.root_dir%/config/routing.php',
+            ),
         ));
 
 .. tip::
@@ -207,7 +210,8 @@ A basic route consists of just two parts: the ``path`` to match and a
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="_welcome" path="/">
                 <default key="_controller">AcmeDemoBundle:Main:homepage</default>
@@ -255,7 +259,8 @@ routes will contain one or more named "wildcard" placeholders:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="blog_show" path="/blog/{slug}">
                 <default key="_controller">AcmeBlogBundle:Blog:show</default>
@@ -304,7 +309,8 @@ the available blog posts for this imaginary blog application:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="blog" path="/blog">
                 <default key="_controller">AcmeBlogBundle:Blog:index</default>
@@ -342,7 +348,8 @@ entries? Update the route to have a new ``{page}`` placeholder:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="blog" path="/blog/{page}">
                 <default key="_controller">AcmeBlogBundle:Blog:index</default>
@@ -385,7 +392,8 @@ This is done by including it in the ``defaults`` collection:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="blog" path="/blog/{page}">
                 <default key="_controller">AcmeBlogBundle:Blog:index</default>
@@ -450,7 +458,8 @@ Take a quick look at the routes that have been created so far:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="blog" path="/blog/{page}">
                 <default key="_controller">AcmeBlogBundle:Blog:index</default>
@@ -515,7 +524,8 @@ requirements can easily be added for each parameter. For example:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="blog" path="/blog/{page}">
                 <default key="_controller">AcmeBlogBundle:Blog:index</default>
@@ -585,7 +595,8 @@ URL:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="homepage" path="/{culture}">
                 <default key="_controller">AcmeDemoBundle:Main:homepage</default>
@@ -654,7 +665,8 @@ be accomplished with the following route configuration:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="contact" path="/contact" methods="GET">
                 <default key="_controller">AcmeDemoBundle:Main:contact</default>
@@ -735,14 +747,18 @@ routing system can be:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="article_show" path="/articles/{culture}/{year}/{title}.{_format}">
+            <route id="article_show"
+                path="/articles/{culture}/{year}/{title}.{_format}">
+
                 <default key="_controller">AcmeDemoBundle:Article:show</default>
                 <default key="_format">html</default>
                 <requirement key="culture">en|fr</requirement>
                 <requirement key="_format">html|rss</requirement>
                 <requirement key="year">\d+</requirement>
+
             </route>
         </routes>
 
@@ -752,14 +768,17 @@ routing system can be:
         use Symfony\Component\Routing\Route;
 
         $collection = new RouteCollection();
-        $collection->add('homepage', new Route('/articles/{culture}/{year}/{title}.{_format}', array(
-            '_controller' => 'AcmeDemoBundle:Article:show',
-            '_format'     => 'html',
-        ), array(
-            'culture' => 'en|fr',
-            '_format' => 'html|rss',
-            'year'    => '\d+',
-        )));
+        $collection->add(
+            'homepage',
+            new Route('/articles/{culture}/{year}/{title}.{_format}', array(
+                '_controller' => 'AcmeDemoBundle:Article:show',
+                '_format'     => 'html',
+            ), array(
+                'culture' => 'en|fr',
+                '_format' => 'html|rss',
+                'year'    => '\d+',
+            ))
+        );
 
         return $collection;
 
@@ -928,7 +947,8 @@ be done by "importing" that file:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <import resource="@AcmeHelloBundle/Resources/config/routing.xml" />
         </routes>
@@ -939,7 +959,9 @@ be done by "importing" that file:
         use Symfony\Component\Routing\RouteCollection;
 
         $collection = new RouteCollection();
-        $collection->addCollection($loader->import("@AcmeHelloBundle/Resources/config/routing.php"));
+        $collection->addCollection(
+            $loader->import("@AcmeHelloBundle/Resources/config/routing.php")
+        );
 
         return $collection;
 
@@ -969,7 +991,8 @@ like this:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="acme_hello" path="/hello/{name}">
                 <default key="_controller">AcmeHelloBundle:Hello:index</default>
@@ -1015,9 +1038,11 @@ instead of simply ``/hello/{name}``:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <import resource="@AcmeHelloBundle/Resources/config/routing.xml" prefix="/admin" />
+            <import resource="@AcmeHelloBundle/Resources/config/routing.xml"
+                prefix="/admin" />
         </routes>
 
     .. code-block:: php
@@ -1027,7 +1052,9 @@ instead of simply ``/hello/{name}``:
 
         $collection = new RouteCollection();
 
-        $acmeHello = $loader->import("@AcmeHelloBundle/Resources/config/routing.php");
+        $acmeHello = $loader->import(
+            "@AcmeHelloBundle/Resources/config/routing.php"
+        );
         $acmeHello->setPrefix('/admin');
 
         $collection->addCollection($acmeHello);
@@ -1216,7 +1243,9 @@ a template helper function:
 
     .. code-block:: html+php
 
-        <a href="<?php echo $view['router']->generate('blog_show', array('slug' => 'my-blog-post')) ?>">
+        <a href="<?php echo $view['router']->generate('blog_show', array(
+            'slug' => 'my-blog-post',
+        )) ?>">
             Read this blog post.
         </a>
 
@@ -1232,7 +1261,9 @@ Absolute URLs can also be generated.
 
     .. code-block:: html+php
 
-        <a href="<?php echo $view['router']->generate('blog_show', array('slug' => 'my-blog-post'), true) ?>">
+        <a href="<?php echo $view['router']->generate('blog_show', array(
+            'slug' => 'my-blog-post',
+        ), true) ?>">
             Read this blog post.
         </a>
 

--- a/book/security.rst
+++ b/book/security.rst
@@ -70,7 +70,8 @@ authentication (i.e. the old-school username/password box):
         <srv:container xmlns="http://symfony.com/schema/dic/security"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:srv="http://symfony.com/schema/dic/services"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <!-- app/config/security.xml -->
 
@@ -91,7 +92,8 @@ authentication (i.e. the old-school username/password box):
                     </memory>
                 </provider>
 
-                <encoder class="Symfony\Component\Security\Core\User\User" algorithm="plaintext" />
+                <encoder class="Symfony\Component\Security\Core\User\User"
+                    algorithm="plaintext" />
             </config>
         </srv:container>
 
@@ -115,8 +117,14 @@ authentication (i.e. the old-school username/password box):
                 'in_memory' => array(
                     'memory' => array(
                         'users' => array(
-                            'ryan' => array('password' => 'ryanpass', 'roles' => 'ROLE_USER'),
-                            'admin' => array('password' => 'kitten', 'roles' => 'ROLE_ADMIN'),
+                            'ryan' => array(
+                                'password' => 'ryanpass',
+                                'roles' => 'ROLE_USER',
+                                ),
+                            'admin' => array(
+                                'password' => 'kitten',
+                                'roles' => 'ROLE_ADMIN',
+                            ),
                         ),
                     ),
                 ),
@@ -308,7 +316,8 @@ First, enable form login under your firewall:
         <srv:container xmlns="http://symfony.com/schema/dic/security"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:srv="http://symfony.com/schema/dic/services"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <!-- app/config/security.xml -->
 
@@ -381,7 +390,8 @@ submission (i.e.  ``/login_check``):
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="login" pattern="/login">
                 <default key="_controller">AcmeSecurityBundle:Security:login</default>
@@ -484,7 +494,8 @@ Finally, create the corresponding template:
             <input type="password" id="password" name="_password" />
 
             {#
-                If you want to control the URL the user is redirected to on success (more details below)
+                If you want to control the URL the user
+                is redirected to on success (more details below)
                 <input type="hidden" name="_target_path" value="/account" />
             #}
 
@@ -506,7 +517,8 @@ Finally, create the corresponding template:
             <input type="password" id="password" name="_password" />
 
             <!--
-                If you want to control the URL the user is redirected to on success (more details below)
+                If you want to control the URL the user
+                is redirected to on success (more details below)
                 <input type="hidden" name="_target_path" value="/account" />
             -->
 
@@ -801,10 +813,25 @@ Take the following ``access_control`` entries as an example:
     .. code-block:: php
 
             'access_control' => array(
-                array('path' => '^/admin', 'role' => 'ROLE_USER_IP', 'ip' => '127.0.0.1'),
-                array('path' => '^/admin', 'role' => 'ROLE_USER_HOST', 'host' => 'symfony.com'),
-                array('path' => '^/admin', 'role' => 'ROLE_USER_METHOD', 'method' => 'POST, PUT'),
-                array('path' => '^/admin', 'role' => 'ROLE_USER'),
+                array(
+                    'path' => '^/admin',
+                    'role' => 'ROLE_USER_IP',
+                    'ip' => '127.0.0.1',
+                ),
+                array(
+                    'path' => '^/admin',
+                    'role' => 'ROLE_USER_HOST',
+                    'host' => 'symfony.com',
+                ),
+                array(
+                    'path' => '^/admin',
+                    'role' => 'ROLE_USER_METHOD',
+                    'method' => 'POST, PUT',
+                ),
+                array(
+                    'path' => '^/admin',
+                    'role' => 'ROLE_USER',
+                ),
             ),
 
 For each incoming request, Symfony will decide which ``access_control``
@@ -894,15 +921,23 @@ given prefix, ``/esi``, from outside access:
     .. code-block:: xml
 
             <access-control>
-                <rule path="^/esi" role="IS_AUTHENTICATED_ANONYMOUSLY" ip="127.0.0.1" />
+                <rule path="^/esi" role="IS_AUTHENTICATED_ANONYMOUSLY"
+                    ip="127.0.0.1" />
                 <rule path="^/esi" role="ROLE_NO_ACCESS" />
             </access-control>
 
     .. code-block:: php
 
             'access_control' => array(
-                array('path' => '^/esi', 'role' => 'IS_AUTHENTICATED_ANONYMOUSLY', 'ip' => '127.0.0.1'),
-                array('path' => '^/esi', 'role' => 'ROLE_NO_ACCESS'),
+                array(
+                    'path' => '^/esi',
+                    'role' => 'IS_AUTHENTICATED_ANONYMOUSLY',
+                    'ip' => '127.0.0.1',
+                ),
+                array(
+                    'path' => '^/esi',
+                    'role' => 'ROLE_NO_ACCESS',
+                ),
             ),
 
 Here is how it works when the path is ``/esi/something`` coming from the
@@ -946,13 +981,18 @@ You can also require a user to access a URL via SSL; just use the
     .. code-block:: xml
 
             <access-control>
-                <rule path="^/cart/checkout" role="IS_AUTHENTICATED_ANONYMOUSLY" requires_channel="https" />
+                <rule path="^/cart/checkout" role="IS_AUTHENTICATED_ANONYMOUSLY"
+                    requires_channel="https" />
             </access-control>
 
     .. code-block:: php
 
             'access_control' => array(
-                array('path' => '^/cart/checkout', 'role' => 'IS_AUTHENTICATED_ANONYMOUSLY', 'requires_channel' => 'https'),
+                array(
+                    'path' => '^/cart/checkout',
+                    'role' => 'IS_AUTHENTICATED_ANONYMOUSLY',
+                    'requires_channel' => 'https',
+                ),
             ),
 
 .. _book-security-securing-controller:
@@ -1087,8 +1127,14 @@ In fact, you've seen this already in the example in this chapter.
                 'default_provider' => array(
                     'memory' => array(
                         'users' => array(
-                            'ryan' => array('password' => 'ryanpass', 'roles' => 'ROLE_USER'),
-                            'admin' => array('password' => 'kitten', 'roles' => 'ROLE_ADMIN'),
+                            'ryan' => array(
+                                'password' => 'ryanpass',
+                                'roles' => 'ROLE_USER',
+                            ),
+                            'admin' => array(
+                                'password' => 'kitten',
+                                'roles' => 'ROLE_ADMIN',
+                            ),
                         ),
                     ),
                 ),
@@ -1202,7 +1248,10 @@ class:
         $container->loadFromExtension('security', array(
             'providers' => array(
                 'main' => array(
-                    'entity' => array('class' => 'Acme\UserBundle\Entity\User', 'property' => 'username'),
+                    'entity' => array(
+                        'class' => 'Acme\UserBundle\Entity\User',
+                        'property' => 'username',
+                    ),
                 ),
             ),
         ));
@@ -1258,12 +1307,19 @@ do the following:
             <!-- ... -->
             <provider name="in_memory">
                 <memory>
-                    <user name="ryan" password="bb87a29949f3a1ee0559f8a57357487151281386" roles="ROLE_USER" />
-                    <user name="admin" password="74913f5cd5f61ec0bcfdb775414c2fb3d161b620" roles="ROLE_ADMIN" />
+                    <user name="ryan"
+                        password="bb87a29949f3a1ee0559f8a57357487151281386"
+                        roles="ROLE_USER" />
+                    <user name="admin"
+                        password="74913f5cd5f61ec0bcfdb775414c2fb3d161b620"
+                        roles="ROLE_ADMIN" />
                 </memory>
             </provider>
 
-            <encoder class="Symfony\Component\Security\Core\User\User" algorithm="sha1" iterations="1" encode_as_base64="false" />
+            <encoder class="Symfony\Component\Security\Core\User\User"
+                algorithm="sha1"
+                iterations="1"
+                encode_as_base64="false" />
         </config>
 
     .. code-block:: php
@@ -1275,8 +1331,14 @@ do the following:
                 'in_memory' => array(
                     'memory' => array(
                         'users' => array(
-                            'ryan' => array('password' => 'bb87a29949f3a1ee0559f8a57357487151281386', 'roles' => 'ROLE_USER'),
-                            'admin' => array('password' => '74913f5cd5f61ec0bcfdb775414c2fb3d161b620', 'roles' => 'ROLE_ADMIN'),
+                            'ryan' => array(
+                                'password' => 'bb87a29949f3a1ee0559f8a57357487151281386',
+                                'roles' => 'ROLE_USER',
+                            ),
+                            'admin' => array(
+                                'password' => '74913f5cd5f61ec0bcfdb775414c2fb3d161b620',
+                                'roles' => 'ROLE_ADMIN',
+                            ),
                         ),
                     ),
                 ),
@@ -1465,7 +1527,10 @@ a new provider that chains the two together:
                     ),
                 ),
                 'user_db' => array(
-                    'entity' => array('class' => 'Acme\UserBundle\Entity\User', 'property' => 'username'),
+                    'entity' => array(
+                        'class' => 'Acme\UserBundle\Entity\User',
+                        'property' => 'username',
+                    ),
                 ),
             ),
         ));
@@ -1503,7 +1568,9 @@ the user from both the ``in_memory`` and ``user_db`` providers.
                     <memory>
                         <user name="foo" password="test" />
                     </memory>
-                    <entity class="Acme\UserBundle\Entity\User" property="username" />
+
+                    <entity class="Acme\UserBundle\Entity\User"
+                        property="username" />
                 </provider>
             </config>
 
@@ -1518,7 +1585,9 @@ the user from both the ``in_memory`` and ``user_db`` providers.
                                 'foo' => array('password' => 'test'),
                             ),
                         ),
-                        'entity' => array('class' => 'Acme\UserBundle\Entity\User', 'property' => 'username'),
+                        'entity' => array(
+                        'class' => 'Acme\UserBundle\Entity\User',
+                        'property' => 'username'),
                     ),
                 ),
             ));
@@ -1627,7 +1696,10 @@ rules by creating a role hierarchy:
         $container->loadFromExtension('security', array(
             'role_hierarchy' => array(
                 'ROLE_ADMIN'       => 'ROLE_USER',
-                'ROLE_SUPER_ADMIN' => array('ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'),
+                'ROLE_SUPER_ADMIN' => array(
+                    'ROLE_ADMIN',
+                    'ROLE_ALLOWED_TO_SWITCH',
+                ),
             ),
         ));
 
@@ -1725,7 +1797,8 @@ a route so that you can use it to generate the URL:
 
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="logout" path="/logout" />
 
@@ -1868,7 +1941,9 @@ to show a link to exit impersonation:
 
         <?php if ($view['security']->isGranted('ROLE_PREVIOUS_ADMIN')): ?>
             <a
-                href="<?php echo $view['router']->generate('homepage', array('_switch_user' => '_exit') ?>"
+                href="<?php echo $view['router']->generate('homepage', array(
+                    '_switch_user' => '_exit',
+                ) ?>"
             >
                 Exit impersonation
             </a>
@@ -1908,7 +1983,10 @@ setting:
             'firewalls' => array(
                 'main'=> array(
                     // ...
-                    'switch_user' => array('role' => 'ROLE_ADMIN', 'parameter' => '_want_to_be_this_user'),
+                    'switch_user' => array(
+                        'role' => 'ROLE_ADMIN',
+                        'parameter' => '_want_to_be_this_user',
+                    ),
                 ),
             ),
         ));

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -464,7 +464,9 @@ invokes the service container extension inside the ``FrameworkBundle``:
             'secret'          => 'xxxxxxxxxx',
             'form'            => array(),
             'csrf-protection' => array(),
-            'router'          => array('resource' => '%kernel.root_dir%/config/routing.php'),
+            'router'          => array(
+                'resource' => '%kernel.root_dir%/config/routing.php',
+            ),
 
             // ...
         ));
@@ -819,8 +821,10 @@ so that it can generate the email content via a template::
 
         protected $templating;
 
-        public function __construct(\Swift_Mailer $mailer, EngineInterface $templating)
-        {
+        public function __construct(
+            \Swift_Mailer $mailer,
+            EngineInterface $templating
+        ) {
             $this->mailer = $mailer;
             $this->templating = $templating;
         }
@@ -890,7 +894,8 @@ to be used for a specific purpose. Take the following example:
 
     .. code-block:: xml
 
-        <service id="foo.twig.extension" class="Acme\HelloBundle\Extension\FooExtension">
+        <service id="foo.twig.extension"
+            class="Acme\HelloBundle\Extension\FooExtension">
             <tag name="twig.extension" />
         </service>
 

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -537,7 +537,10 @@ Including this template from any other template is simple:
             <h1>Recent Articles<h1>
 
             {% for article in articles %}
-                {{ include('AcmeArticleBundle:Article:articleDetails.html.twig', {'article': article}) }}
+                {{ include(
+                    'AcmeArticleBundle:Article:articleDetails.html.twig',
+                    { 'article': article }
+                ) }}
             {% endfor %}
         {% endblock %}
 
@@ -644,7 +647,9 @@ string syntax for controllers (i.e. **bundle**:**controller**:**action**):
 
         {# ... #}
         <div id="sidebar">
-            {{ render(controller('AcmeArticleBundle:Article:recentArticles', { 'max': 3 })) }}
+            {{ render(controller('AcmeArticleBundle:Article:recentArticles', {
+                'max': 3
+            })) }}
         </div>
 
     .. code-block:: html+php
@@ -654,7 +659,10 @@ string syntax for controllers (i.e. **bundle**:**controller**:**action**):
         <!-- ... -->
         <div id="sidebar">
             <?php echo $view['actions']->render(
-                new ControllerReference('AcmeArticleBundle:Article:recentArticles', array('max' => 3))
+                new ControllerReference(
+                    'AcmeArticleBundle:Article:recentArticles',
+                    array('max' => 3)
+                )
             ) ?>
         </div>
 
@@ -740,7 +748,8 @@ in your application configuration:
 
         <!-- app/config/config.xml -->
         <framework:config>
-            <framework:templating hinclude-default-template="AcmeDemoBundle::hinclude.html.twig" />
+            <framework:templating
+                hinclude-default-template="AcmeDemoBundle::hinclude.html.twig" />
         </framework:config>
 
     .. code-block:: php
@@ -749,7 +758,9 @@ in your application configuration:
         $container->loadFromExtension('framework', array(
             // ...
             'templating'      => array(
-                'hinclude_default_template' => array('AcmeDemoBundle::hinclude.html.twig'),
+                'hinclude_default_template' => array(
+                    'AcmeDemoBundle::hinclude.html.twig',
+                ),
             ),
         ));
 
@@ -763,7 +774,9 @@ any global default template that is defined):
 
     .. code-block:: jinja
 
-        {{ render_hinclude(controller('...'),  {'default': 'AcmeDemoBundle:Default:content.html.twig'}) }}
+        {{ render_hinclude(controller('...'),  {
+            'default': 'AcmeDemoBundle:Default:content.html.twig'
+        }) }}
 
     .. code-block:: php
 
@@ -892,7 +905,9 @@ correctly:
 
         <!-- src/Acme/ArticleBundle/Resources/views/Article/recentList.html.php -->
         <?php foreach ($articles in $article): ?>
-            <a href="<?php echo $view['router']->generate('article_show', array('slug' => $article->getSlug()) ?>">
+            <a href="<?php echo $view['router']->generate('article_show', array(
+                'slug' => $article->getSlug(),
+            )) ?>">
                 <?php echo $article->getTitle() ?>
             </a>
         <?php endforeach; ?>
@@ -990,14 +1005,14 @@ stylesheets and Javascripts that you'll need throughout your site:
             {# ... #}
 
             {% block stylesheets %}
-                <link href="{{ asset('/css/main.css') }}" type="text/css" rel="stylesheet" />
+                <link href="{{ asset('/css/main.css') }}" rel="stylesheet" />
             {% endblock %}
         </head>
         <body>
             {# ... #}
 
             {% block javascripts %}
-                <script src="{{ asset('/js/main.js') }}" type="text/javascript"></script>
+                <script src="{{ asset('/js/main.js') }}"></script>
             {% endblock %}
         </body>
     </html>
@@ -1015,7 +1030,7 @@ page. From inside that contact page's template, do the following:
     {% block stylesheets %}
         {{ parent() }}
 
-        <link href="{{ asset('/css/contact.css') }}" type="text/css" rel="stylesheet" />
+        <link href="{{ asset('/css/contact.css') }}" rel="stylesheet" />
     {% endblock %}
 
     {# ... #}
@@ -1033,7 +1048,7 @@ is by default "web").
 
 .. code-block:: html+jinja
 
-   <link href="{{ asset('bundles/acmedemo/css/contact.css') }}" type="text/css" rel="stylesheet" />
+   <link href="{{ asset('bundles/acmedemo/css/contact.css') }}" rel="stylesheet" />
 
 The end result is a page that includes both the ``main.css`` and ``contact.css``
 stylesheets.
@@ -1418,7 +1433,8 @@ console command:
 .. code-block:: bash
 
     # You can check by filename:
-    $ php app/console twig:lint src/Acme/ArticleBundle/Resources/views/Article/recentList.html.twig
+    $ php app/console twig:lint \
+      src/Acme/ArticleBundle/Resources/views/Article/recentList.html.twig
 
     # or by directory:
     $ php app/console twig:lint src/Acme/ArticleBundle/Resources/views
@@ -1474,7 +1490,10 @@ key in the parameter hash:
 
     .. code-block:: html+php
 
-        <a href="<?php echo $view['router']->generate('article_show', array('id' => 123, '_format' => 'pdf')) ?>">
+        <a href="<?php echo $view['router']->generate('article_show', array(
+            'id' => 123,
+            '_format' => 'pdf',
+        )) ?>">
             PDF Version
         </a>
 

--- a/book/validation.rst
+++ b/book/validation.rst
@@ -908,13 +908,22 @@ username and the password are different only if all other validation passes
         {
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
-                $metadata->addPropertyConstraint('username', new Assert\NotBlank());
-                $metadata->addPropertyConstraint('password', new Assert\NotBlank());
+                $metadata->addPropertyConstraint(
+                    'username',
+                    new Assert\NotBlank()
+                );
+                $metadata->addPropertyConstraint(
+                    'password',
+                    new Assert\NotBlank()
+                );
 
-                $metadata->addGetterConstraint('passwordLegal', new Assert\True(array(
-                    'message' => 'The password cannot match your first name',
-                    'groups'  => array('Strict'),
-                )));
+                $metadata->addGetterConstraint(
+                    'passwordLegal',
+                    new Assert\True(array(
+                        'message' => 'The password cannot match your first name',
+                        'groups'  => array('Strict'),
+                    ))
+                );
 
                 $metadata->setGroupSequence(array('User', 'Strict'));
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

There is one thing I'm not sure about and that thing are the wrapped commands:

```
$ php app/console generate:bundle AcmeFooBundle \
--dir src --format yaml
```

I don't know if it is commonly known that the `\` character can be used for multiline commands
