### PR TITLE
[Book][Security] Remove out-dated anchor

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1232,8 +1232,6 @@ cookie will be ever created by Symfony):
     If you use a form login, Symfony will create a cookie even if you set
     ``stateless`` to ``true``.
 
-.. _book-security-checking-vulnerabilities:
-
 Final Words
 -----------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 (only) |
| Fixed tickets |  |

I missed to remove the anchor along with the paragraph in PR #4746.
