### PR TITLE
[WCM] Added depreciation note for the cascade_validation constraint

### DIFF
--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -11,7 +11,7 @@ on all types for which ``form`` is the parent type.
 | Options   | - `action`_                                                        |
 |           | - `allow_extra_fields`_                                            |
 |           | - `by_reference`_                                                  |
-|           | - `cascade_validation`_                                            |
+|           | - `cascade_validation`_ (deprecated as of 2.8)                     |
 |           | - `compound`_                                                      |
 |           | - `constraints`_                                                   |
 |           | - `data`_                                                          |

--- a/reference/forms/types/options/cascade_validation.rst.inc
+++ b/reference/forms/types/options/cascade_validation.rst.inc
@@ -1,6 +1,12 @@
 cascade_validation
 ~~~~~~~~~~~~~~~~~~
 
+.. caution::
+
+    The ``cascade_validation`` option has been deprecated in Symfony 2.8 and will be removed
+    in 3.0. Instead, use the ``Valid`` constraint in your model to cascade validation. Be aware
+    of the fact that the ``validation_group`` option will not be considered for child forms.
+
 **type**: ``boolean`` **default**: ``false``
 
 Set this option to ``true`` to force validation on embedded form types.
@@ -10,11 +16,10 @@ the data from ``CategoryType`` to also be validated.
 
 .. tip::
 
-    Instead of using this option, it is recommended that you use the ``Valid``
+    Instead of using this option, it is recommended that you use the :doc:`Valid </reference/constraints/Valid>`
     constraint in your model to force validation on a child object stored
     on a property. This cascades only the validation but not the use of
-    the ``validation_groups`` option on child forms. You can read more
-    about this in the section about
-    :ref:`Embedding a Single Object <forms-embedding-single-object>`.
+    the :ref:`validation_groups <book-forms-validation-groups>` option on child forms. You can read more
+    about this in the section about :ref:`Embedding a Single Object <forms-embedding-single-object>`.
 
 .. include:: /reference/forms/types/options/_error_bubbling_hint.rst.inc


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8 |
| Fixed tickets | - |

This PR was based on symfony/symfony#12237 and has been updated based
as symfony/symfony#15019.

symfony/symfony-docs#4348
