### PR TITLE
[Cookbook][Logging] add missing Monolog handler type in XML config

### DIFF
--- a/cookbook/logging/monolog_email.rst
+++ b/cookbook/logging/monolog_email.rst
@@ -56,6 +56,7 @@ it is broken down.
                 />
                 <monolog:handler
                     name="swift"
+                    type="swift_mailer"
                     from-email="error@example.com"
                     to-email="error@example.com"
                     subject="An Error Occurred!"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

Omitting the type of a handler leads to an error:

> Symfony\Component\Config\Definition\Exception\InvalidConfigurationException: The child node "type" at path "monolog.handlers.swift" must be configured.
