### PR TITLE
[Form] Replace deprecated form_enctype by form_start

### DIFF
--- a/components/form/introduction.rst
+++ b/components/form/introduction.rst
@@ -480,11 +480,11 @@ helper functions:
 
 .. code-block:: html+jinja
 
-    <form action="#" method="post" {{ form_enctype(form) }}>
+    {{ form_start(form) }}
         {{ form_widget(form) }}
 
         <input type="submit" />
-    </form>
+    {{ form_end(form) }}
 
 .. image:: /images/book/form-simple.png
     :align: center


### PR DESCRIPTION
Deprecated since 2.3. See [form chapter](http://symfony.com/doc/2.3/book/forms.html#rendering-the-form)

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | #4603 |
