### PR TITLE
Adjusted the BC rules to be consistent

### DIFF
--- a/contributing/code/bc.rst
+++ b/contributing/code/bc.rst
@@ -238,7 +238,7 @@ Symfony's classes:
 Type of Change                                      Regular         API
 ==================================================  ==============  ==============
 Remove entirely                                     No              No
-Make final                                          Yes [2]_        No
+Make final                                          No              No
 Make abstract                                       No              No
 Change name or namespace                            No              No
 Change parent class                                 Yes [7]_        Yes [7]_


### PR DESCRIPTION
A previous rule states that we guarantee BC for code extending the class. This rules does not allow marking a class as final as it would be a fatal error for extending code after the upgrade, which is far from being BC.

/cc @fabpot @webmozart
