### PR TITLE
Cleaned up javascript code

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -178,10 +178,10 @@ you need is the JavaScript:
             // keep track of how many email fields have been rendered
             var emailCount = '{{ form.emails|length }}';
 
-            jQuery(document).ready(function(e) {
-                e.preventDefault();
+            jQuery(document).ready(function() {
+                jQuery('#add-another-email').click(function(e) {
+                    e.preventDefault();
 
-                jQuery('#add-another-email').click(function() {
                     var emailList = jQuery('#email-fields-list');
 
                     // grab the prototype template

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -178,7 +178,9 @@ you need is the JavaScript:
             // keep track of how many email fields have been rendered
             var emailCount = '{{ form.emails|length }}';
 
-            jQuery(document).ready(function() {
+            jQuery(document).ready(function(e) {
+                e.preventDefault();
+
                 jQuery('#add-another-email').click(function() {
                     var emailList = jQuery('#email-fields-list');
 

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -192,9 +192,7 @@ you need is the JavaScript:
 
                     // create a new list element and add it to the list
                     var newLi = jQuery('<li></li>').html(newWidget);
-                    newLi.appendTo(jQuery('#email-fields-list'));
-
-                    return false;
+                    newLi.appendTo(emailList);
                 });
             })
         </script>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets | n/a |
1. Reused variable `emailList` which is best practice and easier to read
2. Removed `return false`. There is no use for it in this context and many consider it to be bad use as well. For example: http://fuelyourcoding.com/jquery-events-stop-misusing-return-false/
