### PR TITLE
Changed parameter container to request

### DIFF
--- a/cookbook/security/voters.rst
+++ b/cookbook/security/voters.rst
@@ -67,6 +67,9 @@ and compare the IP address against a set of blacklisted IP addresses:
 
     class ClientIpVoter implements VoterInterface
     {
+        protected $requestStack;
+        protected $blacklistedIp;
+        
         public function __construct(RequestStack $requestStack, array $blacklistedIp = array())
         {
             $this->requestStack  = $requestStack;

--- a/cookbook/security/voters.rst
+++ b/cookbook/security/voters.rst
@@ -61,15 +61,15 @@ and compare the IP address against a set of blacklisted IP addresses:
     // src/Acme/DemoBundle/Security/Authorization/Voter/ClientIpVoter.php
     namespace Acme\DemoBundle\Security\Authorization\Voter;
 
-    use Symfony\Component\DependencyInjection\ContainerInterface;
+    use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
     use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
     class ClientIpVoter implements VoterInterface
     {
-        public function __construct(ContainerInterface $container, array $blacklistedIp = array())
+        public function __construct(Request $request, array $blacklistedIp = array())
         {
-            $this->container     = $container;
+            $this->request       = $request;
             $this->blacklistedIp = $blacklistedIp;
         }
 
@@ -87,8 +87,7 @@ and compare the IP address against a set of blacklisted IP addresses:
 
         public function vote(TokenInterface $token, $object, array $attributes)
         {
-            $request = $this->container->get('request');
-            if (in_array($request->getClientIp(), $this->blacklistedIp)) {
+            if (in_array($this->request->getClientIp(), $this->blacklistedIp)) {
                 return VoterInterface::ACCESS_DENIED;
             }
 
@@ -124,7 +123,7 @@ and tag it as a "security.voter":
         services:
             security.access.blacklist_voter:
                 class:      Acme\DemoBundle\Security\Authorization\Voter\ClientIpVoter
-                arguments:  ["@service_container", [123.123.123.123, 171.171.171.171]]
+                arguments:  ["@request", [123.123.123.123, 171.171.171.171]]
                 public:     false
                 tags:
                     - { name: security.voter }
@@ -134,7 +133,7 @@ and tag it as a "security.voter":
         <!-- src/Acme/AcmeBundle/Resources/config/services.xml -->
         <service id="security.access.blacklist_voter"
                  class="Acme\DemoBundle\Security\Authorization\Voter\ClientIpVoter" public="false">
-            <argument type="service" id="service_container" strict="false" />
+            <argument type="service" id="request strict="false" />
             <argument type="collection">
                 <argument>123.123.123.123</argument>
                 <argument>171.171.171.171</argument>
@@ -151,7 +150,7 @@ and tag it as a "security.voter":
         $definition = new Definition(
             'Acme\DemoBundle\Security\Authorization\Voter\ClientIpVoter',
             array(
-                new Reference('service_container'),
+                new Reference('request'),
                 array('123.123.123.123', '171.171.171.171'),
             ),
         );

--- a/cookbook/security/voters.rst
+++ b/cookbook/security/voters.rst
@@ -133,7 +133,7 @@ and tag it as a "security.voter":
         <!-- src/Acme/AcmeBundle/Resources/config/services.xml -->
         <service id="security.access.blacklist_voter"
                  class="Acme\DemoBundle\Security\Authorization\Voter\ClientIpVoter" public="false">
-            <argument type="service" id="request strict="false" />
+            <argument type="service" id="request" strict="false" />
             <argument type="collection">
                 <argument>123.123.123.123</argument>
                 <argument>171.171.171.171</argument>


### PR DESCRIPTION
There is no need to pass @service_container to the voter, @request is enough.
