### PR TITLE
Change Apache php-fpm proxy configuration

### DIFF
--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -133,7 +133,8 @@ directive to pass requests for PHP files to PHP FPM:
         # SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
 
         # For Apache 2.4.9 or higher
-        # Using SetHandler avoids issues with using ProxyPassMatch in combination with mod_rewrite or mod_autoindex
+        # Using SetHandler avoids issues with using ProxyPassMatch in combination 
+        # with mod_rewrite or mod_autoindex
         <FilesMatch \.php$>
             SetHandler proxy:fcgi://127.0.0.1:9000
         </FilesMatch>

--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -132,8 +132,8 @@ directive to pass requests for PHP files to PHP FPM:
         #
         # SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
 
-        # For Apache 2.4.9 or upper
-        # This avoid problems with ProxyPassMatch and mod_rewrite or mod_autoindex
+        # For Apache 2.4.9 or higher
+        # Using SetHandler avoids issues with using ProxyPassMatch in combination with mod_rewrite or mod_autoindex
         <FilesMatch \.php$>
             SetHandler proxy:fcgi://127.0.0.1:9000
         </FilesMatch>

--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -132,8 +132,14 @@ directive to pass requests for PHP files to PHP FPM:
         #
         # SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
 
-        ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/var/www/project/web/$1
-
+        # For Apache 2.4.9 or upper
+        # This avoid problems with ProxyPassMatch and mod_rewrite or mod_autoindex
+        <FilesMatch \.php$>
+            SetHandler proxy:fcgi://127.0.0.1:9000
+        </FilesMatch>
+        # If you use Apache version below 2.4.9 you must consider update or use this instead
+        # ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/var/www/project/web/$1
+        
         DocumentRoot /var/www/project/web
         <Directory /var/www/project/web>
             # enable the .htaccess rewrites


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | Yes |
| New docs? | No |
| Applies to | All |
| Fixed tickets |  |

I had problems using ProxyPassMatch and mod_rewrite and now I use SetHandler to send the request to proxy. This change works fine and should be the standar configuration in the future for Apache and php-fpm.
You can read the php developers discussion here http://www.serverphorums.com/read.php?7,956732 or some about problems fixed here http://blog.famillecollet.com/post/2014/03/28/PHP-FPM-and-HTTPD-2.4-improvement
