### PR TITLE
Use PSR-3 compatible method

### DIFF
--- a/cookbook/logging/monolog.rst
+++ b/cookbook/logging/monolog.rst
@@ -17,7 +17,7 @@ your controller::
     {
         $logger = $this->get('logger');
         $logger->info('I just got the logger');
-        $logger->err('An error occurred');
+        $logger->error('An error occurred');
 
         // ...
     }


### PR DESCRIPTION
Changed
`$logger->err('An error occurred');`
to 
`$logger->error('An error occurred');`
because it's deprecated and not PSR-3 compatible
