### PR TITLE
Fix to Twig asset function packageName argument

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -110,7 +110,7 @@ asset
 ``path``
     **type**: ``string``
 ``packageName``
-    **type**: ``string``|``null`` **default**: ``null``
+    **type**: ``string`` | ``null`` **default**: ``null``
 ``absolute``
     **type**: ``boolean`` **default**: ``false``
 ``version``


### PR DESCRIPTION
Having no spaces surrounding `|` was causing the argument description to appear as
    **type**: `string ``|`` null` **default**: `null`

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5+ |
| Fixed tickets |  |
