### PR TITLE
Text in index.html.twig for The Big Picture wrong

### DIFF
--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -254,7 +254,7 @@ you'll see the following code:
     {% extends 'base.html.twig' %}
 
     {% block body %}
-        <h1>Welcome to Symfony!</h1>
+        Homepage.
     {% endblock %}
 
 This template is created with `Twig`_, a new template engine created for


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |

The text in the standard "index.html.twig" on "The Big Picture" documentation for the "Templates" section is wrong and needs updating.

The documentation shows: "<h1>Welcome to Symfony!</h1>" but the actual file (by default) has "Homepage.".

Nothing major but a bit misleading and confusing for a brand new user.
