### PR TITLE
[Twig][Form] Moved twig.form.resources to a higher level

### DIFF
--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -439,18 +439,15 @@ form is rendered.
 
         # app/config/config.yml
         twig:
-            form:
-                resources:
-                    - 'AcmeDemoBundle:Form:fields.html.twig'
+            form_themes:
+                - 'AcmeDemoBundle:Form:fields.html.twig'
             # ...
 
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
         <twig:config>
-            <twig:form>
-                <resource>AcmeDemoBundle:Form:fields.html.twig</resource>
-            </twig:form>
+            <twig:form-theme>AcmeDemoBundle:Form:fields.html.twig</twig:form-theme>
             <!-- ... -->
         </twig:config>
 
@@ -458,10 +455,8 @@ form is rendered.
 
         // app/config/config.php
         $container->loadFromExtension('twig', array(
-            'form' => array(
-                'resources' => array(
-                    'AcmeDemoBundle:Form:fields.html.twig',
-                ),
+            'form_themes' => array(
+                'AcmeDemoBundle:Form:fields.html.twig',
             ),
 
             // ...
@@ -477,17 +472,14 @@ resource to use such a layout:
 
         # app/config/config.yml
         twig:
-            form:
-                resources: ['form_table_layout.html.twig']
+            form_themes: ['form_table_layout.html.twig']
             # ...
 
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
         <twig:config>
-            <twig:form>
-                <resource>form_table_layout.html.twig</resource>
-            </twig:form>
+            <twig:form-theme>form_table_layout.html.twig</twig:form-theme>
             <!-- ... -->
         </twig:config>
 
@@ -495,10 +487,8 @@ resource to use such a layout:
 
         // app/config/config.php
         $container->loadFromExtension('twig', array(
-            'form' => array(
-                'resources' => array(
-                    'form_table_layout.html.twig',
-                ),
+            'form_themes' => array(
+                'form_table_layout.html.twig',
             ),
 
             // ...

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -10,14 +10,13 @@ TwigBundle Configuration ("twig")
 
         twig:
             exception_controller:  twig.controller.exception:showAction
-            form:
-                resources:
+            form_themes:
 
-                    # Default:
-                    - form_div_layout.html.twig
+                # Default:
+                - form_div_layout.html.twig
 
-                    # Example:
-                    - MyBundle::form.html.twig
+                # Example:
+                - MyBundle::form.html.twig
             globals:
 
                 # Examples:
@@ -54,9 +53,8 @@ TwigBundle Configuration ("twig")
                                 http://symfony.com/schema/dic/twig http://symfony.com/schema/dic/doctrine/twig-1.0.xsd">
 
             <twig:config auto-reload="%kernel.debug%" autoescape="true" base-template-class="Twig_Template" cache="%kernel.cache_dir%/twig" charset="%kernel.charset%" debug="%kernel.debug%" strict-variables="false">
-                <twig:form>
-                    <twig:resource>MyBundle::form.html.twig</twig:resource>
-                </twig:form>
+                <twig:form-theme>form_div_layout.html.twig</twig:form-theme> <!-- Default -->
+                <twig:form-theme>MyBundle::form.html.twig</twig:form-theme>
                 <twig:global key="foo" id="bar" type="service" />
                 <twig:global key="pi">3.14</twig:global>
             </twig:config>
@@ -65,10 +63,9 @@ TwigBundle Configuration ("twig")
     .. code-block:: php
 
         $container->loadFromExtension('twig', array(
-            'form' => array(
-                'resources' => array(
-                    'MyBundle::form.html.twig',
-                )
+            'form_themes' => array(
+                'form_div_layout.html.twig', // Default
+                'MyBundle::form.html.twig',
              ),
              'globals' => array(
                  'foo' => '@bar',
@@ -82,6 +79,12 @@ TwigBundle Configuration ("twig")
              'debug'               => '%kernel.debug%',
              'strict_variables'    => false,
         ));
+
+.. caution::
+
+    The ``twig.form`` (``<twig:form />`` tag for xml) configuration key
+    has been deprecated and will be removed in 3.0. Instead, use the ``twig.form_themes``
+    option.
 
 Configuration
 -------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no, https://github.com/symfony/symfony/pull/11343 |
| Applies to | >= 2.6 |
| Fixed tickets | - |
