### PR TITLE
Fixes to cookbook/doctrine/registration_form.rst

### DIFF
--- a/cookbook/doctrine/registration_form.rst
+++ b/cookbook/doctrine/registration_form.rst
@@ -240,7 +240,6 @@ controller for displaying the registration form::
     namespace Acme\AccountBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-    use Symfony\Component\HttpFoundation\Request;
 
     use Acme\AccountBundle\Form\Type\RegistrationType;
     use Acme\AccountBundle\Form\Model\Registration;
@@ -270,6 +269,9 @@ And its template:
 
 Next, create the controller which handles the form submission. This performs
 the validation and saves the data into the database::
+
+    use Symfony\Component\HttpFoundation\Request;
+    // ...
 
     public function createAction(Request $request)
     {

--- a/cookbook/doctrine/registration_form.rst
+++ b/cookbook/doctrine/registration_form.rst
@@ -216,6 +216,7 @@ Next, create the form for this ``Registration`` model::
                 'checkbox',
                 array('property_path' => 'termsAccepted')
             );
+            $builder->add('Register', 'submit');
         }
 
         public function getName()
@@ -239,7 +240,7 @@ controller for displaying the registration form::
     namespace Acme\AccountBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-    use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpFoundation\Request;
 
     use Acme\AccountBundle\Form\Type\RegistrationType;
     use Acme\AccountBundle\Form\Model\Registration;


### PR DESCRIPTION
As I was working through this example I noticed a few issues. Firstly, no button to submit the registration form is ever specified. Secondly, in the accountController the Response object is included, but not needed. Thirdly, the Request object is required in the code block for the method createAction in the accountController.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all (or 2.3+) |
| Fixed tickets | none that I know of |
