### PR TITLE
[HTTP Cache] Validation model: Fix header name

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -572,9 +572,16 @@ To see a simple implementation, generate the ETag as the md5 of the content::
     }
 
 The :method:`Symfony\\Component\\HttpFoundation\\Response::isNotModified`
-method compares the ``ETag`` sent with the ``Request`` with the one set
-on the ``Response``. If the two match, the method automatically sets the
-``Response`` status code to 304.
+method compares the ``If-None-Match`` sent with the ``Request`` with the
+``ETag`` header set on the ``Response``. If the two match, the method
+automatically sets the ``Response`` status code to 304.
+
+.. note::
+
+    The ``If-None-Match`` request header equals the ``ETag`` header of the
+    last response sent to the client for the particular resource. This is
+    how the client and server communicate with each other and decide whether
+    or not the resource has been updated since it was cached.
 
 This algorithm is simple enough and very generic, but you need to create the
 whole ``Response`` before being able to compute the ETag, which is sub-optimal.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

In the cache validation model, the response sends an `ETag` header, but the following requests send an `If-None-Match` header. So the `If-None-Match` header from the request is compared to the `ETag` from the previous response. See `Symfony\Component\HttpFoundation\Request::getETags()` which is used by `Symfony\Component\HttpFoundation\Response::isNotModified()`.
