### PR TITLE
Fixed `versionadded` inconsistencies in Symfony 2.5+

### DIFF
--- a/cookbook/security/acl_advanced.rst
+++ b/cookbook/security/acl_advanced.rst
@@ -50,7 +50,7 @@ your application. Each role, or user has its own security identity.
     if for any reason, a user's username was to change, you must ensure its
     security identity is updated too. The
     :method:`MutableAclProvider::updateUserSecurityIdentity() <Symfony\\Component\\Security\\Acl\\Dbal\\MutableAclProvider::updateUserSecurityIdentity>`
-    method is there to handle the update.
+    method is there to handle the update, it was introduced in Symfony 2.5.
 
 Database Table Structure
 ------------------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5+ |
| Fixed tickets | N/A |

Same as symfony/symfony-docs#3471 - Founded some `versionadded` blocks that does not follow the "standard" of having the ".. was introduced in Symfony 2.x" or similar sentence.
