### PR TITLE
Update web_server_configuration.rst

### DIFF
--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -88,6 +88,7 @@ following configuration snippet:
             # enable the .htaccess rewrites
             AllowOverride All
             Require all granted
+            Allow from All
         </Directory>
 
 .. _web-server-apache-fpm:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

On the "Apache 2.4" caution, the "Allow from All" is removed. It shouldn't.
