### PR TITLE
Correct link to scopes page

### DIFF
--- a/cookbook/console/console_command.rst
+++ b/cookbook/console/console_command.rst
@@ -87,7 +87,7 @@ service container. In other words, you have access to any configured service::
         // ...
     }
 
-However, due to the `container scopes </doc/current/cookbook/service_container/scopes.html>`_ this
+However, due to the :doc:`container scopes </cookbook/service_container/scopes>` this
 code doesn't work for some services. For instance, if you try to get the ``request``
 service or any other service related to it, you'll get the following error:
 

--- a/cookbook/console/console_command.rst
+++ b/cookbook/console/console_command.rst
@@ -87,7 +87,7 @@ service container. In other words, you have access to any configured service::
         // ...
     }
 
-However, due to the `container scopes </cookbook/service_container/scopes>`_ this
+However, due to the `container scopes </doc/current/cookbook/service_container/scopes.html>`_ this
 code doesn't work for some services. For instance, if you try to get the ``request``
 service or any other service related to it, you'll get the following error:
 


### PR DESCRIPTION
The current link to scopes page dont work, this is the correct link to the page
