### PR TITLE
Improve ISO references

### DIFF
--- a/book/translation.rst
+++ b/book/translation.rst
@@ -22,8 +22,8 @@ into the language of the user::
 
     The term *locale* refers roughly to the user's language and country. It
     can be any string that your application uses to manage translations and
-    other format differences (e.g. currency format). The `ISO639-1`_
-    *language* code, an underscore (``_``), then the `ISO3166 Alpha-2`_
+    other format differences (e.g. currency format). The `ISO 639-1`_
+    *language* code, an underscore (``_``), then the `ISO 3166-1 alpha-2`_
     *country* code (e.g. ``fr_FR`` for French/France) is recommended.
 
 In this chapter, you'll learn how to use the Translation component in the
@@ -673,6 +673,6 @@ steps:
   be set on the user's session.
 
 .. _`i18n`: http://en.wikipedia.org/wiki/Internationalization_and_localization
-.. _`ISO3166 Alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
-.. _`ISO639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+.. _`ISO 3166-1 alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
+.. _`ISO 639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 .. _`Translatable Extension`: https://github.com/l3pp4rd/DoctrineExtensions

--- a/components/translation/introduction.rst
+++ b/components/translation/introduction.rst
@@ -45,8 +45,8 @@ The constructor of the ``Translator`` class needs one argument: The locale.
 
     The term *locale* refers roughly to the user's language and country. It
     can be any string that your application uses to manage translations and
-    other format differences (e.g. currency format). The `ISO639-1`_
-    *language* code, an underscore (``_``), then the `ISO3166 Alpha-2`_
+    other format differences (e.g. currency format). The `ISO 639-1`_
+    *language* code, an underscore (``_``), then the `ISO 3166-1 alpha-2`_
     *country* code (e.g. ``fr_FR`` for French/France) is recommended.
 
 .. _component-translator-message-catalogs:
@@ -206,5 +206,5 @@ Usage
 Read how to use the Translation component in :doc:`/components/translation/usage`.
 
 .. _Packagist: https://packagist.org/packages/symfony/translation
-.. _`ISO3166 Alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
-.. _`ISO639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+.. _`ISO 3166-1 alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
+.. _`ISO 639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

--- a/reference/constraints/Country.rst
+++ b/reference/constraints/Country.rst
@@ -1,7 +1,7 @@
 Country
 =======
 
-Validates that a value is a valid two-letter country code.
+Validates that a value is a valid `ISO 3166-1 alpha-2`_ country code.
 
 +----------------+------------------------------------------------------------------------+
 | Applies to     | :ref:`property or method <validation-property-target>`                 |
@@ -81,3 +81,5 @@ message
 **type**: ``string`` **default**: ``This value is not a valid country.``
 
 This message is shown if the string is not a valid country code.
+
+.. _`ISO 3166-1 alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes

--- a/reference/constraints/Language.rst
+++ b/reference/constraints/Language.rst
@@ -1,7 +1,8 @@
 Language
 ========
 
-Validates that a value is a valid `ISO 639-1`_ language code.
+Validates that a value is a valid language *Unicode language identifier*
+(e.g. ``fr`` or ``zh-Hant``).
 
 +----------------+------------------------------------------------------------------------+
 | Applies to     | :ref:`property or method <validation-property-target>`                 |
@@ -81,5 +82,3 @@ message
 **type**: ``string`` **default**: ``This value is not a valid language.``
 
 This message is shown if the string is not a valid language code.
-
-.. _`ISO 639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

--- a/reference/constraints/Language.rst
+++ b/reference/constraints/Language.rst
@@ -1,7 +1,7 @@
 Language
 ========
 
-Validates that a value is a valid language code.
+Validates that a value is a valid `ISO 639-1`_ language code.
 
 +----------------+------------------------------------------------------------------------+
 | Applies to     | :ref:`property or method <validation-property-target>`                 |
@@ -81,3 +81,5 @@ message
 **type**: ``string`` **default**: ``This value is not a valid language.``
 
 This message is shown if the string is not a valid language code.
+
+.. _`ISO 639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -3,9 +3,9 @@ Locale
 
 Validates that a value is a valid locale.
 
-The "value" for each locale is either the two letter ISO639-1 *language* code
+The "value" for each locale is either the two letter `ISO 639-1`_ *language* code
 (e.g. ``fr``), or the language code followed by an underscore (``_``), then
-the ISO3166 *country* code (e.g. ``fr_FR`` for French/France).
+the `ISO 3166-1 alpha-2`_ *country* code (e.g. ``fr_FR`` for French/France).
 
 +----------------+------------------------------------------------------------------------+
 | Applies to     | :ref:`property or method <validation-property-target>`                 |
@@ -85,3 +85,6 @@ message
 **type**: ``string`` **default**: ``This value is not a valid locale.``
 
 This message is shown if the string is not a valid locale.
+
+.. _`ISO 639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+.. _`ISO 3166-1 alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -8,9 +8,10 @@ The ``locale`` type is a subset of the ``ChoiceType`` that allows the user
 to select from a large list of locales (language+country). As an added bonus,
 the locale names are displayed in the language of the user.
 
-The "value" for each locale is either the two letter ISO639-1 *language* code
-(e.g. ``fr``), or the language code followed by an underscore (``_``), then
-the ISO3166 *country* code (e.g. ``fr_FR`` for French/France).
+The "value" for each locale is either the two letter `ISO 639-1`_ *language*
+code (e.g. ``fr``), or the language code followed by an underscore (``_``),
+then the `ISO 3166-1 alpha-2`_ *country* code (e.g. ``fr_FR``
+for French/France).
 
 .. note::
 
@@ -85,3 +86,6 @@ These options inherit from the :doc:`form </reference/forms/types/form>` type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/mapped.rst.inc
+
+.. _`ISO 639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+.. _`ISO 3166-1 alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | - |

Fix notations according to http://www.iso.org:
- add missing space between _ISO_ and the number
- _Alpha-2_ > _alpha-2_

Constraints and Fields:
- _Country_ & _Locale_ contraint and _locale_ field type: Add ISO references and Wikipedia links
- _Language_ constraint: add _Unicode language identifier_ hint as for the _language_ field type

If anyone knows an official link to a listing of the _Unicode language identifiers_, please let me know.
