### PR TITLE
Escape the html attribute correctly

### DIFF
--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -299,7 +299,7 @@ new "tag" forms. To render it, make the following change to your template:
 
     .. code-block:: html+jinja
 
-        <ul class="tags" data-prototype="{{ form_widget(form.tags.vars.prototype)|e }}">
+        <ul class="tags" data-prototype="{{ form_widget(form.tags.vars.prototype)|e('html_attr') }}">
             ...
         </ul>
 


### PR DESCRIPTION
As far as I know, escaping something as in the html context for the html attribute can lead to invalid/insecure html code. Please let me know if I'm wrong.

Note: html_attr escape is available since Twig 1.9.0 (used since symfony v2.1.0 release)
