### PR TITLE
[WIP] Reworking most of the registration form:

### DIFF
--- a/cookbook/doctrine/registration_form.rst
+++ b/cookbook/doctrine/registration_form.rst
@@ -341,7 +341,7 @@ Having a Registration form with only Email (no Username)
 
 If you want your users to login via email and you don't need a username, then you
 can remove it from your ``User`` entity entirely. Instead, make ``getUsername()``
-return the ``email`` property.
+return the ``email`` property::
 
     // src/AppBundle/Entity/User.php
     // ...

--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -95,6 +95,8 @@ The actual default value of this option depends on other field options:
 
 .. include:: /reference/forms/types/options/label_attr.rst.inc
 
+.. _reference-form-option-mapped:
+
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. _reference-form-option-max_length:


### PR DESCRIPTION
Hi guys!

| Q | A |
| --- | --- |
| Doc fix? | yes (because it's got bad recommendations) |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | -- |

After trading emails with a user, I realized that we have this very out-dated registration form chapter. Wow :). A summary of the changes:

1) Showing the embedded Registration model is way too hard and unnecessary
2) Stopped persisted plainPassword (why did we do this?)
3) Used AppBundle approach
4) Annotation routing
5) various other small things

This is still a WIP only because I have 2 sections at the bottom I still want to add. Review for what is here now is appreciated.

Honestly, I was a little surprised that entries like this can "hide" in the docs and get so out of date. It's a testament to how big our docs are, but it's a bit of a problem (this is similar to #5184 that had something totally irrelevant in an important doc).

Things to update during merge:
- password encoder
- remove getName() in 2.8
- setDefaultOptions

Thanks!
