### PR TITLE
Added a note about the automatic handling of the memory spool in the CLI

### DIFF
--- a/cookbook/console/sending_emails.rst
+++ b/cookbook/console/sending_emails.rst
@@ -88,6 +88,10 @@ from the ``router`` service and override its settings::
 Using Memory Spooling
 ---------------------
 
+.. versionadded: 2.3
+    When using Symfony 2.3+ and SwiftmailerBundle 2.3.5+, the memory spool is now
+    handled automatically in the CLI and the code below is not necessary anymore.
+
 Sending emails in a console command works the same way as described in the
 :doc:`/cookbook/email/email` cookbook except if memory spooling is used.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | n/a |

since https://github.com/symfony/SwiftmailerBundle/pull/64 flushing the memory spool manually is not necessary anymore when using Symfony 2.3+. I added a versionadded note here, but we might decide to remove the obsolete paragraph instead, making the cookbook only about generating urls (which would require renaming the page then)
