### PR TITLE
Fix technology, vendor and bundle names to their official notation

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -1564,7 +1564,7 @@ Some notable or interesting tasks include:
 .. note::
 
    To be able to load data fixtures to your database, you will need to have
-   the ``DoctrineFixturesBundle`` bundle installed. To learn how to do it,
+   the DoctrineFixturesBundle bundle installed. To learn how to do it,
    read the ":doc:`/bundles/DoctrineFixturesBundle/index`" entry of the
    documentation.
 

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -1485,7 +1485,7 @@ and ``nullable``. Take a few examples:
         fields:
             # A string field length 255 that cannot be null
             # (reflecting the default values for the "length" and *nullable* options)
-            # type attribute is necessary in yaml definitions
+            # type attribute is necessary in YAML definitions
             name:
                 type: string
 
@@ -1502,7 +1502,7 @@ and ``nullable``. Take a few examples:
         <!--
             A string field length 255 that cannot be null
             (reflecting the default values for the "length" and *nullable* options)
-            type attribute is necessary in xml definitions
+            type attribute is necessary in XML definitions
         -->
         <field name="name" type="string" />
         <field name="email"

--- a/book/http_fundamentals.rst
+++ b/book/http_fundamentals.rst
@@ -246,7 +246,7 @@ have all the request information at your fingertips::
 As a bonus, the ``Request`` class does a lot of work in the background that
 you'll never need to worry about. For example, the ``isSecure()`` method
 checks the *three* different values in PHP that can indicate whether or not
-the user is connecting via a secured connection (i.e. ``https``).
+the user is connecting via a secured connection (i.e. HTTPS).
 
 .. sidebar:: ParameterBags and Request attributes
 

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -180,7 +180,7 @@ Symfony itself - into the ``vendor/`` directory.
 .. tip::
 
     When running ``php composer.phar install`` or ``php composer.phar update``,
-    composer will execute post install/update commands to clear the cache
+    Composer will execute post install/update commands to clear the cache
     and install assets. By default, the assets will be copied into your ``web``
     directory.
 

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -321,11 +321,11 @@ Using Source Control
 
 If you're using a version control system like ``Git`` or ``Subversion``, you
 can setup your version control system and begin committing your project to
-it as normal. The Symfony Standard edition *is* the starting point for your
+it as normal. The Symfony Standard Edition *is* the starting point for your
 new project.
 
 For specific instructions on how best to setup your project to be stored
-in git, see :doc:`/cookbook/workflow/new_project_git`.
+in Git, see :doc:`/cookbook/workflow/new_project_git`.
 
 Ignoring the ``vendor/`` Directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/book/internals.rst
+++ b/book/internals.rst
@@ -66,8 +66,8 @@ Dependency Injection component and a powerful plugin system (bundles).
     :doc:`Dependency Injection </book/service_container>` and
     :doc:`Bundles </cookbook/bundles/best_practices>`.
 
-``FrameworkBundle`` Bundle
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+FrameworkBundle
+~~~~~~~~~~~~~~~
 
 The :namespace:`Symfony\\Bundle\\FrameworkBundle` bundle is the bundle that
 ties the main components and libraries together to make a lightweight and fast
@@ -254,7 +254,7 @@ or setup variables so that a Controller can be called after the event. Any
 listener can return a ``Response`` object via the ``setResponse()`` method on
 the event. In this case, all other listeners won't be called.
 
-This event is used by ``FrameworkBundle`` to populate the ``_controller``
+This event is used by the FrameworkBundle to populate the ``_controller``
 ``Request`` attribute, via the
 :class:`Symfony\\Bundle\\FrameworkBundle\\EventListener\\RouterListener`. RequestListener
 uses a :class:`Symfony\\Component\\Routing\\RouterInterface` object to match
@@ -273,7 +273,7 @@ the ``Request`` and determine the Controller name (stored in the
 
 *Event Class*: :class:`Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent`
 
-This event is not used by ``FrameworkBundle``, but can be an entry point used
+This event is not used by the FrameworkBundle, but can be an entry point used
 to modify the controller that should be executed::
 
     use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
@@ -299,7 +299,7 @@ to modify the controller that should be executed::
 
 *Event Class*: :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForControllerResultEvent`
 
-This event is not used by ``FrameworkBundle``, but it can be used to implement
+This event is not used by the FrameworkBundle, but it can be used to implement
 a view sub-system. This event is called *only* if the Controller does *not*
 return a ``Response`` object. The purpose of the event is to allow some other
 return value to be converted into a ``Response``.
@@ -342,7 +342,7 @@ The purpose of this event is to allow other systems to modify or replace the
         // ... modify the response object
     }
 
-The ``FrameworkBundle`` registers several listeners:
+The FrameworkBundle registers several listeners:
 
 * :class:`Symfony\\Component\\HttpKernel\\EventListener\\ProfilerListener`:
   collects data for the current request;
@@ -387,7 +387,7 @@ was already served to the client.
 
 *Event Class*: :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent`
 
-``FrameworkBundle`` registers an
+The FrameworkBundle registers an
 :class:`Symfony\\Component\\HttpKernel\\EventListener\\ExceptionListener` that
 forwards the ``Request`` to a given Controller (the value of the
 ``exception_listener.controller`` parameter -- must be in the

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -840,7 +840,7 @@ format you prefer:
 
 Each top-level entry like ``framework`` or ``twig`` defines the configuration
 for a particular bundle. For example, the ``framework`` key defines the configuration
-for the core Symfony ``FrameworkBundle`` and includes configuration for the
+for the core Symfony FrameworkBundle and includes configuration for the
 routing, templating, and other core systems.
 
 For now, don't worry about the specific configuration options in each section.

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -854,7 +854,7 @@ options of each feature.
     three formats (YAML, XML and PHP). Each has its own advantages and
     disadvantages. The choice of which to use is up to you:
 
-    * *YAML*: Simple, clean and readable (learn more about yaml in
+    * *YAML*: Simple, clean and readable (learn more about YAML in
       ":doc:`/components/yaml/yaml_format`");
 
     * *XML*: More powerful than YAML at times and supports IDE autocompletion;
@@ -867,7 +867,7 @@ Default Configuration Dump
 .. versionadded:: 2.1
     The ``config:dump-reference`` command was added in Symfony 2.1
 
-You can dump the default configuration for a bundle in yaml to the console using
+You can dump the default configuration for a bundle in YAML to the console using
 the ``config:dump-reference`` command.  Here is an example of dumping the default
 FrameworkBundle configuration:
 

--- a/book/propel.rst
+++ b/book/propel.rst
@@ -126,7 +126,7 @@ After creating your ``schema.xml``, generate your model from it by running:
     $ php app/console propel:model:build
 
 This generates each model class to quickly develop your application in the
-``Model/`` directory the ``AcmeStoreBundle`` bundle.
+``Model/`` directory of the ``AcmeStoreBundle`` bundle.
 
 Creating the Database Tables/Schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1175,7 +1175,7 @@ In an upcoming section, you'll learn how to generate URLs from inside templates.
 
 .. tip::
 
-    If the frontend of your application uses AJAX requests, you might want
+    If the frontend of your application uses Ajax requests, you might want
     to be able to generate URLs in JavaScript based on your routing configuration.
     By using the `FOSJsRoutingBundle`_, you can do exactly that:
 

--- a/book/security.rst
+++ b/book/security.rst
@@ -1007,7 +1007,7 @@ authorization from inside a controller::
 
 .. _book-security-securing-controller-annotations:
 
-You can also choose to install and use the optional ``JMSSecurityExtraBundle``,
+You can also choose to install and use the optional JMSSecurityExtraBundle,
 which can secure your controller using annotations::
 
     // ...

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -255,8 +255,8 @@ looks up the value of each parameter and uses it in the service definition.
 .. note::
 
     If you want to use a string that starts with an ``@`` sign as a parameter
-    value (i.e. a very safe mailer password) in a yaml file, you need to escape
-    it by adding another ``@`` sign (This only applies to the YAML format):
+    value (i.e. a very safe mailer password) in a YAML file, you need to escape
+    it by adding another ``@`` sign (this only applies to the YAML format):
 
     .. code-block:: yaml
 

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -464,9 +464,9 @@ In other words, a service container extension configures the services for
 a bundle on your behalf. And as you'll see in a moment, the extension provides
 a sensible, high-level interface for configuring the bundle.
 
-Take the ``FrameworkBundle`` - the core Symfony2 framework bundle - as an
+Take the FrameworkBundle - the core Symfony2 framework bundle - as an
 example. The presence of the following code in your application configuration
-invokes the service container extension inside the ``FrameworkBundle``:
+invokes the service container extension inside the FrameworkBundle:
 
 .. configuration-block::
 
@@ -514,21 +514,21 @@ invokes the service container extension inside the ``FrameworkBundle``:
 
 When the configuration is parsed, the container looks for an extension that
 can handle the ``framework`` configuration directive. The extension in question,
-which lives in the ``FrameworkBundle``, is invoked and the service configuration
-for the ``FrameworkBundle`` is loaded. If you remove the ``framework`` key
+which lives in the FrameworkBundle, is invoked and the service configuration
+for the FrameworkBundle is loaded. If you remove the ``framework`` key
 from your application configuration file entirely, the core Symfony2 services
 won't be loaded. The point is that you're in control: the Symfony2 framework
 doesn't contain any magic or perform any actions that you don't have control
 over.
 
 Of course you can do much more than simply "activate" the service container
-extension of the ``FrameworkBundle``. Each extension allows you to easily
+extension of the FrameworkBundle. Each extension allows you to easily
 customize the bundle, without worrying about how the internal services are
 defined.
 
 In this case, the extension allows you to customize the ``error_handler``,
 ``csrf_protection``, ``router`` configuration and much more. Internally,
-the ``FrameworkBundle`` uses the options specified here to define and configure
+the FrameworkBundle uses the options specified here to define and configure
 the services specific to it. The bundle takes care of creating all the necessary
 ``parameters`` and ``services`` for the service container, while still allowing
 much of the configuration to be easily customized. As an added bonus, most
@@ -934,7 +934,7 @@ the framework.
     Be sure that the ``swiftmailer`` entry appears in your application
     configuration. As was mentioned in :ref:`service-container-extension-configuration`,
     the ``swiftmailer`` key invokes the service extension from the
-    ``SwiftmailerBundle``, which registers the ``mailer`` service.
+    SwiftmailerBundle, which registers the ``mailer`` service.
 
 .. _book-service-container-tags:
 
@@ -975,7 +975,7 @@ to be used for a specific purpose. Take the following example:
         $definition->addTag('twig.extension');
         $container->setDefinition('foo.twig.extension', $definition);
 
-The ``twig.extension`` tag is a special tag that the ``TwigBundle`` uses
+The ``twig.extension`` tag is a special tag that the TwigBundle uses
 during configuration. By giving the service this ``twig.extension`` tag,
 the bundle knows that the ``foo.twig.extension`` service should be registered
 as a Twig extension with Twig. In other words, Twig finds all services tagged

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1278,10 +1278,10 @@ Overriding Core Templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Since the Symfony2 framework itself is just a bundle, core templates can be
-overridden in the same way. For example, the core ``TwigBundle`` contains
+overridden in the same way. For example, the core TwigBundle contains
 a number of different "exception" and "error" templates that can be overridden
 by copying each from the ``Resources/views/Exception`` directory of the
-``TwigBundle`` to, you guessed it, the
+TwigBundle to, you guessed it, the
 ``app/Resources/TwigBundle/views/Exception`` directory.
 
 .. index::

--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -12,7 +12,7 @@ and their structure can be validated using the "Definition" part of the Config
 Component. Configuration values are usually expected to show some kind of
 hierarchy. Also, values should be of a certain type, be restricted in number
 or be one of a given set of values. For example, the following configuration
-(in Yaml) shows a clear hierarchy and some validation rules that should be
+(in YAML) shows a clear hierarchy and some validation rules that should be
 applied to it (like: "the value for ``auto_connect`` must be a boolean value"):
 
 .. code-block:: yaml
@@ -396,10 +396,10 @@ Normalization
 When the config files are processed they are first normalized, then merged
 and finally the tree is used to validate the resulting array. The normalization
 process is used to remove some of the differences that result from different
-configuration formats, mainly the differences between Yaml and XML.
+configuration formats, mainly the differences between YAML and XML.
 
-The separator used in keys is typically ``_`` in Yaml and ``-`` in XML. For
-example, ``auto_connect`` in Yaml and ``auto-connect``. The normalization would
+The separator used in keys is typically ``_`` in YAML and ``-`` in XML. For
+example, ``auto_connect`` in YAML and ``auto-connect``. The normalization would
 make both of these ``auto_connect``.
 
 .. caution::
@@ -407,8 +407,8 @@ make both of these ``auto_connect``.
     The target key will not be altered if it's mixed like
     ``foo-bar_moo`` or if it already exists.
 
-Another difference between Yaml and XML is in the way arrays of values may
-be represented. In Yaml you may have:
+Another difference between YAML and XML is in the way arrays of values may
+be represented. In YAML you may have:
 
 .. code-block:: yaml
 
@@ -447,7 +447,7 @@ a second argument::
         ->end()
     ;
 
-As well as fixing this, ``fixXmlConfig`` ensures that single xml elements
+As well as fixing this, ``fixXmlConfig`` ensures that single XML elements
 are still turned into an array. So you may have:
 
 .. code-block:: xml

--- a/components/config/introduction.rst
+++ b/components/config/introduction.rst
@@ -10,7 +10,7 @@ Introduction
 
 The Config Component provides several classes to help you find, load, combine,
 autofill and validate configuration values of any kind, whatever their source
-may be (Yaml, XML, INI files, or for instance a database).
+may be (YAML, XML, INI files, or for instance a database).
 
 Installation
 ------------

--- a/components/config/resources.rst
+++ b/components/config/resources.rst
@@ -27,7 +27,7 @@ all matches.
 Resource loaders
 ----------------
 
-For each type of resource (Yaml, XML, annotation, etc.) a loader must be defined.
+For each type of resource (YAML, XML, annotation, etc.) a loader must be defined.
 Each loader should implement :class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`
 or extend the abstract :class:`Symfony\\Component\\Config\\Loader\\FileLoader`
 class, which allows for recursively importing other resources::

--- a/components/dependency_injection/introduction.rst
+++ b/components/dependency_injection/introduction.rst
@@ -179,7 +179,7 @@ Setting Up the Container with Configuration Files
 -------------------------------------------------
 
 As well as setting up the services using PHP as above you can also use
-configuration files. This allows you to use XML or Yaml to write the definitions
+configuration files. This allows you to use XML or YAML to write the definitions
 for the services rather than using PHP to define the services as in the above
 examples. In anything but the smallest applications it make sense to organize
 the service definitions by moving them into one or more configuration files.

--- a/components/dependency_injection/parameters.rst
+++ b/components/dependency_injection/parameters.rst
@@ -275,7 +275,7 @@ key, and define the type as ``constant``.
 
 .. note::
 
-    This does not work for Yaml configuration. If you're using Yaml, you can
+    This does not work for YAML configuration. If you're using YAML, you can
     import an XML file to take advantage of this functionality:
 
     .. configuration-block::
@@ -316,7 +316,7 @@ To disable this behavior, use the ``string`` type:
 
 .. note::
 
-    This is not available for Yaml and PHP, because they already have built-in
+    This is not available for YAML and PHP, because they already have built-in
     support for the PHP keywords.
 
 Syntax for Referencing Services
@@ -327,10 +327,10 @@ each format. You can configure the behavior if the referenced service does
 not exist. By default, an exception is thrown when a non-existent service
 is referenced.
 
-Yaml
+YAML
 ~~~~
 
-Start the string with  ``@`` or ``@?`` to reference a service in Yaml.
+Start the string with  ``@`` or ``@?`` to reference a service in YAML.
 
 * ``@mailer`` references the ``mailer`` service. If the service does not
   exists, an exception will be thrown;
@@ -339,7 +339,7 @@ Start the string with  ``@`` or ``@?`` to reference a service in Yaml.
 
 .. tip::
 
-    Use ``@@`` to escape the ``@`` symbol in Yaml. ``@@mailer`` will be
+    Use ``@@`` to escape the ``@`` symbol in YAML. ``@@mailer`` will be
     converted into the string ``"@mailer"`` instead of referencing the
     ``mailer`` service.
 

--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -386,7 +386,7 @@ to create a ``Response``.
 This can be useful if you want to use a "view" layer: instead of returning
 a ``Response`` from the controller, you return data that represents the page.
 A listener to this event could then use this data to create a ``Response`` that
-is in the correct format (e.g HTML, json, etc).
+is in the correct format (e.g HTML, JSON, etc).
 
 At this stage, if no listener sets a response on the event, then an exception
 is thrown: either the controller *or* one of the view listeners must always

--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -482,7 +482,7 @@ as possible to the client (e.g. sending emails).
 
 .. sidebar:: ``kernel.terminate`` in the Symfony Framework
 
-    If you use the ``SwiftmailerBundle`` with Symfony2 and use ``memory``
+    If you use the SwiftmailerBundle with Symfony2 and use ``memory``
     spooling, then the :class:`Symfony\\Bundle\\SwiftmailerBundle\\EventListener\\EmailSenderListener`
     is activated, which actually delivers any emails that you scheduled to
     send during the request.

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -257,7 +257,7 @@ be anything, but it must be an integer. You can configure these types by calling
         ));
     }
 
-Possible types are the ones associated with the ``is_*`` php functions or a
+Possible types are the ones associated with the ``is_*`` PHP functions or a
 class name. You can also pass an array of types as the value. For instance,
 ``array('null', 'string')`` allows ``port`` to be ``null`` or a ``string``.
 

--- a/components/routing/introduction.rst
+++ b/components/routing/introduction.rst
@@ -265,7 +265,7 @@ other loaders that work the same way:
 * :class:`Symfony\\Component\\Routing\\Loader\\PhpFileLoader`
 
 If you use the :class:`Symfony\\Component\\Routing\\Loader\\PhpFileLoader` you
-have to provide the name of a php file which returns a :class:`Symfony\\Component\\Routing\\RouteCollection`::
+have to provide the name of a PHP file which returns a :class:`Symfony\\Component\\Routing\\RouteCollection`::
 
     // RouteProvider.php
     use Symfony\Component\Routing\RouteCollection;

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -6,7 +6,7 @@ The Serializer Component
 ========================
 
    The Serializer Component is meant to be used to turn objects into a
-   specific format (XML, JSON, Yaml, ...) and the other way around.
+   specific format (XML, JSON, YAML, ...) and the other way around.
 
 In order to do so, the Serializer Component follows the following
 simple schema.
@@ -128,7 +128,7 @@ JMSSerializer
 A popular third-party library, `JMS serializer`_, provides a more
 sophisticated albeit more complex solution. This library includes the
 ability to configure how your objects should be serialize/deserialized via
-annotations (as well as YML, XML and PHP), integration with the Doctrine ORM,
+annotations (as well as YAML, XML and PHP), integration with the Doctrine ORM,
 and handling of other complex cases (e.g. circular references).
 
 .. _`JMS serializer`: https://github.com/schmittjoh/serializer

--- a/components/yaml/yaml_format.rst
+++ b/components/yaml/yaml_format.rst
@@ -1,5 +1,5 @@
 .. index::
-    single: Yaml; Yaml Format
+    single: Yaml; YAML Format
 
 The YAML Format
 ===============

--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -44,7 +44,7 @@ Set up your user information with your real name and a working email address:
     Windows users: when installing Git, the installer will ask what to do with
     line endings, and suggests replacing all LF with CRLF. This is the wrong
     setting if you wish to contribute to Symfony! Selecting the as-is method is
-    your best choice, as git will convert your line feeds to the ones in the
+    your best choice, as Git will convert your line feeds to the ones in the
     repository. If you have already installed Git, you can check the value of
     this setting by typing:
 
@@ -375,7 +375,7 @@ patch. Before re-submitting the patch, rebase with ``upstream/master`` or
 .. note::
 
     when doing a ``push --force``, always specify the branch name explicitly
-    to avoid messing other branches in the repo (``--force`` tells git that
+    to avoid messing other branches in the repo (``--force`` tells Git that
     you really want to mess with things so do it carefully).
 
 Often, moderators will ask you to "squash" your commits. This means you will
@@ -397,7 +397,7 @@ type this command, an editor will popup showing a list of commits:
 
 To squash all commits into the first one, remove the word "pick" before the
 second and the last commits, and replace it by the word "squash" or just "s".
-When you save, git will start rebasing, and if successful, will ask you to
+When you save, Git will start rebasing, and if successful, will ask you to
 edit the commit message, which by default is a listing of the commit messages
 of all the commits. When you finish, execute the push command.
 

--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -19,8 +19,8 @@ Dependencies (optional)
 
 To run the entire test suite, including tests that depend on external
 dependencies, Symfony2 needs to be able to autoload them. By default, they are
-autoloaded from `vendor/` under the main root directory (see
-`autoload.php.dist`).
+autoloaded from ``vendor/`` under the main root directory (see
+``autoload.php.dist``).
 
 The test suite needs the following third-party libraries:
 
@@ -80,12 +80,12 @@ command:
 
     $ phpunit
 
-The output should display `OK`. If not, you need to figure out what's going on
+The output should display ``OK``. If not, you need to figure out what's going on
 and if the tests are broken because of your modifications.
 
 .. tip::
 
-    If you want to test a single component type its path after the `phpunit`
+    If you want to test a single component type its path after the ``phpunit``
     command, e.g.:
 
     .. code-block:: bash
@@ -101,18 +101,18 @@ Code Coverage
 -------------
 
 If you add a new feature, you also need to check the code coverage by using
-the `coverage-html` option:
+the ``coverage-html`` option:
 
 .. code-block:: bash
 
     $ phpunit --coverage-html=cov/
 
-Check the code coverage by opening the generated `cov/index.html` page in a
+Check the code coverage by opening the generated ``cov/index.html`` page in a
 browser.
 
 .. tip::
 
-    The code coverage only works if you have XDebug enabled and all
+    The code coverage only works if you have Xdebug enabled and all
     dependencies installed.
 
 .. _install: http://www.phpunit.de/manual/current/en/installation.html

--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -72,9 +72,9 @@ Configuration examples should show all supported formats using
 :ref:`configuration blocks <docs-configuration-blocks>`. The supported formats
 (and their orders) are:
 
-* **Configuration** (including services and routing): Yaml, Xml, Php
-* **Validation**: Yaml, Annotations, Xml, Php
-* **Doctrine Mapping**: Annotations, Yaml, Xml, Php
+* **Configuration** (including services and routing): YAML, XML, PHP
+* **Validation**: YAML, Annotations, XML, PHP
+* **Doctrine Mapping**: Annotations, YAML, XML, PHP
 
 Example
 ~~~~~~~
@@ -101,7 +101,7 @@ Example
 
 .. caution::
 
-    In Yaml you should put a space after ``{`` and before ``}`` (e.g. ``{ _controller: ... }``),
+    In YAML you should put a space after ``{`` and before ``}`` (e.g. ``{ _controller: ... }``),
     but this should not be done in Twig (e.g.  ``{'hello' : 'value'}``).
 
 .. _`the Sphinx documentation`: http://sphinx-doc.org/rest.html#source-code

--- a/cookbook/assetic/uglifyjs.rst
+++ b/cookbook/assetic/uglifyjs.rst
@@ -1,35 +1,35 @@
 .. index::
-   single: Assetic; UglifyJs
+   single: Assetic; UglifyJS
 
-How to Minify CSS/JS Files (using UglifyJs and UglifyCss)
+How to Minify CSS/JS Files (using UglifyJS and UglifyCSS)
 =========================================================
 
-`UglifyJs`_ is a JavaScript parser/compressor/beautifier toolkit. It can be used
+`UglifyJS`_ is a JavaScript parser/compressor/beautifier toolkit. It can be used
 to combine and minify JavaScript assets so that they require less HTTP requests
-and make your site load faster. `UglifyCss`_ is a css compressor/beautifier
-that is very similar to UglifyJs.
+and make your site load faster. `UglifyCSS`_ is a CSS compressor/beautifier
+that is very similar to UglifyJS.
 
-In this cookbook, the installation, configuration and usage of UglifyJs is
-shown in detail. ``UglifyCss`` works pretty much the same way and is only
+In this cookbook, the installation, configuration and usage of UglifyJS is
+shown in detail. UglifyCSS works pretty much the same way and is only
 talked about briefly.
 
-Install UglifyJs
+Install UglifyJS
 ----------------
 
-UglifyJs is available as an `Node.js`_ npm module and can be installed using
-npm. First, you need to `install node.js`_. Afterwards you can install UglifyJs
+UglifyJS is available as an `Node.js`_ npm module and can be installed using
+npm. First, you need to `install Node.js`_. Afterwards you can install UglifyJS
 using npm:
 
 .. code-block:: bash
 
     $ npm install -g uglify-js
 
-This command will install UglifyJs globally and you may need to run it as
+This command will install UglifyJS globally and you may need to run it as
 a root user.
 
 .. note::
 
-    It's also possible to install UglifyJs inside your project only. To do
+    It's also possible to install UglifyJS inside your project only. To do
     this, install it without the ``-g`` option and specify the path where
     to put the module:
 
@@ -39,7 +39,7 @@ a root user.
         $ mkdir app/Resources/node_modules
         $ npm install uglify-js --prefix app/Resources
 
-    It is recommended that you install UglifyJs in your ``app/Resources`` folder
+    It is recommended that you install UglifyJS in your ``app/Resources`` folder
     and add the ``node_modules`` folder to version control. Alternatively,
     you can create an npm `package.json`_ file and specify your dependencies
     there.
@@ -54,11 +54,11 @@ in the ``node_modules`` directory:
 
     $ ./app/Resources/node_modules/.bin/uglifyjs --help
 
-Configure the uglifyjs2 Filter
-------------------------------
+Configure the ``uglifyjs2`` Filter
+----------------------------------
 
 Now we need to configure Symfony2 to use the ``uglifyjs2`` filter when processing
-your javascripts:
+your JavaScripts:
 
 .. configuration-block::
 
@@ -93,7 +93,7 @@ your javascripts:
 
 .. note::
 
-    The path where UglifyJs is installed may vary depending on your system.
+    The path where UglifyJS is installed may vary depending on your system.
     To find out where npm stores the ``bin`` folder, you can use the following
     command:
 
@@ -102,9 +102,9 @@ your javascripts:
         $ npm bin -g
 
     It should output a folder on your system, inside which you should find
-    the UglifyJs executable.
+    the UglifyJS executable.
 
-    If you installed UglifyJs locally, you can find the bin folder inside
+    If you installed UglifyJS locally, you can find the bin folder inside
     the ``node_modules`` folder. It's called ``.bin`` in this case.
 
 You now have access to the ``uglifyjs2`` filter in your application.
@@ -112,7 +112,7 @@ You now have access to the ``uglifyjs2`` filter in your application.
 Minify your Assets
 ------------------
 
-In order to use UglifyJs on your assets, you need to apply it to them. Since
+In order to use UglifyJS on your assets, you need to apply it to them. Since
 your assets are a part of the view layer, this work is done in your templates:
 
 .. configuration-block::
@@ -181,10 +181,10 @@ and :ref:`dump your assetic assets <cookbook-asetic-dump-prod>`.
     rather than the common config file. For details on applying filters by
     file extension, see :ref:`cookbook-assetic-apply-to`.
 
-Install, configure and use UglifyCss
+Install, configure and use UglifyCSS
 ------------------------------------
 
-The usage of UglifyCss works the same way as UglifyJs. First, make sure
+The usage of UglifyCSS works the same way as UglifyJS. First, make sure
 the node package is installed:
 
 .. code-block:: bash
@@ -223,7 +223,7 @@ Next, add the configuration for this filter:
             ),
         ));
 
-To use the filter for your css files, add the filter to the Assetic ``stylesheets``
+To use the filter for your CSS files, add the filter to the Assetic ``stylesheets``
 helper:
 
 .. configuration-block::
@@ -247,8 +247,8 @@ Just like with the ``uglifyjs2`` filter, if you prefix the filter name with
 ``?`` (i.e. ``?uglifycss``), the minification will only happen when you're
 not in debug mode.
 
-.. _`UglifyJs`: https://github.com/mishoo/UglifyJS
-.. _`UglifyCss`: https://github.com/fmarcia/UglifyCSS
+.. _`UglifyJS`: https://github.com/mishoo/UglifyJS
+.. _`UglifyCSS`: https://github.com/fmarcia/UglifyCSS
 .. _`Node.js`: http://nodejs.org/
-.. _`install node.js`: http://nodejs.org/
+.. _`install Node.js`: http://nodejs.org/
 .. _`package.json`: http://package.json.nodejitsu.com/

--- a/cookbook/assetic/yuicompressor.rst
+++ b/cookbook/assetic/yuicompressor.rst
@@ -68,7 +68,7 @@ stylesheets:
 
 .. note::
 
-    Windows users need to remember to update config to proper java location.
+    Windows users need to remember to update config to proper Java location.
     In Windows7 x64 bit by default it's ``C:\Program Files (x86)\Java\jre6\bin\java.exe``.
 
 You now have access to two new Assetic filters in your application:

--- a/cookbook/bundles/extension.rst
+++ b/cookbook/bundles/extension.rst
@@ -515,7 +515,7 @@ Default Configuration Dump
     The ``config:dump-reference`` command was added in Symfony 2.1
 
 The ``config:dump-reference`` command allows a bundle's default configuration to
-be output to the console in yaml.
+be output to the console in YAML.
 
 As long as your bundle's configuration is located in the standard location
 (``YourBundle\DependencyInjection\Configuration``) and does not have a
@@ -555,7 +555,7 @@ Comments and examples can be added to your configuration nodes using the
         }
     }
 
-This text appears as yaml comments in the output of the ``config:dump-reference``
+This text appears as YAML comments in the output of the ``config:dump-reference``
 command.
 
 .. index::

--- a/cookbook/bundles/extension.rst
+++ b/cookbook/bundles/extension.rst
@@ -11,7 +11,7 @@ you'll see a number of different configuration "namespaces", such as ``framework
 you to configure things at a high level and then let the bundle make all the
 low-level, complex changes that result.
 
-For example, the following tells the ``FrameworkBundle`` to enable the form
+For example, the following tells the FrameworkBundle to enable the form
 integration, which involves the defining of quite a few services as well
 as integration of other related components:
 

--- a/cookbook/bundles/inheritance.rst
+++ b/cookbook/bundles/inheritance.rst
@@ -13,7 +13,7 @@ things like controllers, templates, and other files in a bundle's
 For example, suppose that you're installing the `FOSUserBundle`_, but you
 want to override its base ``layout.html.twig`` template, as well as one of
 its controllers. Suppose also that you have your own ``AcmeUserBundle``
-where you want the overridden files to live. Start by registering the ``FOSUserBundle``
+where you want the overridden files to live. Start by registering the FOSUserBundle
 as the "parent" of your bundle::
 
     // src/Acme/UserBundle/AcmeUserBundle.php
@@ -29,7 +29,7 @@ as the "parent" of your bundle::
         }
     }
 
-By making this simple change, you can now override several parts of the ``FOSUserBundle``
+By making this simple change, you can now override several parts of the FOSUserBundle
 simply by creating a file with the same name.
 
 .. note::
@@ -41,7 +41,7 @@ Overriding Controllers
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Suppose you want to add some functionality to the ``registerAction`` of a
-``RegistrationController`` that lives inside ``FOSUserBundle``. To do so,
+``RegistrationController`` that lives inside FOSUserBundle. To do so,
 just create your own ``RegistrationController.php`` file, override the bundle's
 original method, and change its functionality::
 
@@ -79,11 +79,11 @@ Overriding Resources: Templates, Routing, etc
 Most resources can also be overridden, simply by creating a file in the same
 location as your parent bundle.
 
-For example, it's very common to need to override the ``FOSUserBundle``'s
+For example, it's very common to need to override the FOSUserBundle's
 ``layout.html.twig`` template so that it uses your application's base layout.
-Since the file lives at ``Resources/views/layout.html.twig`` in the ``FOSUserBundle``,
-you can create your own file in the same location of ``AcmeUserBundle``.
-Symfony will ignore the file that lives inside the ``FOSUserBundle`` entirely,
+Since the file lives at ``Resources/views/layout.html.twig`` in the FOSUserBundle,
+you can create your own file in the same location of AcmeUserBundle.
+Symfony will ignore the file that lives inside the FOSUserBundle entirely,
 and use your file instead.
 
 The same goes for routing files and some other resources.

--- a/cookbook/bundles/installation.rst
+++ b/cookbook/bundles/installation.rst
@@ -13,7 +13,7 @@ Add Composer Dependencies
 Starting from Symfony 2.1, dependencies are managed with Composer. It's
 a good idea to learn some basics of Composer in `their documentation`_.
 
-Before you can use composer to install a bundle, you should look for a
+Before you can use Composer to install a bundle, you should look for a
 `Packagist`_ package of that bundle. For example, if you search for the popular
 `FOSUserBundle`_ you will find a packaged called `friendsofsymfony/user-bundle`_.
 

--- a/cookbook/bundles/override.rst
+++ b/cookbook/bundles/override.rst
@@ -167,7 +167,7 @@ the constraints to a new validation group:
             </class>
         </constraint-mapping>
 
-Now, update the FosUserBundle configuration, so it uses your validation groups
+Now, update the FOSUserBundle configuration, so it uses your validation groups
 instead of the original ones.
 
 .. _override-translations:

--- a/cookbook/bundles/remove.rst
+++ b/cookbook/bundles/remove.rst
@@ -5,12 +5,12 @@ How to remove the AcmeDemoBundle
 ================================
 
 The Symfony2 Standard Edition comes with a complete demo that lives inside a
-bundle called ``AcmeDemoBundle``. It is a great boilerplate to refer to while
+bundle called AcmeDemoBundle. It is a great boilerplate to refer to while
 starting a project, but you'll probably want to eventually remove it.
 
 .. tip::
 
-    This article uses the ``AcmeDemoBundle`` as an example, but you can use
+    This article uses the AcmeDemoBundle as an example, but you can use
     these steps to remove any bundle.
 
 1. Unregister the bundle in the ``AppKernel``
@@ -18,7 +18,7 @@ starting a project, but you'll probably want to eventually remove it.
 
 To disconnect the bundle from the framework, you should remove the bundle from
 the ``Appkernel::registerBundles()`` method. The bundle is normally found in
-the ``$bundles`` array but the ``AcmeDemoBundle`` is only registered in a
+the ``$bundles`` array but the AcmeDemoBundle is only registered in a
 development environment and you can find him in the if statement after::
 
     // app/AppKernel.php
@@ -58,10 +58,10 @@ and ``_demo``. Remove all three of these entries.
 Some bundles contain configuration in one of the ``app/config/config*.yml``
 files. Be sure to remove the related configuration from these files. You can
 quickly spot bundle configuration by looking at a ``acme_demo`` (or whatever
-the name of the bundle is, e.g. ``fos_user`` for the ``FOSUserBundle``) string in
+the name of the bundle is, e.g. ``fos_user`` for the FOSUserBundle) string in
 the configuration files.
 
-The ``AcmeDemoBundle`` doesn't have configuration. However, the bundle is
+The AcmeDemoBundle doesn't have configuration. However, the bundle is
 used in the configuration for  the ``app/config/security.yml`` file. You can
 use it as a boilerplate for your own security, but you **can** also remove
 everything: it doesn't matter to Symfony if you remove it or not.
@@ -87,7 +87,7 @@ can remove the ``Acme`` directory as well.
 
 .. note::
 
-    This doesn't apply to the ``AcmeDemoBundle`` - no other bundles depend
+    This doesn't apply to the AcmeDemoBundle - no other bundles depend
     on it, so you can skip this step.
 
 Some bundles rely on other bundles, if you remove one of the two, the other

--- a/cookbook/cache/varnish.rst
+++ b/cookbook/cache/varnish.rst
@@ -137,7 +137,7 @@ that will invalidate the cache for a given resource:
             .port = "8080";
         }
 
-        // Acl's can contain IP's, subnets and hostnames
+        // ACL's can contain IP's, subnets and hostnames
         acl purge {
             "localhost";
             "192.168.55.0"/24;
@@ -146,7 +146,7 @@ that will invalidate the cache for a given resource:
         sub vcl_recv {
             // Match PURGE request to avoid cache bypassing
             if (req.request == "PURGE") {
-                // Match client IP to the acl
+                // Match client IP to the ACL
                 if (!client.ip ~ purge) {
                     // Deny access
                     error 405 "Not allowed.";

--- a/cookbook/configuration/apache_router.rst
+++ b/cookbook/configuration/apache_router.rst
@@ -5,7 +5,7 @@ How to use the Apache Router
 ============================
 
 Symfony2, while fast out of the box, also provides various ways to increase that speed with a little bit of tweaking.
-One of these ways is by letting apache handle routes directly, rather than using Symfony2 for this task.
+One of these ways is by letting Apache handle routes directly, rather than using Symfony2 for this task.
 
 Change Router Configuration Parameters
 --------------------------------------

--- a/cookbook/console/console_command.rst
+++ b/cookbook/console/console_command.rst
@@ -12,9 +12,9 @@ Automatically Registering Commands
 ----------------------------------
 
 To make the console commands available automatically with Symfony2, create a
-``Command`` directory inside your bundle and create a php file suffixed with
+``Command`` directory inside your bundle and create a PHP file suffixed with
 ``Command.php`` for each command that you want to provide. For example, if you
-want to extend the ``AcmeDemoBundle`` (available in the Symfony Standard
+want to extend the AcmeDemoBundle (available in the Symfony Standard
 Edition) to greet you from the command line, create ``GreetCommand.php`` and
 add the following to it::
 

--- a/cookbook/console/sending_emails.rst
+++ b/cookbook/console/sending_emails.rst
@@ -95,7 +95,7 @@ Sending emails in a console command works the same way as described in the
 :doc:`/cookbook/email/email` cookbook except if memory spooling is used.
 
 When using memory spooling (see the :doc:`/cookbook/email/spool` cookbook for more
-information), you must be aware that because of how symfony handles console
+information), you must be aware that because of how Symfony handles console
 commands, emails are not sent automatically. You must take care of flushing
 the queue yourself. Use the following code to send emails inside your
 console command::

--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -8,7 +8,7 @@ How to customize Error Pages
 When any exception is thrown in Symfony2, the exception is caught inside the
 ``Kernel`` class and eventually forwarded to a special controller,
 ``TwigBundle:Exception:show`` for handling. This controller, which lives
-inside the core ``TwigBundle``, determines which error template to display and
+inside the core TwigBundle, determines which error template to display and
 the status code that should be set for the given exception.
 
 Error pages can be customized in two different ways, depending on how much
@@ -29,7 +29,7 @@ control you need:
     which allows complete control over exception handling. For more
     information, see :ref:`kernel-kernel.exception`.
 
-All of the error templates live inside ``TwigBundle``. To override the
+All of the error templates live inside the TwigBundle. To override the
 templates, simply rely on the standard method for overriding templates that
 live inside a bundle. For more information, see
 :ref:`overriding-bundle-templates`.
@@ -98,10 +98,10 @@ Symfony uses the following algorithm to determine which template to use:
 .. tip::
 
     To see the full list of default error templates, see the
-    ``Resources/views/Exception`` directory of the ``TwigBundle``. In a
-    standard Symfony2 installation, the ``TwigBundle`` can be found at
+    ``Resources/views/Exception`` directory of the TwigBundle. In a
+    standard Symfony2 installation, the TwigBundle can be found at
     ``vendor/symfony/symfony/src/Symfony/Bundle/TwigBundle``. Often, the easiest way
-    to customize an error page is to copy it from the ``TwigBundle`` into
+    to customize an error page is to copy it from the TwigBundle into
     ``app/Resources/TwigBundle/views/Exception`` and then modify it.
 
 .. note::

--- a/cookbook/deployment-tools.rst
+++ b/cookbook/deployment-tools.rst
@@ -47,7 +47,7 @@ to take some manual steps after transferring the files (see `Common Post-Deploym
 Using Source Control
 ~~~~~~~~~~~~~~~~~~~~
 
-If you're using source control (e.g. git or svn), you can simplify by having
+If you're using source control (e.g. Git or SVN), you can simplify by having
 your live installation also be a copy of your repository. When you're ready
 to upgrade it is as simple as fetching the latest updates from your source
 control system.

--- a/cookbook/doctrine/multiple_entity_managers.rst
+++ b/cookbook/doctrine/multiple_entity_managers.rst
@@ -151,8 +151,8 @@ The following configuration code shows how you can configure two entity managers
 
 In this case, you've defined two entity managers and called them ``default``
 and ``customer``. The ``default`` entity manager manages entities in the
-``AcmeDemoBundle`` and ``AcmeStoreBundle``, while the ``customer`` entity
-manager manages entities in the ``AcmeCustomerBundle``. You've also defined
+AcmeDemoBundle and AcmeStoreBundle, while the ``customer`` entity
+manager manages entities in the AcmeCustomerBundle. You've also defined
 two connections, one for each entity manager.
 
 .. note::

--- a/cookbook/doctrine/multiple_entity_managers.rst
+++ b/cookbook/doctrine/multiple_entity_managers.rst
@@ -151,8 +151,8 @@ The following configuration code shows how you can configure two entity managers
 
 In this case, you've defined two entity managers and called them ``default``
 and ``customer``. The ``default`` entity manager manages entities in the
-AcmeDemoBundle and AcmeStoreBundle, while the ``customer`` entity
-manager manages entities in the AcmeCustomerBundle. You've also defined
+``AcmeDemoBundle`` and ``AcmeStoreBundle``, while the ``customer`` entity
+manager manages entities in the ``AcmeCustomerBundle``. You've also defined
 two connections, one for each entity manager.
 
 .. note::

--- a/cookbook/doctrine/reverse_engineering.rst
+++ b/cookbook/doctrine/reverse_engineering.rst
@@ -97,7 +97,7 @@ entity classes by executing the following two commands.
     $ php app/console doctrine:generate:entities AcmeBlogBundle
 
 The first command generates entity classes with annotation mappings. But
-if you want to use yml or xml mapping instead of annotations, you should
+if you want to use YAML or XML mapping instead of annotations, you should
 execute the second command only.
 
 .. tip::

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -6,7 +6,7 @@ How to Work with Emails During Development
 
 When developing an application which sends email, you will often
 not want to actually send the email to the specified recipient during
-development. If you are using the ``SwiftmailerBundle`` with Symfony2, you
+development. If you are using the SwiftmailerBundle with Symfony2, you
 can easily achieve this through configuration settings without having to
 make any changes to your application's code at all. There are two main
 choices when it comes to handling email during development: (a) disabling the

--- a/cookbook/email/email.rst
+++ b/cookbook/email/email.rst
@@ -6,7 +6,7 @@ How to send an Email
 
 Sending emails is a classic task for any web application and one that has
 special complications and potential pitfalls. Instead of recreating the wheel,
-one solution to send emails is to use the ``SwiftmailerBundle``, which leverages
+one solution to send emails is to use the SwiftmailerBundle, which leverages
 the power of the `Swift Mailer`_ library.
 
 .. note::

--- a/cookbook/email/gmail.rst
+++ b/cookbook/email/gmail.rst
@@ -5,7 +5,7 @@ How to use Gmail to send Emails
 ===============================
 
 During development, instead of using a regular SMTP server to send emails, you
-might find using Gmail easier and more practical. The ``SwiftmailerBundle`` makes
+might find using Gmail easier and more practical. The SwiftmailerBundle makes
 it really easy.
 
 .. tip::

--- a/cookbook/email/spool.rst
+++ b/cookbook/email/spool.rst
@@ -4,7 +4,7 @@
 How to Spool Emails
 ===================
 
-When you are using the ``SwiftmailerBundle`` to send an email from a Symfony2
+When you are using the SwiftmailerBundle to send an email from a Symfony2
 application, it will default to sending the email immediately. You may, however,
 want to avoid the performance hit of the communication between Swift Mailer
 and the email transport, which could cause the user to wait for the next

--- a/cookbook/email/testing.rst
+++ b/cookbook/email/testing.rst
@@ -5,7 +5,7 @@ How to test that an Email is sent in a functional Test
 ======================================================
 
 Sending e-mails with Symfony2 is pretty straightforward thanks to the
-``SwiftmailerBundle``, which leverages the power of the `Swift Mailer`_ library.
+SwiftmailerBundle, which leverages the power of the `Swift Mailer`_ library.
 
 To functionally test that an email was sent, and even assert the email subject,
 content or any other headers, you can use :ref:`the Symfony2 Profiler <internals-profiler>`.

--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -527,7 +527,7 @@ only because in two different scenarios, the data that you can use is available 
 Other than that, the listeners always perform exactly the same things on a given form.
 
 One piece that may still be missing is the client-side updating of your form
-after the sport is selected. This should be handled by making an AJAX call
+after the sport is selected. This should be handled by making an Ajax call
 back to your application. In that controller, you can bind your form, but
 instead of processing it, simply use the bound form to render the updated
-fields. The response from the AJAX call can then be used to update the view.
+fields. The response from the Ajax call can then be used to update the view.

--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -915,7 +915,7 @@ form, modify the ``use`` tag and add the following:
         {% endif %}
     {% endblock %}
 
-In twig, If you're making the form customization inside a separate template, use
+In Twig, If you're making the form customization inside a separate template, use
 the following:
 
 .. code-block:: html+jinja

--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -23,8 +23,8 @@ It is used to test the core types and you can use it to test your types too.
 .. note::
 
     Depending on the way you installed your Symfony or Symfony Form Component
-    the tests may not be downloaded. Use the --prefer-source option with
-    composer if this is the case.
+    the tests may not be downloaded. Use the ``--prefer-source`` option with
+    Composer if this is the case.
 
 The Basics
 ----------

--- a/cookbook/logging/channels_handlers.rst
+++ b/cookbook/logging/channels_handlers.rst
@@ -59,7 +59,7 @@ To do so, just create a new handler and configure it like this:
             </monolog:handlers>
         </monolog:config>
 
-Yaml specification
+YAML specification
 ------------------
 
 You can specify the configuration by many forms:

--- a/cookbook/profiler/matchers.rst
+++ b/cookbook/profiler/matchers.rst
@@ -16,7 +16,7 @@ Using the built-in Matcher
 Symfony2 provides a
 :class:`built-in matcher <Symfony\\Component\\HttpFoundation\\RequestMatcher>`
 which can match paths and IPs. For example, if you want to only show the
-profiler when accessing the page with the ``168.0.0.1`` ip, then you can
+profiler when accessing the page with the ``168.0.0.1`` IP, then you can
 use this configuration:
 
 .. configuration-block::

--- a/cookbook/routing/custom_route_loader.rst
+++ b/cookbook/routing/custom_route_loader.rst
@@ -5,7 +5,7 @@ How to create a custom Route Loader
 ===================================
 
 A custom route loader allows you to add routes to an application without
-including them, for example, in a Yaml file. This comes in handy when
+including them, for example, in a YAML file. This comes in handy when
 you have a bundle but don't want to manually add the routes for the bundle
 to ``app/config/routing.yml``. This may be especially important when you want
 to make the bundle reusable, or when you have open-sourced it as this would
@@ -28,7 +28,7 @@ Loading Routes
 The routes in a Symfony application are loaded by the
 :class:`Symfony\\Bundle\\FrameworkBundle\\Routing\\DelegatingLoader`.
 This loader uses several other loaders (delegates) to load resources of
-different types, for instance Yaml files or ``@Route`` and ``@Method`` annotations
+different types, for instance YAML files or ``@Route`` and ``@Method`` annotations
 in controller files. The specialized loaders implement
 :class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`
 and therefore have two important methods:
@@ -56,7 +56,7 @@ Creating a Custom Loader
 ------------------------
 
 To load routes from some custom source (i.e. from something other than annotations,
-Yaml or XML files), you need to create a custom route loader. This loader
+YAML or XML files), you need to create a custom route loader. This loader
 should implement :class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`.
 
 The sample loader below supports loading routing resources with a type of
@@ -222,7 +222,7 @@ to load secondary routing resources.
 Of course you still need to implement
 :method:`Symfony\\Component\\Config\\Loader\\LoaderInterface::supports`
 and :method:`Symfony\\Component\\Config\\Loader\\LoaderInterface::load`.
-Whenever you want to load another resource - for instance a Yaml routing
+Whenever you want to load another resource - for instance a YAML routing
 configuration file - you can call the
 :method:`Symfony\\Component\\Config\\Loader\\Loader::import` method::
 
@@ -257,7 +257,7 @@ configuration file - you can call the
 
     The resource name and type of the imported routing configuration can
     be anything that would normally be supported by the routing configuration
-    loader (Yaml, XML, PHP, annotation, etc.).
+    loader (YAML, XML, PHP, annotation, etc.).
 
 .. _`FOSRestBundle`: https://github.com/FriendsOfSymfony/FOSRestBundle
 .. _`KnpRadBundle`: https://github.com/KnpLabs/KnpRadBundle

--- a/cookbook/routing/scheme.rst
+++ b/cookbook/routing/scheme.rst
@@ -66,7 +66,7 @@ to always use ``http``.
 
 .. note::
 
-    The Security component provides another way to enforce HTTP or HTTPs via
+    The Security component provides another way to enforce HTTP or HTTPS via
     the ``requires_channel`` setting. This alternative method is better suited
     to secure an "area" of your website (all URLs under ``/admin``) or when
     you want to secure URLs defined in a third party bundle.

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -165,7 +165,7 @@ set an authenticated token in the security context if successful.
         }
     }
 
-This listener checks the request for the expected `X-WSSE` header, matches
+This listener checks the request for the expected ``X-WSSE` header, matches
 the value returned for the expected WSSE information, creates a token using
 that information, and passes the token on to the authentication manager. If
 the proper information is not provided, or the authentication manager throws
@@ -555,7 +555,7 @@ in order to put it to use.
     should use instead of the hard-coded 300 seconds. These two steps are
     not shown here.
 
-The lifetime of each wsse request is now configurable, and can be
+The lifetime of each WSSE request is now configurable, and can be
 set to any desirable value per firewall.
 
 .. configuration-block::

--- a/cookbook/security/force_https.rst
+++ b/cookbook/security/force_https.rst
@@ -4,10 +4,10 @@
 How to force HTTPS or HTTP for Different URLs
 =============================================
 
-You can force areas of your site to use the ``HTTPS`` protocol in the security
+You can force areas of your site to use the HTTPS protocol in the security
 config. This is done through the ``access_control`` rules using the ``requires_channel``
 option. For example, if you want to force all URLs starting with ``/secure``
-to use ``HTTPS`` then you could use the following configuration:
+to use HTTPS then you could use the following configuration:
 
 .. configuration-block::
 
@@ -35,7 +35,7 @@ to use ``HTTPS`` then you could use the following configuration:
             ),
 
 The login form itself needs to allow anonymous access, otherwise users will
-be unable to authenticate. To force it to use ``HTTPS`` you can still use
+be unable to authenticate. To force it to use HTTPS you can still use
 ``access_control`` rules by using the ``IS_AUTHENTICATED_ANONYMOUSLY``
 role:
 
@@ -66,5 +66,5 @@ role:
                 ),
             ),
 
-It is also possible to specify using ``HTTPS`` in the routing configuration
+It is also possible to specify using HTTPS in the routing configuration,
 see :doc:`/cookbook/routing/scheme` for more details.

--- a/cookbook/security/form_login.rst
+++ b/cookbook/security/form_login.rst
@@ -34,7 +34,7 @@ in several ways.
 .. note::
 
     As mentioned, by default the user is redirected back to the page he originally
-    requested. Sometimes, this can cause problems, like if a background AJAX
+    requested. Sometimes, this can cause problems, like if a background Ajax
     request "appears" to be the last visited URL, causing the user to be
     redirected there. For information on controlling this behavior, see
     :doc:`/cookbook/security/target_path`.

--- a/cookbook/security/securing_services.rst
+++ b/cookbook/security/securing_services.rst
@@ -219,7 +219,7 @@ You can then achieve the same results as above using an annotation::
     annotations on public and protected methods, you cannot use them with
     private methods or methods marked final.
 
-The ``JMSSecurityExtraBundle`` also allows you to secure the parameters and return
+The JMSSecurityExtraBundle also allows you to secure the parameters and return
 values of methods. For more information, see the `JMSSecurityExtraBundle`_
 documentation.
 

--- a/cookbook/security/voters.rst
+++ b/cookbook/security/voters.rst
@@ -31,7 +31,7 @@ which requires the following three methods:
     }
 
 The ``supportsAttribute()`` method is used to check if the voter supports
-the given user attribute (i.e: a role, an acl, etc.).
+the given user attribute (i.e: a role, an ACL, etc.).
 
 The ``supportsClass()`` method is used to check if the voter supports the
 current user token class.

--- a/cookbook/service_container/scopes.rst
+++ b/cookbook/service_container/scopes.rst
@@ -113,7 +113,7 @@ If your service depends on a scoped service, the best solution is to put
 it in the same scope (or a narrower one). Usually, this means putting your
 new service in the ``request`` scope.
 
-But this is not always possible (for instance, a twig extension must be in
+But this is not always possible (for instance, a Twig extension must be in
 the ``container`` scope as the Twig environment needs it as a dependency).
 In these cases, you should pass the entire container into your service and
 retrieve your dependency from the container each time you need it to be sure

--- a/cookbook/symfony1.rst
+++ b/cookbook/symfony1.rst
@@ -262,7 +262,7 @@ Routing (``routing.yml``) and Configuration (``config.yml``)
 In symfony1, the ``routing.yml`` and ``app.yml`` configuration files were
 automatically loaded inside any plugin. In Symfony2, routing and application
 configuration inside a bundle must be included manually. For example, to
-include a routing resource from a bundle called ``AcmeDemoBundle``, you can
+include a routing resource from a bundle called AcmeDemoBundle, you can
 do the following:
 
 .. configuration-block::
@@ -296,7 +296,7 @@ do the following:
         return $collection;
 
 This will load the routes found in the ``Resources/config/routing.yml`` file
-of the ``AcmeDemoBundle``. The special ``@AcmeDemoBundle`` is a shortcut syntax
+of the AcmeDemoBundle. The special ``@AcmeDemoBundle`` is a shortcut syntax
 that, internally, resolves to the full path to that bundle.
 
 You can use this same strategy to bring in configuration from a bundle:

--- a/cookbook/symfony1.rst
+++ b/cookbook/symfony1.rst
@@ -164,7 +164,7 @@ defined in the ``composer.json`` file.
 
 If you look at the ``HelloController`` from the Symfony2 Standard Edition you
 can see that it lives in the ``Acme\DemoBundle\Controller`` namespace. Yet, the
-``AcmeDemoBundle`` is not defined in your ``composer.json`` file. Nonetheless are
+AcmeDemoBundle is not defined in your ``composer.json`` file. Nonetheless are
 the files autoloaded. This is because you can tell composer to autoload files
 from specific directories without defining a dependency:
 

--- a/cookbook/workflow/_vendor_deps.rst.inc
+++ b/cookbook/workflow/_vendor_deps.rst.inc
@@ -1,5 +1,5 @@
-Managing Vendor Libraries with composer.json
---------------------------------------------
+Managing Vendor Libraries with ``composer.json``
+------------------------------------------------
 
 How does it work?
 ~~~~~~~~~~~~~~~~~

--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -1,18 +1,18 @@
 .. index::
    single: Workflow; Git
 
-How to Create and store a Symfony2 Project in git
+How to Create and store a Symfony2 Project in Git
 =================================================
 
 .. tip::
 
-    Though this entry is specifically about git, the same generic principles
+    Though this entry is specifically about Git, the same generic principles
     will apply if you're storing your project in Subversion.
 
 Once you've read through :doc:`/book/page_creation` and become familiar with
 using Symfony, you'll no-doubt be ready to start your own project. In this
 cookbook article, you'll learn the best way to start a new Symfony2 project
-that's stored using the `git`_ source control management system.
+that's stored using the `Git`_ source control management system.
 
 Initial Project Setup
 ---------------------
@@ -27,7 +27,7 @@ git repository:
 
 3. Create a new file called ``.gitignore`` at the root of your new project
    (e.g. next to the ``composer.json`` file) and paste the following into it. Files
-   matching these patterns will be ignored by git:
+   matching these patterns will be ignored by Git:
 
    .. code-block:: text
 
@@ -45,18 +45,18 @@ git repository:
    This way you can exclude files/folders often used by your IDE for all of your projects.
 
 4. Copy ``app/config/parameters.yml`` to ``app/config/parameters.yml.dist``.
-   The ``parameters.yml`` file is ignored by git (see above) so that machine-specific
+   The ``parameters.yml`` file is ignored by Git (see above) so that machine-specific
    settings like database passwords aren't committed. By creating the ``parameters.yml.dist``
    file, new developers can quickly clone the project, copy this file to
    ``parameters.yml``, customize it, and start developing.
 
-5. Initialize your git repository:
+5. Initialize your Git repository:
 
    .. code-block:: bash
 
         $ git init
 
-6. Add all of the initial files to git:
+6. Add all of the initial files to Git:
 
    .. code-block:: bash
 
@@ -72,8 +72,8 @@ git repository:
    executing composer. For details, see :ref:`installation-updating-vendors`.
 
 At this point, you have a fully-functional Symfony2 project that's correctly
-committed to git. You can immediately begin development, committing the new
-changes to your git repository.
+committed to Git. You can immediately begin development, committing the new
+changes to your Git repository.
 
 You can continue to follow along with the :doc:`/book/page_creation` chapter
 to learn more about how to configure and develop inside your application.
@@ -95,13 +95,13 @@ Instead of using the ``composer.json`` system for managing your vendor
 libraries, you may instead choose to use native `git submodules`_. There
 is nothing wrong with this approach, though the ``composer.json`` system
 is the official way to solve this problem and probably much easier to
-deal with. Unlike git submodules, ``Composer`` is smart enough to calculate
+deal with. Unlike Git submodules, ``Composer`` is smart enough to calculate
 which libraries depend on which other libraries.
 
 Storing your Project on a Remote Server
 ---------------------------------------
 
-You now have a fully-functional Symfony2 project stored in git. However,
+You now have a fully-functional Symfony2 project stored in Git. However,
 in most cases, you'll also want to store your project on a remote server
 both for backup purposes, and so that other developers can collaborate on
 the project.
@@ -110,11 +110,11 @@ The easiest way to store your project on a remote server is via `GitHub`_.
 Public repositories are free, however you will need to pay a monthly fee
 to host private repositories.
 
-Alternatively, you can store your git repository on any server by creating
+Alternatively, you can store your Git repository on any server by creating
 a `barebones repository`_ and then pushing to it. One library that helps
 manage this is `Gitolite`_.
 
-.. _`git`: http://git-scm.com/
+.. _`Git`: http://git-scm.com/
 .. _`Symfony2 Standard Edition`: http://symfony.com/download
 .. _`git submodules`: http://git-scm.com/book/en/Git-Tools-Submodules
 .. _`GitHub`: https://github.com/

--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -69,7 +69,7 @@ git repository:
         $ git commit -m "Initial commit"
 
 8. Finally, download all of the third-party vendor libraries by
-   executing composer. For details, see :ref:`installation-updating-vendors`.
+   executing Composer. For details, see :ref:`installation-updating-vendors`.
 
 At this point, you have a fully-functional Symfony2 project that's correctly
 committed to Git. You can immediately begin development, committing the new
@@ -95,7 +95,7 @@ Instead of using the ``composer.json`` system for managing your vendor
 libraries, you may instead choose to use native `git submodules`_. There
 is nothing wrong with this approach, though the ``composer.json`` system
 is the official way to solve this problem and probably much easier to
-deal with. Unlike Git submodules, ``Composer`` is smart enough to calculate
+deal with. Unlike Git submodules, Composer is smart enough to calculate
 which libraries depend on which other libraries.
 
 Storing your Project on a Remote Server

--- a/cookbook/workflow/new_project_svn.rst
+++ b/cookbook/workflow/new_project_svn.rst
@@ -37,7 +37,7 @@ widespread standard structure:
 
 .. tip::
 
-    Most subversion hosting should follow this standard practice. This
+    Most Subversion hosting should follow this standard practice. This
     is the recommended layout in `Version Control with Subversion`_ and the
     layout used by most free hosting (see :ref:`svn-hosting`).
 
@@ -59,14 +59,14 @@ To get started, you'll need to download Symfony2 and get the basic Subversion se
 
         $ svn checkout http://myproject.googlecode.com/svn/trunk myproject
 
-4. Copy the Symfony2 project files in the subversion folder:
+4. Copy the Symfony2 project files in the Subversion folder:
 
    .. code-block:: bash
 
         $ mv Symfony/* myproject/
 
 5. Let's now set the ignore rules. Not everything *should* be stored in your
-   subversion repository. Some files (like the cache) are generated and
+   Subversion repository. Some files (like the cache) are generated and
    others (like the database configuration) are meant to be customized
    on each machine. This makes use of the ``svn:ignore`` property, so that
    specific files can be ignored.

--- a/cookbook/workflow/new_project_svn.rst
+++ b/cookbook/workflow/new_project_svn.rst
@@ -11,10 +11,10 @@ How to Create and store a Symfony2 Project in Subversion
 
 Once you've read through :doc:`/book/page_creation` and become familiar with
 using Symfony, you'll no-doubt be ready to start your own project. The
-preferred method to manage Symfony2 projects is using `git`_ but some prefer
+preferred method to manage Symfony2 projects is using `Git`_ but some prefer
 to use `Subversion`_ which is totally fine!. In this cookbook article, you'll
-learn how to manage your project using `svn`_ in a similar manner you
-would do with `git`_.
+learn how to manage your project using `SVN`_ in a similar manner you
+would do with `Git`_.
 
 .. tip::
 
@@ -105,7 +105,7 @@ To get started, you'll need to download Symfony2 and get the basic Subversion se
 
 .. tip::
 
-	If you rely on any "dev" versions, then git may be used to install
+	If you rely on any "dev" versions, then Git may be used to install
 	those libraries, since there is no archive available for download.
 
 At this point, you have a fully-functional Symfony2 project stored in your
@@ -128,7 +128,7 @@ to learn more about how to configure and develop inside your application.
 Subversion hosting solutions
 ----------------------------
 
-The biggest difference between `git`_ and `svn`_ is that Subversion *needs* a
+The biggest difference between `Git`_ and `SVN`_ is that Subversion *needs* a
 central repository to work. You then have several solutions:
 
 - Self hosting: create your own repository and access it either through the
@@ -137,10 +137,10 @@ central repository to work. You then have several solutions:
 
 - Third party hosting: there are a lot of serious free hosting solutions
   available like `GitHub`_, `Google code`_, `SourceForge`_ or `Gna`_. Some of them offer
-  git hosting as well.
+  Git hosting as well.
 
-.. _`git`: http://git-scm.com/
-.. _`svn`: http://subversion.apache.org/
+.. _`Git`: http://git-scm.com/
+.. _`SVN`: http://subversion.apache.org/
 .. _`Subversion`: http://subversion.apache.org/
 .. _`Symfony2 Standard Edition`: http://symfony.com/download
 .. _`Version Control with Subversion`: http://svnbook.red-bean.com/

--- a/cookbook/workflow/new_project_svn.rst
+++ b/cookbook/workflow/new_project_svn.rst
@@ -101,7 +101,7 @@ To get started, you'll need to download Symfony2 and get the basic Subversion se
    developing.
 
 8. Finally, download all of the third-party vendor libraries by
-   executing composer. For details, see :ref:`installation-updating-vendors`.
+   executing Composer. For details, see :ref:`installation-updating-vendors`.
 
 .. tip::
 

--- a/glossary.rst
+++ b/glossary.rst
@@ -67,11 +67,11 @@ Glossary
         chapter.
 
    HTTP Specification
-        The *Http Specification* is a document that describes the Hypertext
+        The *HTTP Specification* is a document that describes the Hypertext
         Transfer Protocol - a set of rules laying out the classic client-server
         request-response communication. The specification defines the format
         used for a request and response as well as the possible HTTP headers
-        that each may have. For more information, read the `Http Wikipedia`_
+        that each may have. For more information, read the `HTTP Wikipedia`_
         article or the `HTTP 1.1 RFC`_.
 
    Environment
@@ -119,7 +119,7 @@ Glossary
         application or for just a part of it. See the
         :doc:`/book/security` chapters.
 
-   Yaml
+   YAML
         *YAML* is a recursive acronym for "YAML Ain't a Markup Language". It's a
         lightweight, humane data serialization language used extensively in
         Symfony2's configuration files.  See the :doc:`/components/yaml/introduction` 

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -269,7 +269,7 @@ Extending Bundles
 
 If you follow these conventions, then you can use :doc:`bundle inheritance</cookbook/bundles/inheritance>`
 to "override" files, controllers or templates. For example, you can create
-a bundle - AcmeNewBundle - and specify that it overrides AcmeDemoBundle.
+a bundle - ``AcmeNewBundle`` - and specify that it overrides AcmeDemoBundle.
 When Symfony loads the ``AcmeDemoBundle:Welcome:index`` controller, it will
 first look for the ``WelcomeController`` class in AcmeNewBundle and, if
 it doesn't exist, then look inside AcmeDemoBundle. This means that one bundle

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -118,9 +118,9 @@ a single ``Bundle`` class that describes it::
         return $bundles;
     }
 
-In addition to the ``AcmeDemoBundle`` that was already talked about, notice
-that the kernel also enables other bundles such as the ``FrameworkBundle``,
-``DoctrineBundle``, ``SwiftmailerBundle``, and ``AsseticBundle`` bundle.
+In addition to the AcmeDemoBundle that was already talked about, notice
+that the kernel also enables other bundles such as the FrameworkBundle,
+DoctrineBundle, SwiftmailerBundle, and AsseticBundle bundle.
 They are all part of the core framework.
 
 Configuring a Bundle
@@ -245,7 +245,7 @@ When you want to reference a file from a bundle, use this notation:
 to the real path to the bundle. For instance, the logical path
 ``@AcmeDemoBundle/Controller/DemoController.php`` would be converted to
 ``src/Acme/DemoBundle/Controller/DemoController.php``, because Symfony knows
-the location of the ``AcmeDemoBundle``.
+the location of the AcmeDemoBundle.
 
 Logical Controller Names
 ........................
@@ -269,10 +269,10 @@ Extending Bundles
 
 If you follow these conventions, then you can use :doc:`bundle inheritance</cookbook/bundles/inheritance>`
 to "override" files, controllers or templates. For example, you can create
-a bundle - ``AcmeNewBundle`` - and specify that it overrides ``AcmeDemoBundle``.
+a bundle - AcmeNewBundle - and specify that it overrides AcmeDemoBundle.
 When Symfony loads the ``AcmeDemoBundle:Welcome:index`` controller, it will
-first look for the ``WelcomeController`` class in ``AcmeNewBundle`` and, if
-it doesn't exist, then look inside ``AcmeDemoBundle``. This means that one bundle
+first look for the ``WelcomeController`` class in AcmeNewBundle and, if
+it doesn't exist, then look inside AcmeDemoBundle. This means that one bundle
 can override almost any part of another bundle!
 
 Do you understand now why Symfony2 is so flexible? Share your bundles between

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -193,8 +193,8 @@ PHP. Have a look at the default configuration:
         spool:     { type: memory }
 
 Each entry like ``framework`` defines the configuration for a specific bundle.
-For example, ``framework`` configures the ``FrameworkBundle`` while ``swiftmailer``
-configures the ``SwiftmailerBundle``.
+For example, ``framework`` configures the FrameworkBundle while ``swiftmailer``
+configures the SwiftmailerBundle.
 
 Each :term:`environment` can override the default configuration by providing a
 specific configuration file. For example, the ``dev`` environment loads the

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -284,7 +284,7 @@ return the contents of a JPG image with a ``Content-Type`` header of ``image/jpg
 
 The template name, ``AcmeDemoBundle:Welcome:index.html.twig``, is the template
 *logical name* and it references the ``Resources/views/Welcome/index.html.twig``
-file inside the ``AcmeDemoBundle`` (located at ``src/Acme/DemoBundle``).
+file inside the AcmeDemoBundle (located at ``src/Acme/DemoBundle``).
 The `Bundles`_ section below will explain why this is useful.
 
 Now, take a look at the routing configuration again and find the ``_demo``

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -7,7 +7,7 @@ FrameworkBundle Configuration ("framework")
 This reference document is a work in progress. It should be accurate, but
 all options are not yet fully covered.
 
-The ``FrameworkBundle`` contains most of the "base" framework functionality
+The FrameworkBundle contains most of the "base" framework functionality
 and can be configured under the ``framework`` key in your application configuration.
 This includes settings related to sessions, translation, forms, validation,
 routing and more.

--- a/reference/constraints/Ip.rst
+++ b/reference/constraints/Ip.rst
@@ -83,7 +83,7 @@ version
 
 **type**: ``string`` **default**: ``4``
 
-This determines exactly *how* the ip address is validated and can take one
+This determines exactly *how* the IP address is validated and can take one
 of a variety of different values:
 
 **All ranges**

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -25,9 +25,9 @@ may also be tags in other bundles you use that aren't listed here.
 +-----------------------------------+---------------------------------------------------------------------------+
 | `assetic.formula_resource`_       | Adds a resource to the current asset manager                              |
 +-----------------------------------+---------------------------------------------------------------------------+
-| `assetic.templating.php`_         | Remove this service if php templating is disabled                         |
+| `assetic.templating.php`_         | Remove this service if PHP templating is disabled                         |
 +-----------------------------------+---------------------------------------------------------------------------+
-| `assetic.templating.twig`_        | Remove this service if twig templating is disabled                        |
+| `assetic.templating.twig`_        | Remove this service if Twig templating is disabled                        |
 +-----------------------------------+---------------------------------------------------------------------------+
 | `data_collector`_                 | Create a class that collects custom data for the profiler                 |
 +-----------------------------------+---------------------------------------------------------------------------+
@@ -209,7 +209,7 @@ assetic.formula_loader
 A Formula loader is a class implementing
 ``Assetic\\Factory\Loader\\FormulaLoaderInterface`` interface. This class
 is responsible for loading assets from a particular kind of resources (for
-instance, twig template). Assetic ships loaders for php and twig templates.
+instance, twig template). Assetic ships loaders for PHP and Twig templates.
 
 An ``alias`` attribute defines the name of the loader.
 
@@ -218,13 +218,13 @@ assetic.formula_resource
 
 **Purpose**: Adds a resource to the current asset manager
 
-A resource is something formulae can be loaded from. For instance, twig
+A resource is something formulae can be loaded from. For instance, Twig
 templates are resources.
 
 assetic.templating.php
 ----------------------
 
-**Purpose**: Remove this service if php templating is disabled
+**Purpose**: Remove this service if PHP templating is disabled
 
 The tagged service will be removed from the container if the
 ``framework.templating.engines`` config section does not contain php.
@@ -232,10 +232,10 @@ The tagged service will be removed from the container if the
 assetic.templating.twig
 -----------------------
 
-**Purpose**: Remove this service if twig templating is disabled
+**Purpose**: Remove this service if Twig templating is disabled
 
 The tagged service will be removed from the container if
-``framework.templating.engines`` config section does not contain twig.
+``framework.templating.engines`` config section does not contain ``twig``.
 
 data_collector
 --------------

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -104,7 +104,7 @@ Filters
 +---------------------------------------------------------------------------------+-------------------------------------------------------------------+
 | ``variable|yaml_encode(inline = 0)``                                            | This will transform the variable text into a YAML syntax.         |
 +---------------------------------------------------------------------------------+-------------------------------------------------------------------+
-| ``variable|yaml_dump``                                                          | This will render a yaml syntax with their type.                   |
+| ``variable|yaml_dump``                                                          | This will render a YAML syntax with their type.                   |
 +---------------------------------------------------------------------------------+-------------------------------------------------------------------+
 | ``classname|abbr_class``                                                        | This will render an ``abbr`` element with the short name of a     |
 |                                                                                 | PHP class.                                                        |


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | - |
| Applies to | 2.2+ |
| Fixed tickets | - |

This PR renames all names of technologies, vendor software and bundles to their official names, following some official source, i.e. a homepage, GitHub, specification or Wikipedia:
- YAML
- Git
- Symfony Standard Edition
- XML
- PHP
- Twig
- Symfony (except when it refers to version 1)
- Subversion / SVN
- UglifyJS
- UglifyCSS
- Apache
- JavaScript
- Java
- Composer
- CSS
- Node.js
- Xdebug
- HTTP
- HTTPS
- Ajax
- IP
- ACL
- FOSUserBundle
- WSSE

It also removes literal formatting from some of them.

In addition, it removes the literal formatting from the official bundle names as this seems to be the more used standard throughout the docs and as a bundle name does not reference a piece of code or a file name etc.:
- FrameworkBundle
- FOSUserBundle
- AcmeDemoBundle
- DoctrineBundle
- DoctrineFixturesBundle
- SwiftmailerBundle
- TwigBundle
- JMSSecurityExtraBundle

Bundle names used in code samples are not affected, e.g.: AcmeUserBundle, AcmeBlogBundle, AcmeNewBundle, AcmeStoreBundle etc.

Along the way, this PR fixes some formatting issues and typos.
