### PR TITLE
[Cookbook][Controller] use the jinja lexer to render Twig code

### DIFF
--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -136,7 +136,7 @@ The cause of this problem is that routing is done before security. If a 404 erro
 occurs, the security layer isn't loaded and thus, the ``is_granted()`` function
 is undefined. The solution is to add the following check before using this function:
 
-.. code-block:: twig
+.. code-block:: jinja
 
     {% if app.user and is_granted('...') %}
         {# ... #}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

Using `twig` works on newer Sphinx versions, but makes it harder for people to build the documentation locally with older versions.
