### PR TITLE
ensure consistency with the note

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -612,7 +612,8 @@ and pass it a ``Link`` object::
 Forms
 ~~~~~
 
-Just like links, you select forms with the ``selectButton()`` method::
+Forms can be selected using their buttons, which can be selected with the
+``selectButton()`` method, just like links::
 
     $buttonCrawlerNode = $crawler->selectButton('submit');
 


### PR DESCRIPTION
The note explains that we are selecting form buttons, not forms.
Confusion ensues if we say otherwise in the introductory sentence.
