### PR TITLE
[WCM] [Components][Process] add documentation for the ProcessBuilder::enableUseExec() method

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -218,17 +218,17 @@ Process Idle Timeout
 .. versionadded:: 2.4
    The :method:`Symfony\\Component\\Process\\Process::setIdleTimeout` method
    was introduced in Symfony 2.4.
-   
+
 In contrast to the timeout of the previous paragraph, the idle timeout only
 considers the time since the last output was produced by the process::
 
    use Symfony\Component\Process\Process;
-   
+
    $process = new Process('something-with-variable-runtime');
    $process->setTimeout(3600);
    $process->setIdleTimeout(60);
    $process->run();
-   
+
 In the case above, a process is considered timed out, when either the total runtime
 exceeds 3600 seconds, or the process does not produce any output for 60 seconds.
 
@@ -257,6 +257,19 @@ When running a program asynchronously, you can send it posix signals with the
 
     POSIX signals are not available on Windows platforms, please refer to the
     `PHP documentation`_ for available signals.
+
+    .. versionadded:: 2.6
+        The ``enableShellWrapper()`` method was introduced in Symfony 2.6.
+
+    When you use the ``ProcessBuilder`` to build a ``Process``, you can use
+    the :method:`Symfony\\Component\\Process\\ProcessBuilder::enableShellWrapper`
+    method to prefix the executed script with "exec"::
+
+        use Symfony\Component\Process\ProcessBuilder;
+
+        $process = new ProcessBuilder(array('find', '/', '-name', '"rabbit"'))
+            ->enableShellWrapper()
+            ->getProcess();
 
 Process Pid
 -----------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony#11335) |
| Applies to | 2.6+ |
| Fixed tickets |  |
