### PR TITLE
DI-tags documentation should contain 'swiftmailer.default.plugin' tag instead of 'swiftmailer.plugin' to work

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -65,7 +65,7 @@ may also be tags in other bundles you use that aren't listed here.
 +-----------------------------------+---------------------------------------------------------------------------+
 | `serializer.normalizer`_          | Register a new normalizer in the ``serializer`` service                   |
 +-----------------------------------+---------------------------------------------------------------------------+
-| `swiftmailer.plugin`_             | Register a custom SwiftMailer Plugin                                      |
+| `swiftmailer.default.plugin`_     | Register a custom SwiftMailer Plugin                                      |
 +-----------------------------------+---------------------------------------------------------------------------+
 | `templating.helper`_              | Make your service available in PHP templates                              |
 +-----------------------------------+---------------------------------------------------------------------------+
@@ -833,14 +833,14 @@ and :class:`Symfony\\Component\\Serializer\\Normalizer\\DenormalizerInterface`.
 
 For more details, see :doc:`/cookbook/serializer`.
 
-swiftmailer.plugin
+swiftmailer.default.plugin
 ------------------
 
 **Purpose**: Register a custom SwiftMailer Plugin
 
 If you're using a custom SwiftMailer plugin (or want to create one), you can
 register it with SwiftMailer by creating a service for your plugin and tagging
-it with ``swiftmailer.plugin`` (it has no options).
+it with ``swiftmailer.default.plugin`` (it has no options).
 
 A SwiftMailer plugin must implement the ``Swift_Events_EventListener`` interface.
 For more information on plugins, see `SwiftMailer's Plugin Documentation`_.

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -834,7 +834,7 @@ and :class:`Symfony\\Component\\Serializer\\Normalizer\\DenormalizerInterface`.
 For more details, see :doc:`/cookbook/serializer`.
 
 swiftmailer.default.plugin
-------------------
+--------------------------
 
 **Purpose**: Register a custom SwiftMailer Plugin
 

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -840,9 +840,12 @@ swiftmailer.default.plugin
 
 If you're using a custom SwiftMailer plugin (or want to create one), you can
 register it with SwiftMailer by creating a service for your plugin and tagging
-it with ``swiftmailer.default.plugin`` (it has no options). ``default`` in this 
-tag is the name of the mailer. You should change it to the name of your mailer 
-in order to use this tag.
+it with ``swiftmailer.default.plugin`` (it has no options). 
+
+.. note::
+
+    ``default`` in this tag is the name of the mailer. You should change it to the
+    name of your mailer in order to use this tag.
 
 A SwiftMailer plugin must implement the ``Swift_Events_EventListener`` interface.
 For more information on plugins, see `SwiftMailer's Plugin Documentation`_.

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -840,7 +840,9 @@ swiftmailer.default.plugin
 
 If you're using a custom SwiftMailer plugin (or want to create one), you can
 register it with SwiftMailer by creating a service for your plugin and tagging
-it with ``swiftmailer.default.plugin`` (it has no options).
+it with ``swiftmailer.default.plugin`` (it has no options). ``default`` in this 
+tag is the name of the mailer. You should change it to the name of your mailer 
+in order to use this tag.
 
 A SwiftMailer plugin must implement the ``Swift_Events_EventListener`` interface.
 For more information on plugins, see `SwiftMailer's Plugin Documentation`_.


### PR DESCRIPTION
  SwiftMailer plugin works only if its service defined with tag 'swiftmailer.default.plugin' and does not work with tag 'swiftmailer.plugin' specified in documentation
