### PR TITLE
Double-quotes instead of single quotes (UnexpectedValueException in Windows 8)

### DIFF
--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -26,7 +26,7 @@ git repository:
 
    .. code-block:: bash
 
-        $ php composer.phar create-project symfony/framework-standard-edition path/ '~2.3'
+        $ php composer.phar create-project symfony/framework-standard-edition path/ "~2.3"
 
    Composer will now download the Standard Distribution along with all of the
    required vendor libraries. For more information about downloading Symfony using

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -20,7 +20,7 @@ directory:
 
 .. code-block:: bash
 
-    $ composer create-project symfony/framework-standard-edition myproject/ '~2.3'
+    $ composer create-project symfony/framework-standard-edition myproject/ "~2.3"
 
 .. note::
 


### PR DESCRIPTION
Using single quotes in Windows command prompt (Windows 8 Pro) returns the following error:
C:\Users\Galdiolo>composer create-project symfony/framework-standard-edition myproject/ '~2.3'
  [UnexpectedValueException]
  Could not parse version constraint '~2.3': Invalid version string "'~2.3'"
