### PR TITLE
Node path is required to filter execution

### DIFF
--- a/cookbook/assetic/uglifyjs.rst
+++ b/cookbook/assetic/uglifyjs.rst
@@ -66,6 +66,7 @@ your JavaScripts:
 
         # app/config/config.yml
         assetic:
+            node: /usr/bin/nodejs
             filters:
                 uglifyjs2:
                     # the path to the uglifyjs executable


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | No |
| Applies to | all |
| Fixed tickets |  |

If you no provide node path in assetic configuration, UglifyCssFilter throw a  `RuntimeException: Path to node executable could not be resolved.` 
