### PR TITLE
[Reference][Twig] Fix typos and formatting

### DIFF
--- a/reference/forms/twig_reference.rst
+++ b/reference/forms/twig_reference.rst
@@ -218,8 +218,7 @@ object:
 
     .. code-block:: html+jinja
 
-        <label for="{{ form.name.vars.id }}"
-            class="{{ form.name.vars.required ? 'required' : '' }}">
+        <label for="{{ form.name.vars.id }}" class="{{ form.name.vars.required ? 'required' : '' }}">
             {{ form.name.vars.label }}
         </label>
 

--- a/reference/forms/twig_reference.rst
+++ b/reference/forms/twig_reference.rst
@@ -218,7 +218,8 @@ object:
 
     .. code-block:: html+jinja
 
-        <label for="{{ form.name.vars.id }}" class="{{ form.name.vars.required ? 'required' : '' }}">
+        <label for="{{ form.name.vars.id }}"
+            class="{{ form.name.vars.required ? 'required' : '' }}">
             {{ form.name.vars.label }}
         </label>
 

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -176,9 +176,8 @@ Symfony Standard Edition Extensions
 The Symfony Standard Edition adds some bundles to the Symfony2 Core Framework.
 Those bundles can have other Twig extensions:
 
-* **Twig Extension** includes all extensions that do not belong to the
-  Twig core but can be interesting. You can read more in 
-  `the official Twig Extensions documentation`_;
+* **Twig Extensions** includes some interesting extensions that do not belong to the
+  Twig core. You can read more in `the official Twig Extensions documentation`_;
 * **Assetic** adds the ``{% stylesheets %}``, ``{% javascripts %}`` and 
   ``{% image %}`` tags. You can read more about them in 
   :doc:`the Assetic Documentation </cookbook/assetic/asset_management>`.

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -32,7 +32,7 @@ Functions
 | ``render(path('route', {params}))``                |                                                                                            |
 | ``render(url('route', {params}))``                 |                                                                                            |
 +----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``render_esi(controller('B:C:a', {params}))``      | This will generates an ESI tag when possible or fallback to the ``render``                 |
+| ``render_esi(controller('B:C:a', {params}))``      | This will generate an ESI tag when possible or fallback to the ``render``                  |
 | ``render_esi(url('route', {params}))``             | behavior otherwise. For more information, see :ref:`templating-embedding-controller`.      |
 | ``render_esi(path('route', {params}))``            |                                                                                            |
 +----------------------------------------------------+--------------------------------------------------------------------------------------------+
@@ -75,28 +75,28 @@ Functions
 +----------------------------------------------------+--------------------------------------------------------------------------------------------+
 | ``logout_path(key)``                               | This will generate the relative logout URL for the given firewall                          |
 +----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``logout_url(key)``                                | Equal to ``logout_path(...)`` but this will generate an absolute url                       |
+| ``logout_url(key)``                                | Equal to ``logout_path(...)`` but this will generate an absolute URL                       |
 +----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``path(name, parameters = {})``                    | Get a relative url for the given route, more information in                                |
+| ``path(name, parameters = {})``                    | Get a relative URL for the given route, more information in                                |
 |                                                    | ":ref:`book-templating-pages`".                                                            |
 +----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``url(name, parameters = {})``                     | Equal to ``path(...)`` but it generates an absolute url                                    |
+| ``url(name, parameters = {})``                     | Equal to ``path(...)`` but it generates an absolute URL                                    |
 +----------------------------------------------------+--------------------------------------------------------------------------------------------+
 
 Filters
 -------
 
 .. versionadded:: 2.1
-    The ``humanize`` filter was added in Symfony2.1
+    The ``humanize`` filter was added in Symfony 2.1
 
 +---------------------------------------------------------------------------------+-------------------------------------------------------------------+
 | Filter Syntax                                                                   | Usage                                                             |
 +=================================================================================+===================================================================+
 | ``text|humanize``                                                               | Makes a technical name human readable (replaces underscores by    |
-|                                                                                 | spaces and capitalizes the string)                                |
+|                                                                                 | spaces and capitalizes the string).                               |
 +---------------------------------------------------------------------------------+-------------------------------------------------------------------+
 | ``text|trans(arguments = {}, domain = 'messages', locale = null)``              | This will translate the text into the current language, more      |
-|                                                                                 | information in .                                                  |
+|                                                                                 | information in                                                    |
 |                                                                                 | :ref:`Translation Filters <book-translation-filters>`.            |
 +---------------------------------------------------------------------------------+-------------------------------------------------------------------+
 | ``text|transchoice(count, arguments = {}, domain = 'messages', locale = null)`` | This will translate the text with pluralization, more information |
@@ -165,8 +165,8 @@ Global Variables
 +-------------------------------------------------------+------------------------------------------------------------------------------------+
 | Variable                                              | Usage                                                                              |
 +=======================================================+====================================================================================+
-| ``app`` *Attributes*: ``app.user``, ``app.request``   | The ``app`` variable is available everywhere, and gives you quick                  |
-| ``app.session``, ``app.environment``, ``app.debug``   | access to many commonly needed objects. The ``app`` variable is                    |
+| ``app`` *Attributes*: ``app.user``, ``app.request``,  | The ``app`` variable is available everywhere, and gives you quick                  |
+| ``app.session``, ``app.environment``, ``app.debug``,  | access to many commonly needed objects. The ``app`` variable is                    |
 | ``app.security``                                      | instance of :class:`Symfony\\Bundle\\FrameworkBundle\\Templating\\GlobalVariables` |
 +-------------------------------------------------------+------------------------------------------------------------------------------------+
 
@@ -178,10 +178,10 @@ Those bundles can have other Twig extensions:
 
 * **Twig Extension** includes all extensions that do not belong to the
   Twig core but can be interesting. You can read more in 
-  `the official Twig Extensions documentation`_
+  `the official Twig Extensions documentation`_;
 * **Assetic** adds the ``{% stylesheets %}``, ``{% javascripts %}`` and 
   ``{% image %}`` tags. You can read more about them in 
-  :doc:`the Assetic Documentation </cookbook/assetic/asset_management>`;
+  :doc:`the Assetic Documentation </cookbook/assetic/asset_management>`.
 
 .. _`the official Twig Extensions documentation`: http://twig.sensiolabs.org/doc/extensions/index.html
 .. _`http://twig.sensiolabs.org/documentation`: http://twig.sensiolabs.org/documentation


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | - |

The line numbers are missing for the Twig+HTML code block in `reference/forms/twig_reference.rst`. I hope this gets fixed by removing the line feed within the HTML tag. Please let me know if this needs to get fixed in a different way.
