### PR TITLE
Updated docs for Monolog "swift" handler in cookbook.

### DIFF
--- a/cookbook/logging/monolog_email.rst
+++ b/cookbook/logging/monolog_email.rst
@@ -28,6 +28,8 @@ it is broken down.
                     type:       swift_mailer
                     from_email: error@example.com
                     to_email:   error@example.com
+                    # or list of recipients
+                    # to_email:   [developer_1@example.com, developer_2@example.com, ...]
                     subject:    An Error Occurred!
                     level:      debug
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets |  |

.. versionadded:: 2.1
    Support for multiple recipients is a new Monolog feature that's available in
    Symfony 2.1. Prior, only a single email address was accepted as `monolog.handlers.swift.to_email` configuration.
