### PR TITLE
Fix priority range values for event listeners.

### DIFF
--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -56,7 +56,7 @@ event is just one of the core kernel events::
     Each event receives a slightly different type of ``$event`` object. For
     the ``kernel.exception`` event, it is :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent`.
     To see what type of object each event listener receives, see :class:`Symfony\\Component\\HttpKernel\\KernelEvents`.
-10
+
 .. note::
 
     When setting a response for the ``kernel.request``, ``kernel.view`` or

--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -56,7 +56,7 @@ event is just one of the core kernel events::
     Each event receives a slightly different type of ``$event`` object. For
     the ``kernel.exception`` event, it is :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent`.
     To see what type of object each event listener receives, see :class:`Symfony\\Component\\HttpKernel\\KernelEvents`.
-
+10
 .. note::
 
     When setting a response for the ``kernel.request``, ``kernel.view`` or
@@ -96,9 +96,8 @@ using a special "tag":
 .. note::
 
     There is an additional tag option ``priority`` that is optional and defaults
-    to 0. This value can be from -1024 to 1024, and the listeners will be executed
-    in the order of their priority (highest to lowest). This is useful when
-    you need to guarantee that one listener is executed before another.
+    to 0. The listeners will be executed in the order of their priority (highest to lowest).
+    This is useful when you need to guarantee that one listener is executed before another.
 
 Request Events, Checking Types
 ------------------------------

--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -96,7 +96,7 @@ using a special "tag":
 .. note::
 
     There is an additional tag option ``priority`` that is optional and defaults
-    to 0. This value can be from -255 to 255, and the listeners will be executed
+    to 0. This value can be from -1024 to 1024, and the listeners will be executed
     in the order of their priority (highest to lowest). This is useful when
     you need to guarantee that one listener is executed before another.
 


### PR DESCRIPTION
According to http://symfony.com/doc/master/reference/dic_tags.html, priority range is from -1024 to +1024.
