### PR TITLE
Switched the first example to a static constructor method

### DIFF
--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -55,8 +55,7 @@ The simplest ``TypeTestCase`` implementation looks like the following::
             $type = new TestedType();
             $form = $this->factory->create($type);
 
-            $object = new TestObject();
-            $object->fromArray($formData);
+            $object = TestObject::fromArray($formData);
 
             // submit the data to the form directly
             $form->submit($formData);


### PR DESCRIPTION
I believe having a non-static method for class instantiation is not something the documentation should encourage. It's much better to use a named constructor here (also note that `TestObject` class code isn't supplied).
