### PR TITLE
[Components][PropertyAccess] Fix PropertyAccessorBuilder usage

### DIFF
--- a/components/property_access/introduction.rst
+++ b/components/property_access/introduction.rst
@@ -209,7 +209,7 @@ enable this feature by using :class:`Symfony\\Component\\PropertyAccess\\Propert
     $person = new Person();
 
     // Enable magic __call
-    $accessor = PropertyAccess::getPropertyAccessorBuilder()
+    $accessor = PropertyAccess::createPropertyAccessorBuilder()
         ->enableMagicCall()
         ->getPropertyAccessor();
 
@@ -305,7 +305,7 @@ see `Enable other Features`_.
     $person = new Person();
 
     // Enable magic __call
-    $accessor = PropertyAccess::getPropertyAccessorBuilder()
+    $accessor = PropertyAccess::createPropertyAccessorBuilder()
         ->enableMagicCall()
         ->getPropertyAccessor();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3, 2.4, 2.5 |
| Fixed tickets |  |

See https://github.com/symfony/PropertyAccess/blob/2.3/PropertyAccess.php

`getPropertyAccessorBuilder` does not exist. But the right fix might be to add the missing method.
