### PR TITLE
Fixed code highlighting

### DIFF
--- a/reference/constraints/Regex.rst
+++ b/reference/constraints/Regex.rst
@@ -32,7 +32,7 @@ characters at the beginning of your string:
         Acme\BlogBundle\Entity\Author:
             properties:
                 description:
-                    - Regex: "/^\w+/"
+                    - Regex: '/^\w+/'
 
     .. code-block:: php-annotations
 
@@ -98,7 +98,7 @@ message:
             properties:
                 firstName:
                     - Regex:
-                        pattern: "/\d/"
+                        pattern: '/\d/'
                         match:   false
                         message: Your name cannot contain a number
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

> Double quoted strings are the only scalar style capable of expressing arbitrary strings, by using “\” escape sequences.
> - http://yaml.org/spec/1.1/#id904245

`\w` and `\d` are invalid escape sequences in Yaml, causing the Yaml highlighter to fail.
