### PR TITLE
[Components][HttpFoundation] Make a small grammatical adjustment

### DIFF
--- a/components/http_foundation/session_configuration.rst
+++ b/components/http_foundation/session_configuration.rst
@@ -181,7 +181,7 @@ which runs reasonably frequently. The ``cookie_lifetime`` would be set to a
 relatively high value, and the garbage collection ``gc_maxlifetime`` would be set
 to destroy sessions at whatever the desired idle period is.
 
-The other option is to specifically checking if a session has expired after the
+The other option is specifically checking if a session has expired after the
 session is started. The session can be destroyed as required. This method of
 processing can allow the expiry of sessions to be integrated into the user
 experience, for example, by displaying a message.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | n/a |

The original form of the phrase - «The other option is to specifically
checking if a session has expired after the session is started.» - is
not entirely grammatically correct, as the infinitive form of «to check»
shall normally be used, or the gerund form, which is the form used in
this commit.
