### PR TITLE
Add missing semicolon

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -224,7 +224,7 @@ When serializing, you can set a callback to format a specific object property::
         return $dateTime instanceof \DateTime
             ? $dateTime->format(\DateTime::ISO8601)
             : '';
-    }
+    };
 
     $normalizer->setCallbacks(array('createdAt' => $callback));
 


### PR DESCRIPTION
Add missing semicolon to 

```
$callback = function ($dateTime) {
        return $dateTime instanceof \DateTime
            ? $dateTime->format(\DateTime::ISO8601)
            : '';
    };
```
