### PR TITLE
Documentation should refers to @Security and no @Secure

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1073,21 +1073,20 @@ authorization from inside a controller::
 
 .. _book-security-securing-controller-annotations:
 
-You can also choose to install and use the optional JMSSecurityExtraBundle,
-which can secure your controller using annotations::
+Thanks to the FrameworkExtraBundle, you can also secure your controller using annotations::
 
     // ...
-    use JMS\SecurityExtraBundle\Annotation\Secure;
+    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
     /**
-     * @Secure(roles="ROLE_ADMIN")
+     * @Security("has_role('ROLE_ADMIN')")
      */
     public function helloAction($name)
     {
         // ...
     }
 
-For more information, see the `JMSSecurityExtraBundle`_ documentation.
+For more information, see the `SensioFrameworkExtraBundle`_ documentation.
 
 Securing other Services
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/book/security.rst
+++ b/book/security.rst
@@ -1086,7 +1086,7 @@ Thanks to the SensioFrameworkExtraBundle, you can also secure your controller us
         // ...
     }
 
-For more information, see the `SensioFrameworkExtraBundle`_ documentation.
+For more information, see the :doc:`FrameworkExtraBundle documentation </bundles/SensioFrameworkExtraBundle/annotations/security>`.
 
 Securing other Services
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -2273,7 +2273,6 @@ Learn more from the Cookbook
 * :doc:`Access Control Lists (ACLs) </cookbook/security/acl>`
 * :doc:`/cookbook/security/remember_me`
 
-.. _`JMSSecurityExtraBundle`: http://jmsyst.com/bundles/JMSSecurityExtraBundle/1.2
 .. _`FOSUserBundle`: https://github.com/FriendsOfSymfony/FOSUserBundle
 .. _`implement the \Serializable interface`: http://php.net/manual/en/class.serializable.php
 .. _`functions-online.com`: http://www.functions-online.com/sha1.html

--- a/book/security.rst
+++ b/book/security.rst
@@ -1086,7 +1086,8 @@ Thanks to the SensioFrameworkExtraBundle, you can also secure your controller us
         // ...
     }
 
-For more information, see the :doc:`FrameworkExtraBundle documentation </bundles/SensioFrameworkExtraBundle/annotations/security>`.
+For more information, see the 
+:doc:`FrameworkExtraBundle documentation </bundles/SensioFrameworkExtraBundle/annotations/security>`.
 
 Securing other Services
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/book/security.rst
+++ b/book/security.rst
@@ -1073,7 +1073,7 @@ authorization from inside a controller::
 
 .. _book-security-securing-controller-annotations:
 
-Thanks to the FrameworkExtraBundle, you can also secure your controller using annotations::
+Thanks to the SensioFrameworkExtraBundle, you can also secure your controller using annotations::
 
     // ...
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes |
| Applies to | 2.4+ |
| Fixed tickets | none |

The @Security annotation is only documented on the FrameworkExtraBundle documentation, which is not the first place when we search informations about security.

I think the Security part of the official documentation should refers to this new annotation which is available with the standart edition of Symfony 2 instead of third libraries.
