### PR TITLE
Fix a typo (missing `) in :doc: link

### DIFF
--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -233,7 +233,7 @@ method returns without actually printing.
     The MonologBridge provides a :class:`Symfony\\Bridge\\Monolog\\Handler\\ConsoleHandler`
     class that allows you to display messages on the console. This is cleaner
     than wrapping your output calls in conditions. For an example use in
-    the Symfony Framework, see :doc:/cookbook/logging/monolog_console.
+    the Symfony Framework, see :doc:`/cookbook/logging/monolog_console`.
 
 Using Command Arguments
 -----------------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4 |
| Fixed tickets |  |
