### PR TITLE
[Cookbook] Fix toctree order

### DIFF
--- a/cookbook/index.rst
+++ b/cookbook/index.rst
@@ -4,30 +4,30 @@ The Cookbook
 .. toctree::
     :hidden:
 
-    workflow/index
-    controller/index
-    routing/index
     assetic/index
-    doctrine/index
-    form/index
-    validation/index
+    bundles/index
+    cache/index
     configuration/index
+    console/index
+    controller/index
+    debugging
+    deployment-tools
+    doctrine/index
+    email/index
+    event_dispatcher/index
+    form/index
+    logging/index
+    profiler/index
+    request/index
+    routing/index
+    security/index
     service_container/index
     session/index
-    bundles/index
-    email/index
-    testing/index
-    security/index
-    cache/index
-    templating/index
-    logging/index
-    console/index
-    debugging
-    event_dispatcher/index
-    request/index
-    profiler/index
-    web_services/index
     symfony1
-    deployment-tools
+    templating/index
+    testing/index
+    validation/index
+    web_services/index
+    workflow/index
 
 .. include:: /cookbook/map.rst.inc


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | - |

When merging into the 2.3, look out for the _Serializer_ item as it does not exist in 2.2.
