### PR TITLE
Fix event_dispatcher AappBundle typo

### DIFF
--- a/cookbook/event_dispatcher/before_after_filters.rst
+++ b/cookbook/event_dispatcher/before_after_filters.rst
@@ -156,7 +156,7 @@ your listener to be called just before any controller is executed.
         # app/config/services.yml
         services:
             app.tokens.action_listener:
-                class: AappBundle\EventListener\TokenListener
+                class: AppBundle\EventListener\TokenListener
                 arguments: ["%tokens%"]
                 tags:
                     - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

This is a typo that exists in 2.5 onwards.

Should I also submit PRs for the newer versions too?
