### PR TITLE
Fixed `versionadded` inconsistencies in Symfony 2.3

### DIFF
--- a/components/http_foundation/trusting_proxies.rst
+++ b/components/http_foundation/trusting_proxies.rst
@@ -15,7 +15,7 @@ headers by default. If you are behind a proxy, you should manually whitelist
 your proxy.
 
 .. versionadded:: 2.3
-    CIDR notation support was introduced, so you can whitelist whole
+    CIDR notation support was introduced in Symfony 2.3, so you can whitelist whole
     subnets (e.g. ``10.0.0.0/8``, ``fc00::/7``).
 
 .. code-block:: php

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -125,7 +125,7 @@ Configures the IP addresses that should be trusted as proxies. For more details,
 see :doc:`/components/http_foundation/trusting_proxies`.
 
 .. versionadded:: 2.3
-    CIDR notation support was introduced, so you can whitelist whole
+    CIDR notation support was introduced in Symfony 2.3, so you can whitelist whole
     subnets (e.g. ``10.0.0.0/8``, ``fc00::/7``).
 
 .. configuration-block::


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | N/A |

Founded some `versionadded` blocks that does not follow the "standard" of having the ".. was introduced in Symfony 2.x" or similar sentence.
