### PR TITLE
Move curly bracket to be on the same line

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -560,8 +560,7 @@ The Crawler can extract information from the nodes::
     $info = $crawler->extract(array('_text', 'href'));
 
     // Executes a lambda for each node and return an array of results
-    $data = $crawler->each(function ($node, $i)
-    {
+    $data = $crawler->each(function ($node, $i) {
         return $node->attr('href');
     });
 


### PR DESCRIPTION
This makes PSR coding standard to pass and also gives more consistency between examples (as curly brackets are on the same line).
