### PR TITLE
[Validator] - EmailConstraint reference

### DIFF
--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -91,11 +91,13 @@ Options
 -------
 
 strict
-~~~~~~~
+~~~~~~
+.. versionadded:: 2.5
+    The ``strict`` option was introduced in Symfony 2.5.
 
 **type**: ``boolean`` **default**: ``false``
 
-Will validate the email against a simple RegularExpression.
+When false, the email will be validated against a simple RegularExpression.
 If true, then the `EmailValidator <https://packagist.org/packages/egulias/email-validator>`_ library
 is required to perform an RFC compilant validation.
 

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -125,4 +125,5 @@ checkHost
 If true, then the :phpfunction:`checkdnsrr` PHP function will be used to
 check the validity of the MX *or* the A *or* the AAAA record of the host
 of the given email.
+
 .. _egulias/email-validator: https://packagist.org/packages/egulias/email-validator

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -7,7 +7,8 @@ cast to a string before being validated.
 +----------------+---------------------------------------------------------------------+
 | Applies to     | :ref:`property or method <validation-property-target>`              |
 +----------------+---------------------------------------------------------------------+
-| Options        | - `message`_                                                        |
+| Options        | - `strict`_                                                         |
+|                | - `message`_                                                        |
 |                | - `checkMX`_                                                        |
 |                | - `checkHost`_                                                      |
 +----------------+---------------------------------------------------------------------+
@@ -88,6 +89,15 @@ Basic Usage
 
 Options
 -------
+
+strict
+~~~~~~~
+
+**type**: ``boolean`` **default**: ``false``
+
+Will validate the email against a simple RegularExpression.
+If true, then the library (`egulias/email-validator`)[https://packagist.org/packages/egulias/email-validator] 
+is required to perform an RFC compilant validation.
 
 message
 ~~~~~~~

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -90,16 +90,16 @@ Basic Usage
 Options
 -------
 
-strict
-~~~~~~
 .. versionadded:: 2.5
     The ``strict`` option was introduced in Symfony 2.5.
 
+strict
+~~~~~~
+
 **type**: ``boolean`` **default**: ``false``
 
-When false, the email will be validated against a simple RegularExpression.
-If true, then the `EmailValidator <https://packagist.org/packages/egulias/email-validator>`_ library
-is required to perform an RFC compilant validation.
+When false, the email will be validated against a simple Regular Expression.
+If true, then the `egulias/email-validator`_ library is required to perform an RFC compilant validation.
 
 message
 ~~~~~~~
@@ -124,3 +124,6 @@ checkHost
 If true, then the :phpfunction:`checkdnsrr` PHP function will be used to
 check the validity of the MX *or* the A *or* the AAAA record of the host
 of the given email.
+
+
+.. _EmailValidator: https://packagist.org/packages/egulias/email-validator

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -98,8 +98,8 @@ strict
 
 **type**: ``boolean`` **default**: ``false``
 
-When false, the email will be validated against a simple Regular Expression.
-If true, then the `EmailValidator`_ library is required to perform an RFC compliant validation.
+When false, the email will be validated against a simple regular expression.
+If true, then the `egulias/email-validator`_ library is required to perform an RFC compliant validation.
 
 message
 ~~~~~~~
@@ -126,4 +126,4 @@ check the validity of the MX *or* the A *or* the AAAA record of the host
 of the given email.
 
 
-.. _EmailValidator: https://packagist.org/packages/egulias/email-validator
+.. _egulias/email-validator: https://packagist.org/packages/egulias/email-validator

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -99,7 +99,8 @@ strict
 **type**: ``boolean`` **default**: ``false``
 
 When false, the email will be validated against a simple regular expression.
-If true, then the `egulias/email-validator`_ library is required to perform an RFC compliant validation.
+If true, then the `egulias/email-validator`_ library is required to perform 
+an RFC compliant validation.
 
 message
 ~~~~~~~
@@ -124,6 +125,4 @@ checkHost
 If true, then the :phpfunction:`checkdnsrr` PHP function will be used to
 check the validity of the MX *or* the A *or* the AAAA record of the host
 of the given email.
-
-
 .. _egulias/email-validator: https://packagist.org/packages/egulias/email-validator

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -96,7 +96,7 @@ strict
 **type**: ``boolean`` **default**: ``false``
 
 Will validate the email against a simple RegularExpression.
-If true, then the library (`egulias/email-validator`)[https://packagist.org/packages/egulias/email-validator] 
+If true, then the `EmailValidator <https://packagist.org/packages/egulias/email-validator>`_ library
 is required to perform an RFC compilant validation.
 
 message

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -99,7 +99,7 @@ strict
 **type**: ``boolean`` **default**: ``false``
 
 When false, the email will be validated against a simple Regular Expression.
-If true, then the `egulias/email-validator`_ library is required to perform an RFC compilant validation.
+If true, then the `EmailValidator`_ library is required to perform an RFC compliant validation.
 
 message
 ~~~~~~~


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes - https://github.com/symfony/symfony/pull/9140 |
| Applies to | master |
| Fixed tickets |  |
## Note

I'm not sure if this behaviour change should go in a page by itself (like https://github.com/symfony/symfony-docs/blob/2.4/components/dependency_injection/lazy_services.rst) since requires the installation of an external library to work.
I appreciate some guide on this since it's my first doc PR, thanks. 
