### PR TITLE
[#3940] Adding php example for an array of emails

### DIFF
--- a/cookbook/logging/monolog_email.rst
+++ b/cookbook/logging/monolog_email.rst
@@ -29,7 +29,7 @@ it is broken down.
                     from_email: error@example.com
                     to_email:   error@example.com
                     # or list of recipients
-                    # to_email:   [developer_1@example.com, developer_2@example.com, ...]
+                    # to_email:   [dev1@example.com, dev2@example.com, ...]
                     subject:    An Error Occurred!
                     level:      debug
 
@@ -82,6 +82,8 @@ it is broken down.
                     'type'       => 'swift_mailer',
                     'from_email' => 'error@example.com',
                     'to_email'   => 'error@example.com',
+                    // or a list of recipients
+                    // 'to_email'   => array('dev1@example.com', 'dev2@example.com', ...),
                     'subject'    => 'An Error Occurred!',
                     'level'      => 'debug',
                 ),


### PR DESCRIPTION
This follows #3940. It just adds the example also to PHP. But I can't see how this would work with XML.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets |  |

Thanks!
