### PR TITLE
As per twigphp/Twig#472, automatic escaping is not yet available

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -135,10 +135,10 @@ Throughout this chapter, template examples will be shown in both Twig and PHP.
     web designers everywhere.
 
     Twig can also do things that PHP can't, such as whitespace control,
-    sandboxing, manual contextual output escaping, and the inclusion of
-    custom functions and filters that only affect templates. Twig contains
-    little features that make writing templates easier and more concise. Take
-    the following example, which combines a loop with a logical ``if``
+    sandboxing, automatic HTML escaping, manual contextual output escaping, 
+    and the inclusion of custom functions and filters that only affect templates.
+    Twig contains little features that make writing templates easier and more concise.
+    Take the following example, which combines a loop with a logical ``if``
     statement:
 
     .. code-block:: html+jinja

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -135,7 +135,7 @@ Throughout this chapter, template examples will be shown in both Twig and PHP.
     web designers everywhere.
 
     Twig can also do things that PHP can't, such as whitespace control,
-    sandboxing, automatic and contextual output escaping, and the inclusion of
+    sandboxing, manual contextual output escaping, and the inclusion of
     custom functions and filters that only affect templates. Twig contains
     little features that make writing templates easier and more concise. Take
     the following example, which combines a loop with a logical ``if``


### PR DESCRIPTION
While it would be a cool feature, it is also impossible to apply automatic escaping in most cases.
Advertising this as a out-of-the-box feature is problematic, as it probably mislead multiple developers
that are using the tool without applying proper contextual escaping.

Ref: twigphp/Twig#472
