### PR TITLE
[#2956] Refactoring the scopes entry

### DIFF
--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -762,22 +762,87 @@ Injecting the Request
 .. versionadded:: 2.4
     The ``request_stack`` service was introduced in version 2.4.
 
-Almost all Symfony2 built-in services behave in the same way: a single
-instance is created by the container which it returns whenever you get it or
-when it is injected into another service. There is one exception in a standard
-Symfony2 application: the ``request`` service.
-
-If you try to inject the ``request`` into a service, you will probably receive
-a
-:class:`Symfony\\Component\\DependencyInjection\\Exception\\ScopeWideningInjectionException`
-exception. That's because the ``request`` can **change** during the life-time
-of a container (when a sub-request is created for instance).
-
 As of Symfony 2.4, instead of injecting the ``request`` service, you should
 inject the ``request_stack`` service instead and access the Request by calling
-the ``getCurrentRequest()`` method. For earlier versions, or if you want to
-understand this problem better, refer to the cookbook article
-:doc:`/cookbook/service_container/scopes`.
+the ``getCurrentRequest()`` method:
+
+    namespace Acme\HelloBundle\Newsletter;
+
+    use Symfony\Component\HttpFoundation\RequestStack;
+
+    class NewsletterManager
+    {
+        protected $requestStack;
+
+        public function __construct(RequestStack $requestStack)
+        {
+            $this->requestStack = $requestStack;
+        }
+
+        public function anyMethod()
+        {
+            $request = $this->requestStack->getCurrentRequest();
+            // ... do something with the request
+        }
+
+        // ...
+    }
+
+Now, just inject the ``request_stack``, which behaves like any normal service:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # src/Acme/HelloBundle/Resources/config/services.yml
+        services:
+            newsletter_manager:
+                class:     "Acme\HelloBundle\Newsletter\NewsletterManager"
+                arguments: ["@request_stack"]
+
+    .. code-block:: xml
+
+        <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service
+                    id="newsletter_manager"
+                    class="Acme\HelloBundle\Newsletter\NewsletterManager"
+                >
+                    <argument type="service" id="request_stack"/>
+                </service>
+            </services>
+        </container>
+
+    .. code-block:: php
+
+        // src/Acme/HelloBundle/Resources/config/services.php
+        use Symfony\Component\DependencyInjection\Definition;
+        use Symfony\Component\DependencyInjection\Reference;
+
+        // ...
+        $container->setDefinition('newsletter_manager', new Definition(
+            'Acme\HelloBundle\Newsletter\NewsletterManager',
+            array(new Reference('request_stack'))
+        ));
+
+.. sidebar: Why not Inject the request Service?
+
+    Almost all Symfony2 built-in services behave in the same way: a single
+    instance is created by the container which it returns whenever you get it or
+    when it is injected into another service. There is one exception in a standard
+    Symfony2 application: the ``request`` service.
+
+    If you try to inject the ``request`` into a service, you will probably receive
+    a
+    :class:`Symfony\\Component\\DependencyInjection\\Exception\\ScopeWideningInjectionException`
+    exception. That's because the ``request`` can **change** during the life-time
+    of a container (when a sub-request is created for instance).
+
 
 .. tip::
 

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -754,6 +754,8 @@ Injecting the dependency by the setter method just needs a change of syntax:
     and "setter injection". The Symfony2 service container also supports
     "property injection".
 
+.. _book-container-request-stack:
+
 Injecting the Request
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Hi guys!

See sha: b84f52c28d969b5143521261d818105824eaea5e for more information. Basically, now that the `request` scope problem is solved with the request_stack, the whole scopes entry is much much less important. I've updated it to use a make-believe example, which I think is pretty good, but creating custom scopes is quite rare.

So, I'm not convinced this entry still has a ton of value, but we've given people good warning at the top so that 99% of people will just solve their problem and move on. And for the 1% that does want to learn more, it's an interesting entry.

As usual, comments on any of my mistakes is appreciated.

Thanks!
