### PR TITLE
Add missing use statement in Building Login Form doc

### DIFF
--- a/cookbook/security/form_login_setup.rst
+++ b/cookbook/security/form_login_setup.rst
@@ -81,8 +81,8 @@ bundle with an empty ``loginAction``::
     // src/AppBundle/Controller/SecurityController.php
     namespace AppBundle\Controller;
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\HttpFoundation\Request;
 
     class SecurityController extends Controller
     {


### PR DESCRIPTION
Also removed use statement for Route as it is only needed
when using annotations for routing

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #5072 |
