### PR TITLE
[Expression]Change title 'Accessing Public Methods'

### DIFF
--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -28,7 +28,7 @@ Working with Objects
 When passing objects into an expression, you can use different syntaxes to
 access properties and call methods on the object.
 
-Accessing Public Methods
+Accessing Public Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Public properties on objects can be accessed by using the ``.`` syntax, similar

--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -29,7 +29,7 @@ When passing objects into an expression, you can use different syntaxes to
 access properties and call methods on the object.
 
 Accessing Public Properties
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Public properties on objects can be accessed by using the ``.`` syntax, similar
 to JavaScript::


### PR DESCRIPTION
Change title 'Accessing Public Methods' to 'Accessing Public Properties' because it's more in relation with the content.
