### PR TITLE
Updated required PHPUnit version

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -7,7 +7,7 @@ Symfony2 test suite to check that you have not broken anything.
 PHPUnit
 -------
 
-To run the Symfony2 test suite, `install`_ PHPUnit 3.6.4 or later first:
+To run the Symfony2 test suite, `install`_ PHPUnit 3.7.28 or later first:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Running tests on version 3.6.4 ends with following error:

```
PHP Fatal error: Call to undefined method Symfony\Component\Form\Tests\SimpleFormTest::callback() in symfony/src/Symfony/Component/Form/Tests/SimpleFormTest.php on line 107
```
