### PR TITLE
Replace form_enctype(form) with form_start(form).

### DIFF
--- a/best_practices/forms.rst
+++ b/best_practices/forms.rst
@@ -145,12 +145,12 @@ view layer:
 
 .. code-block:: html+jinja
 
-    <form method="POST" {{ form_enctype(form) }}>
+    {{ form_start(form) }}
         {{ form_widget(form) }}
 
         <input type="submit" value="Create"
                class="btn btn-default pull-right" />
-    </form>
+    {{ form_end(form) }}
 
 Rendering the Form
 ------------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | >=2.3 |
| Fixed tickets |  |

Since form_enctype(form) is deprecated since 2.3 form_start(form) should be used.
