### PR TITLE
Remove incoherence between Doctrine and Propel introduction paragraphs

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -5,11 +5,13 @@ Databases and Doctrine
 ======================
 
 One of the most common and challenging tasks for any application
-involves persisting and reading information to and from a database. Fortunately,
-Symfony comes integrated with `Doctrine`_, a library whose sole goal is to
-give you powerful tools to make this easy. In this chapter, you'll learn the
-basic philosophy behind Doctrine and see how easy working with a database can
-be.
+involves persisting and reading information to and from a database. Although
+the Symfony full-stack framework doesn't integrate any ORM by default,
+the Symfony Standard Edition, which is the most widely used distribution,
+comes integrated with `Doctrine`_, a library whose sole goal is to give
+you powerful tools to make this easy. In this chapter, you'll learn the
+basic philosophy behind Doctrine and see how easy working with a database
+can be.
 
 .. note::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #4349 |

The introductory paragraph of Doctrine and Propel sections, although both are true in some way, look contradictory, so a rephrase of at least one of the two paragraphs would be convenient.
