### PR TITLE
Clarify service parameters usages

### DIFF
--- a/components/dependency_injection/parameters.rst
+++ b/components/dependency_injection/parameters.rst
@@ -25,6 +25,13 @@ and set a parameter in the container with::
 
     $container->setParameter('mailer.transport', 'sendmail');
 
+.. caution::
+
+    The used ``.`` notation is just a
+    :ref:`Symfony convention <service-naming-conventions>` to make parameters
+    easier to read. Parameters are just flat key-value elements, they can't be
+    inherited.
+
 .. note::
 
     You can only set a parameter before the container is compiled. To learn
@@ -190,9 +197,9 @@ making the class of a service a parameter:
 Array Parameters
 ----------------
 
-Parameters do not need to be flat strings, they can also be arrays. For the XML
-format, you need to use the ``type="collection"`` attribute for all parameters that are
-arrays.
+Parameters do not need to be flat strings, they can also contain array values.
+For the XML format, you need to use the ``type="collection"`` attribute for
+all parameters that are arrays.
 
 .. configuration-block::
 

--- a/components/dependency_injection/parameters.rst
+++ b/components/dependency_injection/parameters.rst
@@ -30,7 +30,7 @@ and set a parameter in the container with::
     The used ``.`` notation is just a
     :ref:`Symfony convention <service-naming-conventions>` to make parameters
     easier to read. Parameters are just flat key-value elements, they can't be
-    inherited.
+    organized into a nested array
 
 .. note::
 

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -133,6 +133,8 @@ Naming Conventions
 * Don't forget to look at the more verbose :doc:`conventions` document for
   more subjective naming considerations.
 
+.. _service-naming-conventions:
+
 Service Naming Conventions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | IRC |

On the IRC channel, there was some confusing about parameters. The dot
notation looked like parameters are one big namespaced tree, with each
group a different node.

This PR adds a caution, so people really know it's just a convention and
parameters are just key-value elements.
