### PR TITLE
previously defined parameter pdo.db_options is an array, don't treat it...

### DIFF
--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -50,7 +50,7 @@ configuration format of your choice):
 
             session.handler.pdo:
                 class:     Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler
-                arguments: ["@pdo", "%pdo.db_options%"]
+                arguments: ["@pdo", %pdo.db_options%]
 
     .. code-block:: xml
 


### PR DESCRIPTION
...as a string

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |
