### PR TITLE
Updated event_listener.rst

### DIFF
--- a/book/internals.rst
+++ b/book/internals.rst
@@ -229,8 +229,8 @@ each event has access to the same basic information:
 * :method:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent::getRequest`
   - returns the current ``Request`` being handled.
 
-``IsMasterRequest()``
-....................
+``isMasterRequest()``
+.....................
 
 The ``isMasterRequest()`` method allows listeners to check the type of the
 request. For instance, if a listener must only be active for master requests,

--- a/book/internals.rst
+++ b/book/internals.rst
@@ -208,6 +208,10 @@ processing must only occur on the master request).
 Events
 ~~~~~~
 
+.. versionadded:: 2.4
+    The ``isMasterRequest()`` method was introduced in Symfony 2.4.
+    Prior, the ``getRequestType()`` method must be used.
+
 Each event thrown by the Kernel is a subclass of
 :class:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent`. This means that
 each event has access to the same basic information:
@@ -216,22 +220,25 @@ each event has access to the same basic information:
   - returns the *type* of the request (``HttpKernelInterface::MASTER_REQUEST``
   or ``HttpKernelInterface::SUB_REQUEST``);
 
+* :method:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent::isMasterRequest`
+  - checks if it is a master request;
+
 * :method:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent::getKernel`
   - returns the Kernel handling the request;
 
 * :method:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent::getRequest`
   - returns the current ``Request`` being handled.
 
-``getRequestType()``
+``IsMasterRequest()``
 ....................
 
-The ``getRequestType()`` method allows listeners to know the type of the
+The ``isMasterRequest()`` method allows listeners to check the type of the
 request. For instance, if a listener must only be active for master requests,
 add the following code at the beginning of your listener method::
 
     use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-    if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+    if (!$event->isMasterRequest()) {
         // return immediately
         return;
     }

--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -665,12 +665,16 @@ argument as follows::
     $response = $kernel->handle($request, HttpKernelInterface::SUB_REQUEST);
     // do something with this response
 
+.. versionadded:: 2.4
+    The ``isMasterRequest()`` method was introduced in Symfony 2.4.
+    Prior, the ``getRequestType()`` method must be used.
+
 This creates another full request-response cycle where this new ``Request`` is
 transformed into a ``Response``. The only difference internally is that some
 listeners (e.g. security) may only act upon the master request. Each listener
 is passed some sub-class of :class:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent`,
-whose :method:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent::getRequestType`
-can be used to figure out if the current request is a "master" or "sub" request.
+whose :method:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent::isMasterRequest`
+can be used to check if the current request is a "master" or "sub" request.
 
 For example, a listener that only needs to act on the master request may
 look like this::
@@ -680,7 +684,7 @@ look like this::
 
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+        if (!$event->isMasterRequest()) {
             return;
         }
 

--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -100,6 +100,10 @@ using a special "tag":
 Request events, checking types
 ------------------------------
 
+.. versionadded:: 2.4
+    The ``isMasterRequest()`` method was introduced in Symfony 2.4.
+    Prior, the ``getRequestType()`` method must be used.
+
 A single page can make several requests (one master request, and then multiple
 sub-requests), which is why when working with the ``KernelEvents::REQUEST``
 event, you might need to check the type of the request. This can be easily
@@ -115,7 +119,7 @@ done as follow::
     {
         public function onKernelRequest(GetResponseEvent $event)
         {
-            if (false === $event->isMasterRequest()) {
+            if (!$event->isMasterRequest()) {
                 // don't do anything if it's not the master request
                 return;
             }
@@ -123,10 +127,6 @@ done as follow::
             // ...
         }
     }
-
-.. versionadded:: 2.4
-    The ``isMasterRequest()`` method was introduced in Symfony 2.4.
-    Prior, the ``getRequestType()`` method must be used.
 
 .. tip::
 

--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -124,6 +124,10 @@ done as follow::
         }
     }
 
+.. versionadded:: 2.4
+    The ``isMasterRequest()`` method was introduced in Symfony 2.4.
+    Prior, the ``getRequestType()`` method must be used.
+
 .. tip::
 
     Two types of request are available in the :class:`Symfony\\Component\\HttpKernel\\HttpKernelInterface`

--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -115,7 +115,7 @@ done as follow::
     {
         public function onKernelRequest(GetResponseEvent $event)
         {
-            if (HttpKernel::MASTER_REQUEST != $event->getRequestType()) {
+            if (false === $event->isMasterRequest()) {
                 // don't do anything if it's not the master request
                 return;
             }


### PR DESCRIPTION
Updated event_listener.rst to use the new KernelEvent::isMasterRequest method

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4+ |
| Fixed tickets | none |
