### PR TITLE
use a global Composer installation

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -447,7 +447,7 @@ into a vendor/ directory:
 
 .. code-block:: bash
 
-    $ php composer.phar install
+    $ composer install
 
 Beside downloading your dependencies, Composer generates a ``vendor/autoload.php`` file,
 which takes care of autoloading for all the files in the Symfony Framework as well as

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -117,16 +117,7 @@ don't have installed it globally, start by reading the next section.
 Installing Composer Globally
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-On Linux and Mac OS X, execute the following two commands to install Composer
-globally:
-
-.. code-block:: bash
-
-    $ curl -sS https://getcomposer.org/installer | php
-    $ sudo mv composer.phar /usr/local/bin/composer
-
-On Windows Systems, download the executable Composer installer that you can find
-on the `Composer download page`_ and follow the steps.
+Start with :doc:`installing Composer globally </cookbook/composer>`.
 
 Creating a Symfony Application with Composer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/book/performance.rst
+++ b/book/performance.rst
@@ -60,7 +60,7 @@ command line, and might become part of your deploy process:
 
 .. code-block:: bash
 
-    $ php composer.phar dump-autoload --optimize
+    $ composer dump-autoload --optimize
 
 Internally, this builds the big class map array in ``vendor/composer/autoload_classmap.php``.
 
@@ -128,8 +128,7 @@ Note that there are two disadvantages when using a bootstrap file:
 * when debugging, one will need to place break points inside the bootstrap file.
 
 If you're using the Symfony Standard Edition, the bootstrap file is automatically
-rebuilt after updating the vendor libraries via the ``php composer.phar install``
-command.
+rebuilt after updating the vendor libraries via the ``composer install`` command.
 
 Bootstrap Files and Byte Code Caches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/components/dependency_injection/lazy_services.rst
+++ b/components/dependency_injection/lazy_services.rst
@@ -30,7 +30,7 @@ the `ProxyManager bridge`_:
 
 .. code-block:: bash
 
-    $ php composer.phar require symfony/proxy-manager-bridge:~2.3
+    $ composer require symfony/proxy-manager-bridge:~2.3
 
 .. note::
 

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -85,13 +85,13 @@ code::
       the server.
 
     For example, consider that your development machines ship ICU 4.8 and the server
-    ICU 4.2. When you run ``php composer.phar update`` on the development machine, version
+    ICU 4.2. When you run ``composer update`` on the development machine, version
     1.2.* of the Icu component will be installed. But after deploying the
-    application, ``php composer.phar install`` will fail with the following error:
+    application, ``composer install`` will fail with the following error:
 
     .. code-block:: bash
 
-        $ php composer.phar install
+        $ composer install
         Loading composer repositories with package information
         Installing dependencies from lock file
         Your requirements could not be resolved to an installable set of packages.
@@ -104,8 +104,8 @@ code::
     The error tells you that the requested version of the Icu component, version
     1.2, is not compatible with PHP's ICU version 4.2.
 
-    One solution to this problem is to run ``php composer.phar update`` instead of
-    ``php composer.phar install``. It is highly recommended **not** to do this. The
+    One solution to this problem is to run ``composer update`` instead of
+    ``composer install``. It is highly recommended **not** to do this. The
     ``update`` command will install the latest versions of each Composer dependency
     to your production server and potentially break the application.
 
@@ -130,7 +130,7 @@ code::
     * "1.0.*" if the server does not have the intl extension installed;
     * "1.1.*" if the server is compiled with ICU 4.2 or lower.
 
-    Finally, run ``php composer.phar update symfony/icu`` on your development machine, test
+    Finally, run ``composer update symfony/icu`` on your development machine, test
     extensively and deploy again. The installation of the dependencies will now
     succeed.
 

--- a/components/using_components.rst
+++ b/components/using_components.rst
@@ -31,16 +31,16 @@ whatever component you want.
 
 .. tip::
 
-    If you get a command not found for ``composer``, you'll need to
-    `Install composer`_. Depending on how you install, you may end up with
-    a ``composer.phar`` file in your directory. In that case, no worries!
-    Just run ``php composer.phar require symfony/finder``.
+    `Install composer`_ if you don't have it already present on your system.
+    Depending on how you install, you may end up with a ``composer.phar``
+    file in your directory. In that case, no worries! Just run
+    ``php composer.phar require symfony/finder``.
 
 If you know you need a specific version of the library, add that to the command:
 
 .. code-block:: bash
 
-    $ composer require symfony/finder:~2.3
+    $ composer require symfony/finder
 
 **3.** Write your code!
 

--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -28,42 +28,24 @@ The test suite needs the following third-party libraries:
 
 To install them all, use `Composer`_:
 
-Step 1: Get `Composer`_
+Step 1: :doc:`Install Composer globally </cookbook/composer>`
+
+Step 2: Install vendors.
 
 .. code-block:: bash
 
-    $ curl -s http://getcomposer.org/installer | php
-
-Make sure you download ``composer.phar`` in the same folder where
-the ``composer.json`` file is located.
-
-Step 2: Install vendors
-
-.. code-block:: bash
-
-    $ php composer.phar install
+    $ composer install
 
 .. note::
 
     Note that the script takes some time to finish.
-
-.. note::
-
-    If you don't have ``curl`` installed, you can also just download the ``installer``
-    file manually at http://getcomposer.org/installer. Place this file into your
-    project and then run:
-
-    .. code-block:: bash
-
-        $ php installer
-        $ php composer.phar install
 
 After installation, you can update the vendors to their latest version with
 the follow command:
 
 .. code-block:: bash
 
-    $ php composer.phar update
+    $ composer --dev update
 
 Running
 -------

--- a/cookbook/bundles/installation.rst
+++ b/cookbook/bundles/installation.rst
@@ -36,7 +36,7 @@ Now that you know the package name, you can install it via Composer:
 
 .. code-block:: bash
 
-    $ php composer.phar require friendsofsymfony/user-bundle
+    $ composer require friendsofsymfony/user-bundle
 
 This will choose the best version for your project, add it to ``composer.json``
 and download the library into the ``vendor/`` directory. If you need a specific

--- a/cookbook/composer.rst
+++ b/cookbook/composer.rst
@@ -1,0 +1,44 @@
+.. index::
+    double: Composer; Installation
+
+Installing Composer
+===================
+
+`Composer`_ is the package manager used by modern PHP applications and the
+recommended way to install Symfony2.
+
+Install Composer on Linux and Mac OS X
+--------------------------------------
+
+To install Composer on Linux or Mac OS X, execute the following two commands:
+
+.. code-block:: bash
+
+    $ curl -sS https://getcomposer.org/installer | php
+    $ sudo mv composer.phar /usr/local/bin/composer
+
+-.. note::
+
+    If you don't have ``curl`` installed, you can also just download the
+    ``installer`` file manually at http://getcomposer.org/installer and
+    then run:
+
+    .. code-block:: bash
+
+        $ php installer
+        $ sudo mv composer.phar /usr/local/bin/composer
+
+Install Composer on Windows
+---------------------------
+
+Download the installer from `getcomposer.org/download`_, execute it and follow
+the instructions.
+
+Learn more
+----------
+
+You can read more about Composer in `its documentation`_.
+
+.. _`Composer`: https://getcomposer.org/
+.. _`getcomposer.org/download`: https://getcomposer.org/download
+.. _`its documentation`: https://getcomposer.org/doc/00-intro.md

--- a/cookbook/deployment/tools.rst
+++ b/cookbook/deployment/tools.rst
@@ -101,7 +101,7 @@ as you normally do:
 
 .. code-block:: bash
 
-    $ php composer.phar install --no-dev --optimize-autoloader
+    $ composer install --no-dev --optimize-autoloader
 
 .. tip::
 
@@ -142,7 +142,7 @@ setup:
 
 * Running any database migrations
 * Clearing your APC cache
-* Running ``assets:install`` (taken care of already in ``composer.phar install``)
+* Running ``assets:install`` (already taken care of in ``composer install``)
 * Add/edit CRON jobs
 * Pushing assets to a CDN
 * ...

--- a/cookbook/index.rst
+++ b/cookbook/index.rst
@@ -7,6 +7,7 @@ The Cookbook
     assetic/index
     bundles/index
     cache/index
+    composer
     configuration/index
     console/index
     controller/index

--- a/cookbook/map.rst.inc
+++ b/cookbook/map.rst.inc
@@ -21,6 +21,10 @@
 
   * :doc:`/cookbook/cache/varnish`
 
+* **Composer**
+
+  * :doc:`/cookbook/composer`
+
 * :doc:`/cookbook/configuration/index`
 
   * :doc:`/cookbook/configuration/environments`

--- a/cookbook/symfony1.rst
+++ b/cookbook/symfony1.rst
@@ -165,7 +165,7 @@ defined in the ``composer.json`` file.
 If you look at the ``HelloController`` from the Symfony2 Standard Edition you
 can see that it lives in the ``Acme\DemoBundle\Controller`` namespace. Yet, the
 AcmeDemoBundle is not defined in your ``composer.json`` file. Nonetheless are
-the files autoloaded. This is because you can tell composer to autoload files
+the files autoloaded. This is because you can tell Composer to autoload files
 from specific directories without defining a dependency:
 
 .. code-block:: json

--- a/cookbook/workflow/_vendor_deps.rst.inc
+++ b/cookbook/workflow/_vendor_deps.rst.inc
@@ -9,18 +9,18 @@ way or another the goal is to download these files into your ``vendor/``
 directory and, ideally, to give you some sane way to manage the exact version
 you need for each.
 
-By default, these libraries are downloaded by running a ``php composer.phar install``
-"downloader" binary. This ``composer.phar`` file is from a library called
-`Composer`_ and you can read more about installing it in the :ref:`Installation <installation-updating-vendors>`
+By default, these libraries are downloaded by running a ``composer install``
+"downloader" binary. This ``composer`` file is from a library called `Composer`_
+and you can read more about installing it in the :ref:`Installation <installation-updating-vendors>`
 chapter.
 
-The ``composer.phar`` file reads from the ``composer.json`` file at the root
+The ``composer`` command reads from the ``composer.json`` file at the root
 of your project. This is an JSON-formatted file, which holds a list of each
 of the external packages you need, the version to be downloaded and more.
-The ``composer.phar`` file also reads from a ``composer.lock`` file, which
-allows you to pin each library to an **exact** version. In fact, if a ``composer.lock``
+``composer`` also reads from a ``composer.lock`` file, which allows you to
+pin each library to an **exact** version. In fact, if a ``composer.lock``
 file exists, the versions inside will override those in ``composer.json``.
-To upgrade your libraries to new versions, run ``php composer.phar update``.
+To upgrade your libraries to new versions, run ``composer update``.
 
 .. tip::
 
@@ -29,7 +29,7 @@ To upgrade your libraries to new versions, run ``php composer.phar update``.
 
     .. code-block:: bash
 
-        $ php composer.phar require doctrine/doctrine-fixtures-bundle
+        $ composer require doctrine/doctrine-fixtures-bundle
 
 To learn more about Composer, see `GetComposer.org`_:
 
@@ -37,12 +37,12 @@ It's important to realize that these vendor libraries are *not* actually part
 of *your* repository. Instead, they're simply un-tracked files that are downloaded
 into the ``vendor/``. But since all the information needed to download these
 files is saved in ``composer.json`` and ``composer.lock`` (which *are* stored
-in the repository), any other developer can use the project, run ``php composer.phar install``,
+in the repository), any other developer can use the project, run ``composer install``,
 and download the exact same set of vendor libraries. This means that you're
 controlling exactly what each vendor library looks like, without needing to
 actually commit them to *your* repository.
 
-So, whenever a developer uses your project, they should run the ``php composer.phar install``
+So, whenever a developer uses your project, they should run the ``composer install``
 script to ensure that all of the needed vendor libraries are downloaded.
 
 .. sidebar:: Upgrading Symfony


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #4170 |

This pull request replaces all mentions of local Composer installations, but uses a gobal Composer installation instead.

**Note:** This should be considered on hold and not be merged until we have an agreement on this in #4170.
