### PR TITLE
Remove redundant "default" connection

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -26,9 +26,6 @@ Full Default Configuration
                 #schema_filter:        ^sf2_
 
                 connections:
-                    default:
-                        dbname:               database
-
                     # A collection of different named connections (e.g. default, conn2, etc)
                     default:
                         dbname:               ~


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | >=2.3 |
| Fixed tickets |  |

There where two connections with same key "default". I just removed the first one. It seems to be a relict from earlier versions.
