### PR TITLE
Fixing simple quotes in double quotes

### DIFF
--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -263,7 +263,7 @@ from the command line, you need to overwrite the HelperSet used by the command::
         $commandTester = new CommandTester($command);
 
         $dialog = $command->getHelper('dialog');
-        $dialog->setInputStream($this->getInputStream('Test\n'));
+        $dialog->setInputStream($this->getInputStream("Test\n"));
         // Equals to a user inputing "Test" and hitting ENTER
         // If you need to enter a confirmation, "yes\n" will work
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets | #3942 |

Some simple quotes should be double quotes, for end of line to be used as such.
