### PR TITLE
Simplified some Symfony installation instructions

### DIFF
--- a/best_practices/creating-the-project.rst
+++ b/best_practices/creating-the-project.rst
@@ -8,35 +8,12 @@ In the past, Symfony projects were created with `Composer`_, the dependency mana
 for PHP applications. However, the current recommendation is to use the **Symfony
 Installer**, which has to be installed before creating your first project.
 
-Linux and Mac OS X Systems
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. best-practice::
 
-Open your command console and execute the following:
+    Use the Symfony Installer to create new Symfony-based projects.
 
-.. code-block:: bash
-
-    $ curl -LsS http://symfony.com/installer > symfony.phar
-    $ sudo mv symfony.phar /usr/local/bin/symfony
-    $ chmod a+x /usr/local/bin/symfony
-
-Now you can execute the Symfony Installer as a global system command called
-``symfony``.
-
-Windows Systems
-~~~~~~~~~~~~~~~
-
-Open your command console and execute the following:
-
-.. code-block:: bash
-
-    c:\> php -r "readfile('http://symfony.com/installer');" > symfony.phar
-
-Then, move the downloaded ``symfony.phar`` file to your projects directory and
-execute it as follows:
-
-.. code-block:: bash
-
-    c:\> php symfony.phar
+Read the :doc:`installation chapter </book/installation>`_ of the Symfony Book to
+learn how to install and use the Symfony Installer.
 
 Creating the Blog Application
 -----------------------------

--- a/best_practices/creating-the-project.rst
+++ b/best_practices/creating-the-project.rst
@@ -15,15 +15,15 @@ Installer**, which has to be installed before creating your first project.
 Read the :doc:`installation chapter </book/installation>` of the Symfony Book to
 learn how to install and use the Symfony Installer.
 
+.. _linux-and-mac-os-x-systems:
+.. _windows-systems:
+
 Creating the Blog Application
 -----------------------------
 
 Now that everything is correctly set up, you can create a new project based on
 Symfony. In your command console, browse to a directory where you have permission
 to create files and execute the following commands:
-
-.. _linux-and-mac-os-x-systems:
-.. _windows-systems:
 
 .. code-block:: bash
 

--- a/best_practices/creating-the-project.rst
+++ b/best_practices/creating-the-project.rst
@@ -22,6 +22,9 @@ Now that everything is correctly set up, you can create a new project based on
 Symfony. In your command console, browse to a directory where you have permission
 to create files and execute the following commands:
 
+.. _linux-and-mac-os-x-systems:
+.. _windows-systems:
+
 .. code-block:: bash
 
     # Linux, Mac OS X

--- a/best_practices/creating-the-project.rst
+++ b/best_practices/creating-the-project.rst
@@ -12,7 +12,7 @@ Installer**, which has to be installed before creating your first project.
 
     Use the Symfony Installer to create new Symfony-based projects.
 
-Read the :doc:`installation chapter </book/installation>`_ of the Symfony Book to
+Read the :doc:`installation chapter </book/installation>` of the Symfony Book to
 learn how to install and use the Symfony Installer.
 
 Creating the Blog Application

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -84,19 +84,22 @@ to meet those requirements.
     distributing them. If you want to verify the integrity of any Symfony
     version, follow the steps `explained in this post`_.
 
-Basing your Project on a Specific Symfony Version
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Basing your Project on a Specific Symfony Branch
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If your project needs to be based on a specific Symfony version, pass the version
-number as the second argument of the ``new`` command:
+If your project needs to be based on a specific Symfony branch, add the branch
+version number as the second argument of the ``new`` command:
 
 .. code-block:: bash
 
     # Linux, Mac OS X
-    $ symfony new my_project_name 2.3.23
+    $ symfony new my_project_name 2.3
 
     # Windows
-    c:\projects\> php symfony.phar new my_project_name 2.3.23
+    c:\projects\> php symfony.phar new my_project_name 2.3
+
+In case you need it, you can even indicate the exact Symfony version number you
+want your project to be based on (e.g. ``symfony new 2.3.23``).
 
 Read the :doc:`Symfony Release process </contributing/community/releases>`
 to better understand why there are several Symfony versions and which one

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -89,16 +89,16 @@ optional second argument of the ``new`` command:
 
 .. code-block:: bash
 
-    // use the most recent version in any Symfony branch
+    # use the most recent version in any Symfony branch
     $ symfony new my_project_name 2.3
     $ symfony new my_project_name 2.5
     $ symfony new my_project_name 2.6
 
-    // use a specific Symfony version
+    # use a specific Symfony version
     $ symfony new my_project_name 2.3.26
     $ symfony new my_project_name 2.6.5
 
-    // use the most recent LTS (Long Term Support) version
+    # use the most recent LTS (Long Term Support) version
     $ symfony new my_project_name lts
 
 Read the :doc:`Symfony Release process </contributing/community/releases>`

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -6,15 +6,14 @@ Installing and Configuring Symfony
 
 The goal of this chapter is to get you up and running with a working application
 built on top of Symfony. In order to simplify the process of creating new
-applications, Symfony provides an installer that must be installed before
-creating the first application.
+applications, Symfony provides an installer application.
 
 Installing the Symfony Installer
 --------------------------------
 
-Using the Symfony Installer is the only recommended way to create new Symfony
-applications. This installer is a PHP application that has to be installed
-only once and then it can create any number of Symfony applications.
+Using the **Symfony Installer** is the only recommended way to create new Symfony
+applications. This installer is a PHP application that has to be installed in your
+system only once and then it can create any number of Symfony applications.
 
 .. note::
 
@@ -29,16 +28,14 @@ ways.
 Linux and Mac OS X Systems
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Open your command console and execute the following three commands:
+Open your command console and execute the following commands:
 
 .. code-block:: bash
 
-    $ curl -LsS http://symfony.com/installer > symfony.phar
-    $ sudo mv symfony.phar /usr/local/bin/symfony
-    $ chmod a+x /usr/local/bin/symfony
+    $ sudo curl -LsS http://symfony.com/installer -o /usr/local/bin/symfony
+    $ sudo chmod a+x /usr/local/bin/symfony
 
-This will create a global ``symfony`` command in your system that will be used
-to create new Symfony applications.
+This will create a global ``symfony`` command in your system.
 
 Windows Systems
 ~~~~~~~~~~~~~~~
@@ -47,21 +44,21 @@ Open your command console and execute the following command:
 
 .. code-block:: bash
 
-    c:\> php -r "readfile('http://symfony.com/installer');" > symfony.phar
+    c:\> php -r "readfile('http://symfony.com/installer');" > symfony
 
-Then, move the downloaded ``symfony.phar`` file to your projects directory and
+Then, move the downloaded ``symfony`` file to your projects directory and
 execute it as follows:
 
 .. code-block:: bash
 
-    c:\> move symfony.phar c:\projects
-    c:\projects\> php symfony.phar
+    c:\> move symfony c:\projects
+    c:\projects\> php symfony
 
 Creating the Symfony Application
 --------------------------------
 
-Once the Symfony Installer is ready, create your first Symfony application with
-the ``new`` command:
+Once the Symfony Installer is available, create your first Symfony application
+with the ``new`` command:
 
 .. code-block:: bash
 
@@ -70,7 +67,7 @@ the ``new`` command:
 
     # Windows
     c:\> cd projects/
-    c:\projects\> php symfony.phar new my_project_name
+    c:\projects\> php symfony new my_project_name
 
 This command creates a new directory called ``my_project_name`` that contains a
 fresh new project based on the most recent stable Symfony version available. In
@@ -84,22 +81,25 @@ to meet those requirements.
     distributing them. If you want to verify the integrity of any Symfony
     version, follow the steps `explained in this post`_.
 
-Basing your Project on a Specific Symfony Branch
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Basing your Project on a Specific Symfony Version
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If your project needs to be based on a specific Symfony branch, add the branch
-version number as the second argument of the ``new`` command:
+In case your project needs to be based on a specific Symfony version, use the
+optional second argument of the ``new`` command:
 
 .. code-block:: bash
 
-    # Linux, Mac OS X
+    // use the most recent version in any Symfony branch
     $ symfony new my_project_name 2.3
+    $ symfony new my_project_name 2.5
+    $ symfony new my_project_name 2.6
 
-    # Windows
-    c:\projects\> php symfony.phar new my_project_name 2.3
+    // use a specific Symfony version
+    $ symfony new my_project_name 2.3.26
+    $ symfony new my_project_name 2.6.5
 
-In case you need it, you can even indicate the exact Symfony version number you
-want your project to be based on (e.g. ``symfony new 2.3.23``).
+    // use the most recent LTS (Long Term Support) version
+    $ symfony new my_project_name lts
 
 Read the :doc:`Symfony Release process </contributing/community/releases>`
 to better understand why there are several Symfony versions and which one

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -35,17 +35,6 @@ On **Linux** and **Mac OS X** systems, execute the following console commands:
     $ sudo mv symfony.phar /usr/local/bin/symfony
     $ chmod a+x /usr/local/bin/symfony
 
-.. note::
-
-    If your system doesn't have cURL installed, execute the following
-    commands instead:
-
-    .. code-block:: bash
-
-        $ php -r "readfile('http://symfony.com/installer');" > symfony.phar
-        $ sudo mv symfony.phar /usr/local/bin/symfony
-        $ chmod a+x /usr/local/bin/symfony
-
 After installing the Symfony installer, you'll have to open a new console window
 to be able to execute the new ``symfony`` command:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #4672 (partially) |

Before merging, the Symfony Installer must release its new version. Last time I checked, creating a new project based on a branch was ready in the GitHub repository, but not in the distributed installer.
