### PR TITLE
Twig naming of custom form types

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -1514,7 +1514,8 @@ separated by a single underscore character (``_``). A few examples are:
 Each fragment follows the same basic pattern: ``type_part``. The ``type`` portion
 corresponds to the field *type* being rendered (e.g. ``textarea``, ``checkbox``,
 ``date``, etc) whereas the ``part`` portion corresponds to *what* is being
-rendered (e.g. ``label``, ``widget``, ``errors``, etc). By default, there
+rendered (e.g. ``label``, ``widget``, ``errors``, etc). The name of your own form
+type is given by the ``getName()`` method in your Form class. By default, there
 are 4 possible *parts* of a form that can be rendered:
 
 +-------------+--------------------------+---------------------------------------------------------+


### PR DESCRIPTION
For a form called `TestForm` with `public function getName() { return 'test'; }` the twig widget will be called `test_widget`
