### PR TITLE
Wrong opening bracket

### DIFF
--- a/book/translation.rst
+++ b/book/translation.rst
@@ -231,7 +231,7 @@ help with message translation of *static blocks of text*:
     {% trans %}Hello %name%{% endtrans %}
 
     {% transchoice count %}
-        {0} There are no apples|{1} There is one apple|]1,Inf] There are %count% apples
+        {0} There are no apples|{1} There is one apple|[1,Inf] There are %count% apples
     {% endtranschoice %}
 
 The ``transchoice`` tag automatically gets the ``%count%`` variable from


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

I am not 100% sure, but I believe this:

```
{0} There are no apples|{1} There is one apple|]1,Inf] There are %count% apples
```

Should be this instead:

```
{0} There are no apples|{1} There is one apple|[1,Inf] There are %count% apples
```

`]1,Inf]` vs `[1,Inf]`

I havent checked the other languages, but those might have the same?
