### PR TITLE
Added a note about the lacking features of Yaml Component

### DIFF
--- a/components/yaml/introduction.rst
+++ b/components/yaml/introduction.rst
@@ -2,15 +2,15 @@
    single: Yaml
    single: Components; Yaml
 
-The YAML Component
+The Yaml Component
 ==================
 
-    The YAML Component loads and dumps YAML files.
+    The Yaml Component loads and dumps YAML files.
 
 What is It?
 -----------
 
-The Symfony2 YAML Component parses YAML strings to convert them to PHP arrays.
+The Symfony2 Yaml Component parses YAML strings to convert them to PHP arrays.
 It is also able to convert PHP arrays to YAML strings.
 
 `YAML`_, *YAML Ain't Markup Language*, is a human friendly data serialization
@@ -18,8 +18,8 @@ standard for all programming languages. YAML is a great format for your
 configuration files. YAML files are as expressive as XML files and as readable
 as INI files.
 
-The Symfony2 YAML Component implements the YAML 1.2 version of the
-specification.
+The Symfony2 Yaml Component implements a selected subset of features defined in
+the `YAML 1.2 version specification`_.
 
 .. tip::
 
@@ -40,8 +40,10 @@ Why?
 Fast
 ~~~~
 
-One of the goal of Symfony YAML is to find the right balance between speed and
-features. It supports just the needed feature to handle configuration files.
+One of the goals of Symfony Yaml is to find the right balance between speed and
+features. It supports just the needed features to handle configuration files.
+Notable lacking features are: document directives, multi-line quoted messages,
+compact block collections and multi-document files.
 
 Real Parser
 ~~~~~~~~~~~
@@ -78,7 +80,7 @@ yourself by referencing common configuration bits.
 Using the Symfony2 YAML Component
 ---------------------------------
 
-The Symfony2 YAML Component is very simple and consists of two main classes:
+The Symfony2 Yaml Component is very simple and consists of two main classes:
 one parses YAML strings (:class:`Symfony\\Component\\Yaml\\Parser`), and the
 other dumps a PHP array to a YAML string
 (:class:`Symfony\\Component\\Yaml\\Dumper`).
@@ -163,7 +165,7 @@ array to its YAML representation:
 
 .. note::
 
-    Of course, the Symfony2 YAML dumper is not able to dump resources. Also,
+    Of course, the Symfony2 Yaml dumper is not able to dump resources. Also,
     even if the dumper is able to dump PHP objects, it is considered to be a
     not supported feature.
 
@@ -213,3 +215,4 @@ representation to the inline one:
 
 .. _YAML: http://yaml.org/
 .. _Packagist: https://packagist.org/packages/symfony/yaml
+.. _`YAML 1.2 version specification`: http://yaml.org/spec/1.2/spec.html


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.3+ |
| Fixed tickets | - |

In `symfony/symfony` repository there are a lot of issues reporting errors of the Yaml Component. These aren't errors but lacking features of the Yaml Component.

This PR tries to clearly state that Yaml Component lacks lots of features on purpose and provides a simple list of the most notable missing features.
