### PR TITLE
cleaned up the code example

### DIFF
--- a/cookbook/security/voters_data_permission.rst
+++ b/cookbook/security/voters_data_permission.rst
@@ -108,13 +108,13 @@ edit a particular object. Here's an example implementation:
             // set the attribute to check against
             $attribute = $attributes[0];
 
-            // get current logged in user
-            $user = $token->getUser();
-
             // check if the given attribute is covered by this voter
             if (!$this->supportsAttribute($attribute)) {
                 return VoterInterface::ACCESS_ABSTAIN;
             }
+
+            // get current logged in user
+            $user = $token->getUser();
 
             // make sure there is a user object (i.e. that the user is logged in)
             if (!$user instanceof UserInterface) {
@@ -122,7 +122,7 @@ edit a particular object. Here's an example implementation:
             }
 
             switch($attribute) {
-                case 'view':
+                case self::VIEW:
                     // the data object could have for example a method isPrivate()
                     // which checks the Boolean attribute $private
                     if (!$post->isPrivate()) {
@@ -130,7 +130,7 @@ edit a particular object. Here's an example implementation:
                     }
                     break;
 
-                case 'edit':
+                case self::EDIT:
                     // we assume that our data object has a method getOwner() to
                     // get the current owner user entity for this data object
                     if ($user->getId() === $post->getOwner()->getId()) {
@@ -138,6 +138,8 @@ edit a particular object. Here's an example implementation:
                     }
                     break;
             }
+            
+            return VoterInterface::ACCESS_DENIED;
         }
     }
 


### PR DESCRIPTION
- added final return for `vote()` function
- moved `$user` below attribute check. if attribute fails, we don't need user
- used already declared constants in switch statement, rather than harcoded strings
