### PR TITLE
Example of getting entity managers directly from the container

### DIFF
--- a/cookbook/doctrine/multiple_entity_managers.rst
+++ b/cookbook/doctrine/multiple_entity_managers.rst
@@ -187,11 +187,14 @@ the default entity manager (i.e. ``default``) is returned::
     {
         public function indexAction()
         {
-            // both return the "default" em
+            // All three return the "default" entity manager
             $em = $this->get('doctrine')->getManager();
             $em = $this->get('doctrine')->getManager('default');
+            $em = $this->get('doctrine.orm.default_entity_manager');
 
-            $customerEm =  $this->get('doctrine')->getManager('customer');
+            // Both of these return the "customer" entity manager
+            $customerEm = $this->get('doctrine')->getManager('customer');
+            $customerEm = $this->get('doctrine.orm.customer_entity_manager');
         }
     }
 


### PR DESCRIPTION
The documentation didn't provide examples of how to obtain the entity managers directly from the DI container.  This is useful when needing to inject the em into other services.

The ems are added to the container using the service id `doctrine.orm.%s_entity_manager`, where `%s` is the em's name.  This is done by [`\Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension::loadOrmEntityManager()`](https://github.com/doctrine/DoctrineBundle/blob/v1.0.0/DependencyInjection/DoctrineExtension.php#L342)

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes? (added example of existing feature) |
| Applies to | all (doctrine/doctrine-bundle v1.0.0+) |
| Fixed tickets | n/a |
