### PR TITLE
Remove redundant references to trusting HttpCache

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -163,10 +163,6 @@ kernel::
 The caching kernel will immediately act as a reverse proxy - caching responses
 from your application and returning them to the client.
 
-Now that you're using a "proxy", you'll need to configure ``127.0.0.1`` under
-the ``trusted_proxies`` configuration (see :ref:`the reference <reference-framework-trusted-proxies>`).
-Without this, the client's IP address and a few other things won't report correctly.
-
 .. tip::
 
     The cache kernel has a special ``getLog()`` method that returns a string

--- a/components/http_foundation/trusting_proxies.rst
+++ b/components/http_foundation/trusting_proxies.rst
@@ -30,12 +30,6 @@ your proxy.
     // only trust proxy headers coming from this IP addresses
     Request::setTrustedProxies(array('192.0.0.1', '10.0.0.0/8'));
 
-.. note::
-
-   When using Symfony's internal reverse proxy (``AppCache.php``) make sure to add
-   ``127.0.0.1`` to the list of trusted proxies.
-
-
 Configuring Header Names
 ------------------------
 

--- a/cookbook/request/load_balancer_reverse_proxy.rst
+++ b/cookbook/request/load_balancer_reverse_proxy.rst
@@ -11,12 +11,6 @@ special ``X-Forwarded-*`` headers. For example, instead of reading the ``REMOTE_
 header (which will now be the IP address of your reverse proxy), the user's
 true IP will be stored in an ``X-Forwarded-For`` header.
 
-.. tip::
-
-    If you're using Symfony's :ref:`AppCache<symfony-gateway-cache>` for caching,
-    then you *are* using a reverse proxy with the IP address ``127.0.0.1``.
-    You'll need to configure that address as a trusted proxy below.
-
 If you don't configure Symfony to look for these headers, you'll get incorrect
 information about the client's IP address, whether or not the client is connecting
 via HTTPS, the client's port and the hostname being requested.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets |  |

Removes references to making `HttpCache` a trusted proxy as https://github.com/symfony/symfony/pull/11937 would cause it to be handled automatically.

Alternatively it could be reworded, but I'm not sure it's useful to say that this happens (since it was a bit odd to have to configure Symfony to let one part of the code base trust another).
