### PR TITLE
Adding a section to emailing showing off absolute_url

### DIFF
--- a/cookbook/email/email.rst
+++ b/cookbook/email/email.rst
@@ -123,7 +123,21 @@ an email is pretty straightforward::
     }
 
 To keep things decoupled, the email body has been stored in a template and
-rendered with the ``renderView()`` method.
+rendered with the ``renderView()`` method. The ``registration.html.twig``
+template might look something like this:
+
+.. code-block:: html+jinja
+
+    {# app/Resources/views/Emails/registration.html.twig #}
+    <h3>You did it! You registered!</h3>
+
+    {# example, assuming you have a route named "login" $}
+    To login, go to: {{ url('login') }}.
+
+    Thanks!
+
+    {# Makes an absolute URL to the /images/logo.png file #}
+    <img src="{{ absolute_url(asset('images/logo.png')) }}"
 
 The ``$message`` object supports many more options, such as including attachments,
 adding HTML content, and much more. Fortunately, Swift Mailer covers the topic

--- a/cookbook/email/email.rst
+++ b/cookbook/email/email.rst
@@ -132,7 +132,7 @@ template might look something like this:
     <h3>You did it! You registered!</h3>
 
     {# example, assuming you have a route named "login" $}
-    To login, go to: {{ url('login') }}.
+    To login, go to: <a href="{{ url('login') }}">...</a>.
 
     Thanks!
 


### PR DESCRIPTION
Hi guys!

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no (but follows from symfony/symfony#13264) |
| Applies to | 2.7+ |
| Fixed tickets | n/a |

I thought we should show off `absolute_url` in a place where you will commonly need it.

Thanks!
