### PR TITLE
[WIP] Documenting the Validator component

### DIFF
--- a/components/index.rst
+++ b/components/index.rst
@@ -28,6 +28,7 @@ The Components
     stopwatch
     templating/index
     translation/index
+    validator/index
     yaml/index
 
 .. include:: /components/map.rst.inc

--- a/components/map.rst.inc
+++ b/components/map.rst.inc
@@ -131,6 +131,7 @@
 * :doc:`/components/validator/index`
 
   * :doc:`/components/validator/introduction`
+  * :doc:`/components/validator/resources`
 
 * :doc:`/components/yaml/index`
 

--- a/components/map.rst.inc
+++ b/components/map.rst.inc
@@ -128,6 +128,10 @@
   * :doc:`/components/translation/introduction`
   * :doc:`/components/translation/usage`
 
+* :doc:`/components/validator/index`
+
+  * :doc:`/components/validator/introduction`
+
 * :doc:`/components/yaml/index`
 
   * :doc:`/components/yaml/introduction`

--- a/components/validator/index.rst
+++ b/components/validator/index.rst
@@ -5,3 +5,4 @@ Validator
     :maxdepth: 2
 
     introduction
+    resources

--- a/components/validator/index.rst
+++ b/components/validator/index.rst
@@ -1,0 +1,7 @@
+Validator
+=========
+
+.. toctree::
+    :maxdepth: 2
+
+    introduction

--- a/components/validator/introduction.rst
+++ b/components/validator/introduction.rst
@@ -69,8 +69,8 @@ What things you can configure will be documented in the following sections.
 Sections
 --------
 
-* :doc:`/components/validator/loading_resources`
-* :doc:`/components/validator/defining_metadata`
+* :doc:`/components/validator/resources`
+* :doc:`/components/validator/metadata`
 * :doc:`/components/validator/validating_values`
 
 .. _`JSR-303 Bean Validation specification`: http://jcp.org/en/jsr/detail?id=303

--- a/components/validator/introduction.rst
+++ b/components/validator/introduction.rst
@@ -37,9 +37,40 @@ to validate a string against a specific length, the only code you need is::
         }
     }
 
+Retrieving a Validator Instance
+-------------------------------
+
+The :class:`Symfony\\Component\\Validator\\Validator` class is the main access
+point of the Validator component. To create a new instance of this class, it
+is recomment to use the :class:`Symfony\\Component\Validator\Validation`
+class.
+
+You can get the ``Validator`` with the default configuration by calling 
+:method:`Validation::createValidator() <Symfony\\Component\\Validator\\Validation::createValidator>`::
+
+    use Symfony\Component\Validator\Validation;
+
+    $validator = Validation::createValidator();
+
+However, a lot of things can be customized. To configure the ``Validator``
+class, you can use the :class:`Symfony\\Component\\Validator\\ValidatorBuilder`.
+This class can be retrieved by using the 
+:method:`Validation::createValidatorBuilder() <Symfony\\Component\\Validator\\Validation::createValidatorBuilder>`
+method::
+
+    use Symfony\Component\Validator\Validation;
+
+    $validator = Validation::createValidatorBuilder()
+        // ... build a custom instance of the Validator
+        ->getValidator();
+
+What things you can configure will be documented in the following sections.
+
 Sections
 --------
 
-* :doc:`/components/validator/configuration`
+* :doc:`/components/validator/loading_resources`
+* :doc:`/components/validator/defining_metadata`
+* :doc:`/components/validator/validating_values`
 
 .. _`JSR-303 Bean Validation specification`: http://jcp.org/en/jsr/detail?id=303

--- a/components/validator/introduction.rst
+++ b/components/validator/introduction.rst
@@ -1,0 +1,45 @@
+.. index::
+   single: Validator
+   single: Components; Validator
+
+The Validator Component
+=======================
+
+    The Validator component provides tools to validate values following the
+    `JSR-303 Bean Validation specification`_.
+
+Installation
+------------
+
+You can install the component in 2 different ways:
+
+* :doc:`Install it via Composer </components/using_components>` (``symfony/validator`` on `Packagist`_);
+* Use the official Git repository (https://github.com/symfony/Validator).
+
+Usage
+-----
+
+The Validator component allows you to use very advanced validation rules, but
+it is also really easy to do very minor validation. For instance, if you want
+to validate a string against a specific length, the only code you need is::
+
+    use Symfony\Component\Validator\Validation;
+    use Symfony\Component\Validator\Constraints\Length;
+
+    $validator = Validation::createValidator();
+
+    $violations = $validator->validateValue('Bernhard', new Length(array('min' => 10)));
+
+    if (0 !== count($violations)) {
+        // there are errors, let's show them
+        foreach ($violations as $violation) {
+            echo $violation->getMessage().'<br>';
+        }
+    }
+
+Sections
+--------
+
+* :doc:`/components/validator/configuration`
+
+.. _`JSR-303 Bean Validation specification`: http://jcp.org/en/jsr/detail?id=303

--- a/components/validator/introduction.rst
+++ b/components/validator/introduction.rst
@@ -20,8 +20,8 @@ Usage
 -----
 
 The Validator component allows you to use very advanced validation rules, but
-it is also really easy to do very minor validation. For instance, if you want
-to validate a string against a specific length, the only code you need is::
+it is also really easy to do easy validation tasks. For instance, if you want
+to validate a string is at least 10 character long, the only code you need is::
 
     use Symfony\Component\Validator\Validation;
     use Symfony\Component\Validator\Constraints\Length;
@@ -31,7 +31,7 @@ to validate a string against a specific length, the only code you need is::
     $violations = $validator->validateValue('Bernhard', new Length(array('min' => 10)));
 
     if (0 !== count($violations)) {
-        // there are errors, let's show them
+        // there are errors, now you can show them
         foreach ($violations as $violation) {
             echo $violation->getMessage().'<br>';
         }
@@ -42,19 +42,20 @@ Retrieving a Validator Instance
 
 The :class:`Symfony\\Component\\Validator\\Validator` class is the main access
 point of the Validator component. To create a new instance of this class, it
-is recomment to use the :class:`Symfony\\Component\Validator\Validation`
+is recommend to use the :class:`Symfony\\Component\Validator\Validation`
 class.
 
-You can get the ``Validator`` with the default configuration by calling 
+You can get a very basic ``Validator`` by calling 
 :method:`Validation::createValidator() <Symfony\\Component\\Validator\\Validation::createValidator>`::
 
     use Symfony\Component\Validator\Validation;
 
     $validator = Validation::createValidator();
 
-However, a lot of things can be customized. To configure the ``Validator``
-class, you can use the :class:`Symfony\\Component\\Validator\\ValidatorBuilder`.
-This class can be retrieved by using the 
+The created validator can be used to validate strings, array, numbers, but it
+can't validate classes. To be able to do that, you have to configure the ``Validator``
+class. To do that, you can use the :class:`Symfony\\Component\\Validator\\ValidatorBuilder`.
+This class can be retrieved by using the
 :method:`Validation::createValidatorBuilder() <Symfony\\Component\\Validator\\Validation::createValidatorBuilder>`
 method::
 

--- a/components/validator/resources.rst
+++ b/components/validator/resources.rst
@@ -7,7 +7,7 @@ Loading Resources
 The Validator uses metadata to validate a value. This metadata defines how a
 class, array or any other value should be validated. When validating a class,
 each class contains its own specific metadata. When validating another value,
-the metadata to passed to the validate methods.
+the metadata must be passed to the validate methods.
 
 Class metadata should be defined somewhere in a configuration file, or in the
 class itself. The ``Validator`` needs to be able to retrieve this metadata
@@ -20,7 +20,7 @@ from the file or class. To do that, it uses a set of loaders.
 The StaticMethodLoader
 ----------------------
 
-The easiest loader is the
+The most basic loader is the
 :class:`Symfony\\Component\\Validator\\Mapping\\Loader\\StaticMethodLoader`.
 This loader will call a static method of the class in order to get the
 metadata for that class. The name of the method is configured using the
@@ -34,7 +34,7 @@ method of the Validator builder::
         ->getValidator();
 
 Now, the retrieved ``Validator`` tries to find the ``loadValidatorMetadata()``
-method of the validated class to load its metadata.
+method of the class to validate to load its metadata.
 
 .. tip::
 
@@ -70,8 +70,9 @@ The AnnotationLoader
 
 At last, the component provides an
 :class:`Symfony\\Component\\Validator\\Mapping\\Loader\\AnnotationLoader`.
-This loader will parse the annotations of a class. Annotations are placed in
-PHPdoc comments (`/** ... */`) and start with an ``@``. For instance::
+This loader uses an annotation reader to parse the annotations of a class.
+Annotations are placed in doc block comments (`/** ... */`) and start with an
+``@``. For instance::
 
     // ...
 
@@ -97,7 +98,7 @@ To disable the annotation loader after it was enabled, call
 .. note::
 
     In order to use the annotation loader, you should have installed the
-    ``doctrine/annotations`` and ``doctrine/cache`` packages of Packagist.
+    ``doctrine/annotations`` and ``doctrine/cache`` packages from Packagist.
 
 Using Multiple Loaders
 ----------------------
@@ -121,9 +122,9 @@ multiple mappings::
 Caching
 -------
 
-Using many loaders to load metadata from different places is very easy for the
-developer, but it can easily slow down your application since each file needs
-to be parsed, validated and converted to a
+Using many loaders to load metadata from different places is very easy when
+creating the metadata, but it can easily slow down your application since each
+file needs to be parsed, validated and converted to a
 :class:`Symfony\\Component\\Validator\\Mapping\\ClassMetadata` instance. To
 solve this problems, you can configure a cacher which will be used to cache
 the ``ClassMetadata`` after it was loaded.
@@ -135,10 +136,11 @@ implements :class:`Symfony\\Component\\Validator\\Mapping\\Cache\\CacheInterface
 
 .. note::
 
-    The loader already use a singleton load mechanism. That means that they
-    will only load and parse a file once and put that in a property, which
-    will be used on the next time. However, the Validator still needs to
-    merge all metadata of one class from every loader when it is requested.
+    The loaders already use a singleton load mechanism. That means that the
+    loaders will only load and parse a file once and put that in a property,
+    which will then be used the next time it is asked for metadata. However,
+    the Validator still needs to merge all metadata of one class from every
+    loader when it is requested.
 
 To set a cacher, call the
 :method:`Symfony\\Component\\Validator\\ValidatorBuilder::setMetadataCache` of
@@ -176,5 +178,5 @@ this custom implementation using
 .. caution::
 
     Since you are using a custom metadata factory, you can't configure loaders
-    and cachers using the helper methods anymore. You now have to inject them
-    into your custom metadata factory yourself.
+    and cachers using the ``add*Mapping()`` methods anymore. You now have to
+    inject them into your custom metadata factory yourself.

--- a/components/validator/resources.rst
+++ b/components/validator/resources.rst
@@ -1,0 +1,180 @@
+.. index::
+    single: Validator; Loading Resources
+
+Loading Resources
+=================
+
+The Validator uses metadata to validate a value. This metadata defines how a
+class, array or any other value should be validated. When validating a class,
+each class contains its own specific metadata. When validating another value,
+the metadata to passed to the validate methods.
+
+Class metadata should be defined somewhere in a configuration file, or in the
+class itself. The ``Validator`` needs to be able to retrieve this metadata
+from the file or class. To do that, it uses a set of loaders.
+
+.. seealso::
+
+    You'll learn how to define the metadata in :doc:`metadata`.
+
+The StaticMethodLoader
+----------------------
+
+The easiest loader is the
+:class:`Symfony\\Component\\Validator\\Mapping\\Loader\\StaticMethodLoader`.
+This loader will call a static method of the class in order to get the
+metadata for that class. The name of the method is configured using the
+:method:`Symfony\\Component\\Validator\\ValidatorBuilder::addMethodMapping`
+method of the Validator builder::
+
+    use Symfony\Component\Validator\Validation;
+
+    $validator = Validation::createValidatorBuilder()
+        ->addMethodMapping('loadValidatorMetadata')
+        ->getValidator();
+
+Now, the retrieved ``Validator`` tries to find the ``loadValidatorMetadata()``
+method of the validated class to load its metadata.
+
+.. tip::
+
+    You can call this method multiple times to add multiple supported method
+    names. You can also use
+    :method:`Symfony\\Component\\Validator\\ValidatorBuilder::addMethodMappings`
+    to set an array of supported method names.
+
+The FileLoaders
+---------------
+
+The component also provides 2 file loaders, one to load Yaml files and one to
+load XML files. Use 
+:method:`Symfony\\Component\\Validator\\ValidatorBuilder::addYamlMapping` or
+:method:`Symfony\\Component\\Validator\\ValidatorBuilder::addXmlMapping` to
+configure the locations of these files::
+
+    use Symfony\Component\Validator\Validation;
+
+    $validator = Validation::createValidatorBuilder()
+        ->addYamlMapping('config/validation.yml')
+        ->getValidator();
+
+.. tip::
+
+    Just like with the method mappings, you can also use 
+    :method:`Symfony\\Component\\Validator\\ValidatorBuilder::addYamlMappings` and
+    :method:`Symfony\\Component\\Validator\\ValidatorBuilder::addXmlMappings`
+    to configure an array of file paths.
+
+The AnnotationLoader
+--------------------
+
+At last, the component provides an
+:class:`Symfony\\Component\\Validator\\Mapping\\Loader\\AnnotationLoader`.
+This loader will parse the annotations of a class. Annotations are placed in
+PHPdoc comments (`/** ... */`) and start with an ``@``. For instance::
+
+    // ...
+
+    /**
+     * @Assert\NotBlank()
+     */
+    protected $name;
+
+To enable the annotation loader, call the 
+:method:`Symfony\\Component\\Validator\\ValidatorBuilder::enableAnnotationMapping`
+method. It takes an optional annotation reader instance, which defaults to
+``Doctrine\Common\Annotations\AnnotationReader``::
+
+    use Symfony\Component\Validator\Validation;
+
+    $validator = Validation::createValidatorBuilder()
+        ->enableAnnotationMapping()
+        ->getValidator();
+
+To disable the annotation loader after it was enabled, call
+:method:`Symfony\\Component\\Validator\\ValidatorBuilder::disableAnnotationMapping`.
+
+.. note::
+
+    In order to use the annotation loader, you should have installed the
+    ``doctrine/annotations`` and ``doctrine/cache`` packages of Packagist.
+
+Using Multiple Loaders
+----------------------
+
+The component provides a 
+:class:`Symfony\\Component\\Validator\\Mapping\\Loader\\LoaderChain` class to
+chain multiple loaders. This means you can configure as many loaders as you
+want at the same time.
+
+The ``ValidatorBuilder`` will already take care of this when you configure
+multiple mappings::
+
+    use Symfony\Component\Validator\Validation;
+
+    $validator = Validation::createValidatorBuilder()
+        ->enableAnnotationMapping()
+        ->addMethodMapping('loadValidatorMetadata')
+        ->addXmlMapping('config/validation.xml')
+        ->getValidator();
+
+Caching
+-------
+
+Using many loaders to load metadata from different places is very easy for the
+developer, but it can easily slow down your application since each file needs
+to be parsed, validated and converted to a
+:class:`Symfony\\Component\\Validator\\Mapping\\ClassMetadata` instance. To
+solve this problems, you can configure a cacher which will be used to cache
+the ``ClassMetadata`` after it was loaded.
+
+The Validator component comes with a
+:class:`Symfony\\Component\\Validator\\Mapping\\Cache\\ApcCache`
+implementation. You can easily create other cachers by creating a class which
+implements :class:`Symfony\\Component\\Validator\\Mapping\\Cache\\CacheInterface`.
+
+.. note::
+
+    The loader already use a singleton load mechanism. That means that they
+    will only load and parse a file once and put that in a property, which
+    will be used on the next time. However, the Validator still needs to
+    merge all metadata of one class from every loader when it is requested.
+
+To set a cacher, call the
+:method:`Symfony\\Component\\Validator\\ValidatorBuilder::setMetadataCache` of
+the Validator builder::
+
+    use Symfony\Component\Validator\Validation;
+    use Symfony\Component\Validator\Mapping\Cache\ApcCache;
+
+    $validator = Validation::createValidatorBuilder()
+        // ... add loaders
+        ->setMetadataCache(new ApcCache('some_apc_prefix'));
+        ->getValidator();
+
+Using a Custom MetadataFactory
+------------------------------
+
+All loaders and the cacher are passed to an instance of
+:class:`Symfony\\Component\\Validator\\Mapping\\ClassMetadataFactory`. This
+class is responsible for creating a ``ClassMetadata`` instance from all the
+configured resources.
+
+You can also use a custom metadata factory implementation by creating a class
+which implements
+:class:`Symfony\\Component\\Validator\\MetadataFactoryInterface`. You can set
+this custom implementation using 
+:method:`Symfony\\Component\\Validator\\ValidatorBuilder::setMetadataFactory`::
+
+    use Acme\Validation\CustomMetadataFactory;
+    use Symfony\Component\Validator\Validation;
+
+    $validator = Validation::createValidatorBuilder()
+        ->setMetadataFactory(new CustomMetadataFactory(...));
+        ->getValidator();
+
+.. caution::
+
+    Since you are using a custom metadata factory, you can't configure loaders
+    and cachers using the helper methods anymore. You now have to inject them
+    into your custom metadata factory yourself.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.3+ |
| Fixed tickets | #958 |

I started documenting one of the last missing components (only
BrowserKit needs some love after this).

This might become just another refactoring of the documentation, since
it'll duplicate a lot of `book/validation`. I don't think it's a problem
if we do the same thing as we did with the translation documentation?
(that was a test, but I think it has gone well?)
## Todo
- [ ] Moving the definition part from the book chapter
- [ ] Writing about validating values (including how to deal with
  violations, like translation, presentation, debugging, etc.)
- [ ] Fix the book chapter
## Todo after this PR is merged (will be transformed into issues)
- [2.5] Update the caching stuff to https://github.com/symfony/symfony/pull/9892
- [2.5] Update for https://github.com/symfony/symfony/pull/10287

/cc @ricardclau, @webmozart
