### PR TITLE
Email message instantiation changed to a more 'symfonysh' way.

### DIFF
--- a/cookbook/email/email.rst
+++ b/cookbook/email/email.rst
@@ -103,7 +103,8 @@ an email is pretty straightforward::
 
     public function indexAction($name)
     {
-        $message = \Swift_Message::newInstance()
+        $mailer = $this->get('mailer');
+        $message = $mailer->createMessage()
             ->setSubject('Hello Email')
             ->setFrom('send@example.com')
             ->setTo('recipient@example.com')
@@ -114,7 +115,7 @@ an email is pretty straightforward::
                 )
             )
         ;
-        $this->get('mailer')->send($message);
+        $mailer->send($message);
 
         return $this->render(...);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

I believe that using a static factory method for instantiation isn't the best way to do it in Symfony. So I suggest updating the Sending Emails example.
