### PR TITLE
Fix a typo in ProgressBar usage example

### DIFF
--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -320,4 +320,4 @@ your own::
 For the ``filename`` to be part of the progress bar, just add the
 ``%filename%`` placeholder in your format::
 
-    $bar->setFormat(" %message%\n %step%/%max%\n Working on %filename%");
+    $bar->setFormat(" %message%\n %current%/%max%\n Working on %filename%");


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5+ |
| Fixed tickets | #5125 |

Docs say `%step%` while the context suggests `%current%` -- looks like a typo.
