### PR TITLE
prevent using Tomcat user when setting directories permissions

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -236,7 +236,7 @@ If there are any issues, correct them now before moving on.
         $ rm -rf app/cache/*
         $ rm -rf app/logs/*
 
-        $ APACHEUSER=`ps aux | grep -E '[a]pache|[h]ttpd' | grep -v root | head -1 | cut -d\  -f1`
+        $ APACHEUSER=`ps aux | grep -E '[a]pache|[h]ttpd' | grep -vE 'root|tomcat' | head -1 | cut -d\  -f1`
         $ sudo chmod +a "$APACHEUSER allow delete,write,append,file_inherit,directory_inherit" app/cache app/logs
         $ sudo chmod +a "`whoami` allow delete,write,append,file_inherit,directory_inherit" app/cache app/logs
 
@@ -251,7 +251,7 @@ If there are any issues, correct them now before moving on.
 
     .. code-block:: bash
 
-		$ APACHEUSER=`ps aux | grep -E '[a]pache|[h]ttpd' | grep -v root | head -1 | cut -d\  -f1`
+		$ APACHEUSER=`ps aux | grep -E '[a]pache|[h]ttpd' | grep -vE 'root|tomcat' | head -1 | cut -d\  -f1`
 		$ sudo setfacl -R -m u:$APACHEUSER:rwX -m u:`whoami`:rwX app/cache app/logs
 		$ sudo setfacl -dR -m u:$APACHEUSER:rwX -m u:`whoami`:rwX app/cache app/logs
 		


### PR DESCRIPTION
Instruction for setting up permissions for cache and log directories sometimes won't work when Tomcat server process is running.This is because APACHEUSER variable will be set to invalid value.
On my system for instance is set to tomcat6 instead of www-data.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | - |
