### PR TITLE
symfony 2.7 requires at least php 5.3.9

### DIFF
--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -21,10 +21,16 @@ Below is the list of required and optional requirements.
 Required
 --------
 
-* PHP needs to be a minimum version of PHP 5.5.9
+* PHP needs to be a minimum version of PHP 5.3.9
 * JSON needs to be enabled
 * ctype needs to be enabled
 * Your ``php.ini`` needs to have the ``date.timezone`` setting
+
+.. caution::
+
+    Be aware that Symfony has some known limitations
+    when using PHP 5.3.16. For more information see the
+    `Requirements section of the README`_.
 
 Optional
 --------
@@ -50,3 +56,5 @@ Doctrine
 If you want to use Doctrine, you will need to have PDO installed. Additionally,
 you need to have the PDO driver installed for the database server you want
 to use.
+
+.. _`Requirements section of the README`: https://github.com/symfony/symfony#requirements


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7 |
| Fixed tickets | none |

https://github.com/symfony/symfony/blob/2.7/composer.json
