### PR TITLE
[WIP][Cookbook][Service Container][Scopes] Synchronized Services Setter Injection Does Not Occur When Entering Scope 

### DIFF
--- a/cookbook/service_container/scopes.rst
+++ b/cookbook/service_container/scopes.rst
@@ -169,6 +169,7 @@ marked as ``synchronized``:
         );
         $definition->setScope('client');
         $definition->setSynchronized(true);
+        $definition->setSynthetic(true);
         $container->setDefinition('client_configuration', $definition);
 
 Now, if you inject this service using setter injection, there are no drawbacks

--- a/cookbook/service_container/scopes.rst
+++ b/cookbook/service_container/scopes.rst
@@ -134,6 +134,7 @@ marked as ``synchronized``:
                 class:        Acme\HelloBundle\Client\ClientConfiguration
                 scope:        client
                 synchronized: true
+                synthetic:    true
                 # ...
 
     .. code-block:: xml
@@ -151,6 +152,7 @@ marked as ``synchronized``:
                     id="client_configuration"
                     scope="client"
                     synchronized="true"
+                    synthetic="true"
                     class="Acme\HelloBundle\Client\ClientConfiguration"
                 />
             </services>
@@ -196,9 +198,9 @@ and everything works without any special code in your service or in your definit
         }
     }
 
-Whenever the ``client`` scope is entered or left, the service container will
-automatically call the ``setClientConfiguration()`` method with the current
-``client_configuration`` instance.
+Whenever the ``client`` scope is active, the service container will
+automatically call the ``setClientConfiguration()`` method when the
+``client_configuration`` service is set in the container.
 
 You might have noticed that the ``setClientConfiguration()`` method accepts
 ``null`` as a valid value for the ``client_configuration`` argument. That's


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | n/a |

My interpretation of the documentation is that synchronized services are injected as dependencies when a given scope is entered or exited.  My expectation is that the process takes place when [Container::enterScope()](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Container.php#L374) or [Container::leaveScope()](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Container.php#L422) are invoked, however it seems that the setter is called only when the [Container::set()](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Container.php#L211) is invoked, which implies that synchronized services must also be synthetic.
