### PR TITLE
[Book] missing versionadded for expression in service_container

### DIFF
--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -623,6 +623,9 @@ the work of instantiating the classes.
 Using the Expression Language
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 2.4
+    The Expression Language functionality was introduced in Symfony 2.4.
+
 The service container also supports an "expression" that allows you to inject
 very specific values into a service.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.4 and up |
| Fixed tickets |  |

The versionadded for expression support is present in the 2.4 and 2.5 but not in 2.6, git tells the branch is up to date. So I have no idea whats wrong :) 
