### PR TITLE
Missing parameter $name

### DIFF
--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -202,7 +202,7 @@ different controller using the ``forward()`` method::
         /**
          * @Route("/", name="homepage")
          */
-        public function indexAction()
+        public function indexAction($name)
         {
             return $this->forward('AppBundle:Blog:index', array(
                 'name'  => $name

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -205,7 +205,8 @@ different controller using the ``forward()`` method::
         public function indexAction($name)
         {
             return $this->forward('AppBundle:Blog:index', array(
-                'name'  => $name
+                    'name'  => $name
+                )
             );
         }
     }


### PR DESCRIPTION
"function indexAction()" misses the parameter $name. This is needed because it is forwarded afterwards.

"function indexAction($name)"
