### PR TITLE
Little typo in assert annotations

### DIFF
--- a/reference/constraints/All.rst
+++ b/reference/constraints/All.rst
@@ -44,8 +44,8 @@ entry in that array:
         {
             /**
              * @Assert\All({
-             *     @Assert\NotBlank
-             *     @Assert\Length(min = "5"),
+             *     @Assert\NotBlank,
+             *     @Assert\Length(min = "5")
              * })
              */
              protected $favoriteColors = array();


### PR DESCRIPTION
Missing comma in annotation provokes an exception "[Syntax Error] Expected Doctrine\Common\Annotations\DocLexer::T_CLOSE_CURLY_BRACES..."
