### PR TITLE
[Form] clarify that password is shown only upon submission

### DIFF
--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -36,10 +36,12 @@ always_empty
 
 If set to true, the field will *always* render blank, even if the corresponding
 field has a value. When set to false, the password field will be rendered
-with the ``value`` attribute set to its true value.
+with the ``value`` attribute set to its true value only upon submission.
 
 Put simply, if for some reason you want to render your password field
-*with* the password value already entered into the box, set this to false.
+*with* the password value already entered into the box, set this to false
+and submit the form.
+
 
 Inherited Options
 -----------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes (symfony/symfony#9809) |
| Applies to | 2.3+ |
| Fixed tickets | na |
