### PR TITLE
Fix Entity namespace alias

### DIFF
--- a/best_practices/controllers.rst
+++ b/best_practices/controllers.rst
@@ -110,8 +110,9 @@ for the homepage of our app:
          */
         public function indexAction()
         {
-            $em = $this->getDoctrine()->getManager();
-            $posts = $em->getRepository('App:Post')->findLatest();
+            $posts = $this->getDoctrine()
+                ->getRepository('AppBundle:Post')
+                ->findLatest();
 
             return $this->render('default/index.html.twig', array(
                 'posts' => $posts


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

Change the Entity namespace alias from `App:Post` to `AppBundle:Post` and use shortcut method so make the code simpler and equal to the newAction later in the chapter
