### PR TITLE
[Contributing][Documentation] Moving polish documentation repository.

### DIFF
--- a/contributing/documentation/translations.rst
+++ b/contributing/documentation/translations.rst
@@ -20,7 +20,7 @@ for. Here is the list of the official *master* repositories:
 * *French*:   https://github.com/symfony-fr/symfony-docs-fr
 * *Italian*:  https://github.com/garak/symfony-docs-it
 * *Japanese*: https://github.com/symfony-japan/symfony-docs-ja
-* *Polish*:   https://github.com/ampluso/symfony-docs-pl
+* *Polish*:   https://github.com/symfony-docs-pl/symfony-docs-pl
 * *Portuguese (Brazilian)*:  https://github.com/andreia/symfony-docs-pt-BR
 * *Spanish*:  https://github.com/gitnacho/symfony-docs-es
 


### PR DESCRIPTION
Moving https://github.com/ampluso/symfony-docs-pl to
https://github.com/symfony-docs-pl/symfony-docs-pl

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets |  |
