### PR TITLE
Missing field in documentation: Added empty_value

### DIFF
--- a/reference/forms/types/birthday.rst
+++ b/reference/forms/types/birthday.rst
@@ -24,6 +24,7 @@ option defaults to 120 years ago to the current year.
 +----------------------+-------------------------------------------------------------------------------+
 | Inherited Options    | - `widget`_                                                                   |
 |                      | - `input`_                                                                    |
+|                      | - `empty_value`_                                                              |  
 |                      | - `months`_                                                                   |
 |                      | - `days`_                                                                     |
 |                      | - `format`_                                                                   |
@@ -60,6 +61,8 @@ These options inherit from the :doc:`date</reference/forms/types/date>` type:
 .. include:: /reference/forms/types/options/date_widget.rst.inc
     
 .. include:: /reference/forms/types/options/date_input.rst.inc
+
+.. include:: /reference/forms/types/options/empty_value.rst.inc
 
 .. include:: /reference/forms/types/options/months.rst.inc
 


### PR DESCRIPTION
The 'empty_value' was missing in the documentation for birthday. This was a minor fix
