### PR TITLE
Indicate that Group Sequence Providers can use YAML

### DIFF
--- a/book/validation.rst
+++ b/book/validation.rst
@@ -1072,7 +1072,7 @@ Now, change the ``User`` class to implement
 add the
 :method:`Symfony\\Component\\Validator\\GroupSequenceProviderInterface::getGroupSequence`,
 which should return an array of groups to use. Also, add the
-``@Assert\GroupSequenceProvider`` annotation to the class. If you imagine
+``@Assert\GroupSequenceProvider`` annotation to the class (or ``group_sequence_provider: true`` to the YAML). If you imagine
 that a method called ``isPremium`` returns true if the user is a premium member,
 then your code might look like this::
 


### PR DESCRIPTION
In the docs, it was unclear that you could use group sequence providers without using annotations. (It took me some trial and error to figure out how to do it.) I've indicated that it can also use YAML, and how to do so. I've never used XML for validation, so I don't feel qualified to add info about XML to the docs.
