### PR TITLE
[Cookbook][Assetic][Apply filter] Added node_paths /usr/lib/node_modules REQUIRED

### DIFF
--- a/cookbook/assetic/apply_to_option.rst
+++ b/cookbook/assetic/apply_to_option.rst
@@ -9,8 +9,8 @@ as you'll see here, files that have a specific extension. To show you how
 to handle each option, let's suppose that you want to use Assetic's CoffeeScript
 filter, which compiles CoffeeScript files into Javascript.
 
-The main configuration is just the paths to coffee and node. These default
-respectively to ``/usr/bin/coffee`` and ``/usr/bin/node``:
+The main configuration is just the paths to coffee, node and node_modules. These default
+respectively to ``/usr/bin/coffee``, ``/usr/bin/node`` and ``/usr/lib/node_modules``:
 
 .. configuration-block::
 
@@ -22,6 +22,7 @@ respectively to ``/usr/bin/coffee`` and ``/usr/bin/node``:
                 coffee:
                     bin: /usr/bin/coffee
                     node: /usr/bin/node
+                    node_paths: [ /usr/lib/node_modules/ ]
 
     .. code-block:: xml
 
@@ -30,7 +31,8 @@ respectively to ``/usr/bin/coffee`` and ``/usr/bin/node``:
             <assetic:filter
                 name="coffee"
                 bin="/usr/bin/coffee"
-                node="/usr/bin/node" />
+                node="/usr/bin/node"
+                node_paths="/usr/lib/node_modules/"/>
         </assetic:config>
 
     .. code-block:: php
@@ -41,6 +43,7 @@ respectively to ``/usr/bin/coffee`` and ``/usr/bin/node``:
                 'coffee' => array(
                     'bin'  => '/usr/bin/coffee',
                     'node' => '/usr/bin/node',
+                    'node_paths' => '/usr/lib/node_modules/',
                 ),
             ),
         ));
@@ -128,6 +131,7 @@ applied to all ``.coffee`` files:
                 coffee:
                     bin: /usr/bin/coffee
                     node: /usr/bin/node
+                    node_paths: [ /usr/lib/node_modules/ ]
                     apply_to: "\.coffee$"
 
     .. code-block:: xml
@@ -138,6 +142,7 @@ applied to all ``.coffee`` files:
                 name="coffee"
                 bin="/usr/bin/coffee"
                 node="/usr/bin/node"
+                node_paths="/usr/lib/node_modules/"
                 apply_to="\.coffee$" />
         </assetic:config>
 
@@ -149,6 +154,7 @@ applied to all ``.coffee`` files:
                 'coffee' => array(
                     'bin'      => '/usr/bin/coffee',
                     'node'     => '/usr/bin/node',
+                    'node_paths' => '/usr/lib/node_modules/',
                     'apply_to' => '\.coffee$',
                 ),
             ),

--- a/cookbook/assetic/apply_to_option.rst
+++ b/cookbook/assetic/apply_to_option.rst
@@ -28,11 +28,12 @@ respectively to ``/usr/bin/coffee``, ``/usr/bin/node`` and ``/usr/lib/node_modul
 
         <!-- app/config/config.xml -->
         <assetic:config>
-            <assetic:filter
+            <assetic:filter 
                 name="coffee"
-                bin="/usr/bin/coffee"
-                node="/usr/bin/node"
-                node_paths="/usr/lib/node_modules/"/>
+                bin="/usr/bin/coffee/"
+                node="/usr/bin/node/">
+                <assetic:node-paths>/usr/lib/node_modules/</assetic:node-path>
+            </assetic:filter>
         </assetic:config>
 
     .. code-block:: php
@@ -43,7 +44,7 @@ respectively to ``/usr/bin/coffee``, ``/usr/bin/node`` and ``/usr/lib/node_modul
                 'coffee' => array(
                     'bin'  => '/usr/bin/coffee',
                     'node' => '/usr/bin/node',
-                    'node_paths' => '/usr/lib/node_modules/',
+                    'node_paths' => array('/usr/lib/node_modules/'),
                 ),
             ),
         ));
@@ -142,10 +143,10 @@ applied to all ``.coffee`` files:
                 name="coffee"
                 bin="/usr/bin/coffee"
                 node="/usr/bin/node"
-                node_paths="/usr/lib/node_modules/"
                 apply_to="\.coffee$" />
+                <assetic:node-paths>/usr/lib/node_modules/</assetic:node-path>
         </assetic:config>
-
+        
     .. code-block:: php
 
         // app/config/config.php
@@ -154,7 +155,7 @@ applied to all ``.coffee`` files:
                 'coffee' => array(
                     'bin'      => '/usr/bin/coffee',
                     'node'     => '/usr/bin/node',
-                    'node_paths' => '/usr/lib/node_modules/',
+                    'node_paths' => array('/usr/lib/node_modules/'),
                     'apply_to' => '\.coffee$',
                 ),
             ),


### PR DESCRIPTION
I was trying, trying and trying one and another method or posibility, until I reached that page: https://github.com/kriswallsmith/assetic/issues/185 that opened my eyes, one option was missing:

node_paths: /usr/lib/node_modules

I continously received:

[exception] 500 | Internal Server Error | Assetic\Exception\FilterException
[message] An error occurred while running:
&#039;/usr/bin/node&#039; &#039;/tmp/assetic_styluswWvcnS&#039;
Error Output:
module.js:340
throw err;
^
Error: Cannot find module &#039;stylus&#039; 

so, this fixes and finishes my 6 hours quest.

I'm using YAML configuration, not tested on XML nor PHP. If you had, please comment.
