### PR TITLE
Documenting createAccessDeniedException() method

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1084,7 +1084,7 @@ authorization from inside a controller::
 
 .. _book-security-securing-controller-annotations:
 
-The ``createAccessDeniedException()`` method creates a special ``AccessDeniedException``
+The :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::createAccessDeniedException()` method creates a special :class:`Symfony\\Component\\Security\\Core\Exception\\AccessDeniedException`
 object, which ultimately triggers a 403 HTTP response inside Symfony.
 
 Thanks to the SensioFrameworkExtraBundle, you can also secure your controller using annotations::

--- a/book/security.rst
+++ b/book/security.rst
@@ -1087,7 +1087,8 @@ authorization from inside a controller::
 .. versionadded:: 2.5
     The ``createAccessDeniedException`` method was introduced in Symfony 2.5.
 
-The :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::createAccessDeniedException()` method creates a special :class:`Symfony\\Component\\Security\\Core\Exception\\AccessDeniedException`
+The :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::createAccessDeniedException()`
+method creates a special :class:`Symfony\\Component\\Security\\Core\Exception\\AccessDeniedException`
 object, which ultimately triggers a 403 HTTP response inside Symfony.
 
 Thanks to the SensioFrameworkExtraBundle, you can also secure your controller using annotations::

--- a/book/security.rst
+++ b/book/security.rst
@@ -1084,6 +1084,9 @@ authorization from inside a controller::
 
 .. _book-security-securing-controller-annotations:
 
+.. versionadded:: 2.5
+    The ``createAccessDeniedException`` method was introduced in Symfony 2.5.
+
 The :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::createAccessDeniedException()` method creates a special :class:`Symfony\\Component\\Security\\Core\Exception\\AccessDeniedException`
 object, which ultimately triggers a 403 HTTP response inside Symfony.
 

--- a/book/security.rst
+++ b/book/security.rst
@@ -1072,18 +1072,20 @@ fine-grained enough in certain cases. When necessary, you can easily force
 authorization from inside a controller::
 
     // ...
-    use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
     public function helloAction($name)
     {
         if (false === $this->get('security.context')->isGranted('ROLE_ADMIN')) {
-            throw new AccessDeniedException();
+            throw $this->createAccessDeniedException('Unable to access this page!');
         }
 
         // ...
     }
 
 .. _book-security-securing-controller-annotations:
+
+The ``createAccessDeniedException()`` method creates a special ``AccessDeniedException``
+object, which ultimately triggers a 403 HTTP response inside Symfony.
 
 Thanks to the SensioFrameworkExtraBundle, you can also secure your controller using annotations::
 


### PR DESCRIPTION
Updating documentation to reflect the changes added in https://github.com/symfony/symfony/pull/9405.

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony#9405) |
| Applies to | 2.5+ |
| Fixed tickets |  |
