### PR TITLE
[#3116] Fixing wrong table name - singular is used elsewhere

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -629,7 +629,7 @@ of the application::
     use Doctrine\ORM\Mapping as ORM;
 
     /**
-     * @ORM\Table(name="acme_roles")
+     * @ORM\Table(name="acme_role")
      * @ORM\Entity()
      */
     class Role implements RoleInterface


### PR DESCRIPTION
See #3116. It seems like there's a preference towards singular names, so this fixes the wrong table name, while keeping everything singular.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets | no |

Thanks!
