### PR TITLE
Removed the redundant usage of layer.

### DIFF
--- a/cookbook/doctrine/dbal.rst
+++ b/cookbook/doctrine/dbal.rst
@@ -2,7 +2,7 @@
    pair: Doctrine; DBAL
 
 How to Use Doctrine's DBAL
-================================
+==========================
 
 .. note::
 

--- a/cookbook/doctrine/dbal.rst
+++ b/cookbook/doctrine/dbal.rst
@@ -1,12 +1,12 @@
 .. index::
    pair: Doctrine; DBAL
 
-How to Use Doctrine's DBAL Layer
+How to Use Doctrine's DBAL
 ================================
 
 .. note::
 
-    This article is about Doctrine DBAL's layer. Typically, you'll work with
+    This article is about the Doctrine DBAL. Typically, you'll work with
     the higher level Doctrine ORM layer, which simply uses the DBAL behind
     the scenes to actually communicate with the database. To read more about
     the Doctrine ORM, see ":doc:`/book/doctrine`".

--- a/cookbook/doctrine/dbal.rst
+++ b/cookbook/doctrine/dbal.rst
@@ -2,7 +2,7 @@
    pair: Doctrine; DBAL
 
 How to Use Doctrine DBAL
-==========================
+========================
 
 .. note::
 

--- a/cookbook/doctrine/dbal.rst
+++ b/cookbook/doctrine/dbal.rst
@@ -1,7 +1,7 @@
 .. index::
    pair: Doctrine; DBAL
 
-How to Use Doctrine's DBAL
+How to Use Doctrine DBAL
 ==========================
 
 .. note::


### PR DESCRIPTION
Since DBAL is database abstraction layer, and is defined in the document as such, to me it reads funny to have it as database abstraction layer layer. It sounds nitpicky, I know, but I find it an easier read this way. Also, the possessive DBAL stuck out ("DBAL's layer") as the DBAL doesn't own a layer, it is the layer whereas Doctrine does own the layer and is properly defined in the header.
