### PR TITLE
Finish #4505: Fixed composer create-project command (windows)

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -135,7 +135,7 @@ version as the second argument of the ``create-project`` command:
 
 .. code-block:: bash
 
-    $ composer create-project symfony/framework-standard-edition my_project_name '2.3.*'
+    $ composer create-project symfony/framework-standard-edition my_project_name "2.3.*"
 
 .. tip::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #4505 |

The composer create-project command as it was doesn't work on windows because of the single astrophes ' . The error returned is:

```
Could not parse version constraint '2.5.*': Invalid version string "'2.5.*'"
```

This is resolved by switching to double astrophes ". The new command is verified to work on ubuntu linux as well.
