### PR TITLE
Add cookbook entry about url trailing slash redirect

### DIFF
--- a/cookbook/map.rst.inc
+++ b/cookbook/map.rst.inc
@@ -115,6 +115,7 @@
   * :doc:`/cookbook/routing/method_parameters`
   * :doc:`/cookbook/routing/service_container_parameters`
   * :doc:`/cookbook/routing/custom_route_loader`
+  * :doc:`/cookbook/routing/redirect_trailing_slash`
 
 * :doc:`/cookbook/security/index`
 

--- a/cookbook/routing/index.rst
+++ b/cookbook/routing/index.rst
@@ -10,3 +10,4 @@ Routing
     method_parameters
     service_container_parameters
     custom_route_loader
+    redirect_trailing_slash

--- a/cookbook/routing/redirect_trailing_slash.rst
+++ b/cookbook/routing/redirect_trailing_slash.rst
@@ -1,0 +1,90 @@
+.. index::
+    single: Routing; Redirect URLs with a trailing slash
+
+Redirect URLs with a Trailing Slash
+===================================
+
+The goal of this cookbook is to demonstrate how to redirect URLs with
+trailing slash to the same URL without a trailing slash
+(for example ``/en/blog/`` to ``/en/blog``).
+
+You have to create a controller that will match any URL with a trailing
+slash, remove the trailing slash (keeping query parameters if any) and
+redirect to the new URL with a 301 response status code::
+
+    // src/Acme/DemoBundle/Controller/RedirectingController.php
+    namespace Acme\DemoBundle\Controller;
+
+    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\HttpFoundation\Request;
+
+    class RedirectingController extends Controller
+    {
+        public function removeTrailingSlashAction(Request $request)
+        {
+            $pathInfo = $request->getPathInfo();
+            $requestUri = $request->getRequestUri();
+
+            $url = str_replace($pathInfo, rtrim($pathInfo, ' /'), $requestUri);
+
+            return $this->redirect($url, 301);
+        }
+    }
+
+And after that, register this controller to be executed whenever a URL
+with a trailing slash is requested:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        remove_trailing_slash:
+            path: /{url}
+            defaults: { _controller: AcmeDemoBundle:Redirecting:removeTrailingSlash }
+            requirements:
+                url: .*/$
+                _method: GET
+
+
+    .. code-block:: xml
+
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <routes xmlns="http://symfony.com/schema/routing">
+            <route id="remove_trailing_slash" path="/{url}">
+                <default key="_controller">AcmeDemoBundle:Redirecting:removeTrailingSlash</default>
+                <requirement key="url">.*/$</requirement>
+                <requirement key="_method">GET</requirement>
+            </route>
+        </routes>
+
+    .. code-block:: php
+
+        use Symfony\Component\Routing\RouteCollection;
+        use Symfony\Component\Routing\Route;
+
+        $collection = new RouteCollection();
+        $collection->add(
+            'remove_trailing_slash',
+            new Route(
+                '/{url}',
+                array(
+                    '_controller' => 'AcmeDemoBundle:Redirecting:removeTrailingSlash',
+                ),
+                array(
+                    'url' => '.*/$',
+                    '_method' => 'GET',
+                )
+            )
+        );
+
+.. note::
+
+    Redirecting a POST request does not work well in old browsers.
+    A 302 on a POST request will send a GET request after the
+    redirection for legacy reasons.
+
+.. caution::
+
+    Make sure to include this route in your routing configuration at
+    the very end of your route listing. Otherwise, you risk to redirect
+    Symfony2 core routes that natively do have a trailing slash.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.2+ |
| Fixed tickets | none |

Like @WouterJ said in [this symfony CMF discussion](https://github.com/symfony-cmf/symfony-cmf-docs/pull/323), it may be interesting to have this in the symfony cookbook.
