### PR TITLE
Fixed variable naming

### DIFF
--- a/components/console/helpers/tablehelper.rst
+++ b/components/console/helpers/tablehelper.rst
@@ -14,7 +14,7 @@ When building a console application it may be useful to display tabular data:
 To display a table, use the :class:`Symfony\\Component\\Console\\Helper\\TableHelper`,
 set headers, rows and render::
 
-    $table = $app->getHelperSet()->get('table');
+    $table = $this->getHelperSet()->get('table');
     $table
         ->setHeaders(array('ISBN', 'Title', 'Author'))
         ->setRows(array(


### PR DESCRIPTION
Changed $app into $this since this is used in the other helpers as well and $app is not available inside a console command.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | - |
