### PR TITLE
Hint Error Bubbling for Collections Edit

### DIFF
--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -13,6 +13,8 @@ object and all sub-objects associated with it.
 | Class          | :class:`Symfony\\Component\\Validator\\Constraints\\Type`           |
 +----------------+---------------------------------------------------------------------+
 
+.. include:: /reference/forms/types/options/_error_bubbling_hint.rst.inc
+
 Basic Usage
 -----------
 

--- a/reference/forms/types/options/_error_bubbling_hint.rst
+++ b/reference/forms/types/options/_error_bubbling_hint.rst
@@ -1,6 +1,7 @@
 .. tip::
 
     By default the ``error_bubbling`` option is enabled for the
-    :doc:`collection Field Type </reference/forms/types/collection>` which passes the errors to the parent form.
-    If you want to attach the errors to the locations where they
-    actually occure you have to set ``error_bubbling`` to ``false``.
+    :doc:`collection Field Type </reference/forms/types/collection>`
+    which passes the errors to the parent form. If you want to  attach
+    the errors to the locations where they actually occure you have to
+    set ``error_bubbling`` to ``false``.

--- a/reference/forms/types/options/_error_bubbling_hint.rst
+++ b/reference/forms/types/options/_error_bubbling_hint.rst
@@ -1,6 +1,6 @@
 .. tip::
 
-By default the :doc:`collection Field Type </reference/forms/types/collection>` has enabled  the option ``error_bubbling``
-which passes the errors to the parent form. If you want to attach the errors
-to the locations where they actually occure you have to set ``error_bubbling``
-to ``false``.
+    By default the ``error_bubbling`` option is enabled for the
+    :doc:`collection Field Type </reference/forms/types/collection>` which passes the errors to the parent form.
+    If you want to attach the errors to the locations where they
+    actually occure you have to set ``error_bubbling`` to ``false``.

--- a/reference/forms/types/options/_error_bubbling_hint.rst
+++ b/reference/forms/types/options/_error_bubbling_hint.rst
@@ -1,0 +1,6 @@
+.. tip::
+
+By default the :doc:`collection Field Type </reference/forms/types/collection>` has enabled  the option ``error_bubbling``
+which passes the errors to the parent form. If you want to attach the errors
+to the locations where they actually occure you have to set ``error_bubbling``
+to ``false``.

--- a/reference/forms/types/options/cascade_validation.rst.inc
+++ b/reference/forms/types/options/cascade_validation.rst.inc
@@ -11,6 +11,5 @@ the data from ``CategoryType`` to also be validated.
 Instead of using this option, you can also use the ``Valid`` constraint in
 your model to force validation on a child object stored on a property.
 
-
-
+.. include:: /reference/forms/types/options/_error_bubbling_hint.rst.inc
 


### PR DESCRIPTION
Added hint regarding the error bubbling default setting on collection entities based on the discussion in #2559.

I have added it to the Valid constraint as well as the cascade_validation setting since you need either setting when validating embedded collections. 
