### PR TITLE
Typo in "methods" requirement

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -654,12 +654,12 @@ be accomplished with the following route configuration:
         contact:
             path:     /contact
             defaults: { _controller: AcmeDemoBundle:Main:contact }
-            methods:  [GET]
+            methods:  GET
 
         contact_process:
             path:     /contact
             defaults: { _controller: AcmeDemoBundle:Main:contactProcess }
-            methods:  [POST]
+            methods:  POST
 
     .. code-block:: xml
 


### PR DESCRIPTION
Routing requirement for "methods" must be a string.
