### PR TITLE
fix bash command display in components/console/usage

### DIFF
--- a/components/console/usage.rst
+++ b/components/console/usage.rst
@@ -80,6 +80,8 @@ with:
 The verbose flag can optionally take a value between 1 (default) and 3 to
 output even more verbose messages:
 
+.. code-block:: bash
+
     $ php app/console list --verbose=2
     $ php app/console list -vv
     $ php app/console list --verbose=3


### PR DESCRIPTION
Fixes the broken display of the command in http://symfony.com/doc/current/components/console/usage.html
Appers first in 2.3
