### PR TITLE
tip for mapping definition

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -585,8 +585,8 @@ The code below shows the implementation of the
 
 .. tip::
 
-   Don't forget to 
-   :ref: `add the repository class to the mapping definition of your entity <book-doctrine-custom-repository-classes>`.
+    Don't forget to add the repository class to the mapping definition of
+    :ref: ` your entity <book-doctrine-custom-repository-classes>`.
 
 To finish the implementation, the configuration of the security layer must be
 changed to tell Symfony to use the new custom entity provider instead of the

--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -583,6 +583,11 @@ The code below shows the implementation of the
         }
     }
 
+.. tip::
+
+   Don't forget to 
+   :ref: `add the repository class to the mapping definition of your entity <book-doctrine-custom-repository-classes>`.
+
 To finish the implementation, the configuration of the security layer must be
 changed to tell Symfony to use the new custom entity provider instead of the
 generic Doctrine entity provider. It's trivial to achieve by removing the

--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -585,8 +585,8 @@ The code below shows the implementation of the
 
 .. tip::
 
-    Don't forget to add the repository class to the mapping definition of
-    :ref: ` your entity <book-doctrine-custom-repository-classes>`.
+    Don't forget to add the repository class to the 
+    :ref: `mapping definition of your entity <book-doctrine-custom-repository-classes>`.
 
 To finish the implementation, the configuration of the security layer must be
 changed to tell Symfony to use the new custom entity provider instead of the


### PR DESCRIPTION
If you follow the link from the security documentation (http://symfony.com/doc/current/book/security.html#loading-users-from-the-database), it's easy to miss the necessary mapping definition for the repository.
