### PR TITLE
Fixing php coding

### DIFF
--- a/cookbook/templating/namespaced_paths.rst
+++ b/cookbook/templating/namespaced_paths.rst
@@ -124,7 +124,7 @@ specific template doesn't exist.
                 '%kernel.root_dir%/../vendor/acme/themes/theme1' => 'theme',
                 '%kernel.root_dir%/../vendor/acme/themes/theme2' => 'theme',
                 '%kernel.root_dir%/../vendor/acme/themes/common' => 'theme',
-            );
+            ),
         ));
 
 Now, you can use the same ``@theme`` namespace to refer to any template located

--- a/cookbook/templating/namespaced_paths.rst
+++ b/cookbook/templating/namespaced_paths.rst
@@ -91,6 +91,8 @@ the first template that exists, starting from the first configured path. This
 feature can be used as a fallback mechanism to load generic templates when the
 specific template doesn't exist.
 
+.. configuration-block::
+
     .. code-block:: yaml
 
         # app/config/config.yml


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | n/a |

There is a syntax error in those arrays, so I fixed it.
I also added the configuration-block macro as it seems to be missing on that page.
