### PR TITLE
Added information about using password_hash to generate bcrypt passwords

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -376,7 +376,7 @@ persisting the encoded password alone is enough.
 
     As of PHP 5.5 you can use the :phpfunction:`password_hash` function to 
     generate encoded passwords. For example in your user entity you may wish
-    to modify your setPassword method to the following::
+    to modify your ``setPassword`` method to the following::
 
         // ...
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -379,9 +379,10 @@ modify your setPassword method to the following::
     // ...
 
     // Set encrypted password
-    public function setPassword($password)
+    public function setPassword($plaintext)
     {
-        $this->password = password_hash($password, PASSWORD_BCRYPT, array('cost' => 15));
+        $options = ['cost' => 15];
+        $this->password = password_hash($plaintext, PASSWORD_BCRYPT, $options);
     }    
 
 .. _reference-security-firewall-context:

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -372,18 +372,20 @@ persisting the encoded password alone is enough.
     All the encoded passwords are ``60`` characters long, so make sure to
     allocate enough space for them to be persisted.
 
-If you are using PHP Version 5.5 you can use the `password_hash`_ function to
-generate encoded passwords. For example in your user entity you may wish to
-modify your setPassword method to the following::
+.. tip:: 
 
-    // ...
+    As of PHP 5.5 you can use the :phpfunction:`password_hash` function to 
+    generate encoded passwords. For example in your user entity you may wish
+    to modify your setPassword method to the following::
 
-    // Set encrypted password
-    public function setPassword($plaintext)
-    {
-        $options = ['cost' => 15];
-        $this->password = password_hash($plaintext, PASSWORD_BCRYPT, $options);
-    }    
+        // ...
+
+        // Set encrypted password
+        public function setPassword($plaintext)
+        {
+            $options = array('cost' => 15);
+            $this->password = password_hash($plaintext, PASSWORD_BCRYPT, $options);
+        }    
 
 .. _reference-security-firewall-context:
 
@@ -487,4 +489,3 @@ To use HTTP-Digest authentication you need to provide a realm and a key:
 
 .. _`PBKDF2`: http://en.wikipedia.org/wiki/PBKDF2
 .. _`ircmaxell/password-compat`: https://packagist.org/packages/ircmaxell/password-compat
-.. _`password_hash`: http://ca2.php.net/password_hash

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -374,6 +374,18 @@ persisting the encoded password alone is enough.
 
     .. _reference-security-firewall-context:
 
+If you are using PHP Version 5.5 you can use the `password_hash`_ function to
+generate encoded passwords. For example in your user entity you may wish to
+modify your setPassword method to the following::
+
+    // ...
+
+    // Set encrypted password
+    public function setPassword($password)
+    {
+        $this->password = password_hash($password, PASSWORD_BCRYPT, array('cost' => 15));
+    }    
+
 Firewall Context
 ----------------
 
@@ -474,3 +486,4 @@ To use HTTP-Digest authentication you need to provide a realm and a key:
 
 .. _`PBKDF2`: http://en.wikipedia.org/wiki/PBKDF2
 .. _`ircmaxell/password-compat`: https://packagist.org/packages/ircmaxell/password-compat
+.. _`password_hash`: http://ca2.php.net/password_hash

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -372,8 +372,6 @@ persisting the encoded password alone is enough.
     All the encoded passwords are ``60`` characters long, so make sure to
     allocate enough space for them to be persisted.
 
-    .. _reference-security-firewall-context:
-
 If you are using PHP Version 5.5 you can use the `password_hash`_ function to
 generate encoded passwords. For example in your user entity you may wish to
 modify your setPassword method to the following::
@@ -385,6 +383,8 @@ modify your setPassword method to the following::
     {
         $this->password = password_hash($password, PASSWORD_BCRYPT, array('cost' => 15));
     }    
+
+.. _reference-security-firewall-context:
 
 Firewall Context
 ----------------


### PR DESCRIPTION
While attempting to add bcrypt encryption to my project I was confused at how I could generate encrypted passwords. I thought it would be handy to include it here for others.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all (or 2.3+) |
| Fixed tickets | none |
