### PR TITLE
Update definition.rst - indentation fix

### DIFF
--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -490,7 +490,7 @@ By changing a string value into an associative array with ``name`` as the key::
         ->children()
             ->arrayNode('connection')
                 ->beforeNormalization()
-                ->ifString()
+                    ->ifString()
                     ->then(function($v) { return array('name'=> $v); })
                 ->end()
                 ->children()


### PR DESCRIPTION
Reverting indentation of a call to "ifString()" back to its correct place.

A commit from 9 months ago changed it by mistake:
https://github.com/symfony/symfony-docs/commit/9a0b4e1edfd61062fcb8181fc0c58a94676579b2#L0L380
