### PR TITLE
Fix method for adding placholders in progressBar

### DIFF
--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -289,7 +289,7 @@ display that are not available in the list of built-in placeholders, you can
 create your own. Let's see how you can create a ``remaining_steps`` placeholder
 that displays the number of remaining steps::
 
-    ProgressBar::setPlaceholderFormatter(
+    ProgressBar::setPlaceholderFormatterDefinition(
         '%remaining_steps%',
         function (ProgressBar $bar, OutputInterface $output) {
             return $bar->getMaxSteps() - $bar->getStep();

--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -290,7 +290,7 @@ create your own. Let's see how you can create a ``remaining_steps`` placeholder
 that displays the number of remaining steps::
 
     ProgressBar::setPlaceholderFormatterDefinition(
-        '%remaining_steps%',
+        'remaining_steps',
         function (ProgressBar $bar, OutputInterface $output) {
             return $bar->getMaxSteps() - $bar->getStep();
         }


### PR DESCRIPTION
The method is called setPlaceholderFormatterDefinition and not setPlaceholderFormatter

see [here](https://github.com/symfony/symfony/blob/2.5/src/Symfony/Component/Console/Helper/ProgressBar.php#L82)

Edit:
I found another glitch: The name of the placeholder must not be packed in %-characters, like it is the case when using the placeholders in the format. As you can see [here](https://github.com/symfony/symfony/blob/2.5/src/Symfony/Component/Console/Helper/ProgressBar.php#L486) the defaults are also not like this and best indication:  it does not work if doing like in the docs :) 
