### PR TITLE
Adding details about the changes to the PdoSessionHandler in 2.6

### DIFF
--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -221,10 +221,10 @@ following (MySQL):
 .. code-block:: sql
 
     CREATE TABLE `session` (
-        `session_id` VARBINARY(128) NOT NULL PRIMARY KEY,
-        `session_data` BLOB NOT NULL,
-        `session_time` INTEGER UNSIGNED NOT NULL,
-        `session_lifetime` MEDIUMINT NOT NULL
+        `sess_id` VARBINARY(128) NOT NULL PRIMARY KEY,
+        `sess_data` BLOB NOT NULL,
+        `sess_time` INTEGER UNSIGNED NOT NULL,
+        `sess_lifetime` MEDIUMINT NOT NULL
     ) COLLATE utf8_bin, ENGINE = InnoDB;
 
 PostgreSQL
@@ -235,10 +235,10 @@ For PostgreSQL, the statement should look like this:
 .. code-block:: sql
 
     CREATE TABLE session (
-        session_id VARCHAR(128) NOT NULL PRIMARY KEY,
-        session_data BYTEA NOT NULL,
-        session_time INTEGER NOT NULL,
-        session_lifetime INTEGER NOT NULL
+        sess_id VARCHAR(128) NOT NULL PRIMARY KEY,
+        sess_data BYTEA NOT NULL,
+        sess_time INTEGER NOT NULL,
+        sess_lifetime INTEGER NOT NULL
     );
 
 Microsoft SQL Server
@@ -249,12 +249,12 @@ For MSSQL, the statement might look like the following:
 .. code-block:: sql
 
     CREATE TABLE [dbo].[session](
-        [session_id] [nvarchar](255) NOT NULL,
-        [session_data] [ntext] NOT NULL,
-        [session_time] [int] NOT NULL,
-        [session_lifetime] [int] NOT NULL,
+        [sess_id] [nvarchar](255) NOT NULL,
+        [sess_data] [ntext] NOT NULL,
+        [sess_time] [int] NOT NULL,
+        [sess_lifetime] [int] NOT NULL,
         PRIMARY KEY CLUSTERED(
-            [session_id] ASC
+            [sess_id] ASC
         ) WITH (
             PAD_INDEX  = OFF,
             STATISTICS_NORECOMPUTE  = OFF,

--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -6,7 +6,7 @@ How to Use PdoSessionHandler to Store Sessions in the Database
 
 .. caution::
 
-    There was a backwards-compatability break in Symfony 2.6: the database
+    There was a backwards-compatibility break in Symfony 2.6: the database
     schema changed slightly. See :ref:`Symfony 2.6 Changes <pdo-session-handle-26-changes>`
     for details.
 
@@ -118,10 +118,9 @@ a second array argument to ``PdoSessionHandler``:
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-
         <services>
-
-            <service id="session.handler.pdo" class="Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler">
+            <service id="session.handler.pdo"
+                class="Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler">
                 <argument type="service" id="pdo" />
                 <argument type="collection">
                     <argument key="db_table">sessions</argument>
@@ -132,17 +131,22 @@ a second array argument to ``PdoSessionHandler``:
     .. code-block:: php
 
         // app/config/config.php
+
+        use Symfony\Component\DependencyInjection\Definition;
         // ...
 
-        $storageDefinition = new Definition('Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler', array(
-            new Reference('pdo'),
-            array('db_table' => 'session')
-        ));
+        $storageDefinition = new Definition(
+            'Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler',
+            array(
+                new Reference('pdo'),
+                array('db_table' => 'session')
+            )
+        );
         $container->setDefinition('session.handler.pdo', $storageDefinition);
 
 .. versionadded:: 2.6
-    The ``db_lifetime_col`` was introduced in Symfony 2.6 This column did
-    not exist previously.
+    The ``db_lifetime_col`` was introduced in Symfony 2.6. Prior to 2.6,
+    this column did not exist.
 
 The following things can be configured:
 
@@ -202,7 +206,7 @@ Example SQL Statements
 
 .. sidebar:: Schema Changes needed when Upgrading to Symfony 2.6
 
-    If you use the `PdoSessionHandler` prior to Symfony 2.6 and upgrade, you'll
+    If you use the ``PdoSessionHandler`` prior to Symfony 2.6 and upgrade, you'll
     need to make a few changes to your session table:
 
     * A new session lifetime (``sess_lifetime`` by default) integer column
@@ -211,6 +215,10 @@ Example SQL Statements
       BLOG type.
 
     Check the SQL statements below for more details.
+
+    To keep the old (2.5 and earlier) functionality, change your class name
+    to use ``LegacyPdoSessionHandler`` instead of ``PdoSessionHandler`` (the
+    legacy class was added in Symfony 2.6.2).
 
 MySQL
 ~~~~~


### PR DESCRIPTION
Hi guys!

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes symfony/symfony#12833 |
| Applies to | 2.6+ |
| Fixed tickets | n/a |

This follows #4557.

This adds more details about the table schema changes to the PdoSessionHandler in 2.6. I also made some improvements (not showing all the extra configuration by default), which I'll backport to 2.3 after this is accepted.

Thanks!
