### PR TITLE
Handle "constraints" option in form unit testing

### DIFF
--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -183,12 +183,15 @@ on other extensions. You need add those extensions to the factory object::
         protected function setUp()
         {
             parent::setUp();
+            
+            $validator = $this->getMock('\Symfony\Component\Validator\ValidatorInterface');
+            $validator->method('validate')->will($this->returnValue(array()));
 
             $this->factory = Forms::createFormFactoryBuilder()
                 ->addExtensions($this->getExtensions())
                 ->addTypeExtension(
                     new FormTypeValidatorExtension(
-                        $this->getMock('Symfony\Component\Validator\ValidatorInterface')
+                        $validator
                     )
                 )
                 ->addTypeGuesser(

--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -177,6 +177,7 @@ on other extensions. You need add those extensions to the factory object::
     use Symfony\Component\Form\Forms;
     use Symfony\Component\Form\FormBuilder;
     use Symfony\Component\Form\Extension\Validator\Type\FormTypeValidatorExtension;
+    use Symfony\Component\Validator\ConstraintViolationList;
 
     class TestedTypeTest extends TypeTestCase
     {
@@ -185,7 +186,7 @@ on other extensions. You need add those extensions to the factory object::
             parent::setUp();
             
             $validator = $this->getMock('\Symfony\Component\Validator\ValidatorInterface');
-            $validator->method('validate')->will($this->returnValue(array()));
+            $validator->method('validate')->will($this->returnValue(new ConstraintViolationList()));
 
             $this->factory = Forms::createFormFactoryBuilder()
                 ->addExtensions($this->getExtensions())


### PR DESCRIPTION
In the current documentation, although a mocked `ValidatorInterface` is being passed to the `FormTypeValidatorExtension`, the actual `validate()` method in it is returning null. This causes any test against a form type that utilizes the extension's `constraints` option to fail, because of the following code in `Symfony\Component\Form\Extension\Validator\EventListener\ValidationListener`:

``` php
            // Validate the form in group "Default"
            $violations = $this->validator->validate($form);

            foreach ($violations as $violation) {
                // Allow the "invalid" constraint to be put onto
                // non-synchronized forms
                $allowNonSynchronized = Form::ERR_INVALID === $violation->getCode();

                $this->violationMapper->mapViolation($violation, $form, $allowNonSynchronized);
            }
```

Note the `foreach` loop that is expecting an array; currently the mocked object returns null and any test fails.

Since the documentation uses the `ValidatorExtension` as a specific example, I think it would be nice for the example code to handle this case, preventing the user from having to dig deeper into the code to discover the problem.
