### PR TITLE
Incorrect code: useIncludePath()

### DIFF
--- a/components/class_loader/class_loader.rst
+++ b/components/class_loader/class_loader.rst
@@ -31,7 +31,7 @@ is straightforward::
     $loader = new ClassLoader();
 
     // to enable searching the include path (eg. for PEAR packages)
-    $loader->useIncludePath(true);
+    $loader->setUseIncludePath(true);
 
     // ... register namespaces and prefixes here - see below
 


### PR DESCRIPTION
Docs of v2.2 and later not in sync with code from v2.2 and later. See: https://github.com/symfony/ClassLoader/blob/2.2/ClassLoader.php#L108
