### PR TITLE
[Cookbook] Fixes a link to the Request class

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -785,7 +785,7 @@ variables that are passed into the expression:
 
 * ``context``: An instance of :class:`Symfony\\Component\\Routing\\RequestContext`,
   which holds the most fundamental information about the route being matched;
-* ``request``: The Symfony :class:`Symfony\\Component\\HttpFoundation\\Request``
+* ``request``: The Symfony :class:`Symfony\\Component\\HttpFoundation\\Request`
   object (see :ref:`component-http-foundation-request`).
 
 .. caution::


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4+ |
| Fixed tickets | - |

This quick fix applies to the functionality introduced in Symfony 2.4, therefore request is to 2.4 branch.
