### PR TITLE
Add missing caching drivers

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -294,8 +294,8 @@ certain classes, but those are for very advanced use-cases only.
 Caching Drivers
 ~~~~~~~~~~~~~~~
 
-For the caching drivers you can specify the values "array", "apc", "memcache",
-"memcached", "xcache" or "service".
+For the caching drivers you can specify the values ``array``, ``apc``, ``memcache``,
+``memcached``, ``redis``, ``wincache``, ``zenddata``, ``xcache`` or ``service``.
 
 The following example shows an overview of the caching configurations:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | 2.3 and above |

https://github.com/symfony/symfony/blob/2.3/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php#L305
