### PR TITLE
[#3334] the data_class option was not introduced in 2.4

### DIFF
--- a/reference/forms/types/options/data_class.rst.inc
+++ b/reference/forms/types/options/data_class.rst.inc
@@ -1,6 +1,3 @@
-.. versionadded:: 2.4
-    The ``data_class`` option was introduced in Symfony 2.4.
-
 data_class
 ~~~~~~~~~~
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |
