### PR TITLE
change version numbers in installation notes to be in line with the docu...

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -57,7 +57,7 @@ Distribution:
 
 .. code-block:: bash
 
-    $ php composer.phar create-project symfony/framework-standard-edition /path/to/webroot/Symfony dev-master
+    $ php composer.phar create-project symfony/framework-standard-edition /path/to/webroot/Symfony 2.5.*
 
 .. tip::
 
@@ -104,10 +104,10 @@ one of the following commands (replacing ``###`` with your actual filename):
 .. code-block:: bash
 
     # for .tgz file
-    $ tar zxvf Symfony_Standard_Vendors_2.4.###.tgz
+    $ tar zxvf Symfony_Standard_Vendors_2.5.###.tgz
 
     # for a .zip file
-    $ unzip Symfony_Standard_Vendors_2.4.###.zip
+    $ unzip Symfony_Standard_Vendors_2.5.###.zip
 
 If you've downloaded "without vendors", you'll definitely need to read the
 next section.


### PR DESCRIPTION
...mented Symfony version

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5 |
| Fixed tickets |  |

This PR updates the version constraints in the installation instructions as described [here](http://symfony.com/doc/current/contributing/documentation/overview.html#when-a-new-branch-is-created-for-a-release):

> Change all version and master references to the correct version (e.g. 2.3). For example, in installation chapters, we reference the version you should use for installation. As an example, see the changes made in PR #2688.
