### PR TITLE
provide node path on configuration

### DIFF
--- a/cookbook/assetic/uglifyjs.rst
+++ b/cookbook/assetic/uglifyjs.rst
@@ -66,6 +66,7 @@ your JavaScripts:
 
         # app/config/config.yml
         assetic:
+            node: /usr/bin/nodejs
             filters:
                 uglifyjs2:
                     # the path to the uglifyjs executable

--- a/cookbook/assetic/uglifyjs.rst
+++ b/cookbook/assetic/uglifyjs.rst
@@ -111,10 +111,11 @@ your JavaScripts:
 
 You now have access to the ``uglifyjs2`` filter in your application.
 
-Configure the ``node binary``
-----------------------------------
+Configure the ``node`` Binary
+-----------------------------
 
-he name of the binary is node you can skip this section.
+Assetic tries to find the node binary automatically. If it cannot be found, you'll
+be able to configure its location using the ``node`` key:
 
 .. configuration-block::
 
@@ -124,12 +125,19 @@ he name of the binary is node you can skip this section.
         assetic:
             # the path to the node executable
             node: /usr/bin/nodejs
+            filters:
+                uglifyjs2:
+                    # the path to the uglifyjs executable
+                    bin: /usr/local/bin/uglifyjs
 
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
         <assetic:config 
-            node="/usr/bin/nodejs">
+            node="/usr/bin/nodejs" >
+            <assetic:filter
+                name="uglifyjs2"
+                bin="/usr/local/bin/uglifyjs" />
         </assetic:config>
 
     .. code-block:: php
@@ -137,6 +145,10 @@ he name of the binary is node you can skip this section.
         // app/config/config.php
         $container->loadFromExtension('assetic', array(
             'node' => '/usr/bin/nodejs',
+            'uglifyjs2' => array(
+                    // the path to the uglifyjs executable
+                    'bin' => '/usr/local/bin/uglifyjs',
+                ),
         ));
 
 Minify your Assets

--- a/cookbook/assetic/uglifyjs.rst
+++ b/cookbook/assetic/uglifyjs.rst
@@ -66,7 +66,6 @@ your JavaScripts:
 
         # app/config/config.yml
         assetic:
-            node: /usr/bin/nodejs
             filters:
                 uglifyjs2:
                     # the path to the uglifyjs executable

--- a/cookbook/assetic/uglifyjs.rst
+++ b/cookbook/assetic/uglifyjs.rst
@@ -112,6 +112,34 @@ your JavaScripts:
 
 You now have access to the ``uglifyjs2`` filter in your application.
 
+Configure the ``node binary``
+----------------------------------
+
+he name of the binary is node you can skip this section.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        assetic:
+            # the path to the node executable
+            node: /usr/bin/nodejs
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+        <assetic:config 
+            node="/usr/bin/nodejs">
+        </assetic:config>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container->loadFromExtension('assetic', array(
+            'node' => '/usr/bin/nodejs',
+        ));
+
 Minify your Assets
 ------------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | No |
| Applies to | all |
| Fixed tickets |  |

If you no provide node path in assetic configuration, UglifyCssFilter throw a  `RuntimeException: Path to node executable could not be resolved.` 
