### PR TITLE
Fixing PHPUnit docs link

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -814,4 +814,4 @@ Learn more
 
 .. _`DemoControllerTest`: https://github.com/symfony/symfony-standard/blob/master/src/Acme/DemoBundle/Tests/Controller/DemoControllerTest.php
 .. _`$_SERVER`: http://php.net/manual/en/reserved.variables.server.php
-.. _`documentation`: http://www.phpunit.de/manual/3.5/en/
+.. _`documentation`: http://phpunit.de/manual/current/en/


### PR DESCRIPTION
It should link to the latest docs, not 3.5.
