### PR TITLE
[Console] Fix Console QuestionHelper $app to $this

### DIFF
--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -14,9 +14,9 @@ Dialog Helper
 The :class:`Symfony\\Component\\Console\\Helper\\DialogHelper` provides
 functions to ask the user for more information. It is included in the default
 helper set, which you can get by calling
-:method:`Symfony\\Component\\Console\\Command\\Command::getHelperSet`::
+:method:`Symfony\\Component\\Console\\Command\\Command::getHelper`::
 
-    $dialog = $this->getHelperSet()->get('dialog');
+    $dialog = $this->getHelper('dialog');
 
 All the methods inside the Dialog Helper have an
 :class:`Symfony\\Component\\Console\\Output\\OutputInterface` as the first
@@ -69,7 +69,7 @@ Autocompletion
 You can also specify an array of potential answers for a given question. These
 will be autocompleted as the user types::
 
-    $dialog = $this->getHelperSet()->get('dialog');
+    $dialog = $this->getHelper('dialog');
     $bundleNames = array('AcmeDemoBundle', 'AcmeBlogBundle', 'AcmeStoreBundle');
     $name = $dialog->ask(
         $output,
@@ -84,7 +84,7 @@ Hiding the User's Response
 You can also ask a question and hide the response. This is particularly
 convenient for passwords::
 
-    $dialog = $this->getHelperSet()->get('dialog');
+    $dialog = $this->getHelper('dialog');
     $password = $dialog->askHiddenResponse(
         $output,
         'What is the database password?',
@@ -152,7 +152,7 @@ Validating a Hidden Response
 
 You can also ask and validate a hidden response::
 
-    $dialog = $this->getHelperSet()->get('dialog');
+    $dialog = $this->getHelper('dialog');
 
     $validator = function ($value) {
         if ('' === trim($value)) {
@@ -186,7 +186,7 @@ Instead, you can use the
 method, which makes sure that the user can only enter a valid string
 from a predefined list::
 
-    $dialog = $this->getHelperSet()->get('dialog');
+    $dialog = $this->getHelper('dialog');
     $colors = array('red', 'blue', 'yellow');
 
     $color = $dialog->select(

--- a/components/console/helpers/formatterhelper.rst
+++ b/components/console/helpers/formatterhelper.rst
@@ -10,9 +10,9 @@ You can do more advanced things with this helper than you can in
 
 The :class:`Symfony\\Component\\Console\\Helper\\FormatterHelper` is included
 in the default helper set, which you can get by calling
-:method:`Symfony\\Component\\Console\\Command\\Command::getHelperSet`::
+:method:`Symfony\\Component\\Console\\Command\\Command::getHelper`::
 
-    $formatter = $this->getHelperSet()->get('formatter');
+    $formatter = $this->getHelper('formatter');
 
 The methods return a string, which you'll usually render to the console by
 passing it to the

--- a/components/console/helpers/progresshelper.rst
+++ b/components/console/helpers/progresshelper.rst
@@ -25,7 +25,7 @@ information, which updates as your command runs:
 To display progress details, use the :class:`Symfony\\Component\\Console\\Helper\\ProgressHelper`,
 pass it a total number of units, and advance the progress as your command executes::
 
-    $progress = $this->getHelperSet()->get('progress');
+    $progress = $this->getHelper('progress');
 
     $progress->start($output, 50);
     $i = 0;

--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -10,9 +10,9 @@ Question Helper
 The :class:`Symfony\\Component\\Console\\Helper\\QuestionHelper` provides
 functions to ask the user for more information. It is included in the default
 helper set, which you can get by calling
-:method:`Symfony\\Component\\Console\\Command\\Command::getHelperSet`::
+:method:`Symfony\\Component\\Console\\Command\\Command::getHelper`::
 
-    $helper = $this->getHelperSet()->get('question');
+    $helper = $this->getHelper('question');
 
 The Question Helper has a single method
 :method:`Symfony\\Component\\Console\\Command\\Command::ask` that needs an
@@ -30,7 +30,7 @@ the following to your command::
     use Symfony\Component\Console\Question\ConfirmationQuestion;
     // ...
 
-    $helper = $this->getHelperSet()->get('question');
+    $helper = $this->getHelper('question');
     $question = new ConfirmationQuestion('Continue with this action?', false);
 
     if (!$helper->ask($input, $output, $question)) {
@@ -73,7 +73,7 @@ from a predefined list::
     use Symfony\Component\Console\Question\ChoiceQuestion;
     // ...
 
-    $helper = $app->getHelperSet()->get('question');
+    $helper = $this->getHelper('question');
     $question = new ChoiceQuestion(
         'Please select your favorite color (defaults to red)',
         array('red', 'blue', 'yellow'),
@@ -107,7 +107,7 @@ this use :method:`Symfony\\Component\\Console\\Question\\ChoiceQuestion::setMult
     use Symfony\Component\Console\Question\ChoiceQuestion;
     // ...
 
-    $helper = $app->getHelperSet()->get('question');
+    $helper = $this->getHelper('question');
     $question = new ChoiceQuestion(
         'Please select your favorite color (defaults to red)',
         array('red', 'blue', 'yellow'),
@@ -206,7 +206,7 @@ You can also use a validator with a hidden question::
     use Symfony\Component\Console\Question\Question;
     // ...
 
-    $helper = $this->getHelperSet()->get('question');
+    $helper = $this->getHelper('question');
 
     $question = new Question('Please enter your password');
     $question->setValidator(function ($value) {

--- a/components/console/helpers/tablehelper.rst
+++ b/components/console/helpers/tablehelper.rst
@@ -21,7 +21,7 @@ When building a console application it may be useful to display tabular data:
 To display a table, use the :class:`Symfony\\Component\\Console\\Helper\\TableHelper`,
 set headers, rows and render::
 
-    $table = $this->getHelperSet()->get('table');
+    $table = $this->getHelper('table');
     $table
         ->setHeaders(array('ISBN', 'Title', 'Author'))
         ->setRows(array(


### PR DESCRIPTION
On `QuestionHelper` page, commands examples for calling `getHelperSet` use the following (where $app is undefined):

``` php
$app->getHelperSet()->get('question');
```

I've changed it to correct:

``` php
$this->getHelperSet()->get('question');
```
