### PR TITLE
[Validation] Fix order of code block: Annotations <=> YAML

### DIFF
--- a/book/validation.rst
+++ b/book/validation.rst
@@ -973,6 +973,18 @@ entity and a new constraint group called ``Premium``:
 
 .. configuration-block::
 
+    .. code-block:: yaml
+
+        # src/Acme/DemoBundle/Resources/config/validation.yml
+        Acme\DemoBundle\Entity\User:
+            properties:
+                name:
+                    - NotBlank
+                creditCard:
+                    - CardScheme
+                        schemes: [VISA]
+                        groups: [Premium]
+
     .. code-block:: php-annotations
 
         // src/Acme/DemoBundle/Entity/User.php
@@ -997,18 +1009,6 @@ entity and a new constraint group called ``Premium``:
              */
             private $creditCard;
         }
-
-    .. code-block:: yaml
-
-        # src/Acme/DemoBundle/Resources/config/validation.yml
-        Acme\DemoBundle\Entity\User:
-            properties:
-                name:
-                    - NotBlank
-                creditCard:
-                    - CardScheme
-                        schemes: [VISA]
-                        groups: [Premium]
 
     .. code-block:: xml
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | - |
| Fixed tickets | - |

Order of code blocks for validation following the guidelines is: YAML, Annotation, XML, PHP
