### PR TITLE
Fix EncryptedSessionProxy::read() code sample.

### DIFF
--- a/cookbook/session/proxy_examples.rst
+++ b/cookbook/session/proxy_examples.rst
@@ -39,7 +39,7 @@ and decrypt the session as required::
 
         public function read($id)
         {
-            $data = parent::write($id, $data);
+            $data = parent::read($id);
 
             return mcrypt_decrypt(\MCRYPT_3DES, $this->key, $data);
         }


### PR DESCRIPTION
This code sample mistakenly calls `parent::write` inside of the `read` method.
