### PR TITLE
[WCM] [The Book, Translations] added doc for translation domain cascading

### DIFF
--- a/book/translation.rst
+++ b/book/translation.rst
@@ -493,6 +493,15 @@ you must specify the domain as the third argument of ``trans()``::
 Symfony2 will now look for the message in the ``admin`` domain of the user's
 locale.
 
+In some cases, you may need a fallback mechanism: you can also provide an
+array of domains instead of a simple string:
+
+    $this->get('translator')->trans('Do something', array(), array('specialized', 'messages', 'last_resort'));
+
+At first, the translator will look for the message in the ``specialized``
+domain. Without result, it will then look in the ``messages`` domain, and
+so on…
+
 .. index::
    single: Translations; User's locale
 

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -493,6 +493,9 @@ you must specify the domain as the third argument of ``trans()``::
 Symfony2 will now look for the message in the ``admin`` domain of the user's
 locale.
 
+.. versionadded:: 2.4
+    Support for translation domain cascading was added in Symfony 2.4.
+
 In some cases, you may need a fallback mechanism: you can also provide an
 array of domains instead:
 

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -509,9 +509,6 @@ At first, the translator will look for the message in the ``specialized``
 domain. Without result, it will then look in the ``messages`` domain, and
 so on…
 
-.. versionadded:: 2.4
-    Support for translation domain cascading was added in Symfony 2.4.
-
 .. index::
    single: Translations; User's locale
 

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -494,13 +494,20 @@ Symfony2 will now look for the message in the ``admin`` domain of the user's
 locale.
 
 In some cases, you may need a fallback mechanism: you can also provide an
-array of domains instead of a simple string:
+array of domains instead:
 
-    $this->get('translator')->trans('Do something', array(), array('specialized', 'messages', 'last_resort'));
+    $this->get('translator')->trans(
+        'Do something',
+        array(),
+        array('specialized', 'messages', 'last_resort')
+    );
 
 At first, the translator will look for the message in the ``specialized``
 domain. Without result, it will then look in the ``messages`` domain, and
 so on…
+
+.. versionadded:: 2.4
+    Support for translation domain cascading was added in Symfony 2.4.
 
 .. index::
    single: Translations; User's locale


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony#8489) |
| Applies to | all (or 2.3+) |

Documentation for an unmerged PR which adds the possibility to use an array of translation domains instead of a single one, thus providing a fallback mechanism.
