### PR TITLE
Added documentation about disabling internal validation of DomCrawler forms

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -671,6 +671,22 @@ their type::
     // Upload a file
     $form['photo']->upload('/path/to/lucas.jpg');
 
+.. versionadded:: 2.4
+    The :method:`Symfony\\Component\\DomCrawler\\Form::disableValidation`
+    method was added in Symfony 2.4.
+
+By default, choice fields (select, radio) have internal validation activated
+to prevent you from setting invalid values. If you want to be able to set
+invalid values, you can use the  ``disableValidation()`` method on either
+the whole form or specific field(s)::
+
+    // Disable validation for a specific field
+    $form['country']->disableValidation()->select('Invalid value');
+
+    // Disable validation for the whole form
+    $form->disableValidation();
+    $form['country']->select('Invalid value');
+
 .. tip::
 
     You can get the values that will be submitted by calling the ``getValues()``


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony#8637) |
| Applies to | 2.4+ |
| Fixed tickets | - |
