### PR TITLE
Clarifying Bundle Best Practices is for *reusable* bundles

### DIFF
--- a/cookbook/bundles/best_practices.rst
+++ b/cookbook/bundles/best_practices.rst
@@ -6,8 +6,8 @@ Best Practices for Reusable Bundles
 
 There are 2 types of bundles:
 
-* Application bundles: only use to build your application;
-* Reusable bundle: meant to be shared across many projects.
+* Application-specific bundles: only used to build your application;
+* Reusable bundles: meant to be shared across many projects.
 
 This article is all about how to structure your **reusable bundles** so that
 they're easy to configure and extend. Many of these recommendations do not

--- a/cookbook/bundles/best_practices.rst
+++ b/cookbook/bundles/best_practices.rst
@@ -1,12 +1,19 @@
 .. index::
    single: Bundle; Best practices
 
-How to Use best Practices for Structuring Bundles
-=================================================
+Best Practices for Reusable Bundles
+===================================
 
-A bundle is a directory that has a well-defined structure and can host anything
-from classes to controllers and web resources. Even if bundles are very
-flexible, you should follow some best practices if you want to distribute them.
+There are 2 types of bundles:
+
+* Application bundles: only use to build your application;
+* Reusable bundle: meant to be shared across many projects.
+
+This article is all about how to structure your **reusable bundles** so that
+they're easy to configure and extend. Many of these recommendations do not
+apply to application bundles because you'll want to keep those as simple
+as possible. For application bundles, just follow the practices shown throughout
+the book and cookbook.
 
 .. index::
    pair: Bundle; Naming conventions


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | No |
| Applies to | 2.3+ |
| Fixed tickets |  |

Hi guys!

I wanted to be a little bit more clear that the bundle best practices doc is all about structuring your reusable bundles, not necessarily your application bundles.

I realize I broke from the Cookbook-standard of "How to..." title, but this title sounded the best to me. I'm also not worried about breaking the anchor on the top title, since it's already the top of the page.

Thanks!
