### PR TITLE
Fixed case where service definition is actually an alias

### DIFF
--- a/components/dependency_injection/tags.rst
+++ b/components/dependency_injection/tags.rst
@@ -133,11 +133,11 @@ custom tag::
     {
         public function process(ContainerBuilder $container)
         {
-            if (!$container->hasDefinition('acme_mailer.transport_chain')) {
+            if (!$container->has('acme_mailer.transport_chain')) {
                 return;
             }
 
-            $definition = $container->getDefinition(
+            $definition = $container->findDefinition(
                 'acme_mailer.transport_chain'
             );
 


### PR DESCRIPTION
If `acme_mailer.transport_chain` service would be an alias, the `hasDefinition` method would return `false` and would fake the expected result.
Same for the further call on `getDefinition` method.
