### PR TITLE
The book: inconsistency in classname used across code examples

### DIFF
--- a/book/http_fundamentals.rst
+++ b/book/http_fundamentals.rst
@@ -430,7 +430,7 @@ by adding an entry for ``/contact`` to your routing configuration file:
     .. code-block:: xml
 
         <route id="contact" path="/contact">
-            <default key="_controller">AcmeBlogBundle:Main:contact</default>
+            <default key="_controller">AcmeDemoBundle:Main:contact</default>
         </route>
 
     .. code-block:: php
@@ -441,7 +441,7 @@ by adding an entry for ``/contact`` to your routing configuration file:
 
         $collection = new RouteCollection();
         $collection->add('contact', new Route('/contact', array(
-            '_controller' => 'AcmeBlogBundle:Main:contact',
+            '_controller' => 'AcmeDemoBundle:Main:contact',
         )));
 
         return $collection;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all (or 2.0+) |
| Fixed tickets | #2824 |

Please see "The Book" > Chapter: "HTTP Fundamental" > Section: "A Symfony Request in Action".

The YAML example contains a class named `AcmeDemoBundle`, however the XML and PHP examples refer to a class named `AcmeBlogBundle`.

This pull request addresses this inconsistency.
