### PR TITLE
Monolog Cookbook Typo Fix: "allows to" should be "allows you to"

### DIFF
--- a/cookbook/logging/monolog.rst
+++ b/cookbook/logging/monolog.rst
@@ -220,7 +220,7 @@ easily. Your formatter must implement
 Adding some extra Data in the Log Messages
 ------------------------------------------
 
-Monolog allows to process the record before logging it to add some
+Monolog allows you to process the record before logging it to add some
 extra data. A processor can be applied for the whole handler stack or
 only for a specific handler.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | none |
