### PR TITLE
When using pbkdf2 or bcrypt length 40 is not enough

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -83,7 +83,7 @@ focus on the most important methods that come from the
         private $salt;
 
         /**
-         * @ORM\Column(type="string", length=40)
+         * @ORM\Column(type="string", length=64)
          */
         private $password;
 


### PR DESCRIPTION
I used this entity to apply bcrypt encoded password but I was not able to login. It took me lot of time to debug that the password is being truncated because column length is less than the password which is being generated by bcrypt or pbkdf2.
