### PR TITLE
Replaced setDefaultOptions by the new configureOptions method

### DIFF
--- a/best_practices/forms.rst
+++ b/best_practices/forms.rst
@@ -21,7 +21,7 @@ form in its own PHP class::
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class PostType extends AbstractType
     {
@@ -36,7 +36,7 @@ form in its own PHP class::
             ;
         }
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'data_class' => 'AppBundle\Entity\Post'

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -471,12 +471,12 @@ you'll need to specify which validation group(s) your form should use::
     ))->add(...);
 
 If you're creating :ref:`form classes <book-form-creating-form-classes>` (a
-good practice), then you'll need to add the following to the ``setDefaultOptions()``
+good practice), then you'll need to add the following to the ``configureOptions()``
 method::
 
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'validation_groups' => array('registration'),
@@ -498,9 +498,9 @@ Disabling Validation
 Sometimes it is useful to suppress the validation of a form altogether. For
 these cases you can set the ``validation_groups`` option to ``false``::
 
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'validation_groups' => false,
@@ -524,10 +524,10 @@ If you need some advanced logic to determine the validation groups (e.g.
 based on submitted data), you can set the ``validation_groups`` option
 to an array callback::
 
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     // ...
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'validation_groups' => array(
@@ -544,10 +544,10 @@ You can also define whole logic inline by using a ``Closure``::
 
     use Acme\AcmeBundle\Entity\Client;
     use Symfony\Component\Form\FormInterface;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     // ...
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'validation_groups' => function(FormInterface $form) {
@@ -567,10 +567,10 @@ of the entity as well you have to adjust the option as follows::
 
     use Acme\AcmeBundle\Entity\Client;
     use Symfony\Component\Form\FormInterface;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     // ...
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'validation_groups' => function(FormInterface $form) {
@@ -1090,9 +1090,9 @@ the choice is ultimately up to you.
     good idea to explicitly specify the ``data_class`` option by adding the
     following to your form type class::
 
-        use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+        use Symfony\Component\OptionsResolver\OptionsResolver;
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'data_class' => 'AppBundle\Entity\Task',
@@ -1321,7 +1321,7 @@ create a form class so that a ``Category`` object can be modified by the user::
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class CategoryType extends AbstractType
     {
@@ -1330,7 +1330,7 @@ create a form class so that a ``Category`` object can be modified by the user::
             $builder->add('name');
         }
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'data_class' => 'AppBundle\Entity\Category',
@@ -1756,13 +1756,13 @@ that all un-rendered fields are output.
 
 The CSRF token can be customized on a form-by-form basis. For example::
 
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class TaskType extends AbstractType
     {
         // ...
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'data_class'      => 'AppBundle\Entity\Task',

--- a/cookbook/doctrine/registration_form.rst
+++ b/cookbook/doctrine/registration_form.rst
@@ -111,7 +111,7 @@ Next, create the form for the ``User`` model::
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class UserType extends AbstractType
     {
@@ -125,7 +125,7 @@ Next, create the form for the ``User`` model::
             ));
         }
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'data_class' => 'Acme\AccountBundle\Entity\User'

--- a/cookbook/form/create_custom_field_type.rst
+++ b/cookbook/form/create_custom_field_type.rst
@@ -24,11 +24,11 @@ for form fields, which is ``<BundleName>\Form\Type``. Make sure the field extend
     namespace AppBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class GenderType extends AbstractType
     {
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'choices' => array(
@@ -72,7 +72,7 @@ important:
     set) the ``multiple`` attribute on the ``select`` field. See `Creating a Template for the Field`_
     for more details.
 
-``setDefaultOptions()``
+``configureOptions()``
     This defines options for your form type that
     can be used in ``buildForm()`` and ``buildView()``. There are a lot of
     options common to all fields (see :doc:`/reference/forms/types/form`),
@@ -345,7 +345,7 @@ method to ``GenderType``, which receives the gender configuration::
     // src/AppBundle/Form/Type/GenderType.php
     namespace AppBundle\Form\Type;
 
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     // ...
 
@@ -359,7 +359,7 @@ method to ``GenderType``, which receives the gender configuration::
             $this->genderChoices = $genderChoices;
         }
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'choices' => $this->genderChoices,

--- a/cookbook/form/create_form_type_extension.rst
+++ b/cookbook/form/create_form_type_extension.rst
@@ -83,7 +83,7 @@ to override one of the following methods:
 
 * ``buildView()``
 
-* ``setDefaultOptions()``
+* ``configureOptions()``
 
 * ``finishView()``
 
@@ -178,7 +178,7 @@ database)::
 Your form type extension class will need to do two things in order to extend
 the ``file`` form type:
 
-#. Override the ``setDefaultOptions`` method in order to add an ``image_path``
+#. Override the ``configureOptions`` method in order to add an ``image_path``
    option;
 #. Override the ``buildForm`` and ``buildView`` methods in order to pass the image
    URL to the view.
@@ -212,9 +212,9 @@ it in the view::
         /**
          * Add the image_path option
          *
-         * @param OptionsResolverInterface $resolver
+         * @param OptionsResolver $resolver
          */
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setOptional(array('image_path'));
         }

--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -113,8 +113,9 @@ You can also use transformers without creating a new custom form type
 by calling ``addModelTransformer`` (or ``addViewTransformer`` - see
 `Model and View Transformers`_) on any field builder::
 
-    use Symfony\Component\Form\FormBuilderInterface;
     use Acme\TaskBundle\Form\DataTransformer\IssueToNumberTransformer;
+    use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class TaskType extends AbstractType
     {
@@ -133,7 +134,7 @@ by calling ``addModelTransformer`` (or ``addViewTransformer`` - see
             );
         }
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver
                 ->setDefaults(array(
@@ -254,7 +255,7 @@ First, create the custom field type class::
     use Symfony\Component\Form\FormBuilderInterface;
     use Acme\TaskBundle\Form\DataTransformer\IssueToNumberTransformer;
     use Doctrine\Common\Persistence\ObjectManager;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class IssueSelectorType extends AbstractType
     {
@@ -277,7 +278,7 @@ First, create the custom field type class::
             $builder->addModelTransformer($transformer);
         }
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolverInterface $resolver)
         {
             $resolver->setDefaults(array(
                 'invalid_message' => 'The selected issue does not exist',

--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -41,7 +41,7 @@ a bare form class looks like::
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class ProductType extends AbstractType
     {
@@ -51,7 +51,7 @@ a bare form class looks like::
             $builder->add('price');
         }
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'data_class' => 'AppBundle\Entity\Product'
@@ -224,7 +224,6 @@ Using an event listener, your form might look like this::
     use Symfony\Component\Form\FormEvents;
     use Symfony\Component\Form\FormEvent;
     use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
     class FriendMessageFormType extends AbstractType
     {
@@ -242,10 +241,6 @@ Using an event listener, your form might look like this::
         public function getName()
         {
             return 'acme_friend_message';
-        }
-
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
-        {
         }
     }
 

--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -84,7 +84,7 @@ Then, create a form class so that a ``Tag`` object can be modified by the user::
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class TagType extends AbstractType
     {
@@ -93,7 +93,7 @@ Then, create a form class so that a ``Tag`` object can be modified by the user::
             $builder->add('name');
         }
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'data_class' => 'Acme\TaskBundle\Entity\Tag',
@@ -118,7 +118,7 @@ Notice that you embed a collection of ``TagType`` forms using the
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class TaskType extends AbstractType
     {
@@ -129,7 +129,7 @@ Notice that you embed a collection of ``TagType`` forms using the
             $builder->add('tags', 'collection', array('type' => new TagType()));
         }
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'data_class' => 'Acme\TaskBundle\Entity\Task',

--- a/cookbook/form/inherit_data_option.rst
+++ b/cookbook/form/inherit_data_option.rst
@@ -90,7 +90,7 @@ for that::
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class LocationType extends AbstractType
     {
@@ -103,7 +103,7 @@ for that::
                 ->add('country', 'text');
         }
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'inherit_data' => true

--- a/cookbook/form/use_empty_data.rst
+++ b/cookbook/form/use_empty_data.rst
@@ -39,7 +39,7 @@ that constructor with no arguments::
     // ...
     use Symfony\Component\Form\AbstractType;
     use AppBundle\Entity\Blog;
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class BlogType extends AbstractType
     {
@@ -51,7 +51,7 @@ that constructor with no arguments::
         }
         // ...
 
-        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'empty_data' => new Blog($this->someDependency),
@@ -72,11 +72,11 @@ if it is needed.
 
 The closure must accept a ``FormInterface`` instance as the first argument::
 
-    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
     use Symfony\Component\Form\FormInterface;
     // ...
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'empty_data' => function (FormInterface $form) {

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -293,7 +293,7 @@ the interface directly::
     class MyFormTypeExtension extends AbstractTypeExtension
     {
         // ... fill in whatever methods you want to override
-        // like buildForm(), buildView(), finishView(), setDefaultOptions()
+        // like buildForm(), buildView(), finishView(), configureOptions()
     }
 
 In order for Symfony to know about your form extension and use it, give it

--- a/reference/forms/types/options/error_mapping.rst.inc
+++ b/reference/forms/types/options/error_mapping.rst.inc
@@ -13,7 +13,7 @@ of the form.
 With customized error mapping, you can do better: map the error to the city
 field so that it displays above it::
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'error_mapping' => array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes |
| Applies to | 2.7 |
| Fixed tickets | #4565 |

Pending on the merge of symfony/symfony#12891.

With this PR all references to setDefaultOptions and the deprecated OptionResolverInterface are removed in 2.7.
