### PR TITLE
Update form_customization.rst

### DIFF
--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -67,7 +67,7 @@ just one line:
 
     .. code-block:: jinja
 
-        {{ form_widget(form) }}
+        {{ form(form) }}
 
     .. code-block:: php
 


### PR DESCRIPTION
In the Form chapter of Book for Symfony 2.3, we use `{{ form(form) }}` to render the entire form ( in contrast to `{{ form_widget(form) }}` for older version of Symfony ). so maybe it should use `{{ form(form) }}` here for consistency.
