### PR TITLE
Change MySQL UTF-8 examples to use utf8mb4

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -134,6 +134,12 @@ for you:
     There's no way to configure these defaults inside Doctrine, as it tries to be
     as agnostic as possible in terms of environment configuration. One way to solve
     this problem is to configure server-level defaults.
+    
+.. caution::
+
+    If you are using MySQL, its `utf8` character set has some shortcomings 
+    which may cause problems. Prefer the `utf8mb4` character set instead, if 
+    your version supports it.
 
     Setting UTF8 defaults for MySQL is as simple as adding a few lines to
     your configuration file  (typically ``my.cnf``):
@@ -141,8 +147,8 @@ for you:
     .. code-block:: ini
 
         [mysqld]
-        collation-server = utf8_general_ci
-        character-set-server = utf8
+        collation-server = utf8mb4_general_ci
+        character-set-server = utf8mb4
 
 .. note::
 

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -134,12 +134,6 @@ for you:
     There's no way to configure these defaults inside Doctrine, as it tries to be
     as agnostic as possible in terms of environment configuration. One way to solve
     this problem is to configure server-level defaults.
-    
-    .. caution::
-
-        If you are using MySQL, its ``utf8`` character set actually only supports 
-        a portion of valid UTF-8 data that you may encounter. Instead, try to 
-        use the newer ``utf8mb4`` if your system supports it.
 
     Setting UTF8 defaults for MySQL is as simple as adding a few lines to
     your configuration file  (typically ``my.cnf``):
@@ -147,8 +141,13 @@ for you:
     .. code-block:: ini
 
         [mysqld]
-        collation-server = utf8mb4_general_ci
-        character-set-server = utf8mb4
+        # Version 5.5.3 introduced "utf8mb4", which is recommended
+        collation-server     = utf8mb4_general_ci # Replaces utf8_general_ci
+        character-set-server = utf8mb4            # Replaces utf8
+
+    We recommend against MySQL's ``utf8`` character set, since it does not
+    support 4-byte unicode characters, and strings containing them will be
+    truncated. This is fixed by the `newer utf8mb4 character set`_.
 
 .. note::
 
@@ -1425,3 +1424,4 @@ For more information about Doctrine, see the *Doctrine* section of the
 .. _`migrations`: http://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html
 .. _`DoctrineFixturesBundle`: http://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html
 .. _`FrameworkExtraBundle documentation`: http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
+.. _`newer utf8mb4 character set`: https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -137,9 +137,9 @@ for you:
     
     .. caution::
 
-        If you are using MySQL, its `utf8` character set actually only supports 
+        If you are using MySQL, its ``utf8`` character set actually only supports 
         a portion of valid UTF-8 data that you may encounter. Instead, try to 
-        use the newer `utf8mb4` if your system supports it.
+        use the newer ``utf8mb4`` if your system supports it.
 
     Setting UTF8 defaults for MySQL is as simple as adding a few lines to
     your configuration file  (typically ``my.cnf``):

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -135,11 +135,11 @@ for you:
     as agnostic as possible in terms of environment configuration. One way to solve
     this problem is to configure server-level defaults.
     
-.. caution::
+    .. caution::
 
-    If you are using MySQL, its `utf8` character set has some shortcomings 
-    which may cause problems. Prefer the `utf8mb4` character set instead, if 
-    your version supports it.
+        If you are using MySQL, its `utf8` character set actually only supports 
+        a portion of valid UTF-8 data that you may encounter. Instead, try to 
+        use the newer `utf8mb4` if your system supports it.
 
     Setting UTF8 defaults for MySQL is as simple as adding a few lines to
     your configuration file  (typically ``my.cnf``):

--- a/cookbook/profiler/data_collector.rst
+++ b/cookbook/profiler/data_collector.rst
@@ -70,12 +70,6 @@ populate the ``$this->data`` property (it takes care of serializing the
             return 'example_memory';
         }
     }
-    
-.. caution::
-
-    The string you use with `getName()` should not collide with standard data-
-    collectors, such as those within the 
-    `Symfony\Component\HttpKernel\DataCollector\` package.
 
 .. _data_collector_tag:
 

--- a/cookbook/profiler/data_collector.rst
+++ b/cookbook/profiler/data_collector.rst
@@ -70,6 +70,12 @@ populate the ``$this->data`` property (it takes care of serializing the
             return 'example_memory';
         }
     }
+    
+.. caution::
+
+    The string you use with `getName()` should not collide with standard data-
+    collectors, such as those within the 
+    `Symfony\Component\HttpKernel\DataCollector\` package.
 
 .. _data_collector_tag:
 

--- a/cookbook/profiler/data_collector.rst
+++ b/cookbook/profiler/data_collector.rst
@@ -67,7 +67,7 @@ populate the ``$this->data`` property (it takes care of serializing the
 
         public function getName()
         {
-            return 'memory';
+            return 'example_memory';
         }
     }
 

--- a/cookbook/profiler/data_collector.rst
+++ b/cookbook/profiler/data_collector.rst
@@ -67,7 +67,7 @@ populate the ``$this->data`` property (it takes care of serializing the
 
         public function getName()
         {
-            return 'example_memory';
+            return 'memory';
         }
     }
 


### PR DESCRIPTION
You might think MySQL's `utf8` is the right choice, but it's actually got some problems handling certain character inputs. The later, corrected mode of `utf8mb4` has fewer surprises.
