### PR TITLE
Use the reserved domains example.com and example.org

### DIFF
--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -57,8 +57,9 @@ Code Examples
   Unless the example requires a custom bundle, make sure to always use the
   ``AppBundle`` bundle to store your code;
 * Use ``Acme`` when the code requires a vendor name;
-* Use ``example.com`` as the domain of sample URLs and ``example.org`` when a
-  second domain is required. Both domains are `reserved by the IANA`_.
+* Use ``example.com`` as the domain of sample URLs and ``example.org`` and
+  ``example.net`` when additional domains are required. All of these domains are
+  `reserved by the IANA`_.
 * To avoid horizontal scrolling on code blocks, we prefer to break a line
   correctly if it crosses the 85th character;
 * When you fold one or more lines of code, place ``...`` in a comment at the point
@@ -176,7 +177,7 @@ In addition, documentation follows these rules:
 
 .. _`the Sphinx documentation`: http://sphinx-doc.org/rest.html#source-code
 .. _`Twig Coding Standards`: http://twig.sensiolabs.org/doc/coding_standards.html
-.. _`reserved by the IANA`: http://www.iana.org/domains/reserved
+.. _`reserved by the IANA`: http://tools.ietf.org/html/rfc2606#section-3
 .. _`American English`: http://en.wikipedia.org/wiki/American_English
 .. _`American English Oxford Dictionary`: http://www.oxforddictionaries.com/definition/american_english/
 .. _`headings and titles`: http://en.wikipedia.org/wiki/Letter_case#Headings_and_publication_titles

--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -57,6 +57,8 @@ Code Examples
   Unless the example requires a custom bundle, make sure to always use the
   ``AppBundle`` bundle to store your code;
 * Use ``Acme`` when the code requires a vendor name;
+* Use ``example.com`` as the domain of sample URLs and ``example.org`` when a
+  second domain is required. Both domains are `reserved by the IANA`_.
 * To avoid horizontal scrolling on code blocks, we prefer to break a line
   correctly if it crosses the 85th character;
 * When you fold one or more lines of code, place ``...`` in a comment at the point
@@ -174,6 +176,7 @@ In addition, documentation follows these rules:
 
 .. _`the Sphinx documentation`: http://sphinx-doc.org/rest.html#source-code
 .. _`Twig Coding Standards`: http://twig.sensiolabs.org/doc/coding_standards.html
+.. _`reserved by the IANA`: http://www.iana.org/domains/reserved
 .. _`American English`: http://en.wikipedia.org/wiki/American_English
 .. _`American English Oxford Dictionary`: http://www.oxforddictionaries.com/definition/american_english/
 .. _`headings and titles`: http://en.wikipedia.org/wiki/Letter_case#Headings_and_publication_titles

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -283,7 +283,7 @@ respond and the user will receive a 500 response.
 
         # app/config/config.yml
         framework:
-            trusted_hosts:  ['acme.com', 'acme.org']
+            trusted_hosts:  ['example.com', 'example.org']
 
     .. code-block:: xml
 
@@ -296,8 +296,8 @@ respond and the user will receive a 500 response.
                 http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
             <framework:config>
-                <trusted-host>acme.com</trusted-host>
-                <trusted-host>acme.org</trusted-host>
+                <trusted-host>example.com</trusted-host>
+                <trusted-host>example.org</trusted-host>
                 <!-- ... -->
             </framework>
         </container>
@@ -306,17 +306,17 @@ respond and the user will receive a 500 response.
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
-            'trusted_hosts' => array('acme.com', 'acme.org'),
+            'trusted_hosts' => array('example.com', 'example.org'),
         ));
 
-Hosts can also be configured using regular expressions (e.g.  ``.*\.?acme.com$``),
+Hosts can also be configured using regular expressions (e.g.  ``.*\.?example.com$``),
 which make it easier to respond to any subdomain.
 
 In addition, you can also set the trusted hosts in the front controller
 using the ``Request::setTrustedHosts()`` method::
 
     // web/app.php
-    Request::setTrustedHosts(array('.*\.?acme.com$', '.*\.?acme.org$'));
+    Request::setTrustedHosts(array('.*\.?example.com$', '.*\.?example.org$'));
 
 The default value for this option is an empty array, meaning that the application
 can respond to any given host.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

Most of the current docs already use the reserved domains, but I think it's OK to add this recommendation to the docs standards.
