### PR TITLE
Normalized the use of the "key-value" term

### DIFF
--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -93,13 +93,13 @@ Session attributes
   Gets an attribute by key;
 
 * :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::all`:
-  Gets all attributes as an array of key => value;
+  Gets all attributes as a key-value array;
 
 * :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::has`:
   Returns true if the attribute exists;
 
 * :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::replace`:
-  Sets multiple attributes at once: takes a keyed array and sets each key => value pair;
+  Sets multiple attributes at once: takes a keyed array and sets each key-value pair;
 
 * :method:`Symfony\\Component\\HttpFoundation\\Session\\Session::remove`:
   Deletes an attribute by key;
@@ -172,7 +172,7 @@ and remember me login settings or other user based state information.
 * :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\NamespacedAttributeBag`
   This implementation allows for attributes to be stored in a structured namespace.
 
-Any plain `key => value` storage system is limited in the extent to which
+Any plain key-value storage system is limited in the extent to which
 complex data can be stored since each key must be unique. You can achieve
 namespacing by introducing a naming convention to the keys so different parts of
 your application could operate without clashing. For example, `module1.foo` and
@@ -208,7 +208,7 @@ has a simple API
   Gets an attribute by key;
 
 * :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::all`:
-  Gets all attributes as an array of key => value;
+  Gets all attributes as a key-value array;
 
 * :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::has`:
   Returns true if the attribute exists;
@@ -217,7 +217,7 @@ has a simple API
   Returns an array of stored attribute keys;
 
 * :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::replace`:
-  Sets multiple attributes at once: takes a keyed array and sets each key => value pair.
+  Sets multiple attributes at once: takes a keyed array and sets each key-value pair.
 
 * :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::remove`:
   Deletes an attribute by key;

--- a/components/yaml/yaml_format.rst
+++ b/components/yaml/yaml_format.rst
@@ -156,7 +156,7 @@ The previous YAML file is equivalent to the following PHP code:
 
     array('PHP', 'Perl', 'Python');
 
-Mappings use a colon followed by a space (``:`` ) to mark each key/value pair:
+Mappings use a colon followed by a space (``:`` ) to mark each key-value pair:
 
 .. code-block:: yaml
 
@@ -233,7 +233,7 @@ A sequence can be written as a comma separated list within square brackets
 
     [PHP, Perl, Python]
 
-A mapping can be written as a comma separated list of key/values within curly
+A mapping can be written as a comma separated list of key-values within curly
 braces (``{}``):
 
 .. code-block:: yaml

--- a/cookbook/bundles/best_practices.rst
+++ b/cookbook/bundles/best_practices.rst
@@ -239,7 +239,7 @@ To provide more flexibility, a bundle can provide configurable settings by
 using the Symfony2 built-in mechanisms.
 
 For simple configuration settings, rely on the default ``parameters`` entry of
-the Symfony2 configuration. Symfony2 parameters are simple key/value pairs; a
+the Symfony2 configuration. Symfony2 parameters are simple key-value pairs; a
 value being any valid PHP value. Each parameter name should start with the
 bundle alias, though this is just a best-practice suggestion. The rest of the
 parameter name will use a period (``.``) to separate different parts (e.g.


### PR DESCRIPTION
In some places this term was spelled "key/value" and in other places it was written as "key => value"
