### PR TITLE
Fix renderer option when embedding an ESI in a PHP template.

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -904,12 +904,12 @@ matter), Symfony2 uses the standard ``render`` helper to configure ESI tags:
 
         <?php echo $view['actions']->render(
             new ControllerReference('...:news', array('max' => 5)),
-            array('renderer' => 'esi'))
+            array('strategy' => 'esi'))
         ?>
 
         <?php echo $view['actions']->render(
             $view['router']->generate('latest_news', array('max' => 5), true),
-            array('renderer' => 'esi'),
+            array('strategy' => 'esi'),
         ) ?>
 
 By using the ``esi`` renderer (via the ``render_esi`` Twig function), you


### PR DESCRIPTION
Hi!
I think I found an error on the Cache documentation regarding ESI fragments in PHP templates. While I couldn't make it to work using array('renderer' => 'esi') as documented, I found out it works with array('strategy' => 'esi').
