### PR TITLE
Flesh out twig-template for custom data-collector

### DIFF
--- a/cookbook/profiler/data_collector.rst
+++ b/cookbook/profiler/data_collector.rst
@@ -106,27 +106,51 @@ Adding Web Profiler Templates
 -----------------------------
 
 When you want to display the data collected by your data collector in the web
-debug toolbar or the web profiler, create a Twig template following this
-skeleton:
+debug toolbar or the web profiler, you will need to create a Twig template. The
+following example can help you get started:
 
 .. code-block:: jinja
 
     {% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
-
+    
     {% block toolbar %}
-        {# the web debug toolbar content #}
+        {# Used for the menu items along the bottom of the screen. #}
+        {% set icon %}
+        <span class="icon"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAcCAQAAADVGmdYAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQffAxkBCDStonIVAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAHpJREFUOMtj3PWfgXRAuqZd/5nIsIdhVBPFmgqIjCuYOrJsYtz1fxuUOYER2TQID8afwIiQ8YIkI4TzCv5D2AgaWSuExJKMIDbA7EEVhQEWXJ6FKUY4D48m7HYU/EcWZ8JlE6qfMELPDcUJuEMPxvYazYTDWRMjOcUyAEswO+VjeQQaAAAAAElFTkSuQmCC" alt=""/></span>
+        <span class="sf-toolbar-status">Example</span>
+        {% endset %}
+    
+        {% set text %}
+        <div class="sf-toolbar-info-piece">
+            <b>Quick roll-over</b>
+            <b>info here</b>
+        </div>
+        {% endset %}
+    
+        {# Omit this next line if you do not have a "panel" section #}
+        {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': true } %}
+    
     {% endblock %}
-
+    
     {% block head %}
-        {# if the web profiler panel needs some specific JS or CSS files #}
+        {# Optional, if you need your own JS or CSS files. #} 
+        {{ parent() }} {# Use parent() to keep the default styles #}        
     {% endblock %}
-
+    
     {% block menu %}
-        {# the menu content #}
+        {# The left-hand menu content when looking at profiler data. #}
+        <span class="label">
+            <span class="icon"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAcCAQAAADVGmdYAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQffAxkBCDStonIVAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAHpJREFUOMtj3PWfgXRAuqZd/5nIsIdhVBPFmgqIjCuYOrJsYtz1fxuUOYER2TQID8afwIiQ8YIkI4TzCv5D2AgaWSuExJKMIDbA7EEVhQEWXJ6FKUY4D48m7HYU/EcWZ8JlE6qfMELPDcUJuEMPxvYazYTDWRMjOcUyAEswO+VjeQQaAAAAAElFTkSuQmCC" alt=""/></span>
+            <strong>Example Collector</strong>
+        </span>
     {% endblock %}
-
+    
     {% block panel %}
-        {# the panel content #}
+        {# Optional, for showing the most details. #} 
+        <h2>Example</h2>
+        <p>
+            <em>Major information goes here</em>
+        </p>
     {% endblock %}
 
 Each block is optional. The ``toolbar`` block is used for the web debug

--- a/cookbook/profiler/data_collector.rst
+++ b/cookbook/profiler/data_collector.rst
@@ -114,7 +114,7 @@ following example can help you get started:
     {% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
     
     {% block toolbar %}
-        {# Used for the menu items along the bottom of the screen. #}
+        {# This toolbar item may appear along the top or bottom of the screen.#}
         {% set icon %}
         <span class="icon"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAcCAQAAADVGmdYAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQffAxkBCDStonIVAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAHpJREFUOMtj3PWfgXRAuqZd/5nIsIdhVBPFmgqIjCuYOrJsYtz1fxuUOYER2TQID8afwIiQ8YIkI4TzCv5D2AgaWSuExJKMIDbA7EEVhQEWXJ6FKUY4D48m7HYU/EcWZ8JlE6qfMELPDcUJuEMPxvYazYTDWRMjOcUyAEswO+VjeQQaAAAAAElFTkSuQmCC" alt=""/></span>
         <span class="sf-toolbar-status">Example</span>
@@ -122,12 +122,17 @@ following example can help you get started:
     
         {% set text %}
         <div class="sf-toolbar-info-piece">
-            <b>Quick roll-over</b>
-            <b>info here</b>
+            <b>Quick piece of data</b>
+            <span>100 units</div>
+        </div>
+        <div class="sf-toolbar-info-piece">
+            <b>Another quick thing</b>
+            <span>300 units</div>
         </div>
         {% endset %}
     
-        {# Omit this next line if you do not have a "panel" section #}
+        {# Set the "link" value to false if you do not have a big "panel" 
+           section that you want to direct the user to. #}
         {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': true } %}
     
     {% endblock %}
@@ -138,7 +143,7 @@ following example can help you get started:
     {% endblock %}
     
     {% block menu %}
-        {# The left-hand menu content when looking at profiler data. #}
+        {# This left-hand menu appears when using the full-screen profiler. #}
         <span class="label">
             <span class="icon"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAcCAQAAADVGmdYAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQffAxkBCDStonIVAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAHpJREFUOMtj3PWfgXRAuqZd/5nIsIdhVBPFmgqIjCuYOrJsYtz1fxuUOYER2TQID8afwIiQ8YIkI4TzCv5D2AgaWSuExJKMIDbA7EEVhQEWXJ6FKUY4D48m7HYU/EcWZ8JlE6qfMELPDcUJuEMPxvYazYTDWRMjOcUyAEswO+VjeQQaAAAAAElFTkSuQmCC" alt=""/></span>
             <strong>Example Collector</strong>

--- a/cookbook/profiler/data_collector.rst
+++ b/cookbook/profiler/data_collector.rst
@@ -112,14 +112,14 @@ following example can help you get started:
 .. code-block:: jinja
 
     {% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
-    
+
     {% block toolbar %}
         {# This toolbar item may appear along the top or bottom of the screen.#}
         {% set icon %}
         <span class="icon"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAcCAQAAADVGmdYAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQffAxkBCDStonIVAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAHpJREFUOMtj3PWfgXRAuqZd/5nIsIdhVBPFmgqIjCuYOrJsYtz1fxuUOYER2TQID8afwIiQ8YIkI4TzCv5D2AgaWSuExJKMIDbA7EEVhQEWXJ6FKUY4D48m7HYU/EcWZ8JlE6qfMELPDcUJuEMPxvYazYTDWRMjOcUyAEswO+VjeQQaAAAAAElFTkSuQmCC" alt=""/></span>
         <span class="sf-toolbar-status">Example</span>
         {% endset %}
-    
+
         {% set text %}
         <div class="sf-toolbar-info-piece">
             <b>Quick piece of data</b>
@@ -130,18 +130,18 @@ following example can help you get started:
             <span>300 units</div>
         </div>
         {% endset %}
-    
+
         {# Set the "link" value to false if you do not have a big "panel" 
            section that you want to direct the user to. #}
         {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': true } %}
-    
+
     {% endblock %}
-    
+
     {% block head %}
         {# Optional, if you need your own JS or CSS files. #} 
         {{ parent() }} {# Use parent() to keep the default styles #}        
     {% endblock %}
-    
+
     {% block menu %}
         {# This left-hand menu appears when using the full-screen profiler. #}
         <span class="label">
@@ -149,7 +149,7 @@ following example can help you get started:
             <strong>Example Collector</strong>
         </span>
     {% endblock %}
-    
+
     {% block panel %}
         {# Optional, for showing the most details. #} 
         <h2>Example</h2>


### PR DESCRIPTION
I think this template will make it easier for people to get started, since it demonstrates a greater range of visual features. 

Users less-experienced in twig may have problems with the old skeleton, since it removes the default CSS styles when visiting the main panel. Adding `{{parent()}}` to the `head` block makes it friendlier.
