### PR TITLE
[WCM] Question Helper - Showing the default answer

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -62,8 +62,8 @@ some name which will be returned by the
 :method:`Symfony\\Component\\Console\\Helper\\QuestionHelper::ask` method.
 If they leave it empty, the default value (``AcmeDemoBundle`` here) is returned.
 
-Showing the default answer
-...........................
+Showing the Default Answer
+..........................
 
 Sometimes, it is beneficial for the user to be aware of the default answer should
 they decide not to give one. If you want the user to know, you can add this to your

--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -65,9 +65,10 @@ If they leave it empty, the default value (``AcmeDemoBundle`` here) is returned.
 Showing the Default Answer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Sometimes, it is beneficial for the user to be aware of the default answer should
-they decide not to give one. If you want the user to know, you can add this to your
-command::
+Sometimes you want to present the default answer to the user that will be
+chosen if they don't provide an answer themself. Use the
+:method:`Symfony\\Component\\Console\\Question\\Question::setShowDefault` method
+to show the default answer::
 
     use Symfony\Component\Console\Question\Question;
     // ...

--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -62,6 +62,23 @@ some name which will be returned by the
 :method:`Symfony\\Component\\Console\\Helper\\QuestionHelper::ask` method.
 If they leave it empty, the default value (``AcmeDemoBundle`` here) is returned.
 
+Showing the default answer
+...........................
+
+Sometimes, it is beneficial for the user to be aware of the default answer should
+they decide not to give one. If you want the user to know, you can add this to your
+command::
+
+    use Symfony\Component\Console\Question\Question;
+    // ...
+
+    $question = new Question('Please enter the name of the bundle', 'AcmeDemoBundle');
+    $question->setShowDefault(true);
+
+    $bundle = $helper->ask($input, $output, $question);
+
+The user will be asked "Please enter the name of the bundle [AcmeDemoBundle]".
+
 Let the User Choose from a List of Answers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -63,7 +63,7 @@ some name which will be returned by the
 If they leave it empty, the default value (``AcmeDemoBundle`` here) is returned.
 
 Showing the Default Answer
-..........................
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sometimes, it is beneficial for the user to be aware of the default answer should
 they decide not to give one. If you want the user to know, you can add this to your


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes - symfony/symfony#11975 |
| Applies to | 2.6 |
| Fixed tickets |  |

This is the documentation for a new feature that I am proposing.
