### PR TITLE
[Translation] Fix fallback parameter name in the framework config

### DIFF
--- a/book/translation.rst
+++ b/book/translation.rst
@@ -536,7 +536,7 @@ locale via routing.
 Fallback and Default Locale
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the locale hasn't been set explicitly in the session, the ``fallback_locale``
+If the locale hasn't been set explicitly in the session, the ``fallback``
 configuration parameter will be used by the ``Translator``. The parameter
 defaults to ``en`` (see `Configuration`_).
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | - |
| Fixed tickets | - |

There is no `fallback_locale` parameter in the `framework` configuration, it is called `fallback` under the `translator`config parameter. Should it be indicated somehow that `fallback` is located under `translator` like `translator.fallback`? I couldn't find any similar approach though.
