### PR TITLE
Removed all occurences of $this->getRequest()

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -562,8 +562,6 @@ Accessing other Services
 When extending the base controller class, you can access any Symfony2 service
 via the ``get()`` method. Here are several common services you might need::
 
-    $request = $this->getRequest();
-
     $templating = $this->get('templating');
 
     $router = $this->get('router');
@@ -632,16 +630,26 @@ by using the native PHP sessions.
 Storing and retrieving information from the session can be easily achieved
 from any controller::
 
-    $session = $this->getRequest()->getSession();
+    use Symfony\Component\HttpFoundation\Request;
 
-    // store an attribute for reuse during a later user request
-    $session->set('foo', 'bar');
+    public function indexAction(Request $request)
+    {
+        $session = $request->getSession();
 
-    // in another controller for another request
-    $foo = $session->get('foo');
+        // store an attribute for reuse during a later user request
+        $session->set('foo', 'bar');
 
-    // use a default value if the key doesn't exist
-    $filters = $session->get('filters', array());
+        // in another controller for another request
+        $foo = $session->get('foo');
+
+
+        // use a default value if the key doesn't exist
+        $filters = $session->get('filters', array());
+
+        // set the user locale
+        $session->setLocale('fr');
+    }
+
 
 These attributes will remain on the user for the remainder of that user's
 session.
@@ -659,11 +667,13 @@ These types of messages are called "flash" messages.
 
 For example, imagine you're processing a form submit::
 
-    public function updateAction()
+    use Symfony\Component\HttpFoundation\Request;
+
+    public function updateAction(Request $request)
     {
         $form = $this->createForm(...);
 
-        $form->bind($this->getRequest());
+        $form->bind($request);
         if ($form->isValid()) {
             // do some sort of processing
 
@@ -744,17 +754,21 @@ The Request Object
 ------------------
 
 Besides the values of the routing placeholders, the controller also has access
-to the ``Request`` object when extending the base ``Controller`` class::
+to the ``Request`` object. The framework injects the ``Request`` object in the
+controller if a variable is type hinted with
+`Symfony\Component\HttpFoundation\Request`::
 
-    $request = $this->getRequest();
+    public function indexAction(Request $request)
+    {
+        $request->isXmlHttpRequest(); // is it an Ajax request?
 
-    $request->isXmlHttpRequest(); // is it an Ajax request?
+        $request->getPreferredLanguage(array('en', 'fr'));
 
-    $request->getPreferredLanguage(array('en', 'fr'));
+        $request->query->get('page'); // get a $_GET parameter
 
-    $request->query->get('page'); // get a $_GET parameter
+        $request->request->get('page'); // get a $_POST parameter
 
-    $request->request->get('page'); // get a $_POST parameter
+    }
 
 Like the ``Response`` object, the request headers are stored in a ``HeaderBag``
 object and are easily accessible.

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -1581,7 +1581,7 @@ an array.
     You can also access POST values (in this case "name") directly through
     the request object, like so::
 
-        $this->get('request')->request->get('name');
+        $request->get('name');
 
     Be advised, however, that in most cases using the getData() method is
     a better choice, since it returns the data (usually an object) after

--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -557,12 +557,14 @@ each ``ETag`` must be unique across all representations of the same resource.
 
 To see a simple implementation, generate the ETag as the md5 of the content::
 
-    public function indexAction()
+    use Symfony\Component\HttpFoundation\Request;
+
+    public function indexAction(Request $request)
     {
         $response = $this->render('MyBundle:Main:index.html.twig');
         $response->setETag(md5($response->getContent()));
         $response->setPublic(); // make sure the response is public/cacheable
-        $response->isNotModified($this->getRequest());
+        $response->isNotModified($request);
 
         return $response;
     }
@@ -604,7 +606,9 @@ For instance, you can use the latest update date for all the objects needed to
 compute the resource representation as the value for the ``Last-Modified``
 header value::
 
-    public function showAction($articleSlug)
+    use Symfony\Component\HttpFoundation\Request;
+
+    public function showAction(Request $request, $articleSlug)
     {
         // ...
 
@@ -617,7 +621,7 @@ header value::
         // Set response as public. Otherwise it will be private by default.
         $response->setPublic();
 
-        if ($response->isNotModified($this->getRequest())) {
+        if ($response->isNotModified($request)) {
             return $response;
         }
 
@@ -653,8 +657,9 @@ the better. The ``Response::isNotModified()`` method does exactly that by
 exposing a simple and efficient pattern::
 
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpFoundation\Request;
 
-    public function showAction($articleSlug)
+    public function showAction(Request $request, $articleSlug)
     {
         // Get the minimum information to compute
         // the ETag or the Last-Modified value
@@ -671,7 +676,7 @@ exposing a simple and efficient pattern::
         $response->setPublic();
 
         // Check that the Response is not modified for the given Request
-        if ($response->isNotModified($this->getRequest())) {
+        if ($response->isNotModified($request)) {
             // return the 304 Response immediately
             return $response;
         } else {

--- a/book/security.rst
+++ b/book/security.rst
@@ -425,13 +425,13 @@ Next, create the controller that will display the login form::
     namespace Acme\SecurityBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\Security\Core\SecurityContext;
 
     class SecurityController extends Controller
     {
-        public function loginAction()
+        public function loginAction(Request $request)
         {
-            $request = $this->getRequest();
             $session = $request->getSession();
 
             // get the login error if there is one

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1403,9 +1403,11 @@ In many cases, you may want to allow a single controller to render multiple
 different formats based on the "request format". For that reason, a common
 pattern is to do the following::
 
-    public function indexAction()
+    use Symfony\Component\HttpFoundation\Request;
+
+    public function indexAction(Request $request)
     {
-        $format = $this->getRequest()->getRequestFormat();
+        $format = $request->getRequestFormat();
 
         return $this->render('AcmeBlogBundle:Blog:index.'.$format.'.twig');
     }

--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -202,7 +202,7 @@ rules::
         class Document
         {
             // ...
-            
+
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
                 $metadata->addPropertyConstraint('file', new Assert\File(array(
@@ -222,12 +222,13 @@ The following controller shows you how to handle the entire process::
     // ...
     use Acme\DemoBundle\Entity\Document;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+    use Symfony\Component\HttpFoundation\Request;
     // ...
 
     /**
      * @Template()
      */
-    public function uploadAction()
+    public function uploadAction(Request $request)
     {
         $document = new Document();
         $form = $this->createFormBuilder($document)
@@ -236,8 +237,8 @@ The following controller shows you how to handle the entire process::
             ->getForm()
         ;
 
-        if ($this->getRequest()->isMethod('POST')) {
-            $form->bind($this->getRequest());
+        if ($request->isMethod('POST')) {
+            $form->bind($request);
             if ($form->isValid()) {
                 $em = $this->getDoctrine()->getManager();
 

--- a/cookbook/doctrine/registration_form.rst
+++ b/cookbook/doctrine/registration_form.rst
@@ -258,13 +258,15 @@ and its template:
 Finally, create the controller which handles the form submission.  This performs
 the validation and saves the data into the database::
 
-    public function createAction()
+    use Symfony\Component\HttpFoundation\Request;
+
+    public function createAction(Request $request)
     {
         $em = $this->getDoctrine()->getEntityManager();
 
         $form = $this->createForm(new RegistrationType(), new Registration());
 
-        $form->bind($this->getRequest());
+        $form->bind($request);
 
         if ($form->isValid()) {
             $registration = $form->getData();

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -691,7 +691,7 @@ the relationship between the removed ``Tag`` and ``Task`` object.
             $editForm = $this->createForm(new TaskType(), $task);
 
             if ($request->isMethod('POST')) {
-                $editForm->bind($this->getRequest());
+                $editForm->bind($request);
 
                 if ($editForm->isValid()) {
 

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -90,17 +90,22 @@ Getting information from the Request
 ------------------------------------
 
 Besides the values of the routing placeholders, the controller also has access
-to the ``Request`` object::
+to the ``Request`` object. The framework injects the ``Request`` object in the
+controller if a variable is type hinted with
+`Symfony\Component\HttpFoundation\Request`::
 
-    $request = $this->getRequest();
+    use Symfony\Component\HttpFoundation\Request;
 
-    $request->isXmlHttpRequest(); // is it an Ajax request?
+    public function indexAction(Request $request)
+    {
+        $request->isXmlHttpRequest(); // is it an Ajax request?
 
-    $request->getPreferredLanguage(array('en', 'fr'));
+        $request->getPreferredLanguage(array('en', 'fr'));
 
-    $request->query->get('page'); // get a $_GET parameter
+        $request->query->get('page'); // get a $_GET parameter
 
-    $request->request->get('page'); // get a $_POST parameter
+        $request->request->get('page'); // get a $_POST parameter
+    }
 
 In a template, you can also access the ``Request`` object via the
 ``app.request`` variable:
@@ -122,16 +127,18 @@ by using native PHP sessions.
 Storing and retrieving information from the session can be easily achieved
 from any controller::
 
-    $session = $this->getRequest()->getSession();
+    use Symfony\Component\HttpFoundation\Request;
 
-    // store an attribute for reuse during a later user request
-    $session->set('foo', 'bar');
+    public function indexAction(Request $request)
+    {
+        $session = $request->getSession();
 
-    // in another controller for another request
-    $foo = $session->get('foo');
+        // store an attribute for reuse during a later user request
+        $session->set('foo', 'bar');
 
-    // use a default value if the key doesn't exist
-    $filters = $session->get('filters', array());
+        // use a default value if the key doesn't exist
+        $filters = $session->get('filters', array());
+    }
 
 You can also store small messages that will only be available for the very
 next request::


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | 2.1 |
| Fixed tickets | - |

Hello. 

The request is a data object, and so the request should not be
inside the container. That's why the request will be removed
from the container in Symfony 3.0

So it is better to let the HttpKernel injects the request when
the user want to use the request.

More over, it is faster. The HttpKernel will always check if the
request should be injected. So injecting the request is time constant.
However, retrieve the request from the container will execute more
calls.

**Note:** I don't know how to deal with all branches. I did (only on my laptop, not pushed yet) the patch for all branches. This patch is not mergeable without conflicts in 2.2. And it is the same for next branches (because of form chapter). What do you want I do ? Should I open a PR per branches ?

**Note2:** I just realized I started by the branch 2.1. If you want can I can push all my code, and then you can easily cherry-pick my commits.
