### PR TITLE
[2.3][Book][Security] Add isPasswordValid doc as in 2.6

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1117,6 +1117,10 @@ In order for this to work, just make sure that you have the encoder for your
 user class (e.g. ``AppBundle\Entity\User``) configured under the ``encoders``
 key in ``app/config/security.yml``.
 
+The ``$encoder`` object also has an ``isPasswordValid`` method, which takes
+the ``User`` object as the first argument and the plain password to check
+as the second argument.
+
 .. caution::
 
     When you allow a user to submit a plaintext password (e.g. registration


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | >=2.3 |
| Fixed tickets |  |

As mentioned in https://github.com/symfony/symfony-docs/pull/4744#issuecomment-68604129 the paragraph from 2.6 branch is also applicable to 2.3.
