### PR TITLE
Corrected latin abbreviation

### DIFF
--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -218,7 +218,7 @@ looks up the value of each parameter and uses it in the service definition.
 .. note::
 
     If you want to use a string that starts with an ``@`` sign as a parameter
-    value (i.e. a very safe mailer password) in a YAML file, you need to escape
+    value (e.g. a very safe mailer password) in a YAML file, you need to escape
     it by adding another ``@`` sign (this only applies to the YAML format):
 
     .. code-block:: yaml


### PR DESCRIPTION
i.e. = _id est_, “that is”
e.g. = _exempli gratia_, “for example”
