### PR TITLE
[Cookbook] Fix doc on Generic Form Type Extensions

### DIFF
--- a/cookbook/form/create_form_type_extension.rst
+++ b/cookbook/form/create_form_type_extension.rst
@@ -12,6 +12,13 @@ But sometimes, you don't really need to add new field types - you want
 to add features on top of existing types. This is where form type
 extensions come in.
 
+Form type extensions have 2 main use-cases:
+
+#. You want to add a **specific feature to a single type** (such
+   as adding a "download" feature to the "file" field type);
+#. You want to add a **generic feature to several types** (such as
+   adding a "help" text to every "input text"-like type).
+
 It might be possible to achieve your goal with custom form rendering, or custom
 form field types. But using form type extensions can be cleaner (by limiting the
 amount of business logic in templates) and more flexible (you can add several
@@ -315,11 +322,14 @@ with an image, you will see it displayed next to the file input.
 Generic Form Type Extensions
 ----------------------------
 
-Although it is not possible to have a form type extension applying to all form
-types, **most** form types natively available in Symfony
-(:doc:`/reference/forms/types`) inherit from the ``form`` form type. Thus, a
-form type extension applying to ``form`` would apply to all of these.
+You can modify several form types at once by specifying their common parent
+(:doc:`/reference/forms/types`). For example, several form types natively
+available in Symfony inherit from the ``text`` form type (such as ``email``,
+``search``, ``url``, etc.). A form type extension applying to ``text`` would
+apply to all of these form types.
 
-A notable exception are the ``button`` from types. Plus, keep in mind that a custom
-form type which doesn't inherit neither ``form`` nor ``button`` could always be
-created.
+In the same way, since **most** form types natively available in Symfony inherit
+from the ``form`` form type, a form type extension applying to ``form`` would
+apply to all of these.  A notable exception are the ``button`` form types. Plus,
+keep in mind that a custom form type which inherit neither ``form`` nor
+``button`` could always be created.

--- a/cookbook/form/create_form_type_extension.rst
+++ b/cookbook/form/create_form_type_extension.rst
@@ -325,8 +325,9 @@ Generic Form Type Extensions
 You can modify several form types at once by specifying their common parent
 (:doc:`/reference/forms/types`). For example, several form types natively
 available in Symfony inherit from the ``text`` form type (such as ``email``,
-``search``, ``url``, etc.). A form type extension applying to ``text`` would
-apply to all of these form types.
+``search``, ``url``, etc.). A form type extension applying to ``text``
+(i.e. whose ``getExtendedType`` method returns ``text``) would apply to all of
+these form types.
 
 In the same way, since **most** form types natively available in Symfony inherit
 from the ``form`` form type, a form type extension applying to ``form`` would

--- a/cookbook/form/create_form_type_extension.rst
+++ b/cookbook/form/create_form_type_extension.rst
@@ -12,18 +12,10 @@ But sometimes, you don't really need to add new field types - you want
 to add features on top of existing types. This is where form type
 extensions come in.
 
-Form type extensions have 2 main use-cases:
-
-#. You want to add a **generic feature to several types** (such as
-   adding a "help" text to every field type);
-#. You want to add a **specific feature to a single type** (such
-   as adding a "download" feature to the "file" field type).
-
-In both those cases, it might be possible to achieve your goal with custom
-form rendering, or custom form field types. But using form type extensions
-can be cleaner (by limiting the amount of business logic in templates)
-and more flexible (you can add several type extensions to a single form
-type).
+It might be possible to achieve your goal with custom form rendering, or custom
+form field types. But using form type extensions can be cleaner (by limiting the
+amount of business logic in templates) and more flexible (you can add several
+type extensions to a single form type).
 
 Form type extensions can achieve most of what custom field types can do,
 but instead of being field types of their own, **they plug into existing types**.
@@ -319,3 +311,15 @@ next to the file field. For example::
 
 When displaying the form, if the underlying model has already been associated
 with an image, you will see it displayed next to the file input.
+
+Generic Form Type Extensions
+----------------------------
+
+Although it is not possible to have a form type extension applying to all form
+types, **most** form types natively available in Symfony
+(:doc:`/reference/forms/types`) inherit from the ``form`` form type. Thus, a
+form type extension applying to ``form`` would apply to all of these.
+
+A notable exception are the ``button`` from types. Plus, keep in mind that a custom
+form type which doesn't inherit neither ``form`` nor ``button`` could always be
+created.

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -296,72 +296,8 @@ form.type_extension
 
 **Purpose**: Create a custom "form extension"
 
-Form type extensions are a way for you took "hook into" the creation of
-any field in your form. For example, the addition of the CSRF token is done
-via a form type extension
-(:class:`Symfony\\Component\\Form\\Extension\\Csrf\\Type\\FormTypeCsrfExtension`).
-
-A form type extension can modify any part of any field in your form. To
-create a form type extension, first create a class that implements the
-:class:`Symfony\\Component\\Form\\FormTypeExtensionInterface` interface.
-For simplicity, you'll often extend an
-:class:`Symfony\\Component\\Form\\AbstractTypeExtension` class instead of
-the interface directly::
-
-    // src/Acme/MainBundle/Form/Type/MyFormTypeExtension.php
-    namespace Acme\MainBundle\Form\Type;
-
-    use Symfony\Component\Form\AbstractTypeExtension;
-
-    class MyFormTypeExtension extends AbstractTypeExtension
-    {
-        // ... fill in whatever methods you want to override
-        // like buildForm(), buildView(), finishView(), setDefaultOptions()
-    }
-
-In order for Symfony to know about your form extension and use it, give
-it the ``form.type_extension`` tag:
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        services:
-            main.form.type.my_form_type_extension:
-                class: Acme\MainBundle\Form\Type\MyFormTypeExtension
-                tags:
-                    - { name: form.type_extension, alias: field }
-
-    .. code-block:: xml
-
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-            <services>
-                <service
-                    id="main.form.type.my_form_type_extension"
-                    class="Acme\MainBundle\Form\Type\MyFormTypeExtension">
-
-                    <tag name="form.type_extension" alias="field" />
-                </service>
-            </services>
-        </container>
-
-    .. code-block:: php
-
-        $container
-            ->register(
-                'main.form.type.my_form_type_extension',
-                'Acme\MainBundle\Form\Type\MyFormTypeExtension'
-            )
-            ->addTag('form.type_extension', array('alias' => 'field'))
-        ;
-
-The ``alias`` key of the tag is the type of field that this extension should
-be applied to. For example, to apply the extension to any form/field, use
-the "form" value.
+For details on creating Form type extensions, read the cookbook article:
+:doc:`/cookbook/form/create_form_type_extension`
 
 .. _reference-dic-type_guesser:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | >=2.3 |
| Fixed tickets | N/A |

Follow up on #5154 (Sorry the first one didn't use the PR Template BTW) and symfony/symfony#14456.

I cleaned up the reference on DIC Tags, I think referring to the cookbook article prevents duplicating documentation (and taking the risk it will get out of date or inconsistent later on, as it did).

Then I removed the mention of Generic FTE at the top of the cookbook article. Since the feature doesn't exists anymore, I think it's better to leave it aside. I simply mentioned why it's impossible in a short last paragraph at the end of the CB entry.

I kept both commit unsquashed because they seemed to address different enough concerns. But I will squash them upon request if you think it's necessary.
