### PR TITLE
Use $this->getRootDir() instead of __DIR__

### DIFF
--- a/cookbook/configuration/environments.rst
+++ b/cookbook/configuration/environments.rst
@@ -45,7 +45,7 @@ class:
 
         public function registerContainerConfiguration(LoaderInterface $loader)
         {
-            $loader->load(__DIR__.'/config/config_'.$this->getEnvironment().'.yml');
+            $loader->load($this->getRootDir().'/config/config_'.$this->getEnvironment().'.yml');
         }
     }
 


### PR DESCRIPTION
Use $this->getRootDir() when loading the configuration file from AppKernel. 

Symfony standard version uses $this->getRootDir() so we should have the same version on both sites.
