### PR TITLE
[Testing] Fix phpunit test dir paths

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -686,7 +686,7 @@ their type::
 Testing Configuration
 ---------------------
 
-The client used by functional tests creates a Kernel that runs in a special
+The Client used by functional tests creates a Kernel that runs in a special
 ``test`` environment. Since Symfony loads the ``app/config/config_test.yml``
 in the ``test`` environment, you can tweak any of your application's settings
 specifically for testing.
@@ -767,7 +767,7 @@ PHPUnit Configuration
 
 Each application has its own PHPUnit configuration, stored in the
 ``app/phpunit.xml.dist`` file. You can edit this file to change the defaults or
-create a ``app/phpunit.xml`` file to setup a configuration for your local
+create an ``app/phpunit.xml`` file to setup a configuration for your local
 machine only.
 
 .. tip::
@@ -777,12 +777,11 @@ machine only.
 
 By default, only the tests from your own custom bundles stored in the standard
 directories ``src/*/*Bundle/Tests`` or ``src/*/Bundle/*Bundle/Tests`` are run
-by the ``phpunit`` command:
+by the ``phpunit`` command, as configured in the ``phpunit.xml.dist`` file:
 
 .. code-block:: xml
 
     <!-- app/phpunit.xml.dist -->
-
     <phpunit>
         <!-- ... -->
         <testsuites>
@@ -800,7 +799,6 @@ configuration adds tests from a custom ``lib/tests`` directory:
 .. code-block:: xml
 
     <!-- app/phpunit.xml.dist -->
-
     <phpunit>
         <!-- ... -->
         <testsuites>
@@ -818,18 +816,14 @@ section:
 .. code-block:: xml
 
     <!-- app/phpunit.xml.dist -->
-
     <phpunit>
         <!-- ... -->
         <filter>
             <whitelist>
-                <directory>../src</directory>
+                <!-- ... -->
                 <directory>../lib</directory>
                 <exclude>
-                    <directory>../src/*/*Bundle/Resources</directory>
-                    <directory>../src/*/*Bundle/Tests</directory>
-                    <directory>../src/*/Bundle/*Bundle/Resources</directory>
-                    <directory>../src/*/Bundle/*Bundle/Tests</directory>
+                    <!-- ... -->
                     <directory>../lib/tests</directory>
                 </exclude>
             </whitelist>

--- a/book/testing.rst
+++ b/book/testing.rst
@@ -21,7 +21,7 @@ it has its own excellent `documentation`_.
     needed to test the Symfony core code itself.
 
 Each test - whether it's a unit test or a functional test - is a PHP class
-that should live in the `Tests/` subdirectory of your bundles. If you follow
+that should live in the ``Tests/`` subdirectory of your bundles. If you follow
 this rule, then you can run all of your application's tests with the following
 command:
 
@@ -686,7 +686,7 @@ their type::
 Testing Configuration
 ---------------------
 
-The Client used by functional tests creates a Kernel that runs in a special
+The client used by functional tests creates a Kernel that runs in a special
 ``test`` environment. Since Symfony loads the ``app/config/config_test.yml``
 in the ``test`` environment, you can tweak any of your application's settings
 specifically for testing.
@@ -766,47 +766,76 @@ PHPUnit Configuration
 ~~~~~~~~~~~~~~~~~~~~~
 
 Each application has its own PHPUnit configuration, stored in the
-``phpunit.xml.dist`` file. You can edit this file to change the defaults or
-create a ``phpunit.xml`` file to tweak the configuration for your local machine.
+``app/phpunit.xml.dist`` file. You can edit this file to change the defaults or
+create a ``app/phpunit.xml`` file to setup a configuration for your local
+machine only.
 
 .. tip::
 
-    Store the ``phpunit.xml.dist`` file in your code repository, and ignore the
+    Store the ``phpunit.xml.dist`` file in your code repository and ignore the
     ``phpunit.xml`` file.
 
-By default, only the tests stored in "standard" bundles are run by the
-``phpunit`` command (standard being tests in the ``src/*/*Bundle/Tests`` or
-``src/*/Bundle/*Bundle/Tests`` directories) But you can easily add more
-directories. For instance, the following configuration adds the tests from
-the installed third-party bundles:
+By default, only the tests from your own custom bundles stored in the standard
+directories ``src/*/*Bundle/Tests`` or ``src/*/Bundle/*Bundle/Tests`` are run
+by the ``phpunit`` command:
 
 .. code-block:: xml
 
-    <!-- hello/phpunit.xml.dist -->
-    <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>../src/*/*Bundle/Tests</directory>
-            <directory>../src/Acme/Bundle/*Bundle/Tests</directory>
-        </testsuite>
-    </testsuites>
+    <!-- app/phpunit.xml.dist -->
+
+    <phpunit>
+        <!-- ... -->
+        <testsuites>
+            <testsuite name="Project Test Suite">
+                <directory>../src/*/*Bundle/Tests</directory>
+                <directory>../src/*/Bundle/*Bundle/Tests</directory>
+            </testsuite>
+        </testsuites>
+        <!-- ... -->
+    </phpunit>
+
+But you can easily add more directories. For instance, the following
+configuration adds tests from a custom ``lib/tests`` directory:
+
+.. code-block:: xml
+
+    <!-- app/phpunit.xml.dist -->
+
+    <phpunit>
+        <!-- ... -->
+        <testsuites>
+            <testsuite name="Project Test Suite">
+                <!-- ... --->
+                <directory>../lib/tests</directory>
+            </testsuite>
+        </testsuites>
+        <!-- ... --->
+    </phpunit>
 
 To include other directories in the code coverage, also edit the ``<filter>``
 section:
 
 .. code-block:: xml
 
-    <!-- ... -->
-    <filter>
-        <whitelist>
-            <directory>../src</directory>
-            <exclude>
-                <directory>../src/*/*Bundle/Resources</directory>
-                <directory>../src/*/*Bundle/Tests</directory>
-                <directory>../src/Acme/Bundle/*Bundle/Resources</directory>
-                <directory>../src/Acme/Bundle/*Bundle/Tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+    <!-- app/phpunit.xml.dist -->
+
+    <phpunit>
+        <!-- ... -->
+        <filter>
+            <whitelist>
+                <directory>../src</directory>
+                <directory>../lib</directory>
+                <exclude>
+                    <directory>../src/*/*Bundle/Resources</directory>
+                    <directory>../src/*/*Bundle/Tests</directory>
+                    <directory>../src/*/Bundle/*Bundle/Resources</directory>
+                    <directory>../src/*/Bundle/*Bundle/Tests</directory>
+                    <directory>../lib/tests</directory>
+                </exclude>
+            </whitelist>
+        </filter>
+        <!-- ... --->
+    </phpunit>
 
 Learn more
 ----------

--- a/book/testing.rst
+++ b/book/testing.rst
@@ -775,7 +775,7 @@ create a ``phpunit.xml`` file to tweak the configuration for your local machine.
     ``phpunit.xml`` file.
 
 By default, only the tests stored in "standard" bundles are run by the
-``phpunit`` command (standard being tests in the ``src/*/Bundle/Tests`` or
+``phpunit`` command (standard being tests in the ``src/*/*Bundle/Tests`` or
 ``src/*/Bundle/*Bundle/Tests`` directories) But you can easily add more
 directories. For instance, the following configuration adds the tests from
 the installed third-party bundles:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

Maybe there could be further improvements: The paragraph that follows is a bit confusing. It says _...the following configuration adds the tests from the installed third-party bundles_ and then the tests from AcmeDemoBundle are included with `<directory>../src/Acme/Bundle/*Bundle/Tests</directory>`. Mh, the AcmeDemoBundle is a 3rd party bundle that resides in `src`? Shouldn't it include a directory from `vendors` instead to demonstrate this? In addition, the AcmeDemoBundle tests are covered by the standard configuration, so there should be no need for an extra configuration.

It continues with _To include other directories in the code coverage.._ and then some dirs from the AcmeDemoBundle are excluded which is also covered by the standard configuration.

What do you think, should I make some more updates here?
