### PR TITLE
[Contributing][Code] link to deciders' GitHub profiles

### DIFF
--- a/contributing/code/core_team.rst
+++ b/contributing/code/core_team.rst
@@ -37,37 +37,37 @@ Active Core Members
 
 * **Project Leader**:
 
-  * **Fabien Potencier** (:leader:`fabpot`).
+  * **Fabien Potencier** (`fabpot`_).
 
 * **Mergers** (``@symfony/mergers`` on GitHub):
 
-  * **Bernhard Schussek** (:merger:`webmozart`) can merge into the Form_,
+  * **Bernhard Schussek** (`webmozart`_) can merge into the Form_,
     Validator_, Icu_, Intl_, Locale_, OptionsResolver_ and PropertyAccess_
     components;
 
-  * **Tobias Schultze** (:merger:`Tobion`) can merge into the Routing_
+  * **Tobias Schultze** (`Tobion`_) can merge into the Routing_
     component;
 
-  * **Romain Neutron** (:merger:`romainneutron`) can merge into the
+  * **Romain Neutron** (`romainneutron`_) can merge into the
     Process_ component;
 
-  * **Nicolas Grekas** (:merger:`nicolas-grekas`) can merge into the Debug_
+  * **Nicolas Grekas** (`nicolas-grekas`_) can merge into the Debug_
     component;
 
-  * **Christophe Coevoet** (:merger:`stof`) can merge into the BrowserKit_,
+  * **Christophe Coevoet** (`stof`_) can merge into the BrowserKit_,
     Config_, Console_, DependencyInjection_, DomCrawler_, EventDispatcher_,
     HttpFoundation_, HttpKernel_, Serializer_, Stopwatch_, DoctrineBridge_,
     MonologBridge_, and TwigBridge_ components;
 
-  * **Kévin Dunglas** (:merger:`dunglas`) can merge into the Serializer_
+  * **Kévin Dunglas** (`dunglas`_) can merge into the Serializer_
     component.
 
 * **Deciders** (``@symfony/deciders`` on GitHub):
 
-  * **Jakub Zalas** (:decider:`jakzal`);
-  * **Jordi Boggiano** (:decider:`seldaek`);
-  * **Lukas Kahwe Smith** (:decider:`lsmith77`);
-  * **Ryan Weaver** (:decider:`weaverryan`).
+  * **Jakub Zalas** (`jakzal`_);
+  * **Jordi Boggiano** (`seldaek`_);
+  * **Lukas Kahwe Smith** (`lsmith77`_);
+  * **Ryan Weaver** (`weaverryan`_).
 
 Core Membership Application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -168,3 +168,14 @@ discretion of the **Project Leader**.
 .. _Stopwatch: https://github.com/symfony/Stopwatch
 .. _TwigBridge: https://github.com/symfony/TwigBridge
 .. _Validator: https://github.com/symfony/Validator
+.. _`fabpot`: https://github.com/fabpot/
+.. _`webmozart`: https://github.com/webmozart/
+.. _`Tobion`: https://github.com/Tobion/
+.. _`romainneutron`: https://github.com/romainneutron/
+.. _`nicolas-grekas`: https://github.com/nicolas-grekas/
+.. _`stof`: https://github.com/stof/
+.. _`dunglas`: https://github.com/dunglas/
+.. _`jakzal`: https://github.com/jakzal/
+.. _`Seldaek`: https://github.com/Seldaek/
+.. _`lsmith77`: https://github.com/lsmith77/
+.. _`weaverryan`: https://github.com/weaverryan/


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

I thought it would be a good idea to be able to easily access the GitHub profiles of the core team members.
