### PR TITLE
Renamed example: "Acme\BlogBundle" -> "AppBundle"

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1169,7 +1169,7 @@ Notice that Symfony adds the string ``Controller`` to the class name (``Blog``
 => ``BlogController``) and ``Action`` to the method name (``show`` => ``showAction``).
 
 You could also refer to this controller using its fully-qualified class name
-and method: ``Acme\BlogBundle\Controller\BlogController::showAction``.
+and method: ``AppBundle\Controller\BlogController::showAction``.
 But if you follow some simple conventions, the logical name is more concise
 and allows more flexibility.
 


### PR DESCRIPTION
In the context of this sentence, the correct fully-qualified class name for the controller seems to be

```
  AppBundle\Controller\BlogController::showAction
```

and not

```
  Acme\BlogBundle\Controller\BlogController::showAction
```
