### PR TITLE
Created Documentation CHANGELOG

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,0 +1,66 @@
+.. index::
+	single: CHANGELOG
+
+The Documentation Changelog
+===========================
+
+This documentation is under current development: All new features needs new
+documentation and bugs/typos get fixed. This article holds all important
+changes of the documentation.
+
+.. tip::
+
+	Do you also want to participate in the Symfony Documentation? Take a look
+	at the ":doc:`/contributing/documentation`" article.
+
+January, 2014
+-------------
+
+New Documentation
+~~~~~~~~~~~~~~~~~
+
+No changes
+
+Fixed Documentation
+~~~~~~~~~~~~~~~~~~~
+
+- `e385d28 <https://github.com/symfony/symfony-docs/commit/e385d28bee7c7418c8175d43befc4954a43a300c>`_ #3503 file extension correction xfliff to xliff (nixilla)
+- `7fe0de3 <https://github.com/symfony/symfony-docs/commit/7fe0de330b2d72155b6b7ec87c59f5a7e7ee4881>`_ #3475 Fixed doc for framework.session.cookie_lifetime refrence. (tyomo4ka)
+- `8155e4c <https://github.com/symfony/symfony-docs/commit/8155e4cab70e481962a4775274a4412a4465ecdc>`_ #3473 Update proxy_examples.rst (AZielinski)
+- `c205bc6 <https://github.com/symfony/symfony-docs/commit/c205bc6798bac34741f2d4d91450aac75ab14b93>`_ #3468 enclose YAML string with double quotes to fix syntax highlighting (xabbuh)
+- `89963cc <https://github.com/symfony/symfony-docs/commit/89963cc246263e7e7cdecd3cad1f019ff9cb28a5>`_ #3463 Fix typos in cookbook/testing/database (ifdattic)
+- `e0a52ec <https://github.com/symfony/symfony-docs/commit/e0a52ecf0cbcf1b5aa029f323588880080f5c6f3>`_ #3460 remove confusing outdated note on interactive rebasing (xabbuh)
+- `6831b13 <https://github.com/symfony/symfony-docs/commit/6831b1337f99c26d9f04eb82990cc3b3ac128de0>`_ #3455 [Contributing][Code] fix indentation so that the text is rendered properly (xabbuh)
+- `ea5816f <https://github.com/symfony/symfony-docs/commit/ea5816f571309decd946bf30aa0b3b84fffacb9e>`_ #3433 [WIP][Reference][Form Types] Update "radio" form type (bicpi)
+- `42c80d1 <https://github.com/symfony/symfony-docs/commit/42c80d12ac760f40834afef76fd42db83d4d4a33>`_ #3448 Overridden tweak (weaverryan)
+- `d9d7c58 <https://github.com/symfony/symfony-docs/commit/d9d7c58ca41ae370545ae25f13857780c089f970>`_ #3444 Fix issue #3442 (ifdattic)
+- `9e2e64b <https://github.com/symfony/symfony-docs/commit/9e2e64b26a355416038b632b7eec89c7c14490cb>`_ #3427 Removed code references to Symfony Standard Distribution (danielcsgomes)
+- `26b8146 <https://github.com/symfony/symfony-docs/commit/26b8146188a3f8bedf2e681d40509b418c8e7ec0>`_ #3415 [#3334] the data_class option was not introduced in 2.4 (xabbuh)
+- `0b2a491 <https://github.com/symfony/symfony-docs/commit/0b2a49199752f60aa1bcc16d48f4c558160e852e>`_ #3414 add missing code-block directive (xabbuh)
+- `4988118 <https://github.com/symfony/symfony-docs/commit/4988118e127dc51d73e2518982c0a0f4ca9206f1>`_ #3432 [Reference][Form Types] Add "max_length" option in form type (nykopol)
+- `26a7b1b <https://github.com/symfony/symfony-docs/commit/26a7b1b80aa654c9293599743f9c0a38054eb4d3>`_ #3423 [Session Configuration] add clarifying notes on session save handler proxies (cordoval)
+
+Minor Documentation Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- `1131247 <https://github.com/symfony/symfony-docs/commit/11312477437e5367da466727acdc89c97b8ed73a>`_ #3508 Add 'in XML' for additional clarity (ifdattic)
+- `a650b93 <https://github.com/symfony/symfony-docs/commit/a650b9364297aa5eaa5ffd3c018b3f0858d12238>`_ #3506 Nykopol overriden options (weaverryan)
+- `ab10035 <https://github.com/symfony/symfony-docs/commit/ab1003501de3e81bc48226b32b53156e2e7a573a>`_ #3505 replace Akamaï with Akamai (xabbuh)
+- `7f56c20 <https://github.com/symfony/symfony-docs/commit/7f56c201ea4cd9b1e7b7ed36ceb2046352a143f2>`_ #3501 [Security] Fix markup (tyx)
+- `80a90ba <https://github.com/symfony/symfony-docs/commit/80a90ba8b5c2eceeb2d80bb1386fb2620b8e0c6e>`_ #3500 Minimize horizontal scrolling in code blocks (improve readability) (ifdattic)
+- `e5bc4ea <https://github.com/symfony/symfony-docs/commit/e5bc4eafeab96b8b12070ce0435b8a77ee85c6c1>`_ #3498 Remove second empty data (xabbuh)
+- `d084d87 <https://github.com/symfony/symfony-docs/commit/d084d876e3ab961c92f2753c73b0a73a75ee7a8b>`_ #3485 [Cookbook][Assetic] Fix "javascripts" tag name typo (bicpi)
+- `3250aba <https://github.com/symfony/symfony-docs/commit/3250aba13ccf8662aa8e38cb624b3adeab0944bc>`_ #3481 Fix code block (minimise horizontal scrolling), typo in yaml (ifdattic)
+- `f285d93 <https://github.com/symfony/symfony-docs/commit/f285d930377d8cbaedccc3ad46853fa72ee6439d>`_ #3451 some language tweaks (AE, third-person perspective) (xabbuh)
+- `2b7e0f6 <https://github.com/symfony/symfony-docs/commit/2b7e0f6f2f9982e600918f447852a6f4c60966a1>`_ #3497 Fix highlighting (WouterJ)
+- `a535ae0 <https://github.com/symfony/symfony-docs/commit/a535ae0383a2a6715021681980877b0205dc3281>`_ #3471 Fixed `````versionadded````` inconsistencies in Symfony 2.3 (danielcsgomes)
+- `f077a8e <https://github.com/symfony/symfony-docs/commit/f077a8e71c4973e7775db8c9fb548a0866d21131>`_ #3465 change wording in versionadded example to be consistent with what we use... (xabbuh)
+- `f9f7548 <https://github.com/symfony/symfony-docs/commit/f9f7548c7a53e62564b30d7e945a9b52b3f358db>`_ #3462 Replace ... with etc (ifdattic)
+- `65efcc4 <https://github.com/symfony/symfony-docs/commit/65efcc4f64365acf5895597bb32e9b611f9bbfcd>`_ #3445 [Reference][Form Types] Add missing (but existing) options to "form" type (bicpi)
+- `1d1b91d <https://github.com/symfony/symfony-docs/commit/1d1b91d6cbd4479e85ff2fdbc2cbab4f7a9a778b>`_ #3431 [Config] add cautionary note on ini file loader limitation (cordoval)
+- `f2eaf9b <https://github.com/symfony/symfony-docs/commit/f2eaf9bbc5d3a73c83ef6e4ce1830bd3e277dcc0>`_ #3419 doctrine file upload example uses dir -- caution added (cordoval)
+- `72b53ad <https://github.com/symfony/symfony-docs/commit/72b53ad4312f74920568e39ebbddc2b3b8008797>`_ #3404 [#3276] Trying to further clarify the session storage directory details (weaverryan)
+- `67b7bbd <https://github.com/symfony/symfony-docs/commit/67b7bbda858337555b7404a17e6ead20d2144eff>`_ #3413 [Cookbook][Bundles] improve explanation of code block for bundle removal (cordoval)
+- `7c5a914 <https://github.com/symfony/symfony-docs/commit/7c5a9141d6dd716e692b27904190225be324f332>`_ #3369 Indicate that Group Sequence Providers can use YAML (karptonite)
+- `1e0311e <https://github.com/symfony/symfony-docs/commit/1e0311ef0124fda8ad0cb07f73a3a52ce3303f2b>`_ #3416 add empty_data option where required option is used (xabbuh)
+- `2be3f52 <https://github.com/symfony/symfony-docs/commit/2be3f52cf5178606e54826e0766f31ce110ee122>`_ #3422 [Cookbook][Custom Authentication Provider] add a note of warning for when forbidding anonymous users (cordoval)

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,17 +1,17 @@
 .. index::
-	single: CHANGELOG
+    single: CHANGELOG
 
 The Documentation Changelog
 ===========================
 
-This documentation is under current development: All new features needs new
-documentation and bugs/typos get fixed. This article holds all important
-changes of the documentation.
+This documentation is always changing: All new features need new documentation
+and bugs/typos get fixed. This article holds all important changes of the
+documentation.
 
 .. tip::
 
-	Do you also want to participate in the Symfony Documentation? Take a look
-	at the ":doc:`/contributing/documentation`" article.
+    Do you also want to participate in the Symfony Documentation? Take a look
+    at the ":doc:`/contributing/documentation`" article.
 
 January, 2014
 -------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.3+ |
| Fixed tickets | #2579 |

This is the second enhancement (after #3328) of the Symfony2 Documentation Process.

This idea came from @shoomyth in #2579. Since @weaverryan is using gh to merge the Pull Requests, it's easy to scan through the commits and find the changes (I'm busy creating an automated script for this).

The plan is to update the changelog each month, so people have a clear view on new articles or fixed things. It'll also be another attribution to the many symfony doc hero's!
This PR lists the changes in the 2.3 branch for January. When we agree with this, it'll be update for changes in the 2.4 and master branches.

My idea was to put a link to this article in the sidebar (ping @fabpot).

We would love to get your opinion about this new change!
