### PR TITLE
removed invalid processors option

### DIFF
--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -21,8 +21,6 @@ Full default Configuration
                     level:               ERROR
                     bubble:              false
                     formatter:           my_formatter
-                    processors:
-                        - some_callable
                 main:
                     type:                fingers_crossed
                     action_level:        WARNING


### PR DESCRIPTION
As per https://github.com/symfony/MonologBundle/issues/77
