### PR TITLE
[Docs] [HTTP] [Trusted proxies] Removed note about adding 127.0.0.1

### DIFF
--- a/components/http_foundation/trusting_proxies.rst
+++ b/components/http_foundation/trusting_proxies.rst
@@ -25,12 +25,6 @@ your proxy.
     // only trust proxy headers coming from this IP addresses
     Request::setTrustedProxies(array('192.0.0.1', '10.0.0.0/8'));
 
-.. note::
-
-   When using Symfony's internal reverse proxy (``AppCache.php``) make sure to add
-   ``127.0.0.1`` to the list of trusted proxies.
-
-
 Configuring Header Names
 ------------------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ (applies to 2.2 too but wasn't stated in the 2.2 docs anyway) |
| Fixed tickets | none |

Removed the note about the need to add 127.0.0.1 to the list of trusted proxies when using Symfony's reversed proxy.

I don't think that adding `127.0.0.1` to the list of trusted proxies is needed. The only place where Symfony uses the list of trusted proxies is in the `FragmentListener` (https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php#L81) and there they are merged with the result of `FragmentListener#getLocalIpAddresses()` (https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php#L96) which already returns `127.0.0.1` among the list of locally (and thus trusted) ips.
