### PR TITLE
Add type hinting for a directly injected service

### DIFF
--- a/cookbook/controller/service.rst
+++ b/cookbook/controller/service.rst
@@ -180,13 +180,14 @@ service and use it directly::
     // src/Acme/HelloBundle/Controller/HelloController.php
     namespace Acme\HelloBundle\Controller;
 
+    use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
     use Symfony\Component\HttpFoundation\Response;
 
     class HelloController
     {
         private $templating;
 
-        public function __construct($templating)
+        public function __construct(EngineInterface $templating)
         {
             $this->templating = $templating;
         }


### PR DESCRIPTION
This PR adds type hinting for directly injected `templating` dependency.
