### PR TITLE
new fix for Propel docs URLs

### DIFF
--- a/book/propel.rst
+++ b/book/propel.rst
@@ -478,6 +478,6 @@ You should read the dedicated section for `Propel commands in Symfony2`_.
 
 .. _`Working With Symfony2`: http://propelorm.org/Propel/cookbook/symfony2/working-with-symfony2.html#installation
 .. _`PropelBundle configuration section`: http://propelorm.org/Propel/cookbook/symfony2/working-with-symfony2.html#configuration
-.. _`Relationships`: http://propelorm.org/documentation/04-relationships.html
-.. _`Behaviors reference section`: http://propelorm.org/documentation/#behaviors-reference
+.. _`Relationships`: http://propelorm.org/Propel/documentation/04-relationships.html
+.. _`Behaviors reference section`: http://propelorm.org/Propel/documentation/#behaviors-reference
 .. _`Propel commands in Symfony2`: http://propelorm.org/Propel/cookbook/symfony2/working-with-symfony2#the-commands


### PR DESCRIPTION
looks like previous fix was incomplete
