### PR TITLE
Symfony\Component\Validator\ExecutionContextInterface is deprecated sinc...

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -50,7 +50,7 @@ Configuration
         namespace Acme\BlogBundle\Entity;
 
         use Symfony\Component\Validator\Constraints as Assert;
-        use Symfony\Component\Validator\ExecutionContextInterface;
+        use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
         class Author
         {
@@ -100,7 +100,7 @@ can set "violations" directly on this object and determine to which field
 those errors should be attributed::
 
     // ...
-    use Symfony\Component\Validator\ExecutionContextInterface;
+    use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
     class Author
     {
@@ -156,7 +156,7 @@ your validation function is ``Vendor\Package\Validator::validate()``::
 
     namespace Vendor\Package;
 
-    use Symfony\Component\Validator\ExecutionContextInterface;
+    use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
     class Validator
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5+ |

Symfony\Component\Validator\ExecutionContextInterface is deprecated since 2.5. 
Replaced by Symfony\Component\Validator\Context\ExecutionContextInterface
