### PR TITLE
Update forms.rst

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -784,7 +784,7 @@ output can be customized on many different levels.
 
         .. code-block:: html+php
 
-            <?php echo $view['form']->get('value')->getTask() ?>
+            <?php echo $form->vars['value']->getTask() ?>
 
 .. index::
    single: Forms; Rendering each field by hand
@@ -890,7 +890,7 @@ to get the ``id``:
 
     .. code-block:: html+php
 
-        <?php echo $form['task']->get('id') ?>
+        <?php echo $form['task']['vars']['id']?>
 
 To get the value used for the form field's name attribute you need to use
 the ``full_name`` value:
@@ -903,7 +903,7 @@ the ``full_name`` value:
 
     .. code-block:: html+php
 
-        <?php echo $form['task']->get('full_name') ?>
+        <?php echo $form['task']['vars']['full_name'] ?>
 
 Twig Template Function Reference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1085,7 +1085,7 @@ the choice is ultimately up to you.
     The field data can be accessed in a controller with::
 
         $form->get('dueDate')->getData();
-        
+
     In addition, the data of an unmapped field can also be modified directly::
 
         $form->get('dueDate')->setData(new \DateTime());

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -784,7 +784,7 @@ output can be customized on many different levels.
 
         .. code-block:: html+php
 
-            <?php echo $view['form']->get('value')->getTask() ?>
+            <?php echo $form->vars['value']->getTask() ?>
 
 .. index::
    single: Forms; Rendering each field by hand
@@ -890,7 +890,7 @@ to get the ``id``:
 
     .. code-block:: html+php
 
-        <?php echo $form['task']->get('id') ?>
+        <?php echo $form['task']['vars']['id']?>
 
 To get the value used for the form field's name attribute you need to use
 the ``full_name`` value:
@@ -903,7 +903,7 @@ the ``full_name`` value:
 
     .. code-block:: html+php
 
-        <?php echo $form['task']->get('full_name') ?>
+        <?php echo $form['task'][vars']['full_name'] ?>
 
 Twig Template Function Reference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -890,7 +890,7 @@ to get the ``id``:
 
     .. code-block:: html+php
 
-        <?php echo $form['task']['vars']['id']?>
+        <?php echo $form['task']->vars['id']?>
 
 To get the value used for the form field's name attribute you need to use
 the ``full_name`` value:
@@ -903,7 +903,7 @@ the ``full_name`` value:
 
     .. code-block:: html+php
 
-        <?php echo $form['task']['vars']['full_name'] ?>
+        <?php echo $form['task']->vars['full_name'] ?>
 
 Twig Template Function Reference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Accessing form values via `vars` property instead of getter. Updated PHP templating examples.
