### PR TITLE
Removing duplicate content

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -127,12 +127,6 @@ All public files and the front controller that handles incoming requests in
 a Symfony2 application live in the ``Symfony/web/`` directory. So, assuming
 you unpacked the archive into your web server's or virtual host's document root,
 your application's URLs will start with ``http://localhost/Symfony/web/``.
-To get nice and short URLs you should point the document root of your web
-server or virtual host to the ``Symfony/web/`` directory. Though this is not
-required for development it is recommended when your application goes into
-production as all system and configuration files become inaccessible to clients.
-For information on configuring your specific web server document root, see
-the following documentation: `Apache`_ | `Nginx`_ .
 
 .. note::
 


### PR DESCRIPTION
The same content can be found at the end of the "Configuration and setup" section. I've removed the more recent content, and because I think the right place is in the "configuration" section.
