### PR TITLE
Update the_controller.rst

### DIFF
--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -204,9 +204,10 @@ different controller using the ``forward()`` method::
          */
         public function indexAction()
         {
-            return $this->forward('AppBundle:Blog:index', array(
-                'name'  => $name
-            );
+            return $this->forward('AppBundle:Default:hello', array(
+                'name'  => 'Fabien',
+                '_format' => 'html'
+            ));
         }
     }
 


### PR DESCRIPTION
Fixed some things:
- Add missing closing parenthesis
- Use the DefaultController helloAction as forward example instead

The latter is to match the rest of the documentation page. The blog controller is not even made yet at this point in the tutorial, so there is no sense in trying to forward there.
