### PR TITLE
Changed wording of roles section

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1702,7 +1702,7 @@ Roles
 
 The idea of a "role" is key to the authorization process. Each user is assigned
 a set of roles and then each resource requires one or more roles. If the user
-has the required roles, access is granted. Otherwise access is denied.
+has any one of the required roles, access is granted. Otherwise access is denied.
 
 Roles are pretty simple, and are basically strings that you can invent and
 use as needed (though roles are objects internally). For example, if you


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #3290 |

Changed wording to make it more clear that any one of the required
 roles for a given resource will allow access to that resource.
