### PR TITLE
use DebugClassLoader class from Debug component instead of the one from ...

### DIFF
--- a/components/class_loader/debug_class_loader.rst
+++ b/components/class_loader/debug_class_loader.rst
@@ -4,14 +4,6 @@
 Debugging a Class Loader
 ========================
 
-The :class:`Symfony\\Component\\ClassLoader\\DebugClassLoader` attempts to
-throw more helpful exceptions when a class isn't found by the registered
-autoloaders. All autoloaders that implement a ``findFile()`` method are replaced
-with a ``DebugClassLoader`` wrapper.
-
-Using the ``DebugClassLoader`` is as easy as calling its static
-:method:`Symfony\\Component\\ClassLoader\\DebugClassLoader::enable` method::
-
-    use Symfony\Component\ClassLoader\DebugClassLoader;
-    
-    DebugClassLoader::enable();
+Since Symfony 2.4, the ``DebugClassLoader`` of the Class Loader component is
+deprecated. Use the
+:doc:`DebugClassLoader provided by the Debug component </components/debug/class_loader>`.

--- a/components/debug/class_loader.rst
+++ b/components/debug/class_loader.rst
@@ -1,0 +1,22 @@
+.. index::
+    single: Class Loader; DebugClassLoader
+    single: Debug; DebugClassLoader
+
+Debugging a Class Loader
+========================
+
+.. versionadded:: 2.4
+    The ``DebugClassLoader`` of the Debug component is new in Symfony 2.4.
+    Previously, it was located in the Class Loader component.
+
+The :class:`Symfony\\Component\\Debug\\DebugClassLoader` attempts to
+throw more helpful exceptions when a class isn't found by the registered
+autoloaders. All autoloaders that implement a ``findFile()`` method are replaced
+with a ``DebugClassLoader`` wrapper.
+
+Using the ``DebugClassLoader`` is as easy as calling its static
+:method:`Symfony\\Component\\Debug\\DebugClassLoader::enable` method::
+
+    use Symfony\Component\ClassLoader\DebugClassLoader;
+
+    DebugClassLoader::enable();

--- a/components/debug/index.rst
+++ b/components/debug/index.rst
@@ -1,0 +1,8 @@
+Debug
+=====
+
+.. toctree::
+    :maxdepth: 2
+
+    introduction
+    class_loader

--- a/components/debug/introduction.rst
+++ b/components/debug/introduction.rst
@@ -30,9 +30,8 @@ Enabling them all is as easy as it can get::
     Debug::enable();
 
 The :method:`Symfony\\Component\\Debug\\Debug::enable` method registers an
-error handler and an exception handler. If the :doc:`ClassLoader component
-</components/class_loader/introduction>` is available, a special class loader
-is also registered.
+error handler, an exception handler and
+:doc:`a special class loader </components/debug/class_loader>`.
 
 Read the following sections for more information about the different available
 tools.

--- a/components/index.rst
+++ b/components/index.rst
@@ -9,7 +9,7 @@ The Components
     config/index
     console/index
     css_selector
-    debug
+    debug/index
     dependency_injection/index
     dom_crawler
     event_dispatcher/index

--- a/components/map.rst.inc
+++ b/components/map.rst.inc
@@ -27,9 +27,10 @@
 
   * :doc:`/components/css_selector`
 
-* **Debug**
+* :doc:`/components/debug/index`
 
-  * :doc:`/components/debug`
+  * :doc:`/components/debug/introduction`
+  * :doc:`/components/debug/class_loader`
 
 * :doc:`/components/dependency_injection/index`
 

--- a/cookbook/configuration/front_controllers_and_kernel.rst
+++ b/cookbook/configuration/front_controllers_and_kernel.rst
@@ -45,8 +45,8 @@ to `decorate`_ the kernel with additional features. Examples include:
 * Configuring the autoloader or adding additional autoloading mechanisms;
 * Adding HTTP level caching by wrapping the kernel with an instance of
   :ref:`AppCache <symfony-gateway-cache>`;
-* Enabling (or skipping) the :doc:`ClassCache </cookbook/debugging>`
-* Enabling the :doc:`Debug component </components/debug>`.
+* Enabling (or skipping) the :doc:`ClassCache </cookbook/debugging>`;
+* Enabling the :doc:`Debug Component </components/debug/introduction>`.
 
 The front controller can be chosen by requesting URLs like:
 


### PR DESCRIPTION
...the Class Loader component

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4 |
| Fixed tickets | #2955 |
