### PR TITLE
Removed duplicate "long"s in length constraint

### DIFF
--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -36,7 +36,7 @@ To verify that the ``firstName`` field length of a class is between "2" and
                         min: 2
                         max: 50
                         minMessage: "Your first name must be at least {{ limit }} characters long"
-                        maxMessage: "Your first name cannot be longer than {{ limit }} characters long"
+                        maxMessage: "Your first name cannot be longer than {{ limit }} characters"
 
     .. code-block:: php-annotations
 
@@ -52,7 +52,7 @@ To verify that the ``firstName`` field length of a class is between "2" and
              *      min = 2,
              *      max = 50,
              *      minMessage = "Your first name must be at least {{ limit }} characters long",
-             *      maxMessage = "Your first name cannot be longer than {{ limit }} characters long"
+             *      maxMessage = "Your first name cannot be longer than {{ limit }} characters"
              * )
              */
              protected $firstName;
@@ -72,7 +72,7 @@ To verify that the ``firstName`` field length of a class is between "2" and
                         <option name="min">2</option>
                         <option name="max">50</option>
                         <option name="minMessage">Your first name must be at least {{ limit }} characters long</option>
-                        <option name="maxMessage">Your first name cannot be longer than {{ limit }} characters long</option>
+                        <option name="maxMessage">Your first name cannot be longer than {{ limit }} characters</option>
                     </constraint>
                 </property>
             </class>
@@ -94,7 +94,7 @@ To verify that the ``firstName`` field length of a class is between "2" and
                     'min'        => 2,
                     'max'        => 50,
                     'minMessage' => 'Your first name must be at least {{ limit }} characters long',
-                    'maxMessage' => 'Your first name cannot be longer than {{ limit }} characters long',
+                    'maxMessage' => 'Your first name cannot be longer than {{ limit }} characters',
                 )));
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | [yes] |
| New docs? | [no] |
| Applies to | 2.5+ |

The maxMessage seems to have one long too many. This does apply to all maintained versions.

Alternative could be:

```
maxMessage: "Your first name cannot be more than {{ limit }} characters long"
```
