### PR TITLE
Cache needs be cleared

### DIFF
--- a/cookbook/configuration/override_dir_structure.rst
+++ b/cookbook/configuration/override_dir_structure.rst
@@ -147,9 +147,9 @@ file:
                 'read_from' => '%kernel.root_dir%/../../public_html',
             ));
 
-    Now you just need to dump the assets again and your application should
+    Now you just need to clear the cache and dump the assets again and your application should
     work:
 
     .. code-block:: bash
-
+        $ php app/console cache:clear --env=prod
         $ php app/console assetic:dump --env=prod --no-debug

--- a/cookbook/configuration/override_dir_structure.rst
+++ b/cookbook/configuration/override_dir_structure.rst
@@ -151,5 +151,6 @@ file:
     work:
 
     .. code-block:: bash
+    
         $ php app/console cache:clear --env=prod
         $ php app/console assetic:dump --env=prod --no-debug


### PR DESCRIPTION
The configuration is cached, so running assetic:dump before clearing the cache won't use the new configuration.
