### PR TITLE
Removed all occurences of $this->getRequest()

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -496,9 +496,9 @@ value to each variable.
     directly by duplicating the current request. When this
     :ref:`sub request <http-kernel-sub-requests>` is executed via the ``http_kernel``
     service the ``HttpKernel`` returns a ``Response`` object::
-    
+
         use Symfony\Component\HttpKernel\HttpKernelInterface;
-    
+
         $path = array(
             '_controller' => 'AcmeHelloBundle:Hello:fancy',
             'name'        => $name,
@@ -585,8 +585,6 @@ Accessing other Services
 When extending the base controller class, you can access any Symfony2 service
 via the ``get()`` method. Here are several common services you might need::
 
-    $request = $this->getRequest();
-
     $templating = $this->get('templating');
 
     $router = $this->get('router');
@@ -655,16 +653,21 @@ by using the native PHP sessions.
 Storing and retrieving information from the session can be easily achieved
 from any controller::
 
-    $session = $this->getRequest()->getSession();
+    use Symfony\Component\HttpFoundation\Response;
 
-    // store an attribute for reuse during a later user request
-    $session->set('foo', 'bar');
+    public function indexAction(Request $request)
+    {
+        $session = $request->getSession();
 
-    // in another controller for another request
-    $foo = $session->get('foo');
+        // store an attribute for reuse during a later user request
+        $session->set('foo', 'bar');
 
-    // use a default value if the key doesn't exist
-    $filters = $session->get('filters', array());
+        // in another controller for another request
+        $foo = $session->get('foo');
+
+        // use a default value if the key doesn't exist
+        $filters = $session->get('filters', array());
+    }
 
 These attributes will remain on the user for the remainder of that user's
 session.
@@ -682,11 +685,13 @@ These types of messages are called "flash" messages.
 
 For example, imagine you're processing a form submit::
 
-    public function updateAction()
+    use Symfony\Component\HttpFoundation\Request;
+
+    public function updateAction(Request $request)
     {
         $form = $this->createForm(...);
 
-        $form->handleRequest($this->getRequest());
+        $form->handleRequest($request);
 
         if ($form->isValid()) {
             // do some sort of processing
@@ -775,17 +780,22 @@ The Request Object
 ------------------
 
 Besides the values of the routing placeholders, the controller also has access
-to the ``Request`` object when extending the base ``Controller`` class::
+to the ``Request`` object. The framework injects the ``Request`` object in the
+controller if a variable is type hinted with
+`Symfony\Component\HttpFoundation\Request`::
 
-    $request = $this->getRequest();
+    use Symfony\Component\HttpFoundation\Request;
 
-    $request->isXmlHttpRequest(); // is it an Ajax request?
+    public function indexAction(Request $request)
+    {
+        $request->isXmlHttpRequest(); // is it an Ajax request?
 
-    $request->getPreferredLanguage(array('en', 'fr'));
+        $request->getPreferredLanguage(array('en', 'fr'));
 
-    $request->query->get('page'); // get a $_GET parameter
+        $request->query->get('page'); // get a $_GET parameter
 
-    $request->request->get('page'); // get a $_POST parameter
+        $request->request->get('page'); // get a $_POST parameter
+    }
 
 Like the ``Response`` object, the request headers are stored in a ``HeaderBag``
 object and are easily accessible.

--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -557,12 +557,14 @@ each ``ETag`` must be unique across all representations of the same resource.
 
 To see a simple implementation, generate the ETag as the md5 of the content::
 
-    public function indexAction()
+    use Symfony\Component\HttpFoundation\Request;
+
+    public function indexAction(Request $request)
     {
         $response = $this->render('MyBundle:Main:index.html.twig');
         $response->setETag(md5($response->getContent()));
         $response->setPublic(); // make sure the response is public/cacheable
-        $response->isNotModified($this->getRequest());
+        $response->isNotModified($request);
 
         return $response;
     }
@@ -604,7 +606,9 @@ For instance, you can use the latest update date for all the objects needed to
 compute the resource representation as the value for the ``Last-Modified``
 header value::
 
-    public function showAction($articleSlug)
+    use Symfony\Component\HttpFoundation\Request;
+
+    public function showAction($articleSlug, Request $request)
     {
         // ...
 
@@ -617,7 +621,7 @@ header value::
         // Set response as public. Otherwise it will be private by default.
         $response->setPublic();
 
-        if ($response->isNotModified($this->getRequest())) {
+        if ($response->isNotModified($request)) {
             return $response;
         }
 
@@ -653,8 +657,9 @@ the better. The ``Response::isNotModified()`` method does exactly that by
 exposing a simple and efficient pattern::
 
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpFoundation\Request;
 
-    public function showAction($articleSlug)
+    public function showAction($articleSlug, Request $request)
     {
         // Get the minimum information to compute
         // the ETag or the Last-Modified value
@@ -671,7 +676,7 @@ exposing a simple and efficient pattern::
         $response->setPublic();
 
         // Check that the Response is not modified for the given Request
-        if ($response->isNotModified($this->getRequest())) {
+        if ($response->isNotModified($request)) {
             // return the 304 Response immediately
             return $response;
         } else {

--- a/book/security.rst
+++ b/book/security.rst
@@ -429,13 +429,13 @@ Next, create the controller that will display the login form::
     namespace Acme\SecurityBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\Security\Core\SecurityContext;
 
     class SecurityController extends Controller
     {
-        public function loginAction()
+        public function loginAction(Request $request)
         {
-            $request = $this->getRequest();
             $session = $request->getSession();
 
             // get the login error if there is one

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -411,12 +411,14 @@ Handling the User's Locale
 The locale of the current user is stored in the request and is accessible
 via the ``request`` object::
 
-    // access the request object in a standard controller
-    $request = $this->getRequest();
+    use Symfony\Component\HttpFoundation\Request;
 
-    $locale = $request->getLocale();
+    public function indexAction(Request $request)
+    {
+        $locale = $request->getLocale();
 
-    $request->setLocale('en_US');
+        $request->setLocale('en_US');
+    }
 
 .. tip::
 

--- a/cookbook/session/locale_sticky_session.rst
+++ b/cookbook/session/locale_sticky_session.rst
@@ -100,4 +100,9 @@ use the :method:`Request::getLocale <Symfony\\Component\\HttpFoundation\\Request
 method::
 
     // from a controller...
-    $locale = $this->getRequest()->getLocale();
+    use Symfony\Component\HttpFoundation\Request;
+
+    public function indexAction(Request $request)
+    {
+        $locale = $request->getLocale();
+    }

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -90,17 +90,22 @@ Getting information from the Request
 ------------------------------------
 
 Besides the values of the routing placeholders, the controller also has access
-to the ``Request`` object::
+to the ``Request`` object. The framework injects the ``Request`` object in the
+controller if a variable is type hinted with
+`Symfony\Component\HttpFoundation\Request`::
 
-    $request = $this->getRequest();
+    use Symfony\Component\HttpFoundation\Request;
 
-    $request->isXmlHttpRequest(); // is it an Ajax request?
+    public function indexAction(Request $request)
+    {
+        $request->isXmlHttpRequest(); // is it an Ajax request?
 
-    $request->getPreferredLanguage(array('en', 'fr'));
+        $request->getPreferredLanguage(array('en', 'fr'));
 
-    $request->query->get('page'); // get a $_GET parameter
+        $request->query->get('page'); // get a $_GET parameter
 
-    $request->request->get('page'); // get a $_POST parameter
+        $request->request->get('page'); // get a $_POST parameter
+    }
 
 In a template, you can also access the ``Request`` object via the
 ``app.request`` variable:
@@ -122,16 +127,21 @@ by using native PHP sessions.
 Storing and retrieving information from the session can be easily achieved
 from any controller::
 
-    $session = $this->getRequest()->getSession();
+    use Symfony\Component\HttpFoundation\Request;
 
-    // store an attribute for reuse during a later user request
-    $session->set('foo', 'bar');
+    public function indexAction(Request $request)
+    {
+        $session = $this->request->getSession();
 
-    // in another controller for another request
-    $foo = $session->get('foo');
+        // store an attribute for reuse during a later user request
+        $session->set('foo', 'bar');
 
-    // use a default value if the key doesn't exist
-    $filters = $session->get('filters', array());
+        // in another controller for another request
+        $foo = $session->get('foo');
+
+        // use a default value if the key doesn't exist
+        $filters = $session->get('filters', array());
+    }
 
 You can also store small messages that will only be available for the very
 next request::


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets | - |

Hello. 

The request is a data object, and so the request should not be
inside the container. That's why the request will be removed
from the container in Symfony 3.0

So it is better to let the HttpKernel injects the request when
the user want to use the request.

More over, it is faster. The HttpKernel will always check if the
request should be injected. So injecting the request is time constant.
However, retrieve the request from the container will execute more
calls.
