### PR TITLE
SetDescription required on Product entities

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -1105,6 +1105,7 @@ Now you can see this new code in action! Imagine you're inside a controller::
             $product = new Product();
             $product->setName('Foo');
             $product->setPrice(19.99);
+            $product->setDescription('Lorem ipsum dolor');
             // relate this product to the category
             $product->setCategory($category);
 


### PR DESCRIPTION
Doctrine sets columns to NOT NULL by default. The code in the example throws an exception without the fix.
