### PR TITLE
Added '-ing' title ending to unify titles look

### DIFF
--- a/components/console/console_arguments.rst
+++ b/components/console/console_arguments.rst
@@ -1,8 +1,10 @@
 .. index::
     single: Console; Console arguments
 
-Understand how Console Arguments are Handled
-============================================
+.. _understand-how-console-arguments-are-handled:
+
+Understanding how Console Arguments Are Handled
+===============================================
 
 It can be difficult to understand the way arguments are handled by the console application.
 The Symfony Console application, like many other CLI utility tools, follows the behavior


### PR DESCRIPTION
Currently all of the titles in Console section use gerund, but not this one.
