### PR TITLE
[Components][Console] Fix askConfirmation() description

### DIFF
--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -33,9 +33,10 @@ the following to your command::
 
 In this case, the user will be asked "Continue with this action?", and will
 return ``true`` if the user answers with ``y`` or ``false`` if the user answers
-with ``n``. The third argument to ``askConfirmation`` is the default value to
-return if the user doesn't enter any input. Any other input will ask the same
-question again.
+with ``n``. The third argument to
+:method:`Symfony\\Component\\Console\\Helper\\DialogHelper::askConfirmation`
+is the default value to return if the user doesn't enter any input. Any other
+input will ask the same question again.
 
 Asking the User for Information
 -------------------------------

--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -31,10 +31,11 @@ the following to your command::
         return;
     }
 
-In this case, the user will be asked "Continue with this action?", and will return
-``true`` if the user answers with ``y`` or false in any other case. The third
-argument to ``askConfirmation`` is the default value to return if the user doesn't
-enter any input.
+In this case, the user will be asked "Continue with this action?", and will
+return ``true`` if the user answers with ``y`` or ``false`` if the user answers
+with ``n``. The third argument to ``askConfirmation`` is the default value to
+return if the user doesn't enter any input. Any other input will ask the same
+question again.
 
 Asking the User for Information
 -------------------------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

`askConfirmation()` only terminates on entering `y`, `n` or nothing. API link added.
