### PR TITLE
[OptionsResolver] Fix wrong namespace in example

### DIFF
--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -99,7 +99,7 @@ system.
 Let's use the :class:`Symfony\\Component\\OptionsResolver\\OptionsResolver`
 class to fix this problem::
 
-    use Symfony\Component\OptionsResolver\Options;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class Mailer
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.6 |
