### PR TITLE
[Cookbook][Session] Fixed headline in proxy_examples

### DIFF
--- a/cookbook/session/proxy_examples.rst
+++ b/cookbook/session/proxy_examples.rst
@@ -2,7 +2,7 @@
    single: Sessions, session proxy, proxy
 
 Session Proxy Examples
-----------------------
+======================
 
 The session proxy mechanism has a variety of uses and this example demonstrates
 two common uses. Rather than injecting the session handler as normal, a handler


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets | - |

The tree is broken in http://symfony.com/doc/2.1/cookbook/session/index.html
