### PR TITLE
Add excluded_ajax_paths new parameter in v2.6

### DIFF
--- a/reference/configuration/web_profiler.rst
+++ b/reference/configuration/web_profiler.rst
@@ -23,10 +23,14 @@ Full default Configuration
             # gives you the opportunity to look at the collected data before following the redirect
             intercept_redirects: false
 
+            # Exclude AJAX requests in the web debug toolbar for specified paths
+            excluded_ajax_paths:  ^/bundles|^/_wdt
+
     .. code-block:: xml
 
         <web-profiler:config
             toolbar="false"
             verbose="true"
             intercept_redirects="false"
+            excluded_ajax_paths="^/bundles|^/_wdt"
         />


### PR DESCRIPTION
```
| Q             | A
| ------------- | ---
| Doc fix?      | no
| New docs?     | yes
| Applies to    | v2.6.x
```

Based on post [New in Symfony 2.6: AJAX requests in the web debug toolbar](http://symfony.com/blog/new-in-symfony-2-6-ajax-requests-in-the-web-debug-toolbar)
