### PR TITLE
[Components][DependencyInjection] fix wrong disable of factories

### DIFF
--- a/components/dependency_injection/factories.rst
+++ b/components/dependency_injection/factories.rst
@@ -4,11 +4,6 @@
 Using a Factory to Create Services
 ==================================
 
-.. versionadded:: 2.6
-    The new :method:`Symfony\\Component\\DependencyInjection\\Definition::setFactory`
-    method was introduced in Symfony 2.6. Refer to older versions for the
-    syntax for factories prior to 2.6.
-
 Symfony's Service Container provides a powerful way of controlling the
 creation of objects, allowing you to specify arguments passed to the constructor
 as well as calling methods and setting parameters. Sometimes, however, this
@@ -16,6 +11,11 @@ will not provide you with everything you need to construct your objects.
 For this situation, you can use a factory to create the object and tell the
 service container to call a method on the factory rather than directly instantiating
 the class.
+
+.. versionadded:: 2.6
+    The new :method:`Symfony\\Component\\DependencyInjection\\Definition::setFactory`
+    method was introduced in Symfony 2.6. Refer to older versions for the
+    syntax for factories prior to 2.6.
 
 Suppose you have a factory that configures and returns a new ``NewsletterManager``
 object::


### PR DESCRIPTION
Move the `versionadded` below the description to fix the rendering.
See http://symfony.com/doc/current/components/dependency_injection/factories.html there is a big whitespace gap.

![symfony-doc-misrendering](https://cloud.githubusercontent.com/assets/904790/6941202/f78dae26-d87d-11e4-944d-ddce95e121e7.png)
