### PR TITLE
Fix documentation for group_sequence_provider

### DIFF
--- a/book/validation.rst
+++ b/book/validation.rst
@@ -1115,7 +1115,7 @@ provides a sequence of groups to be validated:
 
         # src/Acme/DemoBundle/Resources/config/validation.yml
         Acme\DemoBundle\Entity\User:
-            group_sequence_provider: ~
+            group_sequence_provider: true
 
     .. code-block:: php-annotations
 


### PR DESCRIPTION
The current documentation for `group_sequence_provider` option in the docs is wrong.
It states that the option should be set with:

``` YAML
Your\Class\Name:
    group_sequence_provider: ~
    ...
```

But this didn't work.

By looking at the unit test I came up the the right version:

``` YAML
Your\Class\Name:
    group_sequence_provider: true
    ...
```
