### PR TITLE
Correct former TypeTestCase namespace

### DIFF
--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -23,7 +23,7 @@ test the core types and you can use it to test your types too.
 .. versionadded:: 2.3
     The ``TypeTestCase`` has moved to the ``Symfony\Component\Form\Test``
     namespace in 2.3. Previously, the class was located in
-    ``Symfony\Component\Form\Tests\Core\Extension\Type``.
+    ``Symfony\Component\Form\Tests\Extension\Core\Type``.
 
 The Basics
 ----------


### PR DESCRIPTION
The pre 2.3 `TypeTestCase` namespace was incorrect.
