### PR TITLE
cookbok/security/acl.rst

### DIFF
--- a/cookbook/security/acl.rst
+++ b/cookbook/security/acl.rst
@@ -91,7 +91,7 @@ Coming back to the small example from the beginning, you can now implement
 ACL for it.
 
 Once the ACL is created, you can grant access to objects by creating an
-Access Control Entity (ACE) to solidify the relationship between the entity
+Access Control Entry (ACE) to solidify the relationship between the entity
 and your user.
 
 Creating an ACL and Adding an ACE


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | ? |

I believe ACE stands only for Access Control Entry, as used e.g. at http://symfony.com/doc/current/cookbook/security/acl_advanced.html
