### PR TITLE
[Components][DependencyInjection] add note about a use case that requires to compile the container

### DIFF
--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -7,7 +7,9 @@ Compiling the Container
 The service container can be compiled for various reasons. These reasons
 include checking for any potential issues such as circular references and
 making the container more efficient by resolving parameters and removing
-unused services.
+unused services. Also, certain features - like using
+:doc:`parent services </components/dependency_injection/parentservices>` -
+require the container to be compiled.
 
 It is compiled by running::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

As @movetodevnull pointed out in symfony/symfony#10045, the compilation chapter of the DependencyInjection component doesn't give any concrete use case of when it is absolutely needed to compile the container.

We should decide whether or not it makes sense to extend this note, once #3753 is getting merged.
