### PR TITLE
[Reference][Forms] remove the label_attr option which is not available in the button type

### DIFF
--- a/reference/forms/types/button.rst
+++ b/reference/forms/types/button.rst
@@ -15,7 +15,6 @@ A simple, non-responsive button.
 | Options              | - `attr`_                                                            |
 |                      | - `disabled`_                                                        |
 |                      | - `label`_                                                           |
-|                      | - `label_attr`_                                                      |
 |                      | - `translation_domain`_                                              |
 +----------------------+----------------------------------------------------------------------+
 | Overridden options   | - `auto_initialize`_                                                 |
@@ -33,8 +32,6 @@ Options
 .. include:: /reference/forms/types/options/button_disabled.rst.inc
 
 .. include:: /reference/forms/types/options/button_label.rst.inc
-
-.. include:: /reference/forms/types/options/label_attr.rst.inc
 
 .. include:: /reference/forms/types/options/button_translation_domain.rst.inc
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

The `label_attr` is neither defined in the `ButtonType` class nor in the `BaseType` class, but in the `FormType` class instead. Thus, it can't be used for the `button` type.
