### PR TITLE
Remove horizontal scrollbar and change event name to follow conventions

### DIFF
--- a/components/event_dispatcher/traceable_dispatcher.rst
+++ b/components/event_dispatcher/traceable_dispatcher.rst
@@ -17,7 +17,10 @@ Pass the event dispatcher to be wrapped and an instance of the
     // the event dispatcher to debug
     $eventDispatcher = ...;
 
-    $traceableEventDispatcher = new TraceableEventDispatcher($eventDispatcher, new Stopwatch());
+    $traceableEventDispatcher = new TraceableEventDispatcher(
+        $eventDispatcher,
+        new Stopwatch()
+    );
 
 Now, the ``TraceableEventDispatcher`` can be used like any other event dispatcher
 to register event listeners and dispatch events::
@@ -27,11 +30,11 @@ to register event listeners and dispatch events::
     // register an event listener
     $eventListener = ...;
     $priority = ...;
-    $traceableEventDispatcher->addListener('the-event-name', $eventListener, $priority);
+    $traceableEventDispatcher->addListener('event.the_name', $eventListener, $priority);
 
     // dispatch an event
     $event = ...;
-    $traceableEventDispatcher->dispatch('the-event-name', $event);
+    $traceableEventDispatcher->dispatch('event.the_name', $event);
 
 After your application has been processed, you can use the
 :method:`Symfony\\Component\\EventDispatcher\\Debug\\TraceableEventDispatcherInterface::getCalledListeners`


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets |  |

In my opinion the event name should follow the naming conventions http://symfony.com/doc/current/components/event_dispatcher/introduction.html#naming-conventions
