### PR TITLE
Update custom_password_authenticator.rst

### DIFF
--- a/cookbook/security/custom_password_authenticator.rst
+++ b/cookbook/security/custom_password_authenticator.rst
@@ -25,7 +25,7 @@ the user::
 
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface;
-    use Symfony\Component\Security\Core\Authentication\TokenInterface;
+    use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
     use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
     use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
     use Symfony\Component\Security\Core\Exception\AuthenticationException;


### PR DESCRIPTION
Fixed TokenInterface use statement which was causing a "FatalErrorException: Compile Error:" to occur
