### PR TITLE
Note was added to preferred_choices option of entity field type

### DIFF
--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -184,7 +184,7 @@ These options inherit from the :doc:`choice </reference/forms/types/choice>` typ
 
 .. note::
     
-    This option expects for array of objects unlike choice field that requires an array of keys
+    This option expects an array of objects unlike the choice field that requires an array of keys.
 
 .. include:: /reference/forms/types/options/empty_value.rst.inc
 

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -182,6 +182,10 @@ These options inherit from the :doc:`choice </reference/forms/types/choice>` typ
 
 .. include:: /reference/forms/types/options/preferred_choices.rst.inc
 
+.. note::
+    
+    This option expects for array of objects unlike choice field that requires an array of keys
+
 .. include:: /reference/forms/types/options/empty_value.rst.inc
 
 These options inherit from the :doc:`form </reference/forms/types/form>` type:


### PR DESCRIPTION
Note was added to clarify that 'preferred_choices' option expects for array of objects but not for array of keys as default choice field type

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |
