### PR TITLE
Typeo in example of dynamic_form_modification.rst

### DIFF
--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -123,7 +123,7 @@ the event listener might look like the following::
             // check if the Product object is "new"
             // If no data is passed to the form, the data is "null".
             // This should be considered a new "Product"
-            if (!$product || null !== $product->getId()) {
+            if (!$product || null === $product->getId()) {
                 $form->add('name', 'text');
             }
         });


### PR DESCRIPTION
There was a typeo in one of the example blocks of dynamic_form_modification.rst.
For the product to be new, $product->getId() should be equal to NULL, and not different.
