### PR TITLE
[Components][Yaml] don't describe removed usage of Yaml::parse()

### DIFF
--- a/components/yaml/introduction.rst
+++ b/components/yaml/introduction.rst
@@ -138,12 +138,6 @@ string or a file containing YAML. Internally, it calls the
 :method:`Symfony\\Component\\Yaml\\Parser::parse` method, but enhances the
 error if something goes wrong by adding the filename to the message.
 
-.. caution::
-
-    Because it is currently possible to pass a filename to this method, you
-    must validate the input first. Passing a filename is deprecated in
-    Symfony 2.2, and will be removed in Symfony 3.0.
-
 .. _components-yaml-dump:
 
 Writing YAML Files


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no (but related to symfony/symfony#13129) |
| Applies to | 3.0+ |
| Fixed tickets |  |
