### PR TITLE
Updated references to new Session()

### DIFF
--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -12,9 +12,16 @@ object-oriented interface using a variety of session storage drivers.
 Sessions are used via the simple :class:`Symfony\\Component\\HttpFoundation\\Session\\Session`
 implementation of :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionInterface` interface.
 
+.. caution::
+
+    Make sure your Sessions aren't already initliazed (which in Symfony is done automatically),
+    as initializing the Session object causes the session to be started, which can lead to unexpected errors.
+
 Quick example::
 
-    $session = $this->getRequest()->getSession();
+    use Symfony\Component\HttpFoundation\Session\Session;
+
+    $session = new Session();
     $session->start();
 
     // set and get session attributes
@@ -287,7 +294,9 @@ to be used for more complex messaging in your application.
 
 Examples of setting multiple flashes::
 
-    $session = $this->getRequest()->getSession();
+    use Symfony\Component\HttpFoundation\Session\Session;
+
+    $session = new Session();
     $session->start();
 
     // add flash messages

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -14,8 +14,9 @@ implementation of :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionIn
 
 .. caution::
 
-    Make sure your Sessions aren't already initliazed (which in Symfony is done automatically),
-    as initializing the Session object causes the session to be started, which can lead to unexpected errors.
+   Make sure your Sessions aren't already initliazed (which in Symfony is
+   done automatically),  as initializing the Session object causes the
+   session to be started, which can lead to unexpected errors.
 
 Quick example::
 

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -14,10 +14,9 @@ implementation of :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionIn
 
 .. caution::
 
-    Make sure your sessions aren't already initialized (which is, for example,
-    automatically done in the full-stack framework). As initializing the
-    Session object causes the session to be started, which can lead to unexpected
-    errors.
+    Make sure your PHP session isn't already started before using the Session
+    class. If you have a legacy session system that starts your session, see
+    http://symfony.com/doc/current/components/http_foundation/session_php_bridge.html
 
 Quick example::
 

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -14,10 +14,10 @@ implementation of :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionIn
 
 .. caution::
 
-   Make sure your Sessions aren't already initialized (which is done
-   automatically in the full-stack framework), as initializing the
-   Session object causes the session to be started, which can lead
-   to unexpected errors.
+   Make sure your sessions aren't already initialized (which is,
+   for example, automatically done in the full-stack framework).
+   As initializing the Session object causes the session to be
+   started, which can lead to unexpected errors.
 
 Quick example::
 

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -14,9 +14,10 @@ implementation of :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionIn
 
 .. caution::
 
-   Make sure your Sessions aren't already initliazed (which in Symfony is
-   done automatically),  as initializing the Session object causes the
-   session to be started, which can lead to unexpected errors.
+   Make sure your Sessions aren't already initliazed (which is done
+   automatically in the full-stack framework), as initializing the
+   Session object causes the session to be started, which can lead
+   to unexpected errors.
 
 Quick example::
 

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -14,10 +14,10 @@ implementation of :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionIn
 
 .. caution::
 
-   Make sure your sessions aren't already initialized (which is,
-   for example, automatically done in the full-stack framework).
-   As initializing the Session object causes the session to be
-   started, which can lead to unexpected errors.
+    Make sure your sessions aren't already initialized (which is, for example,
+    automatically done in the full-stack framework). As initializing the
+    Session object causes the session to be started, which can lead to unexpected
+    errors.
 
 Quick example::
 

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -16,7 +16,7 @@ Quick example::
 
     use Symfony\Component\HttpFoundation\Session\Session;
 
-    $session = new Session();
+    $session = $this->getRequest()->getSession();
     $session->start();
 
     // set and get session attributes
@@ -291,7 +291,7 @@ Examples of setting multiple flashes::
 
     use Symfony\Component\HttpFoundation\Session\Session;
 
-    $session = new Session();
+    $session = $this->getRequest()->getSession();
     $session->start();
 
     // add flash messages

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -14,8 +14,6 @@ implementation of :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionIn
 
 Quick example::
 
-    use Symfony\Component\HttpFoundation\Session\Session;
-
     $session = $this->getRequest()->getSession();
     $session->start();
 
@@ -288,8 +286,6 @@ application can issue multiple messages for a given type. This allows the API
 to be used for more complex messaging in your application.
 
 Examples of setting multiple flashes::
-
-    use Symfony\Component\HttpFoundation\Session\Session;
 
     $session = $this->getRequest()->getSession();
     $session->start();

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -14,7 +14,7 @@ implementation of :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionIn
 
 .. caution::
 
-   Make sure your Sessions aren't already initliazed (which is done
+   Make sure your Sessions aren't already initialized (which is done
    automatically in the full-stack framework), as initializing the
    Session object causes the session to be started, which can lead
    to unexpected errors.


### PR DESCRIPTION
If you use new Session(), you get a 500 error, with the following message:

``` log
Failed to start the session: already started by PHP.
```

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | I tested 2.4.2, but it most likely will be earlier version as well |
| Fixed tickets | none |
