### PR TITLE
Add note/tip to get phpUnit working

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -78,6 +78,15 @@ command:
 The output should display ``OK``. If not, you need to figure out what's going on
 and if the tests are broken because of your modifications.
 
+.. note::
+
+    phpUnit is not listed in ``composer.json`` of Symfony2 by default. You can add phpUnit
+    and install it (to ``vendor/bin/``) with the following command:
+
+    .. code-block:: bash
+
+        $ php composer.phar require phpunit/phpunit
+
 .. tip::
 
     If you want to test a single component type its path after the ``phpunit``


### PR DESCRIPTION
I just cloned Symfony2 and tried to get the tests running. phpUnit was not installed when using the current composer.json file of Symfony2. Therefore I added a Note how to add it.
Maybe a link to the phpUnit install documentation might help as well?
(http://phpunit.de/manual/current/en/installation.html)
