### PR TITLE
[Components][Form] add versionadded for the data collector form extension

### DIFF
--- a/components/form/form_events.rst
+++ b/components/form/form_events.rst
@@ -110,6 +110,9 @@ the form.
 
 .. sidebar:: ``FormEvents::POST_SET_DATA`` in the Form component
 
+    .. versionadded:: 2.4
+        The data collector extension was introduced in Symfony 2.4.
+
     The :class:`Symfony\\Component\\Form\\Extension\\DataCollector\\EventListener\\DataCollectorListener`
     class is subscribed to listen to the ``FormEvents::POST_SET_DATA`` event
     in order to collect information about the forms from the denormalized
@@ -217,6 +220,9 @@ It can be used to fetch data after denormalization.
     At this point, you cannot add or remove fields to the form.
 
 .. sidebar:: ``FormEvents::POST_SUBMIT`` in the Form component
+
+    .. versionadded:: 2.4
+        The data collector extension was introduced in Symfony 2.4.
 
     The :class:`Symfony\\Component\\Form\\Extension\\DataCollector\\EventListener\\DataCollectorListener`
     subscribes to the ``FormEvents::POST_SUBMIT`` event in order to collect


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4+ |
| Fixed tickets |  |

As @ahsio pointed out in #3886, the data collector extension was added to the Form component in Symfony 2.4.
