### PR TITLE
Add version 2.8 to the release roadmap

### DIFF
--- a/contributing/community/releases.rst
+++ b/contributing/community/releases.rst
@@ -98,7 +98,8 @@ Version  Feature Freeze  Release  End of Maintenance        End of Life
 2.4      09/2013         11/2013  09/2014 (10 months [1]_)  01/2015
 2.5      03/2014         05/2014  01/2015 (8 months)        07/2015
 2.6      09/2014         11/2014  07/2015 (8 months)        01/2016
-**2.7**  03/2015         05/2015  05/2018 (36 months [2]_)  05/2019
+**2.7**  03/2015         05/2015  05/2018 (36 months)       05/2019
+**2.8**  09/2015         11/2015  11/2018 (36 months [2]_)  11/2019
 3.0      09/2015         11/2015  07/2016 (8 months)        01/2017
 3.1      03/2016         05/2016  01/2017 (8 months)        07/2017
 3.2      09/2016         11/2016  07/2017 (8 months)        01/2018
@@ -107,7 +108,7 @@ Version  Feature Freeze  Release  End of Maintenance        End of Life
 =======  ==============  =======  ========================  ===========
 
 .. [1] Symfony 2.4 maintenance has been `extended to September 2014`_.
-.. [2] Symfony 2.7 is the last version of the Symfony 2.x branch.
+.. [2] Symfony 2.8 is the last version of the Symfony 2.x branch.
 
 .. tip::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | [yes] |
| New docs? | [no] |
| Applies to | [Release roadmap] |
| Fixed tickets | [N/A] |

Following the announced published at http://symfony.com/blog/transition-from-symfony-2-7-to-3-0-symfony-2-8-on-its-way

> Symfony 2.8 will be released in November 2015 at the same time as Symfony 3.0. Symfony 2.8 is going to be a LTS release as well to allow people to still have a year to upgrade from 2.8 to 3.2 when it comes out (3.2 being the next LTS release and the first one of the 3.x branch).
