### PR TITLE
Warn users of older PHP versions Crawler might not decode HTML entities properly

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -231,6 +231,7 @@ and :phpclass:`DOMNode` objects:
         $html = $crawler->html();
 
     The ``html`` method is new in Symfony 2.3.
+    In PHP < 5.3.6 it might return html entities which are not properly decoded.
 
 Links
 ~~~~~

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -231,7 +231,12 @@ and :phpclass:`DOMNode` objects:
         $html = $crawler->html();
 
     The ``html`` method is new in Symfony 2.3.
-    In PHP < 5.3.6 it might return html entities which are not properly decoded.
+
+    .. caution::
+
+        Due to an issue in PHP, the ``html()`` method returns wrongly decoded HTML
+        entities in PHP versions lower than 5.3.6 (for example, it returns ``•``
+        instead of ``&bull;``).
 
 Links
 ~~~~~


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3,<2.7 |
| Fixed tickets | - |
