### PR TITLE
[Cookbook][Forms] Add Asterisk alternative using CSS

### DIFF
--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -896,6 +896,17 @@ original template:
 
     See :ref:`cookbook-form-theming-methods` for how to apply this customization.
 
+.. tip::
+
+    Labels of required fields are rendered with a CSS class called ``required``
+    by default. You can use it to add an Asterisk using CSS only:
+
+    .. code-block:: css
+
+        label.required:before {
+            content: "* ";
+        }
+
 Adding "help" messages
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -896,10 +896,10 @@ original template:
 
     See :ref:`cookbook-form-theming-methods` for how to apply this customization.
 
-.. tip::
+.. sidebar:: Using CSS only
 
-    Labels of required fields are rendered with a CSS class called ``required``
-    by default. You can use it to add an Asterisk using CSS only:
+    By default, ``label`` tags of required fields are rendered with a
+    ``required`` CSS class. Thus, you can also add an Asterisk using CSS only:
 
     .. code-block:: css
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | all |
| Fixed tickets | - |

Add tip for simple alternative to prefix required field labels with an Asterisk using CSS only.
