### PR TITLE
remove Yoda condition

### DIFF
--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -196,7 +196,7 @@ level of verbosity.
 It is possible to print a message in a command for only a specific verbosity
 level. For example::
 
-    if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
+    if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
         $output->writeln(...);
     }
 


### PR DESCRIPTION
Yoda conditions : a questionable best practice that makes code less error-prone, but also harder to read for people that don't share the same grammar rules as people from Dagobah. Anyway, they are useful when you want to avoid confusing assignment and equality operators, but I doubt people often write `=` while meaning to write `<=`.
