### PR TITLE
Removed redundant POST request exclusion info

### DIFF
--- a/cookbook/security/target_path.rst
+++ b/cookbook/security/target_path.rst
@@ -10,9 +10,9 @@ the name of the firewall, defined in ``security.yml``). Upon a successful
 login, the user is redirected to this path, as to help them continue from the
 last known page they visited.
 
-On some occasions, this is unexpected. For example when the last request
-URI was an HTTP POST against a route which is configured to allow only a POST
-method, the user is redirected to this route only to get a 404 error.
+On some occasions, this is unexpected. For example when the last request before logout 
+was an XMLHttpRequest route, the user may be redirected back to an invalid 
+route.
 
 To get around this behavior, you would simply need to extend the ``ExceptionListener``
 class and override the default method named ``setTargetPath()``.
@@ -56,9 +56,10 @@ Next, create your own ``ExceptionListener``::
     {
         protected function setTargetPath(Request $request)
         {
-            // Do not save target path for XHR and non-GET requests
+            // Do not save target path for XHR requests
             // You can add any more logic here you want
-            if ($request->isXmlHttpRequest() || 'GET' !== $request->getMethod()) {
+            // Note that non-GET requests are already ignored
+            if ($request->isXmlHttpRequest()) {
                 return;
             }
 

--- a/cookbook/security/target_path.rst
+++ b/cookbook/security/target_path.rst
@@ -10,9 +10,9 @@ the name of the firewall, defined in ``security.yml``). Upon a successful
 login, the user is redirected to this path, as to help them continue from the
 last known page they visited.
 
-On some occasions, this is unexpected. For example when the last request before logout 
-was an XMLHttpRequest route, the user may be redirected back to an invalid 
-route.
+In some situations, this is not ideal. For example when the last request
+URI was an XMLHttpRequest which returned a non-HTML or partial HTML response,
+the user is redirected back to a page which the browser cannot render.
 
 To get around this behavior, you would simply need to extend the ``ExceptionListener``
 class and override the default method named ``setTargetPath()``.

--- a/cookbook/security/target_path.rst
+++ b/cookbook/security/target_path.rst
@@ -10,7 +10,7 @@ the name of the firewall, defined in ``security.yml``). Upon a successful
 login, the user is redirected to this path, as to help them continue from the
 last known page they visited.
 
-In some situations, this is not ideal. For example when the last request
+In some situations, this is not ideal. For example, when the last request
 URI was an XMLHttpRequest which returned a non-HTML or partial HTML response,
 the user is redirected back to a page which the browser cannot render.
 


### PR DESCRIPTION
The default `ExceptionListener::setTargetPath()` already excludes POSTs/PUTs, so suggesting that people should implement their own listener to do this is a bit misleading.

However, doing this to prevent XMLHttpRequest URIs from being saved is still valuable.
