### PR TITLE
Fix PHP requirement in installation documentation

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -20,8 +20,9 @@ Installing a Symfony2 Distribution
 .. tip::
 
     First, check that you have installed and configured a Web server (such
-    as Apache) with PHP 5.3.3 or higher. For more information on Symfony2
-    requirements, see the :doc:`requirements reference </reference/requirements>`.
+    as Apache) with PHP >= 5.3.3 (5.3.8 or higher being highly recommended). For
+    more information on Symfony2 requirements, see the
+    :doc:`requirements reference </reference/requirements>`.
 
 Symfony2 packages "distributions", which are fully-functional applications
 that include the Symfony2 core libraries, a selection of useful bundles, a

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -20,7 +20,7 @@ Installing a Symfony2 Distribution
 .. tip::
 
     First, check that you have installed and configured a Web server (such
-    as Apache) with PHP 5.3.8 or higher. For more information on Symfony2
+    as Apache) with PHP 5.3.3 or higher. For more information on Symfony2
     requirements, see the :doc:`requirements reference </reference/requirements>`.
 
 Symfony2 packages "distributions", which are fully-functional applications

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -20,8 +20,7 @@ Installing a Symfony2 Distribution
 .. tip::
 
     First, check that you have installed and configured a Web server (such
-    as Apache) with PHP >= 5.3.3 (5.3.8 or higher being highly recommended). For
-    more information on Symfony2 requirements, see the
+    as Apache) with PHP. For more information on Symfony2 requirements, see the
     :doc:`requirements reference </reference/requirements>`.
 
 Symfony2 packages "distributions", which are fully-functional applications

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -29,8 +29,6 @@ Required
     Be aware that Symfony2 has some known limitations when using PHP 5.3.8
     or below. For more information see the `Requirements section of the readme`_
 
-.. _`Requirements section of the readme`: https://github.com/symfony/symfony#requirements
-
 Optional
 --------
 
@@ -55,3 +53,5 @@ Doctrine
 If you want to use Doctrine, you will need to have PDO installed. Additionally,
 you need to have the PDO driver installed for the database server you want
 to use.
+
+.. _`Requirements section of the readme`: https://github.com/symfony/symfony#requirements

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -24,6 +24,13 @@ Required
 * ctype needs to be enabled
 * Your ``php.ini`` needs to have the ``date.timezone`` setting
 
+.. caution::
+
+    Be aware that Symfony2 has some known limitations when using PHP 5.3.8
+    or below. For more information see the `Requirements section of the readme`_
+
+.. _`Requirements section of the readme`: https://github.com/symfony/symfony#requirements
+
 Optional
 --------
 


### PR DESCRIPTION
Changed minimal PHP requirement from 5.3.8 to 5.3.3, as it's the version required in composer for symfony/symfony. If 5.3.8 (or higher) is the recommended one, I'll suggest to add a comment about it.
