### PR TITLE
[Console] Fix Console component getHelperSet()->get() to getHelper()

### DIFF
--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -9,7 +9,7 @@ functions to ask the user for more information. It is included in the default
 helper set, which you can get by calling
 :method:`Symfony\\Component\\Console\\Command\\Command::getHelperSet`::
 
-    $dialog = $this->getHelperSet()->get('dialog');
+    $dialog = $this->getHelper('dialog');
 
 All the methods inside the Dialog Helper have an
 :class:`Symfony\\Component\\Console\\Output\\OutputInterface` as the first
@@ -65,7 +65,7 @@ Autocompletion
 You can also specify an array of potential answers for a given question. These
 will be autocompleted as the user types::
 
-    $dialog = $this->getHelperSet()->get('dialog');
+    $dialog = $this->getHelper('dialog');
     $bundleNames = array('AcmeDemoBundle', 'AcmeBlogBundle', 'AcmeStoreBundle');
     $name = $dialog->ask(
         $output,
@@ -83,7 +83,7 @@ Hiding the User's Response
 You can also ask a question and hide the response. This is particularly
 convenient for passwords::
 
-    $dialog = $this->getHelperSet()->get('dialog');
+    $dialog = $this->getHelper('dialog');
     $password = $dialog->askHiddenResponse(
         $output,
         'What is the database password?',
@@ -154,7 +154,7 @@ Validating a Hidden Response
 
 You can also ask and validate a hidden response::
 
-    $dialog = $this->getHelperSet()->get('dialog');
+    $dialog = $this->getHelper('dialog');
 
     $validator = function ($value) {
         if ('' === trim($value)) {
@@ -192,7 +192,7 @@ Instead, you can use the
 method, which makes sure that the user can only enter a valid string
 from a predefined list::
 
-    $dialog = $this->getHelperSet()->get('dialog');
+    $dialog = $this->getHelper('dialog');
     $colors = array('red', 'blue', 'yellow');
 
     $color = $dialog->select(

--- a/components/console/helpers/formatterhelper.rst
+++ b/components/console/helpers/formatterhelper.rst
@@ -12,7 +12,7 @@ The :class:`Symfony\\Component\\Console\\Helper\\FormatterHelper` is included
 in the default helper set, which you can get by calling
 :method:`Symfony\\Component\\Console\\Command\\Command::getHelperSet`::
 
-    $formatter = $this->getHelperSet()->get('formatter');
+    $formatter = $this->getHelper('formatter');
 
 The methods return a string, which you'll usually render to the console by
 passing it to the

--- a/components/console/helpers/progresshelper.rst
+++ b/components/console/helpers/progresshelper.rst
@@ -18,7 +18,7 @@ information, which updates as your command runs:
 To display progress details, use the :class:`Symfony\\Component\\Console\\Helper\\ProgressHelper`,
 pass it a total number of units, and advance the progress as your command executes::
 
-    $progress = $this->getHelperSet()->get('progress');
+    $progress = $this->getHelper('progress');
 
     $progress->start($output, 50);
     $i = 0;

--- a/components/console/helpers/tablehelper.rst
+++ b/components/console/helpers/tablehelper.rst
@@ -14,7 +14,7 @@ When building a console application it may be useful to display tabular data:
 To display a table, use the :class:`Symfony\\Component\\Console\\Helper\\TableHelper`,
 set headers, rows and render::
 
-    $table = $this->getHelperSet()->get('table');
+    $table = $this->getHelper('table');
     $table
         ->setHeaders(array('ISBN', 'Title', 'Author'))
         ->setRows(array(


### PR DESCRIPTION
| Q | A |
| --- | :-: |
| Doc fix? | Yes |
| New docs? | No |
| Applies to | 2.3 |
| Fixed tickets | No |

On Console component, I've fixed the following calls:

``` php
$this->getHelperSet()->get('dialog');
```

to:

``` php
$this->getHelper('dialog');
```

This is related to original PR https://github.com/symfony/symfony-docs/pull/3952
