### PR TITLE
Edited typo in RepositoryClass

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -458,7 +458,7 @@ The code below shows the implementation of the
                 );
             }
 
-            return $this->find($user->getId());
+            return $this->loadUserByUserName($user->getId());
         }
 
         public function supportsClass($class)


### PR DESCRIPTION
There was a typo in one of function call in Repository class.
