### PR TITLE
[WIP][Reference][Form Types] Update "radio" form type

### DIFF
--- a/reference/forms/types/checkbox.rst
+++ b/reference/forms/types/checkbox.rst
@@ -42,17 +42,7 @@ Example Usage
 Field Options
 -------------
 
-value
-~~~~~
-
-**type**: ``mixed`` **default**: ``1``
-
-The value that's actually used as the value for the checkbox. This does
-not affect the value that's set on your object.
-
-.. caution::
-
-    To make a checkbox checked by default, set the `data`_ option to ``true``.
+.. include:: /reference/forms/types/options/value.rst.inc
 
 Inherited options
 -----------------

--- a/reference/forms/types/options/value.rst.inc
+++ b/reference/forms/types/options/value.rst.inc
@@ -1,0 +1,12 @@
+value
+~~~~~
+
+**type**: ``mixed`` **default**: ``1``
+
+The value that's actually used as the value for the checkbox or radio button.
+This does not affect the value that's set on your object.
+
+.. caution::
+
+    To make a checkbox or radio button checked by default, use the `data`_
+    option.

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -28,7 +28,7 @@ If you want to have a Boolean field, use :doc:`checkbox </reference/forms/types/
 |             | - `error_mapping`_                                                  |
 |             | - `mapped`_                                                         |
 +-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`form </reference/forms/types/form>`                           |
+| Parent type | :doc:`form </reference/forms/types/checkbox>`                       |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType` |
 +-------------+---------------------------------------------------------------------+

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -15,10 +15,9 @@ If you want to have a Boolean field, use :doc:`checkbox </reference/forms/types/
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``radio`` field                                           |
 +-------------+---------------------------------------------------------------------+
-| Options     | - `value`_                                                          |
-+-------------+---------------------------------------------------------------------+
-| Inherited   | - `data`_                                                           |
-| options     | - `empty_data`_                                                     |
+| Inherited   | - `value`_                                                          |
+| options     | - `data`_                                                           |
+|             | - `empty_data`_                                                     |
 |             | - `required`_                                                       |
 |             | - `label`_                                                          |
 |             | - `label_attr`_                                                     |
@@ -33,23 +32,13 @@ If you want to have a Boolean field, use :doc:`checkbox </reference/forms/types/
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType` |
 +-------------+---------------------------------------------------------------------+
 
-Field Options
--------------
-
-value
-~~~~~
-
-**type**: ``mixed`` **default**: ``1``
-
-The value that's actually used as the value for the radio button. This does
-not affect the value that's set on your object.
-
-.. caution::
-
-    To make a radio button checked by default, use the `data`_ option.
-
 Inherited Options
 -----------------
+
+These options inherit from the :doc:`checkbox </reference/forms/types/checkbox>`
+type:
+
+.. include:: /reference/forms/types/options/value.rst.inc
 
 These options inherit from the :doc:`form </reference/forms/types/form>` type:
 

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -28,7 +28,7 @@ If you want to have a Boolean field, use :doc:`checkbox </reference/forms/types/
 |             | - `error_mapping`_                                                  |
 |             | - `mapped`_                                                         |
 +-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`form </reference/forms/types/checkbox>`                       |
+| Parent type | :doc:`checkbox </reference/forms/types/checkbox>`                   |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType` |
 +-------------+---------------------------------------------------------------------+


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | #3410 |

`radio`'s parent is `checkbox`, not `form`.

I need some help regarding the task _value option should be removed from this type_:
Should it really be removed? It's because I'm able to set it and it is used in the HTML output. I'm retrieving a boolean value only when I access the submitted data via the form framework but I have also access to the raw, custom value via e.g. `$request->request->get('my_checkbox')`. So maybe it should be moved to the `inherited options` instead for the `radio` field? If yes, the wording would need an update for the `value` option and if no, why keep it for the `checkbox` field?
