### PR TITLE
Added missing tilda (yml config)

### DIFF
--- a/reference/constraints/Country.rst
+++ b/reference/constraints/Country.rst
@@ -24,7 +24,7 @@ Basic Usage
         Acme\UserBundle\Entity\User:
             properties:
                 country:
-                    - Country:
+                    - Country: ~
 
     .. code-block:: php-annotations
 


### PR DESCRIPTION
The tilda was missing for the YAML configuration.
