### PR TITLE
View documentation had a reference to the wrong twig template

### DIFF
--- a/quick_tour/the_view.rst
+++ b/quick_tour/the_view.rst
@@ -157,7 +157,7 @@ First, create an ``embedded.html.twig`` template:
     {# src/Acme/DemoBundle/Resources/views/Demo/embedded.html.twig #}
     Hello {{ name }}
 
-And change the ``index.html.twig`` template to include it:
+And change the ``hello.html.twig`` template to include it:
 
 .. code-block:: jinja
 


### PR DESCRIPTION
Just noticed this little discrepancy in the docs.
