### PR TITLE
update collection.rst - add cascade_validation opt

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -26,6 +26,7 @@ forms, which is useful when creating forms that expose one-to-many relationships
 |             | - `by_reference`_                                                           |
 |             | - `empty_data`_                                                             |
 |             | - `mapped`_                                                                 |
+|             | - `cascade_validation`_                                                     |
 +-------------+-----------------------------------------------------------------------------+
 | Parent type | :doc:`form </reference/forms/types/form>`                                   |
 +-------------+-----------------------------------------------------------------------------+
@@ -360,3 +361,5 @@ error_bubbling
 .. include:: /reference/forms/types/options/by_reference.rst.inc
 
 .. include:: /reference/forms/types/options/empty_data.rst.inc
+
+.. include:: /reference/forms/type/options/cascade_validation.rst.inc


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | all |

It makes sense to describe cascade_validation option in collection
documentation. `Valid` constraint does not suit all needs, especially
when we have to set validation_groups for embed object/forms, and so
cascade_validation should not be that "hidden".
