### PR TITLE
[Form] Fixed typo about _token field name for CSRF protection

### DIFF
--- a/components/form/introduction.rst
+++ b/components/form/introduction.rst
@@ -138,7 +138,7 @@ above snippet and make sure that nobody except your web server can access
 the secret.
 
 Internally, this extension will automatically add a hidden field to every
-form (called ``__token`` by default) whose value is automatically generated
+form (called ``_token`` by default) whose value is automatically generated
 and validated when binding the form.
 
 .. tip::


### PR DESCRIPTION
As seen [here](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php#L53)

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | none |
