### PR TITLE
[WCM][Form] Rename "always_empty" in PasswordType to "reset_on_submit

### DIFF
--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -37,11 +37,11 @@ always_empty
 
 .. caution::
 
-    The ``_always_empty`` option has been deprecated and will be removed in 3.0.
-    Instead, use the ``reset_on_submit`` option.
+    The ``always_empty`` option has been deprecated and will be removed in 3.0.
+    Use the ``reset_on_submit`` option instead.
 
 reset_on_submit
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 **type**: ``Boolean`` **default**: ``true``
 

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -9,7 +9,8 @@ The ``password`` field renders an input password text box.
 +-------------+------------------------------------------------------------------------+
 | Rendered as | ``input`` ``password`` field                                           |
 +-------------+------------------------------------------------------------------------+
-| Options     | - `always_empty`_                                                      |
+| Options     | - `always_empty`_ (deprecated as of 2.6)                               |
+|             | - `reset_on_submit`_                                                   |
 +-------------+------------------------------------------------------------------------+
 | Inherited   | - `max_length`_ (deprecated as of 2.5)                                 |
 | options     | - `empty_data`_                                                        |
@@ -32,6 +33,14 @@ Field Options
 -------------
 
 always_empty
+~~~~~~~~~~~~
+
+.. caution::
+
+    The ``_always_empty`` option has been deprecated and will be removed in 3.0.
+    Instead, use the ``reset_on_submit`` option.
+
+reset_on_submit
 ~~~~~~~~~~~~
 
 **type**: ``Boolean`` **default**: ``true``


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.6+ |
| Fixed tickets | symfony/symfony#6325 |
