### PR TITLE
Updated "query_builder" field option

### DIFF
--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -154,6 +154,9 @@ either be a ``QueryBuilder`` object or a Closure. If using a Closure,
 it should take a single argument, which is the ``EntityRepository`` of
 the entity.
 
+Please note that regardless of the entity type returned by the ``QueryBuilder`` the 
+first entity referenced by it must be that specified through the ``class`` option.
+
 em
 ~~
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

Validation fails because it attempts to match the given data with the identity field of the first entity referenced in the QueryBuilder and not the identity field of the referenced entity that matches the one specified through the 'class' field option. 

Another problem may occur if the name of the identity field of the entity specified through the 'class' field option does not match the name of the identity field of the first entity referenced in the QueryBuilder.

Currently there is no warning to indicate this behavior that affects all form types extending the entity type and also, from what I've seen by examining the code for the validation, there is no simple fix to add such warning or fix this problem.
