### PR TITLE
Update unit_testing.rst

### DIFF
--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -176,6 +176,7 @@ on other extensions. You need add those extensions to the factory object::
             parent::setUp();
 
             $this->factory = Forms::createFormFactoryBuilder()
+                ->addExtensions($this->getExtensions())
                 ->addTypeExtension(
                     new FormTypeValidatorExtension(
                         $this->getMock('Symfony\Component\Validator\ValidatorInterface')


### PR DESCRIPTION
Forget line addExtensions() in example. This line is in FormIntegrationTestCase class. If you don't add this you'll not be able to load additionnal FormType.
