### PR TITLE
Use AppBundle whenever it's possible

### DIFF
--- a/cookbook/assetic/apply_to_option.rst
+++ b/cookbook/assetic/apply_to_option.rst
@@ -59,14 +59,14 @@ templates:
 
     .. code-block:: html+jinja
 
-        {% javascripts '@AcmeFooBundle/Resources/public/js/example.coffee' filter='coffee' %}
+        {% javascripts '@AppBundle/Resources/public/js/example.coffee' filter='coffee' %}
             <script src="{{ asset_url }}" type="text/javascript"></script>
         {% endjavascripts %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->javascripts(
-            array('@AcmeFooBundle/Resources/public/js/example.coffee'),
+            array('@AppBundle/Resources/public/js/example.coffee'),
             array('coffee')
         ) as $url): ?>
             <script src="<?php echo $view->escape($url) ?>" type="text/javascript"></script>
@@ -84,8 +84,8 @@ You can also combine multiple CoffeeScript files into a single output file:
 
     .. code-block:: html+jinja
 
-        {% javascripts '@AcmeFooBundle/Resources/public/js/example.coffee'
-                       '@AcmeFooBundle/Resources/public/js/another.coffee'
+        {% javascripts '@AppBundle/Resources/public/js/example.coffee'
+                       '@AppBundle/Resources/public/js/another.coffee'
             filter='coffee' %}
             <script src="{{ asset_url }}" type="text/javascript"></script>
         {% endjavascripts %}
@@ -94,8 +94,8 @@ You can also combine multiple CoffeeScript files into a single output file:
 
         <?php foreach ($view['assetic']->javascripts(
             array(
-                '@AcmeFooBundle/Resources/public/js/example.coffee',
-                '@AcmeFooBundle/Resources/public/js/another.coffee',
+                '@AppBundle/Resources/public/js/example.coffee',
+                '@AppBundle/Resources/public/js/another.coffee',
             ),
             array('coffee')
         ) as $url): ?>
@@ -170,9 +170,9 @@ being run through the CoffeeScript filter):
 
     .. code-block:: html+jinja
 
-        {% javascripts '@AcmeFooBundle/Resources/public/js/example.coffee'
-                       '@AcmeFooBundle/Resources/public/js/another.coffee'
-                       '@AcmeFooBundle/Resources/public/js/regular.js' %}
+        {% javascripts '@AppBundle/Resources/public/js/example.coffee'
+                       '@AppBundle/Resources/public/js/another.coffee'
+                       '@AppBundle/Resources/public/js/regular.js' %}
             <script src="{{ asset_url }}" type="text/javascript"></script>
         {% endjavascripts %}
 
@@ -180,9 +180,9 @@ being run through the CoffeeScript filter):
 
         <?php foreach ($view['assetic']->javascripts(
             array(
-                '@AcmeFooBundle/Resources/public/js/example.coffee',
-                '@AcmeFooBundle/Resources/public/js/another.coffee',
-                '@AcmeFooBundle/Resources/public/js/regular.js',
+                '@AppBundle/Resources/public/js/example.coffee',
+                '@AppBundle/Resources/public/js/another.coffee',
+                '@AppBundle/Resources/public/js/regular.js',
             )
         ) as $url): ?>
             <script src="<?php echo $view->escape($url) ?>" type="text/javascript"></script>

--- a/cookbook/assetic/asset_management.rst
+++ b/cookbook/assetic/asset_management.rst
@@ -59,14 +59,14 @@ To include JavaScript files, use the ``javascripts`` tag in any template:
 
     .. code-block:: html+jinja
 
-        {% javascripts '@AcmeFooBundle/Resources/public/js/*' %}
+        {% javascripts '@AppBundle/Resources/public/js/*' %}
             <script type="text/javascript" src="{{ asset_url }}"></script>
         {% endjavascripts %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->javascripts(
-            array('@AcmeFooBundle/Resources/public/js/*')
+            array('@AppBundle/Resources/public/js/*')
         ) as $url): ?>
             <script type="text/javascript" src="<?php echo $view->escape($url) ?>"></script>
         <?php endforeach ?>
@@ -81,7 +81,7 @@ To include JavaScript files, use the ``javascripts`` tag in any template:
 
         {# ... #}
         {% block javascripts %}
-            {% javascripts '@AcmeFooBundle/Resources/public/js/*' %}
+            {% javascripts '@AppBundle/Resources/public/js/*' %}
                 <script type="text/javascript" src="{{ asset_url }}"></script>
             {% endjavascripts %}
         {% endblock %}
@@ -92,7 +92,7 @@ To include JavaScript files, use the ``javascripts`` tag in any template:
     You can also include CSS Stylesheets: see :ref:`cookbook-assetic-including-css`.
 
 In this example, all of the files in the ``Resources/public/js/`` directory
-of the ``AcmeFooBundle`` will be loaded and served from a different location.
+of the ``AppBundle`` will be loaded and served from a different location.
 The actual rendered tag might simply look like:
 
 .. code-block:: html
@@ -115,14 +115,14 @@ above, except with the ``stylesheets`` tag:
 
     .. code-block:: html+jinja
 
-        {% stylesheets 'bundles/acme_foo/css/*' filter='cssrewrite' %}
+        {% stylesheets 'bundles/app/css/*' filter='cssrewrite' %}
             <link rel="stylesheet" href="{{ asset_url }}" />
         {% endstylesheets %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->stylesheets(
-            array('bundles/acme_foo/css/*'),
+            array('bundles/app/css/*'),
             array('cssrewrite')
         ) as $url): ?>
             <link rel="stylesheet" href="<?php echo $view->escape($url) ?>" />
@@ -138,7 +138,7 @@ above, except with the ``stylesheets`` tag:
 
         {# ... #}
         {% block stylesheets %}
-            {% stylesheets 'bundles/acme_foo/css/*' filter='cssrewrite' %}
+            {% stylesheets 'bundles/app/css/*' filter='cssrewrite' %}
                 <link rel="stylesheet" href="{{ asset_url }}" />
             {% endstylesheets %}
         {% endblock %}
@@ -151,11 +151,11 @@ the :ref:`cssrewrite <cookbook-assetic-cssrewrite>` filter.
 .. note::
 
     Notice that in the original example that included JavaScript files, you
-    referred to the files using a path like ``@AcmeFooBundle/Resources/public/file.js``,
+    referred to the files using a path like ``@AppBundle/Resources/public/file.js``,
     but that in this example, you referred to the CSS files using their actual,
-    publicly-accessible path: ``bundles/acme_foo/css``. You can use either, except
+    publicly-accessible path: ``bundles/app/css``. You can use either, except
     that there is a known issue that causes the ``cssrewrite`` filter to fail
-    when using the ``@AcmeFooBundle`` syntax for CSS Stylesheets.
+    when using the ``@AppBundle`` syntax for CSS Stylesheets.
 
 .. _cookbook-assetic-including-image:
 
@@ -168,14 +168,14 @@ To include an image you can use the ``image`` tag.
 
     .. code-block:: html+jinja
 
-        {% image '@AcmeFooBundle/Resources/public/images/example.jpg' %}
+        {% image '@AppBundle/Resources/public/images/example.jpg' %}
             <img src="{{ asset_url }}" alt="Example" />
         {% endimage %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->image(
-            array('@AcmeFooBundle/Resources/public/images/example.jpg')
+            array('@AppBundle/Resources/public/images/example.jpg')
         ) as $url): ?>
             <img src="<?php echo $view->escape($url) ?>" alt="Example" />
         <?php endforeach ?>
@@ -198,7 +198,7 @@ You can see an example in the previous section.
 .. caution::
 
     When using the ``cssrewrite`` filter, don't refer to your CSS files using
-    the ``@AcmeFooBundle`` syntax. See the note in the above section for details.
+    the ``@AppBundle`` syntax. See the note in the above section for details.
 
 Combining Assets
 ~~~~~~~~~~~~~~~~
@@ -215,7 +215,7 @@ but still serve them as a single file:
     .. code-block:: html+jinja
 
         {% javascripts
-            '@AcmeFooBundle/Resources/public/js/*'
+            '@AppBundle/Resources/public/js/*'
             '@AcmeBarBundle/Resources/public/js/form.js'
             '@AcmeBarBundle/Resources/public/js/calendar.js' %}
             <script src="{{ asset_url }}"></script>
@@ -225,7 +225,7 @@ but still serve them as a single file:
 
         <?php foreach ($view['assetic']->javascripts(
             array(
-                '@AcmeFooBundle/Resources/public/js/*',
+                '@AppBundle/Resources/public/js/*',
                 '@AcmeBarBundle/Resources/public/js/form.js',
                 '@AcmeBarBundle/Resources/public/js/calendar.js',
             )
@@ -254,8 +254,8 @@ combine third party assets, such as jQuery, with your own into a single file:
     .. code-block:: html+jinja
 
         {% javascripts
-            '@AcmeFooBundle/Resources/public/js/thirdparty/jquery.js'
-            '@AcmeFooBundle/Resources/public/js/*' %}
+            '@AppBundle/Resources/public/js/thirdparty/jquery.js'
+            '@AppBundle/Resources/public/js/*' %}
             <script src="{{ asset_url }}"></script>
         {% endjavascripts %}
 
@@ -263,8 +263,8 @@ combine third party assets, such as jQuery, with your own into a single file:
 
         <?php foreach ($view['assetic']->javascripts(
             array(
-                '@AcmeFooBundle/Resources/public/js/thirdparty/jquery.js',
-                '@AcmeFooBundle/Resources/public/js/*',
+                '@AppBundle/Resources/public/js/thirdparty/jquery.js',
+                '@AppBundle/Resources/public/js/*',
             )
         ) as $url): ?>
             <script src="<?php echo $view->escape($url) ?>"></script>
@@ -287,8 +287,8 @@ configuration under the ``assetic`` section. Read more in the
             assets:
                 jquery_and_ui:
                     inputs:
-                        - '@AcmeFooBundle/Resources/public/js/thirdparty/jquery.js'
-                        - '@AcmeFooBundle/Resources/public/js/thirdparty/jquery.ui.js'
+                        - '@AppBundle/Resources/public/js/thirdparty/jquery.js'
+                        - '@AppBundle/Resources/public/js/thirdparty/jquery.ui.js'
 
     .. code-block:: xml
 
@@ -299,8 +299,8 @@ configuration under the ``assetic`` section. Read more in the
 
             <assetic:config>
                 <assetic:asset name="jquery_and_ui">
-                    <assetic:input>@AcmeFooBundle/Resources/public/js/thirdparty/jquery.js</assetic:input>
-                    <assetic:input>@AcmeFooBundle/Resources/public/js/thirdparty/jquery.ui.js</assetic:input>
+                    <assetic:input>@AppBundle/Resources/public/js/thirdparty/jquery.js</assetic:input>
+                    <assetic:input>@AppBundle/Resources/public/js/thirdparty/jquery.ui.js</assetic:input>
                 </assetic:asset>
             </assetic:config>
         </container>
@@ -312,8 +312,8 @@ configuration under the ``assetic`` section. Read more in the
             'assets' => array(
                 'jquery_and_ui' => array(
                     'inputs' => array(
-                        '@AcmeFooBundle/Resources/public/js/thirdparty/jquery.js',
-                        '@AcmeFooBundle/Resources/public/js/thirdparty/jquery.ui.js',
+                        '@AppBundle/Resources/public/js/thirdparty/jquery.js',
+                        '@AppBundle/Resources/public/js/thirdparty/jquery.ui.js',
                     ),
                 ),
             ),
@@ -328,7 +328,7 @@ with the ``@named_asset`` notation:
 
         {% javascripts
             '@jquery_and_ui'
-            '@AcmeFooBundle/Resources/public/js/*' %}
+            '@AppBundle/Resources/public/js/*' %}
             <script src="{{ asset_url }}"></script>
         {% endjavascripts %}
 
@@ -337,7 +337,7 @@ with the ``@named_asset`` notation:
         <?php foreach ($view['assetic']->javascripts(
             array(
                 '@jquery_and_ui',
-                '@AcmeFooBundle/Resources/public/js/*',
+                '@AppBundle/Resources/public/js/*',
             )
         ) as $url): ?>
             <script src="<?php echo $view->escape($url) ?>"></script>
@@ -406,14 +406,14 @@ into your template:
 
     .. code-block:: html+jinja
 
-        {% javascripts '@AcmeFooBundle/Resources/public/js/*' filter='uglifyjs2' %}
+        {% javascripts '@AppBundle/Resources/public/js/*' filter='uglifyjs2' %}
             <script src="{{ asset_url }}"></script>
         {% endjavascripts %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->javascripts(
-            array('@AcmeFooBundle/Resources/public/js/*'),
+            array('@AppBundle/Resources/public/js/*'),
             array('uglifyjs2')
         ) as $url): ?>
             <script src="<?php echo $view->escape($url) ?>"></script>
@@ -432,14 +432,14 @@ done from the template and is relative to the public document root:
 
     .. code-block:: html+jinja
 
-        {% javascripts '@AcmeFooBundle/Resources/public/js/*' output='js/compiled/main.js' %}
+        {% javascripts '@AppBundle/Resources/public/js/*' output='js/compiled/main.js' %}
             <script src="{{ asset_url }}"></script>
         {% endjavascripts %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->javascripts(
-            array('@AcmeFooBundle/Resources/public/js/*'),
+            array('@AppBundle/Resources/public/js/*'),
             array(),
             array('output' => 'js/compiled/main.js')
         ) as $url): ?>
@@ -555,14 +555,14 @@ some isolated directory (e.g. ``/js/compiled``), to keep things organized:
 
     .. code-block:: html+jinja
 
-        {% javascripts '@AcmeFooBundle/Resources/public/js/*' output='js/compiled/main.js' %}
+        {% javascripts '@AppBundle/Resources/public/js/*' output='js/compiled/main.js' %}
             <script src="{{ asset_url }}"></script>
         {% endjavascripts %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->javascripts(
-            array('@AcmeFooBundle/Resources/public/js/*'),
+            array('@AppBundle/Resources/public/js/*'),
             array(),
             array('output' => 'js/compiled/main.js')
         ) as $url): ?>

--- a/cookbook/assetic/jpeg_optimize.rst
+++ b/cookbook/assetic/jpeg_optimize.rst
@@ -57,7 +57,7 @@ It can now be used from a template:
 
     .. code-block:: html+jinja
 
-        {% image '@AcmeFooBundle/Resources/public/images/example.jpg'
+        {% image '@AppBundle/Resources/public/images/example.jpg'
             filter='jpegoptim' output='/images/example.jpg' %}
             <img src="{{ asset_url }}" alt="Example"/>
         {% endimage %}
@@ -65,7 +65,7 @@ It can now be used from a template:
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->image(
-            array('@AcmeFooBundle/Resources/public/images/example.jpg'),
+            array('@AppBundle/Resources/public/images/example.jpg'),
             array('jpegoptim')
         ) as $url): ?>
             <img src="<?php echo $view->escape($url) ?>" alt="Example"/>
@@ -204,7 +204,7 @@ The Twig template can now be changed to the following:
 
 .. code-block:: html+jinja
 
-    <img src="{{ jpegoptim('@AcmeFooBundle/Resources/public/images/example.jpg') }}" alt="Example"/>
+    <img src="{{ jpegoptim('@AppBundle/Resources/public/images/example.jpg') }}" alt="Example"/>
 
 You can specify the output directory in the config in the following way:
 

--- a/cookbook/assetic/uglifyjs.rst
+++ b/cookbook/assetic/uglifyjs.rst
@@ -161,14 +161,14 @@ your assets are a part of the view layer, this work is done in your templates:
 
     .. code-block:: html+jinja
 
-        {% javascripts '@AcmeFooBundle/Resources/public/js/*' filter='uglifyjs2' %}
+        {% javascripts '@AppBundle/Resources/public/js/*' filter='uglifyjs2' %}
             <script src="{{ asset_url }}"></script>
         {% endjavascripts %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->javascripts(
-            array('@AcmeFooBundle/Resources/public/js/*'),
+            array('@AppBundle/Resources/public/js/*'),
             array('uglifyj2s')
         ) as $url): ?>
             <script src="<?php echo $view->escape($url) ?>"></script>
@@ -176,7 +176,7 @@ your assets are a part of the view layer, this work is done in your templates:
 
 .. note::
 
-    The above example assumes that you have a bundle called ``AcmeFooBundle``
+    The above example assumes that you have a bundle called ``AppBundle``
     and your JavaScript files are in the ``Resources/public/js`` directory under
     your bundle. This isn't important however - you can include your JavaScript
     files no matter where they are.
@@ -197,14 +197,14 @@ apply this filter when debug mode is off (e.g. ``app.php``):
 
     .. code-block:: html+jinja
 
-        {% javascripts '@AcmeFooBundle/Resources/public/js/*' filter='?uglifyjs2' %}
+        {% javascripts '@AppBundle/Resources/public/js/*' filter='?uglifyjs2' %}
             <script src="{{ asset_url }}"></script>
         {% endjavascripts %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->javascripts(
-            array('@AcmeFooBundle/Resources/public/js/*'),
+            array('@AppBundle/Resources/public/js/*'),
             array('?uglifyjs2')
         ) as $url): ?>
             <script src="<?php echo $view->escape($url) ?>"></script>
@@ -272,14 +272,14 @@ helper:
 
     .. code-block:: html+jinja
 
-        {% stylesheets 'bundles/AcmeFoo/css/*' filter='uglifycss' filter='cssrewrite' %}
+        {% stylesheets 'bundles/App/css/*' filter='uglifycss' filter='cssrewrite' %}
              <link rel="stylesheet" href="{{ asset_url }}" />
         {% endstylesheets %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->stylesheets(
-            array('bundles/AcmeFoo/css/*'),
+            array('bundles/App/css/*'),
             array('uglifycss'),
             array('cssrewrite')
         ) as $url): ?>

--- a/cookbook/assetic/yuicompressor.rst
+++ b/cookbook/assetic/yuicompressor.rst
@@ -91,14 +91,14 @@ the view layer, this work is done in your templates:
 
     .. code-block:: html+jinja
 
-        {% javascripts '@AcmeFooBundle/Resources/public/js/*' filter='yui_js' %}
+        {% javascripts '@AppBundle/Resources/public/js/*' filter='yui_js' %}
             <script src="{{ asset_url }}"></script>
         {% endjavascripts %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->javascripts(
-            array('@AcmeFooBundle/Resources/public/js/*'),
+            array('@AppBundle/Resources/public/js/*'),
             array('yui_js')
         ) as $url): ?>
             <script src="<?php echo $view->escape($url) ?>"></script>
@@ -106,7 +106,7 @@ the view layer, this work is done in your templates:
 
 .. note::
 
-    The above example assumes that you have a bundle called ``AcmeFooBundle``
+    The above example assumes that you have a bundle called ``AppBundle``
     and your JavaScript files are in the ``Resources/public/js`` directory under
     your bundle. This isn't important however - you can include your JavaScript
     files no matter where they are.
@@ -119,14 +119,14 @@ can be repeated to minify your stylesheets.
 
     .. code-block:: html+jinja
 
-        {% stylesheets '@AcmeFooBundle/Resources/public/css/*' filter='yui_css' %}
+        {% stylesheets '@AppBundle/Resources/public/css/*' filter='yui_css' %}
             <link rel="stylesheet" type="text/css" media="screen" href="{{ asset_url }}" />
         {% endstylesheets %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->stylesheets(
-            array('@AcmeFooBundle/Resources/public/css/*'),
+            array('@AppBundle/Resources/public/css/*'),
             array('yui_css')
         ) as $url): ?>
             <link rel="stylesheet" type="text/css" media="screen" href="<?php echo $view->escape($url) ?>" />
@@ -145,14 +145,14 @@ apply this filter when debug mode is off.
 
     .. code-block:: html+jinja
 
-        {% javascripts '@AcmeFooBundle/Resources/public/js/*' filter='?yui_js' %}
+        {% javascripts '@AppBundle/Resources/public/js/*' filter='?yui_js' %}
             <script src="{{ asset_url }}"></script>
         {% endjavascripts %}
 
     .. code-block:: html+php
 
         <?php foreach ($view['assetic']->javascripts(
-            array('@AcmeFooBundle/Resources/public/js/*'),
+            array('@AppBundle/Resources/public/js/*'),
             array('?yui_js')
         ) as $url): ?>
             <script src="<?php echo $view->escape($url) ?>"></script>

--- a/cookbook/bundles/extension.rst
+++ b/cookbook/bundles/extension.rst
@@ -23,8 +23,9 @@ following conventions:
 * It has to live in the ``DependencyInjection`` namespace of the bundle;
 
 * The name is equal to the bundle name with the ``Bundle`` suffix replaced by
-  ``Extension`` (e.g. the Extension class of ``AcmeHelloBundle`` would be
-  called ``AcmeHelloExtension``).
+  ``Extension`` (e.g. the Extension class of ``AppBundle`` would be called
+  ``AppExtension`` and the one for ``AcmeHelloBundle`` would be called
+  ``AcmeHelloExtension``).
 
 The Extension class should implement the
 :class:`Symfony\\Component\\DependencyInjection\\Extension\\ExtensionInterface`,

--- a/cookbook/configuration/apache_router.rst
+++ b/cookbook/configuration/apache_router.rst
@@ -52,7 +52,7 @@ Symfony to use the ``ApacheUrlMatcher`` instead of the default one:
 Generating mod_rewrite Rules
 ----------------------------
 
-To test that it's working, create a very basic route for the AcmeDemoBundle:
+To test that it's working, create a very basic route for the AppBundle:
 
 .. configuration-block::
 
@@ -61,20 +61,20 @@ To test that it's working, create a very basic route for the AcmeDemoBundle:
         # app/config/routing.yml
         hello:
             path: /hello/{name}
-            defaults: { _controller: AcmeDemoBundle:Demo:hello }
+            defaults: { _controller: AppBundle:Demo:hello }
 
     .. code-block:: xml
 
         <!-- app/config/routing.xml -->
         <route id="hello" path="/hello/{name}">
-            <default key="_controller">AcmeDemoBundle:Demo:hello</default>
+            <default key="_controller">AppBundle:Demo:hello</default>
         </route>
 
     .. code-block:: php
 
         // app/config/routing.php
         $collection->add('hello', new Route('/hello/{name}', array(
-            '_controller' => 'AcmeDemoBundle:Demo:hello',
+            '_controller' => 'AppBundle:Demo:hello',
         )));
 
 Now generate the mod_rewrite rules:
@@ -93,7 +93,7 @@ Which should roughly output the following:
 
     # hello
     RewriteCond %{REQUEST_URI} ^/hello/([^/]+?)$
-    RewriteRule .* app.php [QSA,L,E=_ROUTING__route:hello,E=_ROUTING_name:%1,E=_ROUTING__controller:AcmeDemoBundle\:Demo\:hello]
+    RewriteRule .* app.php [QSA,L,E=_ROUTING__route:hello,E=_ROUTING_name:%1,E=_ROUTING__controller:AppBundle\:Demo\:hello]
 
 You can now rewrite ``web/.htaccess`` to use the new rules, so with this example
 it should look like this:
@@ -109,7 +109,7 @@ it should look like this:
 
         # hello
         RewriteCond %{REQUEST_URI} ^/hello/([^/]+?)$
-        RewriteRule .* app.php [QSA,L,E=_ROUTING__route:hello,E=_ROUTING_name:%1,E=_ROUTING__controller:AcmeDemoBundle\:Demo\:hello]
+        RewriteRule .* app.php [QSA,L,E=_ROUTING__route:hello,E=_ROUTING_name:%1,E=_ROUTING__controller:AppBundle\:Demo\:hello]
     </IfModule>
 
 .. note::

--- a/cookbook/console/console_command.rst
+++ b/cookbook/console/console_command.rst
@@ -14,11 +14,11 @@ Automatically Registering Commands
 To make the console commands available automatically with Symfony, create a
 ``Command`` directory inside your bundle and create a PHP file suffixed with
 ``Command.php`` for each command that you want to provide. For example, if you
-want to extend the AcmeDemoBundle to greet you from the command line, create
+want to extend the AppBundle to greet you from the command line, create
 ``GreetCommand.php`` and add the following to it::
 
-    // src/Acme/DemoBundle/Command/GreetCommand.php
-    namespace Acme\DemoBundle\Command;
+    // src/AppBundle/Command/GreetCommand.php
+    namespace AppBundle\Command;
 
     use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
     use Symfony\Component\Console\Input\InputArgument;
@@ -147,7 +147,7 @@ instead of
 
     use Symfony\Component\Console\Tester\CommandTester;
     use Symfony\Bundle\FrameworkBundle\Console\Application;
-    use Acme\DemoBundle\Command\GreetCommand;
+    use AppBundle\Command\GreetCommand;
 
     class ListCommandTest extends \PHPUnit_Framework_TestCase
     {
@@ -186,7 +186,7 @@ you can extend your test from
     use Symfony\Component\Console\Tester\CommandTester;
     use Symfony\Bundle\FrameworkBundle\Console\Application;
     use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-    use Acme\DemoBundle\Command\GreetCommand;
+    use AppBundle\Command\GreetCommand;
 
     class ListCommandTest extends WebTestCase
     {

--- a/cookbook/console/logging.rst
+++ b/cookbook/console/logging.rst
@@ -26,8 +26,8 @@ extends :class:`Symfony\\Bundle\\FrameworkBundle\\Command\\ContainerAwareCommand
 This means that you can simply access the standard logger service through the
 container and use it to do the logging::
 
-    // src/Acme/DemoBundle/Command/GreetCommand.php
-    namespace Acme\DemoBundle\Command;
+    // src/AppBundle/Command/GreetCommand.php
+    namespace AppBundle\Command;
 
     use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
     use Symfony\Component\Console\Input\InputArgument;
@@ -84,7 +84,7 @@ First configure a listener for console exception events in the service container
         # app/config/services.yml
         services:
             kernel.listener.command_dispatch:
-                class: Acme\DemoBundle\EventListener\ConsoleExceptionListener
+                class: AppBundle\EventListener\ConsoleExceptionListener
                 arguments:
                     logger: "@logger"
                 tags:
@@ -99,7 +99,7 @@ First configure a listener for console exception events in the service container
                    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="kernel.listener.command_dispatch" class="Acme\DemoBundle\EventListener\ConsoleExceptionListener">
+                <service id="kernel.listener.command_dispatch" class="AppBundle\EventListener\ConsoleExceptionListener">
                     <argument type="service" id="logger"/>
                     <tag name="kernel.event_listener" event="console.exception" />
                 </service>
@@ -113,7 +113,7 @@ First configure a listener for console exception events in the service container
         use Symfony\Component\DependencyInjection\Reference;
 
         $definitionConsoleExceptionListener = new Definition(
-            'Acme\DemoBundle\EventListener\ConsoleExceptionListener',
+            'AppBundle\EventListener\ConsoleExceptionListener',
             array(new Reference('logger'))
         );
         $definitionConsoleExceptionListener->addTag(
@@ -127,8 +127,8 @@ First configure a listener for console exception events in the service container
 
 Then implement the actual listener::
 
-    // src/Acme/DemoBundle/EventListener/ConsoleExceptionListener.php
-    namespace Acme\DemoBundle\EventListener;
+    // src/AppBundle/EventListener/ConsoleExceptionListener.php
+    namespace AppBundle\EventListener;
 
     use Symfony\Component\Console\Event\ConsoleExceptionEvent;
     use Psr\Log\LoggerInterface;
@@ -182,7 +182,7 @@ First configure a listener for console terminate events in the service container
         # app/config/services.yml
         services:
             kernel.listener.command_dispatch:
-                class: Acme\DemoBundle\EventListener\ErrorLoggerListener
+                class: AppBundle\EventListener\ErrorLoggerListener
                 arguments:
                     logger: "@logger"
                 tags:
@@ -197,7 +197,7 @@ First configure a listener for console terminate events in the service container
                    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="kernel.listener.command_dispatch" class="Acme\DemoBundle\EventListener\ErrorLoggerListener">
+                <service id="kernel.listener.command_dispatch" class="AppBundle\EventListener\ErrorLoggerListener">
                     <argument type="service" id="logger"/>
                     <tag name="kernel.event_listener" event="console.terminate" />
                 </service>
@@ -211,7 +211,7 @@ First configure a listener for console terminate events in the service container
         use Symfony\Component\DependencyInjection\Reference;
 
         $definitionErrorLoggerListener = new Definition(
-            'Acme\DemoBundle\EventListener\ErrorLoggerListener',
+            'AppBundle\EventListener\ErrorLoggerListener',
             array(new Reference('logger'))
         );
         $definitionErrorLoggerListener->addTag(
@@ -225,8 +225,8 @@ First configure a listener for console terminate events in the service container
 
 Then implement the actual listener::
 
-    // src/Acme/DemoBundle/EventListener/ErrorLoggerListener.php
-    namespace Acme\DemoBundle\EventListener;
+    // src/AppBundle/EventListener/ErrorLoggerListener.php
+    namespace AppBundle\EventListener;
 
     use Symfony\Component\Console\Event\ConsoleTerminateEvent;
     use Psr\Log\LoggerInterface;

--- a/cookbook/console/sending_emails.rst
+++ b/cookbook/console/sending_emails.rst
@@ -69,7 +69,7 @@ Configuring the Request Context per Command
 To change it only in one command you can simply fetch the Request Context
 from the ``router`` service and override its settings::
 
-   // src/Acme/DemoBundle/Command/DemoCommand.php
+   // src/AppBundle/Command/DemoCommand.php
 
    // ...
    class DemoCommand extends ContainerAwareCommand

--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -178,7 +178,7 @@ to point to it.
 
         # app/config/config.yml
         twig:
-            exception_controller:  AcmeFooBundle:Exception:showException
+            exception_controller:  AppBundle:Exception:showException
 
     .. code-block:: xml
 
@@ -191,7 +191,7 @@ to point to it.
                 http://symfony.com/schema/dic/twig http://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
             <twig:config>
-                <twig:exception-controller>AcmeFooBundle:Exception:showException</twig:exception-controller>
+                <twig:exception-controller>AppBundle:Exception:showException</twig:exception-controller>
             </twig:config>
         </container>
 
@@ -199,7 +199,7 @@ to point to it.
 
         // app/config/config.php
         $container->loadFromExtension('twig', array(
-            'exception_controller' => 'AcmeFooBundle:Exception:showException',
+            'exception_controller' => 'AppBundle:Exception:showException',
             // ...
         ));
 
@@ -265,7 +265,7 @@ another page or rendering specialized error pages.
 
     If your listener calls ``setResponse()`` on the
     :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent`,
-    event propagation will be stopped and the response will be sent to 
+    event propagation will be stopped and the response will be sent to
     the client.
 
 This approach allows you to create centralized and layered error
@@ -277,7 +277,7 @@ several) listeners deal with them.
 
     To see an example, have a look at the `ExceptionListener`_ in the
     Security Component.
-    
+
     It handles various security-related exceptions that are thrown in
     your application (like :class:`Symfony\\Component\\Security\\Core\\Exception\\AccessDeniedException`)
     and takes measures like redirecting the user to the login page,

--- a/cookbook/controller/service.rst
+++ b/cookbook/controller/service.rst
@@ -34,8 +34,8 @@ Defining the Controller as a Service
 A controller can be defined as a service in the same way as any other class.
 For example, if you have the following simple controller::
 
-    // src/Acme/HelloBundle/Controller/HelloController.php
-    namespace Acme\HelloBundle\Controller;
+    // src/AppBundle/Controller/HelloController.php
+    namespace AppBundle\Controller;
 
     use Symfony\Component\HttpFoundation\Response;
 
@@ -53,25 +53,25 @@ Then you can define it as a service as follows:
 
     .. code-block:: yaml
 
-        # src/Acme/HelloBundle/Resources/config/services.yml
+        # app/config/services.yml
         services:
-            acme.hello.controller:
-                class: Acme\HelloBundle\Controller\HelloController
+            app.hello_controller:
+                class: AppBundle\Controller\HelloController
 
     .. code-block:: xml
 
-        <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
+        <!-- app/config/services.xml -->
         <services>
-            <service id="acme.hello.controller" class="Acme\HelloBundle\Controller\HelloController" />
+            <service id="app.hello_controller" class="AppBundle\Controller\HelloController" />
         </services>
 
     .. code-block:: php
 
-        // src/Acme/HelloBundle/Resources/config/services.php
+        // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
 
-        $container->setDefinition('acme.hello.controller', new Definition(
-            'Acme\HelloBundle\Controller\HelloController'
+        $container->setDefinition('app.hello_controller', new Definition(
+            'AppBundle\Controller\HelloController'
         ));
 
 Referring to the Service
@@ -79,9 +79,9 @@ Referring to the Service
 
 To refer to a controller that's defined as a service, use the single colon (:)
 notation. For example, to forward to the ``indexAction()`` method of the service
-defined above with the id ``acme.hello.controller``::
+defined above with the id ``app.hello_controller``::
 
-    $this->forward('acme.hello.controller:indexAction', array('name' => $name));
+    $this->forward('app.hello_controller:indexAction', array('name' => $name));
 
 .. note::
 
@@ -98,20 +98,20 @@ the route ``_controller`` value:
         # app/config/routing.yml
         hello:
             path:     /hello
-            defaults: { _controller: acme.hello.controller:indexAction }
+            defaults: { _controller: app.hello_controller:indexAction }
 
     .. code-block:: xml
 
         <!-- app/config/routing.xml -->
         <route id="hello" path="/hello">
-            <default key="_controller">acme.hello.controller:indexAction</default>
+            <default key="_controller">app.hello_controller:indexAction</default>
         </route>
 
     .. code-block:: php
 
         // app/config/routing.php
         $collection->add('hello', new Route('/hello', array(
-            '_controller' => 'acme.hello.controller:indexAction',
+            '_controller' => 'app.hello_controller:indexAction',
         )));
 
 .. tip::
@@ -133,8 +133,8 @@ For example, if you want to render a template instead of creating the ``Response
 object directly, then your code would look like this if you were extending
 Symfony's base controller::
 
-    // src/Acme/HelloBundle/Controller/HelloController.php
-    namespace Acme\HelloBundle\Controller;
+    // src/AppBundle/Controller/HelloController.php
+    namespace AppBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
@@ -143,7 +143,7 @@ Symfony's base controller::
         public function indexAction($name)
         {
             return $this->render(
-                'AcmeHelloBundle:Hello:index.html.twig',
+                'AppBundle:Hello:index.html.twig',
                 array('name' => $name)
             );
         }
@@ -161,8 +161,8 @@ If you look at the source code for the ``render`` function in Symfony's
 In a controller that's defined as a service, you can instead inject the ``templating``
 service and use it directly::
 
-    // src/Acme/HelloBundle/Controller/HelloController.php
-    namespace Acme\HelloBundle\Controller;
+    // src/AppBundle/Controller/HelloController.php
+    namespace AppBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
     use Symfony\Component\HttpFoundation\Response;
@@ -179,7 +179,7 @@ service and use it directly::
         public function indexAction($name)
         {
             return $this->templating->renderResponse(
-                'AcmeHelloBundle:Hello:index.html.twig',
+                'AppBundle:Hello:index.html.twig',
                 array('name' => $name)
             );
         }
@@ -192,29 +192,29 @@ argument:
 
     .. code-block:: yaml
 
-        # src/Acme/HelloBundle/Resources/config/services.yml
+        # app/config/services.yml
         services:
-            acme.hello.controller:
-                class:     Acme\HelloBundle\Controller\HelloController
+            app.hello_controller:
+                class:     AppBundle\Controller\HelloController
                 arguments: ["@templating"]
 
     .. code-block:: xml
 
-        <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
+        <!-- app/config/services.xml -->
         <services>
-            <service id="acme.hello.controller" class="Acme\HelloBundle\Controller\HelloController">
+            <service id="app.hello_controller" class="AppBundle\Controller\HelloController">
                 <argument type="service" id="templating"/>
             </service>
         </services>
 
     .. code-block:: php
 
-        // src/Acme/HelloBundle/Resources/config/services.php
+        // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\DependencyInjection\Reference;
 
-        $container->setDefinition('acme.hello.controller', new Definition(
-            'Acme\HelloBundle\Controller\HelloController',
+        $container->setDefinition('app.hello_controller', new Definition(
+            'AppBundle\Controller\HelloController',
             array(new Reference('templating'))
         ));
 

--- a/cookbook/doctrine/custom_dql_functions.rst
+++ b/cookbook/doctrine/custom_dql_functions.rst
@@ -19,12 +19,12 @@ In Symfony, you can register your custom DQL functions as follows:
                 # ...
                 dql:
                     string_functions:
-                        test_string: Acme\HelloBundle\DQL\StringFunction
-                        second_string: Acme\HelloBundle\DQL\SecondStringFunction
+                        test_string: AppBundle\DQL\StringFunction
+                        second_string: AppBundle\DQL\SecondStringFunction
                     numeric_functions:
-                        test_numeric: Acme\HelloBundle\DQL\NumericFunction
+                        test_numeric: AppBundle\DQL\NumericFunction
                     datetime_functions:
-                        test_datetime: Acme\HelloBundle\DQL\DatetimeFunction
+                        test_datetime: AppBundle\DQL\DatetimeFunction
 
     .. code-block:: xml
 
@@ -39,10 +39,10 @@ In Symfony, you can register your custom DQL functions as follows:
                 <doctrine:orm>
                     <!-- ... -->
                     <doctrine:dql>
-                        <doctrine:string-function name="test_string">Acme\HelloBundle\DQL\StringFunction</doctrine:string-function>
-                        <doctrine:string-function name="second_string">Acme\HelloBundle\DQL\SecondStringFunction</doctrine:string-function>
-                        <doctrine:numeric-function name="test_numeric">Acme\HelloBundle\DQL\NumericFunction</doctrine:numeric-function>
-                        <doctrine:datetime-function name="test_datetime">Acme\HelloBundle\DQL\DatetimeFunction</doctrine:datetime-function>
+                        <doctrine:string-function name="test_string">AppBundle\DQL\StringFunction</doctrine:string-function>
+                        <doctrine:string-function name="second_string">AppBundle\DQL\SecondStringFunction</doctrine:string-function>
+                        <doctrine:numeric-function name="test_numeric">AppBundle\DQL\NumericFunction</doctrine:numeric-function>
+                        <doctrine:datetime-function name="test_datetime">AppBundle\DQL\DatetimeFunction</doctrine:datetime-function>
                     </doctrine:dql>
                 </doctrine:orm>
             </doctrine:config>
@@ -56,14 +56,14 @@ In Symfony, you can register your custom DQL functions as follows:
                 // ...
                 'dql' => array(
                     'string_functions' => array(
-                        'test_string'   => 'Acme\HelloBundle\DQL\StringFunction',
-                        'second_string' => 'Acme\HelloBundle\DQL\SecondStringFunction',
+                        'test_string'   => 'AppBundle\DQL\StringFunction',
+                        'second_string' => 'AppBundle\DQL\SecondStringFunction',
                     ),
                     'numeric_functions' => array(
-                        'test_numeric' => 'Acme\HelloBundle\DQL\NumericFunction',
+                        'test_numeric' => 'AppBundle\DQL\NumericFunction',
                     ),
                     'datetime_functions' => array(
-                        'test_datetime' => 'Acme\HelloBundle\DQL\DatetimeFunction',
+                        'test_datetime' => 'AppBundle\DQL\DatetimeFunction',
                     ),
                 ),
             ),

--- a/cookbook/doctrine/dbal.rst
+++ b/cookbook/doctrine/dbal.rst
@@ -93,8 +93,8 @@ mapping types, read Doctrine's `Custom Mapping Types`_ section of their document
         doctrine:
             dbal:
                 types:
-                    custom_first:  Acme\HelloBundle\Type\CustomFirst
-                    custom_second: Acme\HelloBundle\Type\CustomSecond
+                    custom_first:  AppBundle\Type\CustomFirst
+                    custom_second: AppBundle\Type\CustomSecond
 
     .. code-block:: xml
 
@@ -107,8 +107,8 @@ mapping types, read Doctrine's `Custom Mapping Types`_ section of their document
 
             <doctrine:config>
                 <doctrine:dbal>
-                    <doctrine:type name="custom_first" class="Acme\HelloBundle\Type\CustomFirst" />
-                    <doctrine:type name="custom_second" class="Acme\HelloBundle\Type\CustomSecond" />
+                    <doctrine:type name="custom_first" class="AppBundle\Type\CustomFirst" />
+                    <doctrine:type name="custom_second" class="AppBundle\Type\CustomSecond" />
                 </doctrine:dbal>
             </doctrine:config>
         </container>
@@ -119,8 +119,8 @@ mapping types, read Doctrine's `Custom Mapping Types`_ section of their document
         $container->loadFromExtension('doctrine', array(
             'dbal' => array(
                 'types' => array(
-                    'custom_first'  => 'Acme\HelloBundle\Type\CustomFirst',
-                    'custom_second' => 'Acme\HelloBundle\Type\CustomSecond',
+                    'custom_first'  => 'AppBundle\Type\CustomFirst',
+                    'custom_second' => 'AppBundle\Type\CustomSecond',
                 ),
             ),
         ));

--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -23,8 +23,8 @@ Basic Setup
 
 First, create a simple Doctrine entity class to work with::
 
-    // src/Acme/DemoBundle/Entity/Document.php
-    namespace Acme\DemoBundle\Entity;
+    // src/AppBundle/Entity/Document.php
+    namespace AppBundle\Entity;
 
     use Doctrine\ORM\Mapping as ORM;
     use Symfony\Component\Validator\Constraints as Assert;
@@ -154,8 +154,8 @@ rules::
 
     .. code-block:: yaml
 
-        # src/Acme/DemoBundle/Resources/config/validation.yml
-        Acme\DemoBundle\Entity\Document:
+        # src/AppBundle/Resources/config/validation.yml
+        AppBundle\Entity\Document:
             properties:
                 file:
                     - File:
@@ -163,8 +163,8 @@ rules::
 
     .. code-block:: php-annotations
 
-        // src/Acme/DemoBundle/Entity/Document.php
-        namespace Acme\DemoBundle\Entity;
+        // src/AppBundle/Entity/Document.php
+        namespace AppBundle\Entity;
 
         // ...
         use Symfony\Component\Validator\Constraints as Assert;
@@ -181,8 +181,8 @@ rules::
 
     .. code-block:: xml
 
-        <!-- src/Acme/DemoBundle/Resources/config/validation.yml -->
-        <class name="Acme\DemoBundle\Entity\Document">
+        <!-- src/AppBundle/Resources/config/validation.yml -->
+        <class name="AppBundle\Entity\Document">
             <property name="file">
                 <constraint name="File">
                     <option name="maxSize">6000000</option>
@@ -192,7 +192,7 @@ rules::
 
     .. code-block:: php
 
-        // src/Acme/DemoBundle/Entity/Document.php
+        // src/AppBundle/Entity/Document.php
         namespace Acme\DemoBundle\Entity;
 
         // ...
@@ -220,7 +220,7 @@ rules::
 The following controller shows you how to handle the entire process::
 
     // ...
-    use Acme\DemoBundle\Entity\Document;
+    use AppBundle\Entity\Document;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
     use Symfony\Component\HttpFoundation\Request;
     // ...

--- a/cookbook/doctrine/multiple_entity_managers.rst
+++ b/cookbook/doctrine/multiple_entity_managers.rst
@@ -49,7 +49,7 @@ The following configuration code shows how you can configure two entity managers
                     default:
                         connection: default
                         mappings:
-                            AcmeDemoBundle:  ~
+                            AppBundle:  ~
                             AcmeStoreBundle: ~
                     customer:
                         connection: customer
@@ -90,7 +90,7 @@ The following configuration code shows how you can configure two entity managers
 
                 <orm default-entity-manager="default">
                     <entity-manager name="default" connection="default">
-                        <mapping name="AcmeDemoBundle" />
+                        <mapping name="AppBundle" />
                         <mapping name="AcmeStoreBundle" />
                     </entity-manager>
 
@@ -134,7 +134,7 @@ The following configuration code shows how you can configure two entity managers
                     'default' => array(
                         'connection' => 'default',
                         'mappings'   => array(
-                            'AcmeDemoBundle'  => null,
+                            'AppBundle'  => null,
                             'AcmeStoreBundle' => null,
                         ),
                     ),
@@ -150,7 +150,7 @@ The following configuration code shows how you can configure two entity managers
 
 In this case, you've defined two entity managers and called them ``default``
 and ``customer``. The ``default`` entity manager manages entities in the
-``AcmeDemoBundle`` and ``AcmeStoreBundle``, while the ``customer`` entity
+``AppBundle`` and ``AcmeStoreBundle``, while the ``customer`` entity
 manager manages entities in the ``AcmeCustomerBundle``. You've also defined
 two connections, one for each entity manager.
 

--- a/cookbook/email/testing.rst
+++ b/cookbook/email/testing.rst
@@ -33,7 +33,7 @@ Start with an easy controller action that sends an e-mail::
 In your functional test, use the ``swiftmailer`` collector on the profiler
 to get information about the messages send on the previous request::
 
-    // src/Acme/DemoBundle/Tests/Controller/MailControllerTest.php
+    // src/AppBundle/Tests/Controller/MailControllerTest.php
     use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
     class MailControllerTest extends WebTestCase

--- a/cookbook/event_dispatcher/before_after_filters.rst
+++ b/cookbook/event_dispatcher/before_after_filters.rst
@@ -74,7 +74,7 @@ controller that matches the request needs token validation.
 A clean and easy way is to create an empty interface and make the controllers
 implement it::
 
-    namespace Acme\DemoBundle\Controller;
+    namespace AppBundle\Controller;
 
     interface TokenAuthenticatedController
     {
@@ -83,9 +83,9 @@ implement it::
 
 A controller that implements this interface simply looks like this::
 
-    namespace Acme\DemoBundle\Controller;
+    namespace AppBundle\Controller;
 
-    use Acme\DemoBundle\Controller\TokenAuthenticatedController;
+    use AppBundle\Controller\TokenAuthenticatedController;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
     class FooController extends Controller implements TokenAuthenticatedController
@@ -104,10 +104,10 @@ Next, you'll need to create an event listener, which will hold the logic
 that you want executed before your controllers. If you're not familiar with
 event listeners, you can learn more about them at :doc:`/cookbook/service_container/event_listener`::
 
-    // src/Acme/DemoBundle/EventListener/TokenListener.php
-    namespace Acme\DemoBundle\EventListener;
+    // src/AppBundle/EventListener/TokenListener.php
+    namespace AppBundle\EventListener;
 
-    use Acme\DemoBundle\Controller\TokenAuthenticatedController;
+    use AppBundle\Controller\TokenAuthenticatedController;
     use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
     use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
@@ -153,33 +153,33 @@ your listener to be called just before any controller is executed.
 
     .. code-block:: yaml
 
-        # app/config/config.yml (or inside your services.yml)
+        # app/config/services.yml
         services:
-            demo.tokens.action_listener:
-                class: Acme\DemoBundle\EventListener\TokenListener
+            app.tokens.action_listener:
+                class: AappBundle\EventListener\TokenListener
                 arguments: ["%tokens%"]
                 tags:
                     - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml (or inside your services.xml) -->
-        <service id="demo.tokens.action_listener" class="Acme\DemoBundle\EventListener\TokenListener">
+        <!-- app/config/services.xml -->
+        <service id="app.tokens.action_listener" class="AppBundle\EventListener\TokenListener">
             <argument>%tokens%</argument>
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" />
         </service>
 
     .. code-block:: php
 
-        // app/config/config.php (or inside your services.php)
+        // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
 
-        $listener = new Definition('Acme\DemoBundle\EventListener\TokenListener', array('%tokens%'));
+        $listener = new Definition('AppBundle\EventListener\TokenListener', array('%tokens%'));
         $listener->addTag('kernel.event_listener', array(
             'event'  => 'kernel.controller',
             'method' => 'onKernelController'
         ));
-        $container->setDefinition('demo.tokens.action_listener', $listener);
+        $container->setDefinition('app.tokens.action_listener', $listener);
 
 With this configuration, your ``TokenListener`` ``onKernelController`` method
 will be executed on each request. If the controller that is about to be executed
@@ -248,10 +248,10 @@ event:
 
     .. code-block:: yaml
 
-        # app/config/config.yml (or inside your services.yml)
+        # app/config/services.yml
         services:
-            demo.tokens.action_listener:
-                class: Acme\DemoBundle\EventListener\TokenListener
+            app.tokens.action_listener:
+                class: AppBundle\EventListener\TokenListener
                 arguments: ["%tokens%"]
                 tags:
                     - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
@@ -259,8 +259,8 @@ event:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml (or inside your services.xml) -->
-        <service id="demo.tokens.action_listener" class="Acme\DemoBundle\EventListener\TokenListener">
+        <!-- app/config/services.xml -->
+        <service id="app.tokens.action_listener" class="AppBundle\EventListener\TokenListener">
             <argument>%tokens%</argument>
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" />
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
@@ -268,10 +268,10 @@ event:
 
     .. code-block:: php
 
-        // app/config/config.php (or inside your services.php)
+        // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
 
-        $listener = new Definition('Acme\DemoBundle\EventListener\TokenListener', array('%tokens%'));
+        $listener = new Definition('AppBundle\EventListener\TokenListener', array('%tokens%'));
         $listener->addTag('kernel.event_listener', array(
             'event'  => 'kernel.controller',
             'method' => 'onKernelController'
@@ -280,7 +280,7 @@ event:
             'event'  => 'kernel.response',
             'method' => 'onKernelResponse'
         ));
-        $container->setDefinition('demo.tokens.action_listener', $listener);
+        $container->setDefinition('app.tokens.action_listener', $listener);
 
 That's it! The ``TokenListener`` is now notified before every controller is
 executed (``onKernelController``) and after every controller returns a response

--- a/cookbook/form/create_custom_field_type.rst
+++ b/cookbook/form/create_custom_field_type.rst
@@ -20,8 +20,8 @@ will be called ``GenderType`` and the file will be stored in the default locatio
 for form fields, which is ``<BundleName>\Form\Type``. Make sure the field extends
 :class:`Symfony\\Component\\Form\\AbstractType`::
 
-    // src/Acme/DemoBundle/Form/Type/GenderType.php
-    namespace Acme\DemoBundle\Form\Type;
+    // src/AppBundle/Form/Type/GenderType.php
+    namespace AppBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -111,7 +111,7 @@ link for details), create a ``gender_widget`` block to handle this:
 
     .. code-block:: html+jinja
 
-        {# src/Acme/DemoBundle/Resources/views/Form/fields.html.twig #}
+        {# src/AppBundle/Resources/views/Form/fields.html.twig #}
         {% block gender_widget %}
             {% spaceless %}
                 {% if expanded %}
@@ -132,7 +132,7 @@ link for details), create a ``gender_widget`` block to handle this:
 
     .. code-block:: html+php
 
-        <!-- src/Acme/DemoBundle/Resources/views/Form/gender_widget.html.php -->
+        <!-- src/AppBundle/Resources/views/Form/gender_widget.html.php -->
         <?php if ($expanded) : ?>
             <ul <?php $view['form']->block($form, 'widget_container_attributes') ?>>
             <?php foreach ($form as $child) : ?>
@@ -164,14 +164,14 @@ link for details), create a ``gender_widget`` block to handle this:
             twig:
                 form:
                     resources:
-                        - 'AcmeDemoBundle:Form:fields.html.twig'
+                        - 'AppBundle:Form:fields.html.twig'
 
         .. code-block:: xml
 
             <!-- app/config/config.xml -->
             <twig:config>
                 <twig:form>
-                    <twig:resource>AcmeDemoBundle:Form:fields.html.twig</twig:resource>
+                    <twig:resource>AppBundle:Form:fields.html.twig</twig:resource>
                 </twig:form>
             </twig:config>
 
@@ -181,7 +181,7 @@ link for details), create a ``gender_widget`` block to handle this:
             $container->loadFromExtension('twig', array(
                 'form' => array(
                     'resources' => array(
-                        'AcmeDemoBundle:Form:fields.html.twig',
+                        'AppBundle:Form:fields.html.twig',
                     ),
                 ),
             ));
@@ -197,7 +197,7 @@ link for details), create a ``gender_widget`` block to handle this:
                 templating:
                     form:
                         resources:
-                            - 'AcmeDemoBundle:Form'
+                            - 'AppBundle:Form'
 
         .. code-block:: xml
 
@@ -212,7 +212,7 @@ link for details), create a ``gender_widget`` block to handle this:
                 <framework:config>
                     <framework:templating>
                         <framework:form>
-                            <framework:resource>AcmeDemoBundle:Form</twig:resource>
+                            <framework:resource>AppBundle:Form</twig:resource>
                         </framework:form>
                     </framework:templating>
                 </framework:config>
@@ -225,7 +225,7 @@ link for details), create a ``gender_widget`` block to handle this:
                 'templating' => array(
                     'form' => array(
                         'resources' => array(
-                            'AcmeDemoBundle:Form',
+                            'AppBundle:Form',
                         ),
                     ),
                 ),
@@ -237,8 +237,8 @@ Using the Field Type
 You can now use your custom field type immediately, simply by creating a
 new instance of the type in one of your forms::
 
-    // src/Acme/DemoBundle/Form/Type/AuthorType.php
-    namespace Acme\DemoBundle\Form\Type;
+    // src/AppBundle/Form/Type/AuthorType.php
+    namespace AppBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
@@ -301,10 +301,10 @@ the ``genders`` parameter value as the first argument to its to-be-created
 
     .. code-block:: yaml
 
-        # src/Acme/DemoBundle/Resources/config/services.yml
+        # src/AppBundle/Resources/config/services.yml
         services:
             acme_demo.form.type.gender:
-                class: Acme\DemoBundle\Form\Type\GenderType
+                class: AppBundle\Form\Type\GenderType
                 arguments:
                     - "%genders%"
                 tags:
@@ -312,20 +312,20 @@ the ``genders`` parameter value as the first argument to its to-be-created
 
     .. code-block:: xml
 
-        <!-- src/Acme/DemoBundle/Resources/config/services.xml -->
-        <service id="acme_demo.form.type.gender" class="Acme\DemoBundle\Form\Type\GenderType">
+        <!-- src/AppBundle/Resources/config/services.xml -->
+        <service id="acme_demo.form.type.gender" class="AppBundle\Form\Type\GenderType">
             <argument>%genders%</argument>
             <tag name="form.type" alias="gender" />
         </service>
 
     .. code-block:: php
 
-        // src/Acme/DemoBundle/Resources/config/services.php
+        // src/AppBundle/Resources/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
 
         $container
             ->setDefinition('acme_demo.form.type.gender', new Definition(
-                'Acme\DemoBundle\Form\Type\GenderType',
+                'AppBundle\Form\Type\GenderType',
                 array('%genders%')
             ))
             ->addTag('form.type', array(
@@ -343,8 +343,8 @@ returned by the ``getName`` method defined earlier. You'll see the importance
 of this in a moment when you use the custom field type. But first, add a ``__construct``
 method to ``GenderType``, which receives the gender configuration::
 
-    // src/Acme/DemoBundle/Form/Type/GenderType.php
-    namespace Acme\DemoBundle\Form\Type;
+    // src/AppBundle/Form/Type/GenderType.php
+    namespace AppBundle\Form\Type;
 
     use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -374,8 +374,8 @@ Great! The ``GenderType`` is now fueled by the configuration parameters and
 registered as a service. Additionally, because you used the ``form.type`` alias in its
 configuration, using the field is now much easier::
 
-    // src/Acme/DemoBundle/Form/Type/AuthorType.php
-    namespace Acme\DemoBundle\Form\Type;
+    // src/AppBundle/Form/Type/AuthorType.php
+    namespace AppBundle\Form\Type;
 
     use Symfony\Component\Form\FormBuilderInterface;
 

--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -36,8 +36,8 @@ Customizing your Form Based on the Underlying Data
 Before jumping right into dynamic form generation, hold on and recall what
 a bare form class looks like::
 
-    // src/Acme/DemoBundle/Form/Type/ProductType.php
-    namespace Acme\DemoBundle\Form\Type;
+    // src/AppBundle/Form/Type/ProductType.php
+    namespace AppBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
@@ -54,7 +54,7 @@ a bare form class looks like::
         public function setDefaultOptions(OptionsResolverInterface $resolver)
         {
             $resolver->setDefaults(array(
-                'data_class' => 'Acme\DemoBundle\Entity\Product'
+                'data_class' => 'AppBundle\Entity\Product'
             ));
         }
 
@@ -90,8 +90,8 @@ Adding an Event Listener to a Form Class
 So, instead of directly adding that ``name`` widget, the responsibility of
 creating that particular field is delegated to an event listener::
 
-    // src/Acme/DemoBundle/Form/Type/ProductType.php
-    namespace Acme\DemoBundle\Form\Type;
+    // src/AppBundle/Form/Type/ProductType.php
+    namespace AppBundle\Form\Type;
 
     // ...
     use Symfony\Component\Form\FormEvent;
@@ -156,11 +156,11 @@ For better reusability or if there is some heavy logic in your event listener,
 you can also move the logic for creating the ``name`` field to an
 :ref:`event subscriber <event_dispatcher-using-event-subscribers>`::
 
-    // src/Acme/DemoBundle/Form/Type/ProductType.php
-    namespace Acme\DemoBundle\Form\Type;
+    // src/AppBundle/Form/Type/ProductType.php
+    namespace AppBundle\Form\Type;
 
     // ...
-    use Acme\DemoBundle\Form\EventListener\AddNameFieldSubscriber;
+    use AppBundle\Form\EventListener\AddNameFieldSubscriber;
 
     class ProductType extends AbstractType
     {
@@ -177,8 +177,8 @@ you can also move the logic for creating the ``name`` field to an
 Now the logic for creating the ``name`` field resides in it own subscriber
 class::
 
-    // src/Acme/DemoBundle/Form/EventListener/AddNameFieldSubscriber.php
-    namespace Acme\DemoBundle\Form\EventListener;
+    // src/AppBundle/Form/EventListener/AddNameFieldSubscriber.php
+    namespace AppBundle\Form\EventListener;
 
     use Symfony\Component\Form\FormEvent;
     use Symfony\Component\Form\FormEvents;
@@ -221,8 +221,8 @@ Creating the Form Type
 
 Using an event listener, your form might look like this::
 
-    // src/Acme/DemoBundle/Form/Type/FriendMessageFormType.php
-    namespace Acme\DemoBundle\Form\Type;
+    // src/AppBundle/Form/Type/FriendMessageFormType.php
+    namespace AppBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
@@ -283,7 +283,7 @@ Customizing the Form Type
 Now that you have all the basics in place you can take advantage of the ``SecurityContext``
 and fill in the listener logic::
 
-    // src/Acme/DemoBundle/FormType/FriendMessageFormType.php
+    // src/AppBundle/FormType/FriendMessageFormType.php
 
     use Symfony\Component\Security\Core\SecurityContext;
     use Doctrine\ORM\EntityRepository;
@@ -319,7 +319,7 @@ and fill in the listener logic::
                     $form = $event->getForm();
 
                     $formOptions = array(
-                        'class' => 'Acme\DemoBundle\Entity\User',
+                        'class' => 'AppBundle\Entity\User',
                         'property' => 'fullName',
                         'query_builder' => function (EntityRepository $er) use ($user) {
                             // build a custom query
@@ -390,7 +390,7 @@ it with :ref:`dic-tags-form-type`.
         # app/config/config.yml
         services:
             acme.form.friend_message:
-                class: Acme\DemoBundle\Form\Type\FriendMessageFormType
+                class: AppBundle\Form\Type\FriendMessageFormType
                 arguments: ["@security.context"]
                 tags:
                     - { name: form.type, alias: acme_friend_message }
@@ -399,7 +399,7 @@ it with :ref:`dic-tags-form-type`.
 
         <!-- app/config/config.xml -->
         <services>
-            <service id="acme.form.friend_message" class="Acme\DemoBundle\Form\Type\FriendMessageFormType">
+            <service id="acme.form.friend_message" class="AppBundle\Form\Type\FriendMessageFormType">
                 <argument type="service" id="security.context" />
                 <tag name="form.type" alias="acme_friend_message" />
             </service>
@@ -408,7 +408,7 @@ it with :ref:`dic-tags-form-type`.
     .. code-block:: php
 
         // app/config/config.php
-        $definition = new Definition('Acme\DemoBundle\Form\Type\FriendMessageFormType');
+        $definition = new Definition('AppBundle\Form\Type\FriendMessageFormType');
         $definition->addTag('form.type', array('alias' => 'acme_friend_message'));
         $container->setDefinition(
             'acme.form.friend_message',
@@ -459,8 +459,8 @@ will need the correct options in order for validation to pass.
 The meetup is passed as an entity field to the form. So we can access each
 sport like this::
 
-    // src/Acme/DemoBundle/Form/Type/SportMeetupType.php
-    namespace Acme\DemoBundle\Form\Type;
+    // src/AppBundle/Form/Type/SportMeetupType.php
+    namespace AppBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
@@ -474,7 +474,7 @@ sport like this::
         {
             $builder
                 ->add('sport', 'entity', array(
-                    'class'       => 'AcmeDemoBundle:Sport',
+                    'class'       => 'AppBundle:Sport',
                     'empty_value' => '',
                 ))
             ;
@@ -491,7 +491,7 @@ sport like this::
                     $positions = null === $sport ? array() : $sport->getAvailablePositions();
 
                     $form->add('position', 'entity', array(
-                        'class'       => 'AcmeDemoBundle:Position',
+                        'class'       => 'AppBundle:Position',
                         'empty_value' => '',
                         'choices'     => $positions,
                     ));
@@ -532,12 +532,12 @@ new field automatically and map it to the submitted client data.
 
 The type would now look like::
 
-    // src/Acme/DemoBundle/Form/Type/SportMeetupType.php
-    namespace Acme\DemoBundle\Form\Type;
+    // src/AppBundle/Form/Type/SportMeetupType.php
+    namespace AppBundle\Form\Type;
 
     // ...
     use Symfony\Component\Form\FormInterface;
-    use Acme\DemoBundle\Entity\Sport;
+    use AppBundle\Entity\Sport;
 
     class SportMeetupType extends AbstractType
     {
@@ -545,7 +545,7 @@ The type would now look like::
         {
             $builder
                 ->add('sport', 'entity', array(
-                    'class'       => 'AcmeDemoBundle:Sport',
+                    'class'       => 'AppBundle:Sport',
                     'empty_value' => '',
                 ));
             ;
@@ -554,7 +554,7 @@ The type would now look like::
                 $positions = null === $sport ? array() : $sport->getAvailablePositions();
 
                 $form->add('position', 'entity', array(
-                    'class'       => 'AcmeDemoBundle:Position',
+                    'class'       => 'AppBundle:Position',
                     'empty_value' => '',
                     'choices'     => $positions,
                 ));
@@ -596,13 +596,13 @@ One piece that is still missing is the client-side updating of your form after
 the sport is selected. This should be handled by making an AJAX call back to
 your application. Assume that you have a sport meetup creation controller::
 
-    // src/Acme/DemoBundle/Controller/MeetupController.php
-    namespace Acme\DemoBundle\Controller;
+    // src/AppBundle/Controller/MeetupController.php
+    namespace AppBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
-    use Acme\DemoBundle\Entity\SportMeetup;
-    use Acme\DemoBundle\Form\Type\SportMeetupType;
+    use AppBundle\Entity\SportMeetup;
+    use AppBundle\Form\Type\SportMeetupType;
     // ...
 
     class MeetupController extends Controller
@@ -617,7 +617,7 @@ your application. Assume that you have a sport meetup creation controller::
             }
 
             return $this->render(
-                'AcmeDemoBundle:Meetup:create.html.twig',
+                'AppBundle:Meetup:create.html.twig',
                 array('form' => $form->createView())
             );
         }
@@ -632,7 +632,7 @@ field according to the current selection in the ``sport`` field:
 
     .. code-block:: html+jinja
 
-        {# src/Acme/DemoBundle/Resources/views/Meetup/create.html.twig #}
+        {# src/AppBundle/Resources/views/Meetup/create.html.twig #}
         {{ form_start(form) }}
             {{ form_row(form.sport) }}    {# <select id="meetup_sport" ... #}
             {{ form_row(form.position) }} {# <select id="meetup_position" ... #}
@@ -667,7 +667,7 @@ field according to the current selection in the ``sport`` field:
 
     .. code-block:: html+php
 
-        <!-- src/Acme/DemoBundle/Resources/views/Meetup/create.html.php -->
+        <!-- src/AppBundle/Resources/views/Meetup/create.html.php -->
         <?php echo $view['form']->start($form) ?>
             <?php echo $view['form']->row($form['sport']) ?>    <!-- <select id="meetup_sport" ... -->
             <?php echo $view['form']->row($form['position']) ?> <!-- <select id="meetup_position" ... -->

--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -282,7 +282,7 @@ can now re-use the form customization across many templates:
 
 .. code-block:: html+jinja
 
-    {# src/Acme/DemoBundle/Resources/views/Form/fields.html.twig #}
+    {# src/AppBundle/Resources/views/Form/fields.html.twig #}
     {% block integer_widget %}
         <div class="integer_widget">
             {% set type = type|default('number') %}
@@ -298,7 +298,7 @@ tell Symfony to use the template via the ``form_theme`` tag:
 
 .. code-block:: html+jinja
 
-    {% form_theme form 'AcmeDemoBundle:Form:fields.html.twig' %}
+    {% form_theme form 'AppBundle:Form:fields.html.twig' %}
 
     {{ form_widget(form.age) }}
 
@@ -315,7 +315,7 @@ name of all the templates as an array using the ``with`` keyword:
 .. code-block:: html+jinja
 
     {% form_theme form with ['::common.html.twig', ':Form:fields.html.twig',
-                             'AcmeDemoBundle:Form:fields.html.twig'] %}
+                             'AppBundle:Form:fields.html.twig'] %}
 
     {# ... #}
 
@@ -329,16 +329,16 @@ You can also apply a form theme to a specific child of your form:
 
 .. code-block:: html+jinja
 
-    {% form_theme form.child 'AcmeDemoBundle:Form:fields.html.twig' %}
+    {% form_theme form.child 'AppBundle:Form:fields.html.twig' %}
 
 This is useful when you want to have a custom theme for a nested form that's
 different than the one of your main form. Just specify both your themes:
 
 .. code-block:: html+jinja
 
-    {% form_theme form 'AcmeDemoBundle:Form:fields.html.twig' %}
+    {% form_theme form 'AppBundle:Form:fields.html.twig' %}
 
-    {% form_theme form.child 'AcmeDemoBundle:Form:fields_child.html.twig' %}
+    {% form_theme form.child 'AppBundle:Form:fields_child.html.twig' %}
 
 .. _cookbook-form-php-theming:
 
@@ -354,7 +354,7 @@ file in order to customize the ``integer_widget`` fragment.
 
 .. code-block:: html+php
 
-    <!-- src/Acme/DemoBundle/Resources/views/Form/integer_widget.html.php -->
+    <!-- src/AppBundle/Resources/views/Form/integer_widget.html.php -->
     <div class="integer_widget">
         <?php echo $view['form']->block($form, 'form_widget_simple', array('type' => isset($type) ? $type : "number")) ?>
     </div>
@@ -367,7 +367,7 @@ tell Symfony to use the theme via the ``setTheme`` helper method:
 
 .. code-block:: php
 
-    <?php $view['form']->setTheme($form, array('AcmeDemoBundle:Form')); ?>
+    <?php $view['form']->setTheme($form, array('AppBundle:Form')); ?>
 
     <?php $view['form']->widget($form['age']) ?>
 
@@ -380,7 +380,7 @@ method:
 
 .. code-block:: php
 
-    <?php $view['form']->setTheme($form['child'], 'AcmeDemoBundle:Form/Child'); ?>
+    <?php $view['form']->setTheme($form['child'], 'AppBundle:Form/Child'); ?>
 
 .. _cookbook-form-twig-import-base-blocks:
 
@@ -426,7 +426,7 @@ the base block by using the ``parent()`` Twig function:
 
 .. code-block:: html+jinja
 
-    {# src/Acme/DemoBundle/Resources/views/Form/fields.html.twig #}
+    {# src/AppBundle/Resources/views/Form/fields.html.twig #}
     {% extends 'form_div_layout.html.twig' %}
 
     {% block integer_widget %}
@@ -454,7 +454,7 @@ Twig
 ~~~~
 
 By using the following configuration, any customized form blocks inside the
-``AcmeDemoBundle:Form:fields.html.twig`` template will be used globally when a
+``AppBundle:Form:fields.html.twig`` template will be used globally when a
 form is rendered.
 
 .. configuration-block::
@@ -465,7 +465,7 @@ form is rendered.
         twig:
             form:
                 resources:
-                    - 'AcmeDemoBundle:Form:fields.html.twig'
+                    - 'AppBundle:Form:fields.html.twig'
             # ...
 
     .. code-block:: xml
@@ -473,7 +473,7 @@ form is rendered.
         <!-- app/config/config.xml -->
         <twig:config>
             <twig:form>
-                <resource>AcmeDemoBundle:Form:fields.html.twig</resource>
+                <resource>AppBundle:Form:fields.html.twig</resource>
             </twig:form>
             <!-- ... -->
         </twig:config>
@@ -484,7 +484,7 @@ form is rendered.
         $container->loadFromExtension('twig', array(
             'form' => array(
                 'resources' => array(
-                    'AcmeDemoBundle:Form:fields.html.twig',
+                    'AppBundle:Form:fields.html.twig',
                 ),
             ),
 
@@ -543,7 +543,7 @@ PHP
 ~~~
 
 By using the following configuration, any customized form fragments inside the
-``src/Acme/DemoBundle/Resources/views/Form`` folder will be used globally when a
+``src/AppBundle/Resources/views/Form`` folder will be used globally when a
 form is rendered.
 
 .. configuration-block::
@@ -555,7 +555,7 @@ form is rendered.
             templating:
                 form:
                     resources:
-                        - 'AcmeDemoBundle:Form'
+                        - 'AppBundle:Form'
             # ...
 
     .. code-block:: xml
@@ -564,7 +564,7 @@ form is rendered.
         <framework:config>
             <framework:templating>
                 <framework:form>
-                    <resource>AcmeDemoBundle:Form</resource>
+                    <resource>AppBundle:Form</resource>
                 </framework:form>
             </framework:templating>
             <!-- ... -->
@@ -578,7 +578,7 @@ form is rendered.
             'templating' => array(
                 'form' => array(
                     'resources' => array(
-                        'AcmeDemoBundle:Form',
+                        'AppBundle:Form',
                     ),
                 ),
              ),
@@ -666,11 +666,11 @@ customize the ``name`` field only:
     .. code-block:: html+php
 
         <!-- Main template -->
-        <?php echo $view['form']->setTheme($form, array('AcmeDemoBundle:Form')); ?>
+        <?php echo $view['form']->setTheme($form, array('AppBundle:Form')); ?>
 
         <?php echo $view['form']->widget($form['name']); ?>
 
-        <!-- src/Acme/DemoBundle/Resources/views/Form/_product_name_widget.html.php -->
+        <!-- src/AppBundle/Resources/views/Form/_product_name_widget.html.php -->
         <div class="text_widget">
               echo $view['form']->block('form_widget_simple') ?>
         </div>
@@ -723,11 +723,11 @@ You can also override the markup for an entire field row using the same method:
     .. code-block:: html+php
 
         <!-- Main template -->
-        <?php echo $view['form']->setTheme($form, array('AcmeDemoBundle:Form')); ?>
+        <?php echo $view['form']->setTheme($form, array('AppBundle:Form')); ?>
 
         <?php echo $view['form']->row($form['name']); ?>
 
-        <!-- src/Acme/DemoBundle/Resources/views/Form/_product_name_row.html.php -->
+        <!-- src/AppBundle/Resources/views/Form/_product_name_row.html.php -->
         <div class="name_row">
             <?php echo $view['form']->label($form) ?>
             <?php echo $view['form']->errors($form) ?>

--- a/cookbook/form/inherit_data_option.rst
+++ b/cookbook/form/inherit_data_option.rst
@@ -12,8 +12,8 @@ The ``inherit_data`` form field option can be very useful when you have some
 duplicated fields in different entities. For example, imagine you have two
 entities, a ``Company`` and a ``Customer``::
 
-    // src/Acme/HelloBundle/Entity/Company.php
-    namespace Acme\HelloBundle\Entity;
+    // src/AppBundle/Entity/Company.php
+    namespace AppBundle\Entity;
 
     class Company
     {
@@ -28,8 +28,8 @@ entities, a ``Company`` and a ``Customer``::
 
 .. code-block:: php
 
-    // src/Acme/HelloBundle/Entity/Customer.php
-    namespace Acme\HelloBundle\Entity;
+    // src/AppBundle/Entity/Customer.php
+    namespace AppBundle\Entity;
 
     class Customer
     {
@@ -47,8 +47,8 @@ As you can see, each entity shares a few of the same fields: ``address``,
 
 Start with building two forms for these entities, ``CompanyType`` and ``CustomerType``::
 
-    // src/Acme/HelloBundle/Form/Type/CompanyType.php
-    namespace Acme\HelloBundle\Form\Type;
+    // src/AppBundle/Form/Type/CompanyType.php
+    namespace AppBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
@@ -65,8 +65,8 @@ Start with building two forms for these entities, ``CompanyType`` and ``Customer
 
 .. code-block:: php
 
-    // src/Acme/HelloBundle/Form/Type/CustomerType.php
-    namespace Acme\HelloBundle\Form\Type;
+    // src/AppBundle/Form/Type/CustomerType.php
+    namespace AppBundle\Form\Type;
 
     use Symfony\Component\Form\FormBuilderInterface;
     use Symfony\Component\Form\AbstractType;
@@ -85,8 +85,8 @@ Instead of including the duplicated fields ``address``, ``zipcode``, ``city``
 and ``country`` in both of these forms, create a third form called ``LocationType``
 for that::
 
-    // src/Acme/HelloBundle/Form/Type/LocationType.php
-    namespace Acme\HelloBundle\Form\Type;
+    // src/AppBundle/Form/Type/LocationType.php
+    namespace AppBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
@@ -130,25 +130,25 @@ access the properties of the ``Customer`` instance instead. Easy, eh?
 
 Finally, make this work by adding the location form to your two original forms::
 
-    // src/Acme/HelloBundle/Form/Type/CompanyType.php
+    // src/AppBundle/Form/Type/CompanyType.php
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         // ...
 
         $builder->add('foo', new LocationType(), array(
-            'data_class' => 'Acme\HelloBundle\Entity\Company'
+            'data_class' => 'AppBundle\Entity\Company'
         ));
     }
 
 .. code-block:: php
 
-    // src/Acme/HelloBundle/Form/Type/CustomerType.php
+    // src/AppBundle/Form/Type/CustomerType.php
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         // ...
 
         $builder->add('bar', new LocationType(), array(
-            'data_class' => 'Acme\HelloBundle\Entity\Customer'
+            'data_class' => 'AppBundle\Entity\Customer'
         ));
     }
 

--- a/cookbook/form/use_empty_data.rst
+++ b/cookbook/form/use_empty_data.rst
@@ -34,11 +34,11 @@ One reason you might use this option is if you want to use a constructor
 that takes arguments. Remember, the default ``data_class`` option calls
 that constructor with no arguments::
 
-    // src/Acme/DemoBundle/Form/Type/BlogType.php
+    // src/AppBundle/Form/Type/BlogType.php
 
     // ...
     use Symfony\Component\Form\AbstractType;
-    use Acme\DemoBundle\Entity\Blog;
+    use AppBundle\Entity\Blog;
     use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
     class BlogType extends AbstractType

--- a/cookbook/profiler/matchers.rst
+++ b/cookbook/profiler/matchers.rst
@@ -67,8 +67,8 @@ profiler.
 To enable the profiler when a ``ROLE_SUPER_ADMIN`` is logged in, you can use
 something like::
 
-    // src/Acme/DemoBundle/Profiler/SuperAdminMatcher.php
-    namespace Acme\DemoBundle\Profiler;
+    // src/AppBundle/Profiler/SuperAdminMatcher.php
+    namespace AppBundle\Profiler;
 
     use Symfony\Component\Security\Core\SecurityContext;
     use Symfony\Component\HttpFoundation\Request;
@@ -95,26 +95,29 @@ Then, you need to configure the service:
 
     .. code-block:: yaml
 
+        # app/config/services.yml
         services:
-            acme_demo.profiler.matcher.super_admin:
-                class: Acme\DemoBundle\Profiler\SuperAdminMatcher
+            app.profiler.matcher.super_admin:
+                class: AppBundle\Profiler\SuperAdminMatcher
                 arguments: ["@security.context"]
 
     .. code-block:: xml
 
+        <!-- app/config/services.xml -->
         <services>
-            <service id="acme_demo.profiler.matcher.super_admin"
-                class="Acme\DemoBundle\Profiler\SuperAdminMatcher">
+            <service id="app.profiler.matcher.super_admin"
+                class="AppBundle\Profiler\SuperAdminMatcher">
                 <argument type="service" id="security.context" />
         </services>
 
     .. code-block:: php
 
+        // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\DependencyInjection\Reference;
 
-        $container->setDefinition('acme_demo.profiler.matcher.super_admin', new Definition(
-            'Acme\DemoBundle\Profiler\SuperAdminMatcher',
+        $container->setDefinition('app.profiler.matcher.super_admin', new Definition(
+            'AppBundle\Profiler\SuperAdminMatcher',
             array(new Reference('security.context'))
         );
 
@@ -130,7 +133,7 @@ profiler to use this service as the matcher:
             # ...
             profiler:
                 matcher:
-                    service: acme_demo.profiler.matcher.super_admin
+                    service: app.profiler.matcher.super_admin
 
     .. code-block:: xml
 
@@ -138,7 +141,7 @@ profiler to use this service as the matcher:
         <framework:config>
             <!-- ... -->
             <framework:profiler
-                service="acme_demo.profiler.matcher.super_admin"
+                service="app.profiler.matcher.super_admin"
             />
         </framework:config>
 
@@ -148,6 +151,6 @@ profiler to use this service as the matcher:
         $container->loadFromExtension('framework', array(
             // ...
             'profiler' => array(
-                'service' => 'acme_demo.profiler.matcher.super_admin',
+                'service' => 'app.profiler.matcher.super_admin',
             ),
         ));

--- a/cookbook/request/mime_type.rst
+++ b/cookbook/request/mime_type.rst
@@ -26,8 +26,8 @@ process and allows you to modify the request object.
 Create the following class, replacing the path with a path to a bundle in your
 project::
 
-    // src/Acme/DemoBundle/RequestListener.php
-    namespace Acme\DemoBundle;
+    // src/AppBundle/EventListener/RequestListener.php
+    namespace AppBundle\EventListener;
 
     use Symfony\Component\HttpKernel\HttpKernelInterface;
     use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -50,23 +50,23 @@ files and register it as a listener by adding the ``kernel.event_listener`` tag:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/services.yml
         services:
-            acme.demobundle.listener.request:
-                class: Acme\DemoBundle\RequestListener
+            app.listener.request:
+                class: AppBundle\EventListener\RequestListener
                 tags:
                     - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/services.xml -->
         <?xml version="1.0" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
             <services>
-                <service id="acme.demobundle.listener.request"
-                    class="Acme\DemoBundle\RequestListener">
+                <service id="app.listener.request"
+                    class="AppBundle\EventListener\RequestListener">
                     <tag name="kernel.event_listener"
                         event="kernel.request"
                         method="onKernelRequest"
@@ -77,15 +77,15 @@ files and register it as a listener by adding the ``kernel.event_listener`` tag:
 
     .. code-block:: php
 
-        # app/config/config.php
-        $definition = new Definition('Acme\DemoBundle\RequestListener');
+        # app/config/services.php
+        $definition = new Definition('AppBundle\EventListener\RequestListener');
         $definition->addTag('kernel.event_listener', array(
             'event'  => 'kernel.request',
             'method' => 'onKernelRequest',
         ));
-        $container->setDefinition('acme.demobundle.listener.request', $definition);
+        $container->setDefinition('app.listener.request', $definition);
 
-At this point, the ``acme.demobundle.listener.request`` service has been
+At this point, the ``app.listener.request`` service has been
 configured and will be notified when the Symfony kernel dispatches the
 ``kernel.request`` event.
 

--- a/cookbook/routing/extra_information.rst
+++ b/cookbook/routing/extra_information.rst
@@ -17,7 +17,7 @@ arguments to your controller:
         blog:
             path:      /blog/{page}
             defaults:
-                _controller: AcmeBlogBundle:Blog:index
+                _controller: AppBundle:Blog:index
                 page:        1
                 title:       "Hello world!"
 
@@ -31,7 +31,7 @@ arguments to your controller:
                 http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="blog" path="/blog/{page}">
-                <default key="_controller">AcmeBlogBundle:Blog:index</default>
+                <default key="_controller">AppBundle:Blog:index</default>
                 <default key="page">1</default>
                 <default key="title">Hello world!</default>
             </route>
@@ -45,7 +45,7 @@ arguments to your controller:
 
         $collection = new RouteCollection();
         $collection->add('blog', new Route('/blog/{page}', array(
-            '_controller' => 'AcmeBlogBundle:Blog:index',
+            '_controller' => 'AppBundle:Blog:index',
             'page'        => 1,
             'title'       => 'Hello world!',
         )));

--- a/cookbook/routing/method_parameters.rst
+++ b/cookbook/routing/method_parameters.rst
@@ -17,17 +17,17 @@ delete it by matching on GET, PUT and DELETE.
 
         blog_show:
             path:     /blog/{slug}
-            defaults: { _controller: AcmeDemoBundle:Blog:show }
+            defaults: { _controller: AppBundle:Blog:show }
             methods:   [GET]
 
         blog_update:
             path:     /blog/{slug}
-            defaults: { _controller: AcmeDemoBundle:Blog:update }
+            defaults: { _controller: AppBundle:Blog:update }
             methods:   [PUT]
 
         blog_delete:
             path:     /blog/{slug}
-            defaults: { _controller: AcmeDemoBundle:Blog:delete }
+            defaults: { _controller: AppBundle:Blog:delete }
             methods:   [DELETE]
 
     .. code-block:: xml
@@ -39,15 +39,15 @@ delete it by matching on GET, PUT and DELETE.
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="blog_show" path="/blog/{slug}" methods="GET">
-                <default key="_controller">AcmeDemoBundle:Blog:show</default>
+                <default key="_controller">AppBundle:Blog:show</default>
             </route>
 
             <route id="blog_update" path="/blog/{slug}" methods="PUT">
-                <default key="_controller">AcmeDemoBundle:Blog:update</default>
+                <default key="_controller">AppBundle:Blog:update</default>
             </route>
 
             <route id="blog_delete" path="/blog/{slug}" methods="DELETE">
-                <default key="_controller">AcmeDemoBundle:Blog:delete</default>
+                <default key="_controller">AppBundle:Blog:delete</default>
             </route>
         </routes>
 
@@ -58,15 +58,15 @@ delete it by matching on GET, PUT and DELETE.
 
         $collection = new RouteCollection();
         $collection->add('blog_show', new Route('/blog/{slug}', array(
-            '_controller' => 'AcmeDemoBundle:Blog:show',
+            '_controller' => 'AppBundle:Blog:show',
         ), array(), array(), '', array(), array('GET')));
 
         $collection->add('blog_update', new Route('/blog/{slug}', array(
-            '_controller' => 'AcmeDemoBundle:Blog:update',
+            '_controller' => 'AppBundle:Blog:update',
         ), array(), array(), '', array(), array('PUT')));
 
         $collection->add('blog_delete', new Route('/blog/{slug}', array(
-            '_controller' => 'AcmeDemoBundle:Blog:delete',
+            '_controller' => 'AppBundle:Blog:delete',
         ), array(), array(), '', array('DELETE')));
 
         return $collection;

--- a/cookbook/routing/redirect_in_config.rst
+++ b/cookbook/routing/redirect_in_config.rst
@@ -28,7 +28,7 @@ action to redirect to this new url:
 
         # load some routes - one should ultimately have the path "/app"
         AppBundle:
-            resource: "@AcmeAppBundle/Controller/"
+            resource: "@AppBundle/Controller/"
             type:     annotation
             prefix:   /app
 
@@ -50,7 +50,7 @@ action to redirect to this new url:
                 http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <!-- load some routes - one should ultimately have the path "/app" -->
-            <import resource="@AcmeAppBundle/Controller/"
+            <import resource="@AppBundle/Controller/"
                 type="annotation"
                 prefix="/app"
             />
@@ -72,13 +72,10 @@ action to redirect to this new url:
         $collection = new RouteCollection();
 
         // load some routes - one should ultimately have the path "/app"
-        $acmeApp = $loader->import(
-            "@AcmeAppBundle/Controller/",
-            "annotation"
-        );
-        $acmeApp->setPrefix('/app');
+        $appRoutes = $loader->import("@AppBundle/Controller/", "annotation");
+        $appRoutes->setPrefix('/app');
 
-        $collection->addCollection($acmeApp);
+        $collection->addCollection($appRoutes);
 
         // redirecting the root
         $collection->add('root', new Route('/', array(

--- a/cookbook/routing/redirect_trailing_slash.rst
+++ b/cookbook/routing/redirect_trailing_slash.rst
@@ -12,8 +12,8 @@ Create a controller that will match any URL with a trailing slash, remove
 the trailing slash (keeping query parameters if any) and redirect to the
 new URL with a 301 response status code::
 
-    // src/Acme/DemoBundle/Controller/RedirectingController.php
-    namespace Acme\DemoBundle\Controller;
+    // src/AppBundle/Controller/RedirectingController.php
+    namespace AppBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
@@ -41,7 +41,7 @@ system, as explained below:
 
         remove_trailing_slash:
             path: /{url}
-            defaults: { _controller: AcmeDemoBundle:Redirecting:removeTrailingSlash }
+            defaults: { _controller: AppBundle:Redirecting:removeTrailingSlash }
             requirements:
                 url: .*/$
             methods: [GET]
@@ -51,7 +51,7 @@ system, as explained below:
         <?xml version="1.0" encoding="UTF-8" ?>
         <routes xmlns="http://symfony.com/schema/routing">
             <route id="remove_trailing_slash" path="/{url}" methods="GET">
-                <default key="_controller">AcmeDemoBundle:Redirecting:removeTrailingSlash</default>
+                <default key="_controller">AppBundle:Redirecting:removeTrailingSlash</default>
                 <requirement key="url">.*/$</requirement>
             </route>
         </routes>
@@ -67,7 +67,7 @@ system, as explained below:
             new Route(
                 '/{url}',
                 array(
-                    '_controller' => 'AcmeDemoBundle:Redirecting:removeTrailingSlash',
+                    '_controller' => 'AppBundle:Redirecting:removeTrailingSlash',
                 ),
                 array(
                     'url' => '.*/$',

--- a/cookbook/routing/scheme.rst
+++ b/cookbook/routing/scheme.rst
@@ -14,7 +14,7 @@ the URI scheme via schemes:
 
         secure:
             path:     /secure
-            defaults: { _controller: AcmeDemoBundle:Main:secure }
+            defaults: { _controller: AppBundle:Main:secure }
             schemes:  [https]
 
     .. code-block:: xml
@@ -26,7 +26,7 @@ the URI scheme via schemes:
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="secure" path="/secure" schemes="https">
-                <default key="_controller">AcmeDemoBundle:Main:secure</default>
+                <default key="_controller">AppBundle:Main:secure</default>
             </route>
         </routes>
 
@@ -37,7 +37,7 @@ the URI scheme via schemes:
 
         $collection = new RouteCollection();
         $collection->add('secure', new Route('/secure', array(
-            '_controller' => 'AcmeDemoBundle:Main:secure',
+            '_controller' => 'AppBundle:Main:secure',
         ), array(), array(), '', array('https')));
 
         return $collection;

--- a/cookbook/routing/service_container_parameters.rst
+++ b/cookbook/routing/service_container_parameters.rst
@@ -21,9 +21,9 @@ inside your routing configuration:
         # app/config/routing.yml
         contact:
             path:     /{_locale}/contact
-            defaults: { _controller: AcmeDemoBundle:Main:contact }
+            defaults: { _controller: AppBundle:Main:contact }
             requirements:
-                _locale: "%acme_demo.locales%"
+                _locale: "%app.locales%"
 
     .. code-block:: xml
 
@@ -34,8 +34,8 @@ inside your routing configuration:
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="contact" path="/{_locale}/contact">
-                <default key="_controller">AcmeDemoBundle:Main:contact</default>
-                <requirement key="_locale">%acme_demo.locales%</requirement>
+                <default key="_controller">AppBundle:Main:contact</default>
+                <requirement key="_locale">%app.locales%</requirement>
             </route>
         </routes>
 
@@ -47,14 +47,14 @@ inside your routing configuration:
 
         $collection = new RouteCollection();
         $collection->add('contact', new Route('/{_locale}/contact', array(
-            '_controller' => 'AcmeDemoBundle:Main:contact',
+            '_controller' => 'AppBundle:Main:contact',
         ), array(
-            '_locale' => '%acme_demo.locales%',
+            '_locale' => '%app.locales%',
         )));
 
         return $collection;
 
-You can now control and set the  ``acme_demo.locales`` parameter somewhere
+You can now control and set the  ``app.locales`` parameter somewhere
 in your container:
 
 .. configuration-block::
@@ -63,19 +63,19 @@ in your container:
 
         # app/config/config.yml
         parameters:
-            acme_demo.locales: en|es
+            app.locales: en|es
 
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
         <parameters>
-            <parameter key="acme_demo.locales">en|es</parameter>
+            <parameter key="app.locales">en|es</parameter>
         </parameters>
 
     .. code-block:: php
 
         // app/config/config.php
-        $container->setParameter('acme_demo.locales', 'en|es');
+        $container->setParameter('app.locales', 'en|es');
 
 You can also use a parameter to define your route path (or part of your
 path):
@@ -86,8 +86,8 @@ path):
 
         # app/config/routing.yml
         some_route:
-            path:     /%acme_demo.route_prefix%/contact
-            defaults: { _controller: AcmeDemoBundle:Main:contact }
+            path:     /%app.route_prefix%/contact
+            defaults: { _controller: AppBundle:Main:contact }
 
     .. code-block:: xml
 
@@ -97,8 +97,8 @@ path):
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="some_route" path="/%acme_demo.route_prefix%/contact">
-                <default key="_controller">AcmeDemoBundle:Main:contact</default>
+            <route id="some_route" path="/%app.route_prefix%/contact">
+                <default key="_controller">AppBundle:Main:contact</default>
             </route>
         </routes>
 
@@ -109,8 +109,8 @@ path):
         use Symfony\Component\Routing\Route;
 
         $collection = new RouteCollection();
-        $collection->add('some_route', new Route('/%acme_demo.route_prefix%/contact', array(
-            '_controller' => 'AcmeDemoBundle:Main:contact',
+        $collection->add('some_route', new Route('/%app.route_prefix%/contact', array(
+            '_controller' => 'AppBundle:Main:contact',
         )));
 
         return $collection;

--- a/cookbook/routing/slash_in_parameter.rst
+++ b/cookbook/routing/slash_in_parameter.rst
@@ -28,7 +28,7 @@ a more permissive regex path.
 
         _hello:
             path:     /hello/{username}
-            defaults: { _controller: AcmeDemoBundle:Demo:hello }
+            defaults: { _controller: AppBundle:Demo:hello }
             requirements:
                 username: .+
 
@@ -41,7 +41,7 @@ a more permissive regex path.
             xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
             <route id="_hello" path="/hello/{username}">
-                <default key="_controller">AcmeDemoBundle:Demo:hello</default>
+                <default key="_controller">AppBundle:Demo:hello</default>
                 <requirement key="username">.+</requirement>
             </route>
         </routes>
@@ -53,7 +53,7 @@ a more permissive regex path.
 
         $collection = new RouteCollection();
         $collection->add('_hello', new Route('/hello/{username}', array(
-            '_controller' => 'AcmeDemoBundle:Demo:hello',
+            '_controller' => 'AppBundle:Demo:hello',
         ), array(
             'username' => '.+',
         )));

--- a/cookbook/security/acl.rst
+++ b/cookbook/security/acl.rst
@@ -99,8 +99,8 @@ Creating an ACL and Adding an ACE
 
 .. code-block:: php
 
-    // src/Acme/DemoBundle/Controller/BlogController.php
-    namespace Acme\DemoBundle\Controller;
+    // src/AppBundle/Controller/BlogController.php
+    namespace AppBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -167,7 +167,7 @@ Checking Access
 
 .. code-block:: php
 
-    // src/Acme/DemoBundle/Controller/BlogController.php
+    // src/AppBundle/Controller/BlogController.php
 
     // ...
 

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -51,8 +51,8 @@ provider.
 
 .. code-block:: php
 
-    // src/Acme/DemoBundle/Security/Authentication/Token/WsseUserToken.php
-    namespace Acme\DemoBundle\Security\Authentication\Token;
+    // src/AppBundle/Security/Authentication/Token/WsseUserToken.php
+    namespace AppBundle\Security\Authentication\Token;
 
     use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 
@@ -97,8 +97,8 @@ set an authenticated token in the security context if successful.
 
 .. code-block:: php
 
-    // src/Acme/DemoBundle/Security/Firewall/WsseListener.php
-    namespace Acme\DemoBundle\Security\Firewall;
+    // src/AppBundle/Security/Firewall/WsseListener.php
+    namespace AppBundle\Security\Firewall;
 
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -106,7 +106,7 @@ set an authenticated token in the security context if successful.
     use Symfony\Component\Security\Core\Exception\AuthenticationException;
     use Symfony\Component\Security\Core\SecurityContextInterface;
     use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
-    use Acme\DemoBundle\Security\Authentication\Token\WsseUserToken;
+    use AppBundle\Security\Authentication\Token\WsseUserToken;
 
     class WsseListener implements ListenerInterface
     {
@@ -193,15 +193,15 @@ the ``PasswordDigest`` header value matches with the user's password.
 
 .. code-block:: php
 
-    // src/Acme/DemoBundle/Security/Authentication/Provider/WsseProvider.php
-    namespace Acme\DemoBundle\Security\Authentication\Provider;
+    // src/AppBundle/Security/Authentication/Provider/WsseProvider.php
+    namespace AppBundle\Security\Authentication\Provider;
 
     use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
     use Symfony\Component\Security\Core\User\UserProviderInterface;
     use Symfony\Component\Security\Core\Exception\AuthenticationException;
     use Symfony\Component\Security\Core\Exception\NonceExpiredException;
     use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-    use Acme\DemoBundle\Security\Authentication\Token\WsseUserToken;
+    use AppBundle\Security\Authentication\Token\WsseUserToken;
 
     class WsseProvider implements AuthenticationProviderInterface
     {
@@ -290,8 +290,8 @@ create a class which implements
 
 .. code-block:: php
 
-    // src/Acme/DemoBundle/DependencyInjection/Security/Factory/WsseFactory.php
-    namespace Acme\DemoBundle\DependencyInjection\Security\Factory;
+    // src/AppBundle/DependencyInjection/Security/Factory/WsseFactory.php
+    namespace AppBundle\DependencyInjection\Security\Factory;
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Reference;
@@ -383,32 +383,32 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
 
     .. code-block:: yaml
 
-        # src/Acme/DemoBundle/Resources/config/services.yml
+        # src/AppBundle/Resources/config/services.yml
         services:
             wsse.security.authentication.provider:
-                class: Acme\DemoBundle\Security\Authentication\Provider\WsseProvider
+                class: AppBundle\Security\Authentication\Provider\WsseProvider
                 arguments: ["", "%kernel.cache_dir%/security/nonces"]
 
             wsse.security.authentication.listener:
-                class: Acme\DemoBundle\Security\Firewall\WsseListener
+                class: AppBundle\Security\Firewall\WsseListener
                 arguments: ["@security.context", "@security.authentication.manager"]
 
     .. code-block:: xml
 
-        <!-- src/Acme/DemoBundle/Resources/config/services.xml -->
+        <!-- src/AppBundle/Resources/config/services.xml -->
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
                 <service id="wsse.security.authentication.provider"
-                    class="Acme\DemoBundle\Security\Authentication\Provider\WsseProvider" public="false">
+                    class="AppBundle\Security\Authentication\Provider\WsseProvider" public="false">
                     <argument /> <!-- User Provider -->
                     <argument>%kernel.cache_dir%/security/nonces</argument>
                 </service>
 
                 <service id="wsse.security.authentication.listener"
-                    class="Acme\DemoBundle\Security\Firewall\WsseListener" public="false">
+                    class="AppBundle\Security\Firewall\WsseListener" public="false">
                     <argument type="service" id="security.context"/>
                     <argument type="service" id="security.authentication.manager" />
                 </service>
@@ -417,13 +417,13 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
 
     .. code-block:: php
 
-        // src/Acme/DemoBundle/Resources/config/services.php
+        // src/AppBundle/Resources/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\DependencyInjection\Reference;
 
         $container->setDefinition('wsse.security.authentication.provider',
             new Definition(
-                'Acme\DemoBundle\Security\Authentication\Provider\WsseProvider', array(
+                'AppBundle\Security\Authentication\Provider\WsseProvider', array(
                     '',
                     '%kernel.cache_dir%/security/nonces',
                 )
@@ -432,7 +432,7 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
 
         $container->setDefinition('wsse.security.authentication.listener',
             new Definition(
-                'Acme\DemoBundle\Security\Firewall\WsseListener', array(
+                'AppBundle\Security\Firewall\WsseListener', array(
                     new Reference('security.context'),
                     new Reference('security.authentication.manager'),
                 )
@@ -444,14 +444,14 @@ factory in your bundle class:
 
 .. code-block:: php
 
-    // src/Acme/DemoBundle/AcmeDemoBundle.php
-    namespace Acme\DemoBundle;
+    // src/AppBundle/AppBundle.php
+    namespace AppBundle;
 
-    use Acme\DemoBundle\DependencyInjection\Security\Factory\WsseFactory;
+    use AppBundle\DependencyInjection\Security\Factory\WsseFactory;
     use Symfony\Component\HttpKernel\Bundle\Bundle;
     use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-    class AcmeDemoBundle extends Bundle
+    class AppBundle extends Bundle
     {
         public function build(ContainerBuilder $container)
         {

--- a/cookbook/security/securing_services.rst
+++ b/cookbook/security/securing_services.rst
@@ -30,8 +30,8 @@ role. Before you add security, the class looks something like this:
 
 .. code-block:: php
 
-    // src/Acme/HelloBundle/Newsletter/NewsletterManager.php
-    namespace Acme\HelloBundle\Newsletter;
+    // src/AppBundle/Newsletter/NewsletterManager.php
+    namespace AppBundle\Newsletter;
 
     class NewsletterManager
     {
@@ -51,7 +51,7 @@ check, this is an ideal candidate for constructor injection, which guarantees
 that the security context object will be available inside the ``NewsletterManager``
 class::
 
-    namespace Acme\HelloBundle\Newsletter;
+    namespace AppBundle\Newsletter;
 
     use Symfony\Component\Security\Core\SecurityContextInterface;
 
@@ -73,36 +73,36 @@ Then in your service configuration, you can inject the service:
 
     .. code-block:: yaml
 
-        # src/Acme/HelloBundle/Resources/config/services.yml
+        # app/config/services.yml
         services:
             newsletter_manager:
-                class:     Acme\HelloBundle\Newsletter\NewsletterManager
+                class:     AppBundle\Newsletter\NewsletterManager
                 arguments: ["@security.context"]
 
     .. code-block:: xml
 
-        <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
+        <!-- app/config/services.xml -->
         <services>
-            <service id="newsletter_manager" class="Acme\HelloBundle\Newsletter\NewsletterManager">
+            <service id="newsletter_manager" class="AppBundle\Newsletter\NewsletterManager">
                 <argument type="service" id="security.context"/>
             </service>
         </services>
 
     .. code-block:: php
 
-        // src/Acme/HelloBundle/Resources/config/services.php
+        // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\DependencyInjection\Reference;
 
         $container->setDefinition('newsletter_manager', new Definition(
-            'Acme\HelloBundle\Newsletter\NewsletterManager',
+            'AppBundle\Newsletter\NewsletterManager',
             array(new Reference('security.context'))
         ));
 
 The injected service can then be used to perform the security check when the
 ``sendNewsletter()`` method is called::
 
-    namespace Acme\HelloBundle\Newsletter;
+    namespace AppBundle\Newsletter;
 
     use Symfony\Component\Security\Core\Exception\AccessDeniedException;
     use Symfony\Component\Security\Core\SecurityContextInterface;
@@ -148,7 +148,7 @@ the :ref:`sidebar <securing-services-annotations-sidebar>` below):
 
     .. code-block:: yaml
 
-        # src/Acme/HelloBundle/Resources/config/services.yml
+        # app/services.yml
 
         # ...
         services:
@@ -159,11 +159,11 @@ the :ref:`sidebar <securing-services-annotations-sidebar>` below):
 
     .. code-block:: xml
 
-        <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
+        <!-- app/services.xml -->
         <!-- ... -->
 
         <services>
-            <service id="newsletter_manager" class="Acme\HelloBundle\Newsletter\NewsletterManager">
+            <service id="newsletter_manager" class="AppBundle\Newsletter\NewsletterManager">
                 <!-- ... -->
                 <tag name="security.secure_service" />
             </service>
@@ -171,12 +171,12 @@ the :ref:`sidebar <securing-services-annotations-sidebar>` below):
 
     .. code-block:: php
 
-        // src/Acme/HelloBundle/Resources/config/services.php
+        // app/services.php
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\DependencyInjection\Reference;
 
         $definition = new Definition(
-            'Acme\HelloBundle\Newsletter\NewsletterManager',
+            'AppBundle\Newsletter\NewsletterManager',
             array(new Reference('security.context'))
         ));
         $definition->addTag('security.secure_service');
@@ -184,7 +184,7 @@ the :ref:`sidebar <securing-services-annotations-sidebar>` below):
 
 You can then achieve the same results as above using an annotation::
 
-    namespace Acme\HelloBundle\Newsletter;
+    namespace AppBundle\Newsletter;
 
     use JMS\SecurityExtraBundle\Annotation\Secure;
     // ...

--- a/cookbook/security/target_path.rst
+++ b/cookbook/security/target_path.rst
@@ -25,29 +25,29 @@ configuration file. This can be done from your main configuration file (in
 
         .. code-block:: yaml
 
-            # src/Acme/HelloBundle/Resources/config/services.yml
+            # app/config/services.yml
             parameters:
                 # ...
-                security.exception_listener.class: Acme\HelloBundle\Security\Firewall\ExceptionListener
+                security.exception_listener.class: AppBundle\Security\Firewall\ExceptionListener
 
         .. code-block:: xml
 
-            <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
+            <!-- app/config/services.xml -->
             <parameters>
                 <!-- ... -->
-                <parameter key="security.exception_listener.class">Acme\HelloBundle\Security\Firewall\ExceptionListener</parameter>
+                <parameter key="security.exception_listener.class">AppBundle\Security\Firewall\ExceptionListener</parameter>
             </parameters>
 
         .. code-block:: php
 
-            // src/Acme/HelloBundle/Resources/config/services.php
+            // app/config/services.php
             // ...
-            $container->setParameter('security.exception_listener.class', 'Acme\HelloBundle\Security\Firewall\ExceptionListener');
+            $container->setParameter('security.exception_listener.class', 'AppBundle\Security\Firewall\ExceptionListener');
 
 Next, create your own ``ExceptionListener``::
 
-    // src/Acme/HelloBundle/Security/Firewall/ExceptionListener.php
-    namespace Acme\HelloBundle\Security\Firewall;
+    // src/AppBundle/Security/Firewall/ExceptionListener.php
+    namespace AppBundle\Security\Firewall;
 
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\Security\Http\Firewall\ExceptionListener as BaseExceptionListener;

--- a/cookbook/security/voters.rst
+++ b/cookbook/security/voters.rst
@@ -37,8 +37,8 @@ and compare the IP address against a set of blacklisted IP addresses:
 
 .. code-block:: php
 
-    // src/Acme/DemoBundle/Security/Authorization/Voter/ClientIpVoter.php
-    namespace Acme\DemoBundle\Security\Authorization\Voter;
+    // src/AppBundle/Security/Authorization/Voter/ClientIpVoter.php
+    namespace AppBundle\Security\Authorization\Voter;
 
     use Symfony\Component\DependencyInjection\ContainerInterface;
     use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
@@ -106,7 +106,7 @@ and tag it as a ``security.voter``:
         # src/Acme/AcmeBundle/Resources/config/services.yml
         services:
             security.access.blacklist_voter:
-                class:     Acme\DemoBundle\Security\Authorization\Voter\ClientIpVoter
+                class:     AppBundle\Security\Authorization\Voter\ClientIpVoter
                 arguments: ["@service_container", [123.123.123.123, 171.171.171.171]]
                 public:    false
                 tags:
@@ -116,7 +116,7 @@ and tag it as a ``security.voter``:
 
         <!-- src/Acme/AcmeBundle/Resources/config/services.xml -->
         <service id="security.access.blacklist_voter"
-                 class="Acme\DemoBundle\Security\Authorization\Voter\ClientIpVoter" public="false">
+                 class="AppBundle\Security\Authorization\Voter\ClientIpVoter" public="false">
             <argument type="service" id="service_container" strict="false" />
             <argument type="collection">
                 <argument>123.123.123.123</argument>
@@ -132,7 +132,7 @@ and tag it as a ``security.voter``:
         use Symfony\Component\DependencyInjection\Reference;
 
         $definition = new Definition(
-            'Acme\DemoBundle\Security\Authorization\Voter\ClientIpVoter',
+            'AppBundle\Security\Authorization\Voter\ClientIpVoter',
             array(
                 new Reference('service_container'),
                 array('123.123.123.123', '171.171.171.171'),

--- a/cookbook/security/voters_data_permission.rst
+++ b/cookbook/security/voters_data_permission.rst
@@ -56,8 +56,8 @@ Creating the custom Voter
 The goal is to create a voter that checks if a user has access to view or
 edit a particular object. Here's an example implementation::
 
-    // src/Acme/DemoBundle/Security/Authorization/Voter/PostVoter.php
-    namespace Acme\DemoBundle\Security\Authorization\Voter;
+    // src/AppBundle/Security/Authorization/Voter/PostVoter.php
+    namespace AppBundle\Security\Authorization\Voter;
 
     use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
     use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -78,13 +78,13 @@ edit a particular object. Here's an example implementation::
 
         public function supportsClass($class)
         {
-            $supportedClass = 'Acme\DemoBundle\Entity\Post';
+            $supportedClass = 'AppBundle\Entity\Post';
 
             return $supportedClass === $class || is_subclass_of($class, $supportedClass);
         }
 
         /**
-         * @var \Acme\DemoBundle\Entity\Post $post
+         * @var \AppBundle\Entity\Post $post
          */
         public function vote(TokenInterface $token, $post, array $attributes)
         {
@@ -153,24 +153,24 @@ and tag it with ``security.voter``:
 
     .. code-block:: yaml
 
-        # src/Acme/DemoBundle/Resources/config/services.yml
+        # src/AppBundle/Resources/config/services.yml
         services:
             security.access.post_voter:
-                class:      Acme\DemoBundle\Security\Authorization\Voter\PostVoter
+                class:      AppBundle\Security\Authorization\Voter\PostVoter
                 public:     false
                 tags:
                    - { name: security.voter }
 
     .. code-block:: xml
 
-        <!-- src/Acme/DemoBundle/Resources/config/services.xml -->
+        <!-- src/AppBundle/Resources/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 http://symfony.com/schema/dic/services/services-1.0.xsd">
             <services>
                 <service id="security.access.post_document_voter"
-                    class="Acme\DemoBundle\Security\Authorization\Voter\PostVoter"
+                    class="AppBundle\Security\Authorization\Voter\PostVoter"
                     public="false">
                     <tag name="security.voter" />
                 </service>
@@ -179,11 +179,11 @@ and tag it with ``security.voter``:
 
     .. code-block:: php
 
-        // src/Acme/DemoBundle/Resources/config/services.php
+        // src/AppBundle/Resources/config/services.php
         $container
             ->register(
                     'security.access.post_document_voter',
-                    'Acme\DemoBundle\Security\Authorization\Voter\PostVoter'
+                    'AppBundle\Security\Authorization\Voter\PostVoter'
             )
             ->addTag('security.voter')
         ;
@@ -196,8 +196,8 @@ from the security context is called.
 
 .. code-block:: php
 
-    // src/Acme/DemoBundle/Controller/PostController.php
-    namespace Acme\DemoBundle\Controller;
+    // src/AppBundle/Controller/PostController.php
+    namespace AppBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Response;

--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -14,8 +14,8 @@ you will create a service that will act as an Exception Listener, allowing
 you to modify how exceptions are shown by your application. The ``KernelEvents::EXCEPTION``
 event is just one of the core kernel events::
 
-    // src/Acme/DemoBundle/EventListener/AcmeExceptionListener.php
-    namespace Acme\DemoBundle\EventListener;
+    // src/AppBundle/EventListener/AcmeExceptionListener.php
+    namespace AppBundle\EventListener;
 
     use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
     use Symfony\Component\HttpFoundation\Response;
@@ -71,25 +71,25 @@ using a special "tag":
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/services.yml
         services:
             kernel.listener.your_listener_name:
-                class: Acme\DemoBundle\EventListener\AcmeExceptionListener
+                class: AppBundle\EventListener\AcmeExceptionListener
                 tags:
                     - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
-        <service id="kernel.listener.your_listener_name" class="Acme\DemoBundle\EventListener\AcmeExceptionListener">
+        <!-- app/config/services.xml -->
+        <service id="kernel.listener.your_listener_name" class="AppBundle\EventListener\AcmeExceptionListener">
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
         </service>
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/services.php
         $container
-            ->register('kernel.listener.your_listener_name', 'Acme\DemoBundle\EventListener\AcmeExceptionListener')
+            ->register('kernel.listener.your_listener_name', 'AppBundle\EventListener\AcmeExceptionListener')
             ->addTag('kernel.event_listener', array('event' => 'kernel.exception', 'method' => 'onKernelException'))
         ;
 
@@ -108,8 +108,8 @@ sub-requests), which is why when working with the ``KernelEvents::REQUEST``
 event, you might need to check the type of the request. This can be easily
 done as follow::
 
-    // src/Acme/DemoBundle/EventListener/AcmeRequestListener.php
-    namespace Acme\DemoBundle\EventListener;
+    // src/AppBundle/EventListener/AcmeRequestListener.php
+    namespace AppBundle\EventListener;
 
     use Symfony\Component\HttpKernel\Event\GetResponseEvent;
     use Symfony\Component\HttpKernel\HttpKernel;

--- a/cookbook/service_container/scopes.rst
+++ b/cookbook/service_container/scopes.rst
@@ -106,8 +106,8 @@ drawbacks. For synchronized services (like the ``request``), using setter
 injection is the best option as it has no drawbacks and everything works
 without any special code in your service or in your definition::
 
-    // src/Acme/HelloBundle/Mail/Mailer.php
-    namespace Acme\HelloBundle\Mail;
+    // src/AppBundle/Mail/Mailer.php
+    namespace AppBundle\Mail;
 
     use Symfony\Component\HttpFoundation\Request;
 
@@ -144,19 +144,19 @@ your code. This should also be taken into account when declaring your service:
 
     .. code-block:: yaml
 
-        # src/Acme/HelloBundle/Resources/config/services.yml
+        # app/config/services.yml
         services:
             greeting_card_manager:
-                class: Acme\HelloBundle\Mail\GreetingCardManager
+                class: AppBundle\Mail\GreetingCardManager
                 calls:
                     - [setRequest, ["@?request="]]
 
     .. code-block:: xml
 
-        <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
+        <!-- app/config/services.xml -->
         <services>
             <service id="greeting_card_manager"
-                class="Acme\HelloBundle\Mail\GreetingCardManager"
+                class="AppBundle\Mail\GreetingCardManager"
             >
                 <call method="setRequest">
                     <argument type="service" id="request" on-invalid="null" strict="false" />
@@ -166,13 +166,13 @@ your code. This should also be taken into account when declaring your service:
 
     .. code-block:: php
 
-        // src/Acme/HelloBundle/Resources/config/services.php
+        // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\DependencyInjection\ContainerInterface;
 
         $definition = $container->setDefinition(
             'greeting_card_manager',
-            new Definition('Acme\HelloBundle\Mail\GreetingCardManager')
+            new Definition('AppBundle\Mail\GreetingCardManager')
         )
         ->addMethodCall('setRequest', array(
             new Reference('request', ContainerInterface::NULL_ON_INVALID_REFERENCE, false)
@@ -225,19 +225,19 @@ Changing the scope of a service should be done in its definition:
 
     .. code-block:: yaml
 
-        # src/Acme/HelloBundle/Resources/config/services.yml
+        # app/config/services.yml
         services:
             greeting_card_manager:
-                class: Acme\HelloBundle\Mail\GreetingCardManager
+                class: AppBundle\Mail\GreetingCardManager
                 scope: request
                 arguments: ["@request"]
 
     .. code-block:: xml
 
-        <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
+        <!-- app/config/services.xml -->
         <services>
             <service id="greeting_card_manager"
-                    class="Acme\HelloBundle\Mail\GreetingCardManager"
+                    class="AppBundle\Mail\GreetingCardManager"
                     scope="request">
                 <argument type="service" id="request" />
             </service>
@@ -245,13 +245,13 @@ Changing the scope of a service should be done in its definition:
 
     .. code-block:: php
 
-        // src/Acme/HelloBundle/Resources/config/services.php
+        // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
 
         $definition = $container->setDefinition(
             'greeting_card_manager',
             new Definition(
-                'Acme\HelloBundle\Mail\GreetingCardManager',
+                'AppBundle\Mail\GreetingCardManager',
                 array(new Reference('request'),
             ))
         )->setScope('request');
@@ -266,8 +266,8 @@ twig extension must be in the ``container`` scope as the Twig environment
 needs it as a dependency). In these cases, you can pass the entire container
 into your service::
 
-    // src/Acme/HelloBundle/Mail/Mailer.php
-    namespace Acme\HelloBundle\Mail;
+    // src/AppBundle/Mail/Mailer.php
+    namespace AppBundle\Mail;
 
     use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -300,30 +300,30 @@ The service config for this class would look something like this:
 
     .. code-block:: yaml
 
-        # src/Acme/HelloBundle/Resources/config/services.yml
+        # app/config/services.yml
         services:
             my_mailer:
-                class:     Acme\HelloBundle\Mail\Mailer
+                class:     AppBundle\Mail\Mailer
                 arguments: ["@service_container"]
                 # scope: container can be omitted as it is the default
 
     .. code-block:: xml
 
-        <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
+        <!-- app/config/services.xml -->
         <services>
-            <service id="my_mailer" class="Acme\HelloBundle\Mail\Mailer">
+            <service id="my_mailer" class="AppBundle\Mail\Mailer">
                  <argument type="service" id="service_container" />
             </service>
         </services>
 
     .. code-block:: php
 
-        // src/Acme/HelloBundle/Resources/config/services.php
+        // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\DependencyInjection\Reference;
 
         $container->setDefinition('my_mailer', new Definition(
-            'Acme\HelloBundle\Mail\Mailer',
+            'AppBundle\Mail\Mailer',
             array(new Reference('service_container'))
         ));
 

--- a/cookbook/session/locale_sticky_session.rst
+++ b/cookbook/session/locale_sticky_session.rst
@@ -19,8 +19,8 @@ The listener will look something like this. Typically, ``_locale`` is used
 as a routing parameter to signify the locale, though it doesn't really matter
 how you determine the desired locale from the request::
 
-    // src/Acme/LocaleBundle/EventListener/LocaleListener.php
-    namespace Acme\LocaleBundle\EventListener;
+    // src/AppBundle/EventListener/LocaleListener.php
+    namespace AppBundle\EventListener;
 
     use Symfony\Component\HttpKernel\Event\GetResponseEvent;
     use Symfony\Component\HttpKernel\KernelEvents;
@@ -67,16 +67,16 @@ Then register the listener:
     .. code-block:: yaml
 
         services:
-            acme_locale.locale_listener:
-                class: Acme\LocaleBundle\EventListener\LocaleListener
+            app.locale_listener:
+                class: AppBundle\EventListener\LocaleListener
                 arguments: ["%kernel.default_locale%"]
                 tags:
                     - { name: kernel.event_subscriber }
 
     .. code-block:: xml
 
-        <service id="acme_locale.locale_listener"
-            class="Acme\LocaleBundle\EventListener\LocaleListener">
+        <service id="app.locale_listener"
+            class="AppBundle\EventListener\LocaleListener">
             <argument>%kernel.default_locale%</argument>
 
             <tag name="kernel.event_subscriber" />
@@ -87,8 +87,8 @@ Then register the listener:
         use Symfony\Component\DependencyInjection\Definition;
 
         $container
-            ->setDefinition('acme_locale.locale_listener', new Definition(
-                'Acme\LocaleBundle\EventListener\LocaleListener',
+            ->setDefinition('app.locale_listener', new Definition(
+                'AppBundle\EventListener\LocaleListener',
                 array('%kernel.default_locale%')
             ))
             ->addTag('kernel.event_subscriber')

--- a/cookbook/templating/PHP.rst
+++ b/cookbook/templating/PHP.rst
@@ -49,21 +49,21 @@ You can now render a PHP template instead of a Twig one simply by using the
 ``.php`` extension in the template name instead of ``.twig``. The controller
 below renders the ``index.html.php`` template::
 
-    // src/Acme/HelloBundle/Controller/HelloController.php
+    // src/AppBundle/Controller/HelloController.php
 
     // ...
     public function indexAction($name)
     {
         return $this->render(
-            'AcmeHelloBundle:Hello:index.html.php',
+            'AppBundle:Hello:index.html.php',
             array('name' => $name)
         );
     }
 
 You can also use the `@Template`_ shortcut to render the default
-``AcmeHelloBundle:Hello:index.html.php`` template::
+``AppBundle:Hello:index.html.php`` template::
 
-    // src/Acme/HelloBundle/Controller/HelloController.php
+    // src/AppBundle/Controller/HelloController.php
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
     // ...
@@ -88,19 +88,19 @@ You can also use the `@Template`_ shortcut to render the default
             // ...
 
             // namespaced templates will no longer work in controllers
-            $this->render('@Acme/Default/index.html.twig');
+            $this->render('@App/Default/index.html.twig');
 
             // you must use the traditional template notation
-            $this->render('AcmeBundle:Default:index.html.twig');
+            $this->render('AppBundle:Default:index.html.twig');
         }
 
     .. code-block:: jinja
 
         {# inside a Twig template, namespaced templates work as expected #}
-        {{ include('@Acme/Default/index.html.twig') }}
+        {{ include('@App/Default/index.html.twig') }}
 
         {# traditional template notation will also work #}
-        {{ include('AcmeBundle:Default:index.html.twig') }}
+        {{ include('AppBundle:Default:index.html.twig') }}
 
 
 .. index::
@@ -119,12 +119,12 @@ the ``extend()`` call:
 
 .. code-block:: html+php
 
-    <!-- src/Acme/HelloBundle/Resources/views/Hello/index.html.php -->
-    <?php $view->extend('AcmeHelloBundle::layout.html.php') ?>
+    <!-- src/AppBundle/Resources/views/Hello/index.html.php -->
+    <?php $view->extend('AppBundle::layout.html.php') ?>
 
     Hello <?php echo $name ?>!
 
-The ``AcmeHelloBundle::layout.html.php`` notation sounds familiar, doesn't it? It
+The ``AppBundle::layout.html.php`` notation sounds familiar, doesn't it? It
 is the same notation used to reference a template. The ``::`` part simply
 means that the controller element is empty, so the corresponding file is
 directly stored under ``views/``.
@@ -133,7 +133,7 @@ Now, have a look at the ``layout.html.php`` file:
 
 .. code-block:: html+php
 
-    <!-- src/Acme/HelloBundle/Resources/views/layout.html.php -->
+    <!-- src/AppBundle/Resources/views/layout.html.php -->
     <?php $view->extend('::base.html.php') ?>
 
     <h1>Hello Application</h1>
@@ -181,8 +181,8 @@ decorating the template. In the ``index.html.php`` template, define a
 
 .. code-block:: html+php
 
-    <!-- src/Acme/HelloBundle/Resources/views/Hello/index.html.php -->
-    <?php $view->extend('AcmeHelloBundle::layout.html.php') ?>
+    <!-- src/AppBundle/Resources/views/Hello/index.html.php -->
+    <?php $view->extend('AppBundle::layout.html.php') ?>
 
     <?php $view['slots']->set('title', 'Hello World Application') ?>
 
@@ -223,17 +223,17 @@ Create a ``hello.html.php`` template:
 
 .. code-block:: html+php
 
-    <!-- src/Acme/HelloBundle/Resources/views/Hello/hello.html.php -->
+    <!-- src/AppBundle/Resources/views/Hello/hello.html.php -->
     Hello <?php echo $name ?>!
 
 And change the ``index.html.php`` template to include it:
 
 .. code-block:: html+php
 
-    <!-- src/Acme/HelloBundle/Resources/views/Hello/index.html.php -->
-    <?php $view->extend('AcmeHelloBundle::layout.html.php') ?>
+    <!-- src/AppBundle/Resources/views/Hello/index.html.php -->
+    <?php $view->extend('AppBundle::layout.html.php') ?>
 
-    <?php echo $view->render('AcmeHelloBundle:Hello:hello.html.php', array('name' => $name)) ?>
+    <?php echo $view->render('AppBundle:Hello:hello.html.php', array('name' => $name)) ?>
 
 The ``render()`` method evaluates and returns the content of another template
 (this is the exact same method as the one used in the controller).
@@ -253,18 +253,18 @@ If you create a ``fancy`` action, and want to include it into the
 
 .. code-block:: html+php
 
-    <!-- src/Acme/HelloBundle/Resources/views/Hello/index.html.php -->
+    <!-- src/AppBundle/Resources/views/Hello/index.html.php -->
     <?php echo $view['actions']->render(
-        new \Symfony\Component\HttpKernel\Controller\ControllerReference('AcmeHelloBundle:Hello:fancy', array(
+        new \Symfony\Component\HttpKernel\Controller\ControllerReference('AppBundle:Hello:fancy', array(
             'name'  => $name,
             'color' => 'green',
         ))
     ) ?>
 
-Here, the ``AcmeHelloBundle:Hello:fancy`` string refers to the ``fancy`` action of the
+Here, the ``AppBundle:Hello:fancy`` string refers to the ``fancy`` action of the
 ``Hello`` controller::
 
-    // src/Acme/HelloBundle/Controller/HelloController.php
+    // src/AppBundle/Controller/HelloController.php
 
     class HelloController extends Controller
     {
@@ -273,7 +273,7 @@ Here, the ``AcmeHelloBundle:Hello:fancy`` string refers to the ``fancy`` action 
             // create some object, based on the $color variable
             $object = ...;
 
-            return $this->render('AcmeHelloBundle:Hello:fancy.html.php', array(
+            return $this->render('AppBundle:Hello:fancy.html.php', array(
                 'name'   => $name,
                 'object' => $object
             ));
@@ -317,10 +317,10 @@ pattern:
 
 .. code-block:: yaml
 
-    # src/Acme/HelloBundle/Resources/config/routing.yml
+    # src/AppBundle/Resources/config/routing.yml
     hello: # The route name
         path:     /hello/{name}
-        defaults: { _controller: AcmeHelloBundle:Hello:index }
+        defaults: { _controller: AppBundle:Hello:index }
 
 Using Assets: Images, JavaScripts and Stylesheets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cookbook/templating/namespaced_paths.rst
+++ b/cookbook/templating/namespaced_paths.rst
@@ -17,15 +17,15 @@ Take the following paths as an example:
 
 .. code-block:: jinja
 
-    {% extends "AcmeDemoBundle::layout.html.twig" %}
-    {% include "AcmeDemoBundle:Foo:bar.html.twig" %}
+    {% extends "AppBundle::layout.html.twig" %}
+    {% include "AppBundle:Foo:bar.html.twig" %}
 
 With namespaced paths, the following works as well:
 
 .. code-block:: jinja
 
-    {% extends "@AcmeDemo/layout.html.twig" %}
-    {% include "@AcmeDemo/Foo/bar.html.twig" %}
+    {% extends "@App/layout.html.twig" %}
+    {% include "@App/Foo/bar.html.twig" %}
 
 Both paths are valid and functional by default in Symfony.
 

--- a/cookbook/templating/render_without_controller.rst
+++ b/cookbook/templating/render_without_controller.rst
@@ -10,7 +10,7 @@ a simple template that doesn't need any data passed into it, you can avoid
 creating the controller entirely, by using the built-in ``FrameworkBundle:Template:template``
 controller.
 
-For example, suppose you want to render a ``AcmeBundle:Static:privacy.html.twig``
+For example, suppose you want to render a ``AppBundle:Static:privacy.html.twig``
 template, which doesn't require that any variables are passed to it. You
 can do this without creating a controller:
 
@@ -22,7 +22,7 @@ can do this without creating a controller:
             path: /privacy
             defaults:
                 _controller: FrameworkBundle:Template:template
-                template:    'AcmeBundle:Static:privacy.html.twig'
+                template:    'AppBundle:Static:privacy.html.twig'
 
     .. code-block:: xml
 
@@ -34,7 +34,7 @@ can do this without creating a controller:
 
             <route id="acme_privacy" path="/privacy">
                 <default key="_controller">FrameworkBundle:Template:template</default>
-                <default key="template">AcmeBundle:Static:privacy.html.twig</default>
+                <default key="template">AppBundle:Static:privacy.html.twig</default>
             </route>
         </routes>
 
@@ -46,7 +46,7 @@ can do this without creating a controller:
         $collection = new RouteCollection();
         $collection->add('acme_privacy', new Route('/privacy', array(
             '_controller'  => 'FrameworkBundle:Template:template',
-            'template'     => 'AcmeBundle:Static:privacy.html.twig',
+            'template'     => 'AppBundle:Static:privacy.html.twig',
         )));
 
         return $collection;
@@ -93,7 +93,7 @@ other variables in your route, you can control exactly how your page is cached:
             path: /privacy
             defaults:
                 _controller:  FrameworkBundle:Template:template
-                template:     'AcmeBundle:Static:privacy.html.twig'
+                template:     'AppBundle:Static:privacy.html.twig'
                 maxAge:       86400
                 sharedAge:    86400
 
@@ -107,7 +107,7 @@ other variables in your route, you can control exactly how your page is cached:
 
             <route id="acme_privacy" path="/privacy">
                 <default key="_controller">FrameworkBundle:Template:template</default>
-                <default key="template">AcmeBundle:Static:privacy.html.twig</default>
+                <default key="template">AppBundle:Static:privacy.html.twig</default>
                 <default key="maxAge">86400</default>
                 <default key="sharedAge">86400</default>
             </route>
@@ -121,7 +121,7 @@ other variables in your route, you can control exactly how your page is cached:
         $collection = new RouteCollection();
         $collection->add('acme_privacy', new Route('/privacy', array(
             '_controller'  => 'FrameworkBundle:Template:template',
-            'template'     => 'AcmeBundle:Static:privacy.html.twig',
+            'template'     => 'AppBundle:Static:privacy.html.twig',
             'maxAge'       => 86400,
             'sharedAge' => 86400,
         )));

--- a/cookbook/templating/twig_extension.rst
+++ b/cookbook/templating/twig_extension.rst
@@ -30,10 +30,10 @@ Create the Extension Class
 To get your custom functionality you must first create a Twig Extension class.
 As an example you'll create a price filter to format a given number into price::
 
-    // src/Acme/DemoBundle/Twig/AcmeExtension.php
-    namespace Acme\DemoBundle\Twig;
+    // src/AppBundle/Twig/AppExtension.php
+    namespace AppBundle\Twig;
 
-    class AcmeExtension extends \Twig_Extension
+    class AppExtension extends \Twig_Extension
     {
         public function getFilters()
         {
@@ -52,7 +52,7 @@ As an example you'll create a price filter to format a given number into price::
 
         public function getName()
         {
-            return 'acme_extension';
+            return 'app_extension';
         }
     }
 
@@ -70,29 +70,29 @@ Now you must let the Service Container know about your newly created Twig Extens
 
     .. code-block:: yaml
 
-        # src/Acme/DemoBundle/Resources/config/services.yml
+        # app/config/services.yml
         services:
-            acme.twig.acme_extension:
-                class: Acme\DemoBundle\Twig\AcmeExtension
+            app.twig_extension:
+                class: AppBundle\Twig\AcmeExtension
                 tags:
                     - { name: twig.extension }
 
     .. code-block:: xml
 
-        <!-- src/Acme/DemoBundle/Resources/config/services.xml -->
+        <!-- app/config/services.xml -->
         <services>
-            <service id="acme.twig.acme_extension" class="Acme\DemoBundle\Twig\AcmeExtension">
+            <service id="app.twig_extension" class="AppBundle\Twig\AcmeExtension">
                 <tag name="twig.extension" />
             </service>
         </services>
 
     .. code-block:: php
 
-        // src/Acme/DemoBundle/Resources/config/services.php
+        // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
 
         $container
-            ->register('acme.twig.acme_extension', '\Acme\DemoBundle\Twig\AcmeExtension')
+            ->register('app.twig_extension', '\AppBundle\Twig\AcmeExtension')
             ->addTag('twig.extension');
 
 .. note::

--- a/cookbook/testing/database.rst
+++ b/cookbook/testing/database.rst
@@ -33,7 +33,7 @@ class.
 
 Suppose the class you want to test looks like this::
 
-    namespace Acme\DemoBundle\Salary;
+    namespace AppBundle\Salary;
 
     use Doctrine\Common\Persistence\ObjectManager;
 
@@ -48,7 +48,7 @@ Suppose the class you want to test looks like this::
 
         public function calculateTotalSalary($id)
         {
-            $employeeRepository = $this->entityManager->getRepository('AcmeDemoBundle::Employee');
+            $employeeRepository = $this->entityManager->getRepository('AppBundle::Employee');
             $employee = $employeeRepository->find($id);
 
             return $employee->getSalary() + $employee->getBonus();
@@ -58,14 +58,14 @@ Suppose the class you want to test looks like this::
 Since the ``ObjectManager`` gets injected into the class through the constructor,
 it's easy to pass a mock object within a test::
 
-    use Acme\DemoBundle\Salary\SalaryCalculator;
+    use AppBundle\Salary\SalaryCalculator;
 
     class SalaryCalculatorTest extends \PHPUnit_Framework_TestCase
     {
         public function testCalculateTotalSalary()
         {
             // First, mock the object to be used in the test
-            $employee = $this->getMock('\Acme\DemoBundle\Entity\Employee');
+            $employee = $this->getMock('\AppBundle\Entity\Employee');
             $employee->expects($this->once())
                 ->method('getSalary')
                 ->will($this->returnValue(1000));

--- a/cookbook/testing/simulating_authentication.rst
+++ b/cookbook/testing/simulating_authentication.rst
@@ -15,14 +15,14 @@ Another way would be to create a token yourself and store it in a session.
 While doing this, you have to make sure that an appropriate cookie is sent
 with a request. The following example demonstrates this technique::
 
-    // src/Acme/DemoBundle/Tests/Controller/DemoControllerTest.php
-    namespace Acme\DemoBundle\Tests\Controller;
+    // src/AppBundle/Tests/Controller/DefaultControllerTest.php
+    namespace Appbundle\Tests\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
     use Symfony\Component\BrowserKit\Cookie;
     use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
-    class DemoControllerTest extends WebTestCase
+    class DefaultControllerTest extends WebTestCase
     {
         private $client = null;
 
@@ -35,10 +35,10 @@ with a request. The following example demonstrates this technique::
         {
             $this->logIn();
 
-            $crawler = $this->client->request('GET', '/demo/secured/hello/Fabien');
+            $crawler = $this->client->request('GET', '/admin');
 
             $this->assertTrue($this->client->getResponse()->isSuccessful());
-            $this->assertGreaterThan(0, $crawler->filter('html:contains("Hello Fabien")')->count());
+            $this->assertGreaterThan(0, $crawler->filter('html:contains("Admin Dashboard")')->count());
         }
 
         private function logIn()

--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -14,8 +14,8 @@ Creating the Constraint Class
 
 First you need to create a Constraint class and extend :class:`Symfony\\Component\\Validator\\Constraint`::
 
-    // src/Acme/DemoBundle/Validator/Constraints/ContainsAlphanumeric.php
-    namespace Acme\DemoBundle\Validator\Constraints;
+    // src/AppBundle/Validator/Constraints/ContainsAlphanumeric.php
+    namespace AppBundle\Validator\Constraints;
 
     use Symfony\Component\Validator\Constraint;
 
@@ -54,8 +54,8 @@ when actually performing the validation.
 
 The validator class is also simple, and only has one required method ``validate()``::
 
-    // src/Acme/DemoBundle/Validator/Constraints/ContainsAlphanumericValidator.php
-    namespace Acme\DemoBundle\Validator\Constraints;
+    // src/AppBundle/Validator/Constraints/ContainsAlphanumericValidator.php
+    namespace AppBundle\Validator\Constraints;
 
     use Symfony\Component\Validator\Constraint;
     use Symfony\Component\Validator\ConstraintValidator;
@@ -91,18 +91,18 @@ Using custom validators is very easy, just as the ones provided by Symfony itsel
 
     .. code-block:: yaml
 
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\DemoBundle\Entity\AcmeEntity:
+        # src/AppBundle/Resources/config/validation.yml
+        AppBundle\Entity\AcmeEntity:
             properties:
                 name:
                     - NotBlank: ~
-                    - Acme\DemoBundle\Validator\Constraints\ContainsAlphanumeric: ~
+                    - AppBundle\Validator\Constraints\ContainsAlphanumeric: ~
 
     .. code-block:: php-annotations
 
-        // src/Acme/DemoBundle/Entity/AcmeEntity.php
+        // src/AppBundle/Entity/AcmeEntity.php
         use Symfony\Component\Validator\Constraints as Assert;
-        use Acme\DemoBundle\Validator\Constraints as AcmeAssert;
+        use AppBundle\Validator\Constraints as AcmeAssert;
 
         class AcmeEntity
         {
@@ -119,26 +119,26 @@ Using custom validators is very easy, just as the ones provided by Symfony itsel
 
     .. code-block:: xml
 
-        <!-- src/Acme/DemoBundle/Resources/config/validation.xml -->
+        <!-- src/AppBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
 
-            <class name="Acme\DemoBundle\Entity\AcmeEntity">
+            <class name="AppBundle\Entity\AcmeEntity">
                 <property name="name">
                     <constraint name="NotBlank" />
-                    <constraint name="Acme\DemoBundle\Validator\Constraints\ContainsAlphanumeric" />
+                    <constraint name="AppBundle\Validator\Constraints\ContainsAlphanumeric" />
                 </property>
             </class>
         </constraint-mapping>
 
     .. code-block:: php
 
-        // src/Acme/DemoBundle/Entity/AcmeEntity.php
+        // src/AppBundle/Entity/AcmeEntity.php
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints\NotBlank;
-        use Acme\DemoBundle\Validator\Constraints\ContainsAlphanumeric;
+        use AppBundle\Validator\Constraints\ContainsAlphanumeric;
 
         class AcmeEntity
         {
@@ -167,6 +167,7 @@ tag and an ``alias`` attribute:
 
     .. code-block:: yaml
 
+        # app/config/services.yml
         services:
             validator.unique.your_validator_name:
                 class: Fully\Qualified\Validator\Class\Name
@@ -175,6 +176,7 @@ tag and an ``alias`` attribute:
 
     .. code-block:: xml
 
+        <!-- app/config/services.xml -->
         <service id="validator.unique.your_validator_name" class="Fully\Qualified\Validator\Class\Name">
             <argument type="service" id="doctrine.orm.default_entity_manager" />
             <tag name="validator.constraint_validator" alias="alias_name" />
@@ -182,6 +184,7 @@ tag and an ``alias`` attribute:
 
     .. code-block:: php
 
+        // app/config/services.php
         $container
             ->register('validator.unique.your_validator_name', 'Fully\Qualified\Validator\Class\Name')
             ->addTag('validator.constraint_validator', array('alias' => 'alias_name'));
@@ -236,10 +239,10 @@ not to the property:
 
     .. code-block:: yaml
 
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\DemoBundle\Entity\AcmeEntity:
+        # src/AppBundle/Resources/config/validation.yml
+        AppBundle\Entity\AcmeEntity:
             constraints:
-                - Acme\DemoBundle\Validator\Constraints\ContainsAlphanumeric: ~
+                - AppBundle\Validator\Constraints\ContainsAlphanumeric: ~
 
     .. code-block:: php-annotations
 
@@ -253,7 +256,7 @@ not to the property:
 
     .. code-block:: xml
 
-        <!-- src/Acme/BlogBundle/Resources/config/validation.xml -->
-        <class name="Acme\DemoBundle\Entity\AcmeEntity">
-            <constraint name="Acme\DemoBundle\Validator\Constraints\ContainsAlphanumeric" />
+        <!-- src/AppBundle/Resources/config/validation.xml -->
+        <class name="AppBundle\Entity\AcmeEntity">
+            <constraint name="AppBundle\Validator\Constraints\ContainsAlphanumeric" />
         </class>

--- a/cookbook/web_services/php_soap_extension.rst
+++ b/cookbook/web_services/php_soap_extension.rst
@@ -59,7 +59,7 @@ a ``HelloService`` object properly:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # app/config/services.yml
         services:
             hello_service:
                 class: Acme\SoapBundle\Services\HelloService
@@ -67,7 +67,7 @@ a ``HelloService`` object properly:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- app/config/services.xml -->
         <services>
             <service id="hello_service" class="Acme\SoapBundle\Services\HelloService">
                 <argument type="service" id="mailer"/>
@@ -76,7 +76,7 @@ a ``HelloService`` object properly:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // app/config/services.php
         $container
             ->register('hello_service', 'Acme\SoapBundle\Services\HelloService')
             ->addArgument(new Reference('mailer'));
@@ -190,7 +190,7 @@ An example WSDL is below.
         </service>
     </definitions>
 
-.. _`PHP SOAP`:          http://php.net/manual/en/book.soap.php
-.. _`NuSOAP`:            http://sourceforge.net/projects/nusoap
-.. _`output buffering`:  http://php.net/manual/en/book.outcontrol.php
-.. _`Zend SOAP`:         http://framework.zend.com/manual/en/zend.soap.server.html
+.. _`PHP SOAP`: http://php.net/manual/en/book.soap.php
+.. _`NuSOAP`: http://sourceforge.net/projects/nusoap
+.. _`output buffering`: http://php.net/manual/en/book.outcontrol.php
+.. _`Zend SOAP`: http://framework.zend.com/manual/en/zend.soap.server.html


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | - |

This PR replaces `AcmeFooBundle`, `AcmeHelloBundle` and `AcmeDemoBundle` by `AppBundle` whenever it's possible in the Cookbook.

This is the first step into making the cookbook compliant with the recent good practices promoted by Symfony (the book is being made compliant in #4431). If we change everything to comply with the good practices, the pull request will be massive and it will take months. That's why I think it's better to do it in several steps using different pull requests.

By the way, this PR also contains some minor tweaks about using the new `app/config/services.yml` file. I can revert those changes if you want it.
