### PR TITLE
[DomCrawler] Warn users of older PHP versions Crawler might not decde html entities properly

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -231,6 +231,7 @@ and :phpclass:`DOMNode` objects:
         $html = $crawler->html();
 
     The ``html`` method is new in Symfony 2.3.
+    In PHP < 5.3.6 it might return html entities which are not properly decoded.
 
 Links
 ~~~~~


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3,<2.7 |
| Fixed tickets | - |

re https://github.com/symfony/symfony/issues/8770
