### PR TITLE
getRequest() is deprecated in version 2.4

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -416,13 +416,13 @@ Next, create the controller that will display the login form::
     namespace Acme\SecurityBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\Security\Core\SecurityContext;
 
     class SecurityController extends Controller
     {
-        public function loginAction()
+        public function loginAction(Request $request)
         {
-            $request = $this->getRequest();
             $session = $request->getSession();
 
             // get the login error if there is one


### PR DESCRIPTION
removed $this->getRequest() and added it as a parameter to be passed to loginAction() method

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4+ |
