### PR TITLE
bug #4273 - fix doctrine version in How to Provide Model Classes for several Doctrine Implementations cookbook

### DIFF
--- a/cookbook/doctrine/mapping_model_classes.rst
+++ b/cookbook/doctrine/mapping_model_classes.rst
@@ -18,7 +18,7 @@ register the mappings for your model classes.
 
 .. versionadded:: 2.3
     The base mapping compiler pass was introduced in Symfony 2.3. The Doctrine bundles
-    support it from DoctrineBundle >= 1.2.1, MongoDBBundle >= 3.0.0,
+    support it from DoctrineBundle >= 1.3.0, MongoDBBundle >= 3.0.0,
     PHPCRBundle >= 1.0.0-alpha2 and the (unversioned) CouchDBBundle supports the
     compiler pass since the `CouchDB Mapping Compiler Pass pull request`_
     was merged.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | #4273 |
