### PR TITLE
[WIP][Reference][Form Types] Add missing options for "form" type

### DIFF
--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -59,3 +59,8 @@ on all fields.
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 
+.. include:: /reference/forms/types/options/extra_fields_message.rst.inc
+
+.. include:: /reference/forms/types/options/post_max_size_message.rst.inc
+
+.. include:: /reference/forms/types/options/pattern.rst.inc

--- a/reference/forms/types/options/extra_fields_message.rst.inc
+++ b/reference/forms/types/options/extra_fields_message.rst.inc
@@ -1,0 +1,9 @@
+extra_fields_message
+~~~~~~~~~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``This form should not contain extra fields.``
+
+This is the validation error message that's used if the submitted form data
+contains one or more fields that are not part of the form definition. The
+placeholder ``{{ extra_fields }}`` can be used to display a comma separated
+list of the submitted extra field names.

--- a/reference/forms/types/options/pattern.rst.inc
+++ b/reference/forms/types/options/pattern.rst.inc
@@ -1,0 +1,16 @@
+pattern
+~~~~~~~
+
+**type**: ``string`` **default**: ``null``
+
+This option adds a ``pattern`` attribute to restrict the field input by a
+regular expression.
+
+.. caution:
+
+    This validation is client-side only.
+
+.. note:
+
+    When using validation constraints, this option is set automatically
+    for some constraints to match the server-side validation.

--- a/reference/forms/types/options/pattern.rst.inc
+++ b/reference/forms/types/options/pattern.rst.inc
@@ -9,7 +9,8 @@ given regular expression.
 .. caution:
 
     The ``pattern`` attribute provides client-side validation for convenience
-    purposes only and cannot replace a reliable server-side validation.
+    purposes only and must not be used as a replacement for reliable
+    server-side validation.
 
 .. note:
 

--- a/reference/forms/types/options/pattern.rst.inc
+++ b/reference/forms/types/options/pattern.rst.inc
@@ -3,12 +3,13 @@ pattern
 
 **type**: ``string`` **default**: ``null``
 
-This option adds a ``pattern`` attribute to restrict the field input by a
-regular expression.
+This adds an HTML5 ``pattern`` attribute to restrict the field input by a
+given regular expression.
 
 .. caution:
 
-    This validation is client-side only.
+    The ``pattern`` attribute provides client-side validation for convenience
+    purposes only and cannot replace a reliable server-side validation.
 
 .. note:
 

--- a/reference/forms/types/options/post_max_size_message.rst.inc
+++ b/reference/forms/types/options/post_max_size_message.rst.inc
@@ -4,8 +4,8 @@ post_max_size_message
 **type**: ``string`` **default**: ``The uploaded file was too large. Please try to upload a smaller file.``
 
 This is the validation error message that's used if submitted POST form data
-exceeds php.ini's ``post_max_size``. The ``{{ max }}`` placeholder can be used
-to display the allowed size.
+exceeds ``php.ini``'s ``post_max_size`` directive. The ``{{ max }}``
+placeholder can be used to display the allowed size.
 
 .. note:
 

--- a/reference/forms/types/options/post_max_size_message.rst.inc
+++ b/reference/forms/types/options/post_max_size_message.rst.inc
@@ -1,0 +1,12 @@
+post_max_size_message
+~~~~~~~~~~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``The uploaded file was too large. Please try to upload a smaller file.``
+
+This is the validation error message that's used if submitted POST form data
+exceeds php.ini's ``post_max_size``. The ``{{ max }}`` placeholder can be used
+to display the allowed size.
+
+.. note:
+
+    Validating the ``post_max_size`` only happens on the root form.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.3+ |
| Fixed tickets | #3410 |

Do we need to point out, that the `pattern` attribute is HTML5 only?
