### PR TITLE
Update routing.rst. Explain using url() v. path().

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1330,7 +1330,9 @@ method::
     $this->generateUrl('blog_show', array('slug' => 'my-blog-post'), true);
     // http://www.example.com/blog/my-blog-post
 
-From a template, it looks like this:
+From a template, in Twig, simply use the ``url()`` function (which generates an absolute URL) 
+rather than the ``path()`` function (which generates a relative URL). In PHP, pass ``true`` 
+to ``generateUrl()``:
 
 .. configuration-block::
 


### PR DESCRIPTION
The original documentation seemed to imply that, when generating absolute URLs from a template, the argument TRUE should be supplied to the url() method. This change explains that in Twig, one uses the url() method to generate an absolute URL.
