### PR TITLE
Varnish only takes into account max-age

### DIFF
--- a/cookbook/cache/varnish.rst
+++ b/cookbook/cache/varnish.rst
@@ -57,7 +57,8 @@ Symfony2 adds automatically:
             // For Varnish < 3.0
             // esi;
         }
-        /* By default Varnish ignores Cache-Control: nocache (https://www.varnish-cache.org/docs/3.0/tutorial/increasing_your_hitrate.html#cache-control),
+        /* By default Varnish ignores Cache-Control: nocache 
+        (https://www.varnish-cache.org/docs/3.0/tutorial/increasing_your_hitrate.html#cache-control),
         so in order avoid caching it has to be done explicitly */
         if (beresp.http.Pragma ~ "no-cache" ||
              beresp.http.Cache-Control ~ "no-cache" ||

--- a/cookbook/cache/varnish.rst
+++ b/cookbook/cache/varnish.rst
@@ -57,7 +57,8 @@ Symfony2 adds automatically:
             // For Varnish < 3.0
             // esi;
         }
-        /* Do not cache if no-cache is found in headers */
+        /* By default Varnish ignores Cache-Control: nocache (https://www.varnish-cache.org/docs/3.0/tutorial/increasing_your_hitrate.html#cache-control),
+        so in order avoid caching it has to be done explicitly */
         if (beresp.http.Pragma ~ "no-cache" ||
              beresp.http.Cache-Control ~ "no-cache" ||
              beresp.http.Cache-Control ~ "private") {

--- a/cookbook/cache/varnish.rst
+++ b/cookbook/cache/varnish.rst
@@ -57,6 +57,12 @@ Symfony2 adds automatically:
             // For Varnish < 3.0
             // esi;
         }
+        /* Do not cache if no-cache is found in headers */
+        if (beresp.http.Pragma ~ "no-cache" ||
+             beresp.http.Cache-Control ~ "no-cache" ||
+             beresp.http.Cache-Control ~ "private") {
+            return (hit_for_pass);
+        }
     }
 
 .. caution::


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | [no] |
| New docs? | [no](PR # on symfony/symfony if applicable) |
| Applies to | [Symfony version 2.3] |
| Fixed tickets |  |

Varnish only takes into account max-age, Symfony by default returns Cache-Control: no-cache so Varnish caches it anyway. You need to specify:

```
if (beresp.http.Pragma ~ "no-cache" ||
             beresp.http.Cache-Control ~ "no-cache" ||
             beresp.http.Cache-Control ~ "private") {
    return (hit_for_pass);
}
```

In order to avoid Varnish from caching content.
