### PR TITLE
[Cookbook][Security] Use uppercase SQL keywords in query

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -200,7 +200,7 @@ user records and encode their password, see :ref:`book-security-encoding-user-pa
 
 .. code-block:: bash
 
-    $ mysql> select * from acme_users;
+    $ mysql> SELECT * FROM acme_users;
     +----+----------+------+------------------------------------------+--------------------+-----------+
     | id | username | salt | password                                 | email              | is_active |
     +----+----------+------+------------------------------------------+--------------------+-----------+
@@ -649,14 +649,14 @@ this:
 
 .. code-block:: bash
 
-    $ mysql> select * from acme_role;
+    $ mysql> SELECT * FROM acme_role;
     +----+-------+------------+
     | id | name  | role       |
     +----+-------+------------+
     |  1 | admin | ROLE_ADMIN |
     +----+-------+------------+
 
-    $ mysql> select * from user_role;
+    $ mysql> SELECT * FROM user_role;
     +---------+---------+
     | user_id | role_id |
     +---------+---------+


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

Following the conventions from the MySQL docs, SQL keywords are written uppercase.
