### PR TITLE
[Components][ClassLoader] remove DebugClassLoader

### DIFF
--- a/components/class_loader/class_loader.rst
+++ b/components/class_loader/class_loader.rst
@@ -12,8 +12,7 @@ load all of your project's classes.
 
     You can use both the ``ApcClassLoader`` and the ``XcacheClassLoader`` to
     :doc:`cache </components/class_loader/cache_class_loader>` a ``ClassLoader``
-    instance or the ``DebugClassLoader`` to :doc:`debug </components/class_loader/debug_class_loader>`
-    it.
+    instance.
 
 Usage
 -----

--- a/components/class_loader/debug_class_loader.rst
+++ b/components/class_loader/debug_class_loader.rst
@@ -1,6 +1,3 @@
-.. index::
-    single: ClassLoader; DebugClassLoader
-
 Debugging a Class Loader
 ========================
 

--- a/components/class_loader/index.rst
+++ b/components/class_loader/index.rst
@@ -9,5 +9,9 @@ ClassLoader
     psr4_class_loader
     map_class_loader
     cache_class_loader
-    debug_class_loader
     class_map_generator
+
+.. toctree::
+    :hidden:
+
+    debug_class_loader

--- a/components/class_loader/introduction.rst
+++ b/components/class_loader/introduction.rst
@@ -23,12 +23,14 @@ the class. Symfony provides three autoloaders, which are able to load your class
 * :doc:`/components/class_loader/map_class_loader`: loads classes using
   a static map from class name to file path.
 
-Additionally, the Symfony ClassLoader component ships with a set of wrapper
-classes which can be used to add additional functionality on top of existing
-autoloaders:
+Additionally, the Symfony ClassLoader component ships with a wrapper class
+which makes it possible
+:doc:`to cache the results of a class loader </components/class_loader/cache_class_loader>`.
 
-* :doc:`/components/class_loader/cache_class_loader`
-* :doc:`/components/class_loader/debug_class_loader`
+When using the :doc:`Debug component </components/debug/introduction>`, you
+can also use a special :doc:`DebugClassLoader </components/debug/class_loader>`
+that eases debugging by throwing more helpful exceptions when a class could
+not be found by a class loader.
 
 Installation
 ------------

--- a/components/map.rst.inc
+++ b/components/map.rst.inc
@@ -7,7 +7,6 @@
   * :doc:`/components/class_loader/psr4_class_loader`
   * :doc:`/components/class_loader/map_class_loader`
   * :doc:`/components/class_loader/cache_class_loader`
-  * :doc:`/components/class_loader/debug_class_loader`
   * :doc:`/components/class_loader/class_map_generator`
 
 * :doc:`/components/config/index`


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | 2.5 |
| Fixed tickets |  |

The `DebugClassLoader` has been moved to the Debug component with
Symfony 2.4 and will be removed in 3.0 (see symfony/symfony#13203).

This replaced #4855 by removing the `DebugClassLoader` docs from ClassLoader component in the 2.5 version, but keeping a redirect to the description in the Debug component. The redirection map entry should then be removed once the changes got merged up into the `master` branch.
