### PR TITLE
Fixed syntax error in varnish config example

### DIFF
--- a/cookbook/cache/varnish.rst
+++ b/cookbook/cache/varnish.rst
@@ -197,7 +197,7 @@ absolute URLs:
         if (req.http.X-Forwarded-Proto == "https" ) {
             set req.http.X-Forwarded-Port = "443";
         } else {
-            set req.http.X-Forwarded-Port = "80"
+            set req.http.X-Forwarded-Port = "80";
         }
     }
 


### PR DESCRIPTION
Yes, I copy & pasted it :|
