### PR TITLE
[Reference][Forms] move versionadded directives for form options directly below the option's headline

### DIFF
--- a/reference/forms/types/options/action.rst.inc
+++ b/reference/forms/types/options/action.rst.inc
@@ -1,8 +1,8 @@
-.. versionadded:: 2.3
-    The ``action`` option was introduced in Symfony 2.3.
-
 action
 ~~~~~~
+
+.. versionadded:: 2.3
+    The ``action`` option was introduced in Symfony 2.3.
 
 **type**: ``string`` **default**: empty string
 

--- a/reference/forms/types/options/empty_value.rst.inc
+++ b/reference/forms/types/options/empty_value.rst.inc
@@ -1,11 +1,11 @@
 empty_value
 ~~~~~~~~~~~
 
-**type**: ``string`` or ``Boolean``
-
 .. versionadded:: 2.3
     Since Symfony 2.3, empty values are also supported if the ``expanded``
     option is set to true.
+
+**type**: ``string`` or ``Boolean``
 
 This option determines whether or not a special "empty" option (e.g. "Choose an option")
 will appear at the top of a select widget. This option only applies if the

--- a/reference/forms/types/options/error_mapping.rst.inc
+++ b/reference/forms/types/options/error_mapping.rst.inc
@@ -1,10 +1,10 @@
 error_mapping
 ~~~~~~~~~~~~~
 
-**type**: ``array`` **default**: ``empty``
-
 .. versionadded:: 2.1
     The ``error_mapping`` option is new to Symfony 2.1.
+
+**type**: ``array`` **default**: ``empty``
 
 This option allows you to modify the target of a validation error.
 

--- a/reference/forms/types/options/method.rst.inc
+++ b/reference/forms/types/options/method.rst.inc
@@ -1,8 +1,8 @@
-.. versionadded:: 2.3
-    The ``method`` option was introduced in Symfony 2.3.
-
 method
 ~~~~~~
+
+.. versionadded:: 2.3
+    The ``method`` option was introduced in Symfony 2.3.
 
 **type**: ``string`` **default**: ``POST``
 

--- a/reference/forms/types/options/with_minutes.rst.inc
+++ b/reference/forms/types/options/with_minutes.rst.inc
@@ -1,8 +1,8 @@
-.. versionadded:: 2.2
-    The ``with_minutes`` option was introduced in Symfony 2.2.
-
 with_minutes
 ~~~~~~~~~~~~
+
+.. versionadded:: 2.2
+    The ``with_minutes`` option was introduced in Symfony 2.2.
 
 **type**: ``Boolean`` **default**: ``true``
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

When you link directly to a form type option (for example, http://symfony.com/doc/current/reference/forms/types/form.html#action), the `versionadded` directive is rendered outside the user's view port which might confuse people. Thus, @WouterJ and me decided to place `versionadded` directives for form type options directly below the option's headline (above the `type` line).
