### PR TITLE
Set twig service as private

### DIFF
--- a/best_practices/templates.rst
+++ b/best_practices/templates.rst
@@ -153,6 +153,7 @@ name is irrelevant because you never use it in your own code):
         app.twig.app_extension:
             class:     AppBundle\Twig\AppExtension
             arguments: ["@markdown"]
+            public: false
             tags:
                 - { name: twig.extension }
 


### PR DESCRIPTION
During the best practices workshop it was suggested that it's best to set services to private if they won't be accessed from your code/container (for performance reasons)

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets |  |
