### PR TITLE
[Book][Routing] Fixed typo on PHP version of a route definition

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -778,7 +778,7 @@ routing system can be:
 
         $collection = new RouteCollection();
         $collection->add(
-            'homepage',
+            'article_show',
             new Route('/articles/{culture}/{year}/{title}.{_format}', array(
                 '_controller' => 'AcmeDemoBundle:Article:show',
                 '_format'     => 'html',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all (or 2.3+) |
| Fixed tickets | - |

On http://symfony.com/doc/master/book/routing.html#advanced-routing-example, the PHP version has a wrong route name.
