### PR TITLE
Update the name of the branch for new BC features

### DIFF
--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -110,7 +110,7 @@ work:
 * ``2.3``, if you are fixing a bug for an existing feature (you may have
   to choose a higher branch if the feature you are fixing was introduced
   in a later version);
-* ``2.7``, if you are adding a new feature which is backward compatible;
+* ``2.8``, if you are adding a new feature which is backward compatible;
 * ``master``, if you are adding a new and backward incompatible feature.
 
 .. note::


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | - |

Updated section `Choose the right Branch` to refer branch `2.8` as the one for new BC features.

PS- Will this be merged into other the branches or should I create a PR for the other ones too.
