### PR TITLE
Added a note about the Symfony versions affected by ICU problems

### DIFF
--- a/components/intl.rst
+++ b/components/intl.rst
@@ -64,7 +64,7 @@ code::
 
     .. note::
 
-        These deployment problems only affect to the following Symfony versions:
+        These deployment problems only affect the following Symfony versions:
         2.3.0 to 2.3.20 versions, any 2.4.x version and 2.5.0 to 2.5.5 versions.
 
     The intl extension internally uses the `ICU library`_ to obtain localization

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -62,6 +62,11 @@ code::
 
 .. sidebar:: ICU and Deployment Problems
 
+    .. note::
+
+        These deployment problems only affect to the following Symfony versions:
+        2.3.0 to 2.3.20 versions, any 2.4.x version and 2.5.0 to 2.5.5 versions.
+
     The intl extension internally uses the `ICU library`_ to obtain localization
     data such as number formats in different languages, country names and more.
     To make this data accessible to userland PHP libraries, Symfony ships a copy


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | #4288 |

At first I thought about a complete rewording/simplification of this explanation, as suggested by Ryan in #4288. But then I realized that the original explanation is great and I thought that maybe we should just mention at the beginning the list of Symfony versions affected by this problem. Let me know what you think.
