### PR TITLE
Removed quotes from "%domain%" in yml routing file, it only works without the quotes

### DIFF
--- a/components/routing/hostname_pattern.rst
+++ b/components/routing/hostname_pattern.rst
@@ -196,7 +196,7 @@ instance, if you want to match both ``m.example.com`` and
                 host:     "m.{domain}"
                 defaults: { _controller: AcmeDemoBundle:Main:mobileHomepage }
                 requirements:
-                    domain: "%domain%"
+                    domain: %domain%
 
             homepage:
                 path:  /


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.2+ |
