### PR TITLE
Fix property path default value

### DIFF
--- a/reference/forms/types/options/property_path.rst.inc
+++ b/reference/forms/types/options/property_path.rst.inc
@@ -1,7 +1,7 @@
 property_path
 ~~~~~~~~~~~~~
 
-**type**: ``any`` **default**: ``the field's value``
+**type**: ``any`` **default**: ``the field's name``
 
 Fields display a property value of the form's domain object by default. When
 the form is submitted, the submitted value is written back into the object.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |

The default value of a property path is its name, not its value.
