### PR TITLE
typo found on php app/console server:run command docs

### DIFF
--- a/cookbook/web_server/built_in.rst
+++ b/cookbook/web_server/built_in.rst
@@ -23,11 +23,11 @@ Starting the Web Server
 -----------------------
 
 Running a Symfony application using PHP's built-in web server is as easy as
-executing the ``server:start`` command:
+executing the ``server:run`` command:
 
 .. code-block:: bash
 
-    $ php app/console server:start
+    $ php app/console server:run
 
 This starts the web server at ``localhost:8000`` in the background that serves
 your Symfony application.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.6+ |
| Fixed tickets |  |

it was only a typo the docs sais that start server with `php app/console server:run` and it is wrong, this will be `php app/console server:run`
