### PR TITLE
Collection of minor fixes: Typos, formatting, improvements, logic

### DIFF
--- a/book/translation.rst
+++ b/book/translation.rst
@@ -850,7 +850,7 @@ texts* and complex expressions:
     templates (in order to avoid side effects).
 
 .. versionadded:: 2.1
-    The ``trans_default_domain`` tag is new in Symfony2.1
+    The ``trans_default_domain`` tag is new in Symfony 2.1
 
 PHP Templates
 ~~~~~~~~~~~~~

--- a/cookbook/assetic/apply_to_option.rst
+++ b/cookbook/assetic/apply_to_option.rst
@@ -119,7 +119,7 @@ work as the regular JavaScript files will not survive the CoffeeScript compilati
 
 This problem can be avoided by using the ``apply_to`` option in the config,
 which allows you to specify that a filter should always be applied to particular
-file extensions. In this case you can specify that the Coffee filter is
+file extensions. In this case you can specify that the ``coffee`` filter is
 applied to all ``.coffee`` files:
 
 .. configuration-block::

--- a/cookbook/assetic/asset_management.rst
+++ b/cookbook/assetic/asset_management.rst
@@ -352,7 +352,7 @@ in your source, you'll likely just see something like this:
 
 .. code-block:: html
 
-    <script src="/app_dev.php/js/abcd123.js"></script>
+    <script src="/js/abcd123.js"></script>
 
 Moreover, that file does **not** actually exist, nor is it dynamically rendered
 by Symfony (as the asset files are in the ``dev`` environment). This is on

--- a/cookbook/assetic/uglifyjs.rst
+++ b/cookbook/assetic/uglifyjs.rst
@@ -104,7 +104,7 @@ your javascripts:
     It should output a folder on your system, inside which you should find
     the UglifyJs executable.
 
-    If you installed UglifyJs locally, you can find the bin folder inside
+    If you installed UglifyJs locally, you can find the ``bin`` folder inside
     the ``node_modules`` folder. It's called ``.bin`` in this case.
 
 You now have access to the ``uglifyjs2`` filter in your application.
@@ -175,7 +175,7 @@ and :ref:`dump your assetic assets <cookbook-asetic-dump-prod>`.
 .. tip::
 
     Instead of adding the filter to the asset tags, you can also globally
-    enable it by adding the apply-to attribute to the filter configuration, for
+    enable it by adding the ``apply_to`` attribute to the filter configuration, for
     example in the ``uglifyjs2`` filter ``apply_to: "\.js$"``. To only have
     the filter applied in production, add this to the ``config_prod`` file
     rather than the common config file. For details on applying filters by

--- a/cookbook/assetic/yuicompressor.rst
+++ b/cookbook/assetic/yuicompressor.rst
@@ -156,9 +156,9 @@ apply this filter when debug mode is off.
 .. tip::
 
     Instead of adding the filter to the asset tags, you can also globally
-    enable it by adding the apply-to attribute to the filter configuration, for
-    example in the yui_js filter ``apply_to: "\.js$"``. To only have the filter
-    applied in production, add this to the config_prod file rather than the
+    enable it by adding the ``apply_to`` attribute to the filter configuration, for
+    example in the ``yui_js`` filter ``apply_to: "\.js$"``. To only have the filter
+    applied in production, add this to the ``config_prod`` file rather than the
     common config file. For details on applying filters by file extension,
     see :ref:`cookbook-assetic-apply-to`.
 

--- a/cookbook/bundles/best_practices.rst
+++ b/cookbook/bundles/best_practices.rst
@@ -56,7 +56,7 @@ class name.
 .. note::
 
     Symfony2 core Bundles do not prefix the Bundle class with ``Symfony``
-    and always add a ``Bundle`` subnamespace; for example:
+    and always add a ``Bundle`` sub-namespace; for example:
     :class:`Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle`.
 
 Each bundle has an alias, which is the lower-cased short version of the bundle

--- a/cookbook/bundles/extension.rst
+++ b/cookbook/bundles/extension.rst
@@ -70,7 +70,7 @@ The second method has several specific advantages:
 * Much more powerful than simply defining parameters: a specific option value
   might trigger the creation of many service definitions;
 
-* Ability to have configuration hierarchy
+* Ability to have configuration hierarchy;
 
 * Smart merging when several configuration files (e.g. ``config_dev.yml``
   and ``config.yml``) override each other's configuration;

--- a/cookbook/bundles/installation.rst
+++ b/cookbook/bundles/installation.rst
@@ -41,7 +41,7 @@ current development version of FOSUserBundle is ``"friendsofsymfony/user-bundle"
 Now you can add the bundle to your ``composer.json`` file and update the
 dependencies. You can do this manually:
 
-1. **Add it to the composer.json file:**
+1. **Add it to the ``composer.json`` file:**
 
    .. code-block:: json
 
@@ -137,7 +137,7 @@ Other Setup
 -----------
 
 At this point, check the ``README`` file of your brand new bundle to see
-what do to next.
+what to do next.
 
 .. _their documentation: http://getcomposer.org/doc/00-intro.md
 .. _Packagist:           https://packagist.org

--- a/cookbook/bundles/remove.rst
+++ b/cookbook/bundles/remove.rst
@@ -57,7 +57,7 @@ and ``_demo``. Remove all three of these entries.
 
 Some bundles contain configuration in one of the ``app/config/config*.yml``
 files. Be sure to remove the related configuration from these files. You can
-quickly spot bundle configuration by looking at a ``acme_demo`` (or whatever
+quickly spot bundle configuration by looking for a ``acme_demo`` (or whatever
 the name of the bundle is, e.g. ``fos_user`` for the ``FOSUserBundle``) string in
 the configuration files.
 

--- a/cookbook/configuration/apache_router.rst
+++ b/cookbook/configuration/apache_router.rst
@@ -45,14 +45,14 @@ Symfony2 to use the ``ApacheUrlMatcher`` instead of the default one:
 
     Note that :class:`Symfony\\Component\\Routing\\Matcher\\ApacheUrlMatcher`
     extends :class:`Symfony\\Component\\Routing\\Matcher\\UrlMatcher` so even
-    if you don't regenerate the url_rewrite rules, everything will work (because
+    if you don't regenerate the mod_rewrite rules, everything will work (because
     at the end of ``ApacheUrlMatcher::match()`` a call to ``parent::match()``
     is done).
 
 Generating mod_rewrite rules
 ----------------------------
 
-To test that it's working, let's create a very basic route for demo bundle:
+To test that it's working, let's create a very basic route for the AcmeDemoBundle:
 
 .. configuration-block::
 
@@ -77,7 +77,7 @@ To test that it's working, let's create a very basic route for demo bundle:
             '_controller' => 'AcmeDemoBundle:Demo:hello',
         )));
 
-Now generate **url_rewrite** rules:
+Now generate the mod_rewrite rules:
 
 .. code-block:: bash
 
@@ -95,7 +95,7 @@ Which should roughly output the following:
     RewriteCond %{REQUEST_URI} ^/hello/([^/]+?)$
     RewriteRule .* app.php [QSA,L,E=_ROUTING__route:hello,E=_ROUTING_name:%1,E=_ROUTING__controller:AcmeDemoBundle\:Demo\:hello]
 
-You can now rewrite `web/.htaccess` to use the new rules, so with this example
+You can now rewrite ``web/.htaccess`` to use the new rules, so with this example
 it should look like this:
 
 .. code-block:: apache
@@ -114,10 +114,10 @@ it should look like this:
 
 .. note::
 
-   Procedure above should be done each time you add/change a route if you want to take full advantage of this setup
+   The procedure above should be done each time you add/change a route if you want to take full advantage of this setup.
 
 That's it!
-You're now all set to use Apache Route rules.
+You're now all set to use Apache routes.
 
 Additional tweaks
 -----------------

--- a/cookbook/configuration/environments.rst
+++ b/cookbook/configuration/environments.rst
@@ -331,10 +331,10 @@ includes the following:
 * ``appDevDebugProjectContainer.php`` - the cached "service container" that
   represents the cached application configuration;
 
-* ``appdevUrlGenerator.php`` - the PHP class generated from the routing
+* ``appDevUrlGenerator.php`` - the PHP class generated from the routing
   configuration and used when generating URLs;
 
-* ``appdevUrlMatcher.php`` - the PHP class used for route matching - look
+* ``appDevUrlMatcher.php`` - the PHP class used for route matching - look
   here to see the compiled regular expression logic used to match incoming
   URLs to different routes;
 

--- a/cookbook/configuration/external_parameters.rst
+++ b/cookbook/configuration/external_parameters.rst
@@ -133,8 +133,8 @@ in the container. The following imports a file named ``parameters.php``.
     closure resources are all supported by the ``imports`` directive.
 
 In ``parameters.php``, tell the service container the parameters that you wish
-to set. This is useful when important configuration is in a nonstandard
-format. The example below includes a Drupal database's configuration in
+to set. This is useful when important configuration is in a non-standard
+format. The example below includes a Drupal database configuration in
 the Symfony service container.
 
 .. code-block:: php

--- a/cookbook/configuration/front_controllers_and_kernel.rst
+++ b/cookbook/configuration/front_controllers_and_kernel.rst
@@ -139,7 +139,7 @@ independently (for example, the admin UI, the frontend UI and database migration
 The Environments
 ----------------
 
-We just mentioned another method the ``AppKernel`` has to implement -
+As just mentioned, the ``AppKernel`` has to implement another method -
 :method:`Symfony\\Component\\HttpKernel\\KernelInterface::registerContainerConfiguration`.
 This method is responsible for loading the application's
 configuration from the right *environment*.

--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -15,10 +15,10 @@ To use it, you just need to change some parameters in ``config.yml`` (or the
 configuration format of your choice):
 
 .. versionadded:: 2.1
-    In Symfony2.1 the class and namespace are slightly modified. You can now
+    In Symfony 2.1 the class and namespace are slightly modified. You can now
     find the session storage classes in the `Session\\Storage` namespace:
     ``Symfony\Component\HttpFoundation\Session\Storage``. Also
-    note that in Symfony2.1 you should configure ``handler_id`` not ``storage_id`` like in Symfony2.0.
+    note that in Symfony 2.1 you should configure ``handler_id`` not ``storage_id`` like in Symfony 2.0.
     Below, you'll notice that ``%session.storage.options%`` is not used anymore.
 
 .. configuration-block::
@@ -134,7 +134,7 @@ database for the session data.
 
 But if you'd like to store the session data in the same database as the rest
 of your project's data, you can use the connection settings from the
-parameter.ini by referencing the database-related parameters defined there:
+``parameters.yml`` file by referencing the database-related parameters defined there:
 
 .. configuration-block::
 

--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -40,7 +40,7 @@ are:
 
     For performance reasons, you will probably want to set
     ``AllowOverride None`` and implement the rewrite rules in the ``web/.htaccess``
-    into the virtualhost config.
+    into the ``VirtualHost`` config.
 
 If you are using **php-cgi**, Apache does not pass HTTP basic username and
 password to PHP by default. To work around this limitation, you should use the
@@ -53,7 +53,7 @@ following configuration snippet:
 .. caution::
 
     In Apache 2.4, ``Order allow,deny`` has been replaced by ``Require all granted``,
-    and hence you need to modify your Directory permission settings as follows:
+    and hence you need to modify your ``Directory`` permission settings as follows:
 
         .. code-block:: apache
 

--- a/cookbook/console/console_command.rst
+++ b/cookbook/console/console_command.rst
@@ -5,8 +5,8 @@ How to create a Console Command
 ===============================
 
 The Console page of the Components section (:doc:`/components/console/introduction`) covers
-how to create a Console command. This cookbook article covers the differences
-when creating Console commands within the Symfony2 framework.
+how to create a console command. This cookbook article covers the differences
+when creating console commands within the Symfony2 framework.
 
 Automatically Registering Commands
 ----------------------------------

--- a/cookbook/console/logging.rst
+++ b/cookbook/console/logging.rst
@@ -184,7 +184,7 @@ method, where exception handling should happen:
     }
 
 In the code above, you disable exception catching so the parent ``run`` method
-will throw all exceptions. When an exception is caught, you simple log it by
+will throw all exceptions. When an exception is caught, you simply log it by
 accessing the ``logger`` service from the service container and then handle
 the rest of the logic in the same way that the parent ``run`` method does
 (specifically, since the parent :method:`run <Symfony\\Bundle\\FrameworkBundle\\Console\\Application::run>`
@@ -192,7 +192,7 @@ method will not handle exceptions rendering and status code handling when
 ``catchExceptions`` is set to false, it has to be done in the overridden
 method).
 
-For the extended Application class to work properly with in console shell mode,
+For the extended ``Application`` class to work properly with in console shell mode,
 you have to do a small trick to intercept the ``autoExit`` setter and store the
 setting in a different property, since the parent property is private.
 

--- a/cookbook/console/usage.rst
+++ b/cookbook/console/usage.rst
@@ -11,7 +11,7 @@ stack framework, some additional global options are available as well.
 By default, console commands run in the ``dev`` environment and you may want
 to change this for some commands. For example, you may want to run some commands
 in the ``prod`` environment for performance reasons. Also, the result of some commands
-will be different depending on the environment. for example, the ``cache:clear``
+will be different depending on the environment. For example, the ``cache:clear``
 command will clear and warm the cache for the specified environment only. To
 clear and warm the ``prod`` cache you need to run:
 

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -136,13 +136,6 @@ Instead, you can set the ``intercept_redirects`` option to ``true`` in the
 ``config_dev.yml`` file, which will cause the redirect to stop and allow
 you to open the report with details of the sent emails.
 
-.. tip::
-
-    Alternatively, you can open the profiler after the redirect and search
-    by the submit URL used on previous request (e.g. ``/contact/handle``).
-    The profiler's search feature allows you to load the profiler information
-    for any past requests.
-
 .. configuration-block::
 
     .. code-block:: yaml
@@ -171,3 +164,10 @@ you to open the report with details of the sent emails.
         $container->loadFromExtension('web_profiler', array(
             'intercept_redirects' => 'true',
         ));
+
+.. tip::
+
+    Alternatively, you can open the profiler after the redirect and search
+    by the submit URL used on the previous request (e.g. ``/contact/handle``).
+    The profiler's search feature allows you to load the profiler information
+    for any past requests.

--- a/cookbook/form/create_custom_field_type.rst
+++ b/cookbook/form/create_custom_field_type.rst
@@ -16,7 +16,7 @@ Defining the Field Type
 
 In order to create the custom field type, first you have to create the class
 representing the field. In this situation the class holding the field type
-will be called `GenderType` and the file will be stored in the default location
+will be called ``GenderType`` and the file will be stored in the default location
 for form fields, which is ``<BundleName>\Form\Type``. Make sure the field extends
 :class:`Symfony\\Component\\Form\\AbstractType`::
 

--- a/cookbook/form/create_form_type_extension.rst
+++ b/cookbook/form/create_form_type_extension.rst
@@ -178,7 +178,7 @@ database)::
 Your form type extension class will need to do two things in order to extend
 the ``file`` form type:
 
-#. Override the ``setDefaultOptions`` method in order to add an image_path
+#. Override the ``setDefaultOptions`` method in order to add an ``image_path``
    option;
 #. Override the ``buildForm`` and ``buildView`` methods in order to pass the image
    URL to the view.

--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -20,8 +20,8 @@ This is where Data Transformers come into play.
 Creating the Transformer
 ------------------------
 
-First, create an `IssueToNumberTransformer` class - this class will be responsible
-for converting to and from the issue number and the Issue object::
+First, create an ``IssueToNumberTransformer`` class - this class will be responsible
+for converting to and from the issue number and the ``Issue`` object::
 
     // src/Acme/TaskBundle/Form/DataTransformer/IssueToNumberTransformer.php
     namespace Acme\TaskBundle\Form\DataTransformer;
@@ -129,17 +129,16 @@ issue field in some form.
 
             public function setDefaultOptions(OptionsResolverInterface $resolver)
             {
-                $resolver->setDefaults(array(
-                    'data_class' => 'Acme\TaskBundle\Entity\Task',
-                ));
-
-                $resolver->setRequired(array(
-                    'em',
-                ));
-
-                $resolver->setAllowedTypes(array(
-                    'em' => 'Doctrine\Common\Persistence\ObjectManager',
-                ));
+                $resolver
+                    ->setDefaults(array(
+                        'data_class' => 'Acme\TaskBundle\Entity\Task',
+                    ))
+                    ->setRequired(array(
+                        'em',
+                    ))
+                    ->setAllowedTypes(array(
+                        'em' => 'Doctrine\Common\Persistence\ObjectManager',
+                    ));
 
                 // ...
             }
@@ -239,7 +238,7 @@ In the above example, you applied the transformer to a normal ``text`` field.
 This was easy, but has two downsides:
 
 1) You need to always remember to apply the transformer whenever you're adding
-a field for issue numbers
+a field for issue numbers.
 
 2) You need to worry about passing in the ``em`` option whenever you're creating
 a form that uses the transformer.

--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -83,9 +83,9 @@ flexibility to your forms.
 Adding An Event Subscriber To A Form Class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-So, instead of directly adding that "name" widget via your ProductType form
+So, instead of directly adding that "name" widget via your ``ProductType`` form
 class, let's delegate the responsibility of creating that particular field
-to an Event Subscriber::
+to an event subscriber::
 
     // src/Acme/DemoBundle/Form/Type/ProductType.php
     namespace Acme\DemoBundle\Form\Type;
@@ -237,7 +237,7 @@ done in the constructor::
 Customizing the Form Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Now that you have all the basics in place you an take advantage of the ``securityContext``
+Now that you have all the basics in place you can take advantage of the ``SecurityContext``
 and fill in the listener logic::
 
     // src/Acme/DemoBundle/FormType/FriendMessageFormType.php

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -239,7 +239,7 @@ When the user submits the form, the submitted data for the ``tags`` field are
 used to construct an ``ArrayCollection`` of ``Tag`` objects, which is then set
 on the ``tag`` field of the ``Task`` instance.
 
-The ``Tags`` collection is accessible naturally via ``$task->getTags()``
+The ``tags`` collection is accessible naturally via ``$task->getTags()``
 and can be persisted to the database or used however you need.
 
 So far, this works great, but this doesn't allow you to dynamically add new
@@ -412,7 +412,7 @@ one example:
 
 .. note::
 
-    It is better to separate your javascript in real JavaScript files than
+    It is better to separate your JavaScript in real JavaScript files than
     to write it inside the HTML as is done here.
 
 Now, each time a user clicks the ``Add a tag`` link, a new sub form will

--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -184,7 +184,7 @@ this folder.
 
     In this example, the customized fragment name is ``integer_widget`` because
     you want to override the HTML ``widget`` for all ``integer`` field types. If
-    you need to customize textarea fields, you would customize ``textarea_widget``.
+    you need to customize ``textarea`` fields, you would customize ``textarea_widget``.
 
     As you can see, the fragment name is a combination of the field type and
     which part of the field is being rendered (e.g. ``widget``, ``label``,
@@ -343,7 +343,7 @@ tell Symfony to use the theme via the ``setTheme`` helper method:
 
 .. code-block:: php
 
-    <?php $view['form']->setTheme($form, array('AcmeDemoBundle:Form')) ;?>
+    <?php $view['form']->setTheme($form, array('AcmeDemoBundle:Form')); ?>
 
     <?php $view['form']->widget($form['age']) ?>
 
@@ -424,7 +424,7 @@ Making Application-wide Customizations
 
 If you'd like a certain form customization to be global to your application,
 you can accomplish this by making the form customizations in an external
-template and then importing it inside your application configuration:
+template and then importing it inside your application configuration.
 
 Twig
 ~~~~
@@ -618,10 +618,11 @@ How to customize an Individual field
 
 So far, you've seen the different ways you can customize the widget output
 of all text field types. You can also customize individual fields. For example,
-suppose you have two ``text`` fields - ``first_name`` and ``last_name`` - but
-you only want to customize one of the fields. This can be accomplished by
-customizing a fragment whose name is a combination of the field id attribute and
-which part of the field is being customized. For example:
+suppose you have two ``text`` fields in a ``product`` form - ``name`` and
+``description`` - but you only want to customize one of the fields. This can be
+accomplished by customizing a fragment whose name is a combination of the field's
+``id`` attribute and which part of the field is being customized. For example, to
+customize the ``name`` field only:
 
 .. configuration-block::
 
@@ -900,7 +901,7 @@ Adding "help" messages
 
 You can also customize your form widgets to have an optional "help" message.
 
-In Twig, If you're making the form customization inside the same template as your
+In Twig, if you're making the form customization inside the same template as your
 form, modify the ``use`` tag and add the following:
 
 .. code-block:: html+jinja
@@ -915,7 +916,7 @@ form, modify the ``use`` tag and add the following:
         {% endif %}
     {% endblock %}
 
-In twig, If you're making the form customization inside a separate template, use
+In twig, if you're making the form customization inside a separate template, use
 the following:
 
 .. code-block:: html+jinja
@@ -969,7 +970,7 @@ Using Form Variables
 --------------------
 
 Most of the functions available for rendering different parts of a form (e.g.
-the form widget, form label, form errors, etc) also allow you to make certain
+the form widget, form label, form errors, etc.) also allow you to make certain
 customizations directly. Look at the following example:
 
 .. configuration-block::

--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -117,7 +117,7 @@ might look like this::
 
 To create your form correctly, you need to make the type available to the
 form factory in your test. The easiest way is to register it manually
-before creating the parent form using PreloadedExtension class::
+before creating the parent form using the ``PreloadedExtension`` class::
 
     // src/Acme/TestBundle/Tests/Form/Type/TestedTypeTests.php
     namespace Acme\TestBundle\Tests\Form\Type;

--- a/cookbook/logging/monolog.rst
+++ b/cookbook/logging/monolog.rst
@@ -10,7 +10,7 @@ inspired by the Python LogBook library.
 Usage
 -----
 
-To log a message simply get the logger service from the container in
+To log a message simply get the ``logger`` service from the container in
 your controller::
 
     public function indexAction()

--- a/cookbook/profiler/data_collector.rst
+++ b/cookbook/profiler/data_collector.rst
@@ -105,7 +105,7 @@ configuration, and tag it with ``data_collector``:
 Adding Web Profiler Templates
 -----------------------------
 
-When you want to display the data collected by your Data Collector in the web
+When you want to display the data collected by your data collector in the web
 debug toolbar or the web profiler, create a Twig template following this
 skeleton:
 
@@ -137,10 +137,17 @@ All blocks have access to the ``collector`` object.
 
 .. tip::
 
-    Built-in templates use a base64 encoded image for the toolbar (``<img
-    src="data:image/png;base64,..."``). You can easily calculate the
-    base64 value for an image with this little script: ``echo
-    base64_encode(file_get_contents($_SERVER['argv'][1]));``.
+    Built-in templates use a base64 encoded image for the toolbar:
+
+    .. code-block:: html
+        <img src="data:image/png;base64,..." />
+
+    You can easily calculate the base64 value for an image with this
+    little script::
+
+        #!/usr/bin/env php
+        <?php
+        echo base64_encode(file_get_contents($_SERVER['argv'][1]));
 
 To enable the template, add a ``template`` attribute to the ``data_collector``
 tag in your configuration. For example, assuming your template is in some

--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -668,7 +668,7 @@ the many-to-many relationship between ``acme_user`` and ``acme_role``. If
 you had one user linked to one role, your database might look something like
 this:
 
-.. code-block:: text
+.. code-block:: bash
 
     $ mysql> select * from acme_role;
     +----+-------+------------+
@@ -677,7 +677,7 @@ this:
     |  1 | admin | ROLE_ADMIN |
     +----+-------+------------+
 
-    mysql> select * from user_role;
+    $ mysql> select * from user_role;
     +---------+---------+
     | user_id | role_id |
     +---------+---------+

--- a/cookbook/security/remember_me.rst
+++ b/cookbook/security/remember_me.rst
@@ -61,7 +61,7 @@ remember me functionality, as it will not always be appropriate. The usual
 way of doing this is to add a checkbox to the login form. By giving the checkbox
 the name ``_remember_me``, the cookie will automatically be set when the checkbox
 is checked and the user successfully logs in. So, your specific login form
-might ultimately look like this:
+might ultimately looks like this:
 
 .. configuration-block::
 

--- a/cookbook/session/locale_sticky_session.rst
+++ b/cookbook/session/locale_sticky_session.rst
@@ -4,7 +4,7 @@
 Making the Locale "Sticky" during a User's Session
 ==================================================
 
-Prior to Symfony 2.1, the locale was stored in a session called ``_locale``.
+Prior to Symfony 2.1, the locale was stored in a session attribute called ``_locale``.
 Since 2.1, it is stored in the Request, which means that it's not "sticky"
 during a user's request. In this article, you'll learn how to make the locale
 of a user "sticky" so that once it's set, that same locale will be used for

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -572,7 +572,7 @@ Full Default Configuration
 
 
 .. versionadded:: 2.1
-    The ```framework.session.auto_start`` setting has been removed in Symfony2.1,
+    The ```framework.session.auto_start`` setting has been removed in Symfony 2.1,
     it will start on demand now.
 
 .. _`protocol-relative`: http://tools.ietf.org/html/rfc3986#section-4.2

--- a/reference/forms/types/options/data_timezone.rst.inc
+++ b/reference/forms/types/options/data_timezone.rst.inc
@@ -4,6 +4,6 @@ data_timezone
 **type**: ``string`` **default**: system default timezone
 
 Timezone that the input data is stored in. This must be one of the
-`PHP supported timezones`_
+`PHP supported timezones`_.
 
 .. _`PHP supported timezones`: http://php.net/manual/en/timezones.php

--- a/reference/forms/types/options/user_timezone.rst.inc
+++ b/reference/forms/types/options/user_timezone.rst.inc
@@ -4,6 +4,6 @@ user_timezone
 **type**: ``string`` **default**: system default timezone
 
 Timezone for how the data should be shown to the user (and therefore also
-the data that the user submits). This must be one of the `PHP supported timezones`_
+the data that the user submits). This must be one of the `PHP supported timezones`_.
 
 .. _`PHP supported timezones`: http://php.net/manual/en/timezones.php

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -18,7 +18,7 @@ Functions
 ---------
 
 .. versionadded:: 2.1
-    The ``csrf_token``, ``logout_path`` and ``logout_url`` functions were added in Symfony2.1
+    The ``csrf_token``, ``logout_path`` and ``logout_url`` functions were added in Symfony 2.1
 
 .. versionadded:: 2.2
     The ``render`` and ``controller`` functions are new in Symfony 2.2. Prior,
@@ -151,7 +151,7 @@ Tests
 -----
 
 .. versionadded:: 2.1
-    The ``selectedchoice`` test was added in Symfony2.1
+    The ``selectedchoice`` test was added in Symfony 2.1
 
 +---------------------------------------------------+------------------------------------------------------------------------------+
 | Test Syntax                                       | Usage                                                                        |


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | - |
| Applies to | 2.2 |
| Fixed tickets | - |

Please note that some changes only make sense in the context of the appropriate section. For instance, the description of form themes for individual form fields introduces an example with a `first_name` and a  `last_name` field, but what follows is code with a product's `name` field. Similarly, in an Assetic cookbook, the code for the prod environment shows a dev controller etc.
