### PR TITLE
Move __construct after the repository assignment

### DIFF
--- a/cookbook/console/commands_as_services.rst
+++ b/cookbook/console/commands_as_services.rst
@@ -90,9 +90,9 @@ have some ``NameRepository`` service that you'll use to get your default value::
 
         public function __construct(NameRepository $nameRepository)
         {
-            parent::__construct();
-            
             $this->nameRepository = $nameRepository;
+            
+            parent::__construct();
         }
 
         protected function configure()


### PR DESCRIPTION
The configure function is called from the parent::__construct(); so the $this->nameRepository is still empty during the configure. Thats why it should be the other way around.
