### PR TITLE
[Security] Added remote_user firewall info and documentation for pre authenticated firewalls

### DIFF
--- a/cookbook/security/pre_authenticated.rst
+++ b/cookbook/security/pre_authenticated.rst
@@ -34,8 +34,8 @@ Enable the x509 authentication for a particular firewall in the security configu
 
     .. code-block:: xml
 
-        <?xml version="1.0" ?>
         <!-- app/config/security.xml -->
+        <?xml version="1.0" ?>
         <srv:container xmlns="http://symfony.com/schema/dic/security"
             xmlns:srv="http://symfony.com/schema/dic/services">
 
@@ -107,8 +107,8 @@ corresponding firewall in your security configuration:
 
     .. code-block:: xml
 
-        <?xml version="1.0" ?>
         <!-- app/config/security.xml -->
+        <?xml version="1.0" ?>
         <srv:container xmlns="http://symfony.com/schema/dic/security"
             xmlns:srv="http://symfony.com/schema/dic/services">
 

--- a/cookbook/security/pre_authenticated.rst
+++ b/cookbook/security/pre_authenticated.rst
@@ -86,7 +86,7 @@ REMOTE_USER based Authentication
 .. versionadded:: 2.6
     REMOTE_USER pre authenticated firewall was introduced in Symfony 2.6.
 
-A lot of authentication modules, like ``auth_kerb` for Apache provide the username
+A lot of authentication modules, like ``auth_kerb`` for Apache provide the username
 using the ``REMOTE_USER`` environment variable. This variable can be trusted by
 the application since the authentication happened before the request reached it.
 

--- a/cookbook/security/pre_authenticated.rst
+++ b/cookbook/security/pre_authenticated.rst
@@ -80,7 +80,7 @@ in the x509 firewall configuration respectively.
     * :doc:`/cookbook/security/custom_provider`
     * :doc:`/cookbook/security/entity_provider`
 
-REMOTE_USER based Authentication
+REMOTE_USER Based Authentication
 --------------------------------
 
 .. versionadded:: 2.6

--- a/cookbook/security/pre_authenticated.rst
+++ b/cookbook/security/pre_authenticated.rst
@@ -66,6 +66,8 @@ the user provider, and sets the ``SSL_CLIENT_S_DN`` as credentials in the
 You can override these by setting the ``user`` and the ``credentials`` keys
 in the x509 firewall configuration respectively.
 
+.. _cookbook-security-pre-authenticated-user-provider-note:
+
 .. note::
 
     An authentication provider will only inform the user provider of the username
@@ -77,3 +79,65 @@ in the x509 firewall configuration respectively.
 
     * :doc:`/cookbook/security/custom_provider`
     * :doc:`/cookbook/security/entity_provider`
+
+REMOTE_USER based Authentication
+--------------------------------
+
+.. versionadded:: 2.6
+    REMOTE_USER pre authenticated firewall was introduced in Symfony 2.6.
+
+A lot of authentication modules, like ``auth_kerb` for Apache provide the username 
+using the ``REMOTE_USER`` environment variable. This variable can be trusted by 
+the application since the authentication happened before the request reached it.
+
+To configure Symfony using the ``REMOTE_USER` environment variable, simply enable the 
+corresponding firewall in your security configuration:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/security.yml
+        security:
+            firewalls:
+                secured_area:
+                    pattern: ^/
+                    remote_user:
+                        provider: your_user_provider
+
+    .. code-block:: xml
+
+        <?xml version="1.0" ?>
+        <!-- app/config/security.xml -->
+        <srv:container xmlns="http://symfony.com/schema/dic/security"
+            xmlns:srv="http://symfony.com/schema/dic/services">
+
+            <config>
+                <firewall name="secured_area" pattern="^/">
+                    <remote-user provider="your_user_provider"/>
+                </firewall>
+            </config>
+        </srv:container>
+
+    .. code-block:: php
+
+        // app/config/security.php
+        $container->loadFromExtension('security', array(
+            'firewalls' => array(
+                'secured_area' => array(
+                    'pattern'     => '^/'
+                    'remote_user' => array(
+                        'provider' => 'your_user_provider',
+                    ),
+                ),
+            ),
+        ));
+
+The firewall will then provide the ``REMOTE_USER`` environment variable to
+your user provider. You can change the variable name used by setting the ``user``
+key in the ``remote_user`` firewall configuration.
+
+.. note::
+
+    Just like for X509 authentication, you will need to configure a "user provider".
+    See :ref:`the note about it <cookbook-security-pre-authenticated-user-provider-note>`.

--- a/cookbook/security/pre_authenticated.rst
+++ b/cookbook/security/pre_authenticated.rst
@@ -73,8 +73,8 @@ in the x509 firewall configuration respectively.
     An authentication provider will only inform the user provider of the username
     that made the request. You will need to create (or use) a "user provider" that
     is referenced by the ``provider`` configuration parameter (``your_user_provider``
-    in the configuration example). This provider will turn the username into a User 
-    object of your choice. For more information on creating or configuring a user 
+    in the configuration example). This provider will turn the username into a User
+    object of your choice. For more information on creating or configuring a user
     provider, see:
 
     * :doc:`/cookbook/security/custom_provider`
@@ -86,11 +86,11 @@ REMOTE_USER based Authentication
 .. versionadded:: 2.6
     REMOTE_USER pre authenticated firewall was introduced in Symfony 2.6.
 
-A lot of authentication modules, like ``auth_kerb` for Apache provide the username 
-using the ``REMOTE_USER`` environment variable. This variable can be trusted by 
+A lot of authentication modules, like ``auth_kerb` for Apache provide the username
+using the ``REMOTE_USER`` environment variable. This variable can be trusted by
 the application since the authentication happened before the request reached it.
 
-To configure Symfony using the ``REMOTE_USER` environment variable, simply enable the 
+To configure Symfony using the ``REMOTE_USER`` environment variable, simply enable the
 corresponding firewall in your security configuration:
 
 .. configuration-block::
@@ -140,4 +140,5 @@ key in the ``remote_user`` firewall configuration.
 .. note::
 
     Just like for X509 authentication, you will need to configure a "user provider".
-    See :ref:`the note about it <cookbook-security-pre-authenticated-user-provider-note>`.
+    See :ref:`the note previous note <cookbook-security-pre-authenticated-user-provider-note>`
+    for more information.

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -121,7 +121,6 @@ Each part will be explained in the next section.
                     stateless: false
                     x509:
                         provider: some_key_from_above
-                    # new in Symfony 2.6
                     remote_user:
                         provider: some_key_from_above
                     http_basic:

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -121,6 +121,9 @@ Each part will be explained in the next section.
                     stateless: false
                     x509:
                         provider: some_key_from_above
+                    # new in Symfony 2.6
+                    remote_user:
+                        provider: some_key_from_above
                     http_basic:
                         provider: some_key_from_above
                     http_digest:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony#10698) |
| Applies to | 2.6+ |
| Fixed tickets | no |

Some documentation for pre authenticated firewalls, and added remote_user configuration reference for this new firewall.
