### PR TITLE
[TwigBundle] Add documentation about generating absolute URL with the asset function

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -991,6 +991,22 @@ assets won't be cached when deployed. For example, ``/images/logo.png`` might
 look like ``/images/logo.png?v2``. For more information, see the :ref:`ref-framework-assets-version`
 configuration option.
 
+.. versionadded:: 2.5
+    Absolute URLs for assets were introduced in Symfony 2.5.
+
+If you need absolute URLs for assets, you can set the third argument (or the
+``absolute`` argument) to ``true``:
+
+.. configuration-block::
+
+    .. code-block:: html+jinja
+
+        <img src="{{ asset('images/logo.png', absolute=true) }}" alt="Symfony!" />
+
+    .. code-block:: html+php
+
+        <img src="<?php echo $view['assets']->getUrl('images/logo.png', null, true) ?>" alt="Symfony!" />
+
 .. index::
    single: Templating; Including stylesheets and JavaScripts
    single: Stylesheets; Including stylesheets

--- a/components/templating/helpers/assetshelper.rst
+++ b/components/templating/helpers/assetshelper.rst
@@ -47,6 +47,23 @@ You can also specify a URL to use in the second parameter of the constructor::
 
 Now URLs are rendered like ``http://cdn.example.com/images/logo.png``.
 
+.. versionadded:: 2.5
+    Absolute URLs for assets were introduced in Symfony 2.5.
+
+You can also use the third argument of the helper to force an absolute URL:
+
+.. code-block:: html+php
+
+   <img src="<?php echo $view['assets']->getUrl('images/logo.png', null, true) ?>">
+   <!-- renders as:
+   <img src="http://yourwebsite.com/foo/bar/images/logo.png">
+   -->
+
+.. note::
+
+    If you already set a URL in the constructor, using the third argument of
+    ``getUrl`` will not affect the generated URL.
+
 Versioning
 ----------
 

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -20,77 +20,77 @@ Functions
 .. versionadded:: 2.4
     The ``expression`` function was introduced in Symfony 2.4.
 
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| Function Syntax                                    | Usage                                                                                      |
-+====================================================+============================================================================================+
-| ``render(uri, options = {})``                      | This will render the fragment for the given controller or URL                              |
-| ``render(controller('B:C:a', {params}))``          | For more information, see :ref:`templating-embedding-controller`.                          |
-| ``render(path('route', {params}))``                |                                                                                            |
-| ``render(url('route', {params}))``                 |                                                                                            |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``render_esi(controller('B:C:a', {params}))``      | This will generate an ESI tag when possible or fallback to the ``render``                  |
-| ``render_esi(url('route', {params}))``             | behavior otherwise. For more information, see :ref:`templating-embedding-controller`.      |
-| ``render_esi(path('route', {params}))``            |                                                                                            |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``render_hinclude(controller(...))``               | This will generates an Hinclude tag for the given controller or URL.                       |
-| ``render_hinclude(url('route', {params}))``        | For more information, see :ref:`templating-embedding-controller`.                          |
-| ``render_hinclude(path('route', {params}))``       |                                                                                            |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``controller(attributes = {}, query = {})``        | Used along with the ``render`` tag to refer to the controller that you want to render.     |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``asset(path, packageName = null)``                | Get the public path of the asset, more information in                                      |
-|                                                    | ":ref:`book-templating-assets`".                                                           |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``asset_version(packageName = null)``              | Get the current version of the package, more information in                                |
-|                                                    | ":ref:`book-templating-assets`".                                                           |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``form(view, variables = {})``                     | This will render the HTML of a complete form, more information in                          |
-|                                                    | in :ref:`the Twig Form reference<reference-forms-twig-form>`.                              |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``form_start(view, variables = {})``               | This will render the HTML start tag of a form, more information in                         |
-|                                                    | in :ref:`the Twig Form reference<reference-forms-twig-start>`.                             |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``form_end(view, variables = {})``                 | This will render the HTML end tag of a form together with all fields that                  |
-|                                                    | have not been rendered yet, more information                                               |
-|                                                    | in :ref:`the Twig Form reference<reference-forms-twig-end>`.                               |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``form_enctype(view)``                             | This will render the required ``enctype="multipart/form-data"`` attribute                  |
-|                                                    | if the form contains at least one file upload field, more information in                   |
-|                                                    | in :ref:`the Twig Form reference <reference-forms-twig-enctype>`.                          |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``form_widget(view, variables = {})``              | This will render a complete form or a specific HTML widget of a field,                     |
-|                                                    | more information in :ref:`the Twig Form reference <reference-forms-twig-widget>`.          |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``form_errors(view)``                              | This will render any errors for the given field or the "global" errors,                    |
-|                                                    | more information in :ref:`the Twig Form reference <reference-forms-twig-errors>`.          |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``form_label(view, label = null, variables = {})`` | This will render the label for the given field, more information in                        |
-|                                                    | :ref:`the Twig Form reference <reference-forms-twig-label>`.                               |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``form_row(view, variables = {})``                 | This will render the row (the field's label, errors and widget) of the given               |
-|                                                    | field, more information in :ref:`the Twig Form reference <reference-forms-twig-row>`.      |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``form_rest(view, variables = {})``                | This will render all fields that have not yet been rendered, more                          |
-|                                                    | information in :ref:`the Twig Form reference <reference-forms-twig-rest>`.                 |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``csrf_token(intention)``                          | This will render a CSRF token. Use this function if you want CSRF protection without       |
-|                                                    | creating a form                                                                            |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``is_granted(role, object = null, field = null)``  | This will return ``true`` if the current user has the required role, more                  |
-|                                                    | information in ":ref:`book-security-template`"                                             |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``logout_path(key)``                               | This will generate the relative logout URL for the given firewall                          |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``logout_url(key)``                                | Equal to ``logout_path(...)`` but this will generate an absolute URL                       |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``path(name, parameters = {})``                    | Get a relative URL for the given route, more information in                                |
-|                                                    | ":ref:`book-templating-pages`".                                                            |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``url(name, parameters = {})``                     | Equal to ``path(...)`` but it generates an absolute URL                                    |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ``expression(expression)``                         | Creates an :class:`Symfony\\Component\\ExpressionLanguage\\Expression` in Twig. See        |
-|                                                    | ":ref:`Template Expressions <book-security-template-expression>`".                         |
-+----------------------------------------------------+--------------------------------------------------------------------------------------------+
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| Function Syntax                                       | Usage                                                                                      |
++=======================================================+============================================================================================+
+| ``render(uri, options = {})``                         | This will render the fragment for the given controller or URL                              |
+| ``render(controller('B:C:a', {params}))``             | For more information, see :ref:`templating-embedding-controller`.                          |
+| ``render(path('route', {params}))``                   |                                                                                            |
+| ``render(url('route', {params}))``                    |                                                                                            |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``render_esi(controller('B:C:a', {params}))``         | This will generate an ESI tag when possible or fallback to the ``render``                  |
+| ``render_esi(url('route', {params}))``                | behavior otherwise. For more information, see :ref:`templating-embedding-controller`.      |
+| ``render_esi(path('route', {params}))``               |                                                                                            |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``render_hinclude(controller(...))``                  | This will generates an Hinclude tag for the given controller or URL.                       |
+| ``render_hinclude(url('route', {params}))``           | For more information, see :ref:`templating-embedding-controller`.                          |
+| ``render_hinclude(path('route', {params}))``          |                                                                                            |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``controller(attributes = {}, query = {})``           | Used along with the ``render`` tag to refer to the controller that you want to render.     |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``asset(path, packageName = null, absolute = false)`` | Get the public path of the asset, more information in                                      |
+|                                                       | ":ref:`book-templating-assets`".                                                           |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``asset_version(packageName = null)``                 | Get the current version of the package, more information in                                |
+|                                                       | ":ref:`book-templating-assets`".                                                           |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``form(view, variables = {})``                        | This will render the HTML of a complete form, more information in                          |
+|                                                       | in :ref:`the Twig Form reference<reference-forms-twig-form>`.                              |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``form_start(view, variables = {})``                  | This will render the HTML start tag of a form, more information in                         |
+|                                                       | in :ref:`the Twig Form reference<reference-forms-twig-start>`.                             |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``form_end(view, variables = {})``                    | This will render the HTML end tag of a form together with all fields that                  |
+|                                                       | have not been rendered yet, more information                                               |
+|                                                       | in :ref:`the Twig Form reference<reference-forms-twig-end>`.                               |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``form_enctype(view)``                                | This will render the required ``enctype="multipart/form-data"`` attribute                  |
+|                                                       | if the form contains at least one file upload field, more information in                   |
+|                                                       | in :ref:`the Twig Form reference <reference-forms-twig-enctype>`.                          |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``form_widget(view, variables = {})``                 | This will render a complete form or a specific HTML widget of a field,                     |
+|                                                       | more information in :ref:`the Twig Form reference <reference-forms-twig-widget>`.          |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``form_errors(view)``                                 | This will render any errors for the given field or the "global" errors,                    |
+|                                                       | more information in :ref:`the Twig Form reference <reference-forms-twig-errors>`.          |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``form_label(view, label = null, variables = {})``    | This will render the label for the given field, more information in                        |
+|                                                       | :ref:`the Twig Form reference <reference-forms-twig-label>`.                               |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``form_row(view, variables = {})``                    | This will render the row (the field's label, errors and widget) of the given               |
+|                                                       | field, more information in :ref:`the Twig Form reference <reference-forms-twig-row>`.      |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``form_rest(view, variables = {})``                   | This will render all fields that have not yet been rendered, more                          |
+|                                                       | information in :ref:`the Twig Form reference <reference-forms-twig-rest>`.                 |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``csrf_token(intention)``                             | This will render a CSRF token. Use this function if you want CSRF protection without       |
+|                                                       | creating a form                                                                            |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``is_granted(role, object = null, field = null)``     | This will return ``true`` if the current user has the required role, more                  |
+|                                                       | information in ":ref:`book-security-template`"                                             |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``logout_path(key)``                                  | This will generate the relative logout URL for the given firewall                          |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``logout_url(key)``                                   | Equal to ``logout_path(...)`` but this will generate an absolute URL                       |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``path(name, parameters = {})``                       | Get a relative URL for the given route, more information in                                |
+|                                                       | ":ref:`book-templating-pages`".                                                            |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``url(name, parameters = {})``                        | Equal to ``path(...)`` but it generates an absolute URL                                    |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ``expression(expression)``                            | Creates an :class:`Symfony\\Component\\ExpressionLanguage\\Expression` in Twig. See        |
+|                                                       | ":ref:`Template Expressions <book-security-template-expression>`".                         |
++-------------------------------------------------------+--------------------------------------------------------------------------------------------+
 
 Filters
 -------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony#10451) |
| Applies to | 2.5+ |
