### PR TITLE
Adjustments to PDO Session storage page

### DIFF
--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -216,6 +216,13 @@ following (MySQL):
         `sess_lifetime` MEDIUMINT NOT NULL
     ) COLLATE utf8_bin, ENGINE = InnoDB;
 
+.. note::
+
+    A ``BLOB`` column type can only store up to 64 kb. If the data stored in
+    a user's session exceeds this, an exception may be thrown or their session
+    will be silently reset. Consider using a ``MEDIUMBLOB`` if you need more
+    space.
+
 PostgreSQL
 ~~~~~~~~~~
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.6+ |
| Fixed tickets | #4609 |
1. Adds a note about the issues with exceeding the max `BLOB` size for mysql - do the other DBMS's have this issue?
2. Remove `PDO` service from example and has `PdoSessionHandler` connect lazily to the db.
3. Make `session.handler.pdo` private
