### PR TITLE
use html+jinja instead of html+twig

### DIFF
--- a/cookbook/security/csrf_in_login_form.rst
+++ b/cookbook/security/csrf_in_login_form.rst
@@ -81,7 +81,7 @@ using the login form:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
 
         {# src/Acme/SecurityBundle/Resources/views/Security/login.html.twig #}
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

For some reason this error terminates the build process on my machine with this stack trace:

``` bash
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.1.3
loading pickled environment... done
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 3 changed, 0 removed
reading sources... [ 33%] cookbook/security/csrf_in_login_form                                                                                                          
Exception occurred:
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 399, in new_subsection
    node=section_node, match_titles=True)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 286, in nested_parse
    node=node, match_titles=match_titles)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 199, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/usr/lib/python2.7/dist-packages/docutils/statemachine.py", line 239, in run
    context, state, transitions)
  File "/usr/lib/python2.7/dist-packages/docutils/statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 2300, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 2312, in explicit_construct
    return method(self, expmatch)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 2055, in directive
    directive_class, match, type_name, option_presets)
  File "/usr/lib/python2.7/dist-packages/docutils/parsers/rst/states.py", line 2104, in run_directive
    result = directive_instance.run()
  File "/home/christian/Webentwicklung/Symfony/docs/symfony/_exts/sensio/sphinx/configurationblock.py", line 51, in run
    innernode = nodes.emphasis(self.formats[child['language']], self.formats[child['language']])
KeyError: u'html+twig'
The full traceback has been saved in /tmp/sphinx-err-3oziXI.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
Either send bugs to the mailing list at <http://groups.google.com/group/sphinx-dev/>,
or report them in the tracker at <http://bitbucket.org/birkenfeld/sphinx/issues/>. Thanks!
make: *** [html] Fehler 1
```
