### PR TITLE
Finish #4370: add a note about apc for php recent versions

### DIFF
--- a/book/performance.rst
+++ b/book/performance.rst
@@ -18,8 +18,9 @@ Use a Byte Code Cache (e.g. APC)
 One of the best (and easiest) things that you should do to improve your performance
 is to use a "byte code cache". The idea of a byte code cache is to remove
 the need to constantly recompile the PHP source code. There are a number of
-`byte code caches`_ available, some of which are open source. The most widely
-used byte code cache is probably `APC`_
+`byte code caches`_ available, some of which are open source. If you are using 
+PHP 5.5 or more, the byte code cache is built-in into PHP runtime. For older versions, 
+the most widely used byte code cache is probably `APC`_
 
 Using a byte code cache really has no downside, and Symfony has been architected
 to perform really well in this type of environment.

--- a/book/performance.rst
+++ b/book/performance.rst
@@ -18,9 +18,9 @@ Use a Byte Code Cache (e.g. APC)
 One of the best (and easiest) things that you should do to improve your performance
 is to use a "byte code cache". The idea of a byte code cache is to remove
 the need to constantly recompile the PHP source code. There are a number of
-`byte code caches`_ available, some of which are open source. If you are using 
-PHP 5.5 or more, the byte code cache is built-in into PHP runtime. For older versions, 
-the most widely used byte code cache is probably `APC`_
+`byte code caches`_ available, some of which are open source. As of PHP 5.5,
+PHP comes with `OPcache`_ built-in. For older versions, the most widely used
+byte code cache is probably `APC`_
 
 Using a byte code cache really has no downside, and Symfony has been architected
 to perform really well in this type of environment.
@@ -140,6 +140,7 @@ feature is disabled in the byte code cache (e.g. ``apc.stat=0`` in APC), there
 is no longer a reason to use a bootstrap file.
 
 .. _`byte code caches`: http://en.wikipedia.org/wiki/List_of_PHP_accelerators
+.. _`OPcache`: http://php.net/manual/en/book.opcache.php
 .. _`APC`: http://php.net/manual/en/book.apc.php
 .. _`autoload.php`: https://github.com/symfony/symfony-standard/blob/master/app/autoload.php
 .. _`bootstrap file`: https://github.com/sensio/SensioDistributionBundle/blob/master/Composer/ScriptHandler.php


### PR DESCRIPTION
Finishes https://github.com/symfony/symfony-docs/pull/4370

Original description:

> apc is not required for php5.5+, I suggest to mention it to avoid people trying to install it on recent php versions

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| fixed tickets | - |
