### PR TITLE
Clarify tip for creating a new AppBundle

### DIFF
--- a/best_practices/creating-the-project.rst
+++ b/best_practices/creating-the-project.rst
@@ -152,8 +152,7 @@ that follows these best practices:
 
 .. tip::
 
-    If you are using Symfony 2.6 or a newer version, the ``AppBundle`` bundle
-    is already generated for you. If you are using an older Symfony version,
+    If your Symfony installation doesn't come with a pre-generated ``AppBundle``,
     you can generate it by hand executing this command:
 
     .. code-block:: bash


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

The tip seems to be confusing, since the AppBundle is also generated with `symfony new blog 2.3.23` (and 2.5.8). In addition the mentioned `generate:bundle` command does not work in SF 2.3 SE, since it stops with a `The namespace must contain a vendor namespace` error.
