### PR TITLE
[Templating] Added a sentence that explains what a Template Helper is

### DIFF
--- a/components/templating/introduction.rst
+++ b/components/templating/introduction.rst
@@ -135,7 +135,8 @@ escaper using the
 Helpers
 -------
 
-The Templating component can be easily extended via helpers. The component has
+The Templating component can be easily extended via helpers. Helpers are PHP objects that 
+provide features useful in a template context. The component has
 2 built-in helpers:
 
 * :doc:`/components/templating/helpers/assetshelper`


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | n/a |

I found a SecurityHelper in the SecurityBundle. I was unsure what this helper was or what it was supposed to do. After some googling I've landed on the templating component documation. This is correct as the `HelperInterface` can be found in [the component](http://symfony.com/doc/current/components/templating/introduction.html#helpers). However, it doesn't explain what a helper is.

After some searching, [the cookbook _does_ explain what a helper is](http://symfony.com/doc/current/cookbook/templating/PHP.html#using-template-helpers). I've pretty much copied over the sentence from the cookbook to the component. If you have a better proposal, I can add that instead.
