### PR TITLE
WSSE Auth: Timing safe comparison

### DIFF
--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -278,6 +278,14 @@ the ``PasswordDigest`` header value matches with the user's password.
     provider for the given token. In the case of multiple providers, the
     authentication manager will then move to the next provider in the list.
 
+.. note::
+
+    The comparsion of the expected and the provided digests uses a constant
+    time comparison provided by the
+    :method:`Symfony\\Component\\Security\\Core\\Util\\StringUtils::equals`
+    method of the ``StringUtils`` class. It is used to mitigate possible
+    `timing attacks`_.
+
 The Factory
 -----------
 
@@ -605,3 +613,4 @@ in the factory and consumed or passed to the other classes in the container.
 
 .. _`WSSE`: http://www.xml.com/pub/a/2003/12/17/dive.html
 .. _`nonce`: http://en.wikipedia.org/wiki/Cryptographic_nonce
+.. _`timing attacks`: http://en.wikipedia.org/wiki/Timing_attack

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -201,6 +201,7 @@ the ``PasswordDigest`` header value matches with the user's password.
     use Symfony\Component\Security\Core\Exception\AuthenticationException;
     use Symfony\Component\Security\Core\Exception\NonceExpiredException;
     use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+    use Symfony\Component\Security\Core\Util\StringUtils;
     use Acme\DemoBundle\Security\Authentication\Token\WsseUserToken;
 
     class WsseProvider implements AuthenticationProviderInterface
@@ -260,7 +261,7 @@ the ``PasswordDigest`` header value matches with the user's password.
             // Validate Secret
             $expected = base64_encode(sha1(base64_decode($nonce).$created.$secret, true));
 
-            return $digest === $expected;
+            return StringUtils::equals($expected, $digest);
         }
 
         public function supports(TokenInterface $token)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | n/a |

I believe we should be providing examples that use timing safe operations when comparing password hashes, or any other kind of sensitive comparison that could leak timing information.
