### PR TITLE
[swiftmailer] Document whitelist option to email redirect

### DIFF
--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -11,7 +11,7 @@ can easily achieve this through configuration settings without having to
 make any changes to your application's code at all. There are two main
 choices when it comes to handling email during development: (a) disabling the
 sending of email altogether or (b) sending all email to a specific
-address.
+address (with optional exceptions).
 
 Disabling Sending
 -----------------
@@ -118,6 +118,51 @@ the replaced address, so you can still see who it would have been sent to.
     additional headers to the email with the overridden addresses in them.
     These are ``X-Swift-Cc`` and ``X-Swift-Bcc`` for the ``CC`` and ``BCC``
     addresses respectively.
+
+Sending to a Specified Address, but with exceptions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Suppose you want to have all email sent to a specific address, instead
+of the address actually specified when sending the message (like in the above scenario),
+but you want certain email addresses not to be redirected in this way.
+This can be done by adding the ``delivery_whitelist`` option:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config_dev.yml
+        swiftmailer:
+            delivery_address: dev@example.com
+            delivery_whitelist:
+               - "/@mydomain.com$/"
+               - "/^admin@specialdomain.com$/"
+
+    .. code-block:: xml
+
+        <!-- app/config/config_dev.xml -->
+
+        <!--
+            xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer"
+            http://symfony.com/schema/dic/swiftmailer http://symfony.com/schema/dic/swiftmailer/swiftmailer-1.0.xsd
+        -->
+
+        <swiftmailer:config delivery-address="dev@example.com" />
+        <swiftmailer:delivery-whitelist>/@mydomain.com$/</swiftmailer:delivery-whitelist>
+        <swiftmailer:delivery-whitelist>/^admin@specialdomain.com$/</swiftmailer:delivery-whitelist>
+    .. code-block:: php
+
+        // app/config/config_dev.php
+        $container->loadFromExtension('swiftmailer', array(
+            'delivery_address'  => "dev@example.com",
+            'delivery_whitelist' => array(
+                '/@mydomain.com$/',
+                '/^admin@specialdomain.com$/'
+            ),
+        ));
+
+In the above example all mail will be redirected to ``dev@example.com``, exept that mail to the single
+address ``admin@specialdomain.com`` and all mail to the domain ``mydomain.com`` will be delivered as normal.
 
 Viewing from the Web Debug Toolbar
 ----------------------------------

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -123,10 +123,10 @@ Sending to a Specified Address but with Exceptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Suppose you want to have all email redirected to a specific address,
-(like in the above scenario to ``dev@example.com``).
-But then you may want email sent to some specific email addresses to go through
-after all, and not be redirected (even if it is in the dev environment).
-This can be done by adding the ``delivery_whitelist`` option:
+(like in the above scenario to ``dev@example.com``). But then you may want
+email sent to some specific email addresses to go through after all, and
+not be redirected (even if it is in the dev environment). This can be done
+by adding the ``delivery_whitelist`` option:
 
 .. configuration-block::
 
@@ -148,16 +148,16 @@ This can be done by adding the ``delivery_whitelist`` option:
 
         <!-- app/config/config_dev.xml -->
 
-        <!--
-            xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer"
-            http://symfony.com/schema/dic/swiftmailer http://symfony.com/schema/dic/swiftmailer/swiftmailer-1.0.xsd
-        -->
+        <?xml version="1.0" charset="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer">
 
-        <swiftmailer:config delivery-address="dev@example.com" />
-        <!-- all email addresses matching this regex will *not* be redirected to dev@example.com -->
-        <swiftmailer:delivery-whitelist>/@specialdomain.com$/</swiftmailer:delivery-whitelist>
-        <!-- all emails sent to admin@mydomain.com won't be redirected to dev@example.com too -->
-        <swiftmailer:delivery-whitelist>/^admin@mydomain.com$/</swiftmailer:delivery-whitelist>
+        <swiftmailer:config delivery-address="dev@example.com">
+            <!-- all email addresses matching this regex will *not* be redirected to dev@example.com -->
+            <swiftmailer:delivery-whitelist>/@specialdomain.com$/</swiftmailer:delivery-whitelist>
+            <!-- all emails sent to admin@mydomain.com won't be redirected to dev@example.com too -->
+            <swiftmailer:delivery-whitelist>/^admin@mydomain.com$/</swiftmailer:delivery-whitelist>
+        </swiftmailer:config>
 
     .. code-block:: php
 

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -119,11 +119,11 @@ the replaced address, so you can still see who it would have been sent to.
     These are ``X-Swift-Cc`` and ``X-Swift-Bcc`` for the ``CC`` and ``BCC``
     addresses respectively.
 
-Sending to a Specified Address, but with exceptions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sending to a Specified Address but with Exceptions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Suppose you normally in your dev environment want to have all email redirected
-to a specific address, (like in the above scenario to ``dev@example,com``).
+to a specific address, (like in the above scenario to ``dev@example.com``).
 But then you may want email sent to some specific email addresses to go through
 after all, and not be redirected (even if it is in the dev environment).
 This can be done by adding the ``delivery_whitelist`` option:
@@ -154,22 +154,30 @@ This can be done by adding the ``delivery_whitelist`` option:
         -->
 
         <swiftmailer:config delivery-address="dev@example.com" />
+        <!-- all email addresses matching this regex will *not* be redirected to dev@example.com -->
         <swiftmailer:delivery-whitelist>/@mydomain.com$/</swiftmailer:delivery-whitelist>
+        <!-- all emails sent to admin@specialdomain.com won't be redirected to dev@example.com too -->
         <swiftmailer:delivery-whitelist>/^admin@specialdomain.com$/</swiftmailer:delivery-whitelist>
+
     .. code-block:: php
 
         // app/config/config_dev.php
         $container->loadFromExtension('swiftmailer', array(
             'delivery_address'  => "dev@example.com",
             'delivery_whitelist' => array(
+                // all email addresses matching this regex will *not* be
+                // redirected to dev@example.com
                 '/@mydomain.com$/',
+
+                // all emails sent to admin@specialdomain.com won't be
+                // redirected to dev@example.com too
                 '/^admin@specialdomain.com$/'
             ),
         ));
 
-In the above example all mail will be redirected to ``dev@example.com``,
-except that mail to the single address ``admin@specialdomain.com`` and all
-mail to the domain ``mydomain.com`` will be delivered as normal.
+In the above example all email messages will be redirected to ``dev@example.com``,
+except messages sent to the ``admin@specialdomain.com`` address or to any email
+address belonging to the domain ``mydomain.com``, which will be delivered as normal.
 
 Viewing from the Web Debug Toolbar
 ----------------------------------

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -161,7 +161,7 @@ This can be done by adding the ``delivery_whitelist`` option:
             ),
         ));
 
-In the above example all mail will be redirected to ``dev@example.com``, exept that mail to the single
+In the above example all mail will be redirected to ``dev@example.com``, except that mail to the single
 address ``admin@specialdomain.com`` and all mail to the domain ``mydomain.com`` will be delivered as normal.
 
 Viewing from the Web Debug Toolbar

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -122,9 +122,10 @@ the replaced address, so you can still see who it would have been sent to.
 Sending to a Specified Address, but with exceptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Suppose you want to have all email sent to a specific address, instead
-of the address actually specified when sending the message (like in the above scenario),
-but you want certain email addresses not to be redirected in this way.
+Suppose you normally in your dev environment want to have all email redirected to a specific address,
+(like in the above scenario to ``dev@example,com``).
+But then you may want email sent to some specific email addresses to go through after all,
+and not be redirected (even if it is in the dev environment).
 This can be done by adding the ``delivery_whitelist`` option:
 
 .. configuration-block::
@@ -135,7 +136,12 @@ This can be done by adding the ``delivery_whitelist`` option:
         swiftmailer:
             delivery_address: dev@example.com
             delivery_whitelist:
+               # all email addresses matching this regex will *not* be
+               # redirected to dev@example.com
                - "/@mydomain.com$/"
+
+               # all emails sent to admin@specialdomain.com won't
+               # be redirected to dev@example.com too
                - "/^admin@specialdomain.com$/"
 
     .. code-block:: xml

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -122,10 +122,10 @@ the replaced address, so you can still see who it would have been sent to.
 Sending to a Specified Address, but with exceptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Suppose you normally in your dev environment want to have all email redirected to a specific address,
-(like in the above scenario to ``dev@example,com``).
-But then you may want email sent to some specific email addresses to go through after all,
-and not be redirected (even if it is in the dev environment).
+Suppose you normally in your dev environment want to have all email redirected
+to a specific address, (like in the above scenario to ``dev@example,com``).
+But then you may want email sent to some specific email addresses to go through
+after all, and not be redirected (even if it is in the dev environment).
 This can be done by adding the ``delivery_whitelist`` option:
 
 .. configuration-block::
@@ -167,8 +167,9 @@ This can be done by adding the ``delivery_whitelist`` option:
             ),
         ));
 
-In the above example all mail will be redirected to ``dev@example.com``, except that mail to the single
-address ``admin@specialdomain.com`` and all mail to the domain ``mydomain.com`` will be delivered as normal.
+In the above example all mail will be redirected to ``dev@example.com``,
+except that mail to the single address ``admin@specialdomain.com`` and all
+mail to the domain ``mydomain.com`` will be delivered as normal.
 
 Viewing from the Web Debug Toolbar
 ----------------------------------

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -154,9 +154,10 @@ by adding the ``delivery_whitelist`` option:
 
         <swiftmailer:config delivery-address="dev@example.com">
             <!-- all email addresses matching this regex will *not* be redirected to dev@example.com -->
-            <swiftmailer:delivery-whitelist>/@specialdomain.com$/</swiftmailer:delivery-whitelist>
+            <swiftmailer:delivery-whitelist-pattern>/@specialdomain.com$/</swiftmailer:delivery-whitelist-pattern>
+
             <!-- all emails sent to admin@mydomain.com won't be redirected to dev@example.com too -->
-            <swiftmailer:delivery-whitelist>/^admin@mydomain.com$/</swiftmailer:delivery-whitelist>
+            <swiftmailer:delivery-whitelist-pattern>/^admin@mydomain.com$/</swiftmailer:delivery-whitelist-pattern>
         </swiftmailer:config>
 
     .. code-block:: php

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -122,8 +122,8 @@ the replaced address, so you can still see who it would have been sent to.
 Sending to a Specified Address but with Exceptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Suppose you normally in your dev environment want to have all email redirected
-to a specific address, (like in the above scenario to ``dev@example.com``).
+Suppose you want to have all email redirected to a specific address,
+(like in the above scenario to ``dev@example.com``).
 But then you may want email sent to some specific email addresses to go through
 after all, and not be redirected (even if it is in the dev environment).
 This can be done by adding the ``delivery_whitelist`` option:

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -138,11 +138,11 @@ This can be done by adding the ``delivery_whitelist`` option:
             delivery_whitelist:
                # all email addresses matching this regex will *not* be
                # redirected to dev@example.com
-               - "/@mydomain.com$/"
+               - "/@specialdomain.com$/"
 
-               # all emails sent to admin@specialdomain.com won't
+               # all emails sent to admin@mydomain.com won't
                # be redirected to dev@example.com too
-               - "/^admin@specialdomain.com$/"
+               - "/^admin@mydomain.com$/"
 
     .. code-block:: xml
 
@@ -155,9 +155,9 @@ This can be done by adding the ``delivery_whitelist`` option:
 
         <swiftmailer:config delivery-address="dev@example.com" />
         <!-- all email addresses matching this regex will *not* be redirected to dev@example.com -->
-        <swiftmailer:delivery-whitelist>/@mydomain.com$/</swiftmailer:delivery-whitelist>
-        <!-- all emails sent to admin@specialdomain.com won't be redirected to dev@example.com too -->
-        <swiftmailer:delivery-whitelist>/^admin@specialdomain.com$/</swiftmailer:delivery-whitelist>
+        <swiftmailer:delivery-whitelist>/@specialdomain.com$/</swiftmailer:delivery-whitelist>
+        <!-- all emails sent to admin@mydomain.com won't be redirected to dev@example.com too -->
+        <swiftmailer:delivery-whitelist>/^admin@mydomain.com$/</swiftmailer:delivery-whitelist>
 
     .. code-block:: php
 
@@ -167,17 +167,17 @@ This can be done by adding the ``delivery_whitelist`` option:
             'delivery_whitelist' => array(
                 // all email addresses matching this regex will *not* be
                 // redirected to dev@example.com
-                '/@mydomain.com$/',
+                '/@specialdomain.com$/',
 
-                // all emails sent to admin@specialdomain.com won't be
+                // all emails sent to admin@mydomain.com won't be
                 // redirected to dev@example.com too
-                '/^admin@specialdomain.com$/'
+                '/^admin@mydomain.com$/',
             ),
         ));
 
 In the above example all email messages will be redirected to ``dev@example.com``,
-except messages sent to the ``admin@specialdomain.com`` address or to any email
-address belonging to the domain ``mydomain.com``, which will be delivered as normal.
+except messages sent to the ``admin@mydomain.com`` address or to any email
+address belonging to the domain ``specialdomain.com``, which will be delivered as normal.
 
 Viewing from the Web Debug Toolbar
 ----------------------------------


### PR DESCRIPTION
The redirectPlugin in switfmailer allows you to specify a white-list of regex's that matches email addresses that are still sent to, when redirecting all email to one address.

Code was added in PR [switfmailer/SwiftmailerBundle#19](https://github.com/symfony/SwiftmailerBundle/pull/19)
