### PR TITLE
[Best Pracitices] restore example in the "Service: No Class Parameter" section

### DIFF
--- a/best_practices/business-logic.rst
+++ b/best_practices/business-logic.rst
@@ -141,7 +141,7 @@ the class namespace as a parameter:
 
     # service definition with class namespace as parameter
     parameters:
-    slugger.class: AppBundle\Utils\Slugger
+        slugger.class: AppBundle\Utils\Slugger
 
     services:
         app.slugger:

--- a/best_practices/business-logic.rst
+++ b/best_practices/business-logic.rst
@@ -140,9 +140,12 @@ the class namespace as a parameter:
     # app/config/services.yml
 
     # service definition with class namespace as parameter
+    parameters:
+    slugger.class: AppBundle\Utils\Slugger
+
     services:
         app.slugger:
-            class: AppBundle\Utils\Slugger
+            class: "%slugger.class%"
 
 This practice is cumbersome and completely unnecessary for your own services:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

In 1fb20e57b0c91686fed925c69f66c327a89bd283 the 'how to NOT do it' config example in the "Best Practices -> Organizing Your Business Logic -> Service: No Class Parameter" section was changed to actually follow the recommendation.
It is especially confusing as the example in the section "Services: Naming and Format" is exactly the same (besides the comment)
