### PR TITLE
Update introduction.rst

### DIFF
--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -603,6 +603,7 @@ a built-in ControllerResolver that can be used to create a working example::
     use Symfony\Component\HttpKernel\HttpKernel;
     use Symfony\Component\EventDispatcher\EventDispatcher;
     use Symfony\Component\HttpKernel\Controller\ControllerResolver;
+    use Symfony\Component\HttpKernel\EventListener\RouterListener;
     use Symfony\Component\Routing\RouteCollection;
     use Symfony\Component\Routing\Route;
     use Symfony\Component\Routing\Matcher\UrlMatcher;


### PR DESCRIPTION
Found that use Symfony\Component\HttpKernel\EventListener\RouterListener; is missing
 in full working example.
