### PR TITLE
fix name of the Yaml component

### DIFF
--- a/components/dependency_injection/introduction.rst
+++ b/components/dependency_injection/introduction.rst
@@ -209,7 +209,7 @@ Loading a YAML config file::
 .. note::
 
     If you want to load YAML config files then you will also need to install
-    :doc:`The YAML component </components/yaml/introduction>`.
+    :doc:`the Yaml component </components/yaml/introduction>`.
 
 If you *do* want to use PHP to create the services then you can move this
 into a separate config file and load it in a similar way::

--- a/components/yaml/introduction.rst
+++ b/components/yaml/introduction.rst
@@ -2,15 +2,15 @@
    single: Yaml
    single: Components; Yaml
 
-The YAML Component
+The Yaml Component
 ==================
 
-    The YAML Component loads and dumps YAML files.
+    The Yaml component loads and dumps YAML files.
 
 What is It?
 -----------
 
-The Symfony2 YAML Component parses YAML strings to convert them to PHP arrays.
+The Symfony2 Yaml component parses YAML strings to convert them to PHP arrays.
 It is also able to convert PHP arrays to YAML strings.
 
 `YAML`_, *YAML Ain't Markup Language*, is a human friendly data serialization
@@ -18,7 +18,7 @@ standard for all programming languages. YAML is a great format for your
 configuration files. YAML files are as expressive as XML files and as readable
 as INI files.
 
-The Symfony2 YAML Component implements the YAML 1.2 version of the
+The Symfony2 Yaml component implements the YAML 1.2 version of the
 specification.
 
 .. tip::
@@ -40,8 +40,9 @@ Why?
 Fast
 ~~~~
 
-One of the goal of Symfony YAML is to find the right balance between speed and
-features. It supports just the needed feature to handle configuration files.
+One of the goals of the Symfony Yaml component is to find the right balance
+between speed and features. It supports just the needed features to handle
+configuration files.
 
 Real Parser
 ~~~~~~~~~~~
@@ -75,10 +76,10 @@ Full Merge Key Support
 Full support for references, aliases, and full merge key. Don't repeat
 yourself by referencing common configuration bits.
 
-Using the Symfony2 YAML Component
+Using the Symfony2 Yaml Component
 ---------------------------------
 
-The Symfony2 YAML Component is very simple and consists of two main classes:
+The Symfony2 Yaml component is very simple and consists of two main classes:
 one parses YAML strings (:class:`Symfony\\Component\\Yaml\\Parser`), and the
 other dumps a PHP array to a YAML string
 (:class:`Symfony\\Component\\Yaml\\Dumper`).


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | related to #4189 |

The component name that is used in the code as well as in the issue tracker used by the symfony/symfony repository is Yaml (instead of YAML). Therefore, this should also be the name being used in the documentation.
