### PR TITLE
Use KernelTestCase instead of WebTestCase for testing code only requiring the Container

### DIFF
--- a/cookbook/console/console_command.rst
+++ b/cookbook/console/console_command.rst
@@ -183,14 +183,14 @@ instead of
 
 To be able to use the fully set up service container for your console tests
 you can extend your test from
-:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase`::
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase`::
 
     use Symfony\Component\Console\Tester\CommandTester;
     use Symfony\Bundle\FrameworkBundle\Console\Application;
-    use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+    use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
     use Acme\DemoBundle\Command\GreetCommand;
 
-    class ListCommandTest extends WebTestCase
+    class ListCommandTest extends KernelTestCase
     {
         public function testExecute()
         {
@@ -214,3 +214,12 @@ you can extend your test from
             // ...
         }
     }
+
+.. versionadded:: 2.5
+    :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase` was
+    extracted from :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase`
+    in Symfony 2.5, where WebTestCase was made to inherit from KernelTestCase.
+    The difference being that WebTestCase makes available an instance of
+    :class:`Symfony\\Bundle\\FrameworkBundle\\Client` via `createClient()`,
+    while KernelTestCase makes available an instance of
+    :class:`Symfony\\Component\\HttpKernel\\KernelInterface` via `createKernel()`.

--- a/cookbook/testing/doctrine.rst
+++ b/cookbook/testing/doctrine.rst
@@ -17,15 +17,15 @@ Functional Testing
 ------------------
 
 If you need to actually execute a query, you will need to boot the kernel
-to get a valid connection. In this case, you'll extend the ``WebTestCase``,
+to get a valid connection. In this case, you'll extend the ``KernelTestCase``,
 which makes all of this quite easy::
 
     // src/Acme/StoreBundle/Tests/Entity/ProductRepositoryFunctionalTest.php
     namespace Acme\StoreBundle\Tests\Entity;
 
-    use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+    use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-    class ProductRepositoryFunctionalTest extends WebTestCase
+    class ProductRepositoryFunctionalTest extends KernelTestCase
     {
         /**
          * @var \Doctrine\ORM\EntityManager
@@ -37,8 +37,7 @@ which makes all of this quite easy::
          */
         public function setUp()
         {
-            static::$kernel = static::createKernel();
-            static::$kernel->boot();
+            self::bootKernel();
             $this->em = static::$kernel->getContainer()
                 ->get('doctrine')
                 ->getManager()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony#9739) |
| Applies to | 2.5 |
| Fixed tickets | none |

This documents using the new KernelTestCase introduced in symfony/symfony#9739, which was recently merged to master for 2.5-dev.

KernelTestCase was extracted from WebTestCase to become a more-focused base class for functional testing code that requires only a container but no client. WebTestCase is then more-focused to be used for tests requiring a client.

If you think this needs any kind of version callout in the docs to highlight the base class change we can add that too.

:rocket:

Previous PR #3244 against the 2.4 branch was closed because the corresponding feature was not merged into 2.4.
