### PR TITLE
[WIP][Reference/Configuration/monolog.rst] "level" and "bubble" options are ignored when monolog handler type = "service"

### DIFF
--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -31,7 +31,7 @@ MonologBundle Configuration ("monolog")
 
                 # Default options and values for some "my_custom_handler" 
                 # Note: "level" and "bubble" options are not used when handler type is "service"
-                #    Those options must configured in the service definition.
+                #    Those options must be configured in the service definition.
                 my_custom_handler:
                     type:                 ~ # Required
                     id:                   ~

--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -30,6 +30,8 @@ MonologBundle Configuration ("monolog")
                     id:                  my_handler
 
                 # Default options and values for some "my_custom_handler" 
+                # Note: "level" and "bubble" options are not used when handler type is "service"
+                #    Those options must configured in the service definition.
                 my_custom_handler:
                     type:                 ~ # Required
                     id:                   ~


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | - |
