### PR TITLE
add clarification for order in which event listeners will be executed

### DIFF
--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -91,7 +91,7 @@ using a special "tag":
 
     There is an additional tag option ``priority`` that is optional and defaults
     to 0. This value can be from -255 to 255, and the listeners will be executed
-    in the order of their priority. This is useful when you need to guarantee
+    in the order of their priority (highest to lowest). This is useful when you need to guarantee
     that one listener is executed before another.
 
 Request events, checking types


### PR DESCRIPTION
Clearing up ambiguity (are event listeners executed in priority or number order?).
