### PR TITLE
Update secure_tools.rst

### DIFF
--- a/components/security/secure_tools.rst
+++ b/components/security/secure_tools.rst
@@ -5,8 +5,8 @@ The Symfony Security component comes with a collection of nice utilities
 related to security. These utilities are used by Symfony, but you should
 also use them if you want to solve the problem they address.
 
-Comparing Strings of the same length
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Comparing Strings
+~~~~~~~~~~~~~~~~~
 
 The time it takes to compare two strings depends on their differences. This
 can be used by an attacker when the two strings represent a hash of a password
@@ -23,8 +23,10 @@ algorithm; you can use the same strategy in your own code thanks to the
 
 .. caution::
 
-    To avoid timing attacks, both strings must be of the same length, the
-    known string must be the first argument and the string based on the user-entered
+    Both arguments must be of the same length to be compared successfully. When
+    arguments of differing length are supplied, `false` can be returned immediately and
+    the length of the known string may be leaked in case of a timing attack.
+    The known string must be the first argument and the string based on the user-entered
     content the second.
     This method is more reliable with PHP 5.6 and superior because it internally uses
     the native `hash_equals`_ PHP function.

--- a/components/security/secure_tools.rst
+++ b/components/security/secure_tools.rst
@@ -5,12 +5,12 @@ The Symfony Security component comes with a collection of nice utilities
 related to security. These utilities are used by Symfony, but you should
 also use them if you want to solve the problem they address.
 
-Comparing Strings
-~~~~~~~~~~~~~~~~~
+Comparing Strings of the same length
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The time it takes to compare two strings depends on their differences. This
-can be used by an attacker when the two strings represent a password for
-instance; it is known as a `Timing attack`_.
+can be used by an attacker when the two strings represent a hash of a password
+for instance; it is known as a `Timing attack`_.
 
 Internally, when comparing two passwords, Symfony uses a constant-time
 algorithm; you can use the same strategy in your own code thanks to the
@@ -18,13 +18,16 @@ algorithm; you can use the same strategy in your own code thanks to the
 
     use Symfony\Component\Security\Core\Util\StringUtils;
 
-    // is some known string (e.g. password) equal to some user input?
-    $bool = StringUtils::equals($knownString, $userInput);
+    // is some known string (e.g. password hash) equal to another string (e.g. hash of some user input)?
+    $bool = StringUtils::equals($knownString, $anotherString);
 
 .. caution::
 
-    To avoid timing attacks, the known string must be the first argument
-    and the user-entered string the second.
+    To avoid timing attacks, both strings must be of the same length, the
+    known string must be the first argument and the string based on the user-entered
+    content the second.
+    This method is more reliable with PHP 5.6 and superior because it internally uses
+    the native `hash_equals`_ PHP function.
 
 Generating a Secure random Number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -58,3 +61,4 @@ to work correctly. Just pass a file name to enable it::
     instance directly from the container: its name is ``security.secure_random``.
 
 .. _`Timing attack`: http://en.wikipedia.org/wiki/Timing_attack
+   _`hash_equals`: http://php.net/manual/en/function.hash-equals.php

--- a/components/security/secure_tools.rst
+++ b/components/security/secure_tools.rst
@@ -18,7 +18,8 @@ algorithm; you can use the same strategy in your own code thanks to the
 
     use Symfony\Component\Security\Core\Util\StringUtils;
 
-    // is some known string (e.g. password hash) equal to another string (e.g. hash of some user input)?
+    // is some known string (e.g. password hash) equal to another string
+    // (e.g. hash ofsome user input)?
     $bool = StringUtils::equals($knownString, $anotherString);
 
 .. caution::
@@ -29,7 +30,7 @@ algorithm; you can use the same strategy in your own code thanks to the
     The known string must be the first argument and the string based on the user-entered
     content the second.
     This method is more reliable with PHP 5.6 and superior because it internally uses
-    the native `hash_equals`_ PHP function.
+    the native :phpfunction:`hash_equals <hash_equals>` PHP function.
 
 Generating a Secure random Number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -63,4 +64,3 @@ to work correctly. Just pass a file name to enable it::
     instance directly from the container: its name is ``security.secure_random``.
 
 .. _`Timing attack`: http://en.wikipedia.org/wiki/Timing_attack
-   _`hash_equals`: http://php.net/manual/en/function.hash-equals.php


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |

Fix a critical mistake in the `secure_tools` doc that can lead to security vulnerabilities.
Using `StringUtils::equals()` with strings of different lengths can lead to critical timing attacks.

See the following PR for the technical background: 
https://github.com/php/php-src/pull/792
https://github.com/symfony/symfony/pull/11822
