### PR TITLE
Updated documentation regarding the SecurityContext split

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -438,7 +438,7 @@ Next, create the controller that will display the login form::
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
-    use Symfony\Component\Security\Core\SecurityContextInterface;
+    use Symfony\Component\Security\Core\Security;
 
     class SecurityController extends Controller
     {
@@ -447,19 +447,19 @@ Next, create the controller that will display the login form::
             $session = $request->getSession();
 
             // get the login error if there is one
-            if ($request->attributes->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
+            if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
                 $error = $request->attributes->get(
-                    SecurityContextInterface::AUTHENTICATION_ERROR
+                    Security::AUTHENTICATION_ERROR
                 );
-            } elseif (null !== $session && $session->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
-                $error = $session->get(SecurityContextInterface::AUTHENTICATION_ERROR);
-                $session->remove(SecurityContextInterface::AUTHENTICATION_ERROR);
+            } elseif (null !== $session && $session->has(Security::AUTHENTICATION_ERROR)) {
+                $error = $session->get(Security::AUTHENTICATION_ERROR);
+                $session->remove(Security::AUTHENTICATION_ERROR);
             } else {
                 $error = '';
             }
 
             // last username entered by the user
-            $lastUsername = (null === $session) ? '' : $session->get(SecurityContextInterface::LAST_USERNAME);
+            $lastUsername = (null === $session) ? '' : $session->get(Security::LAST_USERNAME);
 
             return $this->render(
                 'AcmeSecurityBundle:Security:login.html.twig',
@@ -713,7 +713,7 @@ see :doc:`/cookbook/security/form_login`.
     ``/login_check`` doesn't match any firewall, you'll receive a ``Unable
     to find the controller for path "/login_check"`` exception.
 
-    **4. Multiple firewalls don't share security context**
+    **4. Multiple firewalls don't share the same security context**
 
     If you're using multiple firewalls and you authenticate against one firewall,
     you will *not* be authenticated against any other firewalls automatically.
@@ -1174,7 +1174,7 @@ authorization from inside a controller::
 
     public function helloAction($name)
     {
-        if (false === $this->get('security.context')->isGranted('ROLE_ADMIN')) {
+        if (false === $this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
             throw $this->createAccessDeniedException('Unable to access this page!');
         }
 
@@ -1185,6 +1185,10 @@ authorization from inside a controller::
 
 .. versionadded:: 2.5
     The ``createAccessDeniedException`` method was introduced in Symfony 2.5.
+
+.. versionadded:: 2.6
+     The ``security.authorization_checker`` service was introduced in Symfony 2.6. Prior
+     to Symfony 2.6, you had to use the ``isGranted()`` method of the ``security.context`` service.
 
 The :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::createAccessDeniedException`
 method creates a special :class:`Symfony\\Component\\Security\\Core\\Exception\\AccessDeniedException`
@@ -1618,13 +1622,17 @@ Retrieving the User Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After authentication, the ``User`` object of the current user can be accessed
-via the ``security.context`` service. From inside a controller, this will
+via the ``security.token_storage`` service. From inside a controller, this will
 look like::
 
     public function indexAction()
     {
-        $user = $this->get('security.context')->getToken()->getUser();
+        $user = $this->get('security.token_storage')->getToken()->getUser();
     }
+
+.. versionadded:: 2.6
+    The ``security.token_storage`` service was introduced in Symfony 2.6. Prior
+    to Symfony 2.6, you had to use the ``getToken()`` method of the ``security.context`` service.
 
 In a controller this can be shortcut to:
 
@@ -1895,12 +1903,16 @@ authorization from inside a controller::
 
     public function helloAction($name)
     {
-        if (false === $this->get('security.context')->isGranted('ROLE_ADMIN')) {
+        if (false === $this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
             throw new AccessDeniedException();
         }
 
         // ...
     }
+
+.. versionadded:: 2.6
+     The ``security.authorization_checker`` service was introduced in Symfony 2.6. Prior
+     to Symfony 2.6, you had to use the ``isGranted()`` method of the ``security.context`` service.
 
 .. caution::
 
@@ -1925,7 +1937,7 @@ accepts an :class:`Symfony\\Component\\ExpressionLanguage\\Expression` object::
 
     public function indexAction()
     {
-        if (!$this->get('security.context')->isGranted(new Expression(
+        if (!$this->get('security.authorization_checker')->isGranted(new Expression(
             '"ROLE_ADMIN" in roles or (user and user.isSuperAdmin())'
         ))) {
             throw new AccessDeniedException();
@@ -1933,6 +1945,10 @@ accepts an :class:`Symfony\\Component\\ExpressionLanguage\\Expression` object::
 
         // ...
     }
+
+.. versionadded:: 2.6
+    The ``security.authorization_checker`` service was introduced in Symfony 2.6. Prior
+    to Symfony 2.6, you had to use the ``isGranted()`` method of the ``security.context`` service.
 
 In this example, if the current user has ``ROLE_ADMIN`` or if the current
 user object's ``isSuperAdmin()`` method returns ``true``, then access will
@@ -1979,10 +1995,10 @@ Additionally, you have access to a number of functions inside the expression:
         use Symfony\Component\ExpressionLanguage\Expression;
         // ...
 
-        $sc = $this->get('security.context');
-        $access1 = $sc->isGranted('IS_AUTHENTICATED_REMEMBERED');
+        $authorizationChecker = $this->get('security.authorization_checker');
+        $access1 = $authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED');
 
-        $access2 = $sc->isGranted(new Expression(
+        $access2 = $authorizationChecker->isGranted(new Expression(
             'is_remember_me() or is_fully_authenticated()'
         ));
 

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1168,6 +1168,12 @@ automatically:
             <p>Application Environment: <?php echo $app->getEnvironment() ?></p>
         <?php endif ?>
 
+.. versionadded:: 2.6
+    The global ``app.security`` variable (or the ``$app->getSecurity()``
+    method in PHP templates) is deprecated as of Symfony 2.6. Use `app.user` 
+    (`$app->getUser()`) and `is_granted()` (`$view['security']->isGranted()`)
+    instead.
+
 .. tip::
 
     You can add your own global template variables. See the cookbook example

--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -4,16 +4,22 @@
 Authentication
 ==============
 
+.. versionadded:: 2.6
+    The ``TokenStorageInterface`` was introduced in Symfony 2.6. Prior, you
+    had to use the ``getToken()`` method of the
+    :class:`Symfony\\Component\\Security\\Core\\SecurityContextInterface`.
+
 When a request points to a secured area, and one of the listeners from the
 firewall map is able to extract the user's credentials from the current
 :class:`Symfony\\Component\\HttpFoundation\\Request` object, it should create
 a token, containing these credentials. The next thing the listener should
 do is ask the authentication manager to validate the given token, and return
 an *authenticated* token if the supplied credentials were found to be valid.
-The listener should then store the authenticated token in the security context::
+The listener should then store the authenticated token using 
+:class:`the token storage <Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface>`::
 
     use Symfony\Component\Security\Http\Firewall\ListenerInterface;
-    use Symfony\Component\Security\Core\SecurityContextInterface;
+    use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
     use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
     use Symfony\Component\HttpKernel\Event\GetResponseEvent;
     use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -21,9 +27,9 @@ The listener should then store the authenticated token in the security context::
     class SomeAuthenticationListener implements ListenerInterface
     {
         /**
-         * @var SecurityContextInterface
+         * @var TokenStorageInterface
          */
-        private $securityContext;
+        private $tokenStorage;
 
         /**
          * @var AuthenticationManagerInterface
@@ -54,7 +60,7 @@ The listener should then store the authenticated token in the security context::
                 ->authenticationManager
                 ->authenticate($unauthenticatedToken);
 
-            $this->securityContext->setToken($authenticatedToken);
+            $this->tokenStorage->setToken($authenticatedToken);
         }
     }
 

--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -7,8 +7,8 @@ Authorization
 When any of the authentication providers (see :ref:`authentication_providers`)
 has verified the still-unauthenticated token, an authenticated token will
 be returned. The authentication listener should set this token directly
-in the :class:`Symfony\\Component\\Security\\Core\\SecurityContextInterface`
-using its :method:`Symfony\\Component\\Security\\Core\\SecurityContextInterface::setToken`
+in the :class:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface`
+using its :method:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface::setToken`
 method.
 
 From then on, the user is authenticated, i.e. identified. Now, other parts
@@ -28,6 +28,11 @@ An authorization decision will always be based on a few things:
 * An object (optional)
     Any object for which access control needs to be checked, like
     an article or a comment object.
+
+.. versionadded:: 2.6
+    The ``TokenStorageInterface`` was introduced in Symfony 2.6. Prior, you
+    had to use the ``setToken()`` method of the
+    :class:`Symfony\\Component\\Security\\Core\\SecurityContextInterface`.
 
 .. _components-security-access-decision-manager:
 
@@ -227,23 +232,24 @@ are required for the current user to get access to the application::
         $authenticationManager
     );
 
-Security Context
-~~~~~~~~~~~~~~~~
+Authorization Checker
+~~~~~~~~~~~~~~~~~~~~~
 
 The access decision manager is also available to other parts of the application
-via the :method:`Symfony\\Component\\Security\\Core\\SecurityContext::isGranted`
-method of the :class:`Symfony\\Component\\Security\\Core\\SecurityContext`.
+via the :method:`Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationChecker::isGranted`
+method of the :class:`Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationChecker`.
 A call to this method will directly delegate the question to the access
 decision manager::
 
-    use Symfony\Component\Security\SecurityContext;
+    use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
     use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
-    $securityContext = new SecurityContext(
+    $authorizationChecker = new AuthorizationChecker(
+        $tokenStorage,
         $authenticationManager,
         $accessDecisionManager
     );
 
-    if (!$securityContext->isGranted('ROLE_ADMIN')) {
+    if (!$authorizationChecker->isGranted('ROLE_ADMIN')) {
         throw new AccessDeniedException();
     }

--- a/components/security/firewall.rst
+++ b/components/security/firewall.rst
@@ -30,6 +30,11 @@ certain action or resource of the application::
         throw new AccessDeniedException();
     }
 
+.. versionadded:: 2.6
+    As of Symfony 2.6, the :class:`Symfony\\Component\\Security\\Core\\SecurityContext` class was split 
+    in the :class:`Symfony\\Component\\Security\\Core\\Authentication\\Authorization\\AuthorizationChecker` and 
+    :class:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorage` classes.
+
 .. note::
 
     Read the dedicated sections to learn more about :doc:`/components/security/authentication`
@@ -115,7 +120,7 @@ which will eventually result in an "HTTP/1.1 403: Access Denied" response.
 Entry Points
 ~~~~~~~~~~~~
 
-When the user is not authenticated at all (i.e. when the security context
+When the user is not authenticated at all (i.e. when the token storage
 has no token yet), the firewall's entry point will be called to "start"
 the authentication process. An entry point should implement
 :class:`Symfony\\Component\\Security\\Http\\EntryPoint\\AuthenticationEntryPointInterface`,

--- a/cookbook/profiler/matchers.rst
+++ b/cookbook/profiler/matchers.rst
@@ -70,24 +70,29 @@ something like::
     // src/Acme/DemoBundle/Profiler/SuperAdminMatcher.php
     namespace Acme\DemoBundle\Profiler;
 
-    use Symfony\Component\Security\Core\SecurityContext;
+    use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 
     class SuperAdminMatcher implements RequestMatcherInterface
     {
-        protected $securityContext;
+        protected $authorizationChecker;
 
-        public function __construct(SecurityContext $securityContext)
+        public function __construct(AuthorizationCheckerInterface $authorizationChecker)
         {
-            $this->securityContext = $securityContext;
+            $this->authorizationChecker = $authorizationChecker;
         }
 
         public function matches(Request $request)
         {
-            return $this->securityContext->isGranted('ROLE_SUPER_ADMIN');
+            return $this->authorizationChecker->isGranted('ROLE_SUPER_ADMIN');
         }
     }
+
+.. versionadded:: 2.6
+    The :class:`Symfony\\Component\\Security\\Core\\Authentication\\Authorization\\AuthorizationCheckerInterface` was
+    introduced in Symfony 2.6. Prior, you had to use the ``isGranted`` method of
+    :class:`Symfony\\Component\\Security\\Core\\SecurityContextInterface`.
 
 Then, you need to configure the service:
 
@@ -101,7 +106,7 @@ Then, you need to configure the service:
         services:
             acme_demo.profiler.matcher.super_admin:
                 class: "%acme_demo.profiler.matcher.super_admin.class%"
-                arguments: ["@security.context"]
+                arguments: ["@security.authorization_checker"]
 
     .. code-block:: xml
 
@@ -114,7 +119,7 @@ Then, you need to configure the service:
         <services>
             <service id="acme_demo.profiler.matcher.super_admin"
                 class="%acme_demo.profiler.matcher.super_admin.class%">
-                <argument type="service" id="security.context" />
+                <argument type="service" id="security.authorization_checker" />
         </services>
 
     .. code-block:: php
@@ -129,8 +134,12 @@ Then, you need to configure the service:
 
         $container->setDefinition('acme_demo.profiler.matcher.super_admin', new Definition(
             '%acme_demo.profiler.matcher.super_admin.class%',
-            array(new Reference('security.context'))
+            array(new Reference('security.authorization_checker'))
         );
+
+.. versionadded:: 2.6
+    The ``security.authorization_checker`` service was introduced in Symfony 2.6. Prior
+    to Symfony 2.6, you had to use the ``isGranted()`` method of the ``security.context`` service.
 
 Now the service is registered, the only thing left to do is configure the
 profiler to use this service as the matcher:

--- a/cookbook/security/acl.rst
+++ b/cookbook/security/acl.rst
@@ -129,8 +129,8 @@ Creating an ACL and Adding an ACE
                 $acl = $aclProvider->createAcl($objectIdentity);
 
                 // retrieving the security identity of the currently logged-in user
-                $securityContext = $this->get('security.context');
-                $user = $securityContext->getToken()->getUser();
+                $tokenStorage = $this->get('security.token_storage');
+                $user = $tokenStorage->getToken()->getUser();
                 $securityIdentity = UserSecurityIdentity::fromAccount($user);
 
                 // grant owner access
@@ -177,10 +177,10 @@ Checking Access
 
         public function editCommentAction(Comment $comment)
         {
-            $securityContext = $this->get('security.context');
+            $authorizationChecker = $this->get('security.authorization_checker');
 
             // check for edit access
-            if (false === $securityContext->isGranted('EDIT', $comment)) {
+            if (false === $authorizationChecker->isGranted('EDIT', $comment)) {
                 throw new AccessDeniedException();
             }
 

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -96,13 +96,13 @@ provider.
 The Listener
 ------------
 
-Next, you need a listener to listen on the security context. The listener
+Next, you need a listener to listen on the firewall. The listener
 is responsible for fielding requests to the firewall and calling the authentication
 provider. A listener must be an instance of
 :class:`Symfony\\Component\\Security\\Http\\Firewall\\ListenerInterface`.
 A security listener should handle the
 :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent` event, and
-set an authenticated token in the security context if successful.
+set an authenticated token in the token storage if successful.
 
 .. code-block:: php
 
@@ -111,20 +111,20 @@ set an authenticated token in the security context if successful.
 
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-    use Symfony\Component\Security\Http\Firewall\ListenerInterface;
-    use Symfony\Component\Security\Core\Exception\AuthenticationException;
-    use Symfony\Component\Security\Core\SecurityContextInterface;
     use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+    use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+    use Symfony\Component\Security\Core\Exception\AuthenticationException;
+    use Symfony\Component\Security\Http\Firewall\ListenerInterface;
     use Acme\DemoBundle\Security\Authentication\Token\WsseUserToken;
 
     class WsseListener implements ListenerInterface
     {
-        protected $securityContext;
+        protected $tokenStorage;
         protected $authenticationManager;
 
-        public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager)
+        public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager)
         {
-            $this->securityContext = $securityContext;
+            $this->tokenStorage = $tokenStorage;
             $this->authenticationManager = $authenticationManager;
         }
 
@@ -146,7 +146,7 @@ set an authenticated token in the security context if successful.
 
             try {
                 $authToken = $this->authenticationManager->authenticate($token);
-                $this->securityContext->setToken($authToken);
+                $this->tokenStorage->setToken($authToken);
 
                 return;
             } catch (AuthenticationException $failed) {
@@ -154,9 +154,9 @@ set an authenticated token in the security context if successful.
 
                 // To deny the authentication clear the token. This will redirect to the login page.
                 // Make sure to only clear your token, not those of other authentication listeners.
-                // $token = $this->securityContext->getToken();
+                // $token = $this->tokenStorage->getToken();
                 // if ($token instanceof WsseUserToken && $this->providerKey === $token->getProviderKey()) {
-                //     $this->securityContext->setToken(null);
+                //     $this->tokenStorage->setToken(null);
                 // }
                 // return;
             }
@@ -399,7 +399,7 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
 
             wsse.security.authentication.listener:
                 class: Acme\DemoBundle\Security\Firewall\WsseListener
-                arguments: ["@security.context", "@security.authentication.manager"]
+                arguments: ["@security.token_storage", "@security.authentication.manager"]
 
     .. code-block:: xml
 
@@ -417,7 +417,7 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
 
                 <service id="wsse.security.authentication.listener"
                     class="Acme\DemoBundle\Security\Firewall\WsseListener" public="false">
-                    <argument type="service" id="security.context"/>
+                    <argument type="service" id="security.token_storage"/>
                     <argument type="service" id="security.authentication.manager" />
                 </service>
             </services>
@@ -441,7 +441,7 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
         $container->setDefinition('wsse.security.authentication.listener',
             new Definition(
                 'Acme\DemoBundle\Security\Firewall\WsseListener', array(
-                    new Reference('security.context'),
+                    new Reference('security.token_storage'),
                     new Reference('security.authentication.manager'),
                 )
             )

--- a/cookbook/security/remember_me.rst
+++ b/cookbook/security/remember_me.rst
@@ -162,7 +162,7 @@ In the following example, the action is only allowed if the user has the
 
     public function editAction()
     {
-        if (false === $this->get('security.context')->isGranted(
+        if (false === $this->get('security.authorization_checker')->isGranted(
             'IS_AUTHENTICATED_FULLY'
            )) {
             throw new AccessDeniedException();
@@ -170,6 +170,10 @@ In the following example, the action is only allowed if the user has the
 
         // ...
     }
+
+.. versionadded:: 2.6
+    The ``security.authorization_checker`` service was introduced in Symfony 2.6. Prior
+    to Symfony 2.6, you had to use the ``isGranted()`` method of the ``security.context`` service.
 
 You can also choose to install and use the optional JMSSecurityExtraBundle_,
 which can secure your controller using annotations:

--- a/cookbook/security/securing_services.rst
+++ b/cookbook/security/securing_services.rst
@@ -6,7 +6,7 @@ How to Secure any Service or Method in your Application
 =======================================================
 
 In the security chapter, you can see how to :ref:`secure a controller <book-security-securing-controller>`
-by requesting the ``security.context`` service from the Service Container
+by requesting the ``security.authorization_checker`` service from the Service Container
 and checking the current user's role::
 
     // ...
@@ -14,14 +14,18 @@ and checking the current user's role::
 
     public function helloAction($name)
     {
-        if (false === $this->get('security.context')->isGranted('ROLE_ADMIN')) {
+        if (false === $this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
             throw new AccessDeniedException();
         }
 
         // ...
     }
 
-You can also secure *any* service in a similar way by injecting the ``security.context``
+.. versionadded:: 2.6
+    The ``security.authorization_checker`` service was introduced in Symfony 2.6. Prior
+    to Symfony 2.6, you had to use the ``isGranted()`` method of the ``security.context`` service.
+
+You can also secure *any* service in a similar way by injecting the ``security.authorization_checker``
 service into it. For a general introduction to injecting dependencies into
 services see the :doc:`/book/service_container` chapter of the book. For
 example, suppose you have a ``NewsletterManager`` class that sends out emails
@@ -45,23 +49,23 @@ role. Before you add security, the class looks something like this:
     }
 
 Your goal is to check the user's role when the ``sendNewsletter()`` method is
-called. The first step towards this is to inject the ``security.context``
+called. The first step towards this is to inject the ``security.authorization_checker``
 service into the object. Since it won't make sense *not* to perform the security
 check, this is an ideal candidate for constructor injection, which guarantees
-that the security context object will be available inside the ``NewsletterManager``
+that the authorization checker object will be available inside the ``NewsletterManager``
 class::
 
     namespace Acme\HelloBundle\Newsletter;
 
-    use Symfony\Component\Security\Core\SecurityContextInterface;
+    use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
     class NewsletterManager
     {
-        protected $securityContext;
+        protected $authorizationChecker;
 
-        public function __construct(SecurityContextInterface $securityContext)
+        public function __construct(AuthorizationCheckerInterface $authorizationChecker)
         {
-            $this->securityContext = $securityContext;
+            $this->authorizationChecker = $authorizationChecker;
         }
 
         // ...
@@ -80,7 +84,7 @@ Then in your service configuration, you can inject the service:
         services:
             newsletter_manager:
                 class:     "%newsletter_manager.class%"
-                arguments: ["@security.context"]
+                arguments: ["@security.authorization_checker"]
 
     .. code-block:: xml
 
@@ -91,7 +95,7 @@ Then in your service configuration, you can inject the service:
 
         <services>
             <service id="newsletter_manager" class="%newsletter_manager.class%">
-                <argument type="service" id="security.context"/>
+                <argument type="service" id="security.authorization_checker"/>
             </service>
         </services>
 
@@ -105,7 +109,7 @@ Then in your service configuration, you can inject the service:
 
         $container->setDefinition('newsletter_manager', new Definition(
             '%newsletter_manager.class%',
-            array(new Reference('security.context'))
+            array(new Reference('security.authorization_checker'))
         ));
 
 The injected service can then be used to perform the security check when the
@@ -113,22 +117,22 @@ The injected service can then be used to perform the security check when the
 
     namespace Acme\HelloBundle\Newsletter;
 
+    use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
     use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-    use Symfony\Component\Security\Core\SecurityContextInterface;
     // ...
 
     class NewsletterManager
     {
-        protected $securityContext;
+        protected $authorizationChecker;
 
-        public function __construct(SecurityContextInterface $securityContext)
+        public function __construct(AuthorizationCheckerInterface $authorizationChecker)
         {
-            $this->securityContext = $securityContext;
+            $this->authorizationChecker = $authorizationChecker;
         }
 
         public function sendNewsletter()
         {
-            if (false === $this->securityContext->isGranted('ROLE_NEWSLETTER_ADMIN')) {
+            if (false === $this->authorizationChecker->isGranted('ROLE_NEWSLETTER_ADMIN')) {
                 throw new AccessDeniedException();
             }
 
@@ -186,7 +190,7 @@ the :ref:`sidebar <securing-services-annotations-sidebar>` below):
 
         $definition = new Definition(
             '%newsletter_manager.class%',
-            array(new Reference('security.context'))
+            // ...
         ));
         $definition->addTag('security.secure_service');
         $container->setDefinition('newsletter_manager', $definition);

--- a/cookbook/security/voters_data_permission.rst
+++ b/cookbook/security/voters_data_permission.rst
@@ -25,8 +25,8 @@ How Symfony Uses Voters
 
 In order to use voters, you have to understand how Symfony works with them.
 All voters are called each time you use the ``isGranted()`` method on Symfony's
-security context (i.e. the ``security.context`` service). Each one decides
-if the current user should have access to some resource.
+authorization checker (i.e. the ``security.authorization_checker`` service). Each 
+one decides if the current user should have access to some resource.
 
 Ultimately, Symfony uses one of three different approaches on what to do
 with the feedback from all voters: affirmative, consensus and unanimous.
@@ -194,7 +194,7 @@ How to Use the Voter in a Controller
 ------------------------------------
 
 The registered voter will then always be asked as soon as the method ``isGranted()``
-from the security context is called.
+from the authorization checker is called.
 
 .. code-block:: php
 
@@ -213,12 +213,16 @@ from the security context is called.
             $post = ...;
 
             // keep in mind, this will call all registered security voters
-            if (false === $this->get('security.context')->isGranted('view', $post)) {
+            if (false === $this->get('security.authorization_checker')->isGranted('view', $post)) {
                 throw new AccessDeniedException('Unauthorised access!');
             }
 
             return new Response('<h1>'.$post->getName().'</h1>');
         }
     }
+
+.. versionadded:: 2.6
+    The ``security.authorization_checker`` service was introduced in Symfony 2.6. Prior
+    to Symfony 2.6, you had to use the ``isGranted()`` method of the ``security.context`` service.
 
 It's that easy!

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -933,7 +933,7 @@ security.voter
 
 **Purpose**: To add a custom voter to Symfony's authorization logic
 
-When you call ``isGranted`` on Symfony's security context, a system of "voters"
+When you call ``isGranted`` on Symfony's authorization checker, a system of "voters"
 is used behind the scenes to determine if the user should have access. The
 ``security.voter`` tag allows you to add your own custom voter to that system.
 

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -683,6 +683,10 @@ The available attributes are:
 * ``app.debug``
 * ``app.security``
 
+.. versionadded:: 2.6
+     The ``app.security`` global is deprecated as of 2.6. The user is already available
+     as ``app.user`` and ``is_granted()`` is registered as function.
+
 Symfony Standard Edition Extensions
 -----------------------------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | >=2.6 |
| Fixed tickets | https://github.com/symfony/symfony/pull/11690 |

This PR is to update the documentation regarding my PR on symfony/symfony. I require some feedback regarding:
- Code Examples, I did not change _all_ examples because the class using the `$securityContext` was not updated in my PR as it's Backwards Compatible
- The usage of "security context". The term is correct, but it might get really confusing for people who see that the security context is deprecated. However, this is only regarding the `SecurityContext`, `SecurityContextInterface` and `@security.context`.
- The above point is what confused me too so the docs might be out of context in certain spots, please review this thoroughly 
