### PR TITLE
Changes the followRedirect information

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -483,9 +483,14 @@ For specific details on using the profiler inside a test, see the
 Redirecting
 ~~~~~~~~~~~
 
-When a request returns a redirect response, the client does not follow
-it automatically. You can examine the response and force a redirection
-afterwards with the ``followRedirect()`` method::
+When a request returns a redirect response, the client follows it
+automatically. You can prevent this by issuing the ``followRedirects()``
+method::
+
+    $client->followRedirects(false);
+
+You can examine the response and force a redirection afterwards  with
+the ``followRedirect()`` method::
 
     $crawler = $client->followRedirect();
 

--- a/book/testing.rst
+++ b/book/testing.rst
@@ -484,18 +484,19 @@ Redirecting
 ~~~~~~~~~~~
 
 When a request returns a redirect response, the client follows it
-automatically. You can prevent this by issuing the ``followRedirects()``
-method::
+automatically. You can prevent this by issuing the
+:method:`Symfony\\Component\\HttpKernel\\Client::followRedirects` method::
 
     $client->followRedirects(false);
 
 You can examine the response and force a redirection afterwards  with
-the ``followRedirect()`` method::
+the :method:`Symfony\\Component\\HttpKernel\\Client::followRedirects` method::
 
     $crawler = $client->followRedirect();
 
 If you want the client to automatically follow all redirects, you can
-force him with the ``followRedirects()`` method::
+force him with the
+:method:`Symfony\\Component\\HttpKernel\\Client::followRedirects` method::
 
     $client->followRedirects();
 


### PR DESCRIPTION
The followRedirect() method has changed to automatically follow redirects. I've changed the documentation to reflect this and left a note on how to change it back to the way it used to work.
