### PR TITLE
[forms] Remove tip for skipping validation group section

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -371,11 +371,6 @@ Validation is a very powerful feature of Symfony2 and has its own
 Validation Groups
 ~~~~~~~~~~~~~~~~~
 
-.. tip::
-
-    If you're not using :ref:`validation groups <book-validation-validation-groups>`,
-    then you can skip this section.
-
 If your object takes advantage of :ref:`validation groups <book-validation-validation-groups>`,
 you'll need to specify which validation group(s) your form should use::
 


### PR DESCRIPTION
I think this section has no additional value for the user as this statement could be added on top of every section: If you do not need any feature you may skip the docs for it ;-)

The important link to the validation groups section is not lost because it is available in the next paragraph after the removed tip.
