### PR TITLE
Tips: Usage of AbstractVoter

### DIFF
--- a/cookbook/security/voters_data_permission.rst
+++ b/cookbook/security/voters_data_permission.rst
@@ -53,6 +53,12 @@ does not belong to this voter, it will return ``VoterInterface::ACCESS_ABSTAIN``
 Creating the custom Voter
 -------------------------
 
+.. tip::
+
+    You can extends the
+    :class:`Symfony\\Component\\Security\\Core\\Authorization\\Voter\\AbstractVoter`
+    to ease the implementation of your custom Voter.
+
 The goal is to create a voter that checks if a user has access to view or
 edit a particular object. Here's an example implementation:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.6+ |
| Fixed tickets | - |

Hi,

I think defining a Voter extending the AbstractVoter is more simple for newcomers.

Maybe we can add the same PostVoter's code written with this AbstractVoter for comparison
Or put a sample FooBarVoter code here http://symfony.com/doc/current/cookbook/security/voters.html
Or simply a link to this one http://symfony.com/doc/current/best_practices/security.html#security-voters
