### PR TITLE
Added node_paths /usr/lib/node_modules REQUIRED

### DIFF
--- a/cookbook/assetic/apply_to_option.rst
+++ b/cookbook/assetic/apply_to_option.rst
@@ -9,8 +9,8 @@ as you'll see here, files that have a specific extension. To show you how
 to handle each option, let's suppose that you want to use Assetic's CoffeeScript
 filter, which compiles CoffeeScript files into Javascript.
 
-The main configuration is just the paths to coffee and node. These default
-respectively to ``/usr/bin/coffee`` and ``/usr/bin/node``:
+The main configuration is just the paths to coffee, node and node_modules.
++An example configuration might look like this:
 
 .. configuration-block::
 
@@ -22,15 +22,18 @@ respectively to ``/usr/bin/coffee`` and ``/usr/bin/node``:
                 coffee:
                     bin: /usr/bin/coffee
                     node: /usr/bin/node
+                    node_paths: [ /usr/lib/node_modules ]
 
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
         <assetic:config>
-            <assetic:filter
+            <assetic:filter 
                 name="coffee"
-                bin="/usr/bin/coffee"
-                node="/usr/bin/node" />
+                bin="/usr/bin/coffee/"
+                node="/usr/bin/node/">
+                <assetic:node-paths>/usr/lib/node_modules</assetic:node-paths>
+            </assetic:filter>
         </assetic:config>
 
     .. code-block:: php
@@ -41,6 +44,7 @@ respectively to ``/usr/bin/coffee`` and ``/usr/bin/node``:
                 'coffee' => array(
                     'bin'  => '/usr/bin/coffee',
                     'node' => '/usr/bin/node',
+                    'node_paths' => array('/usr/lib/node_modules'),
                 ),
             ),
         ));
@@ -128,6 +132,7 @@ applied to all ``.coffee`` files:
                 coffee:
                     bin: /usr/bin/coffee
                     node: /usr/bin/node
+                    node_paths: [ /usr/lib/node_modules ]
                     apply_to: "\.coffee$"
 
     .. code-block:: xml
@@ -139,6 +144,7 @@ applied to all ``.coffee`` files:
                 bin="/usr/bin/coffee"
                 node="/usr/bin/node"
                 apply_to="\.coffee$" />
+                <assetic:node-paths>/usr/lib/node_modules</assetic:node-paths>
         </assetic:config>
 
     .. code-block:: php
@@ -149,6 +155,7 @@ applied to all ``.coffee`` files:
                 'coffee' => array(
                     'bin'      => '/usr/bin/coffee',
                     'node'     => '/usr/bin/node',
+                    'node_paths' => '/usr/lib/node_modules',
                     'apply_to' => '\.coffee$',
                 ),
             ),


### PR DESCRIPTION
I proposed this patch for branch 2.2 and is already patched https://github.com/symfony/symfony-docs/commit/f1483240e88722bb53b8d22bd479944ba48d8047, please apply to branch 2.3 and master

I was testing, testing and testing one and another method or posibility, until I reached that page: https://github.com/kriswallsmith/assetic/issues/185 that opened my eyes, and one value was missing:

node_paths /usr/lib/node_modules

I continously received:
[exception] 500 | Internal Server Error | Assetic\Exception\FilterException
[message] An error occurred while running:
&#39;/usr/bin/node&#39; &#39;/tmp/assetic_styluswWvcnS&#39;
Error Output:
module.js:340
throw err;
^
Error: Cannot find module &#39;stylus&#39;

so, this fixes and finishes my 6 hours quest.
