### PR TITLE
'constraints' option not valid on form-classes with no entity

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -1870,6 +1870,10 @@ but here's a short example:
 
 .. tip::
 
+    The ``constraints``  is not valid if you are using :ref:`form classes <book-form-creating-form-classes>`.
+
+.. tip::
+
     If you are using validation groups, you need to either reference the
     ``Default`` group when creating the form, or set the correct group on
     the constraint you are adding.


### PR DESCRIPTION
The 'constraints' option is not valid using form-classes without entity.
