### PR TITLE
[Components][Routing] Fix addPrefix() sample code

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -69,7 +69,7 @@ The route is simple:
         return $collection;
 
 .. versionadded:: 2.2
-    The ``path`` option is new in Symfony2.2, ``pattern`` is used in older
+    The ``path`` option is new in Symfony 2.2, ``pattern`` is used in older
     versions.
 
 The path defined by the ``blog_show`` route acts like ``/blog/*`` where
@@ -704,7 +704,7 @@ be accomplished with the following route configuration:
         return $collection;
 
 .. versionadded:: 2.2
-    The ``methods`` option is added in Symfony2.2. Use the ``_method``
+    The ``methods`` option is added in Symfony 2.2. Use the ``_method``
     requirement in older versions.
 
 Despite the fact that these two routes have identical paths (``/contact``),

--- a/components/routing/introduction.rst
+++ b/components/routing/introduction.rst
@@ -141,28 +141,26 @@ Using Prefixes
 
 You can add routes or other instances of
 :class:`Symfony\\Component\\Routing\\RouteCollection` to *another* collection.
-This way you can build a tree of routes. Additionally you can define a prefix,
-default requirements, default options and host to all routes of a subtree with
-the :method:`Symfony\\Component\\Routing\\RouteCollection::addPrefix` method::
+This way you can build a tree of routes. Additionally you can define a prefix
+and default values for the parameters, requirements, options, schemes and the
+host to all routes of a subtree using methods provided by the
+``RouteCollection`` class::
 
     $rootCollection = new RouteCollection();
 
     $subCollection = new RouteCollection();
     $subCollection->add(...);
     $subCollection->add(...);
-    $subCollection->addPrefix(
-        '/prefix', // prefix
-        array(), // requirements
-        array(), // options
-        'admin.example.com', // host
-        array('https') // schemes
-    );
+    $subCollection->addPrefix('/prefix');
+    $subCollection->addDefaults(array(...));
+    $subCollection->addRequirements(array(...));
+    $subCollection->addOptions(array(...));
+    $subCollection->setHost('admin.example.com');
+    $subCollection->setMethods(array('POST'));
+    $subCollection->setSchemes(array('https'));
 
     $rootCollection->addCollection($subCollection);
 
-.. versionadded:: 2.2
-    The ``addPrefix`` method is added in Symfony2.2. This was part of the
-    ``addCollection`` method in older versions.
 
 Set the Request Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -177,7 +175,9 @@ with this class via its constructor::
         $host = 'localhost',
         $scheme = 'http',
         $httpPort = 80,
-        $httpsPort = 443
+        $httpsPort = 443,
+        $path = '/',
+        $queryString = ''
     )
 
 .. _components-routing-http-foundation:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

The sample code used for demonstrating the
[`Symfony\Component\Routing\RouteCollection::addPrefix()`](http://api.symfony.com/2.3/Symfony/Component/Routing/RouteCollection.html#method_addPrefix) method did not match the signature. I've updated the code to show the provided features when adding a nested route collection. + some minor fixes along the way.
