### PR TITLE
[WCM] [Cookbook] [Console] Improved code example about memory spooling

### DIFF
--- a/cookbook/console/sending_emails.rst
+++ b/cookbook/console/sending_emails.rst
@@ -100,8 +100,16 @@ commands, emails are not sent automatically. You must take care of flushing
 the queue yourself. Use the following code to send emails inside your
 console command::
 
+    $message = new \Swift_Message();
+    
+    // prepare the message...
+    
     $container = $this->getContainer();
     $mailer = $container->get('mailer');
+    
+    $mailer->send($message);
+    
+    // now manually flush the queue
     $spool = $mailer->getTransport()->getSpool();
     $transport = $container->get('swiftmailer.transport.real');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | all |
| Fixed tickets | n/a |

First SF2 PR, so I hope I do this right. I improved this code example a bit, because in the first place it wasn't clear to me that the flushing part should be added to instead of replacing the `$mailer->send()` part.
