### PR TITLE
Added a short cookbook about avoiding the automatic start of the sessions

### DIFF
--- a/cookbook/map.rst.inc
+++ b/cookbook/map.rst.inc
@@ -166,6 +166,7 @@
   * :doc:`/cookbook/session/sessions_directory`
   * :doc:`/cookbook/session/php_bridge`
   * (configuration) :doc:`/cookbook/configuration/pdo_session_storage`
+  * :doc:`/cookbook/session/avoid_session_start`
 
 * **symfony1**
 

--- a/cookbook/session/avoid_session_start.rst
+++ b/cookbook/session/avoid_session_start.rst
@@ -4,14 +4,14 @@
 Avoid Starting Sessions for Anonymous Users
 ===========================================
 
-Sessions in Symfony applications are automatically started when they are necessary.
+Sessions in Symfony applications are automatically started whenever they are necessary.
 This includes writing in the user's session, creating a flash message and logging
 in users. In order to start the session, Symfony creates a cookie which will be
-sent for every request.
+added to every user request.
 
-However, there are other scenarios when a session is started and therefore, a
+However, there are other scenarios when a session is started automatically and a
 cookie will be created even for anonymous users. First, consider the following
-code commonly used to display flash messages:
+template code commonly used to display flash messages:
 
 .. code-block:: html+jinja
 
@@ -37,7 +37,7 @@ cookie. To avoid this behavior, add a check before trying to access the flash me
     {% endif %}
 
 Another scenario where session cookies will be automatically sent is when the
-requested URL is covered by a firewall, no matter if anonymous users can access
+requested URL is covered by a firewall, even when anonymous users can access
 to that URL:
 
 .. code-block:: yaml
@@ -51,4 +51,4 @@ to that URL:
                 anonymous:  ~
 
 This behavior is caused because in Symfony applications, anonymous users are
-technically authenticated,.
+technically authenticated.

--- a/cookbook/session/avoid_session_start.rst
+++ b/cookbook/session/avoid_session_start.rst
@@ -1,0 +1,54 @@
+.. index::
+    single: Sessions, cookies
+
+Avoid Starting Sessions for Anonymous Users
+===========================================
+
+Sessions in Symfony applications are automatically started when they are necessary.
+This includes writing in the user's session, creating a flash message and logging
+in users. In order to start the session, Symfony creates a cookie which will be
+sent for every request.
+
+However, there are other scenarios when a session is started and therefore, a
+cookie will be created even for anonymous users. First, consider the following
+code commonly used to display flash messages:
+
+.. code-block:: html+jinja
+
+    {% for flashMessage in app.session.flashbag.get('notice') %}
+        <div class="flash-notice">
+            {{ flashMessage }}
+        </div>
+    {% endfor %}
+
+Even if the user is not logged in and even if you haven't created any flash message,
+just calling the ``get()`` method of the ``flashbag`` will start a session. This
+may hurt your application performance because all users will receive a session
+cookie. To avoid this behavior, add a check before trying to access the flash messages:
+
+.. code-block:: html+jinja
+
+    {% if app.session.started %}
+        {% for flashMessage in app.session.flashbag.get('notice') %}
+            <div class="flash-notice">
+                {{ flashMessage }}
+            </div>
+        {% endfor %}
+    {% endif %}
+
+Another scenario where session cookies will be automatically sent is when the
+requested URL is covered by a firewall, no matter if anonymous users can access
+to that URL:
+
+.. code-block:: yaml
+
+    # app/config/security.yml
+    security:
+        firewalls:
+            main:
+                pattern:    ^/
+                form_login: ~
+                anonymous:  ~
+
+This behavior is caused because in Symfony applications, anonymous users are
+technically authenticated,.

--- a/cookbook/session/index.rst
+++ b/cookbook/session/index.rst
@@ -8,3 +8,4 @@ Sessions
     locale_sticky_session
     sessions_directory
     php_bridge
+    avoid_session_start


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | all |
| Fixed tickets | #2607 |

Besides all the usual review, I'd like to ask doc reviewers to tell me if there is some way to avoid starting the session in the last case about defining a firewall that covers all URLs. Thanks in advance!
