### PR TITLE
[Security] Fix typo

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -416,7 +416,7 @@ submission (i.e.  ``/login_check``):
 
 .. versionadded:: 2.1
     As of Symfony 2.1, you *must* have routes configured for your ``login_path``,
-    ``check_path`` ``logout`` keys. These keys can be route names (as shown
+    ``check_path`` and ``logout`` keys. These keys can be route names (as shown
     in this example) or URLs that have routes configured for them.
 
 Notice that the name of the ``login`` route matches the ``login_path`` config


### PR DESCRIPTION
Maybe the "logout" key could be even omitted here because the section is not about the logout and the real key to configure is not "logout" but "path" under the key "logout".

Shouldn't this notice be removed in the 2.3 branch since Symfony 2.1 has reached end of maintenance?
