### PR TITLE
Explain form() and form_widget() in form customization

### DIFF
--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -67,7 +67,7 @@ just one line:
 
     .. code-block:: jinja
 
-        {{ form_widget(form) }}
+        {{ form(form) }}
 
     .. code-block:: php
 

--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -67,11 +67,19 @@ just one line:
 
     .. code-block:: jinja
 
+        {# renders all fields #}
+        {{ form_widget(form) }}
+
+        {# renders all fields *and* the form start and end tags #}
         {{ form(form) }}
 
     .. code-block:: php
 
-        <?php echo $view['form']->widget($form); ?>
+        <!-- renders all fields -->
+        <?php echo $view['form']->widget($form) ?>
+
+        <!-- renders all fields *and* the form start and end tags -->
+        <?php echo $view['form']->form($form) ?>
 
 The remainder of this recipe will explain how every part of the form's markup
 can be modified at several different levels. For more information about form


### PR DESCRIPTION
Continues https://github.com/symfony/symfony-docs/pull/4365

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

Original PR description:

> In the Form chapter of Book for Symfony 2.3, we use `{{ form(form) }}` to render the entire form ( in contrast to `{{ form_widget(form) }}` for older version of Symfony ). so maybe it should use `{{ form(form) }}` here for consistency.
