### PR TITLE
Update Symfony reference to 2.7 version

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -59,7 +59,7 @@ Distribution:
 
 .. code-block:: bash
 
-    $ php composer.phar create-project symfony/framework-standard-edition /path/to/webroot/Symfony '~2.5'
+    $ php composer.phar create-project symfony/framework-standard-edition /path/to/webroot/Symfony '~2.7'
 
 .. tip::
 
@@ -112,10 +112,10 @@ one of the following commands (replacing ``###`` with your actual filename):
 .. code-block:: bash
 
     # for .tgz file
-    $ tar zxvf Symfony_Standard_Vendors_2.5.###.tgz
+    $ tar zxvf Symfony_Standard_Vendors_2.7.###.tgz
 
     # for a .zip file
-    $ unzip Symfony_Standard_Vendors_2.5.###.zip
+    $ unzip Symfony_Standard_Vendors_2.7.###.zip
 
 If you've downloaded "without vendors", you'll definitely need to read the
 next section.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7 only |
| Fixed tickets |  |

It's a bit unpractical having to update the version by hand each time a mayor version is released... and hard to remember.

Can this be resolved with a parameter (or something similar) common to the whole documentation??
