### PR TITLE
[2.2][Routing] Try to fix markup

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -173,7 +173,7 @@ file:
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                                 http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-            <framework:config ...>
+            <framework:config>
                 <!-- ... -->
                 <framework:router resource="%kernel.root_dir%/config/routing.xml" />
             </framework:config>


### PR DESCRIPTION
XML section in http://symfony.com/doc/2.2/book/routing.html#creating-routes is missing line number and syntax coloration
