### PR TITLE
Change PHPUnit link to avoid redirect to homepage

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -112,5 +112,5 @@ browser.
     The code coverage only works if you have Xdebug enabled and all
     dependencies installed.
 
-.. _install PHPUnit: http://www.phpunit.de/manual/current/en/installation.html
+.. _install PHPUnit: https://phpunit.de/manual/current/en/installation.html
 .. _`Composer`: http://getcomposer.org/


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

The previous link is redirected to the homepage of phpunit.de. The new one takes to the intended page.
