### PR TITLE
[Security] Add host option

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -151,6 +151,9 @@ that looks like the following:
 Let's look briefly at how security works and how each part of the configuration
 comes into play.
 
+.. versionadded:: 2.4
+    A new property was added to the firewall configuration, where you can make a restriction, called ``host``.
+
 How Security Works: Authentication and Authorization
 ----------------------------------------------------
 

--- a/book/security.rst
+++ b/book/security.rst
@@ -151,10 +151,6 @@ that looks like the following:
 Let's look briefly at how security works and how each part of the configuration
 comes into play.
 
-.. versionadded:: 2.4
-    Support for restricting security firewalls to a specific host was added in
-    Symfony 2.4.
-
 How Security Works: Authentication and Authorization
 ----------------------------------------------------
 

--- a/book/security.rst
+++ b/book/security.rst
@@ -152,7 +152,8 @@ Let's look briefly at how security works and how each part of the configuration
 comes into play.
 
 .. versionadded:: 2.4
-    A new property was added to the firewall configuration, where you can make a restriction, called ``host``.
+    A new property was added to the firewall configuration, where you can 
+make a restriction, called ``host``.
 
 How Security Works: Authentication and Authorization
 ----------------------------------------------------

--- a/book/security.rst
+++ b/book/security.rst
@@ -152,8 +152,8 @@ Let's look briefly at how security works and how each part of the configuration
 comes into play.
 
 .. versionadded:: 2.4
-    A new property was added to the firewall configuration, where you can 
-make a restriction, called ``host``.
+    Support for restricting security firewalls to a specific host was added in
+    Symfony 2.4.
 
 How Security Works: Authentication and Authorization
 ----------------------------------------------------
@@ -1102,7 +1102,7 @@ Thanks to the SensioFrameworkExtraBundle, you can also secure your controller us
         // ...
     }
 
-For more information, see the 
+For more information, see the
 :doc:`FrameworkExtraBundle documentation </bundles/SensioFrameworkExtraBundle/annotations/security>`.
 
 Securing other Services
@@ -2168,6 +2168,7 @@ Learn more from the Cookbook
 * :doc:`Blacklist users by IP address with a custom voter </cookbook/security/voters>`
 * :doc:`Access Control Lists (ACLs) </cookbook/security/acl>`
 * :doc:`/cookbook/security/remember_me`
+* :doc:`How to Restrict Firewalls to a Specific Host </cookbook/security/host_restriction>`
 
 .. _`FOSUserBundle`: https://github.com/FriendsOfSymfony/FOSUserBundle
 .. _`implement the \Serializable interface`: http://php.net/manual/en/class.serializable.php

--- a/cookbook/security/host_restriction.rst
+++ b/cookbook/security/host_restriction.rst
@@ -5,7 +5,7 @@ How to Restrict Firewalls to a Specific Host
 ============================================
 
 .. versionadded:: 2.4
-    Support for restricting security firewalls to a specific host was added in
+    Support for restricting security firewalls to a specific host was introduced in
     Symfony 2.4.
 
 When using the Security component, you can create firewalls that match certain

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -14,7 +14,7 @@ The following is the full default configuration for the security system.
 Each part will be explained in the next section.
 
 .. versionadded:: 2.4
-    Support for restricting security firewalls to a specific host was added in
+    Support for restricting security firewalls to a specific host was introduced in
     Symfony 2.4.
 
 .. configuration-block::
@@ -102,7 +102,7 @@ Each part will be explained in the next section.
                 # Examples:
                 somename:
                     pattern: .*
-                    # restrict the firewall for a specific host
+                    # restrict the firewall to a specific host
                     host: admin\.example\.com
                     request_matcher: some.service.id
                     access_denied_url: /foo/error403

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -98,6 +98,8 @@ Each part will be explained in the next section.
                 # Examples:
                 somename:
                     pattern: .*
+                    # restrict the firewall for a specific host
+                    host: admin\.example\.com
                     request_matcher: some.service.id
                     access_denied_url: /foo/error403
                     access_denied_handler: some.service.id

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -13,6 +13,10 @@ Full Default Configuration
 The following is the full default configuration for the security system.
 Each part will be explained in the next section.
 
+.. versionadded:: 2.4
+    Support for restricting security firewalls to a specific host was added in
+    Symfony 2.4.
+
 .. configuration-block::
 
     .. code-block:: yaml


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4+ |
| Fixed tickets | #3453 |

Host option is missing from documentation and this feature was introduced in 2.4 for the firewall.
