### PR TITLE
[Cookbook][Routing] Update custom_route_loader.rst

### DIFF
--- a/cookbook/routing/custom_route_loader.rst
+++ b/cookbook/routing/custom_route_loader.rst
@@ -64,18 +64,21 @@ To load routes from some custom source (i.e. from something other than annotatio
 YAML or XML files), you need to create a custom route loader. This loader
 has to implement :class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`.
 
+In most cases it's better not to implement
+:class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`
+yourself, but extend from :class:`Symfony\\Component\\Config\\Loader\\Loader`.
+
 The sample loader below supports loading routing resources with a type of
 ``extra``. The type ``extra`` isn't important - you can just invent any resource
 type you want. The resource name itself is not actually used in the example::
 
     namespace AppBundle\Routing;
 
-    use Symfony\Component\Config\Loader\LoaderInterface;
-    use Symfony\Component\Config\Loader\LoaderResolverInterface;
+    use Symfony\Component\Config\Loader\Loader;
     use Symfony\Component\Routing\Route;
     use Symfony\Component\Routing\RouteCollection;
 
-    class ExtraLoader implements LoaderInterface
+    class ExtraLoader extends Loader
     {
         private $loaded = false;
 
@@ -110,17 +113,6 @@ type you want. The resource name itself is not actually used in the example::
         {
             return 'extra' === $type;
         }
-
-        public function getResolver()
-        {
-            // needed, but can be blank, unless you want to load other resources
-            // and if you do, using the Loader base class is easier (see below)
-        }
-
-        public function setResolver(LoaderResolverInterface $resolver)
-        {
-            // same as above
-        }
     }
 
 Make sure the controller you specify really exists. In this case you
@@ -130,6 +122,7 @@ of the ``AppBundle``::
     namespace AppBundle\Controller;
 
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
     class ExtraController extends Controller
     {
@@ -232,11 +225,10 @@ for the ``ExtraLoader``, so it is set to ".".
 More advanced Loaders
 ---------------------
 
-In most cases it's better not to implement
-:class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`
-yourself, but extend from :class:`Symfony\\Component\\Config\\Loader\\Loader`.
-This class knows how to use a
-:class:`Symfony\\Component\\Config\\Loader\\LoaderResolver` to load secondary
+If your custom route loader extends from
+:class:`Symfony\\Component\\Config\\Loader\\Loader` as shown above, you
+can also make use of the provided resolver, an instance of
+:class:`Symfony\\Component\\Config\\Loader\\LoaderResolver`, to load secondary
 routing resources.
 
 Of course you still need to implement

--- a/cookbook/routing/custom_route_loader.rst
+++ b/cookbook/routing/custom_route_loader.rst
@@ -72,6 +72,7 @@ The sample loader below supports loading routing resources with a type of
 ``extra``. The type ``extra`` isn't important - you can just invent any resource
 type you want. The resource name itself is not actually used in the example::
 
+    // src/AppBundle/Routing/ExtraLoader.php
     namespace AppBundle\Routing;
 
     use Symfony\Component\Config\Loader\Loader;
@@ -119,6 +120,7 @@ Make sure the controller you specify really exists. In this case you
 have to create an ``extraAction`` method in the ``ExtraController``
 of the ``AppBundle``::
 
+    // src/AppBundle/Controller/ExtraController.php
     namespace AppBundle\Controller;
 
     use Symfony\Component\HttpFoundation\Response;
@@ -238,6 +240,7 @@ Whenever you want to load another resource - for instance a YAML routing
 configuration file - you can call the
 :method:`Symfony\\Component\\Config\\Loader\\Loader::import` method::
 
+    // src/AppBundle/Routing/AdvancedLoader.php
     namespace AppBundle\Routing;
 
     use Symfony\Component\Config\Loader\Loader;

--- a/cookbook/routing/custom_route_loader.rst
+++ b/cookbook/routing/custom_route_loader.rst
@@ -4,17 +4,21 @@
 How to Create a custom Route Loader
 ===================================
 
-A custom route loader allows you to add routes to an application without
-including them, for example, in a YAML file. This comes in handy when
-you have a bundle but don't want to manually add the routes for the bundle
-to ``app/config/routing.yml``. This may be especially important when you want
-to make the bundle reusable, or when you have open-sourced it as this would
-slow down the installation process and make it error-prone.
+What is a Custom Route Loader
+-----------------------------
 
-Alternatively, you could also use a custom route loader when you want your
-routes to be automatically generated or located based on some convention or
-pattern. One example is the `FOSRestBundle`_ where routing is generated based
-on the names of the action methods in a controller.
+A custom route loader enables you to generate routes based on some
+conventions or patterns. A great example for this use-case is the
+`FOSRestBundle`_ where routes are generated based on the names of the
+action methods in a controller.
+
+A custom route loader does not enable your bundle to inject routes
+without the need to modify the routing configuration
+(e.g. ``app/config/routing.yml``) manually.
+If your bundle provides routes, whether via a configuration file, like
+the `WebProfilerBundle` does, or via a custom route loader, like the 
+`FOSRestBundle`_ does, an entry in the routing configuration is always
+necessary.
 
 .. note::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets |  |

Just some tweaks (including "Acme\DemoBundle" => "AppBundle").

While reading this chapter I wonder, if 

> A custom route loader allows you to add routes to an application without
>  including them, for example, in a YAML file. [...] This may be especially important when you want
>  to make the bundle reusable, or when you have open-sourced it as this would
>  slow down the installation process and make it error-prone.

may raise false expectations. Since also with a route loader it is still required to add something to the routing.yml (or xml). I don't see the benefit of using a custom route loader in a reusable bundle over importing a YAML file from a third-party bundle like FOSUserBundle. It makes totally sense for something like the FOSRestBundle does (generating routes based on conventions), but the chapter introduction sounds, like a Bundle could load its routes without manual tweaks to the config. If I am not wrong, this isn't possible, isn't it?
