### PR TITLE
Fixed the code snippets for the expression language functions

### DIFF
--- a/components/expression_language/extending.rst
+++ b/components/expression_language/extending.rst
@@ -35,7 +35,7 @@ This method has 3 arguments:
 
     $language = new ExpressionLanguage();
     $language->register('lowercase', function ($str) {
-        is_string(%1$s) ? strtolower(%1$s) : %1$s;
+        return sprintf('(is_string(%1$s) ? strtolower(%1$s) : %1$s)', $str);
     }, function ($arguments, $str) {
         if (!is_string($str)) {
             return $str;
@@ -69,11 +69,7 @@ Override ``registerFunctions`` to add your own functions::
             parent::registerFunctions(); // do not forget to also register core functions
 
             $this->register('lowercase', function ($str) {
-                if (!is_string($str)) {
-                    return $str;
-                }
-
-                return sprintf('strtolower(%s)', $str);
+                return sprintf('(is_string(%1$s) ? strtolower(%1$s) : %1$s)', $str);
             }, function ($arguments, $str) {
                 if (!is_string($str)) {
                     return $str;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4+ |
| Fixed tickets | n/a |

The compilation callable was broken for the example of the lowercase function (in 2 different ways in the different snippet as the first one was attempted to be fixed in #3771 but my comment asking to remove the return statement inside the compiled expression was misunderstood and the other return statement returning the compiled expression was removed as well.).
