### PR TITLE
Fixed Typo and better example

### DIFF
--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -608,8 +608,11 @@ First, add a "delete this tag" link to each tag form:
 .. code-block:: javascript
 
     jQuery(document).ready(function() {
+        // Get the ul that holds the collection of tags
+        $collectionHolder = $('ul.tags');
+        
         // add a delete link to all of the existing tag form li elements
-        collectionHolder.find('li').each(function() {
+        $collectionHolder.find('li').each(function() {
             addTagFormDeleteLink($(this));
         });
 


### PR DESCRIPTION
There is a $ missing in the JS code.

I also added two lines from the referenced function, to make clear, that you do not have to add it at the beginning of this function but after the first two lines.
