### PR TITLE
2.3 only - Collection of minor fixes

### DIFF
--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -169,12 +169,12 @@ the above example, the ``allowMissingFields`` option was set to true, meaning
 that if either of the ``personal_email`` or ``short_bio`` elements were missing
 from the ``$personalData`` property, no validation error would occur.
 
+Required and Optional Field Constraints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. versionadded:: 2.3
     The ``Required`` and ``Optional`` constraints were moved to the namespace
     ``Symfony\Component\Validator\Constraints\`` in Symfony 2.3.
-
-Required and Optional Field Constraints
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Constraints for fields within a collection can be wrapped in the ``Required`` or
 ``Optional`` constraint to control whether they should always be applied (``Required``)

--- a/reference/constraints/EqualTo.rst
+++ b/reference/constraints/EqualTo.rst
@@ -95,6 +95,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be equal to {{ compared_value }}``
+**type**: ``string`` **default**: ``This value should be equal to {{ compared_value }}.``
 
 This is the message that will be shown if the value is not equal.

--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -91,7 +91,7 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be greater than {{ compared_value }}``
+**type**: ``string`` **default**: ``This value should be greater than {{ compared_value }}.``
 
 This is the message that will be shown if the value is not greater than the
 comparison value.

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -90,7 +90,7 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be greater than or equal to {{ compared_value }}``
+**type**: ``string`` **default**: ``This value should be greater than or equal to {{ compared_value }}.``
 
 This is the message that will be shown if the value is not greater than or equal
 to the comparison value.

--- a/reference/constraints/IdenticalTo.rst
+++ b/reference/constraints/IdenticalTo.rst
@@ -96,6 +96,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be identical to {{ compared_value_type }} {{ compared_value }}``
+**type**: ``string`` **default**: ``This value should be identical to {{ compared_value_type }} {{ compared_value }}.``
 
 This is the message that will be shown if the value is not identical.

--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -4,8 +4,8 @@ Isbn
 .. versionadded:: 2.3
     The Isbn constraint was added in Symfony 2.3.
 
-This constraint validates that an ISBN (International Standard Book Numbers)
-number is either a valid ISBN-10, a valid ISBN-13 or both.
+This constraint validates that an `International Standard Book Number (ISBN)`_
+is either a valid ISBN-10, a valid ISBN-13 or both.
 
 +----------------+----------------------------------------------------------------------+
 | Applies to     | :ref:`property or method<validation-property-target>`                |
@@ -98,7 +98,7 @@ Available Options
 isbn10
 ~~~~~~
 
-**type**: ``boolean`` [:ref:`default option<validation-default-option>`]
+**type**: ``boolean``
 
 If this required option is set to ``true`` the constraint will check if the
 code is a valid ISBN-10 code.
@@ -106,7 +106,7 @@ code is a valid ISBN-10 code.
 isbn13
 ~~~~~~
 
-**type**: ``boolean`` [:ref:`default option<validation-default-option>`]
+**type**: ``boolean``
 
 If this required option is set to ``true`` the constraint will check if the
 code is a valid ISBN-13 code.
@@ -134,3 +134,5 @@ bothIsbnMessage
 
 The message that will be shown if both the `isbn10`_ and `isbn13`_ options
 are true and the given value does not pass the ISBN-13 nor the ISBN-13 check.
+
+.. _`International Standard Book Number (ISBN)`: http://en.wikipedia.org/wiki/Isbn

--- a/reference/constraints/Issn.rst
+++ b/reference/constraints/Issn.rst
@@ -2,9 +2,9 @@ Issn
 ====
 
 .. versionadded:: 2.3
-    The ISSN validation is new in Symfony 2.3.
+    The Issn constraint was added in Symfony 2.3.
 
-Validates that a value is a valid `ISSN`_.
+Validates that a value is a valid `International Standard Serial Number (ISSN)`_.
 
 +----------------+-----------------------------------------------------------------------+
 | Applies to     | :ref:`property or method<validation-property-target>`                 |
@@ -97,5 +97,5 @@ requireHyphen
 The validator will allow non hyphenated ISSN values by default. When switching
 this to ``true``, the validator requires a hyphenated ISSN value.
 
-.. _`ISSN`: http://en.wikipedia.org/wiki/Issn
+.. _`International Standard Serial Number (ISSN)`: http://en.wikipedia.org/wiki/Issn
 

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -91,7 +91,7 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be less than {{ compared_value }}``
+**type**: ``string`` **default**: ``This value should be less than {{ compared_value }}.``
 
 This is the message that will be shown if the value is not less than the
 comparison value.

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -90,7 +90,7 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be less than or equal to {{ compared_value }}``
+**type**: ``string`` **default**: ``This value should be less than or equal to {{ compared_value }}.``
 
 This is the message that will be shown if the value is not less than or equal
 to the comparison value.

--- a/reference/constraints/NotEqualTo.rst
+++ b/reference/constraints/NotEqualTo.rst
@@ -96,6 +96,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should not be equal to {{ compared_value }}``
+**type**: ``string`` **default**: ``This value should not be equal to {{ compared_value }}.``
 
 This is the message that will be shown if the value is equal.

--- a/reference/constraints/NotIdenticalTo.rst
+++ b/reference/constraints/NotIdenticalTo.rst
@@ -96,6 +96,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should not be identical to {{ compared_value_type }} {{ compared_value }}``
+**type**: ``string`` **default**: ``This value should not be identical to {{ compared_value_type }} {{ compared_value }}.``
 
 This is the message that will be shown if the value is not equal.

--- a/reference/constraints/_comparison-value-option.rst.inc
+++ b/reference/constraints/_comparison-value-option.rst.inc
@@ -1,7 +1,7 @@
 value
 ~~~~~
 
-**type**: ``mixed``
+**type**: ``mixed`` [:ref:`default option<validation-default-option>`]
 
 This option is required. It defines the value to compare to. It can be a
 string, number or object.

--- a/reference/forms/twig_reference.rst
+++ b/reference/forms/twig_reference.rst
@@ -48,7 +48,7 @@ the other helpers to render individual parts of the form instead:
         {{ form_row(form.name) }}
         {{ form_row(form.dueDate) }}
 
-        <input type="submit" value="Submit me"/>
+        {{ form_row(form.submit, { 'label': 'Submit me' }) }}
     {{ form_end(form) }}
 
 .. _reference-forms-twig-start:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | - |
| Applies to | 2.3 |
| Fixed tickets | - |

Some minor fixes for 2.3 only.

The changes for the the Isbn/Issn/Iban validators are all about consistency.

The Isbn validator has no default option - currently two of them are declared to be the default.

Please comment if something is wrong - I'll do an update then.
