### PR TITLE
the Locale component does not have elements tagged with @api

### DIFF
--- a/book/stable_api.rst
+++ b/book/stable_api.rst
@@ -35,7 +35,6 @@ As of Symfony 2.0, the following components have a public tagged API:
 * Finder
 * HttpFoundation
 * HttpKernel
-* Locale
 * Process
 * Routing
 * Templating


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

As far as i can see, there is no element in the Locale component tagged with `@api`.
