### PR TITLE
Added a note about inlined private services

### DIFF
--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -1003,7 +1003,7 @@ By default only public services are shown, but you can also view private service
 
 .. note::
 
-    If a private service is only used as an argument to just one other service,
+    If a private service is only used as an argument to just *one* other service,
     it won't be displayed by the ``container:debug`` command, even when using
     the ``--show-private`` option. See :ref:`inlined-private-services` for a
     more detailed explanation.

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -1001,6 +1001,13 @@ By default only public services are shown, but you can also view private service
 
     $ php app/console container:debug --show-private
 
+.. note::
+
+    If a private service is only used as an argument to just one other service,
+    it won't be displayed by the ``container:debug`` command, even when using
+    the ``--show-private`` option. See :ref:`inlined-private-services` for a
+    more detailed explanation.
+
 You can get more detailed information about a particular service by specifying
 its id:
 

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -1005,8 +1005,8 @@ By default only public services are shown, but you can also view private service
 
     If a private service is only used as an argument to just *one* other service,
     it won't be displayed by the ``container:debug`` command, even when using
-    the ``--show-private`` option. See :ref:`inlined-private-services` for a
-    more detailed explanation.
+    the ``--show-private`` option. See :ref:`Inline Private Services <inlined-private-services>`
+    for more details.
 
 You can get more detailed information about a particular service by specifying
 its id:

--- a/components/dependency_injection/advanced.rst
+++ b/components/dependency_injection/advanced.rst
@@ -18,6 +18,8 @@ However, there are use-cases when you don't want a service to be public. This
 is common when a service is only defined because it could be used as an
 argument for another service.
 
+.. _inlined-private-services:
+
 .. note::
 
     If you use a private service as an argument to only one other service,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.3+ |
| Fixed tickets | - |

When you define private services that are used just as arguments for another service, Symfon2 doesn't define them as services, but inlines them in the other service definition. This slightly improves the performance of the container, but it's confusing for Symfony beginners because the private services aren't displayed by the `container:debug` command even when using the `--show-private` option:

```
$ php app/console container:debug --show-private
```
