### PR TITLE
Updated installation instructions for lazy services

### DIFF
--- a/components/dependency_injection/lazy_services.rst
+++ b/components/dependency_injection/lazy_services.rst
@@ -82,7 +82,8 @@ injected will be the proxy.
 To check if your proxy works you can simply check the interface of the 
 received object.
 
-    var_dump(class_implements($service));
+    .. code-block:: php
+        var_dump(class_implements($service));
     
 If the class implements the ProxyManager\Proxy\LazyLoadingInterface your lazy
 loaded services will work as expected.

--- a/components/dependency_injection/lazy_services.rst
+++ b/components/dependency_injection/lazy_services.rst
@@ -37,7 +37,11 @@ the `ProxyManager bridge`_:
     If you're using the full-stack framework, the proxy manager bridge is already
     included but the actual proxy manager needs to be included. Therefore add
     
-        "ocramius/proxy-manager": ">=0.3.1,<0.4-dev"
+    .. code-block:: json
+
+        "require": {
+            "ocramius/proxy-manager": "0.4.*"
+        }
     
     to your ``composer.json``. Afterwards compile your container and check if you
     get a proxy for your lazy services.

--- a/components/dependency_injection/lazy_services.rst
+++ b/components/dependency_injection/lazy_services.rst
@@ -34,9 +34,13 @@ the `ProxyManager bridge`_:
 
 .. note::
 
-    If you're using the full-stack framework, this package is not included
-    and needs to be added to ``composer.json`` and installed (which is what
-    the above command does).
+    If you're using the full-stack framework, the proxy manager bridge is already
+    included but the actual proxy manager needs to be included. Therefore add
+    
+        "ocramius/proxy-manager": ">=0.3.1,<0.4-dev"
+    
+    to your ``composer.json``. Afterwards compile your container and check if you
+    get a proxy for your lazy services.
 
 Configuration
 -------------

--- a/components/dependency_injection/lazy_services.rst
+++ b/components/dependency_injection/lazy_services.rst
@@ -79,6 +79,14 @@ the same signature of the class representing the service. You can also inject
 the service just like normal into other services. The object that's actually
 injected will be the proxy.
 
+To check if your proxy works you can simply check the interface of the 
+received object.
+
+    var_dump(class_implements($service));
+    
+If the class implements the ProxyManager\Proxy\LazyLoadingInterface your lazy
+loaded services will work as expected.
+
 .. note::
 
     If you don't install the `ProxyManager bridge`_, the container will just

--- a/components/dependency_injection/lazy_services.rst
+++ b/components/dependency_injection/lazy_services.rst
@@ -82,10 +82,11 @@ injected will be the proxy.
 To check if your proxy works you can simply check the interface of the 
 received object.
 
-    .. code-block:: php
-        var_dump(class_implements($service));
+.. code-block:: php
+
+    var_dump(class_implements($service));
     
-If the class implements the ProxyManager\Proxy\LazyLoadingInterface your lazy
+If the class implements the "ProxyManager\Proxy\LazyLoadingInterface" your lazy
 loaded services will work as expected.
 
 .. note::


### PR DESCRIPTION
If you use the full stack framework the proxy-manager-bridge is already included.
Therefore just the actual proxy-manager bundle needs to be installed and this
is adjusted with this PR.
