### PR TITLE
Note about checking symfony requirements by installer

### DIFF
--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -85,10 +85,10 @@ application right away.
 
 .. note::
 
-    When creating the project, the Symfony Installer will check if your system
-    meets the requirements that have to be fulfilled to run your new Symfony
-    application. You can later on perform the requirements check again at will
-    using the Symfony console application:
+   When creating the project, the Symfony Installer will check if your system
+   meets the requirements that have to be fulfilled to run your new Symfony
+   application. You can later on perform the requirements check again at will
+   using the Symfony console application:
 
    .. code-block:: bash
 

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -85,9 +85,10 @@ application right away.
 
 .. note::
 
-   After creating project, Symfony Installer will check if your system meets
-   all the requirements for running Symfony application.
-   You can always check it later by yourself with following console command:
+    When creating the project, the Symfony Installer will check if your system
+    meets the requirements that have to be fulfilled to run your new Symfony
+    application. You can later on perform the requirements check again at will
+    using the Symfony console application:
 
    .. code-block:: bash
 

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -83,6 +83,16 @@ This command downloads the latest Symfony stable version and creates an empty
 project in the ``myproject/`` directory so you can start developing your
 application right away.
 
+.. note::
+
+   After creating project, Symfony Installer will check if your system meets
+   all the requirements for running Symfony application.
+   You can always check it later by yourself with following console command:
+
+   .. code-block:: bash
+
+        $ php myproject/app/check.php
+
 .. _running-symfony2:
 
 Running Symfony


### PR DESCRIPTION
Since version 0.2.0 Installer will also check for symfony requirements - I think it would be good to mention about it in docs.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | addition about https://github.com/symfony/symfony-installer/pull/27 |
| Applies to | >=2.3 |
| Fixed tickets | - |
