### PR TITLE
Add include to option "compound" #3336

### DIFF
--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -9,6 +9,8 @@ See :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType`.
 The ``form`` type predefines a couple of options that are then available
 on all fields.
 
+.. include:: /reference/forms/types/options/compound.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc


### PR DESCRIPTION
As I understood option "compound" had to be in this document. Main issue is #2362.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | #2362 |
