### PR TITLE
Fixing "Undefined method" error in code example

### DIFF
--- a/cookbook/security/impersonating_user.rst
+++ b/cookbook/security/impersonating_user.rst
@@ -93,9 +93,10 @@ over the user's roles until you find one that a ``SwitchUserRole`` object::
     use Symfony\Component\Security\Core\Role\SwitchUserRole;
 
     $authChecker = $this->get('security.authorization_checker');
+    $tokenStorage = $this->get('security.token_storage');
 
     if ($authChecker->isGranted('ROLE_PREVIOUS_ADMIN')) {
-        foreach ($authChecker->getToken()->getRoles() as $role) {
+        foreach ($tokenStorage->getToken()->getRoles() as $role) {
             if ($role instanceof SwitchUserRole) {
                 $impersonatingUser = $role->getSource()->getUser();
                 break;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7 |
| Fixed tickets | - |

The code example tries to call `getToken` on `Symfony\Component\Security\Core\Authorization\AuthorizationChecker`, which fails on Symfony 2.7 because the method is undefined.
This change utilizes the TokenStorage class, introduced in Symfony 2.6
