### PR TITLE
[Cookbook][Security] Explicit 'your_user_provider' configuration parameter

### DIFF
--- a/cookbook/security/pre_authenticated.rst
+++ b/cookbook/security/pre_authenticated.rst
@@ -70,7 +70,10 @@ in the x509 firewall configuration respectively.
 
     An authentication provider will only inform the user provider of the username
     that made the request. You will need to create (or use) a "user provider" that
-    turns that username into a User object of your choice:
+    is referenced by the ``provider`` configuration parameter (``your_user_provider``
+    in the configuration example). This provider will turn the username into a User 
+    object of your choice. For more information on creating or configuring a user 
+    provider, see:
 
     * :doc:`/cookbook/security/custom_provider`
     * :doc:`/cookbook/security/entity_provider`


### PR DESCRIPTION
Following @weaverryan #3921 first improvement, I've added a few lines to the bottom note of the article, to be more precise about the `provider` configuration key.
