### PR TITLE
[Form][2.3] fix `validation_groups` typos

### DIFF
--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -713,7 +713,7 @@ To suppress form validation you can use the ``POST_SUBMIT`` event and prevent
 the :class:`Symfony\\Component\\Form\\Extension\\Validator\\EventListener\\ValidationListener`
 from being called.
 
-The reason for needing to do this is that even if you set ``group_validation``
+The reason for needing to do this is that even if you set ``validation_groups``
 to ``false`` there  are still some integrity checks executed. For example
 an uploaded file will still be checked to see if it is too large and the form
 will still check to see if non-existing fields were submitted. To disable

--- a/reference/forms/types/options/cascade_validation.rst.inc
+++ b/reference/forms/types/options/cascade_validation.rst.inc
@@ -13,7 +13,7 @@ the data from ``CategoryType`` to also be validated.
     Instead of using this option, it is recommended that you use the ``Valid``
     constraint in your model to force validation on a child object stored
     on a property. This cascades only the validation but not the use of
-    the ``validation_group`` option on child forms. You can read more
+    the ``validation_groups`` option on child forms. You can read more
     about this in the section about
     :ref:`Embedding a Single Object <forms-embedding-single-object>`.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | -- |

It's neither `group_validation` nor `validation_group`, but `validation_groups`. :smirk:
