### PR TITLE
Missing attribute 'original'

### DIFF
--- a/best_practices/i18n.rst
+++ b/best_practices/i18n.rst
@@ -83,7 +83,7 @@ English in the application would be:
     <!-- app/Resources/translations/messages.en.xliff -->
     <?xml version="1.0"?>
     <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-        <file source-language="en" target-language="en" datatype="plaintext">
+        <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
             <body>
                 <trans-unit id="1">
                     <source>title.post_list</source>


### PR DESCRIPTION
I copy pasted the example messages.en.xliff provided. Running it on symfony 2.6 required me the attribute 'original'.
I added ' original="file.ext" ' as attribute for the file tag and it worked. However I am not shure about the proper parameter for this attribute.
