### PR TITLE
moving reference from debugging to templating formats to fix problem wit...

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1389,8 +1389,6 @@ in a JavaScript string, use the ``js`` context:
 .. index::
    single: Templating; Formats
 
-.. _template-formats:
-
 Debugging
 ---------
 
@@ -1431,6 +1429,8 @@ console command:
 
     # or using the bundle name:
     $ php app/console twig:lint @AcmeArticleBundle
+
+.. _template-formats:
 
 Template Formats
 ----------------


### PR DESCRIPTION
...h note giving wrong link
