### PR TITLE
Updated examples: SecurityContext to Authorization\AuthorizationChecker

### DIFF
--- a/cookbook/profiler/matchers.rst
+++ b/cookbook/profiler/matchers.rst
@@ -70,22 +70,22 @@ something like::
     // src/Acme/DemoBundle/Profiler/SuperAdminMatcher.php
     namespace Acme\DemoBundle\Profiler;
 
-    use Symfony\Component\Security\Core\SecurityContext;
+    use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 
     class SuperAdminMatcher implements RequestMatcherInterface
     {
-        protected $securityContext;
+        protected $authorizationChecker;
 
-        public function __construct(SecurityContext $securityContext)
+        public function __construct(AuthorizationChecker $authorizationChecker)
         {
-            $this->securityContext = $securityContext;
+            $this->authorizationChecker = $authorizationChecker;
         }
 
         public function matches(Request $request)
         {
-            return $this->securityContext->isGranted('ROLE_SUPER_ADMIN');
+            return $this->authorizationChecker->isGranted('ROLE_SUPER_ADMIN');
         }
     }
 
@@ -101,7 +101,7 @@ Then, you need to configure the service:
         services:
             acme_demo.profiler.matcher.super_admin:
                 class: "%acme_demo.profiler.matcher.super_admin.class%"
-                arguments: ["@security.context"]
+                arguments: ["@security.authorization_checker"]
 
     .. code-block:: xml
 
@@ -114,7 +114,7 @@ Then, you need to configure the service:
         <services>
             <service id="acme_demo.profiler.matcher.super_admin"
                 class="%acme_demo.profiler.matcher.super_admin.class%">
-                <argument type="service" id="security.context" />
+                <argument type="service" id="security.authorization_checker" />
         </services>
 
     .. code-block:: php
@@ -129,7 +129,7 @@ Then, you need to configure the service:
 
         $container->setDefinition('acme_demo.profiler.matcher.super_admin', new Definition(
             '%acme_demo.profiler.matcher.super_admin.class%',
-            array(new Reference('security.context'))
+            array(new Reference('security.authorization_checker'))
         );
 
 Now the service is registered, the only thing left to do is configure the


### PR DESCRIPTION
Updated examples to reflect changes in Symfony 2.6, and the depracated Symfony\Component\Security\Core\SecurityContext class - specifically: symfony/symfony#11690
