### PR TITLE
Add missing semicolons to PropertyAccess examples

### DIFF
--- a/components/property_access/introduction.rst
+++ b/components/property_access/introduction.rst
@@ -363,7 +363,7 @@ configured to enable extra features. To do that you could use the
     $accessorBuilder->disableMagicCall();
 
     // Check if magic __call handling is enabled
-    $accessorBuilder->isMagicCallEnabled() // true or false
+    $accessorBuilder->isMagicCallEnabled(); // true or false
 
     // At the end get the configured property accessor
     $accessor = $accessorBuilder->getPropertyAccessor();
@@ -376,7 +376,7 @@ configured to enable extra features. To do that you could use the
 Or you can pass parameters directly to the constructor (not the recommended way)::
 
     // ...
-    $accessor = new PropertyAccessor(true) // this enables handling of magic __call
+    $accessor = new PropertyAccessor(true); // this enables handling of magic __call
 
 
 .. _Packagist: https://packagist.org/packages/symfony/property-access


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | none |
