### PR TITLE
changing misleading language identifier

### DIFF
--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -8,8 +8,8 @@ The ``language`` type is a subset of the ``ChoiceType`` that allows the user
 to select from a large list of languages. As an added bonus, the language names
 are displayed in the language of the user.
 
-The "value" for each language is the *Unicode language identifier*
-(e.g. ``fr`` or ``zh-Hant``).
+The "value" for each language is the *Unicode language identifier* used in the *International Components for Unicode*
+(e.g. ``fr`` or ``zh_Hant``).
 
 .. note::
 


### PR DESCRIPTION
fixes issue #4251
Typical language standards use dashes, but symfony uses underscores like defined in ICU. So the docs were misleading.
