### PR TITLE
[Cookbook][Form] Renamed getPropertyAccessor to createPropertyAccessor

### DIFF
--- a/cookbook/form/create_form_type_extension.rst
+++ b/cookbook/form/create_form_type_extension.rst
@@ -232,7 +232,7 @@ it in the view::
                 $parentData = $form->getParent()->getData();
 
                 if (null !== $parentData) {
-                    $accessor = PropertyAccess::getPropertyAccessor();
+                    $accessor = PropertyAccess::createPropertyAccessor();
                     $imageUrl = $accessor->getValue($parentData, $options['image_path']);
                 } else {
                      $imageUrl = null;


### PR DESCRIPTION
Fix documentation in cookbook

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | - |
