### PR TITLE
Change '.xliff' extensions to '.xlf'

### DIFF
--- a/best_practices/i18n.rst
+++ b/best_practices/i18n.rst
@@ -80,7 +80,7 @@ English in the application would be:
 
 .. code-block:: xml
 
-    <!-- app/Resources/translations/messages.en.xliff -->
+    <!-- app/Resources/translations/messages.en.xlf -->
     <?xml version="1.0"?>
     <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
         <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -127,7 +127,7 @@ different formats, XLIFF being the recommended format:
 
     .. code-block:: xml
 
-        <!-- messages.fr.xliff -->
+        <!-- messages.fr.xlf -->
         <?xml version="1.0"?>
         <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
             <file source-language="en" datatype="plaintext" original="file.ext">
@@ -359,18 +359,18 @@ must be named according to the following path: ``domain.locale.loader``:
 
 * **locale**: The locale that the translations are for (e.g. ``en_GB``, ``en``, etc);
 
-* **loader**: How Symfony should load and parse the file (e.g. ``xliff``,
+* **loader**: How Symfony should load and parse the file (e.g. ``xlf``,
   ``php``, ``yml``, etc).
 
 The loader can be the name of any registered loader. By default, Symfony
 provides many loaders, including:
 
-* ``xliff``: XLIFF file;
+* ``xlf``: XLIFF file;
 * ``php``: PHP file;
 * ``yml``: YAML file.
 
 The choice of which loader to use is entirely up to you and is a matter of
-taste. The recommended option is to use ``xliff`` for translations.
+taste. The recommended option is to use ``xlf`` for translations.
 For more options, see :ref:`component-translator-message-catalogs`.
 
 .. note::
@@ -400,10 +400,10 @@ key ``Symfony is great``. To find the French translation, Symfony actually
 checks translation resources for several locales:
 
 #. First, Symfony looks for the translation in a ``fr_FR`` translation resource
-   (e.g. ``messages.fr_FR.xliff``);
+   (e.g. ``messages.fr_FR.xlf``);
 
 #. If it wasn't found, Symfony looks for the translation in a ``fr`` translation
-   resource (e.g. ``messages.fr.xliff``);
+   resource (e.g. ``messages.fr.xlf``);
 
 #. If the translation still isn't found, Symfony uses the ``fallbacks`` configuration
    parameter, which defaults to ``en`` (see `Configuration`_).
@@ -661,7 +661,7 @@ bundle.
 
     .. code-block:: xml
 
-        <!-- validators.en.xliff -->
+        <!-- validators.en.xlf -->
         <?xml version="1.0"?>
         <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
             <file source-language="en" datatype="plaintext" original="file.ext">

--- a/components/translation/introduction.rst
+++ b/components/translation/introduction.rst
@@ -188,13 +188,13 @@ organization, translations were split into three different domains:
 loaded like this::
 
     // ...
-    $translator->addLoader('xliff', new XliffFileLoader());
+    $translator->addLoader('xlf', new XliffFileLoader());
 
-    $translator->addResource('xliff', 'messages.fr.xliff', 'fr_FR');
-    $translator->addResource('xliff', 'admin.fr.xliff', 'fr_FR', 'admin');
+    $translator->addResource('xlf', 'messages.fr.xlf', 'fr_FR');
+    $translator->addResource('xlf', 'admin.fr.xlf', 'fr_FR', 'admin');
     $translator->addResource(
-        'xliff',
-        'navigation.fr.xliff',
+        'xlf',
+        'navigation.fr.xlf',
         'fr_FR',
         'navigation'
     );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets |  |

I'm not committed to this PR, since I prefer `.xliff` over `.xlf` extension personally, but when calling `app/console translation:update --output-format xlf en --force` you get a `app/Resources/translations/messages.en.xlf` file and this is especially bad if you already have an equivalent `.xliff` file. In addition `.xlf` is the default extension for distributed translations since https://github.com/symfony/symfony/commit/2cb6260 and `XliffFileDumper` uses the `xlf` extension. So I think it is more consistent to show `.xlf` files in the doc.
