### PR TITLE
[Security] Use the `is_granted` expression to keep consistency with php example above

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1091,7 +1091,7 @@ Thanks to the SensioFrameworkExtraBundle, you can also secure your controller us
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
     /**
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("is_granted('ROLE_ADMIN')")
      */
     public function helloAction($name)
     {

--- a/book/security.rst
+++ b/book/security.rst
@@ -1786,6 +1786,8 @@ Additionally, you have access to a number of functions inside the expression:
   see below;
 * ``has_role``: Checks to see if the user has the given role - equivalent
   to an expression like ``'ROLE_ADMIN' in roles``.
+* ``is_granted``: Similar to the php code like `$securityContext->isGranted('ROLE_USER')`.
+  Unlike `has_role` expression, `is_granted` will call your custom voters if defined.
 
 .. sidebar:: ``is_remember_me`` is different than checking ``IS_AUTHENTICATED_REMEMBERED``
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4 |
| Fixed tickets | - |

As `has_role` expression only check for roles (simple `in_array`) without calling the `AccessDecisionManager`, it does not do the same job that
`$this->get('security.context')->isGranted('ROLE_ADMIN')` used in the php example just above.

It is quiete confusing.
