### PR TITLE
GetResponse*Events stop after a response was set

### DIFF
--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -169,7 +169,7 @@ attributes).
 
 .. note::
 
-    When setting a response for the ``kernel.view`` event, the propagation
+    When setting a response for the ``kernel.request`` event, the propagation
     is stopped. This means listeners with lower priority won't be executed.
 
 .. sidebar:: ``kernel.request`` in the Symfony Framework

--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -391,6 +391,11 @@ At this stage, if no listener sets a response on the event, then an exception
 is thrown: either the controller *or* one of the view listeners must always
 return a ``Response``.
 
+.. note::
+
+    When setting a response for the ``kernel.view`` event, the propagation
+    is stopped, so the lower priority listeners on that event don't get called.
+
 .. sidebar:: ``kernel.view`` in the Symfony Framework
 
     There is no default listener inside the Symfony Framework for the ``kernel.view``
@@ -521,6 +526,11 @@ creates and returns a 404 ``Response``. In fact, the HttpKernel component
 comes with an :class:`Symfony\\Component\\HttpKernel\\EventListener\\ExceptionListener`,
 which if you choose to use, will do this and more by default (see the sidebar
 below for more details).
+
+.. note::
+
+    When setting a response for the ``kernel.exception`` event, the propagation
+    is stopped, so the lower priority listeners on that event don't get called.
 
 .. sidebar:: ``kernel.exception`` in the Symfony Framework
 

--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -167,6 +167,11 @@ return a ``Response`` directly, or to add information to the ``Request``
 (e.g. setting the locale or setting some other information on the ``Request``
 attributes).
 
+.. note::
+
+    When setting a response for the ``kernel.view`` event, the propagation
+    is stopped, so the lower priority listeners on that event don't get called.
+
 .. sidebar:: ``kernel.request`` in the Symfony Framework
 
     The most important listener to ``kernel.request`` in the Symfony Framework

--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -170,7 +170,7 @@ attributes).
 .. note::
 
     When setting a response for the ``kernel.view`` event, the propagation
-    is stopped, so the lower priority listeners on that event don't get called.
+    is stopped. This means listeners with lower priority won't be executed.
 
 .. sidebar:: ``kernel.request`` in the Symfony Framework
 
@@ -399,7 +399,7 @@ return a ``Response``.
 .. note::
 
     When setting a response for the ``kernel.view`` event, the propagation
-    is stopped, so the lower priority listeners on that event don't get called.
+    is stopped. This means listeners with lower priority won't be executed.
 
 .. sidebar:: ``kernel.view`` in the Symfony Framework
 
@@ -535,7 +535,7 @@ below for more details).
 .. note::
 
     When setting a response for the ``kernel.exception`` event, the propagation
-    is stopped, so the lower priority listeners on that event don't get called.
+    is stopped. This means listeners with lower priority won't be executed.
 
 .. sidebar:: ``kernel.exception`` in the Symfony Framework
 

--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -57,6 +57,12 @@ event is just one of the core kernel events::
     the ``kernel.exception`` event, it is :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent`.
     To see what type of object each event listener receives, see :class:`Symfony\\Component\\HttpKernel\\KernelEvents`.
 
+.. note::
+
+    When setting a response for the ``kernel.view`` or ``kernel.exception``
+    events, the propagation is stopped, so the lower priority listeners on
+    that event don't get called.
+
 Now that the class is created, you just need to register it as a service and
 notify Symfony that it is a "listener" on the ``kernel.exception`` event by
 using a special "tag":

--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -59,9 +59,9 @@ event is just one of the core kernel events::
 
 .. note::
 
-    When setting a response for the ``kernel.view`` or ``kernel.exception``
-    events, the propagation is stopped, so the lower priority listeners on
-    that event don't get called.
+    When setting a response for the ``kernel.request``, ``kernel.view`` and
+    ``kernel.exception`` events, the propagation is stopped, so the lower
+    priority listeners on that event don't get called.
 
 Now that the class is created, you just need to register it as a service and
 notify Symfony that it is a "listener" on the ``kernel.exception`` event by


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | All versions |
| Fixed tickets | #4516 |

The kernel.view and kernel.exception events stop propagation when a response is set, and it wasn't noted on the documentation.
