### PR TITLE
[Contributing][Code] add note on Symfony SE forks for bug reports

### DIFF
--- a/contributing/code/bugs.rst
+++ b/contributing/code/bugs.rst
@@ -25,6 +25,10 @@ If your problem definitely looks like a bug, report it using the official bug
 * Describe the steps needed to reproduce the bug with short code examples
   (providing a unit test that illustrates the bug is best);
 
+* If the bug you experienced affects more than one layer, providing a simple
+  failing unit test may not be sufficient. In this case, please fork the
+  `Symfony Standard Edition`_ and reproduce your issue on a new branch;
+
 * Give as much detail as possible about your environment (OS, PHP version,
   Symfony version, enabled extensions, ...);
 
@@ -35,3 +39,4 @@ If your problem definitely looks like a bug, report it using the official bug
 .. _forum: http://forum.symfony-project.org/
 .. _IRC channel: irc://irc.freenode.net/symfony
 .. _tracker: https://github.com/symfony/symfony/issues
+.. _Symfony Standard Edition: https://github.com/symfony/symfony-standard/


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

As @javiereguiluz stated in symfony/symfony#11494, the way to report bugs can be improved. One of the things that could be done, is to add a note to make a bug reproducable by forking the Symfony Standard Edition with the modifications needed to reproduce a particular issue.
