### PR TITLE
[book] [controller] fixed the code of a session sample code

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -666,10 +666,10 @@ from any controller::
         // store an attribute for reuse during a later user request
         $session->set('foo', 'bar');
 
-        // in another controller for another request
-        $foo = $session->get('foo');
+        // get the attribute set by another controller in another request
+        $foobar = $session->get('foobar');
 
-        // use a default value if the key doesn't exist
+        // use a default value if the attribute doesn't exist
         $filters = $session->get('filters', array());
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | - |

This code was updated in the past to use the $request controller
injection and the resulting code was a bit confusing. When you get
the attribute set by another controller, it's better to use a
different attribute name, to make it clear that it wasn't set at
this controller.
