### PR TITLE
ensure that destination directories don't exist before creating them

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ function sparse_checkout {
     git remote add -f origin http://github.com/$1/$2
     echo Resources/doc > .git/info/sparse-checkout
     git checkout master
+    rm -rf ../bundles/$2
     mv Resources/doc ../bundles/$2
     cd ..
     rm -rf sparse_checkout
@@ -18,5 +19,6 @@ sparse_checkout sensiolabs SensioGeneratorBundle
 sparse_checkout doctrine DoctrineFixturesBundle
 sparse_checkout doctrine DoctrineMigrationsBundle
 sparse_checkout doctrine DoctrineMongoDBBundle
+rm -rf cmf
 git clone http://github.com/symfony-cmf/symfony-cmf-docs cmf
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

The `install.sh` script fails if you run it multiple times (e.g. to update the bundle and CMF docs).
