### PR TITLE
Removing some installation instructions

### DIFF
--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -19,24 +19,10 @@ that's stored using the `Git`_ source control management system.
 Initial Project Setup
 ---------------------
 
-To get started, you'll need to download Symfony and initialize your local
-git repository:
+To get started, you'll need to download Symfony and get things running. See
+the :doc:`/book/installation` chapter for details.
 
-#. Download the `Symfony Standard Edition`_ using Composer:
-
-   .. code-block:: bash
-
-        $ php composer.phar create-project symfony/framework-standard-edition path/ '~2.5'
-
-   .. tip::
-
-       Add the ``-vvv`` flag to see everything that Composer is doing - this is
-       especially useful on a slow connection where it may seem that nothing is
-       happening.
-
-   Composer will now download the Standard Distribution along with all of the
-   required vendor libraries. For more information about downloading Symfony using
-   Composer, see `Installing Symfony using Composer`_.
+Once your project is running, just follow these simple steps:
 
 #. Initialize your Git repository:
 
@@ -89,16 +75,6 @@ to learn more about how to configure and develop inside your application.
 .. _cookbook-managing-vendor-libraries:
 
 .. include:: _vendor_deps.rst.inc
-
-Vendors and Submodules
-~~~~~~~~~~~~~~~~~~~~~~
-
-Instead of using the ``composer.json`` system for managing your vendor
-libraries, you may instead choose to use native `git submodules`_. There
-is nothing wrong with this approach, though the ``composer.json`` system
-is the official way to solve this problem and probably much easier to
-deal with. Unlike Git submodules, Composer is smart enough to calculate
-which libraries depend on which other libraries.
 
 Storing your Project on a remote Server
 ---------------------------------------

--- a/cookbook/workflow/new_project_svn.rst
+++ b/cookbook/workflow/new_project_svn.rst
@@ -53,20 +53,20 @@ First, download and get your Symfony project running by following the
 Once you have your new project directory and things are working, follow along
 with these steps:
 
-1. Checkout the Subversion repository that will host this project. Suppose
+#. Checkout the Subversion repository that will host this project. Suppose
    it is hosted on `Google code`_ and called ``myproject``:
 
    .. code-block:: bash
 
         $ svn checkout http://myproject.googlecode.com/svn/trunk myproject
 
-2. Copy the Symfony project files in the Subversion folder:
+#. Copy the Symfony project files in the Subversion folder:
 
    .. code-block:: bash
 
         $ mv Symfony/* myproject/
 
-3. Now, set the ignore rules. Not everything *should* be stored in your Subversion
+#. Now, set the ignore rules. Not everything *should* be stored in your Subversion
    repository. Some files (like the cache) are generated and others (like
    the database configuration) are meant to be customized on each machine.
    This makes use of the ``svn:ignore`` property, so that specific files can
@@ -87,21 +87,21 @@ with these steps:
 
         $ svn ci -m "commit basic Symfony ignore list (vendor, app/bootstrap*, app/config/parameters.yml, app/cache/*, app/logs/*, web/bundles)"
 
-4. The rest of the files can now be added and committed to the project:
+#. The rest of the files can now be added and committed to the project:
 
    .. code-block:: bash
 
         $ svn add --force .
         $ svn ci -m "add basic Symfony Standard 2.X.Y"
 
-5. Copy ``app/config/parameters.yml`` to ``app/config/parameters.yml.dist``.
+#. Copy ``app/config/parameters.yml`` to ``app/config/parameters.yml.dist``.
    The ``parameters.yml`` file is ignored by svn (see above) so that
    machine-specific settings like database passwords aren't committed. By
    creating the ``parameters.yml.dist`` file, new developers can quickly clone
    the project, copy this file to ``parameters.yml``, customize it, and start
    developing.
 
-6. Finally, download all of the third-party vendor libraries by
+#. Finally, download all of the third-party vendor libraries by
    executing Composer. For details, see :ref:`installation-updating-vendors`.
 
 .. tip::

--- a/cookbook/workflow/new_project_svn.rst
+++ b/cookbook/workflow/new_project_svn.rst
@@ -94,20 +94,12 @@ with these steps:
         $ svn add --force .
         $ svn ci -m "add basic Symfony Standard 2.X.Y"
 
-#. Copy ``app/config/parameters.yml`` to ``app/config/parameters.yml.dist``.
-   The ``parameters.yml`` file is ignored by svn (see above) so that
-   machine-specific settings like database passwords aren't committed. By
-   creating the ``parameters.yml.dist`` file, new developers can quickly clone
-   the project, copy this file to ``parameters.yml``, customize it, and start
-   developing.
-
-#. Finally, download all of the third-party vendor libraries by
-   executing Composer. For details, see :ref:`installation-updating-vendors`.
-
-.. tip::
-
-	If you rely on any "dev" versions, then Git may be used to install
-	those libraries, since there is no archive available for download.
+That's it! Since the ``app/config/parameters.yml`` file is ignored, you can
+store machine-specific settings like database passwords here without committing
+them. The ``parameters.yml.dist`` file *is* committed, but is not read by
+Symfony. And by adding any new keys you need to both files, new developers
+can quickly clone the project, copy this file to ``parameters.yml``, customize
+it, and start developing.
 
 At this point, you have a fully-functional Symfony project stored in your
 Subversion repository. The development can start with commits in the Subversion

--- a/cookbook/workflow/new_project_svn.rst
+++ b/cookbook/workflow/new_project_svn.rst
@@ -46,28 +46,27 @@ widespread standard structure:
 Initial Project Setup
 ---------------------
 
-To get started, you'll need to download Symfony and get the basic Subversion setup:
+To get started, you'll need to download Symfony and get the basic Subversion setup.
+First, download and get your Symfony project running by following the
+:doc:`Installation </book/installation>` chapter.
 
-1. Download the `Symfony Standard Edition`_ with or without vendors.
+Once you have your new project directory and things are working, follow along
+with these steps:
 
-2. Unzip/untar the distribution. It will create a folder called Symfony with
-   your new project structure, config files, etc. Rename it to whatever you
-   like.
-
-3. Checkout the Subversion repository that will host this project. Suppose
+1. Checkout the Subversion repository that will host this project. Suppose
    it is hosted on `Google code`_ and called ``myproject``:
 
    .. code-block:: bash
 
         $ svn checkout http://myproject.googlecode.com/svn/trunk myproject
 
-4. Copy the Symfony project files in the Subversion folder:
+2. Copy the Symfony project files in the Subversion folder:
 
    .. code-block:: bash
 
         $ mv Symfony/* myproject/
 
-5. Now, set the ignore rules. Not everything *should* be stored in your Subversion
+3. Now, set the ignore rules. Not everything *should* be stored in your Subversion
    repository. Some files (like the cache) are generated and others (like
    the database configuration) are meant to be customized on each machine.
    This makes use of the ``svn:ignore`` property, so that specific files can
@@ -88,21 +87,21 @@ To get started, you'll need to download Symfony and get the basic Subversion set
 
         $ svn ci -m "commit basic Symfony ignore list (vendor, app/bootstrap*, app/config/parameters.yml, app/cache/*, app/logs/*, web/bundles)"
 
-6. The rest of the files can now be added and committed to the project:
+4. The rest of the files can now be added and committed to the project:
 
    .. code-block:: bash
 
         $ svn add --force .
         $ svn ci -m "add basic Symfony Standard 2.X.Y"
 
-7. Copy ``app/config/parameters.yml`` to ``app/config/parameters.yml.dist``.
+5. Copy ``app/config/parameters.yml`` to ``app/config/parameters.yml.dist``.
    The ``parameters.yml`` file is ignored by svn (see above) so that
    machine-specific settings like database passwords aren't committed. By
    creating the ``parameters.yml.dist`` file, new developers can quickly clone
    the project, copy this file to ``parameters.yml``, customize it, and start
    developing.
 
-8. Finally, download all of the third-party vendor libraries by
+6. Finally, download all of the third-party vendor libraries by
    executing Composer. For details, see :ref:`installation-updating-vendors`.
 
 .. tip::


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | all |
| Fixed tickets | n/a |

Hi guys!

This removes some duplicate installation instructions. I want less docs, without explaining less :). Duplicate like this is an opportunity to give users more paths for no reason. I'm sure we have more things like this - like details on handling parameters.yml or other things.

Thanks!
