### PR TITLE
[Security] Hidden front controller for Nginx

### DIFF
--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -202,6 +202,8 @@ are:
             try_files $uri /app.php$is_args$args;
         }
         # DEV
+        # Be sure to remove app_dev.php and config.php scripts when app is
+        # deployed to PROD environment, this rule only must be placed on DEV
         location ~ ^/(app_dev|config)\.php(/|$) {
             fastcgi_pass unix:/var/run/php5-fpm.sock;
             fastcgi_split_path_info ^(.+\.php)(/.*)$;

--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -197,6 +197,13 @@ are:
         server_name domain.tld www.domain.tld;
         root /var/www/project/web;
 
+        if ($request_uri ~ "/app\.php(/|$)") {
+            # prevent explicit access and hide front controller
+            # remove this block if you want to allow uri's like
+            # http://domain.tld/app.php/some-path
+            return 404;
+        }
+
         location / {
             # try to serve file directly, fallback to app.php
             try_files $uri /app.php$is_args$args;

--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -197,24 +197,29 @@ are:
         server_name domain.tld www.domain.tld;
         root /var/www/project/web;
 
-        if ($request_uri ~ "/app\.php(/|$)") {
-            # prevent explicit access and hide front controller
-            # remove this block if you want to allow uri's like
-            # http://domain.tld/app.php/some-path
-            return 404;
-        }
-
         location / {
             # try to serve file directly, fallback to app.php
             try_files $uri /app.php$is_args$args;
         }
-
-        location ~ ^/(app|app_dev|config)\.php(/|$) {
+        # DEV
+        location ~ ^/(app_dev|config)\.php(/|$) {
             fastcgi_pass unix:/var/run/php5-fpm.sock;
             fastcgi_split_path_info ^(.+\.php)(/.*)$;
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param HTTPS off;
+        }
+        # PROD
+        location ~ ^/app\.php(/|$) {
+            fastcgi_pass unix:/var/run/php5-fpm.sock;
+            fastcgi_split_path_info ^(.+\.php)(/.*)$;
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_param HTTPS off;
+            # prevent explicit access and hide front controller
+            # remove "internal" directive if you want to allow uri's like
+            # http://domain.tld/app.php/some-path
+            internal;
         }
 
         error_log /var/log/nginx/project_error.log;


### PR DESCRIPTION
For Nginx in PROD env, this makes more difficult to know that app is running Symfony.

app.php is widely known as our default front controller.
It is a small effort by security through obscurity.
For Apache, [this 301 must be replaced by 404](https://github.com/symfony/symfony-standard/blob/77ee2a83c085169e0bd221510b5693dca504f682/web/.htaccess#L37).

| Q | A |
| --- | --- |
| Doc fix? | no |
| New feature? | no |
| Applies to | 2.0+ |
| Tests pass? | yes |
| Fixed tickets |  |
