### PR TITLE
[Book][Propel] fix url of Propel Documentation

### DIFF
--- a/book/propel.rst
+++ b/book/propel.rst
@@ -476,8 +476,8 @@ Commands
 
 You should read the dedicated section for `Propel commands in Symfony2`_.
 
-.. _`Working With Symfony2`: http://propelorm.org/cookbook/symfony2/working-with-symfony2.html#installation
-.. _`PropelBundle configuration section`: http://propelorm.org/cookbook/symfony2/working-with-symfony2.html#configuration
+.. _`Working With Symfony2`: http://propelorm.org/Propel/cookbook/symfony2/working-with-symfony2.html#installation
+.. _`PropelBundle configuration section`: http://propelorm.org/Propel/cookbook/symfony2/working-with-symfony2.html#configuration
 .. _`Relationships`: http://propelorm.org/documentation/04-relationships.html
 .. _`Behaviors reference section`: http://propelorm.org/documentation/#behaviors-reference
-.. _`Propel commands in Symfony2`: http://propelorm.org/cookbook/symfony2/working-with-symfony2#the-commands
+.. _`Propel commands in Symfony2`: http://propelorm.org/Propel/cookbook/symfony2/working-with-symfony2#the-commands


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

The Propel Documentation was updated, and these reference is in Propel 1.x documentation
