### PR TITLE
Add Session Cache Limiting section for NativeSessionStorage

### DIFF
--- a/components/http_foundation/session_configuration.rst
+++ b/components/http_foundation/session_configuration.rst
@@ -102,6 +102,36 @@ method.
 
 For the sake of clarity, some key options are explained in this documentation.
 
+Session Cache Limiting
+~~~~~~~~~~~~~~~~~~~~~~
+
+To avoid users seeing stale data, it's common for session-enabled resources to be
+sent with headers that disable caching. For this purpose PHP Sessions has the
+``sessions.cache_limiter`` option, which determines which headers, if any, will be
+sent with the response when the session in started.
+
+Upon construction,
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage`
+sets this global option to ``""`` (send no headers) in case the developer wishes to
+use a :class:`Symfony\\Component\\HttpFoundation\\Response` object to manage
+response headers.
+
+.. caution::
+
+    If you rely on PHP Sessions to manage HTTP caching, you *must* manually set the
+    ``cache_limiter`` option in
+    :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage`
+    to a non-empty value.
+
+    For example, you may set it to PHP's default value during construction:
+
+    Example usage::
+
+        use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+
+        $options['cache_limiter'] = session_cache_limiter();
+        $storage = new NativeSessionStorage($options);
+
 Session Cookie Lifetime
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.1+ |
| Fixed tickets | (none) |

We're implementing HttpFoundation (by itself) to replace our native session implementation and noticed that NativeSessionStorage [eliminates the global session.cache_limiter value](https://github.com/symfony/symfony/commit/39526df67c4bd8afe199a301734e556c8aa26b6b). I understand _why_ it must do this, but users should be warned that the default usage prescribed in the manual will cause all pages to be sent with no cache-busting headers.
