### PR TITLE
Added a code example for emailing on 4xx and 5xx errors without 404's

### DIFF
--- a/cookbook/logging/monolog_email.rst
+++ b/cookbook/logging/monolog_email.rst
@@ -19,7 +19,12 @@ it is broken down.
             handlers:
                 mail:
                     type:         fingers_crossed
+                    # 500 errors are logged at the critical level
                     action_level: critical
+                    # to also log 400 level errors (but not 404's):
+                    # action_level: error
+                    # excluded_404:
+                    #     - ^/
                     handler:      buffered
                 buffered:
                     type:    buffer
@@ -48,6 +53,12 @@ it is broken down.
                     type="fingers_crossed"
                     action-level="critical"
                     handler="buffered"
+                    <!--
+                    To also log 400 level errors (but not 404's):
+                    action-level="error"
+                    And add this child inside this monolog:handler
+                    <monolog:excluded-404>^/</monolog:excluded-404>
+                    -->
                 />
                 <monolog:handler
                     name="buffered"
@@ -81,6 +92,11 @@ it is broken down.
                 'mail' => array(
                     'type'         => 'fingers_crossed',
                     'action_level' => 'critical',
+                    // to also log 400 level errors (but not 404's):
+                    // 'action_level' => 'error',
+                    // 'excluded_404s' => array(
+                    //     '^/',
+                    // ),
                     'handler'      => 'buffered',
                 ),
                 'buffered' => array(
@@ -108,7 +124,8 @@ setting means that the output is then passed onto the ``buffered`` handler.
 .. tip::
 
     If you want both 400 level and 500 level errors to trigger an email,
-    set the ``action_level`` to ``error`` instead of ``critical``.
+    set the ``action_level`` to ``error`` instead of ``critical``. See the
+    code above for an example.
 
 The ``buffered`` handler simply keeps all the messages for a request and
 then passes them onto the nested handler in one go. If you do not use this


### PR DESCRIPTION
Hi guys!

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | -- |

I thought this is useful, because this is how I actually set this up (I _do_ want 403 errors emailed, for example, but definitely not all the 404 garbage).

Thanks!
