### PR TITLE
Use static Request methods in Trusting Proxies doc

### DIFF
--- a/components/http_foundation/trusting_proxies.rst
+++ b/components/http_foundation/trusting_proxies.rst
@@ -22,10 +22,8 @@ your proxy.
 
     use Symfony\Component\HttpFoundation\Request;
 
-    $request = Request::createFromGlobals();
-
     // only trust proxy headers coming from this IP addresses
-    $request->setTrustedProxies(array('192.0.0.1', '10.0.0.0/8'));
+    Request::setTrustedProxies(array('192.0.0.1', '10.0.0.0/8'));
 
 Configuring Header Names
 ------------------------
@@ -40,10 +38,10 @@ By default, the following proxy headers are trusted:
 If your reverse proxy uses a different header name for any of these, you
 can configure that header name via :method:`Symfony\\Component\\HttpFoundation\\Request::setTrustedHeaderName`::
 
-    $request->setTrustedHeaderName(Request::HEADER_CLIENT_IP, 'X-Proxy-For');
-    $request->setTrustedHeaderName(Request::HEADER_CLIENT_HOST, 'X-Proxy-Host');
-    $request->setTrustedHeaderName(Request::HEADER_CLIENT_PORT, 'X-Proxy-Port');
-    $request->setTrustedHeaderName(Request::HEADER_CLIENT_PROTO, 'X-Proxy-Proto');
+    Request::setTrustedHeaderName(Request::HEADER_CLIENT_IP, 'X-Proxy-For');
+    Request::setTrustedHeaderName(Request::HEADER_CLIENT_HOST, 'X-Proxy-Host');
+    Request::setTrustedHeaderName(Request::HEADER_CLIENT_PORT, 'X-Proxy-Port');
+    Request::setTrustedHeaderName(Request::HEADER_CLIENT_PROTO, 'X-Proxy-Proto');
 
 Not trusting certain Headers
 ----------------------------
@@ -53,4 +51,4 @@ listed above are trusted. If you need to trust some of these headers but
 not others, you can do that as well::
 
     // disables trusting the ``X-Forwarded-Proto`` header, the default header is used
-    $request->setTrustedHeaderName(Request::HEADER_CLIENT_PROTO, '');
+    Request::setTrustedHeaderName(Request::HEADER_CLIENT_PROTO, '');


### PR DESCRIPTION
As these methods manipulate static properties, it makes sense to use the static methods. This also means that we don't need to create a throwaway Request instance just to set the trusted proxies.
