### PR TITLE
EventDispatch implements the Mediator pattern, not the Observer pattern

### DIFF
--- a/components/event_dispatcher/introduction.rst
+++ b/components/event_dispatcher/introduction.rst
@@ -20,7 +20,7 @@ or after a method is executed, without interfering with other plugins. This is
 not an easy problem to solve with single inheritance, and multiple inheritance
 (were it possible with PHP) has its own drawbacks.
 
-The Symfony2 Event Dispatcher component implements the `Observer`_ pattern in
+The Symfony2 Event Dispatcher component implements the `Mediator`_ pattern in
 a simple and effective way to make all these things possible and to make your
 projects truly extensible.
 
@@ -492,7 +492,7 @@ listener via the
 Now, any listeners to ``store.order`` that have not yet been called will *not*
 be called.
 
-.. _Observer: http://en.wikipedia.org/wiki/Observer_pattern
+.. _Mediator: http://en.wikipedia.org/wiki/Mediator_pattern
 .. _Closures: http://php.net/manual/en/functions.anonymous.php
 .. _PHP callable: http://www.php.net/manual/en/language.pseudo-types.php#language.types.callback
 .. _Packagist: https://packagist.org/packages/symfony/event-dispatcher


### PR DESCRIPTION
Anthony Ferrara @ircmaxell does a great job of pointing out the differences between the Mediator and Observer pattern in his blog post [Handling Plugins In PHP](http://blog.ircmaxell.com/2012/03/handling-plugins-in-php.html).

The two patterns appear very similar but differ in which object does the event emitting:

An implementation of the Observer pattern would allow _each_ object/entity/service to individually allow subscribing to its events and it would notify all listeners itself: `OrderPersister->notify('order.create', $order)`

But a Mediator pattern implementation would be like the Symfony EventDispatcher object that is centrally-configured with listeners and then notifies those listeners of events on behalf of its external collaborators: Inside a controller `$this->persister->create($order);` then inside Persister::create() -- `$this->dispatcher->notify('order.create', $order)`

:ocean: 
