### PR TITLE
[WCM] Removed warning about using swiftmailer handler with memory spool

### DIFF
--- a/cookbook/logging/monolog_email.rst
+++ b/cookbook/logging/monolog_email.rst
@@ -107,14 +107,6 @@ to and from addresses and the subject.
 You can combine these handlers with other handlers so that the errors still
 get logged on the server as well as the emails being sent:
 
-.. caution::
-
-    The default spool setting for swiftmailer is set to ``memory``, which
-    means that emails are sent at the very end of the request. However, this
-    does not work with buffered logs at the moment. In order to enable emailing
-    logs per the example below, you are must comment out the ``spool: { type: memory }``
-    line in the ``config.yml`` file.
-
 .. configuration-block::
 
     .. code-block:: yaml


### PR DESCRIPTION
If symfony/symfony#8780 is merged this warning can be removed.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | #8780 |
