### PR TITLE
Update dbal.rst

### DIFF
--- a/cookbook/doctrine/dbal.rst
+++ b/cookbook/doctrine/dbal.rst
@@ -141,11 +141,8 @@ mapping type:
         # app/config/config.yml
         doctrine:
             dbal:
-                connections:
-                    default:
-                        # other connections parameters
-                        mapping_types:
-                            enum: string
+               mapping_types:
+                  enum: string
 
     .. code-block:: xml
 
@@ -158,11 +155,7 @@ mapping type:
 
             <doctrine:config>
                 <doctrine:dbal>
-                <doctrine:dbal default-connection="default">
-                    <doctrine:connection>
-                        <!-- other connections parameters -->
-                        <doctrine:mapping-type name="enum">string</doctrine:mapping-type>
-                    </doctrine:connection>
+                     <doctrine:mapping-type name="enum">string</doctrine:mapping-type>
                 </doctrine:dbal>
             </doctrine:config>
         </container>
@@ -172,14 +165,9 @@ mapping type:
         // app/config/config.php
         $container->loadFromExtension('doctrine', array(
             'dbal' => array(
-                'connections' => array(
-                    'default' => array(
-                        // other connection parameers
-                        'mapping_types' => array(
-                            'enum'  => 'string',
-                        ),
-                    ),
-                ),
+               mapping_types' => array(
+                  'enum'  => 'string',
+               ),
             ),
         ));
 


### PR DESCRIPTION
The SchemaTool throws an error if mapping_types are configured under default.connection. If configured under dbal everything works fine.
