### PR TITLE
Update home of DoctrineExtensions.

### DIFF
--- a/cookbook/doctrine/common_extensions.rst
+++ b/cookbook/doctrine/common_extensions.rst
@@ -22,12 +22,12 @@ To do this, you have two options:
 #. Implement this services directly by following the documentation for integration
    with Symfony2: `Install Gedmo Doctrine2 extensions in Symfony2`_
 
-.. _`DoctrineExtensions`: https://github.com/l3pp4rd/DoctrineExtensions
+.. _`DoctrineExtensions`: https://github.com/Atlantic18/DoctrineExtensions
 .. _`StofDoctrineExtensionsBundle`: https://github.com/stof/StofDoctrineExtensionsBundle
-.. _`Sluggable`: https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/sluggable.md
-.. _`Translatable`: https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/translatable.md
-.. _`Timestampable`: https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/timestampable.md
-.. _`Loggable`: https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/loggable.md
-.. _`Tree`: https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/tree.md
-.. _`Sortable`: https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/sortable.md
-.. _`Install Gedmo Doctrine2 extensions in Symfony2`: https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/symfony2.md
+.. _`Sluggable`: https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/sluggable.md
+.. _`Translatable`: https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/translatable.md
+.. _`Timestampable`: https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/timestampable.md
+.. _`Loggable`: https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/loggable.md
+.. _`Tree`: https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/tree.md
+.. _`Sortable`: https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/sortable.md
+.. _`Install Gedmo Doctrine2 extensions in Symfony2`: https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/symfony2.md


### PR DESCRIPTION
As you can read in the 2014-03-20 DoctrineExtensions update: https://github.com/Atlantic18/DoctrineExtensions/blob/master/README.md#latest-updates

> DoctrineExtensions has new home on github under an unbrella of ORM designer organization.
