### PR TITLE
Simplified the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
     - "2.7"
 
 install: 
-    - "git submodule update --init"
     - "bash install.sh"
     - "pip install -q -r requirements.txt --use-mirrors"
 


### PR DESCRIPTION
Submodules are already handled by Travis itself, so no need to do it a second time

This should be applied in all branches where the Travis config is available
