### PR TITLE
Removed unnecessary use statement

### DIFF
--- a/cookbook/debugging.rst
+++ b/cookbook/debugging.rst
@@ -47,8 +47,6 @@ below::
     $loader = require_once __DIR__.'/../app/autoload.php';
     require_once __DIR__.'/../app/AppKernel.php';
 
-    use Symfony\Component\HttpFoundation\Request;
-
     $kernel = new AppKernel('dev', true);
     // $kernel->loadClassCache();
     $request = Request::createFromGlobals();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

Found a rather unnecessary "use" statement in the code example in the "debugging" cookbook. Makes it difficult to spot the changes between one code example and the following one and know what changed.
