### PR TITLE
Order has one param without spaces

### DIFF
--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -45,7 +45,7 @@ The **minimum configuration** to get your application running under Apache is:
         DocumentRoot /var/www/project/web
         <Directory /var/www/project/web>
             AllowOverride All
-            Order allow, deny
+            Order allow,deny
             Allow from All
         </Directory>
 
@@ -76,7 +76,7 @@ and increase web server performance:
         DocumentRoot /var/www/project/web
         <Directory /var/www/project/web>
             AllowOverride None
-            Order allow, deny
+            Order allow,deny
             Allow from All
 
             <IfModule mod_rewrite.c>
@@ -223,7 +223,7 @@ should look something like this:
         <Directory /var/www/project/web>
             # enable the .htaccess rewrites
             AllowOverride All
-            Order allow, deny
+            Order allow,deny
             Allow from all
         </Directory>
 

--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -45,7 +45,7 @@ The **minimum configuration** to get your application running under Apache is:
         DocumentRoot /var/www/project/web
         <Directory /var/www/project/web>
             AllowOverride All
-            Order allow,deny
+            Order Allow,Deny
             Allow from All
         </Directory>
 
@@ -76,7 +76,7 @@ and increase web server performance:
         DocumentRoot /var/www/project/web
         <Directory /var/www/project/web>
             AllowOverride None
-            Order allow,deny
+            Order Allow,Deny
             Allow from All
 
             <IfModule mod_rewrite.c>
@@ -110,7 +110,7 @@ and increase web server performance:
 Using mod_php/PHP-CGI with Apache 2.4
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In Apache 2.4, ``Order allow,deny`` has been replaced by ``Require all granted``.
+In Apache 2.4, ``Order Allow,Deny`` has been replaced by ``Require all granted``.
 Hence, you need to modify your ``Directory`` permission settings as follows:
 
 .. code-block:: apache
@@ -223,7 +223,7 @@ should look something like this:
         <Directory /var/www/project/web>
             # enable the .htaccess rewrites
             AllowOverride All
-            Order allow,deny
+            Order Allow,Deny
             Allow from all
         </Directory>
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | none |

from http://httpd.apache.org/docs/current/mod/mod_access_compat.html#order
"Ordering is one of:

Allow,Deny
First, all Allow directives are evaluated; at least one must match, or the request is rejected. Next, all Deny directives are evaluated. If any matches, the request is rejected. Last, any requests which do not match an Allow or a Deny directive are denied by default.

Deny,Allow
First, all Deny directives are evaluated; if any match, the request is denied unless it also matches an Allow directive. Any requests which do not match any Allow or Deny directives are permitted.

Mutual-failure
This order has the same effect as Order Allow,Deny and is deprecated in its favor."
