### PR TITLE
Move debug commands to debug namespace

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -613,12 +613,15 @@ via the ``get()`` method. Here are several common services you might need::
     $mailer = $this->get('mailer');
 
 There are countless other services available and you are encouraged to define
-your own. To list all available services, use the ``container:debug`` console
+your own. To list all available services, use the ``debug:container`` console
 command:
 
 .. code-block:: bash
 
-    $ php app/console container:debug
+    $ php app/console debug:container
+
+.. versionadded:: 2.6
+    Prior to Symfony 2.6, this command was called ``container:debug``.
 
 For more information, see the :doc:`/book/service_container` chapter.
 

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1192,12 +1192,15 @@ Visualizing & Debugging Routes
 
 While adding and customizing routes, it's helpful to be able to visualize
 and get detailed information about your routes. A great way to see every route
-in your application is via the ``router:debug`` console command. Execute
+in your application is via the ``debug:router`` console command. Execute
 the command by running the following from the root of your project.
 
 .. code-block:: bash
 
-    $ php app/console router:debug
+    $ php app/console debug:router
+
+.. versionadded:: 2.6
+    Prior to Symfony 2.6, this command was called ``router:debug``.
 
 This command will print a helpful list of *all* the configured routes in
 your application:
@@ -1216,7 +1219,7 @@ the route name after the command:
 
 .. code-block:: bash
 
-    $ php app/console router:debug article_show
+    $ php app/console debug:router article_show
 
 Likewise, if you want to test whether a URL matches a given route, you can
 use the ``router:match`` console command:

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -1169,18 +1169,21 @@ console. To show all services and the class for each service, run:
 
 .. code-block:: bash
 
-    $ php app/console container:debug
+    $ php app/console debug:container
+
+.. versionadded:: 2.6
+    Prior to Symfony 2.6, this command was called ``container:debug``.
 
 By default only public services are shown, but you can also view private services:
 
 .. code-block:: bash
 
-    $ php app/console container:debug --show-private
+    $ php app/console debug:container --show-private
 
 .. note::
 
     If a private service is only used as an argument to just *one* other service,
-    it won't be displayed by the ``container:debug`` command, even when using
+    it won't be displayed by the ``debug:container`` command, even when using
     the ``--show-private`` option. See :ref:`Inline Private Services <inlined-private-services>`
     for more details.
 
@@ -1189,7 +1192,7 @@ its id:
 
 .. code-block:: bash
 
-    $ php app/console container:debug my_mailer
+    $ php app/console debug:container my_mailer
 
 Learn more
 ----------

--- a/book/testing.rst
+++ b/book/testing.rst
@@ -459,7 +459,10 @@ injection container::
 
 Be warned that this does not work if you insulate the client or if you use an
 HTTP layer. For a list of services available in your application, use the
-``container:debug`` console task.
+``debug:container`` console task.
+
+.. versionadded:: 2.6
+    Prior to Symfony 2.6, this command was called ``container:debug``.
 
 .. tip::
 

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -662,10 +662,13 @@ Debugging Translations
 ----------------------
 
 .. versionadded:: 2.5
-    The ``translation:debug`` command was introduced in Symfony 2.5.
+    The ``debug:translation`` command was introduced in Symfony 2.5.
+
+.. versionadded:: 2.6
+    Prior to Symfony 2.6, this command was called ``translation:debug``.
 
 When maintaining a bundle, you may use or remove the usage of a translation
-message without updating all message catalogues. The ``translation:debug``
+message without updating all message catalogues. The ``debug:translation``
 command helps you to find these missing or unused translation messages for a
 given locale. It shows you a table with the result when translating the
 message in the given locale and the result when the fallback would be used.
@@ -774,7 +777,7 @@ To inspect all messages in the ``fr`` locale for the AcmeDemoBundle, run:
 
 .. code-block:: bash
 
-    $ php app/console translation:debug fr AcmeDemoBundle
+    $ php app/console debug:translation fr AcmeDemoBundle
 
 You will get this output:
 
@@ -815,15 +818,15 @@ By default all domains are inspected, but it is possible to specify a single dom
 
 .. code-block:: bash
 
-    $ php app/console translation:debug en AcmeDemoBundle --domain=messages
+    $ php app/console debug:translation en AcmeDemoBundle --domain=messages
 
 When bundles have a lot of messages, it is useful to display only the unused
 or only the missing messages, by using the ``--only-unused`` or ``--only-missing`` switches:
 
 .. code-block:: bash
 
-    $ php app/console translation:debug en AcmeDemoBundle --only-unused
-    $ php app/console translation:debug en AcmeDemoBundle --only-missing
+    $ php app/console debug:translation en AcmeDemoBundle --only-unused
+    $ php app/console debug:translation en AcmeDemoBundle --only-missing
 
 Summary
 -------


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/pull/11627

Should we specify that it has been added in 2.6 and that backward compatibility is ensured ?
