### PR TITLE
Clarified how to load translations from db

### DIFF
--- a/book/translation.rst
+++ b/book/translation.rst
@@ -333,7 +333,7 @@ taste.
     You can also store translations in a database, or any other storage by
     providing a custom class implementing the
     :class:`Symfony\\Component\\Translation\\Loader\\LoaderInterface` interface.
-    See the `translation.loader tag`_ for more information.
+    See the :ref:`dic-tags-translation-loader` tag for more information.
 
 .. index::
    single: Translations; Creating translation resources
@@ -1014,4 +1014,3 @@ steps:
 .. _`Translatable Extension`: https://github.com/l3pp4rd/DoctrineExtensions
 .. _`ISO3166 Alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
 .. _`ISO639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-.. _`translation.loader tag`: http://symfony.com/doc/current/reference/dic_tags.html#translation-loader

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -332,7 +332,7 @@ taste.
 
     You can also store translations in a database, or any other storage by
     providing a custom class implementing the
-    :class:`Symfony\\Component\\Translation\\Loader\\LoaderInterface` interface. 
+    :class:`Symfony\\Component\\Translation\\Loader\\LoaderInterface` interface.
     See the `translation loader tag`_ for more information.
 
 .. index::

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -333,7 +333,7 @@ taste.
     You can also store translations in a database, or any other storage by
     providing a custom class implementing the
     :class:`Symfony\\Component\\Translation\\Loader\\LoaderInterface` interface.
-    See the `translation loader tag`_ for more information.
+    See the `translation.loader tag`_ for more information.
 
 .. index::
    single: Translations; Creating translation resources
@@ -1014,4 +1014,4 @@ steps:
 .. _`Translatable Extension`: https://github.com/l3pp4rd/DoctrineExtensions
 .. _`ISO3166 Alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
 .. _`ISO639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-.. _`translation loader tag`: http://symfony.com/doc/current/reference/dic_tags.html#translation-loader
+.. _`translation.loader tag`: http://symfony.com/doc/current/reference/dic_tags.html#translation-loader

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -332,7 +332,8 @@ taste.
 
     You can also store translations in a database, or any other storage by
     providing a custom class implementing the
-    :class:`Symfony\\Component\\Translation\\Loader\\LoaderInterface` interface.
+    :class:`Symfony\\Component\\Translation\\Loader\\LoaderInterface` interface. 
+    See the `translation loader tag`_ for more information.
 
 .. index::
    single: Translations; Creating translation resources
@@ -1013,3 +1014,4 @@ steps:
 .. _`Translatable Extension`: https://github.com/l3pp4rd/DoctrineExtensions
 .. _`ISO3166 Alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
 .. _`ISO639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+.. _`translation loader tag`: http://symfony.com/doc/current/reference/dic_tags.html#translation-loader

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -861,6 +861,8 @@ templates):
             ->addTag('templating.helper', array('alias' => 'alias_name'))
         ;
 
+.. _dic-tags-translation-loader:
+
 translation.loader
 ------------------
 


### PR DESCRIPTION
Added a link to the translation.loader tag, because there it's actually explained how to register a custom message loader.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

With kind regards,
Simon.
