### PR TITLE
fixed code to use Twig function `form_end` by adding its missing `form` argument

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -175,7 +175,7 @@ That's it! Just three lines are needed to render the complete form:
     Renders all the fields, which includes the field element itself, a label
     and any validation error messages for the field.
 
-``form_end()``
+``form_end(form)``
     Renders the end tag of the form and any fields that have not
     yet been rendered, in case you rendered each field yourself. This is useful
     for rendering hidden fields and taking advantage of the automatic


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 and up |
| Fixed tickets | -- |
