### PR TITLE
remove useless use of variable

### DIFF
--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -419,7 +419,7 @@ sport like this::
 
             $builder->addEventListener(
                 FormEvents::PRE_SET_DATA,
-                function(FormEvent $event) use($user, $factory){
+                function(FormEvent $event) use($factory){
                     $form = $event->getForm();
 
                     // this would be your entity, i.e. SportMeetup


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

Removed the use of the `$user` variable in the [Dynamic generation for submitted Forms](http://symfony.com/doc/current/cookbook/form/dynamic_form_modification.html#dynamic-generation-for-submitted-forms) example. It was probably a leftover from the [Customizing the Form Type](http://symfony.com/doc/current/cookbook/form/dynamic_form_modification.html#customizing-the-form-type) section.
