### PR TITLE
Callback: [Validator, validate] expects validate to be static

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -160,7 +160,7 @@ your validation function is ``Vendor\Package\Validator::validate()``::
 
     class Validator
     {
-        public function validate($object, ExecutionContextInterface $context)
+        public static function validate($object, ExecutionContextInterface $context)
         {
             // ...
         }


### PR DESCRIPTION
Otherwise you'll get:

```
ContextErrorException: Runtime Notice: call_user_func() expects parameter 1 to be a valid callback, non-static method Vendor\Package\Validator::validate() should not be called statically in Symfony/Component/Validator/Constraints/CallbackValidator.php
```
