### PR TITLE
[Form] Deprecated read_only option

### DIFF
--- a/reference/forms/twig_reference.rst
+++ b/reference/forms/twig_reference.rst
@@ -344,6 +344,7 @@ object:
 | ``value``              | The value that will be used when rendering (commonly the ``value`` HTML attribute). |
 +------------------------+-------------------------------------------------------------------------------------+
 | ``read_only``          | If ``true``, ``readonly="readonly"`` is added to the field.                         |
+|                        | (deprecated as of 2.5, to be removed in 3.0, use ``attr["readonly"]`` instead)      |
 +------------------------+-------------------------------------------------------------------------------------+
 | ``disabled``           | If ``true``, ``disabled="disabled"`` is added to the field.                         |
 +------------------------+-------------------------------------------------------------------------------------+

--- a/reference/forms/types/birthday.rst
+++ b/reference/forms/types/birthday.rst
@@ -33,7 +33,7 @@ option defaults to 120 years ago to the current year.
 |                      | - `data`_                                                                     |
 |                      | - `invalid_message`_                                                          |
 |                      | - `invalid_message_parameters`_                                               |
-|                      | - `read_only`_                                                                |
+|                      | - `read_only`_ (deprecated as of 2.5)                                         |
 |                      | - `disabled`_                                                                 |
 |                      | - `mapped`_                                                                   |
 |                      | - `inherit_data`_                                                             |

--- a/reference/forms/types/checkbox.rst
+++ b/reference/forms/types/checkbox.rst
@@ -20,7 +20,7 @@ if the box is unchecked, the value will be set to false.
 | options     | - `required`_                                                          |
 |             | - `label`_                                                             |
 |             | - `label_attr`_                                                        |
-|             | - `read_only`_                                                         |
+|             | - `read_only`_ (deprecated as of 2.5)                                  |
 |             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
 |             | - `error_mapping`_                                                     |

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -28,7 +28,7 @@ option.
 | options     | - `label`_                                                                   |
 |             | - `label_attr`_                                                              |
 |             | - `data`_                                                                    |
-|             | - `read_only`_                                                               |
+|             | - `read_only`_ (deprecated as of 2.5)                                        |
 |             | - `disabled`_                                                                |
 |             | - `error_mapping`_                                                           |
 |             | - `mapped`_                                                                  |

--- a/reference/forms/types/country.rst
+++ b/reference/forms/types/country.rst
@@ -36,7 +36,7 @@ you should just use the ``choice`` type directly.
 |             | - `label`_                                                            |
 |             | - `label_attr`_                                                       |
 |             | - `data`_                                                             |
-|             | - `read_only`_                                                        |
+|             | - `read_only`_ (deprecated as of 2.5)                                 |
 |             | - `disabled`_                                                         |
 |             | - `mapped`_                                                           |
 +-------------+-----------------------------------------------------------------------+

--- a/reference/forms/types/currency.rst
+++ b/reference/forms/types/currency.rst
@@ -29,7 +29,7 @@ should just use the ``choice`` type directly.
 |             | - `label`_                                                             |
 |             | - `label_attr`_                                                        |
 |             | - `data`_                                                              |
-|             | - `read_only`_                                                         |
+|             | - `read_only`_ (deprecated as of 2.5)                                  |
 |             | - `disabled`_                                                          |
 |             | - `mapped`_                                                            |
 +-------------+------------------------------------------------------------------------+

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -35,7 +35,7 @@ day, and year) or three select boxes (see the `widget`_ option).
 | Inherited            | - `data`_                                                                   |
 | options              | - `invalid_message`_                                                        |
 |                      | - `invalid_message_parameters`_                                             |
-|                      | - `read_only`_                                                              |
+|                      | - `read_only`_ (deprecated as of 2.5)                                       |
 |                      | - `disabled`_                                                               |
 |                      | - `mapped`_                                                                 |
 |                      | - `inherit_data`_                                                           |

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -36,7 +36,7 @@ data can be a ``DateTime`` object, a string, a timestamp or an array.
 | Inherited            | - `data`_                                                                   |
 | options              | - `invalid_message`_                                                        |
 |                      | - `invalid_message_parameters`_                                             |
-|                      | - `read_only`_                                                              |
+|                      | - `read_only`_ (deprecated as of 2.5)                                       |
 |                      | - `disabled`_                                                               |
 |                      | - `mapped`_                                                                 |
 |                      | - `inherit_data`_                                                           |

--- a/reference/forms/types/email.rst
+++ b/reference/forms/types/email.rst
@@ -17,7 +17,7 @@ The ``email`` field is a text field that is rendered using the HTML5
 |             | - `label_attr`_                                                     |
 |             | - `data`_                                                           |
 |             | - `trim`_                                                           |
-|             | - `read_only`_                                                      |
+|             | - `read_only`_ (deprecated as of 2.5)                               |
 |             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
 |             | - `error_mapping`_                                                  |

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -31,7 +31,7 @@ objects from the database.
 |             | - `label`_                                                       |
 |             | - `label_attr`_                                                  |
 |             | - `data`_                                                        |
-|             | - `read_only`_                                                   |
+|             | - `read_only`_ (deprecated as of 2.5)                            |
 |             | - `disabled`_                                                    |
 |             | - `error_bubbling`_                                              |
 |             | - `error_mapping`_                                               |

--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -15,7 +15,7 @@ The ``file`` type represents a file input in your form.
 | options     | - `required`_                                                       |
 |             | - `label`_                                                          |
 |             | - `label_attr`_                                                     |
-|             | - `read_only`_                                                      |
+|             | - `read_only`_ (deprecated as of 2.5)                               |
 |             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
 |             | - `error_mapping`_                                                  |

--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -16,7 +16,7 @@ on all types for which ``form`` is the parent type.
 |           | - `label_attr`_                                                    |
 |           | - `constraints`_                                                   |
 |           | - `cascade_validation`_                                            |
-|           | - `read_only`_                                                     |
+|           | - `read_only`_ (deprecated as of 2.5)                              |
 |           | - `trim`_                                                          |
 |           | - `mapped`_                                                        |
 |           | - `property_path`_                                                 |

--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -24,7 +24,7 @@ integers. By default, all non-integer values (e.g. 6.78) will round down (e.g. 6
 |             | - `label`_                                                            |
 |             | - `label_attr`_                                                       |
 |             | - `data`_                                                             |
-|             | - `read_only`_                                                        |
+|             | - `read_only`_ (deprecated as of 2.5)                                 |
 |             | - `disabled`_                                                         |
 |             | - `error_bubbling`_                                                   |
 |             | - `error_mapping`_                                                    |

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -37,7 +37,7 @@ you should just use the ``choice`` type directly.
 |             | - `label`_                                                             |
 |             | - `label_attr`_                                                        |
 |             | - `data`_                                                              |
-|             | - `read_only`_                                                         |
+|             | - `read_only`_ (deprecated as of 2.5)                                  |
 |             | - `disabled`_                                                          |
 |             | - `mapped`_                                                            |
 +-------------+------------------------------------------------------------------------+

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -39,7 +39,7 @@ you should just use the ``choice`` type directly.
 |             | - `label`_                                                             |
 |             | - `label_attr`_                                                        |
 |             | - `data`_                                                              |
-|             | - `read_only`_                                                         |
+|             | - `read_only`_ (deprecated as of 2.5)                                  |
 |             | - `disabled`_                                                          |
 |             | - `mapped`_                                                            |
 +-------------+------------------------------------------------------------------------+

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -24,7 +24,7 @@ how the input and output of the data is handled.
 |             | - `label`_                                                          |
 |             | - `label_attr`_                                                     |
 |             | - `data`_                                                           |
-|             | - `read_only`_                                                      |
+|             | - `read_only`_ (deprecated as of 2.5)                               |
 |             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
 |             | - `error_mapping`_                                                  |

--- a/reference/forms/types/number.rst
+++ b/reference/forms/types/number.rst
@@ -20,7 +20,7 @@ you want to use for your number.
 |             | - `label`_                                                           |
 |             | - `label_attr`_                                                      |
 |             | - `data`_                                                            |
-|             | - `read_only`_                                                       |
+|             | - `read_only`_ (deprecated as of 2.5)                                |
 |             | - `disabled`_                                                        |
 |             | - `error_bubbling`_                                                  |
 |             | - `error_mapping`_                                                   |

--- a/reference/forms/types/options/read_only.rst.inc
+++ b/reference/forms/types/options/read_only.rst.inc
@@ -1,3 +1,8 @@
+.. caution::
+
+    The ``read_only`` option has been deprecated and will be removed in 3.0.
+    Instead, use the ``attr`` option by setting it to an array with a ``readonly`` key.
+
 read_only
 ~~~~~~~~~
 

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -17,7 +17,7 @@ The ``password`` field renders an input password text box.
 |             | - `label`_                                                             |
 |             | - `label_attr`_                                                        |
 |             | - `trim`_                                                              |
-|             | - `read_only`_                                                         |
+|             | - `read_only`_ (deprecated as of 2.5)                                  |
 |             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
 |             | - `error_mapping`_                                                     |

--- a/reference/forms/types/percent.rst
+++ b/reference/forms/types/percent.rst
@@ -23,7 +23,7 @@ This field adds a percentage sign "``%``" after the input box.
 |             | - `label`_                                                            |
 |             | - `label_attr`_                                                       |
 |             | - `data`_                                                             |
-|             | - `read_only`_                                                        |
+|             | - `read_only`_ (deprecated as of 2.5)                                 |
 |             | - `disabled`_                                                         |
 |             | - `error_bubbling`_                                                   |
 |             | - `error_mapping`_                                                    |

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -21,7 +21,7 @@ If you want to have a Boolean field, use :doc:`checkbox </reference/forms/types/
 |             | - `required`_                                                       |
 |             | - `label`_                                                          |
 |             | - `label_attr`_                                                     |
-|             | - `read_only`_                                                      |
+|             | - `read_only`_ (deprecated as of 2.5)                               |
 |             | - `disabled`_                                                       |
 |             | - `error_bubbling`_                                                 |
 |             | - `error_mapping`_                                                  |

--- a/reference/forms/types/search.rst
+++ b/reference/forms/types/search.rst
@@ -18,7 +18,7 @@ Read about the input search field at `DiveIntoHTML5.info`_
 |             | - `label`_                                                           |
 |             | - `label_attr`_                                                      |
 |             | - `trim`_                                                            |
-|             | - `read_only`_                                                       |
+|             | - `read_only`_ (deprecated as of 2.5)                                |
 |             | - `disabled`_                                                        |
 |             | - `error_bubbling`_                                                  |
 |             | - `error_mapping`_                                                   |

--- a/reference/forms/types/text.rst
+++ b/reference/forms/types/text.rst
@@ -16,7 +16,7 @@ The text field represents the most basic input text field.
 |             | - `label_attr`_                                                    |
 |             | - `data`_                                                          |
 |             | - `trim`_                                                          |
-|             | - `read_only`_                                                     |
+|             | - `read_only`_ (deprecated as of 2.5)                              |
 |             | - `disabled`_                                                      |
 |             | - `error_bubbling`_                                                |
 |             | - `error_mapping`_                                                 |

--- a/reference/forms/types/textarea.rst
+++ b/reference/forms/types/textarea.rst
@@ -16,7 +16,7 @@ Renders a ``textarea`` HTML element.
 |             | - `label_attr`_                                                        |
 |             | - `trim`_                                                              |
 |             | - `data`_                                                              |
-|             | - `read_only`_                                                         |
+|             | - `read_only`_ (deprecated as of 2.5)                                  |
 |             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
 |             | - `error_mapping`_                                                     |

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -32,7 +32,7 @@ as a ``DateTime`` object, a string, a timestamp or an array.
 | Inherited            | - `invalid_message`_                                                        |
 | options              | - `invalid_message_parameters`_                                             |
 |                      | - `data`_                                                                   |
-|                      | - `read_only`_                                                              |
+|                      | - `read_only`_ (deprecated as of 2.5)                                       |
 |                      | - `disabled`_                                                               |
 |                      | - `mapped`_                                                                 |
 |                      | - `inherit_data`_                                                           |

--- a/reference/forms/types/timezone.rst
+++ b/reference/forms/types/timezone.rst
@@ -30,7 +30,7 @@ you should just use the ``choice`` type directly.
 |             | - `label`_                                                             |
 |             | - `label_attr`_                                                        |
 |             | - `data`_                                                              |
-|             | - `read_only`_                                                         |
+|             | - `read_only`_ (deprecated as of 2.5)                                  |
 |             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
 |             | - `error_mapping`_                                                     |

--- a/reference/forms/types/url.rst
+++ b/reference/forms/types/url.rst
@@ -20,7 +20,7 @@ have a protocol.
 |             | - `label_attr`_                                                   |
 |             | - `data`_                                                         |
 |             | - `trim`_                                                         |
-|             | - `read_only`_                                                    |
+|             | - `read_only`_ (deprecated as of 2.5)                             |
 |             | - `disabled`_                                                     |
 |             | - `error_bubbling`_                                               |
 |             | - `error_mapping`_                                                |


### PR DESCRIPTION
Please see https://github.com/symfony/symfony/pull/10830

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | master |
| Fixed tickets | - |
