### PR TITLE
Compiled PHP for customized route matching

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -822,7 +822,7 @@ variables that are passed into the expression:
     Behind the scenes, expressions are compiled down to raw PHP. Our example
     would generate the following PHP in the cache directory::
 
-        if (rtrim($pathinfo, '/contact') === '' && (
+        if ('/contact' === $pathinfo && (
             in_array($context->getMethod(), array(0 => "GET", 1 => "HEAD"))
             && preg_match("/firefox/i", $request->headers->get("User-Agent"))
         )) {

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -822,7 +822,7 @@ variables that are passed into the expression:
     Behind the scenes, expressions are compiled down to raw PHP. Our example
     would generate the following PHP in the cache directory::
 
-        if ('/contact' === $pathinfo && (
+        if (0 === strpos($pathinfo, '/contact') && (
             in_array($context->getMethod(), array(0 => "GET", 1 => "HEAD"))
             && preg_match("/firefox/i", $request->headers->get("User-Agent"))
         )) {


### PR DESCRIPTION
The second parameter of `rtrim()` is a character mask. By checking if `rtrim($pathinfo, '/contact') === ''`, `$pathinfo` could be any URL containing those characters and not only "/contact" which was configured as the route path, for example:

```
$pathinfo = '/octocat';
var_dump(rtrim($pathinfo, '/contact') === ''); // bool(true)
```
