### PR TITLE
DQL custom functions on doctrine reference page

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -440,6 +440,7 @@ In Symfony, you can register your custom DQL functions as follows:
 However, if you are only using one entity manager, DQL functions can be registed like this:
 
 .. code-block:: yaml
+
     doctrine:
         orm:
             # ...

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -424,59 +424,23 @@ for each entity manager can be placed directly under doctrine.orm config level.
         orm:
             # ...
             query_cache_driver:
-                type:                 array # Required
-                host:                 ~
-                port:                 ~
-                instance_class:       ~
-                class:                ~
+               # ...
             metadata_cache_driver:
-                type:                 array # Required
-                host:                 ~
-                port:                 ~
-                instance_class:       ~
-                class:                ~
+                # ...
             result_cache_driver:
-                type:                 array # Required
-                host:                 ~
-                port:                 ~
-                instance_class:       ~
-                class:                ~
-            connection:           ~
+                # ...
+            connection: ~
             class_metadata_factory_name:  Doctrine\ORM\Mapping\ClassMetadataFactory
             default_repository_class:  Doctrine\ORM\EntityRepository
-            auto_mapping:         false
+            auto_mapping: false
             hydrators:
-                # An array of hydrator names
-                hydrator_name:                 []
+                # ...
             mappings:
-                # An array of mappings, which may be a bundle name or something else
-                mapping_name:
-                    mapping:              true
-                    type:                 ~
-                    dir:                  ~
-                    alias:                ~
-                    prefix:               ~
-                    is_bundle:            ~
+                # ...
             dql:
-                # a collection of string functions
-                string_functions:
-                    # example
-                    # test_string: Acme\HelloBundle\DQL\StringFunction
-
-                # a collection of numeric functions
-                numeric_functions:
-                    # example
-                    # test_numeric: Acme\HelloBundle\DQL\NumericFunction
-
-                # a collection of datetime functions
-                datetime_functions:
-                    # example
-                    # test_datetime: Acme\HelloBundle\DQL\DatetimeFunction
+                # ...
             filters:
-                # An array of filters
-                some_filter:
-                    class:                ~ # Required
-                    enabled:              false
+                # ...
 
 This shorten version is commonly used in other documentation sections. Keep in mind that you can't use both syntax at same time.
 

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -443,7 +443,7 @@ level.
             filters:
                 # ...
 
-This shorten version is commonly used in other documentation sections.
-Keep in mind that you can't use both syntax at the same time.
+This shortened version is commonly used in other documentation sections.
+Keep in mind that you can't use both syntaxes at the same time.
 
 .. _`DQL User Defined Functions`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/cookbook/dql-user-defined-functions.html

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -412,12 +412,11 @@ service where ``[name]`` is the name of the connection.
 
 .. _DBAL documentation: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html
 
-Shortened Configuration syntax
+Shortened Configuration Syntax
 ------------------------------
 
 When you are only using one entity manager, all config options available
-for each entity manager can be placed directly under ``doctrine.orm`` config
-level. 
+can be placed directly under ``doctrine.orm`` config level. 
 
 .. code-block:: yaml
 

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -413,7 +413,7 @@ service where ``[name]`` is the name of the connection.
 .. _DBAL documentation: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html
 
 Shortened Configuration syntax
------------------------------
+------------------------------
 
 When you are only using one entity manager, all config options available
 for each entity manager can be placed directly under ``doctrine.orm`` config

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -412,46 +412,72 @@ service where ``[name]`` is the name of the connection.
 
 .. _DBAL documentation: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html
 
-Register Custom DQL Functions
+Shorten configuration syntax
 -----------------------------
 
-Doctrine allows you to specify custom DQL functions. For more information
-on this topic, read Doctrine's cookbook article "`DQL User Defined Functions`_".
-
-In Symfony, you can register your custom DQL functions as follows:
+When you are only using one entity manager, all config options available 
+for each entity manager can be placed directly under doctrine.orm config level. 
 
 .. code-block:: yaml
 
     doctrine:
         orm:
             # ...
-            entity_managers:
-                default:
-                    # ...
-                    dql:
-                        string_functions:
-                            test_string: Acme\HelloBundle\DQL\StringFunction
-                            second_string: Acme\HelloBundle\DQL\SecondStringFunction
-                        numeric_functions:
-                            test_numeric: Acme\HelloBundle\DQL\NumericFunction
-                        datetime_functions:
-                            test_datetime: Acme\HelloBundle\DQL\DatetimeFunction
-
-However, if you are only using one entity manager, DQL functions can be registed like this:
-
-.. code-block:: yaml
-
-    doctrine:
-        orm:
-            # ...
+            query_cache_driver:
+                type:                 array # Required
+                host:                 ~
+                port:                 ~
+                instance_class:       ~
+                class:                ~
+            metadata_cache_driver:
+                type:                 array # Required
+                host:                 ~
+                port:                 ~
+                instance_class:       ~
+                class:                ~
+            result_cache_driver:
+                type:                 array # Required
+                host:                 ~
+                port:                 ~
+                instance_class:       ~
+                class:                ~
+            connection:           ~
+            class_metadata_factory_name:  Doctrine\ORM\Mapping\ClassMetadataFactory
+            default_repository_class:  Doctrine\ORM\EntityRepository
+            auto_mapping:         false
+            hydrators:
+                # An array of hydrator names
+                hydrator_name:                 []
+            mappings:
+                # An array of mappings, which may be a bundle name or something else
+                mapping_name:
+                    mapping:              true
+                    type:                 ~
+                    dir:                  ~
+                    alias:                ~
+                    prefix:               ~
+                    is_bundle:            ~
             dql:
+                # a collection of string functions
                 string_functions:
-                    test_string: Acme\HelloBundle\DQL\StringFunction
-                    second_string: Acme\HelloBundle\DQL\SecondStringFunction
-                numeric_functions:
-                    test_numeric: Acme\HelloBundle\DQL\NumericFunction
-                datetime_functions:
-                    test_datetime: Acme\HelloBundle\DQL\DatetimeFunction
+                    # example
+                    # test_string: Acme\HelloBundle\DQL\StringFunction
 
+                # a collection of numeric functions
+                numeric_functions:
+                    # example
+                    # test_numeric: Acme\HelloBundle\DQL\NumericFunction
+
+                # a collection of datetime functions
+                datetime_functions:
+                    # example
+                    # test_datetime: Acme\HelloBundle\DQL\DatetimeFunction
+            filters:
+                # An array of filters
+                some_filter:
+                    class:                ~ # Required
+                    enabled:              false
+
+This shorten version is commonly used in other documentation sections. Keep in mind that you can't use both syntax at same time.
 
 .. _`DQL User Defined Functions`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/cookbook/dql-user-defined-functions.html

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -421,6 +421,7 @@ on this topic, read Doctrine's cookbook article "`DQL User Defined Functions`_".
 In Symfony, you can register your custom DQL functions as follows:
 
 .. code-block:: yaml
+
     doctrine:
         orm:
             # ...

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -412,7 +412,7 @@ service where ``[name]`` is the name of the connection.
 
 .. _DBAL documentation: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html
 
-Shorten configuration syntax
+Shortened Configuration syntax
 -----------------------------
 
 When you are only using one entity manager, all config options available

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -411,3 +411,42 @@ Each connection is also accessible via the ``doctrine.dbal.[name]_connection``
 service where ``[name]`` is the name of the connection.
 
 .. _DBAL documentation: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html
+
+Register Custom DQL Functions
+-----------------------------
+
+Doctrine allows you to specify custom DQL functions. For more information
+on this topic, read Doctrine's cookbook article "`DQL User Defined Functions`_".
+
+In Symfony, you can register your custom DQL functions as follows:
+
+.. code-block:: yaml
+    doctrine:
+        orm:
+            # ...
+            entity_managers:
+                default:
+                    # ...
+                    dql:
+                        string_functions:
+                            test_string: Acme\HelloBundle\DQL\StringFunction
+                            second_string: Acme\HelloBundle\DQL\SecondStringFunction
+                        numeric_functions:
+                            test_numeric: Acme\HelloBundle\DQL\NumericFunction
+                        datetime_functions:
+                            test_datetime: Acme\HelloBundle\DQL\DatetimeFunction
+
+However, if you are only using one entity manager, DQL functions can be registed like this:
+
+.. code-block:: yaml
+    doctrine:
+        orm:
+            # ...
+            dql:
+                string_functions:
+                    test_string: Acme\HelloBundle\DQL\StringFunction
+                    second_string: Acme\HelloBundle\DQL\SecondStringFunction
+                numeric_functions:
+                    test_numeric: Acme\HelloBundle\DQL\NumericFunction
+                datetime_functions:
+                    test_datetime: Acme\HelloBundle\DQL\DatetimeFunction

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -452,3 +452,6 @@ However, if you are only using one entity manager, DQL functions can be registed
                     test_numeric: Acme\HelloBundle\DQL\NumericFunction
                 datetime_functions:
                     test_datetime: Acme\HelloBundle\DQL\DatetimeFunction
+
+
+.. _`DQL User Defined Functions`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/cookbook/dql-user-defined-functions.html

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -415,8 +415,9 @@ service where ``[name]`` is the name of the connection.
 Shorten configuration syntax
 -----------------------------
 
-When you are only using one entity manager, all config options available 
-for each entity manager can be placed directly under doctrine.orm config level. 
+When you are only using one entity manager, all config options available
+for each entity manager can be placed directly under ``doctrine.orm`` config
+level. 
 
 .. code-block:: yaml
 
@@ -442,6 +443,7 @@ for each entity manager can be placed directly under doctrine.orm config level.
             filters:
                 # ...
 
-This shorten version is commonly used in other documentation sections. Keep in mind that you can't use both syntax at same time.
+This shorten version is commonly used in other documentation sections.
+Keep in mind that you can't use both syntax at the same time.
 
 .. _`DQL User Defined Functions`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/cookbook/dql-user-defined-functions.html


### PR DESCRIPTION
Custom DQL functions can be configured in two ways, according to what I was told [ here ](https://github.com/symfony/symfony-docs/pull/3939)

It should be clearified in doctrine reference page because It may confuse some people that just read the cookbook  section about [custom DQL functions](http://symfony.com/doc/current/cookbook/doctrine/custom_dql_functions.html)
