### PR TITLE
[Reference][Constraints] Remove invalid default option markers; fix messages

### DIFF
--- a/reference/constraints/Blank.rst
+++ b/reference/constraints/Blank.rst
@@ -84,6 +84,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be blank``
+**type**: ``string`` **default**: ``This value should be blank.``
 
 This is the message that will be shown if the value is not blank.

--- a/reference/constraints/CardScheme.rst
+++ b/reference/constraints/CardScheme.rst
@@ -123,7 +123,7 @@ For more information about the used schemes, see `Wikipedia: Issuer identificati
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``Unsupported card type or invalid card number``
+**type**: ``string`` **default**: ``Unsupported card type or invalid card number.``
 
 The message shown when the value does not pass the ``CardScheme`` check.
 

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -311,7 +311,7 @@ will fail.
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``The value you selected is not a valid choice``
+**type**: ``string`` **default**: ``The value you selected is not a valid choice.``
 
 This is the message that you will receive if the ``multiple`` option is set
 to ``false``, and the underlying value is not in the valid array of choices.
@@ -319,7 +319,7 @@ to ``false``, and the underlying value is not in the valid array of choices.
 multipleMessage
 ~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``One or more of the given values is invalid``
+**type**: ``string`` **default**: ``One or more of the given values is invalid.``
 
 This is the message that you will receive if the ``multiple`` option is set
 to ``true``, and one of the values on the underlying array being checked
@@ -328,7 +328,7 @@ is not in the array of valid choices.
 minMessage
 ~~~~~~~~~~
 
-**type**: ``string`` **default**: ``You must select at least {{ limit }} choices``
+**type**: ``string`` **default**: ``You must select at least {{ limit }} choices.``
 
 This is the validation error message that's displayed when the user chooses
 too few choices per the `min`_ option.
@@ -336,7 +336,7 @@ too few choices per the `min`_ option.
 maxMessage
 ~~~~~~~~~~
 
-**type**: ``string`` **default**: ``You must select at most {{ limit }} choices``
+**type**: ``string`` **default**: ``You must select at most {{ limit }} choices.``
 
 This is the validation error message that's displayed when the user chooses
 too many options per the `max`_ option.

--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -305,7 +305,7 @@ error will be returned. If set to ``true``, extra fields are ok.
 extraFieldsMessage
 ~~~~~~~~~~~~~~~~~~
 
-**type**: ``Boolean`` **default**: ``The fields {{ fields }} were not expected``
+**type**: ``Boolean`` **default**: ``The fields {{ fields }} were not expected.``
 
 The message shown if `allowExtraFields`_ is false and an extra field is detected.
 
@@ -322,7 +322,7 @@ option are not present in the underlying collection.
 missingFieldsMessage
 ~~~~~~~~~~~~~~~~~~~~
 
-**type**: ``Boolean`` **default**: ``The fields {{ fields }} are missing``
+**type**: ``Boolean`` **default**: ``The fields {{ fields }} are missing.``
 
 The message shown if `allowMissingFields`_ is false and one or more fields
 are missing from the underlying collection.

--- a/reference/constraints/Count.rst
+++ b/reference/constraints/Count.rst
@@ -108,7 +108,7 @@ Options
 min
 ~~~
 
-**type**: ``integer`` [:ref:`default option <validation-default-option>`]
+**type**: ``integer``
 
 This required option is the "min" count value. Validation will fail if the given
 collection elements count is **less** than this min value.
@@ -116,7 +116,7 @@ collection elements count is **less** than this min value.
 max
 ~~~
 
-**type**: ``integer`` [:ref:`default option <validation-default-option>`]
+**type**: ``integer``
 
 This required option is the "max" count value. Validation will fail if the given
 collection elements count is **greater** than this max value.
@@ -124,21 +124,21 @@ collection elements count is **greater** than this max value.
 minMessage
 ~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This collection should contain {{ limit }} elements or more.``.
+**type**: ``string`` **default**: ``This collection should contain {{ limit }} elements or more.``
 
 The message that will be shown if the underlying collection elements count is less than the `min`_ option.
 
 maxMessage
 ~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This collection should contain {{ limit }} elements or less.``.
+**type**: ``string`` **default**: ``This collection should contain {{ limit }} elements or less.``
 
 The message that will be shown if the underlying collection elements count is more than the `max`_ option.
 
 exactMessage
 ~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This collection should contain exactly {{ limit }} elements.``.
+**type**: ``string`` **default**: ``This collection should contain exactly {{ limit }} elements.``
 
 The message that will be shown if min and max values are equal and the underlying collection elements 
 count is not exactly this value.

--- a/reference/constraints/Country.rst
+++ b/reference/constraints/Country.rst
@@ -78,6 +78,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value is not a valid country``
+**type**: ``string`` **default**: ``This value is not a valid country.``
 
 This message is shown if the string is not a valid country code.

--- a/reference/constraints/Date.rst
+++ b/reference/constraints/Date.rst
@@ -80,6 +80,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value is not a valid date``
+**type**: ``string`` **default**: ``This value is not a valid date.``
 
 This message is shown if the underlying data is not a valid date.

--- a/reference/constraints/DateTime.rst
+++ b/reference/constraints/DateTime.rst
@@ -80,6 +80,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value is not a valid datetime``
+**type**: ``string`` **default**: ``This value is not a valid datetime.``
 
 This message is shown if the underlying data is not a valid datetime.

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -92,7 +92,7 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value is not a valid email address``
+**type**: ``string`` **default**: ``This value is not a valid email address.``
 
 This message is shown if the underlying data is not a valid email address.
 

--- a/reference/constraints/False.rst
+++ b/reference/constraints/False.rst
@@ -112,6 +112,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be false``
+**type**: ``string`` **default**: ``This value should be false.``
 
 This message is shown if the underlying data is not false.

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -182,14 +182,14 @@ You can find a list of existing mime types on the `IANA website`_
 maxSizeMessage
 ~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The file is too large ({{ size }}). Allowed maximum size is {{ limit }}``
+**type**: ``string`` **default**: ``The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.``
 
 The message displayed if the file is larger than the `maxSize`_ option.
 
 mimeTypesMessage
 ~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}``
+**type**: ``string`` **default**: ``The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.``
 
 The message displayed if the mime type of the file is not a valid mime type
 per the `mimeTypes`_ option.
@@ -197,7 +197,7 @@ per the `mimeTypes`_ option.
 notFoundMessage
 ~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The file could not be found``
+**type**: ``string`` **default**: ``The file could not be found.``
 
 The message displayed if no file can be found at the given path. This error
 is only likely if the underlying value is a string path, as a ``File`` object
@@ -206,7 +206,7 @@ cannot be constructed with an invalid file path.
 notReadableMessage
 ~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The file is not readable``
+**type**: ``string`` **default**: ``The file is not readable.``
 
 The message displayed if the file exists, but the PHP ``is_readable`` function
 fails when passed the path to the file.
@@ -214,7 +214,7 @@ fails when passed the path to the file.
 uploadIniSizeErrorMessage
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The file is too large. Allowed maximum size is {{ limit }}``
+**type**: ``string`` **default**: ``The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.``
 
 The message that is displayed if the uploaded file is larger than the ``upload_max_filesize``
 ``php.ini`` setting.
@@ -222,7 +222,7 @@ The message that is displayed if the uploaded file is larger than the ``upload_m
 uploadFormSizeErrorMessage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The file is too large``
+**type**: ``string`` **default**: ``The file is too large.``
 
 The message that is displayed if the uploaded file is larger than allowed
 by the HTML file input field.
@@ -230,7 +230,7 @@ by the HTML file input field.
 uploadErrorMessage
 ~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The file could not be uploaded``
+**type**: ``string`` **default**: ``The file could not be uploaded.``
 
 The message that is displayed if the uploaded file could not be uploaded
 for some unknown reason, such as the file upload failed or it couldn't be written

--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -160,7 +160,7 @@ You can find a list of existing image mime types on the `IANA website`_
 mimeTypesMessage
 ~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This file is not a valid image``
+**type**: ``string`` **default**: ``This file is not a valid image.``
 
 .. versionadded:: 2.1
     All of the min/max width/height options are new to Symfony 2.1.
@@ -200,7 +200,7 @@ value in pixels.
 sizeNotDetectedMessage
 ~~~~~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The size of the image could not be detected``
+**type**: ``string`` **default**: ``The size of the image could not be detected.``
 
 If the system is unable to determine the size of the image, this error will
 be displayed. This will only occur when at least one of the four size constraint
@@ -209,28 +209,28 @@ options has been set.
 maxWidthMessage
 ~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px``
+**type**: ``string`` **default**: ``The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.``
 
 The error message if the width of the image exceeds `maxWidth`_.
 
 minWidthMessage
 ~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px``
+**type**: ``string`` **default**: ``The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.``
 
 The error message if the width of the image is less than `minWidth`_.
 
 maxHeightMessage
 ~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px``
+**type**: ``string`` **default**: ``The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.``
 
 The error message if the height of the image exceeds `maxHeight`_.
 
 minHeightMessage
 ~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px``
+**type**: ``string`` **default**: ``The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.``
 
 The error message if the height of the image is less than `minHeight`_.
 

--- a/reference/constraints/Ip.rst
+++ b/reference/constraints/Ip.rst
@@ -113,6 +113,6 @@ of a variety of different values:
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This is not a valid IP address``
+**type**: ``string`` **default**: ``This is not a valid IP address.``
 
 This message is shown if the string is not a valid IP address.

--- a/reference/constraints/Language.rst
+++ b/reference/constraints/Language.rst
@@ -78,6 +78,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value is not a valid language``
+**type**: ``string`` **default**: ``This value is not a valid language.``
 
 This message is shown if the string is not a valid language code.

--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -108,7 +108,7 @@ Options
 min
 ~~~
 
-**type**: ``integer`` [:ref:`default option <validation-default-option>`]
+**type**: ``integer``
 
 This required option is the "min" length value. Validation will fail if the given
 value's length is **less** than this min value.
@@ -116,7 +116,7 @@ value's length is **less** than this min value.
 max
 ~~~
 
-**type**: ``integer`` [:ref:`default option <validation-default-option>`]
+**type**: ``integer``
 
 This required option is the "max" length value. Validation will fail if the given
 value's length is **greater** than this max value.
@@ -134,21 +134,21 @@ is used.
 minMessage
 ~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This value is too short. It should have {{ limit }} characters or more.``.
+**type**: ``string`` **default**: ``This value is too short. It should have {{ limit }} characters or more.``
 
 The message that will be shown if the underlying value's length is less than the `min`_ option.
 
 maxMessage
 ~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This value is too long. It should have {{ limit }} characters or less.``.
+**type**: ``string`` **default**: ``This value is too long. It should have {{ limit }} characters or less.``
 
 The message that will be shown if the underlying value's length is more than the `max`_ option.
 
 exactMessage
 ~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This value should have exactly {{ limit }} characters.``.
+**type**: ``string`` **default**: ``This value should have exactly {{ limit }} characters.``
 
 The message that will be shown if min and max values are equal and the underlying
 value's length is not exactly this value.

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -82,6 +82,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value is not a valid locale``
+**type**: ``string`` **default**: ``This value is not a valid locale.``
 
 This message is shown if the string is not a valid locale.

--- a/reference/constraints/Luhn.rst
+++ b/reference/constraints/Luhn.rst
@@ -93,7 +93,7 @@ Available Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``Invalid card number``
+**type**: ``string`` **default**: ``Invalid card number.``
 
 The default message supplied when the value does not pass the Luhn check.
 

--- a/reference/constraints/Max.rst
+++ b/reference/constraints/Max.rst
@@ -103,7 +103,7 @@ value is **greater** than this max value.
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be {{ limit }} or less``
+**type**: ``string`` **default**: ``This value should be {{ limit }} or less.``
 
 The message that will be shown if the underlying value is greater than the
 `limit`_ option.
@@ -111,7 +111,7 @@ The message that will be shown if the underlying value is greater than the
 invalidMessage
 ~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be a valid number``
+**type**: ``string`` **default**: ``This value should be a valid number.``
 
 The message that will be shown if the underlying value is not a number (per
 the :phpfunction:`is_numeric` PHP function).

--- a/reference/constraints/MaxLength.rst
+++ b/reference/constraints/MaxLength.rst
@@ -98,7 +98,7 @@ of the give string is **greater** than this number.
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value is too long. It should have {{ limit }} characters or less``
+**type**: ``string`` **default**: ``This value is too long. It should have {{ limit }} characters or less.``
 
 The message that will be shown if the underlying string has a length that
 is longer than the `limit`_ option.

--- a/reference/constraints/Min.rst
+++ b/reference/constraints/Min.rst
@@ -103,7 +103,7 @@ value is **less** than this min value.
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be {{ limit }} or more``
+**type**: ``string`` **default**: ``This value should be {{ limit }} or more.``
 
 The message that will be shown if the underlying value is less than the `limit`_
 option.
@@ -111,7 +111,7 @@ option.
 invalidMessage
 ~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be a valid number``
+**type**: ``string`` **default**: ``This value should be a valid number.``
 
 The message that will be shown if the underlying value is not a number (per
 the :phpfunction:`is_numeric` PHP function).

--- a/reference/constraints/MinLength.rst
+++ b/reference/constraints/MinLength.rst
@@ -103,7 +103,7 @@ of the give string is **less** than this number.
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value is too short. It should have {{ limit }} characters or more``
+**type**: ``string`` **default**: ``This value is too short. It should have {{ limit }} characters or more.``
 
 The message that will be shown if the underlying string has a length that
 is shorter than the `limit`_ option.

--- a/reference/constraints/NotBlank.rst
+++ b/reference/constraints/NotBlank.rst
@@ -83,6 +83,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should not be blank``
+**type**: ``string`` **default**: ``This value should not be blank.``
 
 This is the message that will be shown if the value is blank.

--- a/reference/constraints/NotNull.rst
+++ b/reference/constraints/NotNull.rst
@@ -83,6 +83,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should not be null``
+**type**: ``string`` **default**: ``This value should not be null.``
 
 This is the message that will be shown if the value is ``null``.

--- a/reference/constraints/Null.rst
+++ b/reference/constraints/Null.rst
@@ -83,6 +83,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be null``
+**type**: ``string`` **default**: ``This value should be null.``
 
 This is the message that will be shown if the value is not ``null``.

--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -107,7 +107,7 @@ Options
 min
 ~~~
 
-**type**: ``integer`` [:ref:`default option <validation-default-option>`]
+**type**: ``integer``
 
 This required option is the "min" value. Validation will fail if the given
 value is **less** than this min value.
@@ -115,7 +115,7 @@ value is **less** than this min value.
 max
 ~~~
 
-**type**: ``integer`` [:ref:`default option <validation-default-option>`]
+**type**: ``integer``
 
 This required option is the "max" value. Validation will fail if the given
 value is **greater** than this max value.

--- a/reference/constraints/Regex.rst
+++ b/reference/constraints/Regex.rst
@@ -274,6 +274,6 @@ string does **not** match the `pattern`_ regular expression.
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value is not valid``
+**type**: ``string`` **default**: ``This value is not valid.``
 
 This is the message that will be shown if this validator fails.

--- a/reference/constraints/Time.rst
+++ b/reference/constraints/Time.rst
@@ -83,6 +83,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value is not a valid time``
+**type**: ``string`` **default**: ``This value is not a valid time.``
 
 This message is shown if the underlying data is not a valid time.

--- a/reference/constraints/True.rst
+++ b/reference/constraints/True.rst
@@ -122,6 +122,6 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be true``
+**type**: ``string`` **default**: ``This value should be true.``
 
 This message is shown if the underlying data is not true.

--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -115,6 +115,6 @@ as determined by PHP's ``is_`` functions.
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value should be of type {{ type }}``
+**type**: ``string`` **default**: ``This value should be of type {{ type }}.``
 
 The message if the underlying data is not of the given type.

--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -79,7 +79,7 @@ Options
 message
 ~~~~~~~
 
-**type**: ``string`` **default**: ``This value is not a valid URL``
+**type**: ``string`` **default**: ``This value is not a valid URL.``
 
 This message is shown if the URL is invalid.
 

--- a/reference/constraints/UserPassword.rst
+++ b/reference/constraints/UserPassword.rst
@@ -106,7 +106,7 @@ Options
 message
 ~~~~~~~
 
-**type**: ``message`` **default**: ``This value should be the user current password``
+**type**: ``message`` **default**: ``This value should be the user current password.``
 
 This is the message that's displayed when the underlying string does *not*
 match the current user's password.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | - |
| Applies to | 2.2+ |
| Fixed tickets | - |

For some constraints there was one or more default option indicated which is not a default option according to the Symfony code.

In addition, I fixed the constraint messages, some were missing the dot at the end while some had it twice. `suffix` was missing in the File constraint messages.
