### PR TITLE
Bumped symfony version number to 2.6 in flat php composer.json example

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -435,7 +435,7 @@ content:
 
     {
         "require": {
-            "symfony/symfony": "2.5.*"
+            "symfony/symfony": "2.6.*"
         },
         "autoload": {
             "files": ["model.php","controllers.php"]


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.6.* |
| Fixed tickets | / |
