### PR TITLE
Revert "Removed warning about using swiftmailer handler with memory spool"

### DIFF
--- a/cookbook/logging/monolog_email.rst
+++ b/cookbook/logging/monolog_email.rst
@@ -107,6 +107,14 @@ to and from addresses and the subject.
 You can combine these handlers with other handlers so that the errors still
 get logged on the server as well as the emails being sent:
 
+.. caution::
+
+    The default spool setting for swiftmailer is set to ``memory``, which
+    means that emails are sent at the very end of the request. However, this
+    does not work with buffered logs at the moment. In order to enable emailing
+    logs per the example below, you are must comment out the ``spool: { type: memory }``
+    line in the ``config.yml`` file.
+
 .. configuration-block::
 
     .. code-block:: yaml

--- a/cookbook/logging/monolog_email.rst
+++ b/cookbook/logging/monolog_email.rst
@@ -112,7 +112,7 @@ get logged on the server as well as the emails being sent:
     The default spool setting for swiftmailer is set to ``memory``, which
     means that emails are sent at the very end of the request. However, this
     does not work with buffered logs at the moment. In order to enable emailing
-    logs per the example below, you are must comment out the ``spool: { type: memory }``
+    logs per the example below, you must comment out the ``spool: { type: memory }``
     line in the ``config.yml`` file.
 
 .. configuration-block::


### PR DESCRIPTION
This reverts commit 1262487380d02ac3239b452ff4a5ef4f1d683342.

There is [apparently no way](https://github.com/symfony/symfony-docs/commit/1262487380d02ac3239b452ff4a5ef4f1d683342#commitcomment-4393759) people in 2.3 can get this bugfix. Even when installing MonologBundle 2.4.1 , it does not work for me.
