### PR TITLE
[Best Practices] readd mistakenly removed label

### DIFF
--- a/best_practices/security.rst
+++ b/best_practices/security.rst
@@ -123,6 +123,8 @@ Using ``@Security``, this looks like:
         // ...
     }
 
+.. _best-practices-directly-isGranted:
+
 Checking Permissions without @Security
 --------------------------------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

The button was mistakenly removed in c090a744c2ded4ff33b9f0f462adfdac8f5dae43.
