### PR TITLE
Added anchor for permissions

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -212,6 +212,8 @@ to check your configuration:
 
 If there are any issues, correct them now before moving on.
 
+.. _book-installation-permissions:
+
 .. sidebar:: Setting up Permissions
 
     One common issue is that the ``app/cache`` and ``app/logs`` directories


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

This is quite a common problem on IRC. #symfony IRC now has a nice bot which parses the docs and indexes it, so we can easily link to sections (thanks to the great @mitom). If a sidebar doesn't have an anchor, it's impossible to link to it correctly. Adding a named anchor fixes that.
