### PR TITLE
[Cookbook][Forms] Add how to generic form type extension

### DIFF
--- a/cookbook/form/create_form_type_extension.rst
+++ b/cookbook/form/create_form_type_extension.rst
@@ -129,6 +129,9 @@ The ``alias`` key of the tag is the type of field that this extension should
 be applied to. In your case, as you want to extend the ``file`` field type,
 you will use ``file`` as an alias.
 
+If you want to apply the extension to all field types, you can specify ``form``
+as alias and value returned by ``getExtendedType()``.
+
 Adding the extension Business Logic
 -----------------------------------
 


### PR DESCRIPTION
I spent almost 15 minutes trying to find how to create a generic Form Type Extension.

I found the doc in http://symfony.com/doc/current/reference/dic_tags.html#form-type-extension and http://stackoverflow.com/questions/24307849/how-to-overwrite-all-symfony2-form-types-and-add-some-property-in-version-2-2 (in which a comment specifies the answer for Symfony 2.3+)

The cookbook article mentions it's possible, but not how to do it.
This PR aims to add the information directly in the cookbook article in order to make it easier to find.
