### PR TITLE
Fix use mistakes

### DIFF
--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -140,6 +140,9 @@ output. For example::
 It is possible to define your own styles using the class
 :class:`Symfony\\Component\\Console\\Formatter\\OutputFormatterStyle`::
 
+    use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+
+    // ...
     $style = new OutputFormatterStyle('red', 'yellow', array('bold', 'blink'));
     $output->getFormatter()->setStyle('fire', $style);
     $output->writeln('<fire>foo</fire>');

--- a/components/templating/helpers/assetshelper.rst
+++ b/components/templating/helpers/assetshelper.rst
@@ -71,6 +71,8 @@ To avoid using the cached resource after updating the old resource, you can
 use versions which you bump every time you release a new project. The version
 can be specified in the third argument::
 
+    use Symfony\Component\Templating\Asset\PathPackage;
+
     // ...
     $templateEngine->set(new AssetsHelper(null, null, '328rad75'));
 

--- a/components/templating/helpers/assetshelper.rst
+++ b/components/templating/helpers/assetshelper.rst
@@ -71,8 +71,6 @@ To avoid using the cached resource after updating the old resource, you can
 use versions which you bump every time you release a new project. The version
 can be specified in the third argument::
 
-    use Symfony\Component\Templating\Asset\PathPackage;
-
     // ...
     $templateEngine->set(new AssetsHelper(null, null, '328rad75'));
 
@@ -106,6 +104,8 @@ Asset path generation is handled internally by packages. The component provides
 
 You can also use multiple packages::
 
+    use Symfony\Component\Templating\Asset\PathPackage;
+    
     // ...
     $templateEngine->set(new AssetsHelper());
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |

On http://symfony.com/doc/current/components/config/resources.html at "new YamlUserLoader", we have also a missing "use" statement. But i'm not sure if we need there one.
