### PR TITLE
Fixed some small typos in code example

### DIFF
--- a/cookbook/security/api_key_authentication.rst
+++ b/cookbook/security/api_key_authentication.rst
@@ -38,7 +38,7 @@ value and then a User object is created::
     {
         protected $userProvider;
 
-        public function __construct(ApiKeyUserProviderInterface $userProvider)
+        public function __construct(ApiKeyUserProvider $userProvider)
         {
             $this->userProvider = $userProvider;
         }

--- a/cookbook/security/api_key_authentication.rst
+++ b/cookbook/security/api_key_authentication.rst
@@ -145,7 +145,7 @@ The ``$userProvider`` might look something like this::
     use Symfony\Component\Security\Core\User\UserInterface;
     use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 
-    class ApiKeyUserProvider extends UserProviderInterface
+    class ApiKeyUserProvider implements UserProviderInterface
     {
         public function getUsernameForApiKey($apiKey)
         {

--- a/cookbook/security/api_key_authentication.rst
+++ b/cookbook/security/api_key_authentication.rst
@@ -59,7 +59,7 @@ value and then a User object is created::
         public function authenticateToken(TokenInterface $token, UserProviderInterface $userProvider, $providerKey)
         {
             $apiKey = $token->getCredentials();
-            $username = $this->userProvider->getUsernameForApiKey($apiKey)
+            $username = $this->userProvider->getUsernameForApiKey($apiKey);
 
             if (!$username) {
                 throw new AuthenticationException(


### PR DESCRIPTION
Hi,

I found some small typos in the code example and fixed it:
http://symfony.com/doc/current/cookbook/security/api_key_authentication.html

Cheers,

Robin
