### PR TITLE
[contributing] added the link for the BC promise article

### DIFF
--- a/contributing/community/releases.rst
+++ b/contributing/community/releases.rst
@@ -179,3 +179,4 @@ version is published every two years and there is a year to upgrade.
 .. _SensioLabs:     http://sensiolabs.com/
 .. _roadmap notification: http://symfony.com/roadmap
 .. _timeline calculator: http://symfony.com/roadmap
+.. _Backwards Compatibility Promise: http://symfony.com/doc/2.3/contributing/code/bc.html


### PR DESCRIPTION
Travis is reporting errors for every documentation build:

![travis_error](https://cloud.githubusercontent.com/assets/73419/2558077/45493920-b730-11e3-99d3-17fe654b3998.png)

Apparently, this error is caused because the `contributing/community/releases.rst` file links to the BC Promise article but doesn't define the link.
