### PR TITLE
[Cookbook][Security] don't output message from AuthenticationException

### DIFF
--- a/cookbook/security/form_login_setup.rst
+++ b/cookbook/security/form_login_setup.rst
@@ -25,7 +25,7 @@ First, enable form login under your firewall:
         # app/config/security.yml
         security:
             # ...
-        
+
             firewalls:
                 default:
                     anonymous: ~
@@ -98,7 +98,7 @@ under your ``form_login`` configuration (``/login`` and ``/login_check``):
 .. configuration-block::
 
     .. code-block:: php-annotations
-    
+
         // src/AppBundle/Controller/SecurityController.php
         // ...
         use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -165,7 +165,7 @@ form::
 
     // src/AppBundle/Controller/SecurityController.php
     // ...
-    
+
     // ADD THIS use STATEMENT above your class
     use Symfony\Component\Security\Core\SecurityContextInterface;
 
@@ -182,7 +182,7 @@ form::
             $error = $session->get(SecurityContextInterface::AUTHENTICATION_ERROR);
             $session->remove(SecurityContextInterface::AUTHENTICATION_ERROR);
         } else {
-            $error = '';
+            $error = null;
         }
 
         // last username entered by the user
@@ -218,7 +218,7 @@ Finally, create the template:
         {# ... you will probably extends your base template, like base.html.twig #}
 
         {% if error %}
-            <div>{{ error.message }}</div>
+            <div>{{ error.messageKey|trans(error.messageData) }}</div>
         {% endif %}
 
         <form action="{{ path('login_check') }}" method="post">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

Displaying the message of an `AuthenticationException` might expose
sensitive data to the user.
