### PR TITLE
Fixed typo in the yml validation

### DIFF
--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -194,7 +194,7 @@ property.
     .. code-block:: yaml
 
         # src/Acme/HelloBundle/Resources/config/validation.yml
-        Acme\HelloBundle\Author:
+        Acme\HelloBundle\Entity\Author:
             properties:
                 address:
                     - Valid: ~


### PR DESCRIPTION
The `Valid` property should be added to `Acme\HelloBundle\Entity\Author` instead of `Acme\HelloBundle\Author`.
