### PR TITLE
Normalize excluded_404s in monolog cookbook

### DIFF
--- a/cookbook/logging/monolog_email.rst
+++ b/cookbook/logging/monolog_email.rst
@@ -23,7 +23,7 @@ it is broken down.
                     action_level: critical
                     # to also log 400 level errors (but not 404's):
                     # action_level: error
-                    # excluded_404:
+                    # excluded_404s:
                     #     - ^/
                     handler:      buffered
                 buffered:


### PR DESCRIPTION
Although excluded_404 works as a key in the configuration, the actual key MonologBundle looks for is excluded_404s. This makes it consistent with the php code block later in this file, and also in cookbook/logging/monolog_regex_based_excludes.html.
