### PR TITLE
clarified that IP of reverse proxy cache must be an untrusted proxy

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -891,7 +891,10 @@ enabled, it's recommended to secure access to ESI URLs. Indeed, some ESI may
 contain some private content like the current logged in user's information. To
 prevent any direct access to these resources from a web browser (by guessing the
 ESI URL pattern), the ESI route **must** be secured to be only visible from
-the trusted reverse proxy cache.
+the reverse proxy cache. Furthermore, the IP of the reverse proxy cache must not be
+in the list of trusted proxies, as this would cause the original client's IP,
+or the IP of an untrusted proxy, to be the one matched against the ACL rule instead.
+
 
 .. versionadded:: 2.3
     Version 2.3 allows multiple IP addresses in a single rule with the ``ips: [a, b]``


### PR DESCRIPTION
I've noticed that when securing ESI routes by IP, one must not have the IP of the reverse proxy cache as a trusted proxy, otherwise the original request IP (or a non trusted proxy IP) would be the one being matched against the ACL rule instead.
