### PR TITLE
Updated twig reference with optimizations and paths

### DIFF
--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -44,6 +44,8 @@ TwigBundle Configuration ("twig")
             strict_variables:          ~
             auto_reload:               ~
             optimizations:             ~
+            paths:
+                "%kernel.root_dir%/../vendor/acme/foo-bar/templates": foo_bar
 
     .. code-block:: xml
 
@@ -53,12 +55,14 @@ TwigBundle Configuration ("twig")
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                                 http://symfony.com/schema/dic/twig http://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
-            <twig:config auto-reload="%kernel.debug%" autoescape="true" base-template-class="Twig_Template" cache="%kernel.cache_dir%/twig" charset="%kernel.charset%" debug="%kernel.debug%" strict-variables="false">
+            <twig:config auto-reload="%kernel.debug%" autoescape="true" base-template-class="Twig_Template" cache="%kernel.cache_dir%/twig" charset="%kernel.charset%" debug="%kernel.debug%" strict-variables="false" optimizations="true">
                 <twig:form>
                     <twig:resource>MyBundle::form.html.twig</twig:resource>
                 </twig:form>
                 <twig:global key="foo" id="bar" type="service" />
                 <twig:global key="pi">3.14</twig:global>
+                <twig:exception-controller>AcmeFooBundle:Exception:showException</twig:exception-controller>
+                <twig:path namespace="foo_bar">%kernel.root_dir%/../vendor/acme/foo-bar/templates</twig:path>
             </twig:config>
         </container>
 
@@ -74,13 +78,18 @@ TwigBundle Configuration ("twig")
                  'foo' => '@bar',
                  'pi'  => 3.14,
              ),
-             'auto_reload'         => '%kernel.debug%',
-             'autoescape'          => true,
-             'base_template_class' => 'Twig_Template',
-             'cache'               => '%kernel.cache_dir%/twig',
-             'charset'             => '%kernel.charset%',
-             'debug'               => '%kernel.debug%',
-             'strict_variables'    => false,
+             'auto_reload'          => '%kernel.debug%',
+             'autoescape'           => true,
+             'base_template_class'  => 'Twig_Template',
+             'cache'                => '%kernel.cache_dir%/twig',
+             'charset'              => '%kernel.charset%',
+             'debug'                => '%kernel.debug%',
+             'strict_variables'     => false,
+             'exception_controller' => 'AcmeFooBundle:Exception:showException',
+             'optimizations'        => true,
+             'paths' => array(
+                 '%kernel.root_dir%/../vendor/acme/foo-bar/templates' => 'foo_bar',
+             ),
         ));
 
 Configuration


### PR DESCRIPTION
Added information about `optimizations` and `paths` twig configs to reference

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | >=2.3 |
| Fixed tickets | - |
