### PR TITLE
Completed the needed context to successfully test commands with Helpers

### DIFF
--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -247,13 +247,18 @@ Testing a Command which Expects Input
 If you want to write a unit test for a command which expects some kind of input
 from the command line, you need to overwrite the HelperSet used by the command::
 
+    use Symfony\Component\Console\Application;
     use Symfony\Component\Console\Helper\DialogHelper;
     use Symfony\Component\Console\Helper\HelperSet;
+    use Symfony\Component\Console\Tester\CommandTester;
 
     // ...
     public function testExecute()
     {
         // ...
+        $application = new Application();
+        $application->add(new MyCommand());
+        $command = $application->find('my:command:name');
         $commandTester = new CommandTester($command);
 
         $dialog = $command->getHelper('dialog');
@@ -279,3 +284,8 @@ By setting the input stream of the ``DialogHelper``, you imitate what the
 console would do internally with all user input through the cli. This way
 you can test any user interaction (even complex ones) by passing an appropriate
 input stream.
+
+.. seealso::
+
+    You find more information about testing commands in the console component
+    docs about :ref:`testing console commands <component-console-testing-commands>`.

--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -411,6 +411,8 @@ tools capable of helping you with different tasks:
 * :doc:`/components/console/helpers/tablehelper`: displays tabular data as a table
 * :doc:`/components/console/helpers/dialoghelper`: (deprecated) interactively ask the user for information
 
+.. _component-console-testing-commands:
+
 Testing Commands
 ----------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #4581 |

As mentioned in symfony/symfony#12798 the explanation about the initialization is not clear.
Therefore I have added the needed context and a reference to the related cookbook article.
