### PR TITLE
Remove no longer necessary factory

### DIFF
--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -270,11 +270,9 @@ and fill in the listener logic::
                 );
             }
 
-            $factory = $builder->getFormFactory();
-
             $builder->addEventListener(
                 FormEvents::PRE_SET_DATA,
-                function(FormEvent $event) use($user, $factory){
+                function(FormEvent $event) use ($user) {
                     $form = $event->getForm();
 
                     $formOptions = array(
@@ -289,7 +287,7 @@ and fill in the listener logic::
 
                     // create the field, this is similar the $builder->add()
                     // field name, field type, data, options
-                    $form->add($factory->createNamed('friend', 'entity', null, $formOptions));
+                    $form->add('friend', 'entity', $formOptions);
                 }
             );
         }

--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -370,15 +370,21 @@ it with :ref:`dic-tags-form-type`.
 If you wish to create it from within a controller or any other service that has
 access to the form factory, you then use::
 
-    class FriendMessageController extends Controller
+    use Symfony\Component\DependencyInjection\ContainerAware;
+
+    class FriendMessageController extends ContainerAware
     {
         public function newAction(Request $request)
         {
-            $form = $this->createForm('acme_friend_message');
+            $form = $this->get('form.factory')->create('acme_friend_message');
 
             // ...
         }
     }
+
+If you extend the ``Symfony\Bundle\FrameworkBundle\Controller\Controller`` class, you can simply call::
+
+    $form = $this->createForm('acme_friend_message');
 
 You can also easily embed the form type into another form::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | - |

The doc says you don't have to use the factory anymore since 2.2, yet does so itself a couple of paragraphs later.

The other occurrences of factory usages will be fixed by #2927 

The second commit applies to earlier verrsion as well, but if i'm not mistaken, these docs aren't maintained anymore?
