### PR TITLE
Correction to suggested individual twig rendering of password and confirmation entries in 'repeated' component.

### DIFF
--- a/reference/forms/types/repeated.rst
+++ b/reference/forms/types/repeated.rst
@@ -79,8 +79,8 @@ To render each field individually, use something like this:
 
     .. code-block:: jinja
 
-        {{ form_row(form.password.first) }}
-        {{ form_row(form.password.second) }}
+        {{ form_row(form.password.password) }}
+        {{ form_row(form.password.confirm) }}
 
     .. code-block:: php
 


### PR DESCRIPTION
The corrected lines worked for me, whereas the suggested lines led to
the error message 'Method "first" for object
"Symfony\Component\Form\FormView" does not exist'.  (Same error message
described in this thread:
http://forum.symfony-project.org/viewtopic.php?f=23&t=36193.)  I read
the "password" and "confirm" strings out of of the HTML generated by
symfony.  I am not sure whether this is a bug in documentation, a bug in
the 'repeated' object, or the result of a misuse on my part.
