### PR TITLE
Trim default is false in password field

### DIFF
--- a/reference/forms/types/options/trim.rst.inc
+++ b/reference/forms/types/options/trim.rst.inc
@@ -4,6 +4,6 @@ trim
 **type**: ``Boolean`` **default**: ``true``
 
 If true, the whitespace of the submitted string value will be stripped
-via the ``trim()`` function when the data is bound. This guarantees that
+via the :phpfunction:`trim` function when the data is bound. This guarantees that
 if a value is submitted with extra whitespace, it will be removed before
 the value is merged back onto the underlying object.

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -82,6 +82,6 @@ trim
 **type**: ``Boolean`` **default**: ``false``
 
 If true, the whitespace of the submitted string value will be stripped
-via the ``trim()`` function when the data is bound. This guarantees that
+via the :phpfunction:`trim` function when the data is bound. This guarantees that
 if a value is submitted with extra whitespace, it will be removed before
 the value is merged back onto the underlying object.

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -78,7 +78,9 @@ The default value is ``''`` (the empty string).
 
 trim
 ~~~~
-**type**: ``Boolean`` **default**: ``false``
+
+**type**: ``bool`` **default**: ``false``
+
 If true, the whitespace of the submitted string value will be stripped
 via the ``trim()`` function when the data is bound. This guarantees that
 if a value is submitted with extra whitespace, it will be removed before

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -76,4 +76,10 @@ The default value is ``''`` (the empty string).
 
 .. include:: /reference/forms/types/options/required.rst.inc
 
-.. include:: /reference/forms/types/options/trim.rst.inc
+trim
+~~~~
+**type**: ``Boolean`` **default**: ``false``
+If true, the whitespace of the submitted string value will be stripped
+via the ``trim()`` function when the data is bound. This guarantees that
+if a value is submitted with extra whitespace, it will be removed before
+the value is merged back onto the underlying object.

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -79,7 +79,7 @@ The default value is ``''`` (the empty string).
 trim
 ~~~~
 
-**type**: ``bool`` **default**: ``false``
+**type**: ``Boolean`` **default**: ``false``
 
 If true, the whitespace of the submitted string value will be stripped
 via the ``trim()`` function when the data is bound. This guarantees that


### PR DESCRIPTION
The Password field define the inherited trim option to false.
