### PR TITLE
[Components][HttpKernel] Add FINISH_REQUEST to events overview table

### DIFF
--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -569,21 +569,23 @@ each event has their own event object:
 
 .. _component-http-kernel-event-table:
 
-+-------------------+-------------------------------+-------------------------------------------------------------------------------------+
-| **Name**          | ``KernelEvents`` **Constant** | **Argument passed to the listener**                                                 |
-+-------------------+-------------------------------+-------------------------------------------------------------------------------------+
-| kernel.request    | ``KernelEvents::REQUEST``     | :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent`                    |
-+-------------------+-------------------------------+-------------------------------------------------------------------------------------+
-| kernel.controller | ``KernelEvents::CONTROLLER``  | :class:`Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent`               |
-+-------------------+-------------------------------+-------------------------------------------------------------------------------------+
-| kernel.view       | ``KernelEvents::VIEW``        | :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForControllerResultEvent` |
-+-------------------+-------------------------------+-------------------------------------------------------------------------------------+
-| kernel.response   | ``KernelEvents::RESPONSE``    | :class:`Symfony\\Component\\HttpKernel\\Event\\FilterResponseEvent`                 |
-+-------------------+-------------------------------+-------------------------------------------------------------------------------------+
-| kernel.terminate  | ``KernelEvents::TERMINATE``   | :class:`Symfony\\Component\\HttpKernel\\Event\\PostResponseEvent`                   |
-+-------------------+-------------------------------+-------------------------------------------------------------------------------------+
-| kernel.exception  | ``KernelEvents::EXCEPTION``   | :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent`        |
-+-------------------+-------------------------------+-------------------------------------------------------------------------------------+
++-----------------------+----------------------------------+-------------------------------------------------------------------------------------+
+| **Name**              | ``KernelEvents`` **Constant**    | **Argument passed to the listener**                                                 |
++-----------------------+----------------------------------+-------------------------------------------------------------------------------------+
+| kernel.request        | ``KernelEvents::REQUEST``        | :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent`                    |
++-----------------------+----------------------------------+-------------------------------------------------------------------------------------+
+| kernel.controller     | ``KernelEvents::CONTROLLER``     | :class:`Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent`               |
++-----------------------+----------------------------------+-------------------------------------------------------------------------------------+
+| kernel.view           | ``KernelEvents::VIEW``           | :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForControllerResultEvent` |
++-----------------------+----------------------------------+-------------------------------------------------------------------------------------+
+| kernel.response       | ``KernelEvents::RESPONSE``       | :class:`Symfony\\Component\\HttpKernel\\Event\\FilterResponseEvent`                 |
++-----------------------+----------------------------------+-------------------------------------------------------------------------------------+
+| kernel.finish_request | ``KernelEvents::FINISH_REQUEST`` | :class:`Symfony\\Component\\HttpKernel\\Event\\FinishRequestEvent`                  |
++-----------------------+----------------------------------+-------------------------------------------------------------------------------------+
+| kernel.terminate      | ``KernelEvents::TERMINATE``      | :class:`Symfony\\Component\\HttpKernel\\Event\\PostResponseEvent`                   |
++-----------------------+----------------------------------+-------------------------------------------------------------------------------------+
+| kernel.exception      | ``KernelEvents::EXCEPTION``      | :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent`        |
++-----------------------+----------------------------------+-------------------------------------------------------------------------------------+
 
 .. _http-kernel-working-example:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony#8904) |
| Applies to | 2.4+ |
| Fixed tickets | #2959 |

It's not the whole doc for the event, but I've started by adding it to the events overview table, it needed a reformatting because of the long name.
