### PR TITLE
[WCM][Security][Acl] Documentation for the new updateUserSecurityIdentity method in Dbal\MutableAclProvider

### DIFF
--- a/cookbook/security/acl_advanced.rst
+++ b/cookbook/security/acl_advanced.rst
@@ -45,6 +45,13 @@ Security Identities
 This is analog to the object identity, but represents a user, or a role in
 your application. Each role, or user has its own security identity.
 
+.. versionadded:: 2.5
+    For users, the security identity is based on the username. This means that,
+    if for any reason, a user's username was to change, you must ensure its
+    security identity is updated too. The method ``updateUserSecurityIdentity``
+    of the :class:`Symfony\\Component\\Security\\Acl\\Dbal\\MutableAclProvider`
+    class is there to handle the update.
+
 Database Table Structure
 ------------------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony#8650) |
| Applies to | 2.5+ |
| Fixed tickets | N/A |

The documentation for symfony/symfony#8650
