### PR TITLE
Removed an admonition that is no longer true for Symfony 2.6+

### DIFF
--- a/cookbook/serializer.rst
+++ b/cookbook/serializer.rst
@@ -101,11 +101,4 @@ Here is an example on how to load the
         $definition->addTag('serializer.normalizer');
         $container->setDefinition('get_set_method_normalizer', $definition);
 
-.. note::
-
-    The :class:`Symfony\\Component\\Serializer\\Normalizer\\GetSetMethodNormalizer`
-    is broken by design. As soon as you have a circular object graph, an
-    infinite loop is created when calling the getters. You're encouraged
-    to add your own normalizers that fit your use-case.
-
 .. _JMSSerializerBundle: http://jmsyst.com/bundles/JMSSerializerBundle


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.6+ |
| Fixed tickets | #5069 |

In Symfony 2.6 and newer, circular references are no longer a problem, as explained in http://symfony.com/doc/current/components/serializer.html#handling-circular-references
