### PR TITLE
Add version added note for the debug:event-dispatcher command

### DIFF
--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -143,6 +143,9 @@ done as follow::
 Debugging Event Listeners
 -------------------------
 
+.. versionadded:: 2.6
+    The ``debug:event-dispatcher`` command was introduced in Symfony 2.6.
+
 You can find out what listeners are registered in the event dispatcher
 using the console. To show all events and their listeners, run:
 


### PR DESCRIPTION
Related to #4319, adds a note that the `debug:event-dispatcher` was introduced in 2.6.

ping @xabbuh
