### PR TITLE
Fix example namespace

### DIFF
--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -71,7 +71,7 @@ The default authentication manager is an instance of
 
     use Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager;
 
-    // instances of Symfony\Component\Security\Core\Authentication\AuthenticationProviderInterface
+    // instances of Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface
     $providers = array(...);
 
     $authenticationManager = new AuthenticationProviderManager($providers);


### PR DESCRIPTION
Hi,

I've found a mistake on example in security component.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.0 to 3.0 |
| Fixed tickets | none |
