### PR TITLE
Update introduction.rst

### DIFF
--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -460,7 +460,7 @@ method::
             $command = $application->find('demo:greet');
             $commandTester = new CommandTester($command);
             $commandTester->execute(
-                array('command' => $command->getName(), 'name' => 'Fabien')
+                array('command' => $command->getName(), 'name' => 'Fabien', '--iterations' => 5)
             );
 
             $this->assertRegExp('/Fabien/', $commandTester->getDisplay());


### PR DESCRIPTION
In my opinion a note or example needs to be added to the command test example to show that the option name needs to be prefixed with a double hyphen.

Admittedly there is a similar example of passing an option to a command at https://github.com/symfony/symfony-docs/blob/2.4/components/console/introduction.rst#calling-an-existing-command but this could easily be missed.
