### PR TITLE
Cookbook/Security/Entity_Provider join wasn't passing UserInterface

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -240,7 +240,7 @@ the username and then check the password (more on passwords in a moment):
             <firewall name="default" pattern="^/" provider="our_db_provider">
                 <http-basic />
             </firewall>
-            
+
             <!-- ... -->
         </config>
 
@@ -474,7 +474,7 @@ For more details on these methods, see :class:`Symfony\\Component\\Security\\Cor
 
 .. tip::
 
-    Don't forget to add the repository class to the 
+    Don't forget to add the repository class to the
     :ref:`mapping definition of your entity <book-doctrine-custom-repository-classes>`.
 
 To finish this, just remove the ``property`` key from the user provider in
@@ -720,7 +720,8 @@ fetch the user and their associated roles with a single query::
                 ->where('u.username = :username OR u.email = :email')
                 ->setParameter('username', $username)
                 ->setParameter('email', $username)
-                ->getQuery();
+                ->getQuery()
+                ->getOneOrNullResult();
 
             // ...
         }


### PR DESCRIPTION
The join towards the bottom of the page was returning a Doctrine Query object instead of a User object. Adding the `getOneOrNullResult()` allows it to pass the User object implementing UserInterface.

Also, it looks like my IDE striped some unnecessary whitespace.
