### PR TITLE
Example to include templates doesn't work

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -558,7 +558,7 @@ Including this template from any other template is simple:
 
             <?php foreach ($articles as $article): ?>
                 <?php echo $view->render(
-                    'Article/article_details.html.php',
+                    '::article/article_details.html.php',
                     array('article' => $article)
                 ) ?>
             <?php endforeach ?>


### PR DESCRIPTION
The PHP example for including templates within templates doesn't work.

Without the colons, the engine looks for `article_details.html.php` in `app\Resources\` instead of `app\Resources\views\article`
