### PR TITLE
Fix typos in code

### DIFF
--- a/cookbook/console/logging.rst
+++ b/cookbook/console/logging.rst
@@ -190,7 +190,7 @@ First configure a listener for console terminate events in the service container
         # app/config/services.yml
         services:
             kernel.listener.command_dispatch:
-                class: Acme\DemoBundle\EventListener\ConsoleTerminateListener
+                class: Acme\DemoBundle\EventListener\ErrorLoggerListener
                 arguments:
                     logger: "@logger"
                 tags:
@@ -205,7 +205,7 @@ First configure a listener for console terminate events in the service container
                    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="kernel.listener.command_dispatch" class="Acme\DemoBundle\EventListener\ConsoleTerminateListener">
+                <service id="kernel.listener.command_dispatch" class="Acme\DemoBundle\EventListener\ErrorLoggerListener">
                     <argument type="service" id="logger"/>
                     <tag name="kernel.event_listener" event="console.terminate" />
                 </service>
@@ -218,28 +218,28 @@ First configure a listener for console terminate events in the service container
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\DependencyInjection\Reference;
 
-        $definitionConsoleTerminateListener = new Definition(
-            'Acme\DemoBundle\EventListener\ConsoleTerminateListener',
+        $definitionErrorLoggerListener = new Definition(
+            'Acme\DemoBundle\EventListener\ErrorLoggerListener',
             array(new Reference('logger'))
         );
-        $definitionConsoleTerminateListener->addTag(
+        $definitionErrorLoggerListener->addTag(
             'kernel.event_listener',
             array('event' => 'console.terminate')
         );
         $container->setDefinition(
             'kernel.listener.command_dispatch',
-            $definitionConsoleTerminateListener
+            $definitionErrorLoggerListener
         );
 
 Then implement the actual listener::
 
-    // src/Acme/DemoBundle/EventListener/ConsoleTerminateListener.php
+    // src/Acme/DemoBundle/EventListener/ErrorLoggerListener.php
     namespace Acme\DemoBundle\EventListener;
 
     use Symfony\Component\Console\Event\ConsoleTerminateEvent;
     use Psr\Log\LoggerInterface;
 
-    class ConsoleTerminateListener
+    class ErrorLoggerListener
     {
         private $logger;
 

--- a/cookbook/console/logging.rst
+++ b/cookbook/console/logging.rst
@@ -204,12 +204,8 @@ First configure a listener for console terminate events in the service container
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-            <parameters>
-                <parameter key="console_terminate_listener.class">Acme\DemoBundle\EventListener\ConsoleTerminateListener</parameter>
-            </parameters>
-
             <services>
-                <service id="kernel.listener.command_dispatch" class="%console_terminate_listener.class%">
+                <service id="kernel.listener.command_dispatch" class="Acme\DemoBundle\EventListener\ConsoleTerminateListener">
                     <argument type="service" id="logger"/>
                     <tag name="kernel.event_listener" event="console.terminate" />
                 </service>
@@ -222,12 +218,8 @@ First configure a listener for console terminate events in the service container
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\DependencyInjection\Reference;
 
-        $container->setParameter(
-            'console_terminate_listener.class',
-            'Acme\DemoBundle\EventListener\ConsoleTerminateListener'
-        );
         $definitionConsoleTerminateListener = new Definition(
-            '%console_terminate_listener.class%',
+            'Acme\DemoBundle\EventListener\ConsoleTerminateListener',
             array(new Reference('logger'))
         );
         $definitionConsoleTerminateListener->addTag(

--- a/cookbook/console/logging.rst
+++ b/cookbook/console/logging.rst
@@ -205,11 +205,11 @@ First configure a listener for console terminate events in the service container
                    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <parameters>
-                <parameter key="console_exception_listener.class">Acme\DemoBundle\EventListener\ConsoleExceptionListener</parameter>
+                <parameter key="console_terminate_listener.class">Acme\DemoBundle\EventListener\ConsoleTerminateListener</parameter>
             </parameters>
 
             <services>
-                <service id="kernel.listener.command_dispatch" class="%console_exception_listener.class%">
+                <service id="kernel.listener.command_dispatch" class="%console_terminate_listener.class%">
                     <argument type="service" id="logger"/>
                     <tag name="kernel.event_listener" event="console.terminate" />
                 </service>
@@ -223,31 +223,31 @@ First configure a listener for console terminate events in the service container
         use Symfony\Component\DependencyInjection\Reference;
 
         $container->setParameter(
-            'console_exception_listener.class',
-            'Acme\DemoBundle\EventListener\ConsoleExceptionListener'
+            'console_terminate_listener.class',
+            'Acme\DemoBundle\EventListener\ConsoleTerminateListener'
         );
-        $definitionConsoleExceptionListener = new Definition(
-            '%console_exception_listener.class%',
+        $definitionConsoleTerminateListener = new Definition(
+            '%console_terminate_listener.class%',
             array(new Reference('logger'))
         );
-        $definitionConsoleExceptionListener->addTag(
+        $definitionConsoleTerminateListener->addTag(
             'kernel.event_listener',
             array('event' => 'console.terminate')
         );
         $container->setDefinition(
             'kernel.listener.command_dispatch',
-            $definitionConsoleExceptionListener
+            $definitionConsoleTerminateListener
         );
 
 Then implement the actual listener::
 
-    // src/Acme/DemoBundle/EventListener/ConsoleExceptionListener.php
+    // src/Acme/DemoBundle/EventListener/ConsoleTerminateListener.php
     namespace Acme\DemoBundle\EventListener;
 
     use Symfony\Component\Console\Event\ConsoleTerminateEvent;
     use Psr\Log\LoggerInterface;
 
-    class ConsoleExceptionListener
+    class ConsoleTerminateListener
     {
         private $logger;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets |  |

PS 1: As so far I used only yaml files for services not sure if the changes to XML and PHP code blocks are correct

PS 2: Maybe I configured something wrong or something like that (or you could point me in the right direction for more information), but I don't think the terminate listener will work. In my opinion when command is exited with exception the exit code should be more than zero, but on `ConsoleTerminateEvent` and even on `ConsoleExceptionEvent` the exit code is `0`
