### PR TITLE
[WIP] Add REST API cookbook entry

### DIFF
--- a/cookbook/web_services/index.rst
+++ b/cookbook/web_services/index.rst
@@ -4,4 +4,5 @@ Web Services
 .. toctree::
     :maxdepth: 2
 
+    rest_api
     php_soap_extension

--- a/cookbook/web_services/rest_api.rst
+++ b/cookbook/web_services/rest_api.rst
@@ -1,0 +1,29 @@
+.. index::
+    single: Web Services; REST API
+
+How to Create a REST Web Service in a Symfony2 Controller
+=========================================================
+
+A REST controller must be able to list, retrieve, create and update a resource.
+This resource can be anything from a Doctrine entity to a domain object or a network device.
+
+.. note::
+
+    There is plenty of way to implement to REST API with Symfony2, we will show you how to implement
+    a simple API with core components but you can also look at `FOSRestBundle`_ if you are looking
+    at building a large API with hypermedia, versionning, automatic routing and more.
+
+Setting up the routing
+----------------------
+
+Dealing with response code
+--------------------------
+
+Exposing resources in different formats
+---------------------------------------
+
+Updating Doctrine entities
+--------------------------
+
+
+.. _`FOSRestBundle`:     https://github.com/FriendsOfSymfony/FOSRestBundle


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | all (or 2.3+) |
| Fixed tickets |  |

Following [this thread](https://groups.google.com/forum/#!topic/resting-with-symfony/-09AA7E_PYs) on the resting-with-symfony ML, 
we think adding a cookbook entry about REST API could be a good thing. FOSRestBundle is not the only response here and I think it's important to get some basics skills before using such a bundle.

At the moment I only have a quick plan,
but we need to choose what we should expose in this documentation for the update / create actions.
- using the form component to update the resource via "application/x-www-form-urlencoded"?
- using the serializer to parse a payload?
- using something like the [RestBundle BodyListener](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/EventListener/BodyListener.php) and the [JsonToFormDecoder](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/Decoder/JsonToFormDecoder.php)?

Also we need to draw the line somewhere about RESTful. I do not think we should tell in this cookbook how to implement everything (hypermedia and such).

Please ping me if you have time to help, I will give you write access to the branch directly.
