### PR TITLE
New validation API usage in Class Constraint Validator

### DIFF
--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -232,6 +232,7 @@ With this, the validator ``validate()`` method gets an object as its first argum
             if ($protocol->getFoo() != $protocol->getBar()) {
                 // If you're using the new 2.5 validation API (you probably are!)
                 $this->context->buildViolation($constraint->message)
+                    ->atPath('foo')
                     ->addViolation();
 
                 // If you're using the old 2.4 validation API

--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -230,12 +230,19 @@ With this, the validator ``validate()`` method gets an object as its first argum
         public function validate($protocol, Constraint $constraint)
         {
             if ($protocol->getFoo() != $protocol->getBar()) {
+                // If you're using the new 2.5 validation API (you probably are!)
+                $this->context->buildViolation($constraint->message)
+                    ->addViolation();
+
+                // If you're using the old 2.4 validation API
+                /*
                 $this->context->addViolationAt(
                     'foo',
                     $constraint->message,
                     array(),
                     null
                 );
+                */
             }
         }
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5 |
| Fixed tickets |  |

The code in the documentation about Class Constraint Validator was still using the deprecated validation API
