### PR TITLE
fix typo and move reference to the appropriate file

### DIFF
--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -151,5 +151,3 @@ These options inherit from the :doc:`field </reference/forms/types/form>` type:
 .. include:: /reference/forms/types/options/virtual.rst.inc
 
 .. include:: /reference/forms/types/options/error_mapping.rst.inc
-
-.. _`RFC 3339`: http://tools.ietf.org/html/rfc3339

--- a/reference/forms/types/options/date_format.rst.inc
+++ b/reference/forms/types/options/date_format.rst.inc
@@ -20,9 +20,10 @@ For more information on valid formats, see `Date/Time Format Syntax`_::
 
 .. note::
 
-    If you want your field to be rendered as an HTML5 "date" field, you have
+    If you want your field to be rendered as an HTML5 "date" field, you have to
     use a ``single_text`` widget with the ``yyyy-MM-dd`` format (the `RFC 3339`_
     format) which is the default value if you use the ``single_text`` widget.
 
 .. _`Date/Time Format Syntax`: http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
 .. _`IntlDateFormatter::MEDIUM`: http://www.php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants
+.. _`RFC 3339`: http://tools.ietf.org/html/rfc3339


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

This fixes a typo and move the url to RFC 3339 to file where it is used.
