### PR TITLE
Split Security into Authentication & Authorization

### DIFF
--- a/cookbook/map.rst.inc
+++ b/cookbook/map.rst.inc
@@ -143,26 +143,29 @@
   * :doc:`/cookbook/routing/redirect_trailing_slash`
   * :doc:`/cookbook/routing/extra_information`
 
-* :doc:`/cookbook/security/index`
+* :doc:`Authentication </cookbook/security/index>`
 
   * :doc:`/cookbook/security/form_login_setup`
   * :doc:`/cookbook/security/entity_provider`
   * :doc:`/cookbook/security/remember_me`
   * :doc:`/cookbook/security/impersonating_user`
-  * :doc:`/cookbook/security/voters`
-  * :doc:`/cookbook/security/voters_data_permission`
-  * :doc:`/cookbook/security/acl`
-  * :doc:`/cookbook/security/acl_advanced`
-  * :doc:`/cookbook/security/force_https`
   * :doc:`/cookbook/security/form_login`
-  * :doc:`/cookbook/security/securing_services`
   * :doc:`/cookbook/security/custom_provider`
   * :doc:`/cookbook/security/custom_authentication_provider`
   * :doc:`/cookbook/security/pre_authenticated`
   * :doc:`/cookbook/security/target_path`
   * :doc:`/cookbook/security/csrf_in_login_form`
-  * :doc:`/cookbook/security/access_control`
   * :doc:`/cookbook/security/multiple_user_providers`
+
+* :doc:`Authorization </cookbook/security/index>`
+
+  * :doc:`/cookbook/security/voters`
+  * :doc:`/cookbook/security/voters_data_permission`
+  * :doc:`/cookbook/security/acl`
+  * :doc:`/cookbook/security/acl_advanced`
+  * :doc:`/cookbook/security/force_https`
+  * :doc:`/cookbook/security/securing_services`
+  * :doc:`/cookbook/security/access_control`
 
 * **Serializer**
 

--- a/cookbook/security/index.rst
+++ b/cookbook/security/index.rst
@@ -1,7 +1,8 @@
 Security
 ========
 
-* Authentication
+Authentication
+--------------
 
 .. toctree::
     :maxdepth: 2
@@ -18,8 +19,8 @@ Security
     csrf_in_login_form
     multiple_user_providers
 
-
-* Authorization
+Authorization
+-------------
 
 .. toctree::
     :maxdepth: 2
@@ -31,3 +32,4 @@ Security
     force_https
     securing_services
     access_control
+

--- a/cookbook/security/index.rst
+++ b/cookbook/security/index.rst
@@ -1,6 +1,8 @@
 Security
 ========
 
+* Authentication
+
 .. toctree::
     :maxdepth: 2
 
@@ -8,17 +10,24 @@ Security
     entity_provider
     remember_me
     impersonating_user
-    voters
-    voters_data_permission
-    acl
-    acl_advanced
-    force_https
     form_login
-    securing_services
     custom_provider
     custom_authentication_provider
     pre_authenticated
     target_path
     csrf_in_login_form
-    access_control
     multiple_user_providers
+
+
+* Authorization
+
+.. toctree::
+    :maxdepth: 2
+
+    voters
+    voters_data_permission
+    acl
+    acl_advanced
+    force_https
+    securing_services
+    access_control


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | ~ |

I have divided the security part into Authentication and Authorization. This is done visually only, structure wise they are still together. There's still an issue regarding the sorting, it will be a lot clearer if the lists are re-sorted but I will do this in another PR once this is done.

I think I've update all the index pages that mention this, but if I missed something, I can add that.
