### PR TITLE
fix SQL: table names

### DIFF
--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -150,7 +150,7 @@ a second array argument to ``PdoSessionHandler``:
 
 The following things can be configured:
 
-* ``db_table``: (default ``session``) The name of the session table in your
+* ``db_table``: (default ``sessions``) The name of the session table in your
   database;
 * ``db_id_col``: (default ``sess_id``) The name of the id column in your
   session table (VARCHAR(128));

--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -229,7 +229,7 @@ following (MySQL):
 
 .. code-block:: sql
 
-    CREATE TABLE `session` (
+    CREATE TABLE `sessions` (
         `sess_id` VARBINARY(128) NOT NULL PRIMARY KEY,
         `sess_data` BLOB NOT NULL,
         `sess_time` INTEGER UNSIGNED NOT NULL,
@@ -243,7 +243,7 @@ For PostgreSQL, the statement should look like this:
 
 .. code-block:: sql
 
-    CREATE TABLE session (
+    CREATE TABLE sessions (
         sess_id VARCHAR(128) NOT NULL PRIMARY KEY,
         sess_data BYTEA NOT NULL,
         sess_time INTEGER NOT NULL,
@@ -257,7 +257,7 @@ For MSSQL, the statement might look like the following:
 
 .. code-block:: sql
 
-    CREATE TABLE [dbo].[session](
+    CREATE TABLE [dbo].[sessions](
         [sess_id] [nvarchar](255) NOT NULL,
         [sess_data] [ntext] NOT NULL,
         [sess_time] [int] NOT NULL,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | Symfony 2.x |
| Fixed tickets | #4794 |

Table name for sessions should be the same for all examples (see symfony config above with `sessions` table name)
