### PR TITLE
[Reference] Reorder and group hidden toctrees

### DIFF
--- a/reference/forms/types.rst
+++ b/reference/forms/types.rst
@@ -8,34 +8,40 @@ Form Types Reference
    :maxdepth: 1
    :hidden:
 
-   types/birthday
-   types/checkbox
-   types/choice
-   types/collection
-   types/country
-   types/date
-   types/datetime
+   types/text
+   types/textarea
    types/email
-   types/entity
-   types/file
-   types/field
-   types/form
-   types/hidden
    types/integer
-   types/language
-   types/locale
    types/money
    types/number
    types/password
    types/percent
-   types/radio
-   types/repeated
    types/search
-   types/text
-   types/textarea
-   types/time
-   types/timezone
    types/url
+
+   types/choice
+   types/entity
+   types/country
+   types/language
+   types/locale
+   types/timezone
+
+   types/date
+   types/datetime
+   types/time
+   types/birthday
+
+   types/checkbox
+   types/file
+   types/radio
+
+   types/collection
+   types/repeated
+
+   types/hidden
+
+   types/field
+   types/form
 
 A form is composed of *fields*, each of which are built with the help of
 a field *type* (e.g. a ``text`` type, ``choice`` type, etc). Symfony2 comes

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -5,21 +5,22 @@ Reference Documents
     :hidden:
 
     configuration/framework
-    configuration/assetic
     configuration/doctrine
     configuration/security
+    configuration/assetic
     configuration/swiftmailer
     configuration/twig
     configuration/monolog
     configuration/web_profiler
+
     configuration/kernel
 
     forms/types
+    constraints
     forms/twig_reference
 
     twig_reference
 
-    constraints
     dic_tags
     requirements
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | - |

Reordered the hidden toctrees according to the visible TOCs so that the Prev/Next links will work correctly.
There's some merge work for 2.3 needed because of the new field types `currency`, `submit`, `reset`, `button` and the removed "field" type.
