### PR TITLE
[WCM] removed call to deprecated getRequest() method

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1523,9 +1523,9 @@ In many cases, you may want to allow a single controller to render multiple
 different formats based on the "request format". For that reason, a common
 pattern is to do the following::
 
-    public function indexAction()
+    public function indexAction(Request $request)
     {
-        $format = $this->getRequest()->getRequestFormat();
+        $format = $request->getRequestFormat();
 
         return $this->render('AcmeBlogBundle:Blog:index.'.$format.'.twig');
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5+ |
| Fixed tickets |  |
