### PR TITLE
Fixed composer create-project command (windows)

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -59,7 +59,7 @@ Distribution:
 
 .. code-block:: bash
 
-    $ php composer.phar create-project symfony/framework-standard-edition /path/to/webroot/Symfony '2.3.*'
+    $ php composer.phar create-project symfony/framework-standard-edition /path/to/webroot/Symfony "2.3.*"
 
 .. tip::
 

--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -26,7 +26,7 @@ git repository:
 
    .. code-block:: bash
 
-        $ php composer.phar create-project symfony/framework-standard-edition path/ '~2.5'
+        $ php composer.phar create-project symfony/framework-standard-edition path/ "~2.5"
 
    .. tip::
 


### PR DESCRIPTION
The composer create-project command as it was doesn't work on windows because of the single astrophes ' . The error returned is:

```
Could not parse version constraint '2.5.*': Invalid version string "'2.5.*'"
```

This is resolved by switching to double astrophes ". The new command is verified to work on ubuntu linux as well.
