### PR TITLE
Removed code references to Symfony Standard Distribution

### DIFF
--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -35,7 +35,7 @@ Creating a basic Command
 To make a console command that greets you from the command line, create ``GreetCommand.php``
 and add the following to it::
 
-    namespace Acme\DemoBundle\Command;
+    namespace Acme\Command;
 
     use Symfony\Component\Console\Command\Command;
     use Symfony\Component\Console\Input\InputArgument;
@@ -86,9 +86,9 @@ an ``Application`` and adds commands to it::
 
     #!/usr/bin/env php
     <?php
-    // app/console
+    // application.php
 
-    use Acme\DemoBundle\Command\GreetCommand;
+    use Acme\Command\GreetCommand;
     use Symfony\Component\Console\Application;
 
     $application = new Application();
@@ -99,7 +99,7 @@ Test the new console command by running the following
 
 .. code-block:: bash
 
-    $ app/console demo:greet Fabien
+    $ php application.php demo:greet Fabien
 
 This will print the following to the command line:
 
@@ -111,7 +111,7 @@ You can also use the ``--yell`` option to make everything uppercase:
 
 .. code-block:: bash
 
-    $ app/console demo:greet Fabien --yell
+    $ php application.php demo:greet Fabien --yell
 
 This prints::
 
@@ -232,8 +232,8 @@ The command can now be used in either of the following ways:
 
 .. code-block:: bash
 
-    $ app/console demo:greet Fabien
-    $ app/console demo:greet Fabien Potencier
+    $ php application.php demo:greet Fabien
+    $ php application.php demo:greet Fabien Potencier
 
 It is also possible to let an argument take a list of values (imagine you want
 to greet all your friends). For this it must be specified at the end of the
@@ -251,7 +251,7 @@ To use this, just specify as many names as you want:
 
 .. code-block:: bash
 
-    $ app/console demo:greet Fabien Ryan Bernhard
+    $ php application.php demo:greet Fabien Ryan Bernhard
 
 You can access the ``names`` argument as an array::
 
@@ -321,8 +321,8 @@ flag:
 
 .. code-block:: bash
 
-    $ app/console demo:greet Fabien
-    $ app/console demo:greet Fabien --iterations=5
+    $ php application.php demo:greet Fabien
+    $ php application.php demo:greet Fabien --iterations=5
 
 The first example will only print once, since ``iterations`` is empty and
 defaults to ``1`` (the last argument of ``addOption``). The second example
@@ -333,8 +333,8 @@ will work:
 
 .. code-block:: bash
 
-    $ app/console demo:greet Fabien --iterations=5 --yell
-    $ app/console demo:greet Fabien --yell --iterations=5
+    $ php application.php demo:greet Fabien --iterations=5 --yell
+    $ php application.php demo:greet Fabien --yell --iterations=5
 
 There are 4 option variants you can use:
 
@@ -380,9 +380,9 @@ useful one is the :class:`Symfony\\Component\\Console\\Tester\\CommandTester`
 class. It uses special input and output classes to ease testing without a real
 console::
 
+    use Acme\Command\GreetCommand;
     use Symfony\Component\Console\Application;
     use Symfony\Component\Console\Tester\CommandTester;
-    use Acme\DemoBundle\Command\GreetCommand;
 
     class ListCommandTest extends \PHPUnit_Framework_TestCase
     {
@@ -409,9 +409,9 @@ You can test sending arguments and options to the command by passing them
 as an array to the :method:`Symfony\\Component\\Console\\Tester\\CommandTester::execute`
 method::
 
+    use Acme\Command\GreetCommand;
     use Symfony\Component\Console\Application;
     use Symfony\Component\Console\Tester\CommandTester;
-    use Acme\DemoBundle\Command\GreetCommand;
 
     class ListCommandTest extends \PHPUnit_Framework_TestCase
     {
@@ -491,6 +491,7 @@ Learn More!
 
 * :doc:`/components/console/usage`
 * :doc:`/components/console/single_command_tool`
+* :doc:`/components/console/events`
 
 .. _Packagist: https://packagist.org/packages/symfony/console
 .. _ANSICON: https://github.com/adoxa/ansicon/downloads

--- a/components/console/single_command_tool.rst
+++ b/components/console/single_command_tool.rst
@@ -66,6 +66,7 @@ You can also simplify how you execute the application::
     #!/usr/bin/env php
     <?php
     // command.php
+
     use Acme\Tool\MyApplication;
 
     $application = new MyApplication();

--- a/components/console/usage.rst
+++ b/components/console/usage.rst
@@ -9,12 +9,12 @@ built-in options as well as a couple of built-in commands for the Console compon
 
 .. note::
 
-    These examples assume you have added a file ``app/console`` to run at
+    These examples assume you have added a file ``application.php`` to run at
     the cli::
 
         #!/usr/bin/env php
-        # app/console
         <?php
+        // application.php
 
         use Symfony\Component\Console\Application;
 
@@ -30,26 +30,26 @@ and the registered commands:
 
 .. code-block:: bash
 
-    $ php app/console list
+    $ php application.php list
 
 You can get the same output by not running any command as well
 
 .. code-block:: bash
 
-    $ php app/console
+    $ php application.php
 
 The help command lists the help information for the specified command. For
 example, to get the help for the ``list`` command:
 
 .. code-block:: bash
 
-    $ php app/console help list
+    $ php application.php help list
 
 Running ``help`` without specifying a command will list the global options:
 
 .. code-block:: bash
 
-    $ php app/console help
+    $ php application.php help
 
 Global Options
 ~~~~~~~~~~~~~~
@@ -59,33 +59,33 @@ get help for the list command:
 
 .. code-block:: bash
 
-    $ php app/console list --help
-    $ php app/console list -h
+    $ php application.php list --help
+    $ php application.php list -h
 
 You can suppress output with:
 
 .. code-block:: bash
 
-    $ php app/console list --quiet
-    $ php app/console list -q
+    $ php application.php list --quiet
+    $ php application.php list -q
 
 You can get more verbose messages (if this is supported for a command)
 with:
 
 .. code-block:: bash
 
-    $ php app/console list --verbose
-    $ php app/console list -v
+    $ php application.php list --verbose
+    $ php application.php list -v
 
 The verbose flag can optionally take a value between 1 (default) and 3 to
 output even more verbose messages:
 
 .. code-block:: bash
 
-    $ php app/console list --verbose=2
-    $ php app/console list -vv
-    $ php app/console list --verbose=3
-    $ php app/console list -vvv
+    $ php application.php list --verbose=2
+    $ php application.php list -vv
+    $ php application.php list --verbose=3
+    $ php application.php list -vvv
 
 If you set the optional arguments to give your application a name and version::
 
@@ -95,8 +95,8 @@ then you can use:
 
 .. code-block:: bash
 
-    $ php app/console list --version
-    $ php app/console list -V
+    $ php application.php list --version
+    $ php application.php list -V
 
 to get this information output:
 
@@ -114,20 +114,20 @@ You can force turning on ANSI output coloring with:
 
 .. code-block:: bash
 
-    $ php app/console list --ansi
+    $ php application.php list --ansi
 
 or turn it off with:
 
 .. code-block:: bash
 
-    $ php app/console list --no-ansi
+    $ php application.php list --no-ansi
 
 You can suppress any interactive questions from the command you are running with:
 
 .. code-block:: bash
 
-    $ php app/console list --no-interaction
-    $ php app/console list -n
+    $ php application.php list --no-interaction
+    $ php application.php list -n
 
 Shortcut Syntax
 ~~~~~~~~~~~~~~~
@@ -138,7 +138,7 @@ commands, then you can run ``help`` like this:
 
 .. code-block:: bash
 
-    $ php app/console h
+    $ php application.php h
 
 If you have commands using ``:`` to namespace commands then you just have
 to type the shortest unambiguous text for each part. If you have created the
@@ -147,7 +147,7 @@ can run it with:
 
 .. code-block:: bash
 
-    $ php app/console d:g Fabien
+    $ php application.php d:g Fabien
 
 If you enter a short command that's ambiguous (i.e. there are more than one
 command that match), then no command will be run and some suggestions of


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets |  |

After talk with @WouterJ on symfony/symfony-docs#3426 and IRC about references in the standalone Console component to the framework I decided to submit this PR to change the code that have some references to the Symfony Standard Distribution in the code. 
