### PR TITLE
Fix typo

### DIFF
--- a/components/finder.rst
+++ b/components/finder.rst
@@ -97,7 +97,7 @@ Exclude directories from matching with the
     $finder->in(__DIR__)->exclude('ruby');
 
 .. versionadded:: 2.3
-   The :method:`Symfony\\Component\\Finder\\Finder::ignoreUnreadableDirs``
+   The :method:`Symfony\\Component\\Finder\\Finder::ignoreUnreadableDirs`
    method was added in Symfony 2.3.
 
 It's also possible to ignore directories that you don't have permission to read::


### PR DESCRIPTION
The method ignoreUnreadableDirs() had an extra "`" char

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets |  |
