### PR TITLE
[Components][Event Dispatcher] Fix "store.order" event name in code example

### DIFF
--- a/components/event_dispatcher/introduction.rst
+++ b/components/event_dispatcher/introduction.rst
@@ -306,7 +306,7 @@ the ``dispatch`` method. Now, any listener to the ``store.order`` event will
 receive the ``FilterOrderEvent`` and have access to the ``Order`` object via
 the ``getOrder`` method::
 
-    // some listener class that's been registered for "STORE_ORDER" event
+    // some listener class that's been registered for "store.order" event
     use Acme\StoreBundle\Event\FilterOrderEvent;
 
     public function onStoreOrder(FilterOrderEvent $event)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

The name of the event in this example is `store.event`; `STORE_ORDER` is used for the class constant in `StoreEvents::STORE_ORDER`.
