### PR TITLE
Put version into quotes, otherwise it fails in ZSH

### DIFF
--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -18,7 +18,7 @@ directory:
 
 .. code-block:: bash
 
-    $ composer create-project symfony/framework-standard-edition myproject/ ~2.5
+    $ composer create-project symfony/framework-standard-edition myproject/ '~2.5'
 
 .. note::
 


### PR DESCRIPTION
When using the `zsh` shell, the command fails because of:

```
$ composer create-project symfony/framework-standard-edition myproject/ ~2.5
zsh: no such user or named directory: 2.5
```

This problem does not occur in `bash`.
Quoting the version number does not effect `bash`, and fixes `zsh`.
