### PR TITLE
Update dialoghelper.rst

### DIFF
--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -156,9 +156,10 @@ You can also ask and validate a hidden response::
     $dialog = $this->getHelperSet()->get('dialog');
 
     $validator = function ($value) {
-        if (trim($value) == '') {
+        if ('' === trim($value)) {
             throw new \Exception('The password can not be empty');
         }
+        
         return $value;
     };
 

--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -159,6 +159,7 @@ You can also ask and validate a hidden response::
         if (trim($value) == '') {
             throw new \Exception('The password can not be empty');
         }
+        return $value;
     };
 
     $password = $dialog->askHiddenResponseAndValidate(


### PR DESCRIPTION
At the "Validating a Hidden Response" the example validation didn't respond anything so the $password var was NULL
