### PR TITLE
Adds link to new QuestionHelper

### DIFF
--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -402,10 +402,11 @@ Console Helpers
 The console component also contains a set of "helpers" - different small
 tools capable of helping you with different tasks:
 
-* :doc:`/components/console/helpers/dialoghelper`: interactively ask the user for information
+* :doc:`/components/console/helpers/questionhelper`: interactively ask the user for information
 * :doc:`/components/console/helpers/formatterhelper`: customize the output colorization
 * :doc:`/components/console/helpers/progresshelper`: shows a progress bar
 * :doc:`/components/console/helpers/tablehelper`: displays tabular data as a table
+* :doc:`/components/console/helpers/dialoghelper`: (deprecated) interactively ask the user for information
 
 Testing Commands
 ----------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | 2.5+ |

Following #3752, this adds question helper to the helper list and marks the dialog as deprecated.

Thanks!
