### PR TITLE
Mini fixes

### DIFF
--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -41,9 +41,9 @@ You can also render each of the three parts of the field individually:
     .. code-block:: php
 
         <div>
-            <?php echo $view['form']->label($form['age']) }} ?>
-            <?php echo $view['form']->errors($form['age']) }} ?>
-            <?php echo $view['form']->widget($form['age']) }} ?>
+            <?php echo $view['form']->label($form['age']); ?>
+            <?php echo $view['form']->errors($form['age']); ?>
+            <?php echo $view['form']->widget($form['age']); ?>
         </div>
 
 In both cases, the form label, errors and HTML widget are rendered by using
@@ -71,7 +71,7 @@ just one line:
 
     .. code-block:: php
 
-        <?php echo $view['form']->widget($form) }} ?>
+        <?php echo $view['form']->widget($form); ?>
 
 The remainder of this recipe will explain how every part of the form's markup
 can be modified at several different levels. For more information about form
@@ -645,7 +645,6 @@ which part of the field is being customized. For example:
         <?php echo $view['form']->widget($form['name']); ?>
 
         <!-- src/Acme/DemoBundle/Resources/views/Form/_product_name_widget.html.php -->
-
         <div class="text_widget">
               echo $view['form']->block('form_widget_simple') ?>
         </div>
@@ -666,6 +665,8 @@ You can also override the markup for an entire field row using the same method:
 
     .. code-block:: html+jinja
 
+        {% form_theme form _self %}
+
         {% block _product_name_row %}
             <div class="name_row">
                 {{ form_label(form) }}
@@ -674,10 +675,16 @@ You can also override the markup for an entire field row using the same method:
             </div>
         {% endblock %}
 
+        {{ form_row(form.name) }}
+
     .. code-block:: html+php
 
-        <!-- _product_name_row.html.php -->
+        <!-- Main template -->
+        <?php echo $view['form']->setTheme($form, array('AcmeDemoBundle:Form')); ?>
 
+        <?php echo $view['form']->row($form['name']); ?>
+
+        <!-- src/Acme/DemoBundle/Resources/views/Form/_product_name_row.html.php -->
         <div class="name_row">
             <?php echo $view['form']->label($form) ?>
             <?php echo $view['form']->errors($form) ?>

--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -666,9 +666,6 @@ You can also override the markup for an entire field row using the same method:
 
     .. code-block:: html+jinja
 
-        {# _product_name_row.html.twig #}
-        {% form_theme form _self %}
-
         {% block _product_name_row %}
             <div class="name_row">
                 {{ form_label(form) }}

--- a/cookbook/logging/monolog.rst
+++ b/cookbook/logging/monolog.rst
@@ -46,8 +46,8 @@ The basic handler is the ``StreamHandler`` which writes logs in a stream
 Monolog comes also with a powerful built-in handler for the logging in
 prod environment: ``FingersCrossedHandler``. It allows you to store the
 messages in a buffer and to log them only if a message reaches the
-action level (ERROR in the configuration provided in the standard
-edition) by forwarding the messages to another handler.
+action level (``error`` in the configuration provided in the Standard
+Edition) by forwarding the messages to another handler.
 
 Using several handlers
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
| Fixed tickets | - |

_form_customization_
Preceding code lines are not related to what the code demonstrates: Twig blocks do not need to be defined in separate files; the file does not hold a form, so importing a theme is confusing

_monolog_
Standard Edition uses lowercase `error` value in `config_prod.yml`
