### PR TITLE
Fix function example in expression language component

### DIFF
--- a/components/expression_language/extending.rst
+++ b/components/expression_language/extending.rst
@@ -35,11 +35,7 @@ This method has 3 arguments:
 
     $language = new ExpressionLanguage();
     $language->register('lowercase', function ($str) {
-        if (!is_string($str)) {
-            return $str;
-        }
-
-        return sprintf('strtolower(%s)', $str);
+        return sprintf('$result = (is_string(%1$s)) ? strtolower(%1$s) : %1$s; return $result;', $str);
     }, function ($arguments, $str) {
         if (!is_string($str)) {
             return $str;

--- a/components/expression_language/extending.rst
+++ b/components/expression_language/extending.rst
@@ -35,7 +35,7 @@ This method has 3 arguments:
 
     $language = new ExpressionLanguage();
     $language->register('lowercase', function ($str) {
-        return sprintf('$result = (is_string(%1$s)) ? strtolower(%1$s) : %1$s; return $result;', $str);
+        is_string(%1$s) ? strtolower(%1$s) : %1$s;
     }, function ($arguments, $str) {
         if (!is_string($str)) {
             return $str;


### PR DESCRIPTION
The is_string check needs to be part of the runtime code, not of the compilation code, because it needs to check that the argument is a string, not the compiled code to access it (which is always a string as it is source code. cc @stof
