### PR TITLE
More asset version details

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -991,10 +991,10 @@ assets won't be cached when deployed. For example, ``/images/logo.png`` might
 look like ``/images/logo.png?v2``. For more information, see the :ref:`ref-framework-assets-version`
 configuration option.
 
-.. _`
+.. _`book-templating-version-by-asset`:
 
 .. versionadded:: 2.5
-    Setting versioned URLs on an asset-by-asset basis were introduced in Symfony 2.5.
+    Setting versioned URLs on an asset-by-asset basis was introduced in Symfony 2.5.
 
 If you need to set a version for a specific asset, you can set the fourth
 argument (or the ``version`` argument) to the desired version:
@@ -1003,14 +1003,14 @@ argument (or the ``version`` argument) to the desired version:
 
     .. code-block:: html+jinja
 
-        <img src="{{ asset('images/logo.png', version=3.0) }}" alt="Symfony!" />
+        <img src="{{ asset('images/logo.png', version='3.0') }}" alt="Symfony!" />
 
     .. code-block:: html+php
 
         <img src="<?php echo $view['assets']->getUrl('images/logo.png', null, false, '3.0') ?>" alt="Symfony!" />
 
 If you dont give a version or pass ``null``, the default package version
-(from :ref:`ref-framework-assets-version`) wil be used. If you pass ``false``,
+(from :ref:`ref-framework-assets-version`) will be used. If you pass ``false``,
 versioned URL will be deactivated for this asset.
 
 .. versionadded:: 2.5

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -991,6 +991,28 @@ assets won't be cached when deployed. For example, ``/images/logo.png`` might
 look like ``/images/logo.png?v2``. For more information, see the :ref:`ref-framework-assets-version`
 configuration option.
 
+.. _`
+
+.. versionadded:: 2.5
+    Setting versioned URLs on an asset-by-asset basis were introduced in Symfony 2.5.
+
+If you need to set a version for a specific asset, you can set the fourth
+argument (or the ``version`` argument) to the desired version:
+
+.. configuration-block::
+
+    .. code-block:: html+jinja
+
+        <img src="{{ asset('images/logo.png', version=3.0) }}" alt="Symfony!" />
+
+    .. code-block:: html+php
+
+        <img src="<?php echo $view['assets']->getUrl('images/logo.png', null, false, '3.0') ?>" alt="Symfony!" />
+
+If you dont give a version or pass ``null``, the default package version
+(from :ref:`ref-framework-assets-version`) wil be used. If you pass ``false``,
+versioned URL will be deactivated for this asset.
+
 .. versionadded:: 2.5
     Absolute URLs for assets were introduced in Symfony 2.5.
 
@@ -1006,25 +1028,6 @@ If you need absolute URLs for assets, you can set the third argument (or the
     .. code-block:: html+php
 
         <img src="<?php echo $view['assets']->getUrl('images/logo.png', null, true) ?>" alt="Symfony!" />
-
-.. versionadded:: 2.5
-    Versioned URLs for assets were introduced in Symfony 2.5.
-
-If you need versioned URLs for assets, you can set the fourth argument (or the
-``version`` argument) to the desired version:
-
-.. configuration-block::
-
-    .. code-block:: html+jinja
-
-        <img src="{{ asset('images/logo.png', version=3.0) }}" alt="Symfony!" />
-
-    .. code-block:: html+php
-
-        <img src="<?php echo $view['assets']->getUrl('images/logo.png', null, false, '3.0') ?>" alt="Symfony!" />
-
-If you dont give a version or pass ``null``, the default package version will
-be used. If you pass ``false``, versioned URL will be deactivated.
 
 .. index::
    single: Templating; Including stylesheets and JavaScripts

--- a/components/templating/helpers/assetshelper.rst
+++ b/components/templating/helpers/assetshelper.rst
@@ -83,7 +83,8 @@ second is the version. For instance, ``%s?v=%s`` will be rendered as
 .. versionadded:: 2.5
     On-demand versioned URLs for assets were introduced in Symfony 2.5.
 
-You can also generate a versioned URL using the fourth argument of the helper:
+You can also generate a versioned URL on an asset-by-asset basis using the
+fourth argument of the helper:
 
 .. code-block:: html+php
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -369,6 +369,10 @@ Now, the same asset will be rendered as ``/images/logo.png?v2`` If you use
 this feature, you **must** manually increment the ``assets_version`` value
 before each deployment so that the query parameters change.
 
+It's also possible to set the version value on an asset-by-asset basis (instead
+of using the global version - e.g. ``v2`` - set here). See
+:ref:`Versioning by Asset <book-templating-version-by-asset>` for details.
+
 You can also control how the query string works via the `assets_version_format`_
 option.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no, but follows after #3742 |
| Applies to | 2.5+ |

Hi guys!

This adds some further tweaks to the new feature and docs from #3742:
- moved the absolute asset URL generation part below the new asset versioning feature in the `book/templating` page so that we talk about the "global asset versioning" (i.e. the config option in config.yml) and this new feature right next to each other.
- Added some additional details to make it clear that there is a "global" asset version, and then the ability to override on an asset by asset basis.

I think it's all small details, but @romainneutron if you have a quick chance to look this over, that would be awesome too.

Thanks!
