### PR TITLE
Windows 7 console

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -135,7 +135,7 @@ version as the second argument of the ``create-project`` command:
 
 .. code-block:: bash
 
-    $ composer create-project symfony/framework-standard-edition my_project_name '2.3.*'
+    $ composer create-project symfony/framework-standard-edition my_project_name "2.3.*"
 
 .. tip::
 


### PR DESCRIPTION
Windows 7 console doesn't understand single quotaes ['], only double quotaes ["]
