### PR TITLE
Wrong parameters order and wrong naming

### DIFF
--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -221,8 +221,8 @@ which should be used to encode this user's password::
     // check if the password is valid:
 
     $validPassword = $encoder->isPasswordValid(
+        $encodedPassword,
         $user->getPassword(),
-        $password,
         $user->getSalt());
 
 .. _`CVE-2013-5750`: http://symfony.com/blog/cve-2013-5750-security-issue-in-fosuserbundle-login-form


### PR DESCRIPTION
Wrong parameters order and wrong naming on "Using Password Encoders" section
