### PR TITLE
Fix hostname matching articles

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -707,8 +707,8 @@ form via the same URL, while using distinct controllers for the two actions.
 
     If no ``methods`` are specified, the route will match on *all* methods.
 
-Adding a Host
-~~~~~~~~~~~~~
+Adding a Host Requirement
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.2
     Host matching support was added in Symfony 2.2
@@ -1067,8 +1067,8 @@ from the new routing resource.
     :doc:`FrameworkExtraBundle documentation </bundles/SensioFrameworkExtraBundle/annotations/routing>`
     to see how.
 
-Adding a Host regex to Imported Routes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Adding a Host requirement to Imported Routes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.2
     Host matching support was added in Symfony 2.2

--- a/components/routing/hostname_pattern.rst
+++ b/components/routing/hostname_pattern.rst
@@ -72,7 +72,7 @@ you can use placeholders in your hostname:
 
         projects_homepage:
             path:     /
-            host:     {project_name}.example.com
+            host:     "{project_name}.example.com"
             defaults: { _controller: AcmeDemoBundle:Main:mobileHomepage }
 
         homepage:
@@ -124,7 +124,7 @@ instance, if you want to match both ``m.example.com`` and
 
         mobile_homepage:
             path:     /
-            host:     {subdomain}.example.com
+            host:     "{subdomain}.example.com"
             defaults: 
                 _controller: AcmeDemoBundle:Main:mobileHomepage
                 subdomain: m
@@ -193,7 +193,7 @@ instance, if you want to match both ``m.example.com`` and
 
             mobile_homepage:
                 path:     /
-                host:     m.{domain}
+                host:     "m.{domain}"
                 defaults: { _controller: AcmeDemoBundle:Main:mobileHomepage }
                 requirements:
                     domain: "%domain%"

--- a/components/routing/hostname_pattern.rst
+++ b/components/routing/hostname_pattern.rst
@@ -60,17 +60,63 @@ You can also match on the HTTP *host* of the incoming request.
 Both routes match the same path ``/``, however the first one will match
 only if the host is ``m.example.com``.
 
-Placeholders and Requirements in Hostname Patterns
---------------------------------------------------
+Using Placeholders
+------------------
 
-If you're using the :doc:`DependencyInjection Component </components/dependency_injection/index>`
-(or the full Symfony2 Framework), then you can use
-:ref:`service container parameters <book-service-container-parameters>` as
-variables anywhere in your routes.
+The host option uses the same syntax as the path matching system. This means
+you can use placeholders in your hostname:
 
-You can avoid hardcoding the domain name by using a placeholder and a requirement.
-The ``%domain%`` in requirements is replaced by the value of the ``domain``
-dependency injection container parameter.
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        projects_homepage:
+            path:     /
+            host:     {project_name}.example.com
+            defaults: { _controller: AcmeDemoBundle:Main:mobileHomepage }
+
+        homepage:
+            path:     /
+            defaults: { _controller: AcmeDemoBundle:Main:homepage }
+
+    .. code-block:: xml
+
+        <?xml version="1.0" encoding="UTF-8" ?>
+
+        <routes xmlns="http://symfony.com/schema/routing"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd"
+        >
+
+            <route id="projects_homepage" path="/" host="{project_name}.example.com">
+                <default key="_controller">AcmeDemoBundle:Main:mobileHomepage</default>
+            </route>
+
+            <route id="homepage" path="/">
+                <default key="_controller">AcmeDemoBundle:Main:homepage</default>
+            </route>
+        </routes>
+
+    .. code-block:: php
+
+        use Symfony\Component\Routing\RouteCollection;
+        use Symfony\Component\Routing\Route;
+
+        $collection = new RouteCollection();
+        $collection->add('project_homepage', new Route('/', array(
+            '_controller' => 'AcmeDemoBundle:Main:mobileHomepage',
+        ), array(), array(), '{project_name}.example.com'));
+
+        $collection->add('homepage', new Route('/', array(
+            '_controller' => 'AcmeDemoBundle:Main:homepage',
+        )));
+
+        return $collection;
+
+You can also set requirements and default options for these placeholders. For
+instance, if you want to match both ``m.example.com`` and
+``mobile.example.com``, you use this:
 
 .. configuration-block::
 
@@ -78,25 +124,32 @@ dependency injection container parameter.
 
         mobile_homepage:
             path:     /
-            host:     m.{domain}
-            defaults: { _controller: AcmeDemoBundle:Main:mobileHomepage }
+            host:     {subdomain}.example.com
+            defaults: 
+                _controller: AcmeDemoBundle:Main:mobileHomepage
+                subdomain: m
             requirements:
-                domain: "%domain%"
+                subdomain: m|mobile
 
         homepage:
-            path:  /
+            path:     /
             defaults: { _controller: AcmeDemoBundle:Main:homepage }
 
     .. code-block:: xml
 
         <?xml version="1.0" encoding="UTF-8" ?>
+
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd"
+        >
 
-            <route id="mobile_homepage" path="/" host="m.example.com">
+            <route id="mobile_homepage" path="/" host="{subdomain}.example.com">
                 <default key="_controller">AcmeDemoBundle:Main:mobileHomepage</default>
-                <requirement key="domain">%domain%</requirement>
+                <default key="subdomain">m</default>
+
+                <requirement key="subdomain">m|mobile</requirement>
             </route>
 
             <route id="homepage" path="/">
@@ -112,15 +165,78 @@ dependency injection container parameter.
         $collection = new RouteCollection();
         $collection->add('mobile_homepage', new Route('/', array(
             '_controller' => 'AcmeDemoBundle:Main:mobileHomepage',
+            'subdomain'   => 'm',
         ), array(
-            'domain' => '%domain%',
-        ), array(), 'm.{domain}'));
+            'subdomain' => 'm|mobile',
+        ), array(), '{subdomain}.example.com'));
 
         $collection->add('homepage', new Route('/', array(
             '_controller' => 'AcmeDemoBundle:Main:homepage',
         )));
 
         return $collection;
+
+.. tip::
+
+    Make sure you also include a default option for the ``subdomain``
+    placeholder, otherwise you need to include the subdomains value each time
+    you generate the route.
+
+.. sidebar:: Using Service Parameters
+
+    You can also use service parameters if you do not want to hardcode the
+    hostname:
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            mobile_homepage:
+                path:     /
+                host:     m.{domain}
+                defaults: { _controller: AcmeDemoBundle:Main:mobileHomepage }
+                requirements:
+                    domain: "%domain%"
+
+            homepage:
+                path:  /
+                defaults: { _controller: AcmeDemoBundle:Main:homepage }
+
+        .. code-block:: xml
+
+            <?xml version="1.0" encoding="UTF-8" ?>
+
+            <routes xmlns="http://symfony.com/schema/routing"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+                <route id="mobile_homepage" path="/" host="m.example.com">
+                    <default key="_controller">AcmeDemoBundle:Main:mobileHomepage</default>
+                    <requirement key="domain">%domain%</requirement>
+                </route>
+
+                <route id="homepage" path="/">
+                    <default key="_controller">AcmeDemoBundle:Main:homepage</default>
+                </route>
+            </routes>
+
+        .. code-block:: php
+
+            use Symfony\Component\Routing\RouteCollection;
+            use Symfony\Component\Routing\Route;
+
+            $collection = new RouteCollection();
+            $collection->add('mobile_homepage', new Route('/', array(
+                '_controller' => 'AcmeDemoBundle:Main:mobileHomepage',
+            ), array(
+                'domain' => '%domain%',
+            ), array(), 'm.{domain}'));
+
+            $collection->add('homepage', new Route('/', array(
+                '_controller' => 'AcmeDemoBundle:Main:homepage',
+            )));
+
+            return $collection;
 
 .. _component-routing-host-imported:
 

--- a/components/routing/hostname_pattern.rst
+++ b/components/routing/hostname_pattern.rst
@@ -81,7 +81,7 @@ dependency injection container parameter.
             host:     m.{domain}
             defaults: { _controller: AcmeDemoBundle:Main:mobileHomepage }
             requirements:
-                domain: %domain%
+                domain: "%domain%"
 
         homepage:
             path:  /
@@ -90,7 +90,6 @@ dependency injection container parameter.
     .. code-block:: xml
 
         <?xml version="1.0" encoding="UTF-8" ?>
-
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
@@ -125,10 +124,10 @@ dependency injection container parameter.
 
 .. _component-routing-host-imported:
 
-Adding a Host Regex to Imported Routes
---------------------------------------------
+Using Host Matching of Imported Routes
+--------------------------------------
 
-You can set a host regex on imported routes:
+You can also set the host option on imported routes:
 
 .. configuration-block::
 


### PR DESCRIPTION
The articles were talking about host regexes, while they are no regex but simple strings.
This PR fixes that. It also includes more information how to match multiple hostnames (which
is a common use case for regexes).

| Q | A |
| --- | --- |
| New docs? | yes |
| Doc fix? | yes |
| Applies to | all |
| Fixed tickets | - |
