### PR TITLE
Specify that caught exceptions should be assigned to a variable named `$e`

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -141,6 +141,8 @@ Naming Conventions
 
 * Don't forget to look at the more verbose :doc:`conventions` document for
   more subjective naming considerations.
+  
+* Caught exceptions should assigned to a variable named `$e`.
 
 .. _service-naming-conventions:
 


### PR DESCRIPTION
320 out of 372 catches in the symfony code base use `$e`.

```
git grep "catch (.*Exception" | grep "\$e)" | wc -l                                                                                                                                               
320
git grep "catch (.*Exception" | wc -l
372
```

I think it would be good to make this a standard?

i.e.

```
try {
    // foo
} catch (SomeException $e) {
    // bar
}
```

as opposed to using  variations: `$ex` (5 instances) `$exception` (2 instances), etc.
