### PR TITLE
Fix broken links in form cookbook about submit()

### DIFF
--- a/cookbook/form/direct_submit.rst
+++ b/cookbook/form/direct_submit.rst
@@ -45,9 +45,9 @@ Calling Form::submit() manually
 
 In some cases, you want better control over when exactly your form is submitted
 and what data is passed to it. Instead of using the
-:method:`Symfony\Component\Form\FormInterface::handleRequest`
+:method:`Symfony\\Component\\Form\\FormInterface::handleRequest`
 method, pass the submitted data directly to
-:method:`Symfony\Component\Form\FormInterface::submit`::
+:method:`Symfony\\Component\Form\\FormInterface::submit`::
 
     use Symfony\Component\HttpFoundation\Request;
     // ...
@@ -76,8 +76,8 @@ method, pass the submitted data directly to
 .. tip::
 
     Forms consisting of nested fields expect an array in
-    :method:`Symfony\Component\Form\FormInterface::submit`. You can also submit
-    individual fields by calling :method:`Symfony\Component\Form\FormInterface::submit`
+    :method:`Symfony\\Component\\Form\\FormInterface::submit`. You can also submit
+    individual fields by calling :method:`Symfony\\Component\\Form\\FormInterface::submit`
     directly on the field::
 
         $form->get('firstName')->submit('Fabien');
@@ -90,7 +90,7 @@ Passing a Request to Form::submit() (deprecated)
 .. versionadded:: 2.3
     Before Symfony 2.3, the ``submit`` method was known as ``bind``.
 
-Before Symfony 2.3, the :method:`Symfony\Component\Form\FormInterface::submit`
+Before Symfony 2.3, the :method:`Symfony\\Component\\Form\\FormInterface::submit`
 method accepted a :class:`Symfony\\Component\\HttpFoundation\\Request` object as
 a convenient shortcut to the previous example::
 
@@ -118,7 +118,7 @@ a convenient shortcut to the previous example::
         ));
     }
 
-Passing the :class:`Symfony\\Component\HttpFoundation\\Request` directly to
+Passing the :class:`Symfony\\Component\\HttpFoundation\\Request` directly to
 :method:`Symfony\\Component\\Form\\FormInterface::submit` still works, but is
 deprecated and will be removed in Symfony 3.0. You should use the method
-:method:`Symfony\Component\Form\FormInterface::handleRequest` instead.
+:method:`Symfony\\Component\\Form\\FormInterface::handleRequest` instead.


### PR DESCRIPTION
Currently (almost) all links are broken, as there are missing slashes in API class namespaces.

I.e. try to click any link to API method documentation.
