### PR TITLE
[Reference][Form Types] Add missing docs for "action" and "method" option

### DIFF
--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -59,3 +59,6 @@ on all fields.
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 
+.. include:: /reference/forms/types/options/action.rst.inc
+
+.. include:: /reference/forms/types/options/method.rst.inc

--- a/reference/forms/types/options/action.rst.inc
+++ b/reference/forms/types/options/action.rst.inc
@@ -7,6 +7,6 @@ action
 **type**: ``string`` **default**: empty string
 
 This option specifies where to send the form's data on submission (usually an
-URI). It's value is rendered as the ``action`` attribute of the ``form``
+URI). Its value is rendered as the ``action`` attribute of the ``form``
 element. An empty value is considered a same-document reference, i.e. the form
 will be submitted to the same URI that rendered the form.

--- a/reference/forms/types/options/action.rst.inc
+++ b/reference/forms/types/options/action.rst.inc
@@ -7,5 +7,6 @@ action
 **type**: ``string`` **default**: empty string
 
 This option specifies where to send the form's data on submission (usually an
-URI). An empty value is considered a same-document references, i.e. the form
+URI). It's value is rendered as the ``action`` attribute of the ``form``
+element. An empty value is considered a same-document reference, i.e. the form
 will be submitted to the same URI that rendered the form.

--- a/reference/forms/types/options/action.rst.inc
+++ b/reference/forms/types/options/action.rst.inc
@@ -1,0 +1,11 @@
+.. versionadded:: 2.3
+    The ``action`` option was introduced in Symfony 2.3.
+
+action
+~~~~~~
+
+**type**: ``string`` **default**: empty string
+
+This option specifies where to send the form's data on submission (usually an
+URI). An empty value is considered a same-document references, i.e. the form
+will be submitted to the same URI that rendered the form.

--- a/reference/forms/types/options/method.rst.inc
+++ b/reference/forms/types/options/method.rst.inc
@@ -23,3 +23,9 @@ used to decide whether to process the form submission in the
     render a ``_method`` hidden field in your form. This is used to "fake"
     these HTTP methods, as they're not supported on standard browsers. For
     more information, see :doc:`/cookbook/routing/method_parameters`.
+
+.. note:
+
+    Only the PATCH method allows submitting partial data without that missing
+    fields are set to ``null`` in the underlying data (preserving default
+    values, if any).

--- a/reference/forms/types/options/method.rst.inc
+++ b/reference/forms/types/options/method.rst.inc
@@ -7,7 +7,8 @@ method
 **type**: ``string`` **default**: ``POST``
 
 This option specifies the HTTP method used to submit the form's data. It's
-value is rendered as the ``method`` attribute of the ``form`` element.
+value is rendered as the ``method`` attribute of the ``form`` element and to
+perform some consistency checks when evaluating the form after submission.
 Possible values are:
 
 * POST
@@ -16,11 +17,10 @@ Possible values are:
 * DELETE
 * PATCH
 
-As PUT, DELETE and PATCH are not nativly supported by most clients, Symfony
-simulates them. For more information see
-:doc:`/cookbook/routing/method_parameters`.
+.. note:
 
-.. note::
-
-    Using ``PUT``, ``PATCH`` and ``DELETE`` is only allowed if
-    :ref:`configuration-framework-http_method_override` is enabled.
+    If not natively supported by a client, Symfony allows to simulate PUT,
+    DELETE and PATCH requests by using a POST request instead and passing the
+    intended "real" method by either using a ``X-HTTP-Method-Override``
+    request header or by passing it via the special ``_method`` data field.
+    For more information see :doc:`/cookbook/routing/method_parameters`.

--- a/reference/forms/types/options/method.rst.inc
+++ b/reference/forms/types/options/method.rst.inc
@@ -1,0 +1,20 @@
+.. versionadded:: 2.3
+    The ``method`` option was introduced in Symfony 2.3.
+
+method
+~~~~~~
+
+**type**: ``string`` **default**: ``POST``
+
+This option specifies the HTTP method used to submit the form's data. Possible
+values are:
+
+* POST
+* GET
+* PUT
+* DELETE
+* PATCH
+
+.. note::
+    Using ``PUT``, ``PATCH`` and ``DELETE`` is only allowed if
+    :ref:`configuration-framework-http_method_override` is enabled.

--- a/reference/forms/types/options/method.rst.inc
+++ b/reference/forms/types/options/method.rst.inc
@@ -19,8 +19,7 @@ used to decide whether to process the form submission in the
 
 .. note:
 
-    If not natively supported by a client, Symfony allows to simulate PUT,
-    DELETE and PATCH requests by using a POST request instead and passing the
-    intended "real" method by either using a ``X-HTTP-Method-Override``
-    request header or by passing it via the special ``_method`` data field.
-    For more information see :doc:`/cookbook/routing/method_parameters`.
+    When the method is PUT, PATCH, or DELETE, Symfony will automatically
+    render a ``_method`` hidden field in your form. This is used to "fake"
+    these HTTP methods, as they're not supported on standard browsers. For
+    more information, see :doc:`/cookbook/routing/method_parameters`.

--- a/reference/forms/types/options/method.rst.inc
+++ b/reference/forms/types/options/method.rst.inc
@@ -17,8 +17,10 @@ Possible values are:
 * PATCH
 
 As PUT, DELETE and PATCH are not nativly supported by most clients, Symfony
-simulates them, see :doc:`/cookbook/routing/method_parameters`.
+simulates them. For more information see
+:doc:`/cookbook/routing/method_parameters`.
 
 .. note::
+
     Using ``PUT``, ``PATCH`` and ``DELETE`` is only allowed if
     :ref:`configuration-framework-http_method_override` is enabled.

--- a/reference/forms/types/options/method.rst.inc
+++ b/reference/forms/types/options/method.rst.inc
@@ -6,14 +6,18 @@ method
 
 **type**: ``string`` **default**: ``POST``
 
-This option specifies the HTTP method used to submit the form's data. Possible
-values are:
+This option specifies the HTTP method used to submit the form's data. It's
+value is rendered as the ``method`` attribute of the ``form`` element.
+Possible values are:
 
 * POST
 * GET
 * PUT
 * DELETE
 * PATCH
+
+As PUT, DELETE and PATCH are not nativly supported by most clients, Symfony
+simulates them, see :doc:`/cookbook/routing/method_parameters`.
 
 .. note::
     Using ``PUT``, ``PATCH`` and ``DELETE`` is only allowed if

--- a/reference/forms/types/options/method.rst.inc
+++ b/reference/forms/types/options/method.rst.inc
@@ -6,10 +6,10 @@ method
 
 **type**: ``string`` **default**: ``POST``
 
-This option specifies the HTTP method used to submit the form's data. It's
-value is rendered as the ``method`` attribute of the ``form`` element and to
-perform some consistency checks when evaluating the form after submission.
-Possible values are:
+This option specifies the HTTP method used to submit the form's data. Its
+value is rendered as the ``method`` attribute of the ``form`` element and is
+used to decide whether to process the form submission in the
+``handleRequest()`` method after submission. Possible values are:
 
 * POST
 * GET


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.3+ |
| Fixed tickets | #3410 |

I'm not sure of adding these two options as separate rst-files because I don't think they will get listed as `inherited` options. But no other options are embedded directly. Please let me know if I can improve that.
