### PR TITLE
[Security] Removed deprecated example about SecurityContext

### DIFF
--- a/components/security/firewall.rst
+++ b/components/security/firewall.rst
@@ -1,17 +1,20 @@
 .. index::
    single: Security, Firewall
 
-The Firewall and Security Context
-=================================
+The Firewall and Authorization
+==============================
 
-Central to the Security component is the security context, which is an instance
-of :class:`Symfony\\Component\\Security\\Core\\SecurityContextInterface`. When all
-steps in the process of authenticating the user have been taken successfully,
-you can ask the security context if the authenticated user has access to a
+Central to the Security component is authorization. This is handled by an instance
+of :class:`Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationCheckerInterface`.
+When all steps in the process of authenticating the user have been taken successfully,
+you can ask the authorization checker if the authenticated user has access to a
 certain action or resource of the application::
 
-    use Symfony\Component\Security\Core\SecurityContext;
+    use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
     use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+    // instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
+    $tokenStorage = ...;
 
     // instance of Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface
     $authenticationManager = ...;
@@ -19,20 +22,21 @@ certain action or resource of the application::
     // instance of Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface
     $accessDecisionManager = ...;
 
-    $securityContext = new SecurityContext(
+    $authorizationChecker = new AuthorizationChecker(
+        $tokenStorage,
         $authenticationManager,
         $accessDecisionManager
     );
 
     // ... authenticate the user
 
-    if (!$securityContext->isGranted('ROLE_ADMIN')) {
+    if (!$authorizationChecker->isGranted('ROLE_ADMIN')) {
         throw new AccessDeniedException();
     }
 
 .. versionadded:: 2.6
-    As of Symfony 2.6, the :class:`Symfony\\Component\\Security\\Core\\SecurityContext` class was split 
-    in the :class:`Symfony\\Component\\Security\\Core\\Authentication\\Authorization\\AuthorizationChecker` and 
+    As of Symfony 2.6, the :class:`Symfony\\Component\\Security\\Core\\SecurityContext` class was split
+    in the :class:`Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationChecker` and
     :class:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorage` classes.
 
 .. note::

--- a/cookbook/profiler/matchers.rst
+++ b/cookbook/profiler/matchers.rst
@@ -90,7 +90,7 @@ something like::
     }
 
 .. versionadded:: 2.6
-    The :class:`Symfony\\Component\\Security\\Core\\Authentication\\Authorization\\AuthorizationCheckerInterface` was
+    The :class:`Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationCheckerInterface` was
     introduced in Symfony 2.6. Prior, you had to use the ``isGranted`` method of
     :class:`Symfony\\Component\\Security\\Core\\SecurityContextInterface`.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | ~2.6 |
| Fixed tickets | ~ |

@Einenlum noticed that there was still some documentation referring to the `SecurityContext`. This PR should remove the reference. It also fixes two occurrences where the namespace to the `AuthorizationChecker` in `versionadd` was inccorect, causing broken links to non-existing API pages.

I wasn't sure how to formulate the intro. If there are any suggestions, feel free to provide.
