### PR TITLE
Use ${APACHE_LOG_DIR} instead of /var/log/apache2

### DIFF
--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -32,8 +32,8 @@ are:
             Allow from All
         </Directory>
 
-        ErrorLog /var/log/apache2/project_error.log
-        CustomLog /var/log/apache2/project_access.log combined
+        ErrorLog ${APACHE_LOG_DIR}/project_error.log
+        CustomLog ${APACHE_LOG_DIR}/project_access.log combined
     </VirtualHost>
 
 .. note::

--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -32,10 +32,13 @@ are:
             Allow from All
         </Directory>
 
-        ErrorLog ${APACHE_LOG_DIR}/project_error.log
-        CustomLog ${APACHE_LOG_DIR}/project_access.log combined
+        ErrorLog /var/log/apache2/project_error.log
+        CustomLog /var/log/apache2/project_access.log combined
     </VirtualHost>
-
+.. note::
+    You probably want to use ``${APACHE_LOG_DIR}/`` instead of ``/var/log/apache2/`` 
+    for the logging-paths, if your system supports the ``APACHE_LOG_DIR`` variable.
+    
 .. note::
 
     For performance reasons, you will probably want to set


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | none |

It would be a better solution to use envs in the configfile.
