### PR TITLE
fix parent form types

### DIFF
--- a/reference/forms/types/email.rst
+++ b/reference/forms/types/email.rst
@@ -23,7 +23,7 @@ The ``email`` field is a text field that is rendered using the HTML5
 |             | - `error_mapping`_                                                  |
 |             | - `mapped`_                                                         |
 +-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`form </reference/forms/types/form>`                           |
+| Parent type | :doc:`text </reference/forms/types/text>`                           |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\EmailType` |
 +-------------+---------------------------------------------------------------------+

--- a/reference/forms/types/textarea.rst
+++ b/reference/forms/types/textarea.rst
@@ -22,7 +22,7 @@ Renders a ``textarea`` HTML element.
 |             | - `error_mapping`_                                                     |
 |             | - `mapped`_                                                            |
 +-------------+------------------------------------------------------------------------+
-| Parent type | :doc:`form </reference/forms/types/form>`                              |
+| Parent type | :doc:`text </reference/forms/types/text>`                              |
 +-------------+------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TextareaType` |
 +-------------+------------------------------------------------------------------------+


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | part of #2360 |

The parent type of both the email type and the textarea type is not the form type but instead the text type.
