### PR TITLE
Removed outdated translations from the official list

### DIFF
--- a/contributing/documentation/translations.rst
+++ b/contributing/documentation/translations.rst
@@ -20,9 +20,7 @@ for. Here is the list of the official *master* repositories:
 * *French*:   https://github.com/symfony-fr/symfony-docs-fr
 * *Italian*:  https://github.com/garak/symfony-docs-it
 * *Japanese*: https://github.com/symfony-japan/symfony-docs-ja
-* *Polish*:   https://github.com/symfony-docs-pl/symfony-docs-pl
 * *Portuguese (Brazilian)*:  https://github.com/andreia/symfony-docs-pt-BR
-* *Spanish*:  https://github.com/gitnacho/symfony-docs-es
 
 .. note::
 


### PR DESCRIPTION
Looking at the activity of these 2 translations, I think it's safe to say that they aren't up to date with the documentation.

@chrisbujok and @gitnacho please tell me if this isn't true. I have a hard time understanding your issues and commit messages to really tell if this is true.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

/cc @fabpot
