### PR TITLE
Adding 'attr' option to the Textarea options list

### DIFF
--- a/reference/forms/types/textarea.rst
+++ b/reference/forms/types/textarea.rst
@@ -9,8 +9,9 @@ Renders a ``textarea`` HTML element.
 +-------------+------------------------------------------------------------------------+
 | Rendered as | ``textarea`` tag                                                       |
 +-------------+------------------------------------------------------------------------+
-| Inherited   | - `data`_                                                              |
-| options     | - `disabled`_                                                          |
+| Inherited   | - `attr`_                                                              |
+| options     | - `data`_                                                              |
+|             | - `disabled`_                                                          |
 |             | - `empty_data`_                                                        |
 |             | - `error_bubbling`_                                                    |
 |             | - `error_mapping`_                                                     |
@@ -31,6 +32,8 @@ Inherited Options
 -----------------
 
 These options inherit from the :doc:`form </reference/forms/types/form>` type:
+
+.. include:: /reference/forms/types/options/attr.rst.inc
 
 .. include:: /reference/forms/types/options/data.rst.inc
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | nope |
| Applies to | all? |
| Fixed tickets | ? |

`attr` is a quite useful option, but not yet listed here, so I added it.
BTW, the `attr.rst.inc` file already includes an `attr` conf. example concerning textareas.
