### PR TITLE
Fixed typo

### DIFF
--- a/reference/forms/types/options/inherit_data.rst.inc
+++ b/reference/forms/types/options/inherit_data.rst.inc
@@ -6,6 +6,6 @@ inherit_data
 
 **type**: ``boolean`` **default**: ``false``
 
-This option determines if the form will inherit data form its parent form.
+This option determines if the form will inherit data from its parent form.
 This can be useful is you have a set of fields that are duplicated across
 multiple forms. See :doc:`/cookbook/form/inherit_data_option`.


### PR DESCRIPTION
Was:

> This option determines if the form will inherit data form its parent form.

Changed to:

> This option determines if the form will inherit data from its parent form.
