### PR TITLE
[Components][Form] Fixed typo in datetime type reference

### DIFF
--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -75,7 +75,7 @@ format
 **type**: ``string`` **default**: ``Symfony\Component\Form\Extension\Core\Type\DateTimeType::HTML5_FORMAT``
 
 If the ``widget`` option is set to ``single_text``, this option specifies
- the format of the input, i.e. how Symfony will interpret the given input
+the format of the input, i.e. how Symfony will interpret the given input
 as a datetime string. It defaults to the `RFC 3339`_ format which is used
 by the HTML5 ``datetime`` field. Keeping the default value will cause the
 field to be rendered as an ``input`` field with ``type="datetime"``.

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -74,8 +74,8 @@ format
 
 **type**: ``string`` **default**: ``Symfony\Component\Form\Extension\Core\Type\DateTimeType::HTML5_FORMAT``
 
-If the ``widget`` option is set to ``single_text``, this option specifies the
-the format of the input, i.e. how Symfony will interpret the given input
+If the ``widget`` option is set to ``single_text``, this option specifies
+ the format of the input, i.e. how Symfony will interpret the given input
 as a datetime string. It defaults to the `RFC 3339`_ format which is used
 by the HTML5 ``datetime`` field. Keeping the default value will cause the
 field to be rendered as an ``input`` field with ``type="datetime"``.


### PR DESCRIPTION
Fixed "the the" typo.
