### PR TITLE
[Form] Deprecated max_length and pattern options

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -707,8 +707,8 @@ the correct values of a number of field options.
   (i.e. is the field ``nullable``). This is very useful, as your client-side
   validation will automatically match your validation rules.
 
-* ``max_length``: If the field is some sort of text field, then the ``max_length``
-  option can be guessed from the validation constraints (if ``Length`` or
+* ``maxlength``: If the field is some sort of text field, then the ``maxlength``
+  option attribute can be guessed from the validation constraints (if ``Length`` or
   ``Range`` is used) or from the Doctrine metadata (via the field's length).
 
 .. note::
@@ -719,7 +719,7 @@ the correct values of a number of field options.
 If you'd like to change one of the guessed values, you can override it by
 passing the option in the options field array::
 
-    ->add('task', null, array('max_length' => 4))
+    ->add('task', null, array('attr' => array('maxlength' => 4)))
 
 .. index::
    single: Forms; Rendering in a template

--- a/reference/forms/twig_reference.rst
+++ b/reference/forms/twig_reference.rst
@@ -350,9 +350,11 @@ object:
 | ``required``           | If ``true``, a ``required`` attribute is added to the field to activate HTML5       |
 |                        | validation. Additionally, a ``required`` class is added to the label.               |
 +------------------------+-------------------------------------------------------------------------------------+
-| ``max_length``         | Adds a ``maxlength`` HTML attribute to the element.                                 |
+| ``max_length``         | Adds a ``maxlength`` HTML attribute to the element. (deprecated as of 2.5, to be    |
+|                        | removed in 3.0, use ``attr["maxlength"]`` instead)                                  |
 +------------------------+-------------------------------------------------------------------------------------+
-| ``pattern``            | Adds a ``pattern`` HTML attribute to the element.                                   |
+| ``pattern``            | Adds a ``pattern`` HTML attribute to the element. (deprecated as of 2.5, to be      |
+|                        | removed in 3.0, use ``attr["pattern"]`` instead)                                    |
 +------------------------+-------------------------------------------------------------------------------------+
 | ``label``              | The string label that will be rendered.                                             |
 +------------------------+-------------------------------------------------------------------------------------+

--- a/reference/forms/types/email.rst
+++ b/reference/forms/types/email.rst
@@ -10,7 +10,7 @@ The ``email`` field is a text field that is rendered using the HTML5
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``email`` field (a text box)                              |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | - `max_length`_                                                     |
+| Inherited   | - `max_length`_ (deprecated as of 2.5)                              |
 | options     | - `empty_data`_                                                     |
 |             | - `required`_                                                       |
 |             | - `label`_                                                          |

--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -20,7 +20,7 @@ on all types for which ``form`` is the parent type.
 |           | - `trim`_                                                          |
 |           | - `mapped`_                                                        |
 |           | - `property_path`_                                                 |
-|           | - `max_length`_                                                    |
+|           | - `max_length`_ (deprecated as of 2.5)                             |
 |           | - `by_reference`_                                                  |
 |           | - `error_bubbling`_                                                |
 |           | - `inherit_data`_                                                  |
@@ -29,7 +29,7 @@ on all types for which ``form`` is the parent type.
 |           | - `invalid_message_parameters`_                                    |
 |           | - `extra_fields_message`_                                          |
 |           | - `post_max_size_message`_                                         |
-|           | - `pattern`_                                                       |
+|           | - `pattern`_ (deprecated as of 2.5)                                |
 +-----------+--------------------------------------------------------------------+
 | Inherited | - `block_name`_                                                    |
 | options   | - `disabled`_                                                      |

--- a/reference/forms/types/options/max_length.rst.inc
+++ b/reference/forms/types/options/max_length.rst.inc
@@ -1,10 +1,16 @@
+.. caution::
+
+    The ``max_length`` option has been deprecated and will be removed in 3.0.
+    Instead, use the ``attr`` option by setting it to an array with a ``maxlength`` key.
+
 max_length
 ~~~~~~~~~~
 
 **type**: ``integer`` **default**: ``null``
 
-If this option is not null, an attribute ``maxlength`` is added, which 
-is used by some browsers to limit the amount of text in a field. 
+If this option is not null, an attribute ``maxlength`` is added, which
+is used by some browsers to limit the amount of text in a field.
 
-This is just a browser validation, so data must still be validated 
+This is just a browser validation, so data must still be validated
 server-side.
+

--- a/reference/forms/types/options/pattern.rst.inc
+++ b/reference/forms/types/options/pattern.rst.inc
@@ -1,3 +1,8 @@
+.. caution::
+
+    The ``pattern`` option has been deprecated and will be removed in 3.0.
+    Instead, use the ``attr`` option by setting it to an array with a ``pattern`` key.
+
 pattern
 ~~~~~~~
 

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -11,7 +11,7 @@ The ``password`` field renders an input password text box.
 +-------------+------------------------------------------------------------------------+
 | Options     | - `always_empty`_                                                      |
 +-------------+------------------------------------------------------------------------+
-| Inherited   | - `max_length`_                                                        |
+| Inherited   | - `max_length`_ (deprecated as of 2.5)                                 |
 | options     | - `empty_data`_                                                        |
 |             | - `required`_                                                          |
 |             | - `label`_                                                             |

--- a/reference/forms/types/search.rst
+++ b/reference/forms/types/search.rst
@@ -12,7 +12,7 @@ Read about the input search field at `DiveIntoHTML5.info`_
 +-------------+----------------------------------------------------------------------+
 | Rendered as | ``input search`` field                                               |
 +-------------+----------------------------------------------------------------------+
-| Inherited   | - `max_length`_                                                      |
+| Inherited   | - `max_length`_ (deprecated as of 2.5)                               |
 | options     | - `empty_data`_                                                      |
 |             | - `required`_                                                        |
 |             | - `label`_                                                           |

--- a/reference/forms/types/text.rst
+++ b/reference/forms/types/text.rst
@@ -9,7 +9,7 @@ The text field represents the most basic input text field.
 +-------------+--------------------------------------------------------------------+
 | Rendered as | ``input`` ``text`` field                                           |
 +-------------+--------------------------------------------------------------------+
-| Inherited   | - `max_length`_                                                    |
+| Inherited   | - `max_length`_ (deprecated as of 2.5)                             |
 | options     | - `empty_data`_                                                    |
 |             | - `required`_                                                      |
 |             | - `label`_                                                         |

--- a/reference/forms/types/textarea.rst
+++ b/reference/forms/types/textarea.rst
@@ -9,7 +9,7 @@ Renders a ``textarea`` HTML element.
 +-------------+------------------------------------------------------------------------+
 | Rendered as | ``textarea`` tag                                                       |
 +-------------+------------------------------------------------------------------------+
-| Inherited   | - `max_length`_                                                        |
+| Inherited   | - `max_length`_ (deprecated as of 2.5)                                 |
 | options     | - `empty_data`_                                                        |
 |             | - `required`_                                                          |
 |             | - `label`_                                                             |

--- a/reference/forms/types/url.rst
+++ b/reference/forms/types/url.rst
@@ -13,7 +13,7 @@ have a protocol.
 +-------------+-------------------------------------------------------------------+
 | Options     | - `default_protocol`_                                             |
 +-------------+-------------------------------------------------------------------+
-| Inherited   | - `max_length`_                                                   |
+| Inherited   | - `max_length`_ (deprecated as of 2.5)                            |
 | options     | - `empty_data`_                                                   |
 |             | - `required`_                                                     |
 |             | - `label`_                                                        |


### PR DESCRIPTION
See https://github.com/symfony/symfony/pull/10001

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | master |
| Fixed tickets | - |
