### PR TITLE
[Cookbook][Controller] replace docs for removed `forward()` method

### DIFF
--- a/cookbook/controller/service.rst
+++ b/cookbook/controller/service.rst
@@ -258,7 +258,13 @@ controller:
 :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::forward` (service: ``http_kernel``)
     .. code-block:: php
 
-        $httpKernel->forward($controller, $path, $query);
+        use Symfony\Component\HttpKernel\HttpKernelInterface;
+        // ...
+
+        $request = ...;
+        $attributes = array_merge($path, array('_controller' => $controller));
+        $subRequest = $request->duplicate($query, null, $attributes);
+        $httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
 
 :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::generateUrl` (service: ``router``)
     .. code-block:: php


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | symfony/symfony#8783 |

The `forward()` method was removed from the `HttpKernel` class in the FrameworkBundle in Symfony 2.3. Instead, the current request needs to be duplicated and handled by the kernel's `handle()` method.
