### PR TITLE
Added the schema_filter option to the reference

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -21,6 +21,9 @@ Full default configuration
                     some_custom_type:
                         class:                Acme\HelloBundle\MyCustomType
                         commented:            true
+                # If enabled all tables not prefixed with sf2_ will be ignored by the schema
+                # tool. This is for custom tables which should not be altered automatically.
+                #schema_filter:        ^sf2_ 
 
                 connections:
                     default:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | ? |
| Fixed tickets | - |

Shall the optional setting be added to XML as well? How?
I am unsure if it is actually to which version this relates to the DoctrineBundle.

Relates to doctrine/migrations#101
