### PR TITLE
[Config] removed a reference to always()

### DIFF
--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -535,7 +535,6 @@ following ways:
 - ``ifArray()``
 - ``ifInArray()``
 - ``ifNotInArray()``
-- ``always()``
 
 A validation rule also requires a "then" part:
 


### PR DESCRIPTION
As this section is about validation, I think it is not the right place to mention that method, which seems to target normalization stage instead.
