### PR TITLE
adding note to assetic cache busting

### DIFF
--- a/reference/configuration/assetic.rst
+++ b/reference/configuration/assetic.rst
@@ -49,6 +49,9 @@ Full Default Configuration
                 # An array of named filters (e.g. some_filter, some_other_filter)
                 some_filter:                 []
             workers:
+                # see https://github.com/symfony/AsseticBundle/pull/119
+                # Cache can also be busted via the framework.templating.assets_version
+                # setting - see the "framework" configuration section
                 cache_busting:
                     enabled:              false
             twig:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | 2.5+ |
| Fixed tickets | n/a |

Hi guys!

Just a small note after #4449. I don't know anything about this feature, so I thought we'd at least link to the pull request. But I also wanted people to know that there is another way that's more documented. Really, I don't know why we have 2 ways - or is the cache-busting different between these 2?

Thanks!
