### PR TITLE
[Cookbook][Security] usage of a non-default entity manager in an entity user provider

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -358,6 +358,69 @@ entity user provider to load User entity objects from the database by using
 the ``username`` unique field. In other words, this tells Symfony how to
 fetch the user from the database before checking the password validity.
 
+.. note::
+
+    By default, the entity provider uses the default entity manager to fetch
+    user information from the database. If you,
+    :doc:`use multiple entity managers </cookbook/doctrine/multiple_entity_managers>`,
+    you can specify which manager to use with the ``manager_name`` option:
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # app/config/config.yml
+            security:
+                # ...
+
+                providers:
+                    administrators:
+                        entity:
+                            class: AcmeUserBundle:User
+                            property: username
+                            manager_name: customer
+
+                # ...
+
+        .. code-block:: xml
+
+            <!-- app/config/config.xml -->
+            <?xml version="1.0" encoding="UTF-8"?>
+            <srv:container xmlns="http://symfony.com/schema/dic/security"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:srv="http://symfony.com/schema/dic/services"
+                xsi:schemaLocation="http://symfony.com/schema/dic/services
+                    http://symfony.com/schema/dic/services/services-1.0.xsd">
+                <config>
+                    <!-- ... -->
+
+                    <provider name="administrators">
+                        <entity class="AcmeUserBundle:User"
+                            property="username"
+                            manager-name="customer" />
+                    </provider>
+
+                    <!-- ... -->
+                </config>
+            </srv:container>
+
+        .. code-block:: php
+
+            // app/config/config.php
+            $container->loadFromExtension('security', array(
+                // ...
+                'providers' => array(
+                    'administrator' => array(
+                        'entity' => array(
+                            'class' => 'AcmeUserBundle:User',
+                            'property' => 'username',
+                            'manager_name' => 'customer',
+                        ),
+                    ),
+                ),
+                // ...
+            ));
+
 Forbid inactive Users
 ---------------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #4021 |

The cookbook on entity user providers for the Security component only
describes how to create an entity provider using the default entity
manager. This may not be sufficient enough if you have multiple entity
managers and therefore be eplicit with the entity manager to use in
the user provider.
