### PR TITLE
[OptionsResolver] Fix syntax errors in code examples (missing in_array closing slashes)

### DIFF
--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -199,6 +199,7 @@ value you guess based on the host. You can do that easily by using a
 Closure as the default value::
 
     use Symfony\Component\OptionsResolver\Options;
+    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
     // ...
     protected function setDefaultOptions(OptionsResolverInterface $resolver)
@@ -207,7 +208,7 @@ Closure as the default value::
 
         $resolver->setDefaults(array(
             'port' => function (Options $options) {
-                if (in_array($options['host'], array('127.0.0.1', 'localhost')) {
+                if (in_array($options['host'], array('127.0.0.1', 'localhost'))) {
                     return 80;
                 }
                 
@@ -305,7 +306,7 @@ need to use the other options for normalizing::
 
         $resolver->setNormalizers(array(
             'host' => function (Options $options, $value) {
-                if (!in_array(substr($value, 0, 7), array('http://', 'https://')) {
+                if (!in_array(substr($value, 0, 7), array('http://', 'https://'))) {
                     if ($options['ssl']) {
                         $value = 'https://'.$value;
                     } else {


### PR DESCRIPTION
This pull request fixes 2 syntax errors when using `in_array()` in conditions (missing the last closing slash).
It also adds a missing `use` statement in one code example.

I've based the change on 2.1 as it issue was already there. But it can easily be rebased on 2.2 if needed.
