### PR TITLE
Removed wrong reference to cookbook

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -508,9 +508,6 @@ points.
 For a full example of this listener, read the :doc:`/cookbook/service_container/event_listener`
 cookbook entry.
 
-For another practical example of a kernel listener, see the cookbook
-article: :doc:`/cookbook/request/mime_type`.
-
 Core Event Listener Reference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5 |
| Fixed tickets |  |

The /cookbook/request/mime_type article does not contain an example to register a kernel listener since 2.5
