### PR TITLE
Update built_in.rst

### DIFF
--- a/cookbook/web_server/built_in.rst
+++ b/cookbook/web_server/built_in.rst
@@ -55,10 +55,9 @@ script:
     
 .. note
 
-    Under most Linux distributions, you can prepend `$(pwd)` to your router path to make it relative to your current working directory
+    Under most Linux distributions, you can prepend `$(pwd)` 
+    to your router path to make it relative to your current working directory
     
-.. note
-
     Under Windows, you can prepend with the `%CD%` special environment variable
 
 If your application's document root differs from the standard directory layout,

--- a/cookbook/web_server/built_in.rst
+++ b/cookbook/web_server/built_in.rst
@@ -47,7 +47,7 @@ script:
 
 .. code-block:: bash
 
-    $ php app/console server:run --env=test --router=app/config/router_test.php
+    $ php app/console server:run --env=test --router=../app/config/router_test.php
 
 If your application's document root differs from the standard directory layout,
 you have to pass the correct location using the ``--docroot`` option:

--- a/cookbook/web_server/built_in.rst
+++ b/cookbook/web_server/built_in.rst
@@ -49,16 +49,16 @@ script:
 
     $ php app/console server:run --env=test --router=router_test.php
 
-.. caution
+.. caution::
 
-    the router path is relative to the application's document root 
+    The router path is relative to the application's document root 
     
-.. note
+.. note::
 
-    Under most Linux distributions, you can prepend `$(pwd)` 
-    to your router path to make it relative to your current working directory
+    Under most Linux distributions, you can prepend ``$(pwd)``
+    to your router path to make it relative to your current working directory.
     
-    Under Windows, you can prepend with the `%CD%` special environment variable
+    Under Windows, you can prepend with the ``%CD%`` special environment variable.
 
 If your application's document root differs from the standard directory layout,
 you have to pass the correct location using the ``--docroot`` option:

--- a/cookbook/web_server/built_in.rst
+++ b/cookbook/web_server/built_in.rst
@@ -49,7 +49,7 @@ script:
 
     $ php app/console server:run --env=test --router=router_test.php
 
-.. warning
+.. caution
 
     the router path is relative to the application's document root 
     

--- a/cookbook/web_server/built_in.rst
+++ b/cookbook/web_server/built_in.rst
@@ -47,7 +47,19 @@ script:
 
 .. code-block:: bash
 
-    $ php app/console server:run --env=test --router=../app/config/router_test.php
+    $ php app/console server:run --env=test --router=router_test.php
+
+.. warning
+
+    the router path is relative to the application's document root 
+    
+.. note
+
+    Under most Linux distributions, you can prepend `$(pwd)` to your router path to make it relative to your current working directory
+    
+.. note
+
+    Under Windows, you can prepend with the `%CD%` special environment variable
 
 If your application's document root differs from the standard directory layout,
 you have to pass the correct location using the ``--docroot`` option:


### PR DESCRIPTION
In the `\Symfony\Bundle\FrameworkBundle\Command\ServerRunCommand` one line reads : $builder->setWorkingDirectory($input->getOption('docroot'));
That does mean than relative paths would be interpreted from 'docroot' which is "web" in the standard distribution.
