### PR TITLE
Update custom_password_authenticator.rst

### DIFF
--- a/cookbook/security/custom_password_authenticator.rst
+++ b/cookbook/security/custom_password_authenticator.rst
@@ -66,7 +66,7 @@ the user::
                 }
 
                 return new UsernamePasswordToken(
-                    $user->getUsername(),
+                    $user,
                     $user->getPassword(),
                     $providerKey,
                     $user->getRoles()


### PR DESCRIPTION
Correct me if I am wrong... but because we are passing here `username` as first argument to `UsernamePasswordToken`, when one would like to use method `getUser()` from base `Controller`: 

```
...
if (!$this->container->has('security.context')) {
            throw new \LogicException('The SecurityBundle is not registered in your application.');
        }

        if (null === $token = $this->container->get('security.context')->getToken()) {
            return null;
        }

        if (!is_object($user = $token->getUser())) {
            return null;
        }

        return $user;
...
```

it will fail to get actually logged in user and return null.
