### PR TITLE
[Reference] fix code block order

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -344,17 +344,6 @@ object.
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # AppBundle/Resources/config/validation.yml
-        AppBundle\Entity\Task:
-            properties:
-                task:
-                    - NotBlank: ~
-                dueDate:
-                    - NotBlank: ~
-                    - Type: \DateTime
-
     .. code-block:: php-annotations
 
         // AppBundle/Entity/Task.php
@@ -373,6 +362,17 @@ object.
              */
             protected $dueDate;
         }
+
+    .. code-block:: yaml
+
+        # AppBundle/Resources/config/validation.yml
+        AppBundle\Entity\Task:
+            properties:
+                task:
+                    - NotBlank: ~
+                dueDate:
+                    - NotBlank: ~
+                    - Type: \DateTime
 
     .. code-block:: xml
 

--- a/cookbook/doctrine/file_uploads.rst
+++ b/cookbook/doctrine/file_uploads.rst
@@ -152,15 +152,6 @@ rules::
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/AppBundle/Resources/config/validation.yml
-        AppBundle\Entity\Document:
-            properties:
-                file:
-                    - File:
-                        maxSize: 6000000
-
     .. code-block:: php-annotations
 
         // src/AppBundle/Entity/Document.php
@@ -178,6 +169,15 @@ rules::
 
             // ...
         }
+
+    .. code-block:: yaml
+
+        # src/AppBundle/Resources/config/validation.yml
+        AppBundle\Entity\Document:
+            properties:
+                file:
+                    - File:
+                        maxSize: 6000000
 
     .. code-block:: xml
 

--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -89,15 +89,6 @@ Using custom validators is very easy, just as the ones provided by Symfony itsel
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/AppBundle/Resources/config/validation.yml
-        AppBundle\Entity\AcmeEntity:
-            properties:
-                name:
-                    - NotBlank: ~
-                    - AppBundle\Validator\Constraints\ContainsAlphanumeric: ~
-
     .. code-block:: php-annotations
 
         // src/AppBundle/Entity/AcmeEntity.php
@@ -116,6 +107,15 @@ Using custom validators is very easy, just as the ones provided by Symfony itsel
 
             // ...
         }
+
+    .. code-block:: yaml
+
+        # src/AppBundle/Resources/config/validation.yml
+        AppBundle\Entity\AcmeEntity:
+            properties:
+                name:
+                    - NotBlank: ~
+                    - AppBundle\Validator\Constraints\ContainsAlphanumeric: ~
 
     .. code-block:: xml
 
@@ -237,13 +237,6 @@ not to the property:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/AppBundle/Resources/config/validation.yml
-        AppBundle\Entity\AcmeEntity:
-            constraints:
-                - AppBundle\Validator\Constraints\ContainsAlphanumeric: ~
-
     .. code-block:: php-annotations
 
         /**
@@ -253,6 +246,13 @@ not to the property:
         {
             // ...
         }
+
+    .. code-block:: yaml
+
+        # src/AppBundle/Resources/config/validation.yml
+        AppBundle\Entity\AcmeEntity:
+            constraints:
+                - AppBundle\Validator\Constraints\ContainsAlphanumeric: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/All.rst
+++ b/reference/constraints/All.rst
@@ -22,17 +22,6 @@ entry in that array:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/UserBundle/Resources/config/validation.yml
-        Acme\UserBundle\Entity\User:
-            properties:
-                favoriteColors:
-                    - All:
-                        - NotBlank:  ~
-                        - Length:
-                            min: 5
-
     .. code-block:: php-annotations
 
         // src/Acme/UserBundle/Entity/User.php
@@ -50,6 +39,17 @@ entry in that array:
              */
              protected $favoriteColors = array();
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/UserBundle/Resources/config/validation.yml
+        Acme\UserBundle\Entity\User:
+            properties:
+                favoriteColors:
+                    - All:
+                        - NotBlank:  ~
+                        - Length:
+                            min: 5
 
     .. code-block:: xml
 

--- a/reference/constraints/Blank.rst
+++ b/reference/constraints/Blank.rst
@@ -24,14 +24,6 @@ of an ``Author`` class were blank, you could do the following:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                firstName:
-                    - Blank: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -46,6 +38,14 @@ of an ``Author`` class were blank, you could do the following:
              */
             protected $firstName;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                firstName:
+                    - Blank: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -32,14 +32,6 @@ Setup
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            constraints:
-                - Callback:
-                    methods:   [isAuthorValid]
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -53,6 +45,14 @@ Setup
         class Author
         {
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            constraints:
+                - Callback:
+                    methods:   [isAuthorValid]
 
     .. code-block:: xml
 
@@ -139,15 +139,6 @@ process. Each method can be one of the following formats:
 
     .. configuration-block::
 
-        .. code-block:: yaml
-
-            # src/Acme/BlogBundle/Resources/config/validation.yml
-            Acme\BlogBundle\Entity\Author:
-                constraints:
-                    - Callback:
-                        methods:
-                            -    [Acme\BlogBundle\MyStaticValidatorClass, isAuthorValid]
-
         .. code-block:: php-annotations
 
             // src/Acme/BlogBundle/Entity/Author.php
@@ -161,6 +152,15 @@ process. Each method can be one of the following formats:
             class Author
             {
             }
+
+        .. code-block:: yaml
+
+            # src/Acme/BlogBundle/Resources/config/validation.yml
+            Acme\BlogBundle\Entity\Author:
+                constraints:
+                    - Callback:
+                        methods:
+                            -    [Acme\BlogBundle\MyStaticValidatorClass, isAuthorValid]
 
         .. code-block:: xml
 

--- a/reference/constraints/CardScheme.rst
+++ b/reference/constraints/CardScheme.rst
@@ -27,6 +27,21 @@ on an object that will contain a credit card number.
 
 .. configuration-block::
 
+    .. code-block:: php-annotations
+
+        // src/Acme/SubscriptionBundle/Entity/Transaction.php
+        namespace Acme\SubscriptionBundle\Entity\Transaction;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Transaction
+        {
+            /**
+             * @Assert\CardScheme(schemes = {"VISA"}, message = "Your credit card number is invalid.")
+             */
+            protected $cardNumber;
+        }
+
     .. code-block:: yaml
 
         # src/Acme/SubscriptionBundle/Resources/config/validation.yml
@@ -56,21 +71,6 @@ on an object that will contain a credit card number.
                 </property>
             </class>
         </constraint-mapping>
-
-    .. code-block:: php-annotations
-
-        // src/Acme/SubscriptionBundle/Entity/Transaction.php
-        namespace Acme\SubscriptionBundle\Entity\Transaction;
-
-        use Symfony\Component\Validator\Constraints as Assert;
-
-        class Transaction
-        {
-            /**
-             * @Assert\CardScheme(schemes = {"VISA"}, message = "Your credit card number is invalid.")
-             */
-            protected $cardNumber;
-        }
 
     .. code-block:: php
 

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -36,16 +36,6 @@ If your valid choice list is simple, you can pass them in directly via the
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                gender:
-                    - Choice:
-                        choices:  [male, female]
-                        message:  Choose a valid gender.
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -60,6 +50,16 @@ If your valid choice list is simple, you can pass them in directly via the
              */
             protected $gender;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                gender:
+                    - Choice:
+                        choices:  [male, female]
+                        message:  Choose a valid gender.
 
     .. code-block:: xml
 
@@ -129,14 +129,6 @@ constraint.
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                gender:
-                    - Choice: { callback: getGenders }
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -151,6 +143,14 @@ constraint.
              */
             protected $gender;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                gender:
+                    - Choice: { callback: getGenders }
 
     .. code-block:: xml
 
@@ -194,14 +194,6 @@ you can pass the class name and the method as an array.
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                gender:
-                    - Choice: { callback: [Util, getGenders] }
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -216,6 +208,14 @@ you can pass the class name and the method as an array.
              */
             protected $gender;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                gender:
+                    - Choice: { callback: [Util, getGenders] }
 
     .. code-block:: xml
 

--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -52,22 +52,6 @@ blank but is no longer than 100 characters in length, you would do the following
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                profileData:
-                    - Collection:
-                        fields:
-                            personal_email: Email
-                            short_bio:
-                                - NotBlank
-                                - Length:
-                                    max:   100
-                                    maxMessage: Your short bio is too long!
-                        allowMissingFields: true
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -97,6 +81,22 @@ blank but is no longer than 100 characters in length, you would do the following
                  'short_bio',
              );
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                profileData:
+                    - Collection:
+                        fields:
+                            personal_email: Email
+                            short_bio:
+                                - NotBlank
+                                - Length:
+                                    max:   100
+                                    maxMessage: Your short bio is too long!
+                        allowMissingFields: true
 
     .. code-block:: xml
 
@@ -189,22 +189,6 @@ field is optional but must be a valid email if supplied, you can do the followin
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                profile_data:
-                    - Collection:
-                        fields:
-                            personal_email:
-                                - Required
-                                    - NotBlank: ~
-                                    - Email: ~
-                            alternate_email:
-                                - Optional:
-                                    - Email: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -224,6 +208,22 @@ field is optional but must be a valid email if supplied, you can do the followin
              */
              protected $profileData = array('personal_email');
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                profile_data:
+                    - Collection:
+                        fields:
+                            personal_email:
+                                - Required
+                                    - NotBlank: ~
+                                    - Email: ~
+                            alternate_email:
+                                - Optional:
+                                    - Email: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/Count.rst
+++ b/reference/constraints/Count.rst
@@ -26,18 +26,6 @@ you might add the following:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/EventBundle/Resources/config/validation.yml
-        Acme\EventBundle\Entity\Participant:
-            properties:
-                emails:
-                    - Count:
-                        min: 1
-                        max: 5
-                        minMessage: "You must specify at least one email"
-                        maxMessage: "You cannot specify more than {{ limit }} emails"
-
     .. code-block:: php-annotations
 
         // src/Acme/EventBundle/Entity/Participant.php
@@ -57,6 +45,18 @@ you might add the following:
              */
              protected $emails = array();
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/EventBundle/Resources/config/validation.yml
+        Acme\EventBundle\Entity\Participant:
+            properties:
+                emails:
+                    - Count:
+                        min: 1
+                        max: 5
+                        minMessage: "You must specify at least one email"
+                        maxMessage: "You cannot specify more than {{ limit }} emails"
 
     .. code-block:: xml
 

--- a/reference/constraints/Country.rst
+++ b/reference/constraints/Country.rst
@@ -18,14 +18,6 @@ Basic Usage
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/UserBundle/Resources/config/validation.yml
-        Acme\UserBundle\Entity\User:
-            properties:
-                country:
-                    - Country: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/UserBundle/Entity/User.php
@@ -40,6 +32,14 @@ Basic Usage
              */
              protected $country;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/UserBundle/Resources/config/validation.yml
+        Acme\UserBundle\Entity\User:
+            properties:
+                country:
+                    - Country: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/Currency.rst
+++ b/reference/constraints/Currency.rst
@@ -24,14 +24,6 @@ currency, you could do the following:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/EcommerceBundle/Resources/config/validation.yml
-        Acme\EcommerceBundle\Entity\Order:
-            properties:
-                currency:
-                    - Currency: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/EcommerceBundle/Entity/Order.php
@@ -46,6 +38,14 @@ currency, you could do the following:
              */
             protected $currency;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/EcommerceBundle/Resources/config/validation.yml
+        Acme\EcommerceBundle\Entity\Order:
+            properties:
+                currency:
+                    - Currency: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/Date.rst
+++ b/reference/constraints/Date.rst
@@ -20,14 +20,6 @@ Basic Usage
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                birthday:
-                    - Date: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -42,6 +34,14 @@ Basic Usage
              */
              protected $birthday;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                birthday:
+                    - Date: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/DateTime.rst
+++ b/reference/constraints/DateTime.rst
@@ -20,14 +20,6 @@ Basic Usage
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                createdAt:
-                    - DateTime: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -42,6 +34,14 @@ Basic Usage
              */
              protected $createdAt;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                createdAt:
+                    - DateTime: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -21,16 +21,6 @@ Basic Usage
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                email:
-                    - Email:
-                        message: The email "{{ value }}" is not a valid email.
-                        checkMX: true
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -48,6 +38,16 @@ Basic Usage
              */
              protected $email;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                email:
+                    - Email:
+                        message: The email "{{ value }}" is not a valid email.
+                        checkMX: true
 
     .. code-block:: xml
 

--- a/reference/constraints/EqualTo.rst
+++ b/reference/constraints/EqualTo.rst
@@ -32,15 +32,6 @@ If you want to ensure that the ``age`` of a ``Person`` class is equal to
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/SocialBundle/Resources/config/validation.yml
-        Acme\SocialBundle\Entity\Person:
-            properties:
-                age:
-                    - EqualTo:
-                        value: 20
-
     .. code-block:: php-annotations
 
         // src/Acme/SocialBundle/Entity/Person.php
@@ -57,6 +48,15 @@ If you want to ensure that the ``age`` of a ``Person`` class is equal to
              */
             protected $age;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/SocialBundle/Resources/config/validation.yml
+        Acme\SocialBundle\Entity\Person:
+            properties:
+                age:
+                    - EqualTo:
+                        value: 20
 
     .. code-block:: xml
 

--- a/reference/constraints/False.rst
+++ b/reference/constraints/False.rst
@@ -39,15 +39,6 @@ method returns **false**:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author
-            getters:
-                stateInvalid:
-                    - 'False':
-                        message: You've entered an invalid state.
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -67,6 +58,15 @@ method returns **false**:
                 // ...
              }
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author
+            getters:
+                stateInvalid:
+                    - 'False':
+                        message: You've entered an invalid state.
 
     .. code-block:: xml
 

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -68,17 +68,6 @@ below a certain file size and a valid PDF, add the following:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                bioFile:
-                    - File:
-                        maxSize: 1024k
-                        mimeTypes: [application/pdf, application/x-pdf]
-                        mimeTypesMessage: Please upload a valid PDF
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -97,6 +86,17 @@ below a certain file size and a valid PDF, add the following:
              */
             protected $bioFile;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                bioFile:
+                    - File:
+                        maxSize: 1024k
+                        mimeTypes: [application/pdf, application/x-pdf]
+                        mimeTypesMessage: Please upload a valid PDF
 
     .. code-block:: xml
 

--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -28,15 +28,6 @@ If you want to ensure that the ``age`` of a ``Person`` class is greater than
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/SocialBundle/Resources/config/validation.yml
-        Acme\SocialBundle\Entity\Person:
-            properties:
-                age:
-                    - GreaterThan:
-                        value: 18
-
     .. code-block:: php-annotations
 
         // src/Acme/SocialBundle/Entity/Person.php
@@ -53,6 +44,15 @@ If you want to ensure that the ``age`` of a ``Person`` class is greater than
              */
             protected $age;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/SocialBundle/Resources/config/validation.yml
+        Acme\SocialBundle\Entity\Person:
+            properties:
+                age:
+                    - GreaterThan:
+                        value: 18
 
     .. code-block:: xml
 

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -27,15 +27,6 @@ or equal to ``18``, you could do the following:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/SocialBundle/Resources/config/validation.yml
-        Acme\SocialBundle\Entity\Person:
-            properties:
-                age:
-                    - GreaterThanOrEqual:
-                        value: 18
-
     .. code-block:: php-annotations
 
         // src/Acme/SocialBundle/Entity/Person.php
@@ -52,6 +43,15 @@ or equal to ``18``, you could do the following:
              */
             protected $age;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/SocialBundle/Resources/config/validation.yml
+        Acme\SocialBundle\Entity\Person:
+            properties:
+                age:
+                    - GreaterThanOrEqual:
+                        value: 18
 
     .. code-block:: xml
 

--- a/reference/constraints/Iban.rst
+++ b/reference/constraints/Iban.rst
@@ -27,15 +27,6 @@ will contain an International Bank Account Number.
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/SubscriptionBundle/Resources/config/validation.yml
-        Acme\SubscriptionBundle\Entity\Transaction:
-            properties:
-                bankAccountNumber:
-                    - Iban:
-                        message: This is not a valid International Bank Account Number (IBAN).
-
     .. code-block:: php-annotations
 
         // src/Acme/SubscriptionBundle/Entity/Transaction.php
@@ -50,6 +41,15 @@ will contain an International Bank Account Number.
              */
             protected $bankAccountNumber;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/SubscriptionBundle/Resources/config/validation.yml
+        Acme\SubscriptionBundle\Entity\Transaction:
+            properties:
+                bankAccountNumber:
+                    - Iban:
+                        message: This is not a valid International Bank Account Number (IBAN).
 
     .. code-block:: xml
 

--- a/reference/constraints/IdenticalTo.rst
+++ b/reference/constraints/IdenticalTo.rst
@@ -33,15 +33,6 @@ If you want to ensure that the ``age`` of a ``Person`` class is equal to
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/SocialBundle/Resources/config/validation.yml
-        Acme\SocialBundle\Entity\Person:
-            properties:
-                age:
-                    - IdenticalTo:
-                        value: 20
-
     .. code-block:: php-annotations
 
         // src/Acme/SocialBundle/Entity/Person.php
@@ -58,6 +49,15 @@ If you want to ensure that the ``age`` of a ``Person`` class is equal to
              */
             protected $age;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/SocialBundle/Resources/config/validation.yml
+        Acme\SocialBundle\Entity\Person:
+            properties:
+                age:
+                    - IdenticalTo:
+                        value: 20
 
     .. code-block:: xml
 

--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -66,18 +66,6 @@ it is between a certain size, add the following:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author
-            properties:
-                headshot:
-                    - Image:
-                        minWidth: 200
-                        maxWidth: 400
-                        minHeight: 200
-                        maxHeight: 400
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -97,6 +85,18 @@ it is between a certain size, add the following:
              */
             protected $headshot;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author
+            properties:
+                headshot:
+                    - Image:
+                        minWidth: 200
+                        maxWidth: 400
+                        minHeight: 200
+                        maxHeight: 400
 
     .. code-block:: xml
 

--- a/reference/constraints/Ip.rst
+++ b/reference/constraints/Ip.rst
@@ -21,14 +21,6 @@ Basic Usage
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                ipAddress:
-                    - Ip: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -43,6 +35,14 @@ Basic Usage
              */
              protected $ipAddress;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                ipAddress:
+                    - Ip: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -29,17 +29,6 @@ on an  object that will contain a ISBN number.
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BookcaseBundle/Resources/config/validation.yml
-        Acme\BookcaseBundle\Entity\Book:
-            properties:
-                isbn:
-                    - Isbn:
-                        isbn10: true
-                        isbn13: true
-                        bothIsbnMessage: This value is neither a valid ISBN-10 nor a valid ISBN-13.
-
     .. code-block:: php-annotations
 
         // src/Acme/BookcaseBundle/Entity/Book.php
@@ -58,6 +47,17 @@ on an  object that will contain a ISBN number.
              */
             protected $isbn;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BookcaseBundle/Resources/config/validation.yml
+        Acme\BookcaseBundle\Entity\Book:
+            properties:
+                isbn:
+                    - Isbn:
+                        isbn10: true
+                        isbn13: true
+                        bothIsbnMessage: This value is neither a valid ISBN-10 nor a valid ISBN-13.
 
     .. code-block:: xml
 

--- a/reference/constraints/Issn.rst
+++ b/reference/constraints/Issn.rst
@@ -23,14 +23,6 @@ Basic Usage
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/JournalBundle/Resources/config/validation.yml
-        Acme\JournalBundle\Entity\Journal:
-            properties:
-                issn:
-                    - Issn: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/JournalBundle/Entity/Journal.php
@@ -45,6 +37,14 @@ Basic Usage
              */
              protected $issn;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/JournalBundle/Resources/config/validation.yml
+        Acme\JournalBundle\Entity\Journal:
+            properties:
+                issn:
+                    - Issn: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/Language.rst
+++ b/reference/constraints/Language.rst
@@ -19,14 +19,6 @@ Basic Usage
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/UserBundle/Resources/config/validation.yml
-        Acme\UserBundle\Entity\User:
-            properties:
-                preferredLanguage:
-                    - Language: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/UserBundle/Entity/User.php
@@ -41,6 +33,14 @@ Basic Usage
              */
              protected $preferredLanguage;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/UserBundle/Resources/config/validation.yml
+        Acme\UserBundle\Entity\User:
+            properties:
+                preferredLanguage:
+                    - Language: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -26,18 +26,6 @@ To verify that the ``firstName`` field length of a class is between "2" and
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/EventBundle/Resources/config/validation.yml
-        Acme\EventBundle\Entity\Participant:
-            properties:
-                firstName:
-                    - Length:
-                        min: 2
-                        max: 50
-                        minMessage: "Your first name must be at least {{ limit }} characters long"
-                        maxMessage: "Your first name cannot be longer than {{ limit }} characters"
-
     .. code-block:: php-annotations
 
         // src/Acme/EventBundle/Entity/Participant.php
@@ -57,6 +45,18 @@ To verify that the ``firstName`` field length of a class is between "2" and
              */
              protected $firstName;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/EventBundle/Resources/config/validation.yml
+        Acme\EventBundle\Entity\Participant:
+            properties:
+                firstName:
+                    - Length:
+                        min: 2
+                        max: 50
+                        minMessage: "Your first name must be at least {{ limit }} characters long"
+                        maxMessage: "Your first name cannot be longer than {{ limit }} characters"
 
     .. code-block:: xml
 

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -28,15 +28,6 @@ If you want to ensure that the ``age`` of a ``Person`` class is less than
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/SocialBundle/Resources/config/validation.yml
-        Acme\SocialBundle\Entity\Person:
-            properties:
-                age:
-                    - LessThan:
-                        value: 80
-
     .. code-block:: php-annotations
 
         // src/Acme/SocialBundle/Entity/Person.php
@@ -53,6 +44,15 @@ If you want to ensure that the ``age`` of a ``Person`` class is less than
              */
             protected $age;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/SocialBundle/Resources/config/validation.yml
+        Acme\SocialBundle\Entity\Person:
+            properties:
+                age:
+                    - LessThan:
+                        value: 80
 
     .. code-block:: xml
 

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -27,15 +27,6 @@ equal to ``80``, you could do the following:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/SocialBundle/Resources/config/validation.yml
-        Acme\SocialBundle\Entity\Person:
-            properties:
-                age:
-                    - LessThanOrEqual:
-                        value: 80
-
     .. code-block:: php-annotations
 
         // src/Acme/SocialBundle/Entity/Person.php
@@ -52,6 +43,15 @@ equal to ``80``, you could do the following:
              */
             protected $age;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/SocialBundle/Resources/config/validation.yml
+        Acme\SocialBundle\Entity\Person:
+            properties:
+                age:
+                    - LessThanOrEqual:
+                        value: 80
 
     .. code-block:: xml
 

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -22,14 +22,6 @@ Basic Usage
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/UserBundle/Resources/config/validation.yml
-        Acme\UserBundle\Entity\User:
-            properties:
-                locale:
-                    - Locale: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/UserBundle/Entity/User.php
@@ -44,6 +36,14 @@ Basic Usage
              */
              protected $locale;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/UserBundle/Resources/config/validation.yml
+        Acme\UserBundle\Entity\User:
+            properties:
+                locale:
+                    - Locale: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/Luhn.rst
+++ b/reference/constraints/Luhn.rst
@@ -26,15 +26,6 @@ will contain a credit card number.
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/SubscriptionBundle/Resources/config/validation.yml
-        Acme\SubscriptionBundle\Entity\Transaction:
-            properties:
-                cardNumber:
-                    - Luhn:
-                        message: Please check your credit card number.
-
     .. code-block:: php-annotations
 
         // src/Acme/SubscriptionBundle/Entity/Transaction.php
@@ -49,6 +40,15 @@ will contain a credit card number.
              */
             protected $cardNumber;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/SubscriptionBundle/Resources/config/validation.yml
+        Acme\SubscriptionBundle\Entity\Transaction:
+            properties:
+                cardNumber:
+                    - Luhn:
+                        message: Please check your credit card number.
 
     .. code-block:: xml
 

--- a/reference/constraints/NotBlank.rst
+++ b/reference/constraints/NotBlank.rst
@@ -23,14 +23,6 @@ were not blank, you could do the following:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                firstName:
-                    - NotBlank: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -45,6 +37,14 @@ were not blank, you could do the following:
              */
             protected $firstName;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                firstName:
+                    - NotBlank: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/NotEqualTo.rst
+++ b/reference/constraints/NotEqualTo.rst
@@ -33,15 +33,6 @@ If you want to ensure that the ``age`` of a ``Person`` class is not equal to
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/SocialBundle/Resources/config/validation.yml
-        Acme\SocialBundle\Entity\Person:
-            properties:
-                age:
-                    - NotEqualTo:
-                        value: 15
-
     .. code-block:: php-annotations
 
         // src/Acme/SocialBundle/Entity/Person.php
@@ -58,6 +49,15 @@ If you want to ensure that the ``age`` of a ``Person`` class is not equal to
              */
             protected $age;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/SocialBundle/Resources/config/validation.yml
+        Acme\SocialBundle\Entity\Person:
+            properties:
+                age:
+                    - NotEqualTo:
+                        value: 15
 
     .. code-block:: xml
 

--- a/reference/constraints/NotIdenticalTo.rst
+++ b/reference/constraints/NotIdenticalTo.rst
@@ -33,15 +33,6 @@ If you want to ensure that the ``age`` of a ``Person`` class is *not* equal to
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/SocialBundle/Resources/config/validation.yml
-        Acme\SocialBundle\Entity\Person:
-            properties:
-                age:
-                    - NotIdenticalTo:
-                        value: 15
-
     .. code-block:: php-annotations
 
         // src/Acme/SocialBundle/Entity/Person.php
@@ -58,6 +49,15 @@ If you want to ensure that the ``age`` of a ``Person`` class is *not* equal to
              */
             protected $age;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/SocialBundle/Resources/config/validation.yml
+        Acme\SocialBundle\Entity\Person:
+            properties:
+                age:
+                    - NotIdenticalTo:
+                        value: 15
 
     .. code-block:: xml
 

--- a/reference/constraints/NotNull.rst
+++ b/reference/constraints/NotNull.rst
@@ -23,14 +23,6 @@ were not strictly equal to ``null``, you would:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                firstName:
-                    - NotNull: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -45,6 +37,14 @@ were not strictly equal to ``null``, you would:
              */
             protected $firstName;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                firstName:
+                    - NotNull: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/Null.rst
+++ b/reference/constraints/Null.rst
@@ -23,14 +23,6 @@ of an ``Author`` class exactly equal to ``null``, you could do the following:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                firstName:
-                    - 'Null': ~
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -45,6 +37,14 @@ of an ``Author`` class exactly equal to ``null``, you could do the following:
              */
             protected $firstName;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                firstName:
+                    - 'Null': ~
 
     .. code-block:: xml
 

--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -25,18 +25,6 @@ the following:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/EventBundle/Resources/config/validation.yml
-        Acme\EventBundle\Entity\Participant:
-            properties:
-                height:
-                    - Range:
-                        min: 120
-                        max: 180
-                        minMessage: You must be at least {{ limit }}cm tall to enter
-                        maxMessage: You cannot be taller than {{ limit }}cm to enter
-
     .. code-block:: php-annotations
 
         // src/Acme/EventBundle/Entity/Participant.php
@@ -56,6 +44,18 @@ the following:
              */
              protected $height;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/EventBundle/Resources/config/validation.yml
+        Acme\EventBundle\Entity\Participant:
+            properties:
+                height:
+                    - Range:
+                        min: 120
+                        max: 180
+                        minMessage: You must be at least {{ limit }}cm tall to enter
+                        maxMessage: You cannot be taller than {{ limit }}cm to enter
 
     .. code-block:: xml
 

--- a/reference/constraints/Regex.rst
+++ b/reference/constraints/Regex.rst
@@ -26,14 +26,6 @@ characters at the beginning of your string:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                description:
-                    - Regex: '/^\w+/'
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -48,6 +40,14 @@ characters at the beginning of your string:
              */
             protected $description;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                description:
+                    - Regex: '/^\w+/'
 
     .. code-block:: xml
 
@@ -91,17 +91,6 @@ message:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                firstName:
-                    - Regex:
-                        pattern: '/\d/'
-                        match:   false
-                        message: Your name cannot contain a number
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -120,6 +109,17 @@ message:
              */
             protected $firstName;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                firstName:
+                    - Regex:
+                        pattern: '/\d/'
+                        match:   false
+                        message: Your name cannot contain a number
 
     .. code-block:: xml
 
@@ -194,16 +194,6 @@ to specify the HTML5 compatible pattern in the ``htmlPattern`` option:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                name:
-                    - Regex:
-                        pattern: "/^[a-z]+$/i"
-                        htmlPattern: "^[a-zA-Z]+$"
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -221,6 +211,16 @@ to specify the HTML5 compatible pattern in the ``htmlPattern`` option:
              */
             protected $name;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                name:
+                    - Regex:
+                        pattern: "/^[a-z]+$/i"
+                        htmlPattern: "^[a-zA-Z]+$"
 
     .. code-block:: xml
 

--- a/reference/constraints/Time.rst
+++ b/reference/constraints/Time.rst
@@ -23,14 +23,6 @@ of the day when the event starts:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/EventBundle/Resources/config/validation.yml
-        Acme\EventBundle\Entity\Event:
-            properties:
-                startsAt:
-                    - Time: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/EventBundle/Entity/Event.php
@@ -45,6 +37,14 @@ of the day when the event starts:
              */
              protected $startsAt;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/EventBundle/Resources/config/validation.yml
+        Acme\EventBundle\Entity\Event:
+            properties:
+                startsAt:
+                    - Time: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/True.rst
+++ b/reference/constraints/True.rst
@@ -44,15 +44,6 @@ Then you can constrain this method with ``True``.
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            getters:
-                tokenValid:
-                    - 'True':
-                        message: The token is invalid.
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -72,6 +63,15 @@ Then you can constrain this method with ``True``.
                 return $this->token == $this->generateToken();
             }
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            getters:
+                tokenValid:
+                    - 'True':
+                        message: The token is invalid.
 
     .. code-block:: xml
 

--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -21,16 +21,6 @@ Basic Usage
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                age:
-                    - Type:
-                        type: integer
-                        message: The value {{ value }} is not a valid {{ type }}.
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -45,6 +35,16 @@ Basic Usage
              */
             protected $age;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                age:
+                    - Type:
+                        type: integer
+                        message: The value {{ value }} is not a valid {{ type }}.
 
     .. code-block:: xml
 

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -30,16 +30,6 @@ table:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/UserBundle/Resources/config/validation.yml
-        Acme\UserBundle\Entity\Author:
-            constraints:
-                - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity: email
-            properties:
-                email:
-                    - Email: ~
-
     .. code-block:: php-annotations
 
         // Acme/UserBundle/Entity/Author.php
@@ -67,6 +57,16 @@ table:
 
             // ...
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/UserBundle/Resources/config/validation.yml
+        Acme\UserBundle\Entity\Author:
+            constraints:
+                - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity: email
+            properties:
+                email:
+                    - Email: ~
 
     .. code-block:: xml
 
@@ -169,16 +169,6 @@ Consider this example:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/AdministrationBundle/Resources/config/validation.yml
-        Acme\AdministrationBundle\Entity\Service:
-            constraints:
-                - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
-                    fields: [host, port]
-                    errorPath: port
-                    message: 'This port is already in use on that host.'
-
     .. code-block:: php-annotations
 
         // src/Acme/AdministrationBundle/Entity/Service.php
@@ -207,6 +197,16 @@ Consider this example:
              */
             public $port;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/AdministrationBundle/Resources/config/validation.yml
+        Acme\AdministrationBundle\Entity\Service:
+            constraints:
+                - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
+                    fields: [host, port]
+                    errorPath: port
+                    message: 'This port is already in use on that host.'
 
     .. code-block:: xml
 

--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -19,14 +19,6 @@ Basic Usage
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/BlogBundle/Resources/config/validation.yml
-        Acme\BlogBundle\Entity\Author:
-            properties:
-                bioUrl:
-                    - Url: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/BlogBundle/Entity/Author.php
@@ -41,6 +33,14 @@ Basic Usage
              */
              protected $bioUrl;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/BlogBundle/Resources/config/validation.yml
+        Acme\BlogBundle\Entity\Author:
+            properties:
+                bioUrl:
+                    - Url: ~
 
     .. code-block:: xml
 

--- a/reference/constraints/UserPassword.rst
+++ b/reference/constraints/UserPassword.rst
@@ -39,15 +39,6 @@ password:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/UserBundle/Resources/config/validation.yml
-        Acme\UserBundle\Form\Model\ChangePassword:
-            properties:
-                oldPassword:
-                    - Symfony\Component\Security\Core\Validator\Constraints\UserPassword:
-                        message: "Wrong value for your current password"
-
     .. code-block:: php-annotations
 
         // src/Acme/UserBundle/Form/Model/ChangePassword.php
@@ -64,6 +55,15 @@ password:
              */
              protected $oldPassword;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/UserBundle/Resources/config/validation.yml
+        Acme\UserBundle\Form\Model\ChangePassword:
+            properties:
+                oldPassword:
+                    - Symfony\Component\Security\Core\Validator\Constraints\UserPassword:
+                        message: "Wrong value for your current password"
 
     .. code-block:: xml
 

--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -48,27 +48,6 @@ an ``Address`` instance in the ``$address`` property.
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/HelloBundle/Resources/config/validation.yml
-        Acme\HelloBundle\Entity\Address:
-            properties:
-                street:
-                    - NotBlank: ~
-                zipCode:
-                    - NotBlank: ~
-                    - Length:
-                        max: 5
-
-        Acme\HelloBundle\Entity\Author:
-            properties:
-                firstName:
-                    - NotBlank: ~
-                    - Length:
-                        min: 4
-                lastName:
-                    - NotBlank: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/HelloBundle/Entity/Address.php
@@ -110,6 +89,27 @@ an ``Address`` instance in the ``$address`` property.
 
             protected $address;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/HelloBundle/Resources/config/validation.yml
+        Acme\HelloBundle\Entity\Address:
+            properties:
+                street:
+                    - NotBlank: ~
+                zipCode:
+                    - NotBlank: ~
+                    - Length:
+                        max: 5
+
+        Acme\HelloBundle\Entity\Author:
+            properties:
+                firstName:
+                    - NotBlank: ~
+                    - Length:
+                        min: 4
+                lastName:
+                    - NotBlank: ~
 
     .. code-block:: xml
 
@@ -191,14 +191,6 @@ property.
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/Acme/HelloBundle/Resources/config/validation.yml
-        Acme\HelloBundle\Entity\Author:
-            properties:
-                address:
-                    - Valid: ~
-
     .. code-block:: php-annotations
 
         // src/Acme/HelloBundle/Entity/Author.php
@@ -213,6 +205,14 @@ property.
              */
             protected $address;
         }
+
+    .. code-block:: yaml
+
+        # src/Acme/HelloBundle/Resources/config/validation.yml
+        Acme\HelloBundle\Entity\Author:
+            properties:
+                address:
+                    - Valid: ~
 
     .. code-block:: xml
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

The new documentation standard for the order of code blocks in
validation contraint configurations is _Annotations_, _YAML_, _XML_,
_PHP_. This commit fixes the order of the configuration examples.
