### PR TITLE
Add the missing output variable

### DIFF
--- a/components/console/helpers/table.rst
+++ b/components/console/helpers/table.rst
@@ -25,6 +25,9 @@ To display a table, use :class:`Symfony\\Component\\Console\\Helper\\Table`,
 set the headers, set the rows and then render the table::
 
     use Symfony\Component\Console\Helper\Table;
+    use Symfony\Component\Console\Output\ConsoleOutput;
+
+    $output = new ConsoleOutput();
 
     $table = new Table($output);
     $table


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | [yes] |
| New docs? | [no] |
| Applies to | [2.5, 2.6] |
| Fixed tickets | [NIL] |

For the 2.3 branch there is no `table.rst` file as it is introduced in 2.5 .

I have checkout from 2.5 and created the PR .

Let me know if I need to send this to master for 2.5 is not LTS .
