### PR TITLE
[Reference] link translation DIC tags to components section

### DIFF
--- a/components/translation/custom_formats.rst
+++ b/components/translation/custom_formats.rst
@@ -18,6 +18,8 @@ message. A translation file would look like this:
     (goodbye)(au revoir)
     (hello)(bonjour)
 
+.. _components-translation-custom-loader:
+
 Creating a Custom Loader
 ------------------------
 
@@ -64,6 +66,8 @@ Once created, it can be used as any other loader::
     echo $translator->trans('welcome');
 
 It will print *"accueil"*.
+
+.. _components-translation-custom-dumper:
 
 Creating a Custom Dumper
 ------------------------

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -1029,32 +1029,12 @@ translation.loader
 **Purpose**: To register a custom service that loads translations
 
 By default, translations are loaded from the filesystem in a variety of different
-formats (YAML, XLIFF, PHP, etc). If you need to load translations from some
-other source, first create a class that implements the
-:class:`Symfony\\Component\\Translation\\Loader\\LoaderInterface` interface::
+formats (YAML, XLIFF, PHP, etc).
 
-    // src/Acme/MainBundle/Translation/MyCustomLoader.php
-    namespace Acme\MainBundle\Translation;
+.. seealso::
 
-    use Symfony\Component\Translation\Loader\LoaderInterface;
-    use Symfony\Component\Translation\MessageCatalogue;
-
-    class MyCustomLoader implements LoaderInterface
-    {
-        public function load($resource, $locale, $domain = 'messages')
-        {
-            $catalogue = new MessageCatalogue($locale);
-
-            // some how load up some translations from the "resource"
-            // then set them into the catalogue
-            $catalogue->set('hello.world', 'Hello World!', $domain);
-
-            return $catalogue;
-        }
-    }
-
-Your custom loader's ``load`` method is responsible for returning a
-:Class:`Symfony\\Component\\Translation\\MessageCatalogue`.
+    Learn how to :ref:`load custom formats <components-translation-custom-loader>`
+    in the components section.
 
 Now, register your loader as a service and tag it with ``translation.loader``:
 
@@ -1251,6 +1231,11 @@ This is the name that's used to determine which dumper should be used.
             'Acme\DemoBundle\Translation\JsonFileDumper'
         )
             ->addTag('translation.dumper', array('alias' => 'json'));
+
+.. seealso::
+
+    Learn how to :ref:`dump to custom formats <components-translation-custom-dumper>`
+    in the components section.
 
 .. _reference-dic-tags-twig-extension:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

The `translation.loader` and `translation.dumper` DIC tags link to the respective sections in the Translation component documentation (in addition to the changes done in #4166).
