### PR TITLE
fix elseif statement

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -367,7 +367,7 @@ on the requested URI:
     require_once 'controllers.php';
 
     // route the request internally
-    $uri = $_SERVER['REQUEST_URI'];
+    $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
     if ('/index.php' == $uri) {
         list_action();
     } elseif ('/index.php/show' == $uri && isset($_GET['id'])) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | -- |

In this example of the book, the elseif block always evaluates to FALSE since $_SERVER['REQUEST_URI'] includes the query string, therefore if $uri equals to '/index.php/show' then $_GET['id'] is never set, and the list_action() is never executed.

Here I propose a fix by cleaning the query string from the URI before assigning it to $uri, using the built-in function parse_url().
