### PR TITLE
[Cookbook][Console] Error in example code

### DIFF
--- a/cookbook/console/commands_as_services.rst
+++ b/cookbook/console/commands_as_services.rst
@@ -91,6 +91,7 @@ have some ``NameRepository`` service that you'll use to get your default value::
         public function __construct(NameRepository $nameRepository)
         {
             $this->nameRepository = $nameRepository;
+            parent::__construct();
         }
 
         protected function configure()


### PR DESCRIPTION
The example code was not working. When overriding Command::__construct(), you need to call the parent instructor.
