### PR TITLE
added the example Twig Code for the HTML5 no novalidate attribute

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -420,6 +420,11 @@ corresponding errors printed out with the form.
    but are being prevented by your browser from, for example, submitting
    blank fields.
 
+    .. code-block:: html+jinja
+
+       {# src/Acme/DemoBundle/Resources/views/Default/new.html.twig #}
+       {{ form(form, { 'attr': {'novalidate': 'novalidate' }}) }}
+
 Validation is a very powerful feature of Symfony2 and has its own
 :doc:`dedicated chapter </book/validation>`.
 

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -420,10 +420,16 @@ corresponding errors printed out with the form.
    but are being prevented by your browser from, for example, submitting
    blank fields.
 
-    .. code-block:: html+jinja
+   .. code-block:: html+jinja
 
-       {# src/Acme/DemoBundle/Resources/views/Default/new.html.twig #}
-       {{ form(form, {'attr': {'novalidate': 'novalidate'}}) }}
+     {# src/Acme/DemoBundle/Resources/views/Default/new.html.twig #}
+     {{ form(form, {'attr': {'novalidate': 'novalidate'}}) }}
+
+   .. code-block:: html+php
+
+      <?php echo $view['form']->form($form, array(
+         'attr' => array('novalidate' => 'novalidate'),
+      )) ?>
 
 Validation is a very powerful feature of Symfony2 and has its own
 :doc:`dedicated chapter </book/validation>`.

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -423,7 +423,7 @@ corresponding errors printed out with the form.
     .. code-block:: html+jinja
 
        {# src/Acme/DemoBundle/Resources/views/Default/new.html.twig #}
-       {{ form(form, { 'attr': {'novalidate': 'novalidate' }}) }}
+       {{ form(form, {'attr': {'novalidate': 'novalidate'}}) }}
 
 Validation is a very powerful feature of Symfony2 and has its own
 :doc:`dedicated chapter </book/validation>`.

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -423,10 +423,12 @@ corresponding errors printed out with the form.
    .. code-block:: html+jinja
 
      {# src/Acme/DemoBundle/Resources/views/Default/new.html.twig #}
+     
      {{ form(form, {'attr': {'novalidate': 'novalidate'}}) }}
 
    .. code-block:: html+php
-
+      <!-- src/Acme/DemoBundle/Resources/views/Default/new.html.php -->
+      
       <?php echo $view['form']->form($form, array(
          'attr' => array('novalidate' => 'novalidate'),
       )) ?>

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -420,18 +420,21 @@ corresponding errors printed out with the form.
    but are being prevented by your browser from, for example, submitting
    blank fields.
 
-   .. code-block:: html+jinja
+.. configuration-block::
 
-     {# src/Acme/DemoBundle/Resources/views/Default/new.html.twig #}
-     
-     {{ form(form, {'attr': {'novalidate': 'novalidate'}}) }}
+    .. code-block:: html+jinja
 
-   .. code-block:: html+php
-      <!-- src/Acme/DemoBundle/Resources/views/Default/new.html.php -->
-      
-      <?php echo $view['form']->form($form, array(
-         'attr' => array('novalidate' => 'novalidate'),
-      )) ?>
+        {# src/Acme/DemoBundle/Resources/views/Default/new.html.twig #}
+
+        {{ form(form, {'attr': {'novalidate': 'novalidate'}}) }}
+
+    .. code-block:: html+php
+
+        <!-- src/Acme/DemoBundle/Resources/views/Default/new.html.php -->
+
+        <?php echo $view['form']->form($form, array(
+            'attr' => array('novalidate' => 'novalidate'),
+        )) ?>
 
 Validation is a very powerful feature of Symfony2 and has its own
 :doc:`dedicated chapter </book/validation>`.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes, a Twig example was added |
| Applies to | 2.3 |
| Fixed tickets | no PR |

in the form documentation, there is a notice about the no validate HTML5 attribute, but without the twig example.

Symfony 2.3 added the method {{ form(form) }} used in the example
