### PR TITLE
Use consistent method chaining in BlogBundle sample application

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -550,7 +550,8 @@ them for you. Here's the same sample application, now built in Symfony2::
     {
         public function listAction()
         {
-            $posts = $this->get('doctrine')->getManager()
+            $posts = $this->get('doctrine')
+                ->getManager()
                 ->createQuery('SELECT p FROM AcmeBlogBundle:Post p')
                 ->execute();
 
@@ -565,8 +566,7 @@ them for you. Here's the same sample application, now built in Symfony2::
             $post = $this->get('doctrine')
                 ->getManager()
                 ->getRepository('AcmeBlogBundle:Post')
-                ->find($id)
-            ;
+                ->find($id);
 
             if (!$post) {
                 // cause the 404 page not found to be displayed


### PR DESCRIPTION
- Moved semicolon to end of last chained method
- Moved getManager() to next line to avoid having multiple chained
  methods in the same line
