### PR TITLE
[Serializer] Fix class name

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -241,7 +241,7 @@ CamelCase to snake_case
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.7
-    The :class:`Symfony\\Component\\Serializer\\NameConverter\\CamelCaseToUnderscoreNameConverter`
+    The :class:`Symfony\\Component\\Serializer\\NameConverter\\CamelCaseToSnakeCaseNameConverter`
     interface was introduced in Symfony 2.7.
 
 In many formats, it's common to use underscores to separate words (also known


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7, master |
| Fixed tickets |  |

CamelCaseToSnakeCaseNameConverter instead of CamelCaseToUnderscoreNameConverter
