### PR TITLE
[Book][Security] Update code example to fit description

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1175,8 +1175,8 @@ in the following way from a controller::
     // whatever *your* User object is
     $user = new AppBundle\Entity\User();
     $plainPassword = 'ryanpass';
-    $encoded = $this->container->get('security.password_encoder')
-        ->encodePassword($user, $plainPassword);
+    $encoder = $this->container->get('security.password_encoder');
+    $encoded = $encoder->encodePassword($user, $plainPassword);
 
     $user->setPassword($encoded);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | >=2.6 |
| Fixed tickets |  |

The text mentions an `$encoder` object, which wasn't created in the code example.

In addition, I think the paragraph 

> The `$encoder` object also has an `isPasswordValid` method, which takes
> the `User` object as the first argument and the plain password to check
> as the second argument.

is also applicable to the 2.3 version (https://github.com/symfony/symfony-docs/blob/2.3/book/security.rst#dynamically-encoding-a-password), where the code example already provides an `$encoder` variable. Should I add it there?
