### PR TITLE
[Components][Form] Correct a typo

### DIFF
--- a/components/form/introduction.rst
+++ b/components/form/introduction.rst
@@ -137,7 +137,7 @@ and validated when binding the form.
 
 .. tip::
 
-    If you're not using the HttpFoundation component, load use
+    If you're not using the HttpFoundation component, you can use
     :class:`Symfony\\Component\\Form\\Extension\\Csrf\\CsrfProvider\\DefaultCsrfProvider`
     instead, which relies on PHP's native session handling::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | n/a |

Removed uncorrect "load use" phrase part, and replaced it with "you can
use", which I guess conveys the original meaning of the phrase better.
