### PR TITLE
Re-write of Page Creation

### DIFF
--- a/book/bundles.rst
+++ b/book/bundles.rst
@@ -1,0 +1,173 @@
+.. index::
+   single: Bundles
+
+.. _page-creation-bundles:
+
+The Bundle System
+-----------------
+
+A bundle is similar to a plugin in other software, but even better. The key
+difference is that *everything* is a bundle in Symfony, including both the
+core framework functionality and the code written for your application.
+Bundles are first-class citizens in Symfony. This gives you the flexibility
+to use pre-built features packaged in `third-party bundles`_ or to distribute
+your own bundles. It makes it easy to pick and choose which features to enable
+in your application and to optimize them the way you want.
+
+.. note::
+
+   While you'll learn the basics here, an entire cookbook entry is devoted
+   to the organization and best practices of :doc:`bundles </cookbook/bundles/best_practices>`.
+
+A bundle is simply a structured set of files within a directory that implement
+a single feature. You might create a BlogBundle, a ForumBundle or
+a bundle for user management (many of these exist already as open source
+bundles). Each directory contains everything related to that feature, including
+PHP files, templates, stylesheets, JavaScripts, tests and anything else.
+Every aspect of a feature exists in a bundle and every feature lives in a
+bundle.
+
+An application is made up of bundles as defined in the ``registerBundles()``
+method of the ``AppKernel`` class::
+
+    // app/AppKernel.php
+    public function registerBundles()
+    {
+        $bundles = array(
+            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+            new Symfony\Bundle\TwigBundle\TwigBundle(),
+            new Symfony\Bundle\MonologBundle\MonologBundle(),
+            new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
+            new Symfony\Bundle\DoctrineBundle\DoctrineBundle(),
+            new Symfony\Bundle\AsseticBundle\AsseticBundle(),
+            new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
+        );
+
+        if (in_array($this->getEnvironment(), array('dev', 'test'))) {
+            $bundles[] = new Acme\DemoBundle\AcmeDemoBundle();
+            $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
+            $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
+            $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
+        }
+
+        return $bundles;
+    }
+
+With the ``registerBundles()`` method, you have total control over which bundles
+are used by your application (including the core Symfony bundles).
+
+.. tip::
+
+   A bundle can live *anywhere* as long as it can be autoloaded (via the
+   autoloader configured at ``app/autoload.php``).
+
+Creating a Bundle
+~~~~~~~~~~~~~~~~~
+
+The Symfony Standard Edition comes with a handy task that creates a fully-functional
+bundle for you. Of course, creating a bundle by hand is pretty easy as well.
+
+To show you how simple the bundle system is, create a new bundle called
+AcmeTestBundle and enable it.
+
+.. tip::
+
+    The ``Acme`` portion is just a dummy name that should be replaced by
+    some "vendor" name that represents you or your organization (e.g.
+    ABCTestBundle for some company named ``ABC``).
+
+Start by creating a ``src/Acme/TestBundle/`` directory and adding a new file
+called ``AcmeTestBundle.php``::
+
+    // src/Acme/TestBundle/AcmeTestBundle.php
+    namespace Acme\TestBundle;
+
+    use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+    class AcmeTestBundle extends Bundle
+    {
+    }
+
+.. tip::
+
+   The name AcmeTestBundle follows the standard
+   :ref:`Bundle naming conventions <bundles-naming-conventions>`. You could
+   also choose to shorten the name of the bundle to simply TestBundle by naming
+   this class TestBundle (and naming the file ``TestBundle.php``).
+
+This empty class is the only piece you need to create the new bundle. Though
+commonly empty, this class is powerful and can be used to customize the behavior
+of the bundle.
+
+Now that you've created the bundle, enable it via the ``AppKernel`` class::
+
+    // app/AppKernel.php
+    public function registerBundles()
+    {
+        $bundles = array(
+            // ...
+            // register your bundle
+            new Acme\TestBundle\AcmeTestBundle(),
+        );
+        // ...
+
+        return $bundles;
+    }
+
+And while it doesn't do anything yet, AcmeTestBundle is now ready to be used.
+
+And as easy as this is, Symfony also provides a command-line interface for
+generating a basic bundle skeleton:
+
+.. code-block:: bash
+
+    $ php app/console generate:bundle --namespace=Acme/TestBundle
+
+The bundle skeleton generates with a basic controller, template and routing
+resource that can be customized. You'll learn more about Symfony's command-line
+tools later.
+
+.. tip::
+
+   Whenever creating a new bundle or using a third-party bundle, always make
+   sure the bundle has been enabled in ``registerBundles()``. When using
+   the ``generate:bundle`` command, this is done for you.
+
+Bundle Directory Structure
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The directory structure of a bundle is simple and flexible. By default, the
+bundle system follows a set of conventions that help to keep code consistent
+between all Symfony bundles. Take a look at AcmeDemoBundle, as it contains some
+of the most common elements of a bundle:
+
+``Controller/``
+    Contains the controllers of the bundle (e.g. ``RandomController.php``).
+
+``DependencyInjection/``
+    Holds certain Dependency Injection Extension classes, which may import service
+    configuration, register compiler passes or more (this directory is not
+    necessary).
+
+``Resources/config/``
+    Houses configuration, including routing configuration (e.g. ``routing.yml``).
+
+``Resources/views/``
+    Holds templates organized by controller name (e.g. ``Hello/index.html.twig``).
+
+``Resources/public/``
+    Contains web assets (images, stylesheets, etc) and is copied or symbolically
+    linked into the project ``web/`` directory via the ``assets:install`` console
+    command.
+
+``Tests/``
+    Holds all tests for the bundle.
+
+A bundle can be as small or large as the feature it implements. It contains
+only the files you need and nothing else.
+
+As you move through the book, you'll learn how to persist objects to a database,
+create and validate forms, create translations for your application, write
+tests and much more. Each of these has their own place and role within the
+bundle.

--- a/book/bundles.rst
+++ b/book/bundles.rst
@@ -23,12 +23,12 @@ A bundle is simply a structured set of files within a directory that implement
 a single feature. You might create a BlogBundle, a ForumBundle or
 a bundle for user management (many of these exist already as open source
 bundles). Each directory contains everything related to that feature, including
-PHP files, templates, stylesheets, JavaScripts, tests and anything else.
+PHP files, templates, stylesheets, JavaScript files, tests and anything else.
 Every aspect of a feature exists in a bundle and every feature lives in a
 bundle.
 
-An application is made up of bundles as defined in the ``registerBundles()``
-method of the ``AppKernel`` class::
+Bundles used in your applications must be enabled by registering them in
+the ``registerBundles()`` method of the ``AppKernel`` class::
 
     // app/AppKernel.php
     public function registerBundles()
@@ -42,10 +42,10 @@ method of the ``AppKernel`` class::
             new Symfony\Bundle\DoctrineBundle\DoctrineBundle(),
             new Symfony\Bundle\AsseticBundle\AsseticBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
+            new AppBundle\AppBundle(),
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {
-            $bundles[] = new Acme\DemoBundle\AcmeDemoBundle();
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
@@ -124,7 +124,7 @@ generating a basic bundle skeleton:
 
     $ php app/console generate:bundle --namespace=Acme/TestBundle
 
-The bundle skeleton generates with a basic controller, template and routing
+The bundle skeleton generates a basic controller, template and routing
 resource that can be customized. You'll learn more about Symfony's command-line
 tools later.
 

--- a/book/bundles.rst
+++ b/book/bundles.rst
@@ -4,7 +4,7 @@
 .. _page-creation-bundles:
 
 The Bundle System
------------------
+=================
 
 A bundle is similar to a plugin in other software, but even better. The key
 difference is that *everything* is a bundle in Symfony, including both the
@@ -63,7 +63,7 @@ are used by your application (including the core Symfony bundles).
    autoloader configured at ``app/autoload.php``).
 
 Creating a Bundle
-~~~~~~~~~~~~~~~~~
+-----------------
 
 The Symfony Standard Edition comes with a handy task that creates a fully-functional
 bundle for you. Of course, creating a bundle by hand is pretty easy as well.
@@ -135,7 +135,7 @@ tools later.
    the ``generate:bundle`` command, this is done for you.
 
 Bundle Directory Structure
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 
 The directory structure of a bundle is simple and flexible. By default, the
 bundle system follows a set of conventions that help to keep code consistent

--- a/book/bundles.rst
+++ b/book/bundles.rst
@@ -171,3 +171,5 @@ As you move through the book, you'll learn how to persist objects to a database,
 create and validate forms, create translations for your application, write
 tests and much more. Each of these has their own place and role within the
 bundle.
+
+_`third-party bundles`: http://knpbundles.com

--- a/book/configuration.rst
+++ b/book/configuration.rst
@@ -1,0 +1,281 @@
+.. index::
+   single: Configuration
+
+Configuring Symfony (and Environments)
+======================================
+
+An application consists of a collection of bundles representing all the
+features and capabilities of your application. Each bundle can be customized
+via configuration files written in YAML, XML or PHP. By default, the main
+configuration file lives in the ``app/config/`` directory and is called
+either ``config.yml``, ``config.xml`` or ``config.php`` depending on which
+format you prefer:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        imports:
+            - { resource: parameters.yml }
+            - { resource: security.yml }
+
+        framework:
+            secret:          "%secret%"
+            router:          { resource: "%kernel.root_dir%/config/routing.yml" }
+            # ...
+
+        # Twig Configuration
+        twig:
+            debug:            "%kernel.debug%"
+            strict_variables: "%kernel.debug%"
+
+        # ...
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xmlns:twig="http://symfony.com/schema/dic/twig"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony
+                http://symfony.com/schema/dic/symfony/symfony-1.0.xsd
+                http://symfony.com/schema/dic/twig
+                http://symfony.com/schema/dic/twig/twig-1.0.xsd">
+
+            <imports>
+                <import resource="parameters.yml" />
+                <import resource="security.yml" />
+            </imports>
+
+            <framework:config secret="%secret%">
+                <framework:router resource="%kernel.root_dir%/config/routing.xml" />
+                <!-- ... -->
+            </framework:config>
+
+            <!-- Twig Configuration -->
+            <twig:config debug="%kernel.debug%" strict-variables="%kernel.debug%" />
+
+            <!-- ... -->
+        </container>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $this->import('parameters.yml');
+        $this->import('security.yml');
+
+        $container->loadFromExtension('framework', array(
+            'secret' => '%secret%',
+            'router' => array(
+                'resource' => '%kernel.root_dir%/config/routing.php',
+            ),
+            // ...
+        ));
+
+        // Twig Configuration
+        $container->loadFromExtension('twig', array(
+            'debug'            => '%kernel.debug%',
+            'strict_variables' => '%kernel.debug%',
+        ));
+
+        // ...
+
+.. note::
+
+   You'll learn exactly how to load each file/format in the next section
+   `Environments`_.
+
+Each top-level entry like ``framework`` or ``twig`` defines the configuration
+for a particular bundle. For example, the ``framework`` key defines the configuration
+for the core Symfony FrameworkBundle and includes configuration for the
+routing, templating, and other core systems.
+
+For now, don't worry about the specific configuration options in each section.
+The configuration file ships with sensible defaults. As you read more and
+explore each part of Symfony, you'll learn about the specific configuration
+options of each feature.
+
+.. sidebar:: Configuration Formats
+
+    Throughout the chapters, all configuration examples will be shown in all
+    three formats (YAML, XML and PHP). Each has its own advantages and
+    disadvantages. The choice of which to use is up to you:
+
+    * *YAML*: Simple, clean and readable (learn more about YAML in
+      ":doc:`/components/yaml/yaml_format`");
+
+    * *XML*: More powerful than YAML at times and supports IDE autocompletion;
+
+    * *PHP*: Very powerful but less readable than standard configuration formats.
+
+Default Configuration Dump
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can dump the default configuration for a bundle in YAML to the console using
+the ``config:dump-reference`` command. Here is an example of dumping the default
+FrameworkBundle configuration:
+
+.. code-block:: bash
+
+    $ app/console config:dump-reference FrameworkBundle
+
+The extension alias (configuration key) can also be used:
+
+.. code-block:: bash
+
+    $ app/console config:dump-reference framework
+
+.. note::
+
+    See the cookbook article: :doc:`/cookbook/bundles/extension` for
+    information on adding configuration for your own bundle.
+
+.. index::
+   single: Environments; Introduction
+
+.. _environments-summary:
+.. _page-creation-environments:
+.. _book-page-creation-prod-cache-clear:
+
+Environments
+------------
+
+An application can run in various environments. The different environments
+share the same PHP code (apart from the front controller), but use different
+configuration. For instance, a ``dev`` environment will log warnings and
+errors, while a ``prod`` environment will only log errors. Some files are
+rebuilt on each request in the ``dev`` environment (for the developer's convenience),
+but cached in the ``prod`` environment. All environments live together on
+the same machine and execute the same application.
+
+A Symfony project generally begins with three environments (``dev``, ``test``
+and ``prod``), though creating new environments is easy. You can view your
+application in different environments simply by changing the front controller
+in your browser. To see the application in the ``dev`` environment, access
+the application via the development front controller:
+
+.. code-block:: text
+
+    http://localhost/app_dev.php/random/10
+
+If you'd like to see how your application will behave in the production environment,
+call the ``prod`` front controller instead:
+
+.. code-block:: text
+
+    http://localhost/app.php/random/10
+
+Since the ``prod`` environment is optimized for speed; the configuration,
+routing and Twig templates are compiled into flat PHP classes and cached.
+When viewing changes in the ``prod`` environment, you'll need to clear these
+cached files and allow them to rebuild:
+
+.. code-block:: bash
+
+    $ php app/console cache:clear --env=prod --no-debug
+
+.. note::
+
+   If you open the ``web/app.php`` file, you'll find that it's configured explicitly
+   to use the ``prod`` environment::
+
+       $kernel = new AppKernel('prod', false);
+
+   You can create a new front controller for a new environment by copying
+   this file and changing ``prod`` to some other value.
+
+.. note::
+
+    The ``test`` environment is used when running automated tests and cannot
+    be accessed directly through the browser. See the :doc:`testing chapter </book/testing>`
+    for more details.
+
+.. index::
+   single: Environments; Configuration
+
+Environment Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``AppKernel`` class is responsible for actually loading the configuration
+file of your choice::
+
+    // app/AppKernel.php
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(
+            __DIR__.'/config/config_'.$this->getEnvironment().'.yml'
+        );
+    }
+
+You already know that the ``.yml`` extension can be changed to ``.xml`` or
+``.php`` if you prefer to use either XML or PHP to write your configuration.
+Notice also that each environment loads its own configuration file. Consider
+the configuration file for the ``dev`` environment.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config_dev.yml
+        imports:
+            - { resource: config.yml }
+
+        framework:
+            router:   { resource: "%kernel.root_dir%/config/routing_dev.yml" }
+            profiler: { only_exceptions: false }
+
+        # ...
+
+    .. code-block:: xml
+
+        <!-- app/config/config_dev.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony
+                http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+            <imports>
+                <import resource="config.xml" />
+            </imports>
+
+            <framework:config>
+                <framework:router resource="%kernel.root_dir%/config/routing_dev.xml" />
+                <framework:profiler only-exceptions="false" />
+            </framework:config>
+
+            <!-- ... -->
+        </container>
+
+    .. code-block:: php
+
+        // app/config/config_dev.php
+        $loader->import('config.php');
+
+        $container->loadFromExtension('framework', array(
+            'router' => array(
+                'resource' => '%kernel.root_dir%/config/routing_dev.php',
+            ),
+            'profiler' => array('only-exceptions' => false),
+        ));
+
+        // ...
+
+The ``imports`` key is similar to a PHP ``include`` statement and guarantees
+that the main configuration file (``config.yml``) is loaded first. The rest
+of the file tweaks the default configuration for increased logging and other
+settings conducive to a development environment.
+
+Both the ``prod`` and ``test`` environments follow the same model: each environment
+imports the base configuration file and then modifies its configuration values
+to fit the needs of the specific environment. This is just a convention,
+but one that allows you to reuse most of your configuration and customize
+just pieces of it between environments.

--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -681,7 +681,7 @@ at how migrating the blog from flat PHP to Symfony has improved life:
   allows for new developers to be productive in your project more quickly;
 
 * 100% of the code you write is for *your* application. You **don't need
-  to develop or maintain low-level utilities** such as :ref:`autoloading <autoloading-introduction-sidebar>`,
+  to develop or maintain low-level utilities** such as autoloading,
   :doc:`routing </book/routing>`, or rendering :doc:`controllers </book/controller>`;
 
 * Symfony gives you **access to open source tools** such as Doctrine and the

--- a/book/index.rst
+++ b/book/index.rst
@@ -11,6 +11,8 @@ The Book
     controller
     routing
     templating
+    configuration
+    bundles
     doctrine
     propel
     testing

--- a/book/map.rst.inc
+++ b/book/map.rst.inc
@@ -5,6 +5,8 @@
 * :doc:`/book/controller`
 * :doc:`/book/routing`
 * :doc:`/book/templating`
+* :doc:`/book/configuration`
+* :doc:`/book/bundles`
 * :doc:`/book/doctrine`
 * :doc:`/book/propel`
 * :doc:`/book/testing`

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -2,27 +2,25 @@
    single: Page creation
 
 .. _creating-pages-in-symfony2:
+.. _creating-pages-in-symfony:
 
-Creating Pages in Symfony
-=========================
+Create your First Page in Symfony
+=================================
 
-Creating a new page in Symfony is a simple two-step process:
+Creating a new page - whether it's an HTML page or a JSON endpoint - is a
+simple two-step process:
 
-* *Create a route*: A route defines the URL (e.g. ``/about``) to your page
-  and specifies a controller (which is a PHP function) that Symfony should
-  execute when the URL of an incoming request matches the route path;
+#. *Create a route*: A route is the URL (e.g. ``/about``) to your page and
+   points to a controller;
 
-* *Create a controller*: A controller is a PHP function that takes the incoming
-  request and transforms it into the Symfony ``Response`` object that's
-  returned to the user.
+#. *Create a controller*: A controller is the function you write that builds
+   the page. You take the incoming request information and use it to create
+   a Symfony ``Response``, which could hold HTML content, a JSON string or
+   anything else.
 
-This simple approach is beautiful because it matches the way that the Web works.
-Every interaction on the Web is initiated by an HTTP request. The job of
-your application is simply to interpret the request and return the appropriate
+Just like on the web, every interaction is initiated by an HTTP request.
+Your job is pure and simple: understand that request and return the appropriate
 HTTP response.
-
-Symfony follows this philosophy and provides you with tools and conventions
-to keep your application organized as it grows in users and complexity.
 
 .. index::
    single: Page creation; Environments & Front Controllers

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -68,7 +68,7 @@ Before diving into this, test it out!
 
     If you setup a proper virtual host in :doc:`Apache or Nginx </cookbook/configuration/web_server_configuration>`,
     replace ``http://localhost:8000`` with your host name - like
-    ``http://symfony.local/app_dev.php/lucky/number``.
+    ``http://symfony.dev/app_dev.php/lucky/number``.
 
 If you see a lucky number being printed back to you, congratulations! But
 before you run off to play the lottery, check out how this works.
@@ -407,7 +407,7 @@ in your controller.
 
 The ``{% extends 'base.html.twig' %}`` points to a layout file that lives
 at `app/Resources/views/base.html.twig`_ and came with your new project.
-It's *really* basic (an unstyled HTML structure) and it's your's to customize.
+It's *really* basic (an unstyled HTML structure) and it's yours to customize.
 The ``{% block body %}`` part uses Twig's :ref:`inheritance system <twig-inheritance>`
 to put the content into the middle of the ``base.html.twig`` layout.
 
@@ -549,9 +549,9 @@ is ``app/config/config.yml``:
         // ...
 
 The ``framework`` key configures FrameworkBundle, the ``twig`` key configures
-TwigBundle and so on. A *lot* of behavior in Symfony can be controlled.
-To find out how, see the :doc:`Configuration Reference </reference/index>`
-section.
+TwigBundle and so on. A *lot* of behavior in Symfony can be controlled just
+by changing one option in this configuration file. To find out how, see the
+:doc:`Configuration Reference </reference/index>` section.
 
 Or, to get a big example dump of all of the valid configuration under a key,
 use the handy ``app/console`` command:
@@ -561,7 +561,7 @@ use the handy ``app/console`` command:
     $ app/console config:dump-reference framework
 
 There's a lot more power behind Symfony's configuration system, including
-environment, imports and parameters. To learn all of it, see the
+environments, imports and parameters. To learn all of it, see the
 :doc:`Configuration </book/configuration>` chapter.
 
 What's Next?

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -83,8 +83,6 @@ and is where you build the page. The only rule is that a controller *must*
 return a Symfony :ref:`Response <component-http-foundation-response>` object
 (and you'll even learn to bend this rule eventually).
 
-.. _book-page-creation-prod-cache-clear:
-
 .. sidebar:: What's the ``app_dev.php`` in the URL?
 
     Great question! By including ``app_dev.php`` in the URL, you're executing

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -34,7 +34,7 @@ Creating a Page: Route and Controller
 
 Suppose you want to create a page - ``/lucky/number`` - that generates a
 lucky (well, random) number and prints it. To do that, create a class and
-a method inside of it that will be executed when someone goes to ``/lucky/random``::
+a method inside of it that will be executed when someone goes to ``/lucky/number``::
 
     // src/AppBundle/Controller/LuckyController.php
     namespace AppBundle\Controller;
@@ -59,8 +59,6 @@ a method inside of it that will be executed when someone goes to ``/lucky/random
     }
 
 Before diving into this, test it out!
-
-.. code-block:: text
 
     http://localhost:8000/app_dev.php/lucky/number
 
@@ -128,8 +126,6 @@ Just add a second method to ``LuckyController``::
     }
 
 Try this out in your browser:
-
-.. code-block:: text
 
     http://localhost:8000/app_dev.php/api/lucky/number
 
@@ -251,8 +247,6 @@ The best part is that you can access this value and use it in your controller::
     }
 
 Try it by going to ``/lucky/number/XX`` - replacing XX with *any* number:
-
-.. code-block:: text
 
     http://localhost:8000/app_dev.php/lucky/number/7
 
@@ -410,8 +404,6 @@ The ``{% block body %}`` part uses Twig's :ref:`inheritance system <twig-inherit
 to put the content into the middle of the ``base.html.twig`` layout.
 
 Refresh to see your template in action!
-
-.. code-block:: text
 
     http://localhost:8000/app_dev.php/lucky/number/9
 

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -15,12 +15,11 @@ simple two-step process:
 
 #. *Create a controller*: A controller is the function you write that builds
    the page. You take the incoming request information and use it to create
-   a Symfony ``Response``, which could hold HTML content, a JSON string or
-   anything else.
+   a Symfony ``Response`` object, which can hold HTML content, a JSON string
+   or anything else.
 
 Just like on the web, every interaction is initiated by an HTTP request.
-Your job is pure and simple: understand that request and return the appropriate
-HTTP response.
+Your job is pure and simple: understand that request and return a response.
 
 .. index::
    single: Page creation; Example
@@ -59,7 +58,7 @@ a method inside of it that will be executed when someone goes to ``/lucky/random
         }
     }
 
-Before explaining this, try it out!
+Before diving into this, test it out!
 
 .. code-block:: text
 
@@ -71,15 +70,15 @@ Before explaining this, try it out!
     replace ``http://localhost:8000`` with your host name - like
     ``http://symfony.local/app_dev.php/lucky/number``.
 
-If you see a lucky number being printed back to you, congratulations!
+If you see a lucky number being printed back to you, congratulations! But
+before you run off to play the lottery, check out how this works.
 
 The ``@Route`` above ``numberAction()`` is called an *annotation* and it
 defines the URL pattern. You can also write routes in YAML (or other formats):
-read about this in the :doc:`routing </book/routing>` chapter. In fact, most
-routing example in the documentation will have tabs to show you how each
-format looks.
+read about this in the :doc:`routing </book/routing>` chapter. Actually, most
+routing examples in the docs have tabs that show you how each format looks.
 
-The method below the annotation - ``numberAction`` - is called the *contrller*
+The method below the annotation - ``numberAction`` - is called the *controller*
 and is where you build the page. The only rule is that a controller *must*
 return a Symfony :ref:`Response <component-http-foundation-response>` object
 (and you'll even learn to bend this rule eventually).
@@ -90,8 +89,8 @@ return a Symfony :ref:`Response <component-http-foundation-response>` object
 
     Great question! By including ``app_dev.php`` in the URL, you're executing
     Symfony through a file - ``web/app_dev.php`` - that boots it in the ``dev``
-    environment. This enables great debugging tools and rebuilds any cached
-    files automatically. For production, you'll use clean URLS - like
+    environment. This enables great debugging tools and rebuilds cached
+    files automatically. For production, you'll use clean URLs - like
     ``http://localhost:8000/lucky/number`` - that execute a different file -
     ``app.php`` - that's optimized for speed. To learn more about this and
     environments, see :ref:`book-page-creation-prod-cache-clear`.
@@ -100,10 +99,11 @@ Creating a JSON Response
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``Response`` object you return in your controller can contain HTML, JSON
-or anything you want. And you can easily set HTTP headers or the status code.
+or even a binary file like an image or PDF. You can easily set HTTP headers
+or the status code.
 
-Suppose you want to create a JSON endpoint that returns a lucky number. Just
-add a second method to ``LuckyController``::
+Suppose you want to create a JSON endpoint that returns the lucky number.
+Just add a second method to ``LuckyController``::
 
     // src/AppBundle/Controller/LuckyController.php
     // ...
@@ -164,10 +164,10 @@ You can even shorten this with the handy :class:`Symfony\\Component\\HttpFoundat
 Dynamic URL Patterns: /lucky/number/{count}
 -------------------------------------------
 
-You're doing great! But Symfony's routing can do a lot more. Suppose now
-that you want a user to be able to go to ``/lucky/number/5`` in order to
-generate *5* lucky numbers at once. Update the route to have a ``{wildcard}``
-part at the end:
+Woh, you're doing great! But Symfony's routing can do a lot more. Suppose
+now that you want a user to be able to go to ``/lucky/number/5`` to generate
+*5* lucky numbers at once. Update the route to have a ``{wildcard}`` part
+at the end:
 
 .. configuration-block::
 
@@ -258,10 +258,14 @@ Try it by going to ``/lucky/number/XX`` - replacing XX with *any* number:
 
     http://localhost:8000/app_dev.php/lucky/number/7
 
-You should see *7* lucky numbers printed out! The routing system can do a
-*lot* more, like supporting multiple placeholders (e.g. ``/blog/{category}/{page})``),
-making placeholders optional and forcing placeholder to match a regular expression
-(e.g. so that ``{count}`` *must* be a number).
+You should see *7* lucky numbers printed out! You can get the value of any
+``{placeholder}`` in your route by adding a ``$placeholder`` argument to
+your controller. Just make sure they have the same name.
+
+The routing system can do a *lot* more, like supporting multiple placeholders
+(e.g. ``/blog/{category}/{page})``), making placeholders optional and forcing
+placeholder to match a regular expression (e.g. so that ``{count}`` *must*
+be a number).
 
 Find out about all of this and become a routing expert in the
 :doc:`Routing </book/routing>` chapter.
@@ -271,10 +275,10 @@ Rendering a Template (with the Service Container)
 
 If you're returning HTML from your controller, you'll probably want to render
 a template. Fortunately, Symfony comes with Twig: a templating language that's
-easy to learn, powerful and fun to use.
+easy, powerful and actually quite fun.
 
-So far, ``LuckyController`` doesn't extend any base class. In order to use
-Twig - or many other tools in Symfony - you'll need to extend Symfony's base
+So far, ``LuckyController`` doesn't extend any base class. The easiest way
+to use Twig - or many other tools in Symfony - is to extend Symfony's base
 :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller` class::
     
     // src/AppBundle/Controller/LuckyController.php
@@ -309,10 +313,7 @@ To render a Twig template, use a service called ``templating``::
          */
         public function numberAction($count)
         {
-            $numbers = array();
-            for ($i = 0; $i < $count; $i++) {
-                $numbers[] = rand(0, 100);
-            }
+            // ...
             $numbersList = implode(', ', $numbers);
 
             $html = $this->container->get('templating')->render(
@@ -328,12 +329,12 @@ To render a Twig template, use a service called ``templating``::
 
 You'll learn a lot more about the important "service container" as you keep
 reading. For now, you just need to know that it holds a lot of objects, and
-you can "get" any object by using its nickname, like ``templating`` or ``logger``.
-The ``templating`` service is an instance of :class:`Symfony\\Bundle\\TwigBundle\\TwigEngine`
+you can ``get()`` any object by using its nickname, like ``templating`` or
+``logger``. The ``templating`` service is an instance of :class:`Symfony\\Bundle\\TwigBundle\\TwigEngine`
 and this has a ``render()`` method.
 
-And by extending the ``Controller`` class, you also get a lot of shortcut
-methods, like ``render()``. Use it to shorten the code::
+But this can get even easier! By extending the ``Controller`` class, you
+also get a lot of shortcut methods, like ``render()``::
 
     // src/AppBundle/Controller/LuckyController.php
     // ...
@@ -343,6 +344,8 @@ methods, like ``render()``. Use it to shorten the code::
      */
     public function numberAction($count)
     {
+        // ...
+
         /*
         $html = $this->container->get('templating')->render(
             'lucky/number.html.twig',
@@ -361,6 +364,11 @@ methods, like ``render()``. Use it to shorten the code::
 
 Learn more about these shortcut methods and how they work in the
 :doc:`Controller </book/controller>` chapter.
+
+.. tip::
+
+    For more advanced users, you can also
+    :doc:`register your controllers as services </cookbook/controller/service>`.
 
 Create the Template
 ~~~~~~~~~~~~~~~~~~~
@@ -394,7 +402,8 @@ a ``number.html.twig`` file inside of it:
 
 Welcome to Twig! This simple file already shows off the basics: like how
 the ``{{ variableName }}`` syntax is used to print something. The ``luckyNumberList``
-is a variable that you're passing into the template from the controller.
+is a variable that you're passing into the template from the ``render`` call
+in your controller.
 
 The ``{% extends 'base.html.twig' %}`` points to a layout file that lives
 at `app/Resources/views/base.html.twig`_ and came with your new project.
@@ -412,17 +421,17 @@ If you view the source code, you now have a basic HTML structure thanks to
 ``base.html.twig``.
 
 This is just the surface of Twig's power. When you're ready to master its
-syntax, loop over arrays, render other templates or other cool things, read
+syntax, loop over arrays, render other templates and other cool things, read
 the :doc:`Templating </book/templating>` chapter.
 
 Exploring the Project
 ---------------------
 
-You've already created a flexible URL, rendered template that uses inheritance
+You've already created a flexible URL, rendered a template that uses inheritance
 and created a JSON endpoint. Nice!
 
-Now, take a minute to explore the files in your project. You've already worked
-inside the two most important directories:
+It's time to explore and demystify the files in your project. You've already
+worked inside the two most important directories:
 
 ``app/``
     Contains things like configuration and templates. Basically, anything
@@ -445,14 +454,14 @@ and everything lives inside of it. A bundle is like a "plugin" and you can
 `find open source bundles`_ and install them into your project. But even
 *your* code lives in a bundle - typically ``AppBundle`` (though there's
 nothing special about ``AppBundle``). To find out more about bundles and
-when you might create new ones (hint: sharing code between projects), see
-the :doc:`Bundles </book/bundles>` chapter.
+why you might create multiple bundles (hint: sharing code between projects),
+see the :doc:`Bundles </book/bundles>` chapter.
 
 So what about the other directories in the project?
 
 ``vendor/``
     Vendor (i.e. third-party) libraries and bundles are downloaded here by
-    `Composer`_ package manager.
+    the `Composer`_ package manager.
 
 ``web/``
     This is the document root for the project and contains any publicly accessible
@@ -461,8 +470,8 @@ So what about the other directories in the project?
 
 .. seealso::
 
-    If you need to, you can override the default directory structure.
-    See :doc:`/cookbook/configuration/override_dir_structure`.
+    Symfony is flexible. If you need to, you can easily override the default
+    directory structure. See :doc:`/cookbook/configuration/override_dir_structure`.
 
 Application Configuration
 -------------------------
@@ -558,8 +567,10 @@ environment, imports and parameters. To learn all of it, see the
 What's Next?
 ------------
 
-If you've made it this far, you are already starting to master Symfony.
-Now, finish mastering the fundamentals by reading these chapters:
+Congrats! You're already starting to master Symfony and learn a whole new
+way of building beautiful, functional, fast and maintainable apps.
+
+Ok, time to finish mastering the fundamentals by reading these chapters:
 
 * :doc:`/book/controller`
 * :doc:`/book/routing`
@@ -569,8 +580,8 @@ Then, learn about Symfony's :doc:`service container </book/service_container>`
 the :doc:`form system </book/forms>`, using :doc:`Doctrine </book/doctrine>`
 if you need to query a database and more. in the :doc:`Symfony Book </book/index>`.
 
-There's also a :doc:`Cookbook </cookbook/index>` packed with more advanced
-"how to" articles to solve *a lot* of common problems.
+There's also a :doc:`Cookbook </cookbook/index>` *packed* with more advanced
+"how to" articles to solve *a lot* of problems.
 
 Have fun!
 

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -23,184 +23,178 @@ Your job is pure and simple: understand that request and return the appropriate
 HTTP response.
 
 .. index::
-   single: Page creation; Environments & Front Controllers
-
-.. _page-creation-environments:
-
-Environments & Front Controllers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Every Symfony application runs within an :term:`environment`. An environment
-is a specific set of configuration and loaded bundles, represented by a string.
-The same application can be run with different configurations by running the
-application in different environments. Symfony comes with three environments
-defined — ``dev``, ``test`` and ``prod`` — but you can create your own as well.
-
-Environments are useful by allowing a single application to have a dev environment
-built for debugging and a production environment optimized for speed. You might
-also load specific bundles based on the selected environment. For example,
-Symfony comes with the WebProfilerBundle (described below), enabled only
-in the ``dev`` and ``test`` environments.
-
-Symfony comes with two web-accessible front controllers: ``app_dev.php``
-provides the ``dev`` environment, and ``app.php`` provides the ``prod`` environment.
-All web accesses to Symfony normally go through one of these front controllers.
-(The ``test`` environment is normally only used when running unit tests, and so
-doesn't have a dedicated front controller. The console tool also provides a
-front controller that can be used with any environment.)
-
-When the front controller initializes the kernel, it provides two parameters:
-the environment, and also whether the kernel should run in debug mode.
-To make your application respond faster, Symfony maintains a cache under the
-``app/cache/`` directory. When debug mode is enabled (such as ``app_dev.php``
-does by default), this cache is flushed automatically whenever you make changes
-to any code or configuration. When running in debug mode, Symfony runs
-slower, but your changes are reflected without having to manually clear the
-cache.
-
-.. index::
    single: Page creation; Example
 
-The "Random Number" Page
-------------------------
+Creating a Page: Route and Controller
+-------------------------------------
 
-In this chapter, you'll develop an application that can generate random numbers.
-When you're finished, the user will be able to get a random number between ``1``
-and the upper limit set by the URL:
+.. tip::
+
+    Before continuing, make sure you've read the :doc:`Installation </book/installation>`
+    chapter and can access your new Symfony app in the browser.
+
+Suppose you want to create a page - ``/lucky/number`` - that generates a
+lucky (well, random) number and prints it. To do that, create a class and
+a method inside of it that will be executed when someone goes to ``/lucky/random``::
+
+    // src/AppBundle/Controller/LuckyController.php
+    namespace AppBundle\Controller;
+
+    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Symfony\Component\HttpFoundation\Response;
+
+    class LuckyController
+    {
+        /**
+         * @Route("/lucky/number")
+         */
+        public function numberAction()
+        {
+            $number = rand(0, 100);
+
+            return new Response(
+                '<html><body>Lucky number: '.$number.'</body></html>'
+            );
+        }
+    }
+
+Before explaining this, try it out!
 
 .. code-block:: text
 
-    http://localhost/app_dev.php/random/100
+    http://localhost:8000/app_dev.php/lucky/number
 
-Actually, you'll be able to replace ``100`` with any other number to generate
-numbers up to that upper limit. To create the page, follow the simple two-step
-process.
+.. tip::
 
-.. note::
+    If you setup a proper virtual host in :doc:`Apache or Nginx </cookbook/configuration/web_server_configuration>`,
+    replace ``http://localhost:8000`` with your host name - like
+    ``http://symfony.local/app_dev.php/lucky/number``.
 
-    The tutorial assumes that you've already downloaded Symfony and configured
-    your webserver. The above URL assumes that ``localhost`` points to the
-    ``web`` directory of your new Symfony project. For detailed information
-    on this process, see the documentation on the web server you are using.
-    Here are some relevant documentation pages for the web server you might be using:
+If you see a lucky number being printed back to you, congratulations!
 
-    * For Apache HTTP Server, refer to `Apache's DirectoryIndex documentation`_
-    * For Nginx, refer to `Nginx HttpCoreModule location documentation`_
+The ``@Route`` above ``numberAction()`` is called an *annotation* and it
+defines the URL pattern. You can also write routes in YAML (or other formats):
+read about this in the :doc:`routing </book/routing>` chapter. In fact, most
+routing example in the documentation will have tabs to show you how each
+format looks.
 
-Before you begin: Create the Bundle
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The method below the annotation - ``numberAction`` - is called the *contrller*
+and is where you build the page. The only rule is that a controller *must*
+return a Symfony :ref:`Response <component-http-foundation-response>` object
+(and you'll even learn to bend this rule eventually).
 
-Before you begin, you'll need to create a *bundle*. In Symfony, a :term:`bundle`
-is like a plugin, except that all the code in your application will live
-inside a bundle.
+.. _book-page-creation-prod-cache-clear:
 
-A bundle is nothing more than a directory that houses everything related
-to a specific feature, including PHP classes, configuration, and even stylesheets
-and JavaScript files (see :ref:`page-creation-bundles`).
+.. sidebar:: What's the ``app_dev.php`` in the URL?
 
-Depending on the way you installed Symfony, you may already have a bundle called
-AcmeDemoBundle. Browse the ``src/`` directory of your project and check
-if there is a ``DemoBundle/`` directory inside an ``Acme/`` directory. If those
-directories already exist, skip the rest of this section and go directly to
-create the route.
+    Great question! By including ``app_dev.php`` in the URL, you're executing
+    Symfony through a file - ``web/app_dev.php`` - that boots it in the ``dev``
+    environment. This enables great debugging tools and rebuilds any cached
+    files automatically. For production, you'll use clean URLS - like
+    ``http://localhost:8000/lucky/number`` - that execute a different file -
+    ``app.php`` - that's optimized for speed. To learn more about this and
+    environments, see :ref:`book-page-creation-prod-cache-clear`.
 
-To create a bundle called AcmeDemoBundle (a play bundle that you'll
-build in this chapter), run the following command and follow the on-screen
-instructions (use all the default options):
-
-.. code-block:: bash
-
-    $ php app/console generate:bundle --namespace=Acme/DemoBundle --format=yml
-
-Behind the scenes, a directory is created for the bundle at ``src/Acme/DemoBundle``.
-A line is also automatically added to the ``app/AppKernel.php`` file so that
-the bundle is registered with the kernel::
-
-    // app/AppKernel.php
-    public function registerBundles()
-    {
-        $bundles = array(
-            // ...
-            new Acme\DemoBundle\AcmeDemoBundle(),
-        );
-        // ...
-
-        return $bundles;
-    }
-
-Now that you have a bundle setup, you can begin building your application
-inside the bundle.
-
-Step 1: Create the Route
+Creating a JSON Response
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, the routing configuration file in a Symfony application is
-located at ``app/config/routing.yml``. Like all configuration in Symfony,
-you can also choose to use XML or PHP out of the box to configure routes.
+The ``Response`` object you return in your controller can contain HTML, JSON
+or anything you want. And you can easily set HTTP headers or the status code.
 
-If you look at the main routing file, you'll see that Symfony already added an
-entry when you generated the AcmeDemoBundle:
+Suppose you want to create a JSON endpoint that returns a lucky number. Just
+add a second method to ``LuckyController``::
+
+    // src/AppBundle/Controller/LuckyController.php
+    // ...
+
+    class LuckyController
+    {
+        // ...
+
+        /**
+         * @Route("/api/lucky/number")
+         */
+        public function apiNumberAction()
+        {
+            $data = array(
+                'lucky_number' => rand(0, 100),
+            );
+
+            return new Response(
+                json_encode($data),
+                200,
+                array('Content-Type' => 'application/json')
+            );
+        }
+    }
+
+Try this out in your browser:
+
+.. code-block:: text
+
+    http://localhost:8000/app_dev.php/api/lucky/number
+
+You can even shorten this with the handy :class:`Symfony\\Component\\HttpFoundation\\JsonResponse`::
+
+    // src/AppBundle/Controller/LuckyController.php
+    // ...
+
+    // --> don't forget this new use statement
+    use Symfony\Component\HttpFoundation\JsonResponse;
+
+    class LuckyController
+    {
+        // ...
+
+        /**
+         * @Route("/api/lucky/number")
+         */
+        public function apiNumberAction()
+        {
+            $data = array(
+                'lucky_number' => rand(0, 100),
+            );
+
+            // calls json_encode and sets the Content-Type header
+            return new JsonResponse($data);
+        }
+    }
+
+Dynamic URL Patterns: /lucky/number/{count}
+-------------------------------------------
+
+You're doing great! But Symfony's routing can do a lot more. Suppose now
+that you want a user to be able to go to ``/lucky/number/5`` in order to
+generate *5* lucky numbers at once. Update the route to have a ``{wildcard}``
+part at the end:
 
 .. configuration-block::
+
+    .. code-block:: php-annotations
+
+        // src/AppBundle/Controller/LuckyController.php
+        // ...
+
+        class LuckyController
+        {
+            /**
+             * @Route("/lucky/number/{count}")
+             */
+            public function numberAction()
+            {
+                // ...
+            }
+
+            // ...
+        }        
 
     .. code-block:: yaml
 
         # app/config/routing.yml
-        acme_website:
-            resource: "@AcmeDemoBundle/Resources/config/routing.yml"
-            prefix:   /
-
-    .. code-block:: xml
-
-        <!-- app/config/routing.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <routes xmlns="http://symfony.com/schema/routing"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing
-                http://symfony.com/schema/routing/routing-1.0.xsd">
-
-            <import
-                resource="@AcmeDemoBundle/Resources/config/routing.xml"
-                prefix="/" />
-        </routes>
-
-    .. code-block:: php
-
-        // app/config/routing.php
-        use Symfony\Component\Routing\RouteCollection;
-
-        $acmeDemo = $loader->import('@AcmeDemoBundle/Resources/config/routing.php');
-        $acmeDemo->addPrefix('/');
-
-        $collection = new RouteCollection();
-        $collection->addCollection($acmeDemo);
-
-        return $collection;
-
-This entry is pretty basic: it tells Symfony to load routing configuration
-from the ``Resources/config/routing.yml`` (``routing.xml`` or ``routing.php``
-in the XML and PHP code example respectively) file that lives inside the
-AcmeDemoBundle. This means that you place routing configuration directly in
-``app/config/routing.yml`` or organize your routes throughout your application,
-and import them from here.
-
-.. note::
-
-    You are not limited to load routing configurations that are of the same
-    format. For example, you could also load a YAML file in an XML configuration
-    and vice versa.
-
-Now that the ``routing.yml`` file from the bundle is being imported, add
-the new route that defines the URL of the page that you're about to create:
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # src/Acme/DemoBundle/Resources/config/routing.yml
-        random:
-            path:     /random/{limit}
-            defaults: { _controller: AcmeDemoBundle:Random:index }
+        lucky_number:
+            path:     /lucky/number/{count}
+            defaults: { _controller: AppBundle:Lucky:number }
 
     .. code-block:: xml
 
@@ -211,8 +205,8 @@ the new route that defines the URL of the page that you're about to create:
             xsi:schemaLocation="http://symfony.com/schema/routing
                 http://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="random" path="/random/{limit}">
-                <default key="_controller">AcmeDemoBundle:Random:index</default>
+            <route id="lucky_number" path="/lucky/number/{count}">
+                <default key="_controller">AppBundle:Lucky:number</default>
             </route>
         </routes>
 
@@ -223,595 +217,273 @@ the new route that defines the URL of the page that you're about to create:
         use Symfony\Component\Routing\Route;
 
         $collection = new RouteCollection();
-        $collection->add('random', new Route('/random/{limit}', array(
-            '_controller' => 'AcmeDemoBundle:Random:index',
+        $collection->add('lucky_number', new Route('/lucky/number/{count}', array(
+            '_controller' => 'AppBundle:Lucky:number',
         )));
 
         return $collection;
 
-The routing consists of two basic pieces: the ``path``, which is the URL
-that this route will match, and a ``defaults`` array, which specifies the
-controller that should be executed. The placeholder syntax in the path
-(``{limit}``) is a wildcard. It means that ``/random/10``, ``/random/327``
-or any other similar URL will match this route. The ``{limit}`` placeholder
-parameter will also be passed to the controller so that you can use its value
-to generate the proper random number.
+Because of the ``{count}`` "placeholder", the URL to the page is *different*:
+it now works for URLs matching ``/lucky/number/*`` - for example ``/lucky/number/5``.
+The best part is that you can access this value and use it in your controller::
 
-.. note::
+    // src/AppBundle/Controller/LuckyController.php
+    // ...
 
-  The routing system has many more great features for creating flexible
-  and powerful URL structures in your application. For more details, see
-  the chapter all about :doc:`Routing </book/routing>`.
-
-Step 2: Create the Controller
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When a URL such as ``/random/10`` is handled by the application, the ``random``
-route is matched and the ``AcmeDemoBundle:Random:index`` controller is executed
-by the framework. The second step of the page-creation process is to create
-that controller.
-
-The controller - ``AcmeDemoBundle:Random:index`` is the *logical* name of
-the controller, and it maps to the ``indexAction`` method of a PHP class
-called ``Acme\DemoBundle\Controller\RandomController``. Start by creating this
-file inside your AcmeDemoBundle::
-
-    // src/Acme/DemoBundle/Controller/RandomController.php
-    namespace Acme\DemoBundle\Controller;
-
-    class RandomController
+    class LuckyController
     {
-    }
 
-In reality, the controller is nothing more than a PHP method that you create
-and Symfony executes. This is where your code uses information from the request
-to build and prepare the resource being requested. Except in some advanced
-cases, the end product of a controller is always the same: a Symfony ``Response``
-object.
-
-Create the ``indexAction`` method that Symfony will execute when the ``random``
-route is matched::
-
-    // src/Acme/DemoBundle/Controller/RandomController.php
-    namespace Acme\DemoBundle\Controller;
-
-    use Symfony\Component\HttpFoundation\Response;
-
-    class RandomController
-    {
-        public function indexAction($limit)
+        /**
+         * @Route("/lucky/number/{count}")
+         */
+        public function numberAction($count)
         {
+            $numbers = array();
+            for ($i = 0; $i < $count; $i++) {
+                $numbers[] = rand(0, 100);
+            }
+            $numbersList = implode(', ', $numbers);
+
             return new Response(
-                '<html><body>Number: '.rand(1, $limit).'</body></html>'
+                '<html><body>Lucky numbers: '.$numbersList.'</body></html>'
             );
         }
+
+        // ...
     }
 
-The controller is simple: it creates a new ``Response`` object, whose first
-argument is the content that should be used in the response (a small HTML
-page in this example).
-
-Congratulations! After creating only a route and a controller, you already
-have a fully-functional page! If you've setup everything correctly, your
-application should generate a random number for you:
+Try it by going to ``/lucky/number/XX`` - replacing XX with *any* number:
 
 .. code-block:: text
 
-    http://localhost/app_dev.php/random/10
+    http://localhost:8000/app_dev.php/lucky/number/7
 
-.. _book-page-creation-prod-cache-clear:
+You should see *7* lucky numbers printed out! The routing system can do a
+*lot* more, like supporting multiple placeholders (e.g. ``/blog/{category}/{page})``),
+making placeholders optional and forcing placeholder to match a regular expression
+(e.g. so that ``{count}`` *must* be a number).
 
-.. tip::
+Find out about all of this and become a routing expert in the
+:doc:`Routing </book/routing>` chapter.
 
-    You can also view your app in the "prod" :ref:`environment <environments-summary>`
-    by visiting:
+Rendering a Template (with the Service Container)
+-------------------------------------------------
 
-    .. code-block:: text
+If you're returning HTML from your controller, you'll probably want to render
+a template. Fortunately, Symfony comes with Twig: a templating language that's
+easy to learn, powerful and fun to use.
 
-        http://localhost/app.php/random/10
+So far, ``LuckyController`` doesn't extend any base class. In order to use
+Twig - or many other tools in Symfony - you'll need to extend Symfony's base
+:class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller` class::
+    
+    // src/AppBundle/Controller/LuckyController.php
+    // ...
 
-    If you get an error, it's likely because you need to clear your cache
-    by running:
-
-    .. code-block:: bash
-
-        $ php app/console cache:clear --env=prod --no-debug
-
-An optional, but common, third step in the process is to create a template.
-
-.. note::
-
-   Controllers are the main entry point for your code and a key ingredient
-   when creating pages. Much more information can be found in the
-   :doc:`Controller Chapter </book/controller>`.
-
-Optional Step 3: Create the Template
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Templates allow you to move all the presentation code (e.g. HTML) into
-a separate file and reuse different portions of the page layout. Instead
-of writing the HTML inside the controller, render a template instead:
-
-.. code-block:: php
-    :linenos:
-
-    // src/Acme/DemoBundle/Controller/RandomController.php
-    namespace Acme\DemoBundle\Controller;
-
+    // --> add this new use statement
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
-    class RandomController extends Controller
+    class LuckyController extends Controller
     {
-        public function indexAction($limit)
-        {
-            $number = rand(1, $limit);
-
-            return $this->render(
-                'AcmeDemoBundle:Random:index.html.twig',
-                array('number' => $number)
-            );
-
-            // render a PHP template instead
-            // return $this->render(
-            //     'AcmeDemoBundle:Random:index.html.php',
-            //     array('number' => $number)
-            // );
-        }
+        // ...
     }
 
-.. note::
+Using the ``templating`` Service
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   In order to use the :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::render`
-   method, your controller must extend the
-   :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller` class,
-   which adds shortcuts for tasks that are common inside controllers. This
-   is done in the above example by adding the ``use`` statement on line 4
-   and then extending ``Controller`` on line 6.
+This doesn't change anything, but it *does* give you access to Symfony's
+:doc:`container </book/service_container>`: an array-like object that gives
+you access to *every* useful object in the system. These useful objects are
+called *services*, and Symfony ships with a service object that can render
+Twig templates, another that can log messages and many more.
 
-The ``render()`` method creates a ``Response`` object filled with the content
-of the given, rendered template. Like any other controller, you will ultimately
-return that ``Response`` object.
+To render a Twig template, use a service called ``templating``::
 
-Notice that there are two different examples for rendering the template.
-By default, Symfony supports two different templating languages: classic
-PHP templates and the succinct but powerful `Twig`_ templates. Don't be
-alarmed - you're free to choose either or even both in the same project.
+    // src/AppBundle/Controller/LuckyController.php
+    // ...
 
-The controller renders the ``AcmeDemoBundle:Random:index.html.twig`` template,
-which uses the following naming convention:
+    class LuckyController extends Controller
+    {
+        /**
+         * @Route("/lucky/number/{count}")
+         */
+        public function numberAction($count)
+        {
+            $numbers = array();
+            for ($i = 0; $i < $count; $i++) {
+                $numbers[] = rand(0, 100);
+            }
+            $numbersList = implode(', ', $numbers);
 
-    **BundleName**:**ControllerName**:**TemplateName**
+            $html = $this->container->get('templating')->render(
+                'lucky/number.html.twig',
+                array('luckyNumberList' => $numbersList)
+            );
 
-This is the *logical* name of the template, which is mapped to a physical
-location using the following convention.
+            return new Response($html);
+        }
 
-    **/path/to/BundleName**/Resources/views/**ControllerName**/**TemplateName**
+        // ...
+    }
 
-In this case, AcmeDemoBundle is the bundle name, ``Random`` is the
-controller, and ``index.html.twig`` the template:
+You'll learn a lot more about the important "service container" as you keep
+reading. For now, you just need to know that it holds a lot of objects, and
+you can "get" any object by using its nickname, like ``templating`` or ``logger``.
+The ``templating`` service is an instance of :class:`Symfony\\Bundle\\TwigBundle\\TwigEngine`
+and this has a ``render()`` method.
+
+And by extending the ``Controller`` class, you also get a lot of shortcut
+methods, like ``render()``. Use it to shorten the code::
+
+    // src/AppBundle/Controller/LuckyController.php
+    // ...
+
+    /**
+     * @Route("/lucky/number/{count}")
+     */
+    public function numberAction($count)
+    {
+        /*
+        $html = $this->container->get('templating')->render(
+            'lucky/number.html.twig',
+            array('luckyNumberList' => $numbersList)
+        );
+
+        return new Response($html);
+        */
+
+        // render: a shortcut that does the same as above
+        return $this->render(
+            'lucky/number.html.twig',
+            array('luckyNumberList' => $numbersList)
+        );
+    }
+
+Learn more about these shortcut methods and how they work in the
+:doc:`Controller </book/controller>` chapter.
+
+Create the Template
+~~~~~~~~~~~~~~~~~~~
+
+If you refresh now, you'll get an error:
+
+    Unable to find template "lucky/number.html.twig"
+
+Fix that by creating a new ``app/Resources/views/lucky`` directory and putting
+a ``number.html.twig`` file inside of it:
 
 .. configuration-block::
 
     .. code-block:: jinja
-       :linenos:
 
-        {# src/Acme/DemoBundle/Resources/views/Random/index.html.twig #}
-        {% extends '::base.html.twig' %}
+        {# app/Resources/views/lucky/number.html.twig #}
+        {% extends 'base.html.twig' %}
 
         {% block body %}
-            Number: {{ number }}
+            <h1>Lucky Numbers: {{ luckyNumberList }}</h1>
         {% endblock %}
 
     .. code-block:: html+php
 
-        <!-- src/Acme/DemoBundle/Resources/views/Random/index.html.php -->
-        <?php $view->extend('::base.html.php') ?>
+        <!-- app/Resources/views/lucky/number.html.php -->
+        <?php $view->extend('base.html.php') ?>
 
-        Number: <?php echo $view->escape($number) ?>
+        <?php $view['slots']->start('body') ?>
+            <h1>Lucky Numbers: <?php echo $view->escape($luckyNumberList) ?>
+        <?php $view['slots']->stop() ?>
 
-Step through the Twig template line-by-line:
+Welcome to Twig! This simple file already shows off the basics: like how
+the ``{{ variableName }}`` syntax is used to print something. The ``luckyNumberList``
+is a variable that you're passing into the template from the controller.
 
-* *line 2*: The ``extends`` token defines a parent template. The template
-  explicitly defines a layout file inside of which it will be placed.
+The ``{% extends 'base.html.twig' %}`` points to a layout file that lives
+at `app/Resources/views/base.html.twig`_ and came with your new project.
+It's *really* basic (an unstyled HTML structure) and it's your's to customize.
+The ``{% block body %}`` part uses Twig's :ref:`inheritance system <twig-inheritance>`
+to put the content into the middle of the ``base.html.twig`` layout.
 
-* *line 4*: The ``block`` token says that everything inside should be placed
-  inside a block called ``body``. As you'll see, it's the responsibility
-  of the parent template (``base.html.twig``) to ultimately render the
-  block called ``body``.
+Refresh to see your template in action!
 
-The parent template, ``::base.html.twig``, is missing both the **BundleName**
-and **ControllerName** portions of its name (hence the double colon (``::``)
-at the beginning). This means that the template lives outside of the bundle
-and in the ``app`` directory:
+.. code-block:: text
 
-.. configuration-block::
+    http://localhost:8000/app_dev.php/lucky/number/9
 
-    .. code-block:: html+jinja
+If you view the source code, you now have a basic HTML structure thanks to
+``base.html.twig``.
 
-        {# app/Resources/views/base.html.twig #}
-        <!DOCTYPE html>
-        <html>
-            <head>
-                <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-                <title>{% block title %}Welcome!{% endblock %}</title>
-                {% block stylesheets %}{% endblock %}
-                <link rel="shortcut icon" href="{{ asset('favicon.ico') }}" />
-            </head>
-            <body>
-                {% block body %}{% endblock %}
-                {% block javascripts %}{% endblock %}
-            </body>
-        </html>
+This is just the surface of Twig's power. When you're ready to master its
+syntax, loop over arrays, render other templates or other cool things, read
+the :doc:`Templating </book/templating>` chapter.
 
-    .. code-block:: html+php
+Exploring the Project
+---------------------
 
-        <!-- app/Resources/views/base.html.php -->
-        <!DOCTYPE html>
-        <html>
-            <head>
-                <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-                <title><?php $view['slots']->output('title', 'Welcome!') ?></title>
-                <?php $view['slots']->output('stylesheets') ?>
-                <link rel="shortcut icon"
-                    href="<?php echo $view['assets']->getUrl('favicon.ico') ?>" />
-            </head>
-            <body>
-                <?php $view['slots']->output('_content') ?>
-                <?php $view['slots']->output('javascripts') ?>
-            </body>
-        </html>
+You've already created a flexible URL, rendered template that uses inheritance
+and created a JSON endpoint. Nice!
 
-The base template file defines the HTML layout and renders the ``body`` block
-that you defined in the ``index.html.twig`` template. It also renders a ``title``
-block, which you could choose to define in the ``index.html.twig`` template.
-Since you did not define the ``title`` block in the child template, it defaults
-to "Welcome!".
-
-Templates are a powerful way to render and organize the content for your
-page. A template can render anything, from HTML markup, to CSS code, or anything
-else that the controller may need to return.
-
-In the lifecycle of handling a request, the templating engine is simply
-an optional tool. Recall that the goal of each controller is to return a
-``Response`` object. Templates are a powerful, but optional, tool for creating
-the content for that ``Response`` object.
-
-.. index::
-   single: Directory Structure
-
-The Directory Structure
------------------------
-
-After just a few short sections, you already understand the philosophy behind
-creating and rendering pages in Symfony. You've also already begun to see
-how Symfony projects are structured and organized. By the end of this section,
-you'll know where to find and put different types of files and why.
-
-Though entirely flexible, by default, each Symfony :term:`application` has
-the same basic and recommended directory structure:
+Now, take a minute to explore the files in your project. You've already worked
+inside the two most important directories:
 
 ``app/``
-    This directory contains the application configuration.
+    Contains things like configuration and templates. Basically, anything
+    that is *not* PHP code goes here.
 
 ``src/``
-    All the project PHP code is stored under this directory.
+    Your PHP code lives here.
+
+99% of the time, you'll be working in ``src/`` (PHP files) or ``app/`` (everything
+else). As you get more advanced, you'll learn what can be done inside each
+of these.
+
+The ``app/`` directory also holds a few other things, like the cache directory
+``app/cache/``, the logs directory ``app/logs/`` and ``app/AppKernel.php``,
+which you'll use to enable new bundles (and one of a *very* short list of
+PHP files in ``app/``).
+
+The ``src/`` directory has just one directory - ``src/AppBundle`` -
+and everything lives inside of it. A bundle is like a "plugin" and you can
+`find open source bundles`_ and install them into your project. But even
+*your* code lives in a bundle - typically ``AppBundle`` (though there's
+nothing special about ``AppBundle``). To find out more about bundles and
+when you might create new ones (hint: sharing code between projects), see
+the :doc:`Bundles </book/bundles>` chapter.
+
+So what about the other directories in the project?
 
 ``vendor/``
-    Any vendor libraries are placed here by convention.
+    Vendor (i.e. third-party) libraries and bundles are downloaded here by
+    `Composer`_ package manager.
 
 ``web/``
-    This is the web root directory and contains any publicly accessible files.
+    This is the document root for the project and contains any publicly accessible
+    files, like CSS, images and the Symfony front controllers that execute
+    the app (``app_dev.php`` and ``app.php``).
 
 .. seealso::
 
-    You can easily override the default directory structure. See
-    :doc:`/cookbook/configuration/override_dir_structure` for more
-    information.
-
-.. _the-web-directory:
-
-The Web Directory
-~~~~~~~~~~~~~~~~~
-
-The web root directory is the home of all public and static files including
-images, stylesheets, and JavaScript files. It is also where each
-:term:`front controller` lives::
-
-    // web/app.php
-    require_once __DIR__.'/../app/bootstrap.php.cache';
-    require_once __DIR__.'/../app/AppKernel.php';
-
-    use Symfony\Component\HttpFoundation\Request;
-
-    $kernel = new AppKernel('prod', false);
-    $kernel->loadClassCache();
-    $kernel->handle(Request::createFromGlobals())->send();
-
-The front controller file (``app.php`` in this example) is the actual PHP
-file that's executed when using a Symfony application and its job is to
-use a Kernel class, ``AppKernel``, to bootstrap the application.
-
-.. tip::
-
-    Having a front controller means different and more flexible URLs than
-    are used in a typical flat PHP application. When using a front controller,
-    URLs are formatted in the following way:
-
-    .. code-block:: text
-
-        http://localhost/app.php/random/10
-
-    The front controller, ``app.php``, is executed and the "internal:" URL
-    ``/random/10`` is routed internally using the routing configuration.
-    By using Apache ``mod_rewrite`` rules, you can force the ``app.php`` file
-    to be executed without needing to specify it in the URL:
-
-    .. code-block:: text
-
-        http://localhost/random/10
-
-Though front controllers are essential in handling every request, you'll
-rarely need to modify or even think about them. They'll be mentioned again
-briefly in the `Environments`_ section.
-
-The Application (``app``) Directory
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-As you saw in the front controller, the ``AppKernel`` class is the main entry
-point of the application and is responsible for all configuration. As such,
-it is stored in the ``app/`` directory.
-
-This class must implement two methods that define everything that Symfony
-needs to know about your application. You don't even need to worry about
-these methods when starting - Symfony fills them in for you with sensible
-defaults.
-
-``registerBundles()``
-    Returns an array of all bundles needed to run the application (see
-    :ref:`page-creation-bundles`).
-
-``registerContainerConfiguration()``
-    Loads the main application configuration resource file (see the
-    `Application Configuration`_ section).
-
-In day-to-day development, you'll mostly use the ``app/`` directory to modify
-configuration and routing files in the ``app/config/`` directory (see
-`Application Configuration`_). It also contains the application cache
-directory (``app/cache``), a log directory (``app/logs``) and a directory
-for application-level resource files, such as templates (``app/Resources``).
-You'll learn more about each of these directories in later chapters.
-
-.. _autoloading-introduction-sidebar:
-
-.. sidebar:: Autoloading
-
-    When Symfony is loading, a special file - ``vendor/autoload.php`` - is
-    included. This file is created by Composer and will autoload all
-    application files living in the ``src/`` folder as well as all
-    third-party libraries mentioned in the ``composer.json`` file.
-
-    Because of the autoloader, you never need to worry about using ``include``
-    or ``require`` statements. Instead, Composer uses the namespace of a class
-    to determine its location and automatically includes the file on your
-    behalf the instant you need a class.
-
-    The autoloader is already configured to look in the ``src/`` directory
-    for any of your PHP classes. For autoloading to work, the class name and
-    path to the file have to follow the same pattern:
-
-    .. code-block:: text
-
-        Class Name:
-            Acme\DemoBundle\Controller\RandomController
-        Path:
-            src/Acme/DemoBundle/Controller/RandomController.php
-
-The Source (``src``) Directory
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Put simply, the ``src/`` directory contains all the actual code (PHP code,
-templates, configuration files, stylesheets, etc) that drives *your* application.
-When developing, the vast majority of your work will be done inside one or
-more bundles that you create in this directory.
-
-But what exactly is a :term:`bundle`?
-
-.. _page-creation-bundles:
-
-The Bundle System
------------------
-
-A bundle is similar to a plugin in other software, but even better. The key
-difference is that *everything* is a bundle in Symfony, including both the
-core framework functionality and the code written for your application.
-Bundles are first-class citizens in Symfony. This gives you the flexibility
-to use pre-built features packaged in `third-party bundles`_ or to distribute
-your own bundles. It makes it easy to pick and choose which features to enable
-in your application and to optimize them the way you want.
-
-.. note::
-
-   While you'll learn the basics here, an entire cookbook entry is devoted
-   to the organization and best practices of :doc:`bundles </cookbook/bundles/best_practices>`.
-
-A bundle is simply a structured set of files within a directory that implement
-a single feature. You might create a BlogBundle, a ForumBundle or
-a bundle for user management (many of these exist already as open source
-bundles). Each directory contains everything related to that feature, including
-PHP files, templates, stylesheets, JavaScripts, tests and anything else.
-Every aspect of a feature exists in a bundle and every feature lives in a
-bundle.
-
-An application is made up of bundles as defined in the ``registerBundles()``
-method of the ``AppKernel`` class::
-
-    // app/AppKernel.php
-    public function registerBundles()
-    {
-        $bundles = array(
-            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Symfony\Bundle\SecurityBundle\SecurityBundle(),
-            new Symfony\Bundle\TwigBundle\TwigBundle(),
-            new Symfony\Bundle\MonologBundle\MonologBundle(),
-            new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
-            new Symfony\Bundle\DoctrineBundle\DoctrineBundle(),
-            new Symfony\Bundle\AsseticBundle\AsseticBundle(),
-            new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
-        );
-
-        if (in_array($this->getEnvironment(), array('dev', 'test'))) {
-            $bundles[] = new Acme\DemoBundle\AcmeDemoBundle();
-            $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
-            $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
-            $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
-        }
-
-        return $bundles;
-    }
-
-With the ``registerBundles()`` method, you have total control over which bundles
-are used by your application (including the core Symfony bundles).
-
-.. tip::
-
-   A bundle can live *anywhere* as long as it can be autoloaded (via the
-   autoloader configured at ``app/autoload.php``).
-
-Creating a Bundle
-~~~~~~~~~~~~~~~~~
-
-The Symfony Standard Edition comes with a handy task that creates a fully-functional
-bundle for you. Of course, creating a bundle by hand is pretty easy as well.
-
-To show you how simple the bundle system is, create a new bundle called
-AcmeTestBundle and enable it.
-
-.. tip::
-
-    The ``Acme`` portion is just a dummy name that should be replaced by
-    some "vendor" name that represents you or your organization (e.g.
-    ABCTestBundle for some company named ``ABC``).
-
-Start by creating a ``src/Acme/TestBundle/`` directory and adding a new file
-called ``AcmeTestBundle.php``::
-
-    // src/Acme/TestBundle/AcmeTestBundle.php
-    namespace Acme\TestBundle;
-
-    use Symfony\Component\HttpKernel\Bundle\Bundle;
-
-    class AcmeTestBundle extends Bundle
-    {
-    }
-
-.. tip::
-
-   The name AcmeTestBundle follows the standard
-   :ref:`Bundle naming conventions <bundles-naming-conventions>`. You could
-   also choose to shorten the name of the bundle to simply TestBundle by naming
-   this class TestBundle (and naming the file ``TestBundle.php``).
-
-This empty class is the only piece you need to create the new bundle. Though
-commonly empty, this class is powerful and can be used to customize the behavior
-of the bundle.
-
-Now that you've created the bundle, enable it via the ``AppKernel`` class::
-
-    // app/AppKernel.php
-    public function registerBundles()
-    {
-        $bundles = array(
-            // ...
-            // register your bundle
-            new Acme\TestBundle\AcmeTestBundle(),
-        );
-        // ...
-
-        return $bundles;
-    }
-
-And while it doesn't do anything yet, AcmeTestBundle is now ready to be used.
-
-And as easy as this is, Symfony also provides a command-line interface for
-generating a basic bundle skeleton:
-
-.. code-block:: bash
-
-    $ php app/console generate:bundle --namespace=Acme/TestBundle
-
-The bundle skeleton generates with a basic controller, template and routing
-resource that can be customized. You'll learn more about Symfony's command-line
-tools later.
-
-.. tip::
-
-   Whenever creating a new bundle or using a third-party bundle, always make
-   sure the bundle has been enabled in ``registerBundles()``. When using
-   the ``generate:bundle`` command, this is done for you.
-
-Bundle Directory Structure
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The directory structure of a bundle is simple and flexible. By default, the
-bundle system follows a set of conventions that help to keep code consistent
-between all Symfony bundles. Take a look at AcmeDemoBundle, as it contains some
-of the most common elements of a bundle:
-
-``Controller/``
-    Contains the controllers of the bundle (e.g. ``RandomController.php``).
-
-``DependencyInjection/``
-    Holds certain Dependency Injection Extension classes, which may import service
-    configuration, register compiler passes or more (this directory is not
-    necessary).
-
-``Resources/config/``
-    Houses configuration, including routing configuration (e.g. ``routing.yml``).
-
-``Resources/views/``
-    Holds templates organized by controller name (e.g. ``Hello/index.html.twig``).
-
-``Resources/public/``
-    Contains web assets (images, stylesheets, etc) and is copied or symbolically
-    linked into the project ``web/`` directory via the ``assets:install`` console
-    command.
-
-``Tests/``
-    Holds all tests for the bundle.
-
-A bundle can be as small or large as the feature it implements. It contains
-only the files you need and nothing else.
-
-As you move through the book, you'll learn how to persist objects to a database,
-create and validate forms, create translations for your application, write
-tests and much more. Each of these has their own place and role within the
-bundle.
+    If you need to, you can override the default directory structure.
+    See :doc:`/cookbook/configuration/override_dir_structure`.
 
 Application Configuration
 -------------------------
 
-An application consists of a collection of bundles representing all the
-features and capabilities of your application. Each bundle can be customized
-via configuration files written in YAML, XML or PHP. By default, the main
-configuration file lives in the ``app/config/`` directory and is called
-either ``config.yml``, ``config.xml`` or ``config.php`` depending on which
-format you prefer:
+Symfony comes with several built-in bundles (open your ``app/AppKernel.php``
+file) and you'll probably install more. The main configuration file for bundles
+is ``app/config/config.yml``:
 
 .. configuration-block::
 
     .. code-block:: yaml
 
         # app/config/config.yml
-        imports:
-            - { resource: parameters.yml }
-            - { resource: security.yml }
+        # ...
 
         framework:
-            secret:          "%secret%"
-            router:          { resource: "%kernel.root_dir%/config/routing.yml" }
+            secret: "%secret%"
+            router:
+                resource: "%kernel.root_dir%/config/routing.yml"
             # ...
 
-        # Twig Configuration
         twig:
             debug:            "%kernel.debug%"
             strict_variables: "%kernel.debug%"
@@ -833,10 +505,7 @@ format you prefer:
                 http://symfony.com/schema/dic/twig
                 http://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
-            <imports>
-                <import resource="parameters.yml" />
-                <import resource="security.yml" />
-            </imports>
+            <!-- ... -->
 
             <framework:config secret="%secret%">
                 <framework:router resource="%kernel.root_dir%/config/routing.xml" />
@@ -852,8 +521,7 @@ format you prefer:
     .. code-block:: php
 
         // app/config/config.php
-        $this->import('parameters.yml');
-        $this->import('security.yml');
+        // ...
 
         $container->loadFromExtension('framework', array(
             'secret' => '%secret%',
@@ -871,234 +539,41 @@ format you prefer:
 
         // ...
 
-.. note::
+The ``framework`` key configures FrameworkBundle, the ``twig`` key configures
+TwigBundle and so on. A *lot* of behavior in Symfony can be controlled.
+To find out how, see the :doc:`Configuration Reference </reference/index>`
+section.
 
-   You'll learn exactly how to load each file/format in the next section
-   `Environments`_.
-
-Each top-level entry like ``framework`` or ``twig`` defines the configuration
-for a particular bundle. For example, the ``framework`` key defines the configuration
-for the core Symfony FrameworkBundle and includes configuration for the
-routing, templating, and other core systems.
-
-For now, don't worry about the specific configuration options in each section.
-The configuration file ships with sensible defaults. As you read more and
-explore each part of Symfony, you'll learn about the specific configuration
-options of each feature.
-
-.. sidebar:: Configuration Formats
-
-    Throughout the chapters, all configuration examples will be shown in all
-    three formats (YAML, XML and PHP). Each has its own advantages and
-    disadvantages. The choice of which to use is up to you:
-
-    * *YAML*: Simple, clean and readable (learn more about YAML in
-      ":doc:`/components/yaml/yaml_format`");
-
-    * *XML*: More powerful than YAML at times and supports IDE autocompletion;
-
-    * *PHP*: Very powerful but less readable than standard configuration formats.
-
-Default Configuration Dump
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can dump the default configuration for a bundle in YAML to the console using
-the ``config:dump-reference`` command. Here is an example of dumping the default
-FrameworkBundle configuration:
-
-.. code-block:: bash
-
-    $ app/console config:dump-reference FrameworkBundle
-
-The extension alias (configuration key) can also be used:
+Or, to get a big example dump of all of the valid configuration under a key,
+use the handy ``app/console`` command:
 
 .. code-block:: bash
 
     $ app/console config:dump-reference framework
 
-.. note::
+There's a lot more power behind Symfony's configuration system, including
+environment, imports and parameters. To learn all of it, see the
+:doc:`Configuration </book/configuration>` chapter.
 
-    See the cookbook article: :doc:`/cookbook/bundles/extension` for
-    information on adding configuration for your own bundle.
-
-.. index::
-   single: Environments; Introduction
-
-.. _environments-summary:
-
-Environments
+What's Next?
 ------------
 
-An application can run in various environments. The different environments
-share the same PHP code (apart from the front controller), but use different
-configuration. For instance, a ``dev`` environment will log warnings and
-errors, while a ``prod`` environment will only log errors. Some files are
-rebuilt on each request in the ``dev`` environment (for the developer's convenience),
-but cached in the ``prod`` environment. All environments live together on
-the same machine and execute the same application.
+If you've made it this far, you are already starting to master Symfony.
+Now, finish mastering the fundamentals by reading these chapters:
 
-A Symfony project generally begins with three environments (``dev``, ``test``
-and ``prod``), though creating new environments is easy. You can view your
-application in different environments simply by changing the front controller
-in your browser. To see the application in the ``dev`` environment, access
-the application via the development front controller:
+* :doc:`/book/controller`
+* :doc:`/book/routing`
+* :doc:`/book/templating`
 
-.. code-block:: text
+Then, learn about Symfony's :doc:`service container </book/service_container>`
+the :doc:`form system </book/forms>`, using :doc:`Doctrine </book/doctrine>`
+if you need to query a database and more. in the :doc:`Symfony Book </book/index>`.
 
-    http://localhost/app_dev.php/random/10
+There's also a :doc:`Cookbook </cookbook/index>` packed with more advanced
+"how to" articles to solve *a lot* of common problems.
 
-If you'd like to see how your application will behave in the production environment,
-call the ``prod`` front controller instead:
+Have fun!
 
-.. code-block:: text
-
-    http://localhost/app.php/random/10
-
-Since the ``prod`` environment is optimized for speed; the configuration,
-routing and Twig templates are compiled into flat PHP classes and cached.
-When viewing changes in the ``prod`` environment, you'll need to clear these
-cached files and allow them to rebuild:
-
-.. code-block:: bash
-
-    $ php app/console cache:clear --env=prod --no-debug
-
-.. note::
-
-   If you open the ``web/app.php`` file, you'll find that it's configured explicitly
-   to use the ``prod`` environment::
-
-       $kernel = new AppKernel('prod', false);
-
-   You can create a new front controller for a new environment by copying
-   this file and changing ``prod`` to some other value.
-
-.. note::
-
-    The ``test`` environment is used when running automated tests and cannot
-    be accessed directly through the browser. See the :doc:`testing chapter </book/testing>`
-    for more details.
-
-.. index::
-   single: Environments; Configuration
-
-Environment Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``AppKernel`` class is responsible for actually loading the configuration
-file of your choice::
-
-    // app/AppKernel.php
-    public function registerContainerConfiguration(LoaderInterface $loader)
-    {
-        $loader->load(
-            __DIR__.'/config/config_'.$this->getEnvironment().'.yml'
-        );
-    }
-
-You already know that the ``.yml`` extension can be changed to ``.xml`` or
-``.php`` if you prefer to use either XML or PHP to write your configuration.
-Notice also that each environment loads its own configuration file. Consider
-the configuration file for the ``dev`` environment.
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # app/config/config_dev.yml
-        imports:
-            - { resource: config.yml }
-
-        framework:
-            router:   { resource: "%kernel.root_dir%/config/routing_dev.yml" }
-            profiler: { only_exceptions: false }
-
-        # ...
-
-    .. code-block:: xml
-
-        <!-- app/config/config_dev.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:framework="http://symfony.com/schema/dic/symfony"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services
-                http://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/symfony
-                http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
-            <imports>
-                <import resource="config.xml" />
-            </imports>
-
-            <framework:config>
-                <framework:router resource="%kernel.root_dir%/config/routing_dev.xml" />
-                <framework:profiler only-exceptions="false" />
-            </framework:config>
-
-            <!-- ... -->
-        </container>
-
-    .. code-block:: php
-
-        // app/config/config_dev.php
-        $loader->import('config.php');
-
-        $container->loadFromExtension('framework', array(
-            'router' => array(
-                'resource' => '%kernel.root_dir%/config/routing_dev.php',
-            ),
-            'profiler' => array('only-exceptions' => false),
-        ));
-
-        // ...
-
-The ``imports`` key is similar to a PHP ``include`` statement and guarantees
-that the main configuration file (``config.yml``) is loaded first. The rest
-of the file tweaks the default configuration for increased logging and other
-settings conducive to a development environment.
-
-Both the ``prod`` and ``test`` environments follow the same model: each environment
-imports the base configuration file and then modifies its configuration values
-to fit the needs of the specific environment. This is just a convention,
-but one that allows you to reuse most of your configuration and customize
-just pieces of it between environments.
-
-Summary
--------
-
-Congratulations! You've now seen every fundamental aspect of Symfony and have
-hopefully discovered how easy and flexible it can be. And while there are
-*a lot* of features still to come, be sure to keep the following basic points
-in mind:
-
-* Creating a page is a three-step process involving a **route**, a **controller**
-  and (optionally) a **template**;
-
-* Each project contains just a few main directories: ``web/`` (web assets and
-  the front controllers), ``app/`` (configuration), ``src/`` (your bundles),
-  and ``vendor/`` (third-party code) (there's also a ``bin/`` directory that's
-  used to help updated vendor libraries);
-
-* Each feature in Symfony (including the Symfony Framework core) is organized
-  into a *bundle*, which is a structured set of files for that feature;
-
-* The **configuration** for each bundle lives in the ``Resources/config``
-  directory of the bundle and can be specified in YAML, XML or PHP;
-
-* The global **application configuration** lives in the ``app/config``
-  directory;
-
-* Each **environment** is accessible via a different front controller (e.g.
-  ``app.php`` and ``app_dev.php``) and loads a different configuration file.
-
-From here, each chapter will introduce you to more and more powerful tools
-and advanced concepts. The more you know about Symfony, the more you'll
-appreciate the flexibility of its architecture and the power it gives you
-to rapidly develop applications.
-
-.. _`Twig`: http://twig.sensiolabs.org
-.. _`third-party bundles`: http://knpbundles.com
-.. _`Symfony Standard Edition`: http://symfony.com/download
-.. _`Apache's DirectoryIndex documentation`: http://httpd.apache.org/docs/current/mod/mod_dir.html
-.. _`Nginx HttpCoreModule location documentation`: http://wiki.nginx.org/HttpCoreModule#location
+.. _`app/Resources/views/base.html.twig`: https://github.com/symfony/symfony-standard/blob/2.7/app/Resources/views/base.html.twig
+.. _`Composer`: https://getcomposer.org
+.. _`find open source bundles`: http://knpbundles.com

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -177,6 +177,8 @@ regenerate. Remember to do this when deploying your application.
 .. index::
    single: Templating; Inheritance
 
+.. _twig-inheritance:
+
 Template Inheritance and Layouts
 --------------------------------
 

--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -19,7 +19,7 @@ to use PHP :ref:`with Nginx <web-server-nginx>`.
 
     The web directory is the home of all of your application's public and
     static files, including images, stylesheets and JavaScript files. It is
-    also where the front controllers live. For more details, see the :ref:`the-web-directory`.
+    also where the front controllers (``app.php`` and ``app_dev.php``) live.
 
     The web directory serves as the document root when configuring your
     web server. In the examples below, the ``web/`` directory will be the


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | n/a |

Hi guys!

Woh! I'm super excited about this - another step to making Symfony more and more accessible to everyone. The "page creation" chapter should be people's entry point to Symfony (quick tour should be more for advertising I think).

But, when I re-read this chapter - it was terrible (I probably wrote most of it) - way too many long explanations when someone is first starting. It also is one of the last spots to use AcmeDemoBundle.

The goal: let someone read for 10 minutes, get some success/momentum, and link to where to go next (and some other interesting spots, without overwhelming).

A lot was moved to 2 new chapters - bundles and configuration - which I'll re-read soon in the same way. 
Right now - `bundles.rst` and `configuration.rst` are verbatim of what they were before. So, we don't need to review these, other than to make sure they don't have an abrupt start or end (since they were just sections in the middle of `page_creation.rst` before.

Some stuff was just removed. A list is here: https://gist.github.com/weaverryan/252f02b3028888b3f5df

Thanks guys!
