### PR TITLE
[Reference][Forms] move cautions to make them visible

### DIFF
--- a/components/class_loader/debug_class_loader.rst
+++ b/components/class_loader/debug_class_loader.rst
@@ -1,9 +1,11 @@
 .. index::
     single: ClassLoader; DebugClassLoader
-    
+
 Debugging a Class Loader
 ========================
 
-Since Symfony 2.4, the ``DebugClassLoader`` of the Class Loader component is
-deprecated. Use the
-:doc:`DebugClassLoader provided by the Debug component </components/debug/class_loader>`.
+.. caution::
+
+    The ``DebugClassLoader`` from the ClassLoader component was deprecated
+    in Symfony 2.5 and will be removed in Symfony 3.0. Use the
+    :doc:`DebugClassLoader provided by the Debug component </components/debug/class_loader>`.

--- a/components/console/helpers/map.rst.inc
+++ b/components/console/helpers/map.rst.inc
@@ -1,7 +1,7 @@
-* :doc:`/components/console/helpers/dialoghelper`
+* :doc:`/components/console/helpers/dialoghelper` (deprecated as of 2.5)
 * :doc:`/components/console/helpers/formatterhelper`
 * :doc:`/components/console/helpers/progressbar`
-* :doc:`/components/console/helpers/progresshelper`
+* :doc:`/components/console/helpers/progresshelper` (deprecated as of 2.5)
 * :doc:`/components/console/helpers/questionhelper`
 * :doc:`/components/console/helpers/table`
-* :doc:`/components/console/helpers/tablehelper`
+* :doc:`/components/console/helpers/tablehelper` (deprecated as of 2.5)

--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -409,9 +409,9 @@ tools capable of helping you with different tasks:
 
 * :doc:`/components/console/helpers/questionhelper`: interactively ask the user for information
 * :doc:`/components/console/helpers/formatterhelper`: customize the output colorization
-* :doc:`/components/console/helpers/progresshelper`: shows a progress bar
-* :doc:`/components/console/helpers/tablehelper`: displays tabular data as a table
-* :doc:`/components/console/helpers/dialoghelper`: (deprecated) interactively ask the user for information
+* :doc:`/components/console/helpers/progressbar`: shows a progress bar
+* :doc:`/components/console/helpers/table`: displays tabular data as a table
+* :doc:`/components/console/helpers/questionhelper`: interactively ask the user for information
 
 .. _component-console-testing-commands:
 

--- a/reference/forms/types/options/max_length.rst.inc
+++ b/reference/forms/types/options/max_length.rst.inc
@@ -1,10 +1,11 @@
-.. caution::
-
-    The ``max_length`` option has been deprecated and will be removed in 3.0.
-    Instead, use the ``attr`` option by setting it to an array with a ``maxlength`` key.
-
 max_length
 ~~~~~~~~~~
+
+.. caution::
+
+    The ``max_length`` option was deprecated in Symfony 2.5 and will be removed
+    in Symfony 3.0. Use the ``attr`` option instead by setting it to an array
+    with a ``maxlength`` key.
 
 **type**: ``integer`` **default**: ``null``
 

--- a/reference/forms/types/options/pattern.rst.inc
+++ b/reference/forms/types/options/pattern.rst.inc
@@ -1,10 +1,11 @@
-.. caution::
-
-    The ``pattern`` option has been deprecated and will be removed in 3.0.
-    Instead, use the ``attr`` option by setting it to an array with a ``pattern`` key.
-
 pattern
 ~~~~~~~
+
+.. caution::
+
+    The ``pattern`` option was deprecated in Symfony 2.5 and will be removed
+    in Symfony 3.0. Use the ``attr`` option instead by setting it to an array
+    with a ``pattern`` key.
 
 **type**: ``string`` **default**: ``null``
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5+ |
| Fixed tickets |  |

If the reader follows a direct link to the option's description, they
would very likely not see the caution as it was rendered outside the
viewport.
