### PR TITLE
[Components][ClassLoader] don't show deprecated usage of Yaml::parse()

### DIFF
--- a/components/class_loader/psr4_class_loader.rst
+++ b/components/class_loader/psr4_class_loader.rst
@@ -55,7 +55,7 @@ first need to configure the ``Psr4ClassLoader``:
     $loader->addPrefix('Symfony\\Component\\Yaml\\', __DIR__.'/lib/Yaml');
     $loader->register();
 
-    $data = Yaml::parse(__DIR__.'/config.yml');
+    $data = Yaml::parse(file_get_contents(__DIR__.'/config.yml'));
 
 First of all, the class loader is loaded manually using a ``require``
 statement, since there is no autoload mechanism yet. With the


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5+ |
| Fixed tickets |  |
