### PR TITLE
Ignore submodules running `git status`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "sphinx-php"]
 	path = _exts
 	url = http://github.com/fabpot/sphinx-php
+	ignore = untracked


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to |  |
| Fixed tickets |  |

When doing

``` bash
symfony-docs$ git st
On branch master
Your branch is up-to-date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)

    modified:   _exts (untracked content)

no changes added to commit (use "git add" and/or "git commit -a")
```

the directory `_exts` should not get listed.

The patch is based on http://stackoverflow.com/questions/5127178/gitignore-files-added-inside-git-submodules ... ready that issue there is another option `dirty`.

Not sure what's best so:
- [ ] choose between `dirty` and `untracked`
