### PR TITLE
[Form] Replaced "form_widget" by "form_row" in collection example

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -160,7 +160,7 @@ you need is the JavaScript:
             {# ... #}
 
             {# store the prototype on the data-prototype attribute #}
-            <ul id="email-fields-list" data-prototype="{{ form_widget(form.emails.vars.prototype)|e }}">
+            <ul id="email-fields-list" data-prototype="{{ form_row(form.emails.vars.prototype)|e }}">
             {% for emailField in form.emails %}
                 <li>
                     {{ form_errors(emailField) }}


### PR DESCRIPTION
Hi,

In the Form reference documentation, for the `collection` field, an example is given about rendering the prototype.
But `form_widget`Twig function is used instead of `form_row`. This is a bad advice in my opinion, as rendered HTML is then different than the one for an already here field. In example, we will be missing the label.

The small fix change the function used.
