### PR TITLE
[Reference] consistent & complete config examples

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -356,32 +356,37 @@ The following block shows all possible configuration keys:
 
     .. code-block:: xml
 
-        <!-- xmlns:doctrine="http://symfony.com/schema/dic/doctrine" -->
-        <!-- xsi:schemaLocation="http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd"> -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
-        <doctrine:config>
-            <doctrine:dbal
-                name="default"
-                dbname="database"
-                host="localhost"
-                port="1234"
-                user="user"
-                password="secret"
-                driver="pdo_mysql"
-                driver-class="MyNamespace\MyDriverImpl"
-                path="%kernel.data_dir%/data.sqlite"
-                memory="true"
-                unix-socket="/tmp/mysql.sock"
-                wrapper-class="MyDoctrineDbalConnectionWrapper"
-                charset="UTF8"
-                logging="%kernel.debug%"
-                platform-service="MyOwnDatabasePlatformService"
-            >
-                <doctrine:option key="foo">bar</doctrine:option>
-                <doctrine:mapping-type name="enum">string</doctrine:mapping-type>
-                <doctrine:type name="custom">Acme\HelloBundle\MyCustomType</doctrine:type>
-            </doctrine:dbal>
-        </doctrine:config>
+            <doctrine:config>
+                <doctrine:dbal
+                    name="default"
+                    dbname="database"
+                    host="localhost"
+                    port="1234"
+                    user="user"
+                    password="secret"
+                    driver="pdo_mysql"
+                    driver-class="MyNamespace\MyDriverImpl"
+                    path="%kernel.data_dir%/data.sqlite"
+                    memory="true"
+                    unix-socket="/tmp/mysql.sock"
+                    wrapper-class="MyDoctrineDbalConnectionWrapper"
+                    charset="UTF8"
+                    logging="%kernel.debug%"
+                    platform-service="MyOwnDatabasePlatformService">
+
+                    <doctrine:option key="foo">bar</doctrine:option>
+                    <doctrine:mapping-type name="enum">string</doctrine:mapping-type>
+                    <doctrine:type name="custom">Acme\HelloBundle\MyCustomType</doctrine:type>
+                </doctrine:dbal>
+            </doctrine:config>
+        </container>
 
 If you want to configure multiple connections in YAML, put them under the
 ``connections`` key and give them a unique name:

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -101,21 +101,26 @@ have installed `PhpStormOpener`_ and use PHPstorm, you will do something like:
 
     .. code-block:: yaml
 
+        # app/config/config.yml
         framework:
             ide: "pstorm://%%f:%%l"
 
     .. code-block:: xml
 
-        <?xml version="1.0" charset="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/service"
-            xmlns:framework="http://symfony.com/schema/dic/symfony">
+        <!-- app/config/config.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
             <framework:config ide="pstorm://%%f:%%l" />
-
         </container>
 
     .. code-block:: php
 
+        // app/config/config.php
         $container->loadFromExtension('framework', array(
             'ide' => 'pstorm://%%f:%%l',
         ));
@@ -155,17 +160,26 @@ see :doc:`/cookbook/request/load_balancer_reverse_proxy`.
 
     .. code-block:: yaml
 
+        # app/config/config.yml
         framework:
             trusted_proxies:  [192.0.0.1, 10.0.0.0/8]
 
     .. code-block:: xml
 
-        <framework:config trusted-proxies="192.0.0.1, 10.0.0.0/8">
-            <!-- ... -->
-        </framework>
+        <!-- app/config/config.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+            <framework:config trusted-proxies="192.0.0.1, 10.0.0.0/8" />
+        </container>
 
     .. code-block:: php
 
+        // app/config/config.php
         $container->loadFromExtension('framework', array(
             'trusted_proxies' => array('192.0.0.1', '10.0.0.0/8'),
         ));
@@ -282,9 +296,17 @@ the value to ``null``:
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <framework:config>
-            <framework:session save-path="null" />
-        </framework:config>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+            <framework:config>
+                <framework:session save-path="null" />
+            </framework:config>
+        </container>
 
     .. code-block:: php
 
@@ -370,15 +392,24 @@ Now, activate the ``assets_version`` option:
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <framework:templating assets-version="v2">
-            <framework:engine id="twig" />
-        </framework:templating>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+            <framework:templating assets-version="v2">
+                <!-- ... -->
+                <framework:engine>twig</framework:engine>
+            </framework:templating>
+        </container>
 
     .. code-block:: php
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
-            ...,
+            // ...
             'templating'      => array(
                 'engines'        => array('twig'),
                 'assets_version' => 'v2',

--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -200,29 +200,35 @@ Full default Configuration
 
     .. code-block:: xml
 
-        <swiftmailer:config
-            transport="smtp"
-            username=""
-            password=""
-            host="localhost"
-            port="false"
-            encryption=""
-            auth_mode=""
-            sender_address=""
-            delivery_address=""
-            disable_delivery=""
-            logging="%kernel.debug%"
-        >
-            <swiftmailer:spool
-                path="%kernel.cache_dir%/swiftmailer/spool"
-                type="file"
-            />
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/swiftmailer http://symfony.com/schema/dic/swiftmailer/swiftmailer-1.0.xsd">
 
-            <swiftmailer:antiflood
-                sleep="0"
-                threshold="99"
-            />
-        </swiftmailer:config>
+            <swiftmailer:config
+                transport="smtp"
+                username=""
+                password=""
+                host="localhost"
+                port="false"
+                encryption=""
+                auth_mode=""
+                sender_address=""
+                delivery_address=""
+                disable_delivery=""
+                logging="%kernel.debug%"
+                >
+                <swiftmailer:spool
+                    path="%kernel.cache_dir%/swiftmailer/spool"
+                    type="file" />
+
+                <swiftmailer:antiflood
+                    sleep="0"
+                    threshold="99" />
+            </swiftmailer:config>
+        </container>
 
 Using multiple Mailers
 ----------------------

--- a/reference/constraints/All.rst
+++ b/reference/constraints/All.rst
@@ -24,7 +24,7 @@ entry in that array:
 
     .. code-block:: yaml
 
-        # src/UserBundle/Resources/config/validation.yml
+        # src/Acme/UserBundle/Resources/config/validation.yml
         Acme\UserBundle\Entity\User:
             properties:
                 favoriteColors:
@@ -37,15 +37,15 @@ entry in that array:
 
         // src/Acme/UserBundle/Entity/User.php
         namespace Acme\UserBundle\Entity;
-        
+
         use Symfony\Component\Validator\Constraints as Assert;
-  
+
         class User
         {
             /**
              * @Assert\All({
              *     @Assert\NotBlank,
-             *     @Assert\Length(min = "5")
+             *     @Assert\Length(min = 5)
              * })
              */
              protected $favoriteColors = array();
@@ -77,7 +77,7 @@ entry in that array:
 
         // src/Acme/UserBundle/Entity/User.php
         namespace Acme\UserBundle\Entity;
-       
+
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
 

--- a/reference/constraints/Blank.rst
+++ b/reference/constraints/Blank.rst
@@ -26,7 +26,7 @@ of an ``Author`` class were blank, you could do the following:
 
     .. code-block:: yaml
 
-        # src/BlogBundle/Resources/config/validation.yml
+        # src/Acme/BlogBundle/Resources/config/validation.yml
         Acme\BlogBundle\Entity\Author:
             properties:
                 firstName:

--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -98,17 +98,17 @@ those errors should be attributed::
 
     // ...
     use Symfony\Component\Validator\ExecutionContextInterface;
-    
+
     class Author
     {
         // ...
         private $firstName;
-    
+
         public function isAuthorValid(ExecutionContextInterface $context)
         {
             // somehow you have an array of "fake names"
             $fakeNames = array();
-        
+
             // check if the name is actually a fake name
             if (in_array($this->getFirstName(), $fakeNames)) {
                 $context->addViolationAt('firstname', 'This name sounds totally fake!', array(), null);
@@ -155,7 +155,7 @@ process. Each method can be one of the following formats:
 
             /**
              * @Assert\Callback(methods={
-             *     { "Acme\BlogBundle\MyStaticValidatorClass", "isAuthorValid"}
+             *     { "Acme\BlogBundle\MyStaticValidatorClass", "isAuthorValid" }
              * })
              */
             class Author
@@ -208,10 +208,10 @@ process. Each method can be one of the following formats:
     object being validated (e.g. ``Author``) as well as the ``ExecutionContextInterface``::
 
         namespace Acme\BlogBundle;
-    
+
         use Symfony\Component\Validator\ExecutionContextInterface;
         use Acme\BlogBundle\Entity\Author;
-    
+
         class MyStaticValidatorClass
         {
             public static function isAuthorValid(Author $author, ExecutionContextInterface $context)

--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -85,7 +85,7 @@ blank but is no longer than 100 characters in length, you would do the following
              *             @Assert\NotBlank(),
              *             @Assert\Length(
              *                 max = 100,
-             *                 maxMessage = "Your bio is too long!"
+             *                 maxMessage = "Your short bio is too long!"
              *             )
              *         }
              *     },
@@ -117,7 +117,7 @@ blank but is no longer than 100 characters in length, you would do the following
                                 <constraint name="NotBlank" />
                                 <constraint name="Length">
                                     <option name="max">100</option>
-                                    <option name="maxMessage">Your bio is too long!</option>
+                                    <option name="maxMessage">Your short bio is too long!</option>
                                 </constraint>
                             </value>
                         </option>
@@ -146,7 +146,10 @@ blank but is no longer than 100 characters in length, you would do the following
                         'personal_email' => new Assert\Email(),
                         'lastName' => array(
                             new Assert\NotBlank(),
-                            new Assert\Length(array("max" => 100)),
+                            new Assert\Length(array(
+                                'max' => 100,
+                                'maxMessage' => 'Your short bio is too long!',
+                            )),
                         ),
                     ),
                     'allowMissingFields' => true,
@@ -215,13 +218,11 @@ field is optional but must be a valid email if supplied, you can do the followin
              * @Assert\Collection(
              *     fields={
              *         "personal_email"  = @Assert\Required({@Assert\NotBlank, @Assert\Email}),
-             *         "alternate_email" = @Assert\Optional(@Assert\Email),
+             *         "alternate_email" = @Assert\Optional(@Assert\Email)
              *     }
              * )
              */
-             protected $profileData = array(
-                 'personal_email',
-             );
+             protected $profileData = array('personal_email');
         }
 
     .. code-block:: xml

--- a/reference/constraints/Country.rst
+++ b/reference/constraints/Country.rst
@@ -20,7 +20,7 @@ Basic Usage
 
     .. code-block:: yaml
 
-        # src/UserBundle/Resources/config/validation.yml
+        # src/Acme/UserBundle/Resources/config/validation.yml
         Acme\UserBundle\Entity\User:
             properties:
                 country:
@@ -36,7 +36,7 @@ Basic Usage
         class User
         {
             /**
-             * @Assert\Country
+             * @Assert\Country()
              */
              protected $country;
         }

--- a/reference/constraints/Currency.rst
+++ b/reference/constraints/Currency.rst
@@ -26,7 +26,7 @@ currency, you could do the following:
 
     .. code-block:: yaml
 
-        # src/EcommerceBundle/Resources/config/validation.yml
+        # src/Acme/EcommerceBundle/Resources/config/validation.yml
         Acme\EcommerceBundle\Entity\Order:
             properties:
                 currency:
@@ -50,11 +50,17 @@ currency, you could do the following:
     .. code-block:: xml
 
         <!-- src/Acme/EcommerceBundle/Resources/config/validation.xml -->
-        <class name="Acme\EcommerceBundle\Entity\Order">
-            <property name="currency">
-                <constraint name="Currency" />
-            </property>
-        </class>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\EcommerceBundle\Entity\Order">
+                <property name="currency">
+                    <constraint name="Currency" />
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 
@@ -82,4 +88,4 @@ message
 
 This is the message that will be shown if the value is not a valid currency.
 
-.. _`3-letter ISO 4217`: http://en.wikipedia.org/wiki/ISO_4217 
+.. _`3-letter ISO 4217`: http://en.wikipedia.org/wiki/ISO_4217

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -23,7 +23,7 @@ Basic Usage
 
     .. code-block:: yaml
 
-        # src/BlogBundle/Resources/config/validation.yml
+        # src/Acme/BlogBundle/Resources/config/validation.yml
         Acme\BlogBundle\Entity\Author:
             properties:
                 email:
@@ -71,7 +71,7 @@ Basic Usage
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
 

--- a/reference/constraints/EqualTo.rst
+++ b/reference/constraints/EqualTo.rst
@@ -8,7 +8,7 @@ Validates that a value is equal to another value, defined in the options. To
 force that a value is *not* equal, see :doc:`/reference/constraints/NotEqualTo`.
 
 .. caution::
-    
+
     This constraint compares using ``==``, so ``3`` and ``"3"`` are considered
     equal. Use :doc:`/reference/constraints/IdenticalTo` to compare with
     ``===``.
@@ -34,7 +34,7 @@ If you want to ensure that the ``age`` of a ``Person`` class is equal to
 
     .. code-block:: yaml
 
-        # src/SocialBundle/Resources/config/validation.yml
+        # src/Acme/SocialBundle/Resources/config/validation.yml
         Acme\SocialBundle\Entity\Person:
             properties:
                 age:
@@ -61,13 +61,19 @@ If you want to ensure that the ``age`` of a ``Person`` class is equal to
     .. code-block:: xml
 
         <!-- src/Acme/SocialBundle/Resources/config/validation.xml -->
-        <class name="Acme\SocialBundle\Entity\Person">
-            <property name="age">
-                <constraint name="EqualTo">
-                    <option name="value">20</option>
-                </constraint>
-            </property>
-        </class>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\SocialBundle\Entity\Person">
+                <property name="age">
+                    <constraint name="EqualTo">
+                        <option name="value">20</option>
+                    </constraint>
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 

--- a/reference/constraints/False.rst
+++ b/reference/constraints/False.rst
@@ -41,7 +41,7 @@ method returns **false**:
 
     .. code-block:: yaml
 
-        # src/BlogBundle/Resources/config/validation.yml
+        # src/Acme/BlogBundle/Resources/config/validation.yml
         Acme\BlogBundle\Entity\Author
             getters:
                 stateInvalid:

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -78,7 +78,6 @@ below a certain file size and a valid PDF, add the following:
                         maxSize: 1024k
                         mimeTypes: [application/pdf, application/x-pdf]
                         mimeTypesMessage: Please upload a valid PDF
-                        
 
     .. code-block:: php-annotations
 

--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -30,7 +30,7 @@ If you want to ensure that the ``age`` of a ``Person`` class is greater than
 
     .. code-block:: yaml
 
-        # src/SocialBundle/Resources/config/validation.yml
+        # src/Acme/SocialBundle/Resources/config/validation.yml
         Acme\SocialBundle\Entity\Person:
             properties:
                 age:
@@ -57,13 +57,19 @@ If you want to ensure that the ``age`` of a ``Person`` class is greater than
     .. code-block:: xml
 
         <!-- src/Acme/SocialBundle/Resources/config/validation.xml -->
-        <class name="Acme\SocialBundle\Entity\Person">
-            <property name="age">
-                <constraint name="GreaterThan">
-                    <option name="value">18</option>
-                </constraint>
-            </property>
-        </class>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\SocialBundle\Entity\Person">
+                <property name="age">
+                    <constraint name="GreaterThan">
+                        <option name="value">18</option>
+                    </constraint>
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -29,7 +29,7 @@ or equal to ``18``, you could do the following:
 
     .. code-block:: yaml
 
-        # src/SocialBundle/Resources/config/validation.yml
+        # src/Acme/SocialBundle/Resources/config/validation.yml
         Acme\SocialBundle\Entity\Person:
             properties:
                 age:
@@ -56,13 +56,19 @@ or equal to ``18``, you could do the following:
     .. code-block:: xml
 
         <!-- src/Acme/SocialBundle/Resources/config/validation.xml -->
-        <class name="Acme\SocialBundle\Entity\Person">
-            <property name="age">
-                <constraint name="GreaterThanOrEqual">
-                    <option name="value">18</option>
-                </constraint>
-            </property>
-        </class>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\SocialBundle\Entity\Person">
+                <property name="age">
+                    <constraint name="GreaterThanOrEqual">
+                        <option name="value">18</option>
+                    </constraint>
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 

--- a/reference/constraints/Iban.rst
+++ b/reference/constraints/Iban.rst
@@ -36,22 +36,11 @@ will contain an International Bank Account Number.
                     - Iban:
                         message: This is not a valid International Bank Account Number (IBAN).
 
-    .. code-block:: xml
-
-        <!-- src/Acme/SubscriptionBundle/Resources/config/validation.xml -->
-        <class name="Acme\SubscriptionBundle\Entity\Transaction">
-            <property name="bankAccountNumber">
-                <constraint name="Iban">
-                    <option name="message">This is not a valid International Bank Account Number (IBAN).</option>
-                </constraint>
-            </property>
-        </class>
-
     .. code-block:: php-annotations
 
         // src/Acme/SubscriptionBundle/Entity/Transaction.php
-        namespace Acme\SubscriptionBundle\Entity\Transaction;
-        
+        namespace Acme\SubscriptionBundle\Entity;
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Transaction
@@ -62,11 +51,28 @@ will contain an International Bank Account Number.
             protected $bankAccountNumber;
         }
 
+    .. code-block:: xml
+
+        <!-- src/Acme/SubscriptionBundle/Resources/config/validation.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\SubscriptionBundle\Entity\Transaction">
+                <property name="bankAccountNumber">
+                    <constraint name="Iban">
+                        <option name="message">This is not a valid International Bank Account Number (IBAN).</option>
+                    </constraint>
+                </property>
+            </class>
+        </constraint-mapping>
+
     .. code-block:: php
 
         // src/Acme/SubscriptionBundle/Entity/Transaction.php
-        namespace Acme\SubscriptionBundle\Entity\Transaction;
-        
+        namespace Acme\SubscriptionBundle\Entity;
+
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
 

--- a/reference/constraints/IdenticalTo.rst
+++ b/reference/constraints/IdenticalTo.rst
@@ -9,7 +9,7 @@ To force that a value is *not* identical, see
 :doc:`/reference/constraints/NotIdenticalTo`.
 
 .. caution::
-    
+
     This constraint compares using ``===``, so ``3`` and ``"3"`` are *not*
     considered equal. Use :doc:`/reference/constraints/EqualTo` to compare
     with ``==``.
@@ -35,7 +35,7 @@ If you want to ensure that the ``age`` of a ``Person`` class is equal to
 
     .. code-block:: yaml
 
-        # src/SocialBundle/Resources/config/validation.yml
+        # src/Acme/SocialBundle/Resources/config/validation.yml
         Acme\SocialBundle\Entity\Person:
             properties:
                 age:
@@ -62,13 +62,19 @@ If you want to ensure that the ``age`` of a ``Person`` class is equal to
     .. code-block:: xml
 
         <!-- src/Acme/SocialBundle/Resources/config/validation.xml -->
-        <class name="Acme\SocialBundle\Entity\Person">
-            <property name="age">
-                <constraint name="IdenticalTo">
-                    <option name="value">20</option>
-                </constraint>
-            </property>
-        </class>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\SocialBundle\Entity\Person">
+                <property name="age">
+                    <constraint name="IdenticalTo">
+                        <option name="value">20</option>
+                    </constraint>
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 

--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -77,11 +77,12 @@ it is between a certain size, add the following:
                         maxWidth: 400
                         minHeight: 200
                         maxHeight: 400
-                        
 
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
+        namespace Acme\BlogBundle\Entity;
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
@@ -120,15 +121,13 @@ it is between a certain size, add the following:
     .. code-block:: php
 
         // src/Acme/BlogBundle/Entity/Author.php
-        // ...
+        namespace Acme\BlogBundle\Entity;
 
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints\Image;
 
         class Author
         {
-            // ...
-
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
                 $metadata->addPropertyConstraint('headshot', new Image(array(

--- a/reference/constraints/Ip.rst
+++ b/reference/constraints/Ip.rst
@@ -23,7 +23,7 @@ Basic Usage
 
     .. code-block:: yaml
 
-        # src/BlogBundle/Resources/config/validation.yml
+        # src/Acme/BlogBundle/Resources/config/validation.yml
         Acme\BlogBundle\Entity\Author:
             properties:
                 ipAddress:
@@ -33,7 +33,7 @@ Basic Usage
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
@@ -63,10 +63,10 @@ Basic Usage
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
-  
+
         class Author
         {
             public static function loadValidatorMetadata(ClassMetadata $metadata)

--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -43,6 +43,8 @@ on an  object that will contain a ISBN number.
     .. code-block:: php-annotations
 
         // src/Acme/BookcaseBundle/Entity/Book.php
+        namespace Acme\BookcaseBundle\Entity;
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Book
@@ -60,15 +62,21 @@ on an  object that will contain a ISBN number.
     .. code-block:: xml
 
         <!-- src/Acme/BookcaseBundle/Resources/config/validation.xml -->
-        <class name="Acme\BookcaseBundle\Entity\Book">
-            <property name="isbn">
-                <constraint name="Isbn">
-                    <option name="isbn10">true</option>
-                    <option name="isbn13">true</option>
-                    <option name="bothIsbnMessage">This value is neither a valid ISBN-10 nor a valid ISBN-13.</option>
-                </constraint>
-            </property>
-        </class>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\BookcaseBundle\Entity\Book">
+                <property name="isbn">
+                    <constraint name="Isbn">
+                        <option name="isbn10">true</option>
+                        <option name="isbn13">true</option>
+                        <option name="bothIsbnMessage">This value is neither a valid ISBN-10 nor a valid ISBN-13.</option>
+                    </constraint>
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 

--- a/reference/constraints/Issn.rst
+++ b/reference/constraints/Issn.rst
@@ -25,7 +25,7 @@ Basic Usage
 
     .. code-block:: yaml
 
-        # src/JournalBundle/Resources/config/validation.yml
+        # src/Acme/JournalBundle/Resources/config/validation.yml
         Acme\JournalBundle\Entity\Journal:
             properties:
                 issn:
@@ -49,11 +49,17 @@ Basic Usage
     .. code-block:: xml
 
         <!-- src/Acme/JournalBundle/Resources/config/validation.xml -->
-        <class name="Acme\JournalBundle\Entity\Journal">
-            <property name="issn">
-                <constraint name="Issn" />
-            </property>
-        </class>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\JournalBundle\Entity\Journal">
+                <property name="issn">
+                    <constraint name="Issn" />
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 

--- a/reference/constraints/Language.rst
+++ b/reference/constraints/Language.rst
@@ -21,7 +21,7 @@ Basic Usage
 
     .. code-block:: yaml
 
-        # src/UserBundle/Resources/config/validation.yml
+        # src/Acme/UserBundle/Resources/config/validation.yml
         Acme\UserBundle\Entity\User:
             properties:
                 preferredLanguage:
@@ -31,13 +31,13 @@ Basic Usage
 
         // src/Acme/UserBundle/Entity/User.php
         namespace Acme\UserBundle\Entity;
-        
+
         use Symfony\Component\Validator\Constraints as Assert;
-  
+
         class User
         {
             /**
-             * @Assert\Language
+             * @Assert\Language()
              */
              protected $preferredLanguage;
         }
@@ -61,7 +61,7 @@ Basic Usage
 
         // src/Acme/UserBundle/Entity/User.php
         namespace Acme\UserBundle\Entity;
-        
+
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
 

--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -35,8 +35,8 @@ To verify that the ``firstName`` field length of a class is between "2" and
                     - Length:
                         min: 2
                         max: 50
-                        minMessage: "Your first name must be at least {{ limit }} characters length"
-                        maxMessage: "Your first name cannot be longer than {{ limit }} characters length"
+                        minMessage: "Your first name must be at least {{ limit }} characters long"
+                        maxMessage: "Your first name cannot be longer than {{ limit }} characters long"
 
     .. code-block:: php-annotations
 
@@ -49,10 +49,10 @@ To verify that the ``firstName`` field length of a class is between "2" and
         {
             /**
              * @Assert\Length(
-             *      min = "2",
-             *      max = "50",
-             *      minMessage = "Your first name must be at least {{ limit }} characters length",
-             *      maxMessage = "Your first name cannot be longer than {{ limit }} characters length"
+             *      min = 2,
+             *      max = 50,
+             *      minMessage = "Your first name must be at least {{ limit }} characters long",
+             *      maxMessage = "Your first name cannot be longer than {{ limit }} characters long"
              * )
              */
              protected $firstName;
@@ -71,8 +71,8 @@ To verify that the ``firstName`` field length of a class is between "2" and
                     <constraint name="Length">
                         <option name="min">2</option>
                         <option name="max">50</option>
-                        <option name="minMessage">Your first name must be at least {{ limit }} characters length</option>
-                        <option name="maxMessage">Your first name cannot be longer than {{ limit }} characters length</option>
+                        <option name="minMessage">Your first name must be at least {{ limit }} characters long</option>
+                        <option name="maxMessage">Your first name cannot be longer than {{ limit }} characters long</option>
                     </constraint>
                 </property>
             </class>
@@ -93,8 +93,8 @@ To verify that the ``firstName`` field length of a class is between "2" and
                 $metadata->addPropertyConstraint('firstName', new Assert\Length(array(
                     'min'        => 2,
                     'max'        => 50,
-                    'minMessage' => 'Your first name must be at least {{ limit }} characters length',
-                    'maxMessage' => 'Your first name cannot be longer than {{ limit }} characters length',
+                    'minMessage' => 'Your first name must be at least {{ limit }} characters long',
+                    'maxMessage' => 'Your first name cannot be longer than {{ limit }} characters long',
                 )));
             }
         }

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -30,7 +30,7 @@ If you want to ensure that the ``age`` of a ``Person`` class is less than
 
     .. code-block:: yaml
 
-        # src/SocialBundle/Resources/config/validation.yml
+        # src/Acme/SocialBundle/Resources/config/validation.yml
         Acme\SocialBundle\Entity\Person:
             properties:
                 age:
@@ -57,13 +57,19 @@ If you want to ensure that the ``age`` of a ``Person`` class is less than
     .. code-block:: xml
 
         <!-- src/Acme/SocialBundle/Resources/config/validation.xml -->
-        <class name="Acme\SocialBundle\Entity\Person">
-            <property name="age">
-                <constraint name="LessThan">
-                    <option name="value">80</option>
-                </constraint>
-            </property>
-        </class>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\SocialBundle\Entity\Person">
+                <property name="age">
+                    <constraint name="LessThan">
+                        <option name="value">80</option>
+                    </constraint>
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -29,7 +29,7 @@ equal to ``80``, you could do the following:
 
     .. code-block:: yaml
 
-        # src/SocialBundle/Resources/config/validation.yml
+        # src/Acme/SocialBundle/Resources/config/validation.yml
         Acme\SocialBundle\Entity\Person:
             properties:
                 age:
@@ -56,13 +56,19 @@ equal to ``80``, you could do the following:
     .. code-block:: xml
 
         <!-- src/Acme/SocialBundle/Resources/config/validation.xml -->
-        <class name="Acme\SocialBundle\Entity\Person">
-            <property name="age">
-                <constraint name="LessThanOrEqual">
-                    <option name="value">80</option>
-                </constraint>
-            </property>
-        </class>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\SocialBundle\Entity\Person">
+                <property name="age">
+                    <constraint name="LessThanOrEqual">
+                        <option name="value">80</option>
+                    </constraint>
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -24,7 +24,7 @@ Basic Usage
 
     .. code-block:: yaml
 
-        # src/UserBundle/Resources/config/validation.yml
+        # src/Acme/UserBundle/Resources/config/validation.yml
         Acme\UserBundle\Entity\User:
             properties:
                 locale:
@@ -34,13 +34,13 @@ Basic Usage
 
         // src/Acme/UserBundle/Entity/User.php
         namespace Acme\UserBundle\Entity;
-        
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class User
         {
             /**
-             * @Assert\Locale
+             * @Assert\Locale()
              */
              protected $locale;
         }
@@ -64,10 +64,10 @@ Basic Usage
 
         // src/Acme/UserBundle/Entity/User.php
         namespace Acme\UserBundle\Entity;
-        
+
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
-  
+
         class User
         {
             public static function loadValidatorMetadata(ClassMetadata $metadata)

--- a/reference/constraints/Luhn.rst
+++ b/reference/constraints/Luhn.rst
@@ -38,7 +38,7 @@ will contain a credit card number.
     .. code-block:: php-annotations
 
         // src/Acme/SubscriptionBundle/Entity/Transaction.php
-        namespace Acme\SubscriptionBundle\Entity\Transaction;
+        namespace Acme\SubscriptionBundle\Entity;
 
         use Symfony\Component\Validator\Constraints as Assert;
 
@@ -70,7 +70,7 @@ will contain a credit card number.
     .. code-block:: php
 
         // src/Acme/SubscriptionBundle/Entity/Transaction.php
-        namespace Acme\SubscriptionBundle\Entity\Transaction;
+        namespace Acme\SubscriptionBundle\Entity;
 
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;

--- a/reference/constraints/NotBlank.rst
+++ b/reference/constraints/NotBlank.rst
@@ -25,7 +25,7 @@ were not blank, you could do the following:
 
     .. code-block:: yaml
 
-        # src/BlogBundle/Resources/config/validation.yml
+        # src/Acme/BlogBundle/Resources/config/validation.yml
         Acme\BlogBundle\Entity\Author:
             properties:
                 firstName:

--- a/reference/constraints/NotEqualTo.rst
+++ b/reference/constraints/NotEqualTo.rst
@@ -9,7 +9,7 @@ options. To force that a value is equal, see
 :doc:`/reference/constraints/EqualTo`.
 
 .. caution::
-    
+
     This constraint compares using ``!=``, so ``3`` and ``"3"`` are considered
     equal. Use :doc:`/reference/constraints/NotIdenticalTo` to compare with
     ``!==``.
@@ -35,7 +35,7 @@ If you want to ensure that the ``age`` of a ``Person`` class is not equal to
 
     .. code-block:: yaml
 
-        # src/SocialBundle/Resources/config/validation.yml
+        # src/Acme/SocialBundle/Resources/config/validation.yml
         Acme\SocialBundle\Entity\Person:
             properties:
                 age:
@@ -62,13 +62,19 @@ If you want to ensure that the ``age`` of a ``Person`` class is not equal to
     .. code-block:: xml
 
         <!-- src/Acme/SocialBundle/Resources/config/validation.xml -->
-        <class name="Acme\SocialBundle\Entity\Person">
-            <property name="age">
-                <constraint name="NotEqualTo">
-                    <option name="value">15</option>
-                </constraint>
-            </property>
-        </class>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\SocialBundle\Entity\Person">
+                <property name="age">
+                    <constraint name="NotEqualTo">
+                        <option name="value">15</option>
+                    </constraint>
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 

--- a/reference/constraints/NotIdenticalTo.rst
+++ b/reference/constraints/NotIdenticalTo.rst
@@ -9,7 +9,7 @@ options. To force that a value is identical, see
 :doc:`/reference/constraints/IdenticalTo`.
 
 .. caution::
-    
+
     This constraint compares using ``!==``, so ``3`` and ``"3"`` are
     considered not equal. Use :doc:`/reference/constraints/NotEqualTo` to compare
     with ``!=``.
@@ -35,7 +35,7 @@ If you want to ensure that the ``age`` of a ``Person`` class is *not* equal to
 
     .. code-block:: yaml
 
-        # src/SocialBundle/Resources/config/validation.yml
+        # src/Acme/SocialBundle/Resources/config/validation.yml
         Acme\SocialBundle\Entity\Person:
             properties:
                 age:
@@ -62,13 +62,19 @@ If you want to ensure that the ``age`` of a ``Person`` class is *not* equal to
     .. code-block:: xml
 
         <!-- src/Acme/SocialBundle/Resources/config/validation.xml -->
-        <class name="Acme\SocialBundle\Entity\Person">
-            <property name="age">
-                <constraint name="NotIdenticalTo">
-                    <option name="value">15</option>
-                </constraint>
-            </property>
-        </class>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+            <class name="Acme\SocialBundle\Entity\Person">
+                <property name="age">
+                    <constraint name="NotIdenticalTo">
+                        <option name="value">15</option>
+                    </constraint>
+                </property>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 

--- a/reference/constraints/NotNull.rst
+++ b/reference/constraints/NotNull.rst
@@ -25,7 +25,7 @@ were not strictly equal to ``null``, you would:
 
     .. code-block:: yaml
 
-        # src/BlogBundle/Resources/config/validation.yml
+        # src/Acme/BlogBundle/Resources/config/validation.yml
         Acme\BlogBundle\Entity\Author:
             properties:
                 firstName:

--- a/reference/constraints/Null.rst
+++ b/reference/constraints/Null.rst
@@ -35,7 +35,7 @@ of an ``Author`` class exactly equal to ``null``, you could do the following:
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
@@ -65,7 +65,7 @@ of an ``Author`` class exactly equal to ``null``, you could do the following:
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
 

--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -34,8 +34,8 @@ the following:
                     - Range:
                         min: 120
                         max: 180
-                        minMessage: You must be at least 120cm tall to enter
-                        maxMessage: You cannot be taller than 180cm to enter
+                        minMessage: You must be at least {{ limit }}cm tall to enter
+                        maxMessage: You cannot be taller than {{ limit }}cm to enter
 
     .. code-block:: php-annotations
 
@@ -50,8 +50,8 @@ the following:
              * @Assert\Range(
              *      min = 120,
              *      max = 180,
-             *      minMessage = "You must be at least 120cm tall to enter",
-             *      maxMessage = "You cannot be taller than 180cm to enter"
+             *      minMessage = "You must be at least {{ limit }}cm tall to enter",
+             *      maxMessage = "You cannot be taller than {{ limit }}cm to enter"
              * )
              */
              protected $height;
@@ -70,8 +70,8 @@ the following:
                     <constraint name="Range">
                         <option name="min">120</option>
                         <option name="max">180</option>
-                        <option name="minMessage">You must be at least 120cm tall to enter</option>
-                        <option name="maxMessage">You cannot be taller than 180cm to enter</option>
+                        <option name="minMessage">You must be at least {{ limit }}cm tall to enter</option>
+                        <option name="maxMessage">You cannot be taller than {{ limit }}cm to enter</option>
                     </constraint>
                 </property>
             </class>
@@ -92,8 +92,8 @@ the following:
                 $metadata->addPropertyConstraint('height', new Assert\Range(array(
                     'min'        => 120,
                     'max'        => 180,
-                    'minMessage' => 'You must be at least 120cm tall to enter',
-                    'maxMessage' => 'You cannot be taller than 180cm to enter',
+                    'minMessage' => 'You must be at least {{ limit }}cm tall to enter',
+                    'maxMessage' => 'You cannot be taller than {{ limit }}cm to enter',
                 )));
             }
         }

--- a/reference/constraints/Regex.rst
+++ b/reference/constraints/Regex.rst
@@ -38,7 +38,7 @@ characters at the beginning of your string:
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
@@ -70,7 +70,7 @@ characters at the beginning of your string:
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
 
@@ -106,7 +106,7 @@ message:
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
@@ -189,8 +189,8 @@ pattern. This means that the delimiters are removed (e.g. ``/[a-z]+/`` becomes `
 
 However, there are some other incompatibilities between both patterns which
 cannot be fixed by the constraint. For instance, the HTML5 ``pattern`` attribute
-does not support flags. If you have a pattern like ``/[a-z]+/i`` you need to
-specify the HTML5 compatible pattern in the ``htmlPattern`` option:
+does not support flags. If you have a pattern like ``/[a-z]+/i``, you need
+to specify the HTML5 compatible pattern in the ``htmlPattern`` option:
 
 .. configuration-block::
 
@@ -208,7 +208,7 @@ specify the HTML5 compatible pattern in the ``htmlPattern`` option:
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
@@ -244,7 +244,7 @@ specify the HTML5 compatible pattern in the ``htmlPattern`` option:
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
 

--- a/reference/constraints/True.rst
+++ b/reference/constraints/True.rst
@@ -50,7 +50,8 @@ Then you can constrain this method with ``True``.
         Acme\BlogBundle\Entity\Author:
             getters:
                 tokenValid:
-                    - 'True': { message: "The token is invalid." }
+                    - 'True':
+                        message: The token is invalid.
 
     .. code-block:: php-annotations
 
@@ -96,11 +97,11 @@ Then you can constrain this method with ``True``.
 
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints\True;
-        
+
         class Author
         {
             protected $token;
-            
+
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
                 $metadata->addGetterConstraint('tokenValid', new True(array(

--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -23,7 +23,7 @@ Basic Usage
 
     .. code-block:: yaml
 
-        # src/BlogBundle/Resources/config/validation.yml
+        # src/Acme/BlogBundle/Resources/config/validation.yml
         Acme\BlogBundle\Entity\Author:
             properties:
                 age:
@@ -65,7 +65,7 @@ Basic Usage
         </constraint-mapping>
 
     .. code-block:: php
-        
+
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
 

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -42,7 +42,7 @@ table:
 
     .. code-block:: php-annotations
 
-        // Acme/UserBundle/Entity/User.php
+        // Acme/UserBundle/Entity/Author.php
         namespace Acme\UserBundle\Entity;
 
         use Symfony\Component\Validator\Constraints as Assert;
@@ -79,7 +79,6 @@ table:
             <class name="Acme\UserBundle\Entity\Author">
                 <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
                     <option name="fields">email</option>
-                    <option name="message">This email already exists.</option>
                 </constraint>
                 <property name="email">
                     <constraint name="Email" />
@@ -104,7 +103,6 @@ table:
             {
                 $metadata->addConstraint(new UniqueEntity(array(
                     'fields'  => 'email',
-                    'message' => 'This email already exists.',
                 )));
 
                 $metadata->addPropertyConstraint('email', new Assert\Email());

--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -21,7 +21,7 @@ Basic Usage
 
     .. code-block:: yaml
 
-        # src/BlogBundle/Resources/config/validation.yml
+        # src/Acme/BlogBundle/Resources/config/validation.yml
         Acme\BlogBundle\Entity\Author:
             properties:
                 bioUrl:
@@ -31,7 +31,7 @@ Basic Usage
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Author
@@ -61,10 +61,10 @@ Basic Usage
 
         // src/Acme/BlogBundle/Entity/Author.php
         namespace Acme\BlogBundle\Entity;
-        
+
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
-  
+
         class Author
         {
             public static function loadValidatorMetadata(ClassMetadata $metadata)
@@ -72,7 +72,7 @@ Basic Usage
                 $metadata->addPropertyConstraint('bioUrl', new Assert\Url());
             }
         }
-  
+
 Options
 -------
 

--- a/reference/constraints/UserPassword.rst
+++ b/reference/constraints/UserPassword.rst
@@ -40,7 +40,7 @@ password:
 
     .. code-block:: yaml
 
-        # src/UserBundle/Resources/config/validation.yml
+        # src/Acme/UserBundle/Resources/config/validation.yml
         Acme\UserBundle\Form\Model\ChangePassword:
             properties:
                 oldPassword:
@@ -66,15 +66,17 @@ password:
 
     .. code-block:: xml
 
-        <!-- src/UserBundle/Resources/config/validation.xml -->
+        <!-- src/Acme/UserBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
 
             <class name="Acme\UserBundle\Form\Model\ChangePassword">
-                <property name="Symfony\Component\Security\Core\Validator\Constraints\UserPassword">
-                    <option name="message">Wrong value for your current password</option>
+                <property name="oldPassword">
+                    <constraint name="Symfony\Component\Security\Core\Validator\Constraints\UserPassword">
+                        <option name="message">Wrong value for your current password</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -85,7 +85,7 @@ an ``Address`` instance in the ``$address`` property.
 
             /**
              * @Assert\NotBlank
-             * @Assert\Length(max = "5")
+             * @Assert\Length(max = 5)
              */
             protected $zipCode;
         }
@@ -93,11 +93,13 @@ an ``Address`` instance in the ``$address`` property.
         // src/Acme/HelloBundle/Entity/Author.php
         namespace Acme\HelloBundle\Entity;
 
+        use Symfony\Component\Validator\Constraints as Assert;
+
         class Author
         {
             /**
              * @Assert\NotBlank
-             * @Assert\Length(min = "4")
+             * @Assert\Length(min = 4)
              */
             protected $firstName;
 
@@ -159,9 +161,7 @@ an ``Address`` instance in the ``$address`` property.
             {
                 $metadata->addPropertyConstraint('street', new Assert\NotBlank());
                 $metadata->addPropertyConstraint('zipCode', new Assert\NotBlank());
-                $metadata->addPropertyConstraint(
-                    'zipCode',
-                    new Assert\Length(array("max" => 5)));
+                $metadata->addPropertyConstraint('zipCode', new Assert\Length(array("max" => 5)));
             }
         }
 

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -126,9 +126,17 @@ And then register it as a tagged service:
 
     .. code-block:: xml
 
-        <service id="acme.my_worker" class="MyWorker>
-            <tag name="assetic.factory_worker" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service id="acme.my_worker" class="MyWorker>
+                    <tag name="assetic.factory_worker" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -177,9 +185,17 @@ Second, define a service:
 
     .. code-block:: xml
 
-        <service id="acme.my_filter" class="MyFilter">
-            <tag name="assetic.filter" alias="my_filter" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service id="acme.my_filter" class="MyFilter">
+                    <tag name="assetic.filter" alias="my_filter" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -317,9 +333,20 @@ the ``form.type_extension`` tag:
 
     .. code-block:: xml
 
-        <service id="main.form.type.my_form_type_extension" class="Acme\MainBundle\Form\Type\MyFormTypeExtension">
-            <tag name="form.type_extension" alias="field" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service
+                    id="main.form.type.my_form_type_extension"
+                    class="Acme\MainBundle\Form\Type\MyFormTypeExtension">
+
+                    <tag name="form.type_extension" alias="field" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -389,9 +416,17 @@ Then register this class and tag it with ``kernel.cache_clearer``:
 
     .. code-block:: xml
 
-        <service id="my_cache_clearer" class="Acme\MainBundle\Cache\MyClearer">
-            <tag name="kernel.cache_clearer" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service id="my_cache_clearer" class="Acme\MainBundle\Cache\MyClearer">
+                    <tag name="kernel.cache_clearer" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -452,9 +487,17 @@ To register your warmer with Symfony, give it the ``kernel.cache_warmer`` tag:
 
     .. code-block:: xml
 
-        <service id="main.warmer.my_custom_warmer" class="Acme\MainBundle\Cache\MyCustomWarmer">
-            <tag name="kernel.cache_warmer" priority="0" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service id="main.warmer.my_custom_warmer" class="Acme\MainBundle\Cache\MyCustomWarmer">
+                    <tag name="kernel.cache_warmer" priority="0" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -600,9 +643,20 @@ configuration, and tag it with ``kernel.event_subscriber``:
 
     .. code-block:: xml
 
-        <service id="kernel.subscriber.your_subscriber_name" class="Fully\Qualified\Subscriber\Class\Name">
-            <tag name="kernel.event_subscriber" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service
+                    id="kernel.subscriber.your_subscriber_name"
+                    class="Fully\Qualified\Subscriber\Class\Name">
+
+                    <tag name="kernel.event_subscriber" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -655,16 +709,24 @@ channel when injecting the logger in a service.
 
     .. code-block:: xml
 
-        <service id="my_service" class="Fully\Qualified\Loader\Class\Name">
-            <argument type="service" id="logger" />
-            <tag name="monolog.logger" channel="acme" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service id="my_service" class="Fully\Qualified\Loader\Class\Name">
+                    <argument type="service" id="logger" />
+                    <tag name="monolog.logger" channel="acme" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
         $definition = new Definition('Fully\Qualified\Loader\Class\Name', array(new Reference('logger'));
         $definition->addTag('monolog.logger', array('channel' => 'acme'));
-        $container->register('my_service', $definition);
+        $container->setDefinition('my_service', $definition);
 
 .. tip::
 
@@ -701,15 +763,24 @@ You can add a processor globally:
 
     .. code-block:: xml
 
-        <service id="my_service" class="Monolog\Processor\IntrospectionProcessor">
-            <tag name="monolog.processor" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service id="my_service" class="Monolog\Processor\IntrospectionProcessor">
+                    <tag name="monolog.processor" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
-        $definition = new Definition('Monolog\Processor\IntrospectionProcessor');
-        $definition->addTag('monolog.processor');
-        $container->register('my_service', $definition);
+        $container
+            ->register('my_service', 'Monolog\Processor\IntrospectionProcessor')
+            ->addTag('monolog.processor')
+        ;
 
 .. tip::
 
@@ -731,15 +802,24 @@ attribute:
 
     .. code-block:: xml
 
-        <service id="my_service" class="Monolog\Processor\IntrospectionProcessor">
-            <tag name="monolog.processor" handler="firephp" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service id="my_service" class="Monolog\Processor\IntrospectionProcessor">
+                    <tag name="monolog.processor" handler="firephp" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
-        $definition = new Definition('Monolog\Processor\IntrospectionProcessor');
-        $definition->addTag('monolog.processor', array('handler' => 'firephp');
-        $container->register('my_service', $definition);
+        $container
+            ->register('my_service', 'Monolog\Processor\IntrospectionProcessor')
+            ->addTag('monolog.processor', array('handler' => 'firephp'))
+        ;
 
 You can also add a processor for a specific logging channel by using the ``channel``
 attribute. This will register the processor only for the ``security`` logging
@@ -757,15 +837,24 @@ channel used in the Security component:
 
     .. code-block:: xml
 
-        <service id="my_service" class="Monolog\Processor\IntrospectionProcessor">
-            <tag name="monolog.processor" channel="security" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service id="my_service" class="Monolog\Processor\IntrospectionProcessor">
+                    <tag name="monolog.processor" channel="security" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
-        $definition = new Definition('Monolog\Processor\IntrospectionProcessor');
-        $definition->addTag('monolog.processor', array('channel' => 'security');
-        $container->register('my_service', $definition);
+        $container
+            ->register('my_service', 'Monolog\Processor\IntrospectionProcessor')
+            ->addTag('monolog.processor', array('channel' => 'security'))
+        ;
 
 .. note::
 
@@ -792,9 +881,20 @@ of your configuration, and tag it with ``routing.loader``:
 
     .. code-block:: xml
 
-        <service id="routing.loader.your_loader_name" class="Fully\Qualified\Loader\Class\Name">
-            <tag name="routing.loader" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service
+                    id="routing.loader.your_loader_name"
+                    class="Fully\Qualified\Loader\Class\Name">
+
+                    <tag name="routing.loader" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -899,9 +999,20 @@ templates):
 
     .. code-block:: xml
 
-        <service id="templating.helper.your_helper_name" class="Fully\Qualified\Helper\Class\Name">
-            <tag name="templating.helper" alias="alias_name" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service
+                    id="templating.helper.your_helper_name"
+                    class="Fully\Qualified\Helper\Class\Name">
+
+                    <tag name="templating.helper" alias="alias_name" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -959,9 +1070,20 @@ Now, register your loader as a service and tag it with ``translation.loader``:
 
     .. code-block:: xml
 
-        <service id="main.translation.my_custom_loader" class="Acme\MainBundle\Translation\MyCustomLoader">
-            <tag name="translation.loader" alias="bin" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service
+                    id="main.translation.my_custom_loader"
+                    class="Acme\MainBundle\Translation\MyCustomLoader">
+
+                    <tag name="translation.loader" alias="bin" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -1043,10 +1165,20 @@ option: ``alias``, which defines the name of the extractor::
 
     .. code-block:: xml
 
-        <service id="acme_demo.translation.extractor.foo"
-            class="Acme\DemoBundle\Translation\FooExtractor">
-            <tag name="translation.extractor" alias="foo" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service
+                    id="acme_demo.translation.extractor.foo"
+                    class="Acme\DemoBundle\Translation\FooExtractor">
+
+                    <tag name="translation.extractor" alias="foo" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -1097,10 +1229,20 @@ This is the name that's used to determine which dumper should be used.
 
     .. code-block:: xml
 
-        <service id="acme_demo.translation.dumper.json"
-            class="Acme\DemoBundle\Translation\JsonFileDumper">
-            <tag name="translation.dumper" alias="json" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service
+                    id="acme_demo.translation.dumper.json"
+                    class="Acme\DemoBundle\Translation\JsonFileDumper">
+
+                    <tag name="translation.dumper" alias="json" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -1132,9 +1274,20 @@ configuration, and tag it with ``twig.extension``:
 
     .. code-block:: xml
 
-        <service id="twig.extension.your_extension_name" class="Fully\Qualified\Extension\Class\Name">
-            <tag name="twig.extension" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service
+                    id="twig.extension.your_extension_name"
+                    class="Fully\Qualified\Extension\Class\Name">
+
+                    <tag name="twig.extension" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -1165,9 +1318,17 @@ also have to be added as regular services:
 
     .. code-block:: xml
 
-        <service id="twig.extension.intl" class="Twig_Extensions_Extension_Intl">
-            <tag name="twig.extension" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service id="twig.extension.intl" class="Twig_Extensions_Extension_Intl">
+                    <tag name="twig.extension" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 
@@ -1198,9 +1359,20 @@ the new loader and tag it with ``twig.loader``:
 
     .. code-block:: xml
 
-        <service id="acme.demo_bundle.loader.some_twig_loader" class="Acme\DemoBundle\Loader\SomeTwigLoader">
-            <tag name="twig.loader" />
-        </service>
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <service
+                    id="acme.demo_bundle.loader.some_twig_loader"
+                    class="Acme\DemoBundle\Loader\SomeTwigLoader">
+
+                    <tag name="twig.loader" />
+                </service>
+            </services>
+        </container>
 
     .. code-block:: php
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

Make configuration examples in the reference section consistent throughout the different configuration formats. Also fixing several syntax issues.

This follow #4114 and #4129.
