### PR TITLE
[Validator] Support "maxSize" given in KiB

### DIFF
--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -20,6 +20,7 @@ form type.
 | Applies to     | :ref:`property or method <validation-property-target>`              |
 +----------------+---------------------------------------------------------------------+
 | Options        | - `maxSize`_                                                        |
+|                | - `binaryFormat`_                                                   |
 |                | - `mimeTypes`_                                                      |
 |                | - `maxSizeMessage`_                                                 |
 |                | - `mimeTypesMessage`_                                               |
@@ -78,7 +79,7 @@ below a certain file size and a valid PDF, add the following:
                         maxSize: 1024k
                         mimeTypes: [application/pdf, application/x-pdf]
                         mimeTypesMessage: Please upload a valid PDF
-                        
+
 
     .. code-block:: php-annotations
 
@@ -150,6 +151,18 @@ have been specified.
 
 Options
 -------
+
+.. versionadded:: 2.6
+    The ``binaryFormat`` option was introduced in Symfony 2.6.
+
+binaryFormat
+~~~~~~~~~~~~
+
+**type**: ``boolean`` **default**: ``null``
+
+When true, the sizes will be displayed in messages with binary suffixes (KiB, MiB).
+When false, the sizes will be displayed with SI suffixes (kB, MB).
+When null, then the binaryFormat will be guessed from the suffix defined in the maxSize option.
 
 maxSize
 ~~~~~~~

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -164,6 +164,8 @@ When true, the sizes will be displayed in messages with binary suffixes (KiB, Mi
 When false, the sizes will be displayed with SI suffixes (kB, MB).
 When null, then the binaryFormat will be guessed from the suffix defined in the maxSize option.
 
+For more information about the difference between binary and SI suffixes, see `Wikipedia: Binary prefix`_.
+
 maxSize
 ~~~~~~~
 
@@ -173,19 +175,21 @@ If set, the size of the underlying file must be below this file size in order
 to be valid. The size of the file can be given in one of the following formats:
 
 * **bytes**: To specify the ``maxSize`` in bytes, pass a value that is entirely
-  numeric (e.g. ``4096``);
+  numeric (e.g. ``4096``).
 
 * **kilobytes**: To specify the ``maxSize`` in kilobytes, pass a number and
-  suffix it with a "k" (e.g. ``200k``);
+  suffix it with a "k" (e.g. ``200k``); 1k = 1 000 bytes.
 
 * **megabytes**: To specify the ``maxSize`` in megabytes, pass a number and
-  suffix it with a "M" (e.g. ``4M``).
+  suffix it with a "M" (e.g. ``4M``); 1M = 1 000 000 bytes.
 
 * **kibibytes**: To specify the ``maxSize`` in kibibytes, pass a number and
-  suffix it with a "Ki" (e.g. ``600Ki``);
+  suffix it with a "Ki" (e.g. ``600Ki``); 1Ki = 1 024 bytes.
 
 * **mebibytes**: To specify the ``maxSize`` in mebibytes, pass a number and
-  suffix it with a "Mi" (e.g. ``8Mi``).
+  suffix it with a "Mi" (e.g. ``8Mi``); 1Mi = 1 048 576 bytes.
+
+For more information about the difference between binary and SI suffixes, see `Wikipedia: Binary prefix`_.
 
 mimeTypes
 ~~~~~~~~~
@@ -257,3 +261,4 @@ to disk.
 
 
 .. _`IANA website`: http://www.iana.org/assignments/media-types/index.html
+.. _`Wikipedia: Binary prefix`: http://en.wikipedia.org/wiki/Binary_prefix

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -154,6 +154,9 @@ Options
 maxSize
 ~~~~~~~
 
+.. versionadded:: 2.6
+    The suffixes ``Ki`` and ``Mi`` were introduced in Symfony 2.6.
+
 **type**: ``mixed``
 
 If set, the size of the underlying file must be below this file size in order
@@ -188,7 +191,7 @@ binaryFormat
 When ``true``, the sizes will be displayed in messages with binary suffixes
 (KiB, MiB). When ``false``, the sizes will be displayed with SI suffixes (kB,
 MB). When ``null``, then the binaryFormat will be guessed from the suffix
-defined in the maxSize option.
+defined in the ``maxSize`` option.
 
 For more information about the difference between binary and SI suffixes,
 see `Wikipedia: Binary prefix`_.

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -162,20 +162,19 @@ maxSize
 If set, the size of the underlying file must be below this file size in order
 to be valid. The size of the file can be given in one of the following formats:
 
-* **bytes**: To specify the ``maxSize`` in bytes, pass a value that is entirely
-  numeric (e.g. ``4096``);
-
-* **kilobytes**: To specify the ``maxSize`` in kilobytes, pass a number and
-  suffix it with a "k" (e.g. ``200k``); 1k = 1,000 bytes;
-
-* **megabytes**: To specify the ``maxSize`` in megabytes, pass a number and
-  suffix it with a "M" (e.g. ``4M``); 1M = 1,000,000 bytes;
-
-* **kibibytes**: To specify the ``maxSize`` in kibibytes, pass a number and
-  suffix it with a "Ki" (e.g. ``600Ki``); 1Ki = 1,024 bytes;
-
-* **mebibytes**: To specify the ``maxSize`` in mebibytes, pass a number and
-  suffix it with a "Mi" (e.g. ``8Mi``); 1Mi = 1,048,576 bytes.
++--------+-----------+-----------------+------+
+| Suffix | Unit Name |      value      | e.g. |
++========+===========+=================+======+
+|        | byte      |          1 byte | 4096 |
++--------+-----------+-----------------+------+
+| k      | kilobyte  |     1,000 bytes | 200k |
++--------+-----------+-----------------+------+
+| M      | megabyte  | 1,000,000 bytes |   2M |
++--------+-----------+-----------------+------+
+| Ki     | kibibyte  |     1,024 bytes | 32Ki |
++--------+-----------+-----------------+------+
+| Mi     | mebibyte  | 1,048,576 bytes |  8Mi |
++--------+-----------+-----------------+------+
 
 For more information about the difference between binary and SI suffixes,
 see `Wikipedia: Binary prefix`_.

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -80,7 +80,6 @@ below a certain file size and a valid PDF, add the following:
                         mimeTypes: [application/pdf, application/x-pdf]
                         mimeTypesMessage: Please upload a valid PDF
 
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -161,19 +160,19 @@ If set, the size of the underlying file must be below this file size in order
 to be valid. The size of the file can be given in one of the following formats:
 
 * **bytes**: To specify the ``maxSize`` in bytes, pass a value that is entirely
-  numeric (e.g. ``4096``).
+  numeric (e.g. ``4096``);
 
 * **kilobytes**: To specify the ``maxSize`` in kilobytes, pass a number and
-  suffix it with a "k" (e.g. ``200k``); 1k = 1 000 bytes.
+  suffix it with a "k" (e.g. ``200k``); 1k = 1,000 bytes;
 
 * **megabytes**: To specify the ``maxSize`` in megabytes, pass a number and
-  suffix it with a "M" (e.g. ``4M``); 1M = 1 000 000 bytes.
+  suffix it with a "M" (e.g. ``4M``); 1M = 1,000,000 bytes;
 
 * **kibibytes**: To specify the ``maxSize`` in kibibytes, pass a number and
-  suffix it with a "Ki" (e.g. ``600Ki``); 1Ki = 1 024 bytes.
+  suffix it with a "Ki" (e.g. ``600Ki``); 1Ki = 1,024 bytes;
 
 * **mebibytes**: To specify the ``maxSize`` in mebibytes, pass a number and
-  suffix it with a "Mi" (e.g. ``8Mi``); 1Mi = 1 048 576 bytes.
+  suffix it with a "Mi" (e.g. ``8Mi``); 1Mi = 1,048,576 bytes.
 
 For more information about the difference between binary and SI suffixes,
 see `Wikipedia: Binary prefix`_.

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -152,22 +152,6 @@ have been specified.
 Options
 -------
 
-.. versionadded:: 2.6
-    The ``binaryFormat`` option was introduced in Symfony 2.6.
-
-binaryFormat
-~~~~~~~~~~~~
-
-**type**: ``boolean`` **default**: ``null``
-
-When ``true``, the sizes will be displayed in messages with binary suffixes
-(KiB, MiB). When ``false``, the sizes will be displayed with SI suffixes (kB,
-MB). When ``null``, then the binaryFormat will be guessed from the suffix
-defined in the maxSize option.
-
-For more information about the difference between binary and SI suffixes,
-see `Wikipedia: Binary prefix`_.
-
 maxSize
 ~~~~~~~
 
@@ -190,6 +174,22 @@ to be valid. The size of the file can be given in one of the following formats:
 
 * **mebibytes**: To specify the ``maxSize`` in mebibytes, pass a number and
   suffix it with a "Mi" (e.g. ``8Mi``); 1Mi = 1 048 576 bytes.
+
+For more information about the difference between binary and SI suffixes,
+see `Wikipedia: Binary prefix`_.
+
+binaryFormat
+~~~~~~~~~~~~
+
+.. versionadded:: 2.6
+    The ``binaryFormat`` option was introduced in Symfony 2.6.
+
+**type**: ``boolean`` **default**: ``null``
+
+When ``true``, the sizes will be displayed in messages with binary suffixes
+(KiB, MiB). When ``false``, the sizes will be displayed with SI suffixes (kB,
+MB). When ``null``, then the binaryFormat will be guessed from the suffix
+defined in the maxSize option.
 
 For more information about the difference between binary and SI suffixes,
 see `Wikipedia: Binary prefix`_.

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -160,11 +160,13 @@ binaryFormat
 
 **type**: ``boolean`` **default**: ``null``
 
-When true, the sizes will be displayed in messages with binary suffixes (KiB, MiB).
-When false, the sizes will be displayed with SI suffixes (kB, MB).
-When null, then the binaryFormat will be guessed from the suffix defined in the maxSize option.
+When ``true``, the sizes will be displayed in messages with binary suffixes
+(KiB, MiB). When ``false``, the sizes will be displayed with SI suffixes (kB,
+MB). When ``null``, then the binaryFormat will be guessed from the suffix
+defined in the maxSize option.
 
-For more information about the difference between binary and SI suffixes, see `Wikipedia: Binary prefix`_.
+For more information about the difference between binary and SI suffixes,
+see `Wikipedia: Binary prefix`_.
 
 maxSize
 ~~~~~~~
@@ -189,7 +191,8 @@ to be valid. The size of the file can be given in one of the following formats:
 * **mebibytes**: To specify the ``maxSize`` in mebibytes, pass a number and
   suffix it with a "Mi" (e.g. ``8Mi``); 1Mi = 1 048 576 bytes.
 
-For more information about the difference between binary and SI suffixes, see `Wikipedia: Binary prefix`_.
+For more information about the difference between binary and SI suffixes,
+see `Wikipedia: Binary prefix`_.
 
 mimeTypes
 ~~~~~~~~~

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -163,10 +163,16 @@ to be valid. The size of the file can be given in one of the following formats:
   numeric (e.g. ``4096``);
 
 * **kilobytes**: To specify the ``maxSize`` in kilobytes, pass a number and
-  suffix it with a lowercase "k" (e.g. ``200k``);
+  suffix it with a "k" (e.g. ``200k``);
 
 * **megabytes**: To specify the ``maxSize`` in megabytes, pass a number and
-  suffix it with a capital "M" (e.g. ``4M``).
+  suffix it with a "M" (e.g. ``4M``).
+
+* **kibibytes**: To specify the ``maxSize`` in kibibytes, pass a number and
+  suffix it with a "Ki" (e.g. ``600Ki``);
+
+* **mebibytes**: To specify the ``maxSize`` in mebibytes, pass a number and
+  suffix it with a "Mi" (e.g. ``8Mi``).
 
 mimeTypes
 ~~~~~~~~~


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | symfony/symfony#11027 |
| Applies to | 2.6 |
| Fixed tickets | symfony/symfony#10962 |

To display the constraint validation message with an expected suffix, this PR add a new option in  File constraint.
