### PR TITLE
Fix cache warmer description

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -406,7 +406,8 @@ kernel.cache_warmer
 **Purpose**: Register your service to be called during the cache warming process
 
 Cache warming occurs whenever you run the ``cache:warmup`` or ``cache:clear``
-task (unless you pass ``--no-warmup`` to ``cache:clear``). The purpose is
+task (unless you pass ``--no-warmup`` to ``cache:clear``). It is also run when
+handling the request, if it wasn't done by one of the commands yet. The purpose is
 to initialize any cache that will be needed by the application and prevent
 the first user from any significant "cache hit" where the cache is generated
 dynamically.
@@ -423,7 +424,7 @@ the :class:`Symfony\\Component\\HttpKernel\\CacheWarmer\\CacheWarmerInterface` i
     {
         public function warmUp($cacheDir)
         {
-            // do some sort of operations to "warm" your cache
+            // ... do some sort of operations to "warm" your cache
         }
 
         public function isOptional()
@@ -433,8 +434,9 @@ the :class:`Symfony\\Component\\HttpKernel\\CacheWarmer\\CacheWarmerInterface` i
     }
 
 The ``isOptional`` method should return true if it's possible to use the
-application without calling this cache warmer. In Symfony 2.0, optional warmers
-are always executed anyways, so this function has no real effect.
+application without calling this cache warmer. In Symfony, optional warmers
+are always executed by default (you can change this by using the
+``--no-optional-warmers`` option when executing the command).
 
 To register your warmer with Symfony, give it the ``kernel.cache_warmer`` tag:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |
- The warmers are also executed on the first request: https://github.com/symfony/HttpKernel/blob/master/Kernel.php#L568-571
- Defining optional warmers has some effects, saying it has no effect is wrong.
