### PR TITLE
[Forms] Fix submit button usage in template

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -806,7 +806,9 @@ used the ``form_row`` helper:
                 {{ form_widget(form.dueDate) }}
             </div>
 
-        <input type="submit" />
+            <div>
+                {{ form_widget(form.save) }}
+            </div>
 
         {{ form_end(form) }}
 
@@ -828,7 +830,9 @@ used the ``form_row`` helper:
                 <?php echo $view['form']->widget($form['dueDate']) ?>
             </div>
 
-            <input type="submit" />
+            <div>
+                <?php echo $view['form']->widget($form['save']) ?>
+            </div>
 
         <?php echo $view['form']->end($form) ?>
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets | - |

In the controller above the form was built with the new "submit" field type, so the submit button should be rendered with the "form_widget()" Twig function following the field type reference. Otherwise the "form_end()" function will render it in addition to the plain HTML "input[type=submit]" button.
