### PR TITLE
Property access tweaks

### DIFF
--- a/components/property_access/introduction.rst
+++ b/components/property_access/introduction.rst
@@ -334,12 +334,11 @@ instead::
 The same is possible for :method:`PropertyAccessor::setValue<Symfony\\Component\\PropertyAccess\\PropertyAccessor::setValue>`:
 Call the
 :method:`PropertyAccessor::isWritable<Symfony\\Component\\PropertyAccess\\PropertyAccessor::isWritable>`
-method to find out whether a property path can be updated. In the third
-argument, you should pass the value that you want to write::
+method to find out whether a property path can be updated::
 
     $person = new Person();
 
-    if ($accessor->isWritable($person, 'firstName', 'Wouter') {
+    if ($accessor->isWritable($person, 'firstName') {
         // ...
     }
 

--- a/components/property_access/introduction.rst
+++ b/components/property_access/introduction.rst
@@ -314,12 +314,13 @@ Checking Property Paths
 
 .. versionadded:: 2.5
     The methods
-    :method:`PropertyAccessor::isReadable<Symfony\\Component\\PropertyAccess\\PropertyAccessor::isReadable>`
+    :method:`PropertyAccessor::isReadable <Symfony\\Component\\PropertyAccess\\PropertyAccessor::isReadable>`
     and
-    :method:`PropertyAccessor::isWritable<Symfony\\Component\\PropertyAccess\\PropertyAccessor::isWritable>`
-    methods were added in Symfony 2.5.
+    :method:`PropertyAccessor::isWritable <Symfony\\Component\\PropertyAccess\\PropertyAccessor::isWritable>`
+    methods were introduced in Symfony 2.5.
 
-When you want to check whether :method:`PropertyAccessor::getValue<Symfony\\Component\\PropertyAccess\\PropertyAccessor::getValue>`
+When you want to check whether
+:method:`PropertyAccessor::getValue<Symfony\\Component\\PropertyAccess\\PropertyAccessor::getValue>`
 can safely be called without actually calling that method, you can use
 :method:`PropertyAccessor::isReadable<Symfony\\Component\\PropertyAccess\\PropertyAccessor::isReadable>`
 instead::


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5+ |
| Fixed tickets | #3729 |

Hi guys!

This follows after #3729 - it includes several small suggestions made by @WouterJ and @xabbuh.

Additionally, this removes the 3rd argument to `isWritable`, which was removed in the orignal PR (symfony/symfony#10570) and didn't make it into the final feature.

Thanks!
