### PR TITLE
Fixed typo in filesystem component

### DIFF
--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -207,7 +207,7 @@ the relative path of a directory given another one::
         '/var/lib/symfony/src/Symfony/',
         '/var/lib/symfony/src/Symfony/Component'
     );
-    // returns 'videos'
+    // returns 'videos/'
     $fs->makePathRelative('/tmp/videos', '/tmp')
 
 mirror


### PR DESCRIPTION
The `makePathRelative` method returns a path with a slash at end.
See this [test case](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php#L793).
