### PR TITLE
Update load_balancer_reverse_proxy.rst

### DIFF
--- a/cookbook/request/load_balancer_reverse_proxy.rst
+++ b/cookbook/request/load_balancer_reverse_proxy.rst
@@ -83,6 +83,9 @@ In this case, you'll need to - *very carefully* - trust *all* proxies.
        $response = $kernel->handle($request);
        // ...
 
+#. Ensure that the trusted_proxies setting in your app/config/config.yml is not set or 
+   it will overwrite the setTrustedProxies call above.
+
 That's it! It's critical that you prevent traffic from all non-trusted sources.
 If you allow outside traffic, they could "spoof" their true IP address and
 other information.

--- a/cookbook/request/load_balancer_reverse_proxy.rst
+++ b/cookbook/request/load_balancer_reverse_proxy.rst
@@ -83,8 +83,8 @@ In this case, you'll need to - *very carefully* - trust *all* proxies.
        $response = $kernel->handle($request);
        // ...
 
-#. Ensure that the trusted_proxies setting in your app/config/config.yml is not set or 
-   it will overwrite the setTrustedProxies call above.
+#. Ensure that the trusted_proxies setting in your ``app/config/config.yml`` is not set or 
+   it will overwrite the ``setTrustedProxies`` call above.
 
 That's it! It's critical that you prevent traffic from all non-trusted sources.
 If you allow outside traffic, they could "spoof" their true IP address and

--- a/cookbook/request/load_balancer_reverse_proxy.rst
+++ b/cookbook/request/load_balancer_reverse_proxy.rst
@@ -83,8 +83,8 @@ In this case, you'll need to - *very carefully* - trust *all* proxies.
        $response = $kernel->handle($request);
        // ...
 
-#. Ensure that the trusted_proxies setting in your ``app/config/config.yml`` is not set or 
-   it will overwrite the ``setTrustedProxies`` call above.
+#. Ensure that the trusted_proxies setting in your ``app/config/config.yml`` 
+   is not set or it will overwrite the ``setTrustedProxies`` call above.
 
 That's it! It's critical that you prevent traffic from all non-trusted sources.
 If you allow outside traffic, they could "spoof" their true IP address and


### PR DESCRIPTION
Remind that the trusted_proxies setting needs to be removed or the setTrustedProxies method call will be overwritten.
