### PR TITLE
[RFC] Proposal to improve the names of the listeners/subscribers methods

### DIFF
--- a/cookbook/event_dispatcher/before_after_filters.rst
+++ b/cookbook/event_dispatcher/before_after_filters.rst
@@ -120,7 +120,7 @@ event listeners, you can learn more about them at :doc:`/cookbook/service_contai
             $this->tokens = $tokens;
         }
 
-        public function onKernelController(FilterControllerEvent $event)
+        public function verifyToken(FilterControllerEvent $event)
         {
             $controller = $event->getController();
 
@@ -159,14 +159,14 @@ your listener to be called just before any controller is executed.
                 class: AppBundle\EventListener\TokenListener
                 arguments: ["%tokens%"]
                 tags:
-                    - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
+                    - { name: kernel.event_listener, event: kernel.controller, method: verifyToken }
 
     .. code-block:: xml
 
         <!-- app/config/services.xml -->
         <service id="app.tokens.action_listener" class="AppBundle\EventListener\TokenListener">
             <argument>%tokens%</argument>
-            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" />
+            <tag name="kernel.event_listener" event="kernel.controller" method="verifyToken" />
         </service>
 
     .. code-block:: php
@@ -177,7 +177,7 @@ your listener to be called just before any controller is executed.
         $listener = new Definition('AppBundle\EventListener\TokenListener', array('%tokens%'));
         $listener->addTag('kernel.event_listener', array(
             'event'  => 'kernel.controller',
-            'method' => 'onKernelController'
+            'method' => 'verifyToken'
         ));
         $container->setDefinition('app.tokens.action_listener', $listener);
 

--- a/cookbook/event_dispatcher/before_after_filters.rst
+++ b/cookbook/event_dispatcher/before_after_filters.rst
@@ -120,7 +120,7 @@ event listeners, you can learn more about them at :doc:`/cookbook/service_contai
             $this->tokens = $tokens;
         }
 
-        public function verifyToken(FilterControllerEvent $event)
+        public function onKernelController(FilterControllerEvent $event)
         {
             $controller = $event->getController();
 
@@ -159,14 +159,14 @@ your listener to be called just before any controller is executed.
                 class: AppBundle\EventListener\TokenListener
                 arguments: ["%tokens%"]
                 tags:
-                    - { name: kernel.event_listener, event: kernel.controller, method: verifyToken }
+                    - { name: kernel.event_listener, event: kernel.controller }
 
     .. code-block:: xml
 
         <!-- app/config/services.xml -->
         <service id="app.tokens.action_listener" class="AppBundle\EventListener\TokenListener">
             <argument>%tokens%</argument>
-            <tag name="kernel.event_listener" event="kernel.controller" method="verifyToken" />
+            <tag name="kernel.event_listener" event="kernel.controller" />
         </service>
 
     .. code-block:: php
@@ -176,8 +176,7 @@ your listener to be called just before any controller is executed.
 
         $listener = new Definition('AppBundle\EventListener\TokenListener', array('%tokens%'));
         $listener->addTag('kernel.event_listener', array(
-            'event'  => 'kernel.controller',
-            'method' => 'verifyToken'
+            'event' => 'kernel.controller',
         ));
         $container->setDefinition('app.tokens.action_listener', $listener);
 
@@ -254,16 +253,16 @@ event:
                 class: AppBundle\EventListener\TokenListener
                 arguments: ["%tokens%"]
                 tags:
-                    - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
-                    - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
+                    - { name: kernel.event_listener, event: kernel.controller }
+                    - { name: kernel.event_listener, event: kernel.response }
 
     .. code-block:: xml
 
         <!-- app/config/services.xml -->
         <service id="app.tokens.action_listener" class="AppBundle\EventListener\TokenListener">
             <argument>%tokens%</argument>
-            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" />
-            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
+            <tag name="kernel.event_listener" event="kernel.controller" />
+            <tag name="kernel.event_listener" event="kernel.response" />
         </service>
 
     .. code-block:: php
@@ -273,12 +272,10 @@ event:
 
         $listener = new Definition('AppBundle\EventListener\TokenListener', array('%tokens%'));
         $listener->addTag('kernel.event_listener', array(
-            'event'  => 'kernel.controller',
-            'method' => 'onKernelController'
+            'event' => 'kernel.controller',
         ));
         $listener->addTag('kernel.event_listener', array(
-            'event'  => 'kernel.response',
-            'method' => 'onKernelResponse'
+            'event' => 'kernel.response',
         ));
         $container->setDefinition('app.tokens.action_listener', $listener);
 

--- a/cookbook/request/mime_type.rst
+++ b/cookbook/request/mime_type.rst
@@ -16,7 +16,7 @@ easily be added. This document will show how you can add the ``jsonp`` format
 and corresponding MIME type.
 
 Create a ``kernel.request`` Listener
--------------------------------------
+------------------------------------
 
 The key to defining a new MIME type is to create a class that will "listen" to
 the ``kernel.request`` event dispatched by the Symfony kernel. The
@@ -34,7 +34,7 @@ project::
 
     class RequestListener
     {
-        public function onKernelRequest(GetResponseEvent $event)
+        public function registerMimeType(GetResponseEvent $event)
         {
             $event->getRequest()->setFormat('jsonp', 'application/javascript');
         }
@@ -55,7 +55,7 @@ files and register it as a listener by adding the ``kernel.event_listener`` tag:
             app.listener.request:
                 class: AppBundle\EventListener\RequestListener
                 tags:
-                    - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+                    - { name: kernel.event_listener, event: kernel.request, method: registerMimeType }
 
     .. code-block:: xml
 
@@ -69,7 +69,7 @@ files and register it as a listener by adding the ``kernel.event_listener`` tag:
                     class="AppBundle\EventListener\RequestListener">
                     <tag name="kernel.event_listener"
                         event="kernel.request"
-                        method="onKernelRequest"
+                        method="registerMimeType"
                     />
                 </service>
             </services>
@@ -81,7 +81,7 @@ files and register it as a listener by adding the ``kernel.event_listener`` tag:
         $definition = new Definition('AppBundle\EventListener\RequestListener');
         $definition->addTag('kernel.event_listener', array(
             'event'  => 'kernel.request',
-            'method' => 'onKernelRequest',
+            'method' => 'registerMimeType',
         ));
         $container->setDefinition('app.listener.request', $definition);
 

--- a/cookbook/request/mime_type.rst
+++ b/cookbook/request/mime_type.rst
@@ -34,7 +34,7 @@ project::
 
     class RequestListener
     {
-        public function registerMimeType(GetResponseEvent $event)
+        public function onKernelRequest(GetResponseEvent $event)
         {
             $event->getRequest()->setFormat('jsonp', 'application/javascript');
         }
@@ -55,7 +55,7 @@ files and register it as a listener by adding the ``kernel.event_listener`` tag:
             app.listener.request:
                 class: AppBundle\EventListener\RequestListener
                 tags:
-                    - { name: kernel.event_listener, event: kernel.request, method: registerMimeType }
+                    - { name: kernel.event_listener, event: kernel.request }
 
     .. code-block:: xml
 
@@ -67,10 +67,7 @@ files and register it as a listener by adding the ``kernel.event_listener`` tag:
             <services>
                 <service id="app.listener.request"
                     class="AppBundle\EventListener\RequestListener">
-                    <tag name="kernel.event_listener"
-                        event="kernel.request"
-                        method="registerMimeType"
-                    />
+                    <tag name="kernel.event_listener" event="kernel.request" />
                 </service>
             </services>
         </container>
@@ -80,8 +77,7 @@ files and register it as a listener by adding the ``kernel.event_listener`` tag:
         # app/config/services.php
         $definition = new Definition('AppBundle\EventListener\RequestListener');
         $definition->addTag('kernel.event_listener', array(
-            'event'  => 'kernel.request',
-            'method' => 'registerMimeType',
+            'event' => 'kernel.request',
         ));
         $container->setDefinition('app.listener.request', $definition);
 

--- a/cookbook/service_container/event_listener.rst
+++ b/cookbook/service_container/event_listener.rst
@@ -76,13 +76,13 @@ using a special "tag":
             kernel.listener.your_listener_name:
                 class: AppBundle\EventListener\AcmeExceptionListener
                 tags:
-                    - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
+                    - { name: kernel.event_listener, event: kernel.exception }
 
     .. code-block:: xml
 
         <!-- app/config/services.xml -->
         <service id="kernel.listener.your_listener_name" class="AppBundle\EventListener\AcmeExceptionListener">
-            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
+            <tag name="kernel.event_listener" event="kernel.exception" />
         </service>
 
     .. code-block:: php
@@ -90,8 +90,44 @@ using a special "tag":
         // app/config/services.php
         $container
             ->register('kernel.listener.your_listener_name', 'AppBundle\EventListener\AcmeExceptionListener')
-            ->addTag('kernel.event_listener', array('event' => 'kernel.exception', 'method' => 'onKernelException'))
+            ->addTag('kernel.event_listener', array('event' => 'kernel.exception'))
         ;
+
+.. note::
+
+    By default, when a listener is executed by a dispatched event, Symfony executes
+    the ``'on'.camelize($eventName)`` method of your listener. In the example above,
+    the event is named ``kernel.exception``, so the method to execute is
+    ``onKernelException()``.
+
+    In case you want to define more semantic method names, configure the method
+    name with the ``method`` option:
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # app/config/services.yml
+            services:
+                kernel.listener.your_listener_name:
+                    class: AppBundle\EventListener\AcmeExceptionListener
+                    tags:
+                        - { name: kernel.event_listener, event: kernel.exception, method: handleErrors }
+
+        .. code-block:: xml
+
+            <!-- app/config/services.xml -->
+            <service id="kernel.listener.your_listener_name" class="AppBundle\EventListener\AcmeExceptionListener">
+                <tag name="kernel.event_listener" event="kernel.exception" method="handleErrors" />
+            </service>
+
+        .. code-block:: php
+
+            // app/config/services.php
+            $container
+                ->register('kernel.listener.your_listener_name', 'AppBundle\EventListener\AcmeExceptionListener')
+                ->addTag('kernel.event_listener', array('event' => 'kernel.exception', 'method' => 'handleErrors'))
+            ;
 
 .. note::
 

--- a/cookbook/session/locale_sticky_session.rst
+++ b/cookbook/session/locale_sticky_session.rst
@@ -35,7 +35,7 @@ how you determine the desired locale from the request::
             $this->defaultLocale = $defaultLocale;
         }
 
-        public function setLocale(GetResponseEvent $event)
+        public function onKernelRequest(GetResponseEvent $event)
         {
             $request = $event->getRequest();
             if (!$request->hasPreviousSession()) {
@@ -55,7 +55,7 @@ how you determine the desired locale from the request::
         {
             return array(
                 // must be registered before the default Locale listener
-                KernelEvents::REQUEST => array(array('setLocale', 17)),
+                KernelEvents::REQUEST => array(array('onKernelRequest', 17)),
             );
         }
     }
@@ -173,7 +173,7 @@ Then register the listener:
                 class: AppBundle\EventListener\UserLocaleListener
                 arguments: [@session]
                 tags:
-                    - { name: kernel.event_listener, event: security.interactive_login, method: setLocale }
+                    - { name: kernel.event_listener, event: security.interactive_login, method: onKernelRequest }
 
     .. code-block:: xml
 
@@ -192,7 +192,7 @@ Then register the listener:
 
                     <tag name="kernel.event_listener"
                         event="security.interactive_login"
-                        method="setLocale" />
+                        method="onKernelRequest" />
                 </service>
             </services>
         </container>
@@ -205,7 +205,7 @@ Then register the listener:
             ->addArgument('session')
             ->addTag(
                 'kernel.event_listener',
-                array('event' => 'security.interactive_login', 'method' => 'setLocale'
+                array('event' => 'security.interactive_login', 'method' => 'onKernelRequest'
             );
 
 .. caution::

--- a/cookbook/session/locale_sticky_session.rst
+++ b/cookbook/session/locale_sticky_session.rst
@@ -35,7 +35,7 @@ how you determine the desired locale from the request::
             $this->defaultLocale = $defaultLocale;
         }
 
-        public function onKernelRequest(GetResponseEvent $event)
+        public function setLocale(GetResponseEvent $event)
         {
             $request = $event->getRequest();
             if (!$request->hasPreviousSession()) {
@@ -55,7 +55,7 @@ how you determine the desired locale from the request::
         {
             return array(
                 // must be registered before the default Locale listener
-                KernelEvents::REQUEST => array(array('onKernelRequest', 17)),
+                KernelEvents::REQUEST => array(array('setLocale', 17)),
             );
         }
     }
@@ -151,7 +151,7 @@ event:
         /**
          * @param InteractiveLoginEvent $event
          */
-        public function onInteractiveLogin(InteractiveLoginEvent $event)
+        public function setLocale(InteractiveLoginEvent $event)
         {
             $user = $event->getAuthenticationToken()->getUser();
 
@@ -173,7 +173,7 @@ Then register the listener:
                 class: AppBundle\EventListener\UserLocaleListener
                 arguments: [@session]
                 tags:
-                    - { name: kernel.event_listener, event: security.interactive_login, method: onInteractiveLogin }
+                    - { name: kernel.event_listener, event: security.interactive_login, method: setLocale }
 
     .. code-block:: xml
 
@@ -192,7 +192,7 @@ Then register the listener:
 
                     <tag name="kernel.event_listener"
                         event="security.interactive_login"
-                        method="onInteractiveLogin" />
+                        method="setLocale" />
                 </service>
             </services>
         </container>
@@ -205,7 +205,7 @@ Then register the listener:
             ->addArgument('session')
             ->addTag(
                 'kernel.event_listener',
-                array('event' => 'security.interactive_login', 'method' => 'onInteractiveLogin'
+                array('event' => 'security.interactive_login', 'method' => 'setLocale'
             );
 
 .. caution::


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

**Please note that this is only a proposal to discuss about it**. If you agree with it, I'll update the rest of the documentation. If you disagree, I'd happily close this issue.

Personally, one of the things I like least about the Symfony docs is the name of the listeners/subscribers methods. The practice of using `on` + event name looks very confusing to me most of the times.

First, the event name is a purely circumstancial thing and it doesn't convey any business logic meaning. For example, in the following two methods, I think the second name is much better:

``` php
public function onKernelRequest() { ... }
public function verifyToken() { ... }
```

Second, I find illogical to use the exact same method name (e.g. `onKernelRequest()`) for methods that perform very different tasks.

Third, I think it's a very redundant practice for the configuration files:

``` yaml
class: AppBundle\EventListener\TokenListener
arguments: ["%tokens%"]
    tags:
        # looks redundant
        - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }

        # looks better and it's easier to understand
        - { name: kernel.event_listener, event: kernel.controller, method: verifyToken }
```

I clearly see the advantages, but I'd also like to know the drawbacks that you can think of about this proposal. Thanks!
