### PR TITLE
added information on AuthenticationFailureHandlerInterface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/cookbook/security/api_key_authentication.rst
+++ b/cookbook/security/api_key_authentication.rst
@@ -213,7 +213,11 @@ exception in ``refreshUser()``.
 Handling Exceptions
 -------------------
 
-In order for you're ``ApiKeyAuthentication`` to correctly display a 403 http status when either bad credentials, or authentication fails you will need to implement the ``AuthenticationFailureHandlerInterface`` on your Authenticator. This will provide a method ``onAuthenticationFailure`` which you can then return a ``Response`` with.
+In order for you're ``ApiKeyAuthentication`` to correctly display a 403
+http status when either bad credentials, or authentication fails you will 
+need to implement the ``AuthenticationFailureHandlerInterface`` on your 
+Authenticator. This will provide a method ``onAuthenticationFailure`` which 
+you can then return a ``Response`` with.
 
     // src/Acme/HelloBundle/Security/ApiKeyAuthenticator.php
     namespace Acme\HelloBundle\Security;

--- a/cookbook/security/api_key_authentication.rst
+++ b/cookbook/security/api_key_authentication.rst
@@ -213,7 +213,7 @@ exception in ``refreshUser()``.
 Handling Authentication Failure
 -------------------------------
 
-In order for you're ``ApiKeyAuthentication`` to correctly display a 403
+In order for your ``ApiKeyAuthentication`` to correctly display a 403
 http status when either bad credentials or authentication fails you will 
 need to implement the :class:`Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface` on your 
 Authenticator. This will provide a method ``onAuthenticationFailure`` which 

--- a/cookbook/security/api_key_authentication.rst
+++ b/cookbook/security/api_key_authentication.rst
@@ -213,17 +213,20 @@ exception in ``refreshUser()``.
 Handling Authentication Failure
 -------------------------------
 
-In order for your ``ApiKeyAuthentication`` to correctly display a 403
-http status when either bad credentials, or authentication fails - you will 
-need to implement the ``AuthenticationFailureHandlerInterface`` on your 
+In order for you're ``ApiKeyAuthentication`` to correctly display a 403
+http status when either bad credentials or authentication fails you will 
+need to implement the :class:`Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface` on your 
 Authenticator. This will provide a method ``onAuthenticationFailure`` which 
-you can then return a ``Response`` with.
+you can use to create an error ``Response``.
 
     // src/Acme/HelloBundle/Security/ApiKeyAuthenticator.php
     namespace Acme\HelloBundle\Security;
 
+    use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
+    use Symfony\Component\Security\Core\Exception\AuthenticationException;
     use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpFoundation\Request;
 
     class ApiKeyAuthenticator implements SimplePreAuthenticatorInterface, AuthenticationFailureHandlerInterface
     {

--- a/cookbook/security/api_key_authentication.rst
+++ b/cookbook/security/api_key_authentication.rst
@@ -210,11 +210,11 @@ exception in ``refreshUser()``.
     If you *do* want to store authentication data in the session so that
     the key doesn't need to be sent on every request, see :ref:`cookbook-security-api-key-session`.
 
-Handling Exceptions
--------------------
+Handling Authentication Failure
+-------------------------------
 
-In order for you're ``ApiKeyAuthentication`` to correctly display a 403
-http status when either bad credentials, or authentication fails you will 
+In order for your ``ApiKeyAuthentication`` to correctly display a 403
+http status when either bad credentials, or authentication fails - you will 
 need to implement the ``AuthenticationFailureHandlerInterface`` on your 
 Authenticator. This will provide a method ``onAuthenticationFailure`` which 
 you can then return a ``Response`` with.

--- a/cookbook/security/api_key_authentication.rst
+++ b/cookbook/security/api_key_authentication.rst
@@ -210,6 +210,27 @@ exception in ``refreshUser()``.
     If you *do* want to store authentication data in the session so that
     the key doesn't need to be sent on every request, see :ref:`cookbook-security-api-key-session`.
 
+Handling Exceptions
+-------------------
+
+In order for you're ``ApiKeyAuthentication`` to correctly display a 403 http status when either bad credentials, or authentication fails you will need to implement the ``AuthenticationFailureHandlerInterface`` on your Authenticator. This will provide a method ``onAuthenticationFailure`` which you can then return a ``Response`` with.
+
+    // src/Acme/HelloBundle/Security/ApiKeyAuthenticator.php
+    namespace Acme\HelloBundle\Security;
+
+    use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+    use Symfony\Component\HttpFoundation\Response;
+
+    class ApiKeyAuthenticator implements SimplePreAuthenticatorInterface, AuthenticationFailureHandlerInterface
+    {
+        //...
+
+        public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+        {
+            return new Response("Authentication Failed.", 403);
+        }
+    }
+
 .. _cookbook-security-api-key-config:
 
 Configuration


### PR DESCRIPTION
The Api Keys documentation made no mention of the AuthenticationFailureHandlerInterface which is required to correctly display Authentication Failure responses. Without it, authentication failures will result in a 500 response. I've made mention to the interface and given an example implementation.

http://symfony.com/doc/current/cookbook/security/api_key_authentication.html#cookbook-security-api-key-config

```
Doc fix? yes
New docs? no
Applies to: 2.4
Fixed tickets: none found
```
