### PR TITLE
[Reference][Constraints] caution on `null` values in Expression constraint

### DIFF
--- a/reference/constraints/Expression.rst
+++ b/reference/constraints/Expression.rst
@@ -217,6 +217,13 @@ more about the expression language syntax, see
                 // ...
             }
 
+    .. caution::
+
+        In Symfony 2.4 and Symfony 2.5, if the property (e.g. ``isTechnicalPost``)
+        were ``null``, the expression would never be called and the value
+        would be seen as valid. To ensure that the value is not ``null``,
+        use the :doc:`NotNull constraint </reference/constraints/NotNull>`.
+
 For more information about the expression and what variables are available
 to you, see the :ref:`expression <reference-constraint-expression-option>`
 option details below.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4, 2.5 |
| Fixed tickets | part of #4191 |

This adds a warning to the reference of the Expression constraint explaining that `null` values won't be validated in Symfony 2.4 and Symfony 2.5.
