### PR TITLE
Fixed typo in hostname_pattern.rst

### DIFF
--- a/components/routing/hostname_pattern.rst
+++ b/components/routing/hostname_pattern.rst
@@ -214,7 +214,7 @@ instance, if you want to match both ``m.example.com`` and
 
                 <route id="mobile_homepage" path="/" host="m.example.com">
                     <default key="_controller">AcmeDemoBundle:Main:mobileHomepage</default>
-                    <default key="domain">%domain%</requirement>
+                    <default key="domain">%domain%</default>
                     <requirement key="domain">%domain%</requirement>
                 </route>
 


### PR DESCRIPTION
Hello, 

I was reading the documentation and i saw a typo error on the closing xml element, it's supposed to be default not requirement.
