### PR TITLE
[Components][Form] Grammar improvement

### DIFF
--- a/components/form/introduction.rst
+++ b/components/form/introduction.rst
@@ -173,7 +173,7 @@ line to your ``composer.json`` file:
     }
 
 The TwigBridge integration provides you with several :doc:`Twig Functions </reference/forms/twig_reference>`
-that help you render each the HTML widget, label and error for each field
+that help you render the HTML widget, label and error for each field
 (as well as a few other things). To configure the integration, you'll need
 to bootstrap or access Twig and add the :class:`Symfony\\Bridge\\Twig\\Extension\\FormExtension`::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | n/a |

I think the "each the" form is not correct in English, as "each" must
generally be used as in "each one of", or "each of", forms that should
not be used here either as the countable aspect is already expressed
by "each field" further in the phrase anyway.
