### PR TITLE
[WIP] Making consistent component names throughout the docs

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -11,8 +11,8 @@ learning the most important features of the form library along the way.
 
 .. note::
 
-   The Symfony form component is a standalone library that can be used outside
-   of Symfony2 projects. For more information, see the `Symfony2 Form Component`_
+   The Symfony Form component is a standalone library that can be used outside
+   of Symfony2 projects. For more information, see the `Symfony2 Form component`_
    on Github.
 
 .. index::
@@ -185,7 +185,7 @@ it into a format that's suitable for being rendered in an HTML form.
    The form system is smart enough to access the value of the protected
    ``task`` property via the ``getTask()`` and ``setTask()`` methods on the
    ``Task`` class. Unless a property is public, it *must* have a "getter" and
-   "setter" method so that the form component can get and put data onto the
+   "setter" method so that the Form component can get and put data onto the
    property. For a Boolean property, you can use an "isser" or "hasser" method
    (e.g. ``isPublished()`` or ``hasReminder()``) instead of a getter (e.g.
    ``getPublished()`` or ``getReminder()``).
@@ -1017,7 +1017,7 @@ Embedded Forms
 Often, you'll want to build a form that will include fields from many different
 objects. For example, a registration form may contain data belonging to
 a ``User`` object as well as many ``Address`` objects. Fortunately, this
-is easy and natural with the form component.
+is easy and natural with the Form component.
 
 Embedding a Single Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1221,7 +1221,7 @@ do this, create a new template file that will store the new markup:
         </div>
 
 The ``form_row`` form fragment is used when rendering most fields via the
-``form_row`` function. To tell the form component to use your new ``form_row``
+``form_row`` function. To tell the Form component to use your new ``form_row``
 fragment defined above, add the following to the top of the template that
 renders the form:
 
@@ -1706,7 +1706,7 @@ Learn more from the Cookbook
 * :doc:`/cookbook/form/dynamic_form_modification`
 * :doc:`/cookbook/form/data_transformers`
 
-.. _`Symfony2 Form Component`: https://github.com/symfony/Form
+.. _`Symfony2 Form component`: https://github.com/symfony/Form
 .. _`DateTime`: http://php.net/manual/en/class.datetime.php
 .. _`Twig Bridge`: https://github.com/symfony/symfony/tree/2.2/src/Symfony/Bridge/Twig
 .. _`form_div_layout.html.twig`: https://github.com/symfony/symfony/blob/2.2/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig

--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -247,7 +247,7 @@ the layout:
 You've now introduced a methodology that allows for the reuse of the
 layout. Unfortunately, to accomplish this, you're forced to use a few ugly
 PHP functions (``ob_start()``, ``ob_get_clean()``) in the template. Symfony2
-uses a ``Templating`` component that allows this to be accomplished cleanly
+uses a Templating component that allows this to be accomplished cleanly
 and easily. You'll see it in action shortly.
 
 Adding a Blog "show" Page
@@ -583,7 +583,7 @@ them for you. Here's the same sample application, now built in Symfony2::
     }
 
 The two controllers are still lightweight. Each uses the :doc:`Doctrine ORM library </book/doctrine>`
-to retrieve objects from the database and the ``Templating`` component to
+to retrieve objects from the database and the Templating component to
 render a template and return a ``Response`` object. The list template is
 now quite a bit simpler:
 
@@ -688,7 +688,7 @@ migrating the blog from flat PHP to Symfony2 has improved life:
   Templating, Security, Form, Validation and Translation components (to name
   a few);
 
-* The application now enjoys **fully-flexible URLs** thanks to the ``Routing``
+* The application now enjoys **fully-flexible URLs** thanks to the Routing
   component;
 
 * Symfony2's HTTP-centric architecture gives you access to powerful tools

--- a/book/http_fundamentals.rst
+++ b/book/http_fundamentals.rst
@@ -293,7 +293,7 @@ and create the appropriate response based on your application logic*.
 .. tip::
 
     The ``Request`` and ``Response`` classes are part of a standalone component
-    included with Symfony called ``HttpFoundation``. This component can be
+    included with Symfony called HttpFoundation. This component can be
     used entirely independently of Symfony and also provides classes for handling
     sessions and file uploads.
 

--- a/book/internals.rst
+++ b/book/internals.rst
@@ -25,8 +25,8 @@ on top of the previous one.
     Composer's autoloader (``vendor/autoload.php``), which is included in
     the ``app/autoload.php`` file.
 
-``HttpFoundation`` Component
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+HttpFoundation Component
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 The deepest level is the :namespace:`Symfony\\Component\\HttpFoundation`
 component. HttpFoundation provides the main objects needed to deal with HTTP.
@@ -46,10 +46,10 @@ variables:
 
 .. note::
 
-    Read more about the :doc:`HttpFoundation Component </components/http_foundation/introduction>`.
+    Read more about the :doc:`HttpFoundation component </components/http_foundation/introduction>`.
 
-``HttpKernel`` Component
-~~~~~~~~~~~~~~~~~~~~~~~~
+HttpKernel Component
+~~~~~~~~~~~~~~~~~~~~
 
 On top of HttpFoundation is the :namespace:`Symfony\\Component\\HttpKernel`
 component. HttpKernel handles the dynamic part of HTTP; it is a thin wrapper
@@ -58,11 +58,11 @@ handled. It also provides extension points and tools that makes it the ideal
 starting point to create a Web framework without too much overhead.
 
 It also optionally adds configurability and extensibility, thanks to the
-Dependency Injection component and a powerful plugin system (bundles).
+DependencyInjection component and a powerful plugin system (bundles).
 
 .. seealso::
 
-    Read more about the :doc:`HttpKernel Component </components/http_kernel/introduction>`,
+    Read more about the :doc:`HttpKernel component </components/http_kernel/introduction>`,
     :doc:`Dependency Injection </book/service_container>` and
     :doc:`Bundles </cookbook/bundles/best_practices>`.
 
@@ -235,8 +235,8 @@ add the following code at the beginning of your listener method::
 
 .. tip::
 
-    If you are not yet familiar with the Symfony2 Event Dispatcher, read the
-    :doc:`Event Dispatcher Component Documentation </components/event_dispatcher/introduction>`
+    If you are not yet familiar with the Symfony2 EventDispatcher, read the
+    :doc:`EventDispatcher component documentation </components/event_dispatcher/introduction>`
     section first.
 
 .. index::
@@ -429,14 +429,14 @@ and set a new ``Exception`` object, or do nothing::
     Read more on the :ref:`kernel.exception event <component-http-kernel-kernel-exception>`.
 
 .. index::
-   single: Event Dispatcher
+   single: EventDispatcher
 
-The Event Dispatcher
---------------------
+The EventDispatcher
+-------------------
 
-The event dispatcher is a standalone component that is responsible for much
+The EventDispatcher is a standalone component that is responsible for much
 of the underlying logic and flow behind a Symfony request. For more information,
-see the :doc:`Event Dispatcher Component Documentation </components/event_dispatcher/introduction>`.
+see the :doc:`EventDispatcher component documentation </components/event_dispatcher/introduction>`.
 
 .. index::
    single: Profiler
@@ -657,4 +657,4 @@ Learn more from the Cookbook
 * :doc:`/cookbook/event_dispatcher/class_extension`
 * :doc:`/cookbook/event_dispatcher/method_behavior`
 
-.. _`Symfony2 Dependency Injection component`: https://github.com/symfony/DependencyInjection
+.. _`Symfony2 DependencyInjection component`: https://github.com/symfony/DependencyInjection

--- a/book/security.rst
+++ b/book/security.rst
@@ -31,7 +31,7 @@ application with HTTP Basic authentication.
 Basic Example: HTTP Authentication
 ----------------------------------
 
-The security component can be configured via your application configuration.
+The Security component can be configured via your application configuration.
 In fact, most standard security setups are just a matter of using the right
 configuration. The following configuration tells Symfony to secure any URL
 matching ``/admin/*`` and to ask the user for credentials using basic HTTP
@@ -1034,7 +1034,7 @@ the one seen in the previous section. For example, suppose you have a service
 You can restrict use of this class - no matter where it's being used from -
 to users that have a specific role.
 
-For more information on how you can use the security component to secure
+For more information on how you can use the Security component to secure
 different services and methods in your application, see :doc:`/cookbook/security/securing_services`.
 
 Access Control Lists (ACLs): Securing Individual Database Objects
@@ -1045,7 +1045,7 @@ posts. Now, you want a user to be able to edit his own comments, but not
 those of other users. Also, as the admin user, you yourself want to be able
 to edit *all* comments.
 
-The security component comes with an optional access control list (ACL) system
+The Security component comes with an optional access control list (ACL) system
 that you can use when you need to control access to individual instances
 of an object in your system. *Without* ACL, you can secure your system so that
 only certain users can edit blog comments in general. But *with* ACL, you
@@ -2035,7 +2035,7 @@ Utilities
 .. versionadded:: 2.2
     The ``StringUtils`` and ``SecureRandom`` classes were added in Symfony 2.2
 
-The Symfony Security Component comes with a collection of nice utilities related
+The Symfony Security component comes with a collection of nice utilities related
 to security. These utilities are used by Symfony, but you should also use
 them if you want to solve the problem they address.
 
@@ -2088,7 +2088,7 @@ Final Words
 -----------
 
 Security can be a deep and complex issue to solve correctly in your application.
-Fortunately, Symfony's security component follows a well-proven security
+Fortunately, Symfony's Security component follows a well-proven security
 model based around *authentication* and *authorization*. Authentication,
 which always happens first, is handled by a firewall whose job is to determine
 the identity of the user through several different methods (e.g. HTTP authentication,

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -1,6 +1,6 @@
 .. index::
    single: Service Container
-   single: Dependency Injection; Container
+   single: DependencyInjection; Container
 
 Service Container
 =================

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -31,7 +31,7 @@ the service container makes writing good code so easy.
 .. tip::
 
     If you want to know a lot more after reading this chapter, check out
-    the :doc:`Dependency Injection Component Documentation </components/dependency_injection/introduction>`.
+    the :doc:`DependencyInjection component documentation </components/dependency_injection/introduction>`.
 
 .. index::
    single: Service Container; What is a service?

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -30,7 +30,7 @@ In this chapter, you'll learn how to prepare an application to support multiple
 locales and then how to create translations for multiple locales. Overall,
 the process has several common steps:
 
-#. Enable and configure Symfony's ``Translation`` component;
+#. Enable and configure Symfony's Translation component;
 
 #. Abstract strings (i.e. "messages") by wrapping them in calls to the ``Translator``;
 

--- a/components/class_loader/cache_class_loader.rst
+++ b/components/class_loader/cache_class_loader.rst
@@ -1,8 +1,8 @@
 .. index::
     single: APC; ApcClassLoader
-    single: Class Loader; ApcClassLoader
-    single: Class Loader; Cache
-    single: Class Loader; XcacheClassLoader
+    single: ClassLoader; ApcClassLoader
+    single: ClassLoader; Cache
+    single: ClassLoader; XcacheClassLoader
     single: XCache; XcacheClassLoader
     
 Cache a Class Loader

--- a/components/class_loader/cache_class_loader.rst
+++ b/components/class_loader/cache_class_loader.rst
@@ -12,7 +12,7 @@ Introduction
 ------------
 
 Finding the file for a particular class can be an expensive task. Luckily,
-the Class Loader Component comes with two classes to cache the mapping
+the ClassLoader component comes with two classes to cache the mapping
 from a class to its containing file. Both the :class:`Symfony\\Component\\ClassLoader\\ApcClassLoader`
 and the :class:`Symfony\\Component\\ClassLoader\\XcacheClassLoader` wrap
 around an object which implements a ``findFile()`` method to find the file

--- a/components/class_loader/class_loader.rst
+++ b/components/class_loader/class_loader.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Class Loader; PSR-0 Class Loader
+   single: ClassLoader; PSR-0 Class Loader
 
 The PSR-0 Class Loader
 ======================

--- a/components/class_loader/debug_class_loader.rst
+++ b/components/class_loader/debug_class_loader.rst
@@ -1,5 +1,5 @@
 .. index::
-    single: Class Loader; DebugClassLoader
+    single: ClassLoader; DebugClassLoader
     
 Debugging a Class Loader
 ========================

--- a/components/class_loader/index.rst
+++ b/components/class_loader/index.rst
@@ -1,5 +1,5 @@
-Class Loader
-============
+ClassLoader
+===========
 
 .. toctree::
     :maxdepth: 2

--- a/components/class_loader/introduction.rst
+++ b/components/class_loader/introduction.rst
@@ -1,10 +1,10 @@
 .. index::
-    single: Components; Class Loader
+    single: Components; ClassLoader
 
-The Class Loader Component
-==========================
+The ClassLoader Component
+=========================
 
-    The Class Loader Component provides tools to autoload your classes and
+    The ClassLoader component provides tools to autoload your classes and
     cache their locations for performance.
 
 Usage
@@ -20,7 +20,7 @@ the class. Symfony2 provides two autoloaders, which are able to load your classe
 * :doc:`/components/class_loader/map_class_loader`: loads classes using
   a static map from class name to file path.
 
-Additionally, the Symfony Class Loader Component ships with a set of wrapper
+Additionally, the Symfony ClassLoader component ships with a set of wrapper
 classes which can be used to add additional functionality on top of existing
 autoloaders:
 

--- a/components/class_loader/map_class_loader.rst
+++ b/components/class_loader/map_class_loader.rst
@@ -1,5 +1,5 @@
 .. index::
-    single: Class Loader; MapClassLoader
+    single: ClassLoader; MapClassLoader
     
 MapClassLoader
 ==============

--- a/components/config/introduction.rst
+++ b/components/config/introduction.rst
@@ -8,7 +8,7 @@ The Config Component
 Introduction
 ------------
 
-The Config Component provides several classes to help you find, load, combine,
+The Config component provides several classes to help you find, load, combine,
 autofill and validate configuration values of any kind, whatever their source
 may be (Yaml, XML, INI files, or for instance a database).
 

--- a/components/console/helpers/index.rst
+++ b/components/console/helpers/index.rst
@@ -11,7 +11,7 @@ The Console Helpers
     formatterhelper
     progresshelper
 
-The Console Components comes with some useful helpers. These helpers contain
+The Console component comes with some useful helpers. These helpers contain
 function to ease some common tasks.
 
 .. include:: map.rst.inc

--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -22,7 +22,7 @@ You can install the component in 2 different ways:
 
 .. note::
 
-    Windows does not support ANSI colors by default so the Console Component detects and
+    Windows does not support ANSI colors by default so the Console component detects and
     disables colors where Windows does not have support. However, if Windows is not
     configured with an ANSI driver and your console commands invoke other scripts which
     emit ANSI color sequences, they will be shown as raw escape characters.

--- a/components/console/usage.rst
+++ b/components/console/usage.rst
@@ -5,7 +5,7 @@ Using Console Commands, Shortcuts and Built-in Commands
 =======================================================
 
 In addition to the options you specify for your commands, there are some
-built-in options as well as a couple of built-in commands for the console component.
+built-in options as well as a couple of built-in commands for the Console component.
 
 .. note::
 

--- a/components/css_selector.rst
+++ b/components/css_selector.rst
@@ -5,7 +5,7 @@
 The CssSelector Component
 =========================
 
-    The CssSelector Component converts CSS selectors to XPath expressions.
+    The CssSelector component converts CSS selectors to XPath expressions.
 
 Installation
 ------------
@@ -41,8 +41,8 @@ be converted to an XPath equivalent. This XPath expression can then be used
 with other functions and classes that use XPath to find elements in a
 document.
 
-The ``CssSelector`` component
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The CssSelector component
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The component's only goal is to convert CSS selectors to their XPath
 equivalents::
@@ -63,7 +63,7 @@ You can use this expression with, for instance, :phpclass:`DOMXPath` or
 .. tip::
 
     The :method:`Crawler::filter() <Symfony\\Component\\DomCrawler\\Crawler::filter>` method
-    uses the ``CssSelector`` component to find elements based on a CSS selector
+    uses the CssSelector component to find elements based on a CSS selector
     string. See the :doc:`/components/dom_crawler` for more details.
 
 Limitations of the CssSelector component

--- a/components/css_selector.rst
+++ b/components/css_selector.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: CSS Selector
+   single: CssSelector
    single: Components; CssSelector
 
 The CssSelector Component

--- a/components/dependency_injection/advanced.rst
+++ b/components/dependency_injection/advanced.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Dependency Injection; Advanced configuration
+   single: DependencyInjection; Advanced configuration
 
 Advanced Container Configuration
 ================================

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -13,7 +13,7 @@ It is compiled by running::
 
     $container->compile();
 
-The compile method uses *Compiler Passes* for the compilation. The Dependency Injection
+The compile method uses *Compiler Passes* for the compilation. The DependencyInjection
 component comes with several passes which are automatically registered for
 compilation. For example the :class:`Symfony\\Component\\DependencyInjection\\Compiler\\CheckDefinitionValidityPass`
 checks for various potential issues with the definitions that have been set
@@ -148,7 +148,7 @@ like this::
     )
 
 Whilst you can manually manage merging the different files, it is much better
-to use :doc:`the Config Component </components/config/introduction>` to merge
+to use :doc:`the Config component </components/config/introduction>` to merge
 and validate the config values. Using the configuration processing you could
 access the config value this way::
 

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -1,5 +1,5 @@
 ﻿.. index::
-   single: Dependency Injection; Compilation
+   single: DependencyInjection; Compilation
 
 Compiling the Container
 =======================

--- a/components/dependency_injection/configurators.rst
+++ b/components/dependency_injection/configurators.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Dependency Injection; Service configurators
+   single: DependencyInjection; Service configurators
 
 Configuring Services with a Service Configurator
 ================================================

--- a/components/dependency_injection/definitions.rst
+++ b/components/dependency_injection/definitions.rst
@@ -1,5 +1,5 @@
 ﻿.. index::
-   single: Dependency Injection; Service definitions
+   single: DependencyInjection; Service definitions
 
 Working with Container Service Definitions
 ==========================================

--- a/components/dependency_injection/factories.rst
+++ b/components/dependency_injection/factories.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Dependency Injection; Factories
+   single: DependencyInjection; Factories
 
 Using a Factory to Create Services
 ==================================

--- a/components/dependency_injection/index.rst
+++ b/components/dependency_injection/index.rst
@@ -1,5 +1,5 @@
-﻿Dependency Injection
-====================
+﻿DependencyInjection
+===================
 
 .. toctree::
     :maxdepth: 2

--- a/components/dependency_injection/introduction.rst
+++ b/components/dependency_injection/introduction.rst
@@ -2,10 +2,10 @@
     single: Dependency Injection
     single: Components; DependencyInjection
 
-The Dependency Injection Component
-==================================
+The DependencyInjection Component
+=================================
 
-    The Dependency Injection component allows you to standardize and centralize
+    The DependencyInjection component allows you to standardize and centralize
     the way objects are constructed in your application.
 
 For an introduction to Dependency Injection and service containers see
@@ -184,7 +184,7 @@ for the services rather than using PHP to define the services as in the above
 examples. In anything but the smallest applications it make sense to organize
 the service definitions by moving them into one or more configuration files.
 To do this you also need to install
-:doc:`the Config Component </components/config/introduction>`.
+:doc:`the Config component </components/config/introduction>`.
 
 Loading an XML config file::
 

--- a/components/dependency_injection/introduction.rst
+++ b/components/dependency_injection/introduction.rst
@@ -1,5 +1,5 @@
 ﻿.. index::
-    single: Dependency Injection
+    single: DependencyInjection
     single: Components; DependencyInjection
 
 The DependencyInjection Component

--- a/components/dependency_injection/parameters.rst
+++ b/components/dependency_injection/parameters.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Dependency Injection; Parameters
+   single: DependencyInjection; Parameters
 
 Introduction to Parameters
 ==========================

--- a/components/dependency_injection/parentservices.rst
+++ b/components/dependency_injection/parentservices.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Dependency Injection; Parent services
+   single: DependencyInjection; Parent services
 
 Managing Common Dependencies with Parent Services
 =================================================

--- a/components/dependency_injection/tags.rst
+++ b/components/dependency_injection/tags.rst
@@ -1,5 +1,5 @@
 ﻿.. index::
-   single: Dependency Injection; Tags
+   single: DependencyInjection; Tags
 
 Working with Tagged Services
 ============================

--- a/components/dependency_injection/types.rst
+++ b/components/dependency_injection/types.rst
@@ -1,5 +1,5 @@
 ﻿.. index::
-   single: Dependency Injection; Injection types
+   single: DependencyInjection; Injection types
 
 Types of Injection
 ==================

--- a/components/dependency_injection/workflow.rst
+++ b/components/dependency_injection/workflow.rst
@@ -12,9 +12,9 @@ Symfony2 full stack framework will help you see how this all fits together,
 whether you are using the full stack framework or looking to use the service
 container in another application.
 
-The full stack framework uses the ``HttpKernel`` component to manage the loading
+The full stack framework uses the HttpKernel component to manage the loading
 of the service container configuration from the application and bundles and
-also handles the compilation and caching. Even if you are not using ``HttpKernel``,
+also handles the compilation and caching. Even if you are not using HttpKernel,
 it should give you an idea of one way of organizing configuration in a modular
 application.
 
@@ -22,7 +22,7 @@ Working with cached Container
 -----------------------------
 
 Before building it, the kernel checks to see if a cached version of the container
-exists. The ``HttpKernel`` has a debug setting and if this is false, the
+exists. The HttpKernel has a debug setting and if this is false, the
 cached version is used if it exists. If debug is true then the kernel
 :doc:`checks to see if configuration is fresh </components/config/caching>`
 and if it is, the cached version of the container is used. If not then the container

--- a/components/dependency_injection/workflow.rst
+++ b/components/dependency_injection/workflow.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Dependency Injection; Workflow
+   single: DependencyInjection; Workflow
 
 Container Building Workflow
 ===========================

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -5,7 +5,7 @@
 The DomCrawler Component
 ========================
 
-    The DomCrawler Component eases DOM navigation for HTML and XML documents.
+    The DomCrawler component eases DOM navigation for HTML and XML documents.
 
 .. note::
 
@@ -58,7 +58,7 @@ interacting with html links and forms as you traverse through the HTML tree.
     official specification. For example, if you nest a `` <p>`` tag inside
     another `` <p>`` tag, it will be moved to be a sibling of the parent tag.
     This is expected and is part of the HTML5 spec. But if you're getting
-    unexpected behavior, this could be a cause. And while the ``DomCrawler``
+    unexpected behavior, this could be a cause. And while the DomCrawler
     isn't meant to dump content, you can see the "fixed" version if your HTML
     by :ref:`dumping it <component-dom-crawler-dumping>`.
 
@@ -73,7 +73,7 @@ Using XPath expressions is really easy::
 
     ``DOMXPath::query`` is used internally to actually perform an XPath query.
 
-Filtering is even easier if you have the ``CssSelector`` Component installed.
+Filtering is even easier if you have the CssSelector component installed.
 This allows you to use jQuery-like selectors to traverse::
 
     $crawler = $crawler->filter('body > p');

--- a/components/event_dispatcher/container_aware_dispatcher.rst
+++ b/components/event_dispatcher/container_aware_dispatcher.rst
@@ -1,8 +1,8 @@
 .. index::
-   single: Event Dispatcher; Service container aware
+   single: EventDispatcher; Service container aware
 
 The Container Aware Event Dispatcher
-====================================
+===================================
 
 .. versionadded:: 2.1
     This feature was moved into the EventDispatcher component in Symfony 2.1.
@@ -11,9 +11,9 @@ Introduction
 ------------
 
 The :class:`Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher` is
-a special event dispatcher implementation which is coupled to the service container
-that is part of :doc:`the Dependency Injection component </components/dependency_injection/introduction>`.
-It allows services to be specified as event listeners making the event dispatcher
+a special EventDispatcher implementation which is coupled to the service container
+that is part of :doc:`the DependencyInjection component </components/dependency_injection/introduction>`.
+It allows services to be specified as event listeners making the EventDispatcher
 extremely powerful.
 
 Services are lazy loaded meaning the services attached as listeners will only be
@@ -34,7 +34,7 @@ into the :class:`Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatc
 Adding Listeners
 ----------------
 
-The *Container Aware Event Dispatcher* can either load specified services
+The *Container Aware EventDispatcher* can either load specified services
 directly, or services that implement :class:`Symfony\\Component\\EventDispatcher\\EventSubscriberInterface`.
 
 The following examples assume the service container has been loaded with any

--- a/components/event_dispatcher/generic_event.rst
+++ b/components/event_dispatcher/generic_event.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Event Dispatcher
+   single: EventDispatcher
 
 The Generic Event Object
 ========================
@@ -8,7 +8,7 @@ The Generic Event Object
     The ``GenericEvent`` event class was added in Symfony 2.1
 
 The base :class:`Symfony\\Component\\EventDispatcher\\Event` class provided by the
-Event Dispatcher component is deliberately sparse to allow the creation of
+EventDispatcher component is deliberately sparse to allow the creation of
 API specific event objects by inheritance using OOP. This allows for elegant and
 readable code in complex applications.
 

--- a/components/event_dispatcher/immutable_dispatcher.rst
+++ b/components/event_dispatcher/immutable_dispatcher.rst
@@ -1,5 +1,5 @@
 .. index::
-    single: Event Dispatcher; Immutable
+    single: EventDispatcher; Immutable
 
 The Immutable Event Dispatcher
 ==============================

--- a/components/event_dispatcher/index.rst
+++ b/components/event_dispatcher/index.rst
@@ -1,5 +1,5 @@
-Event Dispatcher
-================
+EventDispatcher
+===============
 
 .. toctree::
     :maxdepth: 2

--- a/components/event_dispatcher/introduction.rst
+++ b/components/event_dispatcher/introduction.rst
@@ -1,9 +1,9 @@
 .. index::
-   single: Event Dispatcher
+   single: EventDispatcher
    single: Components; EventDispatcher
 
-The Event Dispatcher Component
-==============================
+The EventDispatcher Component
+=============================
 
 Introduction
 ------------
@@ -20,7 +20,7 @@ or after a method is executed, without interfering with other plugins. This is
 not an easy problem to solve with single inheritance, and multiple inheritance
 (were it possible with PHP) has its own drawbacks.
 
-The Symfony2 Event Dispatcher component implements the `Mediator`_ pattern in
+The Symfony2 EventDispatcher component implements the `Mediator`_ pattern in
 a simple and effective way to make all these things possible and to make your
 projects truly extensible.
 
@@ -42,7 +42,7 @@ used. To make this possible, the Symfony2 kernel throws an event -
   the ``Response`` object.
 
 .. index::
-   single: Event Dispatcher; Events
+   single: EventDispatcher; Events
 
 Installation
 ------------
@@ -65,7 +65,7 @@ and passed to all of the listeners. As you'll see later, the ``Event`` object
 itself often contains data about the event being dispatched.
 
 .. index::
-   pair: Event Dispatcher; Naming conventions
+   pair: EventDispatcher; Naming conventions
 
 Naming Conventions
 ..................
@@ -86,7 +86,7 @@ Here are some examples of good event names:
 * ``form.pre_set_data``
 
 .. index::
-   single: Event Dispatcher; Event subclasses
+   single: EventDispatcher; Event subclasses
 
 Event Names and Event Objects
 .............................
@@ -123,7 +123,7 @@ listeners registered with that event::
     $dispatcher = new EventDispatcher();
 
 .. index::
-   single: Event Dispatcher; Listeners
+   single: EventDispatcher; Listeners
 
 Connecting Listeners
 ~~~~~~~~~~~~~~~~~~~~
@@ -204,7 +204,7 @@ instance of ``Symfony\Component\HttpKernel\Event\FilterResponseEvent``::
 .. _event_dispatcher-closures-as-listeners:
 
 .. index::
-   single: Event Dispatcher; Creating and dispatching an event
+   single: EventDispatcher; Creating and dispatching an event
 
 Creating and Dispatching an Event
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -316,7 +316,7 @@ the ``getOrder`` method::
     }
 
 .. index::
-   single: Event Dispatcher; Event subscribers
+   single: EventDispatcher; Event subscribers
 
 .. _event_dispatcher-using-event-subscribers:
 
@@ -398,7 +398,7 @@ example, when the ``kernel.response`` event is triggered, the methods
 are called in that order.
 
 .. index::
-   single: Event Dispatcher; Stopping event flow
+   single: EventDispatcher; Stopping event flow
 
 .. _event_dispatcher-event-propagation:
 
@@ -434,7 +434,7 @@ which returns a boolean value::
     }
 
 .. index::
-   single: Event Dispatcher; Event Dispatcher aware events and listeners
+   single: EventDispatcher; EventDispatcher aware events and listeners
 
 .. _event_dispatcher-dispatcher-aware-events:
 
@@ -529,7 +529,7 @@ time. But when you have a long list of dependencies, using setter injection
 can be the way to go, especially for optional dependencies.
 
 .. index::
-   single: Event Dispatcher; Dispatcher shortcuts
+   single: EventDispatcher; Dispatcher shortcuts
 
 .. _event_dispatcher-shortcuts:
 
@@ -569,7 +569,7 @@ Or::
 and so on...
 
 .. index::
-   single: Event Dispatcher; Event name introspection
+   single: EventDispatcher; Event name introspection
 
 .. _event_dispatcher-event-name-introspection:
 

--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -4,11 +4,11 @@
 The Filesystem Component
 ========================
 
-    The Filesystem components provides basic utilities for the filesystem.
+    The Filesystem component provides basic utilities for the filesystem.
 
 .. versionadded:: 2.1
-    The Filesystem Component is new to Symfony 2.1. Previously, the ``Filesystem``
-    class was located in the ``HttpKernel`` component.
+    The Filesystem component is new to Symfony 2.1. Previously, the ``Filesystem``
+    class was located in the HttpKernel component.
 
 Installation
 ------------

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -5,7 +5,7 @@
 The Finder Component
 ====================
 
-   The Finder Component finds files and directories via an intuitive fluent
+   The Finder component finds files and directories via an intuitive fluent
    interface.
 
 Installation

--- a/components/form/introduction.rst
+++ b/components/form/introduction.rst
@@ -8,7 +8,7 @@ The Form Component
     The Form component allows you to easily create, process and reuse HTML
     forms.
 
-The form component is a tool to help you solve the problem of allowing end-users
+The Form component is a tool to help you solve the problem of allowing end-users
 to interact with the data and modify the data in your application. And though
 traditionally this has been through HTML forms, the component focuses on
 processing data to and from your client and application, whether that data
@@ -89,7 +89,7 @@ array of submitted values.
 
 .. note::
 
-    For more information about the ``HttpFoundation`` component or how to
+    For more information about the HttpFoundation component or how to
     install it, see :doc:`/components/http_foundation/introduction`.
 
 CSRF Protection
@@ -217,11 +217,11 @@ text and other strings.
 
 To add these Twig filters, you can either use the built-in
 :class:`Symfony\\Bridge\\Twig\\Extension\\TranslationExtension` that integrates
-with Symfony's ``Translation`` component, or add the 2 Twig filters yourself,
+with Symfony's Translation component, or add the 2 Twig filters yourself,
 via your own Twig extension.
 
 To use the built-in integration, be sure that your project has Symfony's
-``Translation`` and :doc:`Config </components/config/introduction>` components
+Translation and :doc:`Config </components/config/introduction>` components
 installed. If you're using Composer, you could get the latest 2.1 version
 of each of these by adding the following to your ``composer.json`` file:
 

--- a/components/http_foundation/index.rst
+++ b/components/http_foundation/index.rst
@@ -1,5 +1,5 @@
-HTTP Foundation
-===============
+HttpFoundation
+==============
 
 .. toctree::
     :maxdepth: 2

--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -6,7 +6,7 @@
 The HttpFoundation Component
 ============================
 
-    The HttpFoundation Component defines an object-oriented layer for the HTTP
+    The HttpFoundation component defines an object-oriented layer for the HTTP
     specification.
 
 In PHP, the request is represented by some global variables (``$_GET``,

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -5,7 +5,7 @@
 Session Management
 ==================
 
-The Symfony2 HttpFoundation Component has a very powerful and flexible session
+The Symfony2 HttpFoundation component has a very powerful and flexible session
 subsystem which is designed to provide session management through a simple
 object-oriented interface using a variety of session storage drivers.
 

--- a/components/http_kernel/index.rst
+++ b/components/http_kernel/index.rst
@@ -1,5 +1,5 @@
-HTTP Kernel
-===========
+HTTPKernel
+==========
 
 .. toctree::
     :maxdepth: 2

--- a/components/http_kernel/index.rst
+++ b/components/http_kernel/index.rst
@@ -1,4 +1,4 @@
-HTTPKernel
+HttpKernel
 ==========
 
 .. toctree::

--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -6,8 +6,8 @@
 The HttpKernel Component
 ========================
 
-    The HttpKernel Component provides a structured process for converting
-    a ``Request`` into a ``Response`` by making use of the event dispatcher.
+    The HttpKernel component provides a structured process for converting
+    a ``Request`` into a ``Response`` by making use of the EventDispatcher.
     It's flexible enough to create a full-stack framework (Symfony), a micro-framework
     (Silex) or an advanced CMS system (Drupal).
 
@@ -79,7 +79,7 @@ and talks about how one specific implementation of the HttpKernel - the Symfony
 Framework - works.
 
 Initially, using the :class:`Symfony\\Component\\HttpKernel\\HttpKernel`
-is really simple, and involves creating an :doc:`event dispatcher </components/event_dispatcher/introduction>`
+is really simple, and involves creating an :doc:`EventDispatcher </components/event_dispatcher/introduction>`
 and a :ref:`controller resolver <component-http-kernel-resolve-controller>`
 (explained below). To complete your working kernel, you'll add more event
 listeners to the events discussed below::
@@ -117,7 +117,7 @@ For general information on adding listeners to the events below, see
 
 .. tip::
 
-    Fabien Potencier also wrote a wonderful series on using the ``HttpKernel``
+    Fabien Potencier also wrote a wonderful series on using the HttpKernel
     component and other Symfony2 components to create your own framework. See
     `Create your own framework... on top of the Symfony2 Components`_.
 
@@ -174,7 +174,7 @@ attributes).
     This class executes the routing layer, which returns an *array* of information
     about the matched request, including the ``_controller`` and any placeholders
     that are in the route's pattern (e.g. ``{slug}``). See
-    :doc:`Routing Component </components/routing/introduction>`.
+    :doc:`Routing component </components/routing/introduction>`.
 
     This array of information is stored in the :class:`Symfony\\Component\\HttpFoundation\\Request`
     object's ``attributes`` array. Adding the routing information here doesn't
@@ -514,7 +514,7 @@ exception and create an appropriate error ``Response``.
 
 For example, to generate a 404 page, you might throw a special type of exception
 and then add a listener on this event that looks for this exception and
-creates and returns a 404 ``Response``. In fact, the ``HttpKernel`` component
+creates and returns a 404 ``Response``. In fact, the HttpKernel component
 comes with an :class:`Symfony\\Component\\HttpKernel\\EventListener\\ExceptionListener`,
 which if you choose to use, will do this and more by default (see the sidebar
 below for more details).
@@ -526,7 +526,7 @@ below for more details).
 
     **ExceptionListener in HttpKernel**
 
-    The first comes core to the ``HttpKernel`` component
+    The first comes core to the HttpKernel component
     and is called :class:`Symfony\\Component\\HttpKernel\\EventListener\\ExceptionListener`.
     The listener has several goals:
 

--- a/components/locale.rst
+++ b/components/locale.rst
@@ -5,7 +5,7 @@
 The Locale Component
 ====================
 
-    Locale component provides fallback code to handle cases when the ``intl`` extension is missing.
+    The Locale component provides fallback code to handle cases when the ``intl`` extension is missing.
     Additionally it extends the implementation of a native :phpclass:`Locale` class with several handy methods.
 
 Replacement for the following functions and classes is provided:

--- a/components/map.rst.inc
+++ b/components/map.rst.inc
@@ -22,7 +22,7 @@
   * :doc:`/components/console/single_command_tool`
   * :doc:`/components/console/helpers/index`
 
-* **CSS Selector**
+* **CssSelector**
 
   * :doc:`/components/css_selector`
 
@@ -40,7 +40,7 @@
   * :doc:`/components/dependency_injection/advanced`
   * :doc:`/components/dependency_injection/workflow`
 
-* **DOM Crawler**
+* **DomCrawler**
 
   * :doc:`/components/dom_crawler`
 
@@ -79,7 +79,7 @@
 
   * :doc:`/components/locale`
 
-* **Options Resolver**
+* **OptionsResolver**
 
   * :doc:`/components/options_resolver`
 

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -1,11 +1,11 @@
 .. index::
-    single: Options Resolver
+    single: OptionsResolver
     single: Components; OptionsResolver
 
 The OptionsResolver Component
 =============================
 
-    The OptionsResolver Component helps you configure objects with option
+    The OptionsResolver component helps you configure objects with option
     arrays. It supports default values, option constraints and lazy options.
 
 Installation
@@ -177,7 +177,7 @@ override this default. You don't need to configure ``username`` as an optional
 option. The ``OptionsResolver`` already knows that options with a default
 value are optional.
 
-The ``OptionsResolver`` component also has an
+The OptionsResolver component also has an
 :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::replaceDefaults`
 method. This can be used to override the previous default value. The closure
 that is passed has 2 parameters:

--- a/components/process.rst
+++ b/components/process.rst
@@ -5,7 +5,7 @@
 The Process Component
 =====================
 
-    The Process Component executes commands in sub-processes.
+    The Process component executes commands in sub-processes.
 
 Installation
 ------------

--- a/components/property_access/index.rst
+++ b/components/property_access/index.rst
@@ -1,5 +1,5 @@
-Property Access
-===============
+PropertyAccess
+==============
 
 .. toctree::
     :maxdepth: 2

--- a/components/property_access/introduction.rst
+++ b/components/property_access/introduction.rst
@@ -9,8 +9,8 @@ The PropertyAccess Component
     object or array using a simple string notation.
 
 .. versionadded:: 2.2
-    The PropertyAccess Component is new to Symfony 2.2. Previously, the
-    ``PropertyPath`` class was located in the ``Form`` component.
+    The PropertyAccess component is new to Symfony 2.2. Previously, the
+    ``PropertyPath`` class was located in the Form component.
 
 Installation
 ------------

--- a/components/routing/introduction.rst
+++ b/components/routing/introduction.rst
@@ -5,7 +5,7 @@
 The Routing Component
 =====================
 
-   The Routing Component maps an HTTP request to a set of configuration
+   The Routing component maps an HTTP request to a set of configuration
    variables.
 
 Installation

--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -98,7 +98,7 @@ manager to use them:
     i.e. ``VoterInterface::ACCESS_GRANTED``, ``VoterInterface::ACCESS_DENIED``
     or ``VoterInterface::ACCESS_ABSTAIN``;
 
-The security component contains some standard voters which cover many use
+The Security component contains some standard voters which cover many use
 cases:
 
 AuthenticatedVoter

--- a/components/security/firewall.rst
+++ b/components/security/firewall.rst
@@ -4,7 +4,7 @@
 The Firewall and Security Context
 =================================
 
-Central to the Security Component is the security context, which is an instance
+Central to the Security component is the security context, which is an instance
 of :class:`Symfony\\Component\\Security\\Core\\SecurityContextInterface`. When all
 steps in the process of authenticating the user have been taken successfully,
 you can ask the security context if the authenticated user has access to a
@@ -74,7 +74,7 @@ with the event dispatcher that is used by the :class:`Symfony\\Component\\HttpKe
     $dispatcher->addListener(KernelEvents::REQUEST, array($firewall, 'onKernelRequest');
 
 The firewall is registered to listen to the ``kernel.request`` event that
-will be dispatched by the ``HttpKernel`` at the beginning of each request
+will be dispatched by the HttpKernel at the beginning of each request
 it processes. This way, the firewall may prevent the user from going any
 further than allowed.
 

--- a/components/security/introduction.rst
+++ b/components/security/introduction.rst
@@ -7,7 +7,7 @@ The Security Component
 Introduction
 ------------
 
-The Security Component provides a complete security system for your web
+The Security component provides a complete security system for your web
 application. It ships with facilities for authenticating using HTTP basic
 or digest authentication, interactive form login or X.509 certificate login,
 but also allows you to implement your own authentication strategies.

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -5,10 +5,10 @@
 The Serializer Component
 ========================
 
-   The Serializer Component is meant to be used to turn objects into a
+   The Serializer component is meant to be used to turn objects into a
    specific format (XML, JSON, Yaml, ...) and the other way around.
 
-In order to do so, the Serializer Component follows the following
+In order to do so, the Serializer component follows the following
 simple schema.
 
 .. image:: /images/components/serializer/serializer_workflow.png

--- a/components/stopwatch.rst
+++ b/components/stopwatch.rst
@@ -8,8 +8,8 @@ The Stopwatch Component
     Stopwatch component provides a way to profile code.
 
 .. versionadded:: 2.2
-    The Stopwatch Component is new to Symfony 2.2. Previously, the ``Stopwatch``
-    class was located in the ``HttpKernel`` component (and was new in 2.1).
+    The Stopwatch component is new to Symfony 2.2. Previously, the ``Stopwatch``
+    class was located in the HttpKernel component (and was new in 2.1).
 
 Installation
 ------------

--- a/components/templating/helpers/index.rst
+++ b/components/templating/helpers/index.rst
@@ -10,7 +10,7 @@ The Templating Helpers
     slotshelper
     assetshelper
 
-The Templating Component comes with some useful helpers. These helpers contain
+The Templating component comes with some useful helpers. These helpers contain
 functions to ease some common tasks.
 
 .. include:: map.rst.inc

--- a/components/templating/introduction.rst
+++ b/components/templating/introduction.rst
@@ -5,7 +5,7 @@
 The Templating Component
 ========================
 
-    The Templating Component provides all the tools needed to build any kind
+    The Templating component provides all the tools needed to build any kind
     of template system.
 
     It provides an infrastructure to load template files and optionally

--- a/cookbook/bundles/best_practices.rst
+++ b/cookbook/bundles/best_practices.rst
@@ -148,7 +148,7 @@ All classes and files must follow the Symfony2 coding
 Some classes should be seen as facades and should be as short as possible, like
 Commands, Helpers, Listeners, and Controllers.
 
-Classes that connect to the Event Dispatcher should be suffixed with
+Classes that connect to the event dispatcher should be suffixed with
 ``Listener``.
 
 Exceptions classes should be stored in an ``Exception`` sub-namespace.

--- a/cookbook/bundles/extension.rst
+++ b/cookbook/bundles/extension.rst
@@ -91,7 +91,7 @@ The second method has several specific advantages:
 
 .. index::
    single: Bundle; Extension
-   single: Dependency Injection; Extension
+   single: DependencyInjection; Extension
 
 Creating an Extension Class
 ---------------------------

--- a/cookbook/bundles/extension.rst
+++ b/cookbook/bundles/extension.rst
@@ -494,7 +494,7 @@ configuration arrays together.
 The ``Configuration`` class can be much more complicated than shown here,
 supporting array nodes, "prototype" nodes, advanced validation, XML-specific
 normalization and advanced merging. You can read more about this in
-:doc:`the Config Component documentation </components/config/definition>`.
+:doc:`the Config component documentation </components/config/definition>`.
 You can also see it in action by checking out some of the core Configuration classes,
 such as the one from the `FrameworkBundle Configuration`_ or the `TwigBundle Configuration`_.
 

--- a/cookbook/doctrine/registration_form.rst
+++ b/cookbook/doctrine/registration_form.rst
@@ -84,7 +84,7 @@ the class.
 
     If you want to integrate this User within the security system, you need
     to implement the :ref:`UserInterface <book-security-user-entity>` of the
-    security component.
+    Security component.
 
 .. _cookbook-registration-password-max:
 
@@ -144,7 +144,7 @@ data class (i.e. your ``User`` entity).
 
 .. tip::
 
-    To explore more things about the form component, read :doc:`/book/forms`.
+    To explore more things about the Form component, read :doc:`/book/forms`.
 
 Embedding the User form into a Registration Form
 ------------------------------------------------

--- a/cookbook/event_dispatcher/before_after_filters.rst
+++ b/cookbook/event_dispatcher/before_after_filters.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Event Dispatcher
+   single: EventDispatcher
 
 How to setup before and after Filters
 =====================================

--- a/cookbook/event_dispatcher/class_extension.rst
+++ b/cookbook/event_dispatcher/class_extension.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Event Dispatcher
+   single: EventDispatcher
 
 How to extend a Class without using Inheritance
 ===============================================

--- a/cookbook/event_dispatcher/method_behavior.rst
+++ b/cookbook/event_dispatcher/method_behavior.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Event Dispatcher
+   single: EventDispatcher
 
 How to customize a Method Behavior without using Inheritance
 ============================================================

--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -73,7 +73,7 @@ or if an existing product is being edited (e.g. a product fetched from the datab
 
 Suppose now, that you don't want the user to be able to change the ``name`` value
 once the object has been created. To do this, you can rely on Symfony's
-:doc:`Event Dispatcher </components/event_dispatcher/introduction>`
+:doc:`EventDispatcher </components/event_dispatcher/introduction>`
 system to analyze the data on the object and modify the form based on the
 Product object's data. In this entry, you'll learn how to add this level of
 flexibility to your forms.

--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -194,7 +194,7 @@ this folder.
     More commonly, however, you'll want to customize how errors are displayed
     across *all* fields. You can do this by customizing the ``form_errors``
     fragment. This takes advantage of field type inheritance. Specifically,
-    since the ``text`` type extends from the ``form`` type, the form component
+    since the ``text`` type extends from the ``form`` type, the Form component
     will first look for the type-specific fragment (e.g. ``text_errors``) before
     falling back to its parent fragment name if it doesn't exist (e.g. ``form_errors``).
 
@@ -703,7 +703,7 @@ Customizing Error Output
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. note::
-   The form component only handles *how* the validation errors are rendered,
+   The Form component only handles *how* the validation errors are rendered,
    and not the actual validation error messages. The error messages themselves
    are determined by the validation constraints you apply to your objects.
    For more information, see the chapter on :doc:`validation </book/validation>`.

--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -4,7 +4,7 @@
 How to Unit Test your Forms
 ===========================
 
-The Form Component consists of 3 core objects: a form type (implementing
+The Form component consists of 3 core objects: a form type (implementing
 :class:`Symfony\\Component\\Form\\FormTypeInterface`), the
 :class:`Symfony\\Component\\Form\\Form` and the
 :class:`Symfony\\Component\\Form\\FormView`.
@@ -22,7 +22,7 @@ It is used to test the core types and you can use it to test your types too.
 
 .. note::
 
-    Depending on the way you installed your Symfony or Symfony Form Component
+    Depending on the way you installed your Symfony or Symfony Form component
     the tests may not be downloaded. Use the --prefer-source option with
     composer if this is the case.
 

--- a/cookbook/form/use_virtuals_forms.rst
+++ b/cookbook/form/use_virtuals_forms.rst
@@ -147,7 +147,7 @@ Look at the result::
         ));
     }
 
-With the virtual option set to false (default behavior), the Form Component
+With the virtual option set to false (default behavior), the Form component
 expects each underlying object to have a ``foo`` (or ``bar``) property that
 is either some object or array which contains the four location fields.
 Of course, you don't have this object/array in your entities and you don't want it!

--- a/cookbook/routing/slash_in_parameter.rst
+++ b/cookbook/routing/slash_in_parameter.rst
@@ -15,7 +15,7 @@ matches the ``/hello/{name}`` route, where ``{name}`` equals ``Fabien/Kris``.
 Configure the Route
 -------------------
 
-By default, the Symfony routing components requires that the parameters
+By default, the Symfony Routing component requires that the parameters
 match the following regex path: ``[^/]+``. This means that all characters
 are allowed except ``/``.
 

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -78,7 +78,7 @@ provider.
 
 .. note::
 
-    The ``WsseUserToken`` class extends the security component's
+    The ``WsseUserToken`` class extends the Security component's
     :class:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\AbstractToken`
     class, which provides basic token functionality. Implement the
     :class:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\TokenInterface`
@@ -275,7 +275,7 @@ The Factory
 You have created a custom token, custom listener, and custom provider. Now
 you need to tie them all together. How do you make your provider available
 to your security configuration? The answer is by using a ``factory``. A factory
-is where you hook into the security component, telling it the name of your
+is where you hook into the Security component, telling it the name of your
 provider and any configuration options available for it. First, you must
 create a class which implements
 :class:`Symfony\\Bundle\\SecurityBundle\\DependencyInjection\\Security\\Factory\\SecurityFactoryInterface`.

--- a/cookbook/security/remember_me.rst
+++ b/cookbook/security/remember_me.rst
@@ -122,7 +122,7 @@ before accessing certain resources. For example, you might allow "remember me"
 users to see basic account information, but then require them to actually
 re-authenticate before modifying that information.
 
-The security component provides an easy way to do this. In addition to roles
+The Security component provides an easy way to do this. In addition to roles
 explicitly assigned to them, users are automatically given one of the following
 roles depending on how they are authenticated:
 

--- a/cookbook/security/target_path.rst
+++ b/cookbook/security/target_path.rst
@@ -4,7 +4,7 @@
 How to change the Default Target Path Behavior
 ==============================================
 
-By default, the security component retains the information of the last request
+By default, the Security component retains the information of the last request
 URI in a session variable named ``_security.main.target_path`` (with ``main`` being
 the name of the firewall, defined in ``security.yml``). Upon a successful
 login, the user is redirected to this path, as to help her continue from the

--- a/cookbook/security/voters.rst
+++ b/cookbook/security/voters.rst
@@ -4,7 +4,7 @@
 How to implement your own Voter to blacklist IP Addresses
 =========================================================
 
-The Symfony2 security component provides several layers to authorize users.
+The Symfony2 Security component provides several layers to authorize users.
 One of the layers is called a `voter`. A voter is a dedicated class that checks
 if the user has the rights to be connected to the application. For instance,
 Symfony2 provides a layer that checks if the user is fully authorized or if

--- a/cookbook/service_container/compiler_passes.rst
+++ b/cookbook/service_container/compiler_passes.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Dependency Injection; Compiler passes
+   single: DependencyInjection; Compiler passes
    single: Service Container; Compiler passes
 
 How to work with Compiler Passes in Bundles

--- a/cookbook/service_container/scopes.rst
+++ b/cookbook/service_container/scopes.rst
@@ -1,5 +1,5 @@
 .. index::
-   single: Dependency Injection; Scopes
+   single: DependencyInjection; Scopes
 
 How to work with Scopes
 =======================

--- a/cookbook/service_container/scopes.rst
+++ b/cookbook/service_container/scopes.rst
@@ -13,7 +13,7 @@ Understanding Scopes
 --------------------
 
 The scope of a service controls how long an instance of a service is used
-by the container. The Dependency Injection component provides two generic
+by the container. The DependencyInjection component provides two generic
 scopes:
 
 - ``container`` (the default one): The same instance is used each time you

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -342,7 +342,7 @@ To add your own form type guesser, create a class that implements the
 tag its service definition with ``form.type_guesser`` (it has no options).
 
 To see an example of how this class might look, see the ``ValidatorTypeGuesser``
-class in the ``Form`` component.
+class in the Form component.
 
 kernel.cache_clearer
 --------------------

--- a/reference/forms/twig_reference.rst
+++ b/reference/forms/twig_reference.rst
@@ -183,7 +183,7 @@ to see what options you have available.
 .. tip::
 
     Behind the scenes, these variables are made available to the ``FormView``
-    object of your form when the form component calls ``buildView`` and ``buildViewBottomUp``
+    object of your form when the Form component calls ``buildView`` and ``buildViewBottomUp``
     on each "node" of your form tree. To see what "view" variables a particularly
     field has, find the source code for the form field (and its parent fields)
     and look at the above two functions.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | - |

As discussed in #3173 here's a WIP PR for making the component names consistent.

What I did throughout the whole docs:
- Remove blanks from component names, e.g. Class Loader > ClassLoader
- Remove literal formatting from component names, e.g. `ClassLoader` > ClassLoader
- In normal text: Lowercase the word _component_, e.g. The ClassLoader Component\* > The ClassLoader component
- Uppercase component names where they were not, e.g. ... the console component ... > ... the Console component ...

What I did not:
- Change something that looks like a component name but is more used for the concept behind, e.g. "The dependency injection pattern ..." or "The event dispatcher system ..."
- Change ucfirst of "Component" in headings

Some things are tricky, however:
1. What about the [components entry page](http://symfony.com/doc/current/components/index.html). Do the items on the top-most level refer more to the component or the concept? For example, it says "DOM Crawler" and then below "The DomCrawler" component. I've left this as is, so I read it like "Need a thing to crawl the DOM?" - then "The DomCrawler component" is made for you.
2. What about the index? For instance, the entry "Dependency Injection": Is this more "The Dependency Injection component" or "The Dependency Injection pattern". I've also left this as is - maybe that's just too much ;-) But in any case, below the "Components" key, I've updated everything to the correct names. In contrast, however, I've updated the "Event Dispatcher" index to "EventDispatcher" because nearly everything there refers to the component and not the concept of an event dispatcher (as for the HttpFoundation index etc.)

Please let me know if you have any suggestions.
