### PR TITLE
[Components][Debug] fix DebugClassLoader namespace

### DIFF
--- a/components/debug/class_loader.rst
+++ b/components/debug/class_loader.rst
@@ -17,6 +17,6 @@ with a ``DebugClassLoader`` wrapper.
 Using the ``DebugClassLoader`` is as easy as calling its static
 :method:`Symfony\\Component\\Debug\\DebugClassLoader::enable` method::
 
-    use Symfony\Component\ClassLoader\DebugClassLoader;
+    use Symfony\Component\Debug\DebugClassLoader;
 
     DebugClassLoader::enable();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5+ |
| Fixed tickets |  |

The class loader is located in the Debug component and not in the
ClassLoader component.
