### PR TITLE
Remove mention of *.class parameters from conventions

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -165,7 +165,7 @@ Service Naming Conventions
 
 * Use lowercase letters for service and parameter names;
 
-* A group name uses the underscore notation;
+* A group name uses the underscore notation.
 
 Documentation
 -------------

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -167,9 +167,6 @@ Service Naming Conventions
 
 * A group name uses the underscore notation;
 
-* Each service has a corresponding parameter containing the class name,
-  following the ``SERVICE NAME.class`` convention.
-
 Documentation
 -------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |
