### PR TITLE
Update testing.rst to clarify isRedirect() behavior

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -280,9 +280,9 @@ document::
             $client->getResponse()->getStatusCode()
         );
 
-        // Assert that the response is a redirect to /demo/contact
+        // Assert that the response is a redirect to http://localhost/demo/contact
         $this->assertTrue(
-            $client->getResponse()->isRedirect('/demo/contact')
+            $client->getResponse()->isRedirect('http://localhost/demo/contact')
         );
         // ...or simply check that the response is a redirect to any URL
         $this->assertTrue($client->getResponse()->isRedirect());


### PR DESCRIPTION
Documentation implies that the url path is a sufficient parameter to isRedirect().  Because isRedirect() does an equality check against the Location header, and the location header includes the entire uri, then this is not correct.
