### PR TITLE
remove unnecessary rewrite from nginx conf

### DIFF
--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -77,13 +77,8 @@ are:
         root /var/www/project/web;
 
         location / {
-            # try to serve file directly, fallback to rewrite
-            try_files $uri @rewriteapp;
-        }
-
-        location @rewriteapp {
-            # rewrite all to app.php
-            rewrite ^(.*)$ /app.php/$1 last;
+            # try to serve file directly, fallback to app.php
+            try_files $uri /app.php$is_args$args;
         }
 
         location ~ ^/(app|app_dev|config)\.php(/|$) {


### PR DESCRIPTION
It is unnecessary to rewrite to a different URL when you can simply have the request be handled by app.php
