### PR TITLE
Added missing argument to the evaluator function

### DIFF
--- a/components/expression_language/extending.rst
+++ b/components/expression_language/extending.rst
@@ -40,7 +40,7 @@ This method has 3 arguments:
         }
 
         return sprintf('strtolower(%s)', $str);
-    }, function ($str) {
+    }, function ($arguments, $str) {
         if (!is_string($str)) {
             return $str;
         }
@@ -75,7 +75,7 @@ Override ``registerFunctions`` to add your own functions::
                 }
 
                 return sprintf('strtolower(%s)', $str);
-            }, function ($str) {
+            }, function ($arguments, $str) {
                 if (!is_string($str)) {
                     return $str;
                 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4 |
| Fixed tickets | - |

Evaluator callback was missing the first argument, which should be arguments passed to the `evaluate()` call.
