### PR TITLE
Fix README: contributions should be based off 2.3 or higher

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,9 +7,9 @@ Contributing
 ------------
 
 >**Note**
->Unless you're documenting a feature that's new to a specific version of Symfony
->(e.g. Symfony 2.3), all pull requests must be based off of the **2.2** branch,
->**not** the master or 2.3 branch.
+>Unless you're documenting a feature that was introduced *after* Symfony 2.3 
+>(e.g. in Symfony 2.4), all pull requests must be based off of the **2.3** branch,
+>**not** the master or older branches.
 
 We love contributors! For more information on how you can contribute to the
 Symfony documentation, please read


### PR DESCRIPTION
Per [the documentation](http://symfony.com/doc/current/contributing/documentation/overview.html#contributing) and [WouterJ's comment here](https://github.com/symfony/symfony-docs/pull/3537#issuecomment-33985191), the base branch should be 2.3, not 2.2.  This commit updates the README to reflect the language found in the documentation.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | n/a |
