### PR TITLE
Typo when expression language is used to configure a service.

### DIFF
--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -720,7 +720,7 @@ via a ``container`` variable. Here's another example:
 
             <services>
                 <service id="my_mailer" class="Acme\HelloBundle\Mailer">
-                    <argument type="expression">@=container.hasParameter('some_param') ? parameter('some_param') : 'default_value'</argument>
+                    <argument type="expression">container.hasParameter('some_param') ? parameter('some_param') : 'default_value'</argument>
                 </service>
             </services>
         </container>
@@ -733,7 +733,7 @@ via a ``container`` variable. Here's another example:
         $container->setDefinition('my_mailer', new Definition(
             'Acme\HelloBundle\Mailer',
             array(new Expression(
-                "@=container.hasParameter('some_param') ? parameter('some_param') : 'default_value'"
+                "container.hasParameter('some_param') ? parameter('some_param') : 'default_value'"
             ))
         ));
 


### PR DESCRIPTION
Typo in XML and PHP code block when expression language is used to configure a service.

```
  [Symfony\Component\ExpressionLanguage\SyntaxError]  
  Unexpected character "@" around position 0.       
```
