### PR TITLE
fix response status text

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -879,7 +879,7 @@ Here is how you can configure the Symfony reverse proxy to support the
             if ('127.0.0.1' !== $request->getClientIp()) {
                 return new Response(
                     'Invalid HTTP method',
-                    Response::HTTP_BAD_REQUEST
+                    Response::$statusTexts[400]
                 );
             }
 


### PR DESCRIPTION
`Response::HTTP_BAD_REQUEST` fails for me, because Response do not have constant HTTP_BAD_REQUEST
I'm using `"symfony/symfony": "2.3.0"`
