### PR TITLE
Fixing wrong parameter name in redirecting in config

### DIFF
--- a/cookbook/routing/redirect_in_config.rst
+++ b/cookbook/routing/redirect_in_config.rst
@@ -23,7 +23,7 @@ Your configuration will look like this:
         path:     /
         defaults:
             _controller: FrameworkBundle:Redirect:urlRedirect
-            route: /app
+            path: /app
             permanent: true
 
 In this example, you configure a route for the ``/`` path and let :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController`


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | None |

I am also willing to submit an additionnal section on how to redirect to route instead of path with the controller `FrameworkBundle:Redirect:redirect`. This one is actually using a parameter named `route`.
