### PR TITLE
Correct setting of _controller attribute

### DIFF
--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -660,7 +660,7 @@ argument as follows::
     // create some other request manually as needed
     $request = new Request();
     // for example, possibly set its _controller manually
-    $request->attributes->add('_controller', '...');
+    $request->attributes->set('_controller', '...');
 
     $response = $kernel->handle($request, HttpKernelInterface::SUB_REQUEST);
     // do something with this response


### PR DESCRIPTION
One of the code snippets uses `$request->attributes->add('_controller', '...');`

This is invalid since this expects an array of multiple attributes.

I've corrected the example to use the set method.

``` php
$request->attributes->set('_controller', '...'); 
```
