### PR TITLE
[#5388] change echo and print in examples

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -1205,6 +1205,7 @@ to the given ``Category`` object via their ``category_id`` value.
 
         // prints "Proxies\AppBundleEntityCategoryProxy"
         dump(get_class($category));
+        die();
 
     This proxy object extends the true ``Category`` object, and looks and
     acts exactly like it. The difference is that, by using a proxy object,

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -1204,7 +1204,7 @@ to the given ``Category`` object via their ``category_id`` value.
         $category = $product->getCategory();
 
         // prints "Proxies\AppBundleEntityCategoryProxy"
-        echo get_class($category);
+        dump(get_class($category));
 
     This proxy object extends the true ``Category`` object, and looks and
     acts exactly like it. The difference is that, by using a proxy object,

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -12,11 +12,11 @@ wrapping each with a function capable of translating the text (or "message")
 into the language of the user::
 
     // text will *always* print out in English
-    echo 'Hello World';
+    dump('Hello World');
 
     // text can be translated into the end-user's language or
     // default to English
-    echo $translator->trans('Hello World');
+    dump($translator->trans('Hello World'));
 
 .. note::
 

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -13,10 +13,12 @@ into the language of the user::
 
     // text will *always* print out in English
     dump('Hello World');
+    die();
 
     // text can be translated into the end-user's language or
     // default to English
     dump($translator->trans('Hello World'));
+    die();
 
 .. note::
 

--- a/components/class_loader/class_map_generator.rst
+++ b/components/class_loader/class_map_generator.rst
@@ -50,7 +50,7 @@ method::
 
     use Symfony\Component\ClassLoader\ClassMapGenerator;
 
-    print_r(ClassMapGenerator::createMap(__DIR__.'/library'));
+    dump(ClassMapGenerator::createMap(__DIR__.'/library'));
 
 Given the files and class from the table above, you should see an output like
 this:

--- a/components/class_loader/class_map_generator.rst
+++ b/components/class_loader/class_map_generator.rst
@@ -50,7 +50,7 @@ method::
 
     use Symfony\Component\ClassLoader\ClassMapGenerator;
 
-    dump(ClassMapGenerator::createMap(__DIR__.'/library'));
+    var_dump(ClassMapGenerator::createMap(__DIR__.'/library'));
 
 Given the files and class from the table above, you should see an output like
 this:

--- a/components/css_selector.rst
+++ b/components/css_selector.rst
@@ -51,7 +51,7 @@ equivalents::
 
     use Symfony\Component\CssSelector\CssSelector;
 
-    print CssSelector::toXPath('div.item > h4 > a');
+    dump(CssSelector::toXPath('div.item > h4 > a'));
 
 This gives the following output:
 

--- a/components/css_selector.rst
+++ b/components/css_selector.rst
@@ -51,7 +51,7 @@ equivalents::
 
     use Symfony\Component\CssSelector\CssSelector;
 
-    dump(CssSelector::toXPath('div.item > h4 > a'));
+    var_dump(CssSelector::toXPath('div.item > h4 > a'));
 
 This gives the following output:
 

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -47,7 +47,7 @@ traverse easily::
     $crawler = new Crawler($html);
 
     foreach ($crawler as $domElement) {
-        dump($domElement->nodeName);
+        var_dump($domElement->nodeName);
     }
 
 Specialized :class:`Symfony\\Component\\DomCrawler\\Link` and

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -47,7 +47,7 @@ traverse easily::
     $crawler = new Crawler($html);
 
     foreach ($crawler as $domElement) {
-        print $domElement->nodeName;
+        dump($domElement->nodeName);
     }
 
 Specialized :class:`Symfony\\Component\\DomCrawler\\Link` and

--- a/components/event_dispatcher/generic_event.rst
+++ b/components/event_dispatcher/generic_event.rst
@@ -75,7 +75,7 @@ the event arguments::
     );
     $dispatcher->dispatch('foo', $event);
 
-    dump($event['counter']);
+    var_dump($event['counter']);
 
     class FooListener
     {
@@ -96,7 +96,7 @@ Filtering data::
     $event = new GenericEvent($subject, array('data' => 'Foo'));
     $dispatcher->dispatch('foo', $event);
 
-    dump($event['data']);
+    var_dump($event['data']);
 
     class FooListener
     {

--- a/components/event_dispatcher/generic_event.rst
+++ b/components/event_dispatcher/generic_event.rst
@@ -75,7 +75,7 @@ the event arguments::
     );
     $dispatcher->dispatch('foo', $event);
 
-    echo $event['counter'];
+    dump($event['counter']);
 
     class FooListener
     {
@@ -96,7 +96,7 @@ Filtering data::
     $event = new GenericEvent($subject, array('data' => 'Foo'));
     $dispatcher->dispatch('foo', $event);
 
-    echo $event['data'];
+    dump($event['data']);
 
     class FooListener
     {
@@ -105,3 +105,4 @@ Filtering data::
             $event['data'] = strtolower($event['data']);
         }
     }
+

--- a/components/event_dispatcher/introduction.rst
+++ b/components/event_dispatcher/introduction.rst
@@ -635,7 +635,7 @@ part of the listener's processing logic::
     {
         public function myEventListener(Event $event)
         {
-            echo $event->getName();
+            // ... do something with the event name
         }
     }
 

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -31,13 +31,13 @@ directories::
 
     foreach ($finder as $file) {
         // Dump the absolute path
-        dump($file->getRealpath());
+        var_dump($file->getRealpath());
 
         // Dump the relative path to the file, omitting the filename
-        dump($file->getRelativePath());
+        var_dump($file->getRelativePath());
 
         // Dump the relative path to the file
-        dump($file->getRelativePathname());
+        var_dump($file->getRelativePathname());
     }
 
 The ``$file`` is an instance of :class:`Symfony\\Component\\Finder\\SplFileInfo`

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -30,14 +30,14 @@ directories::
     $finder->files()->in(__DIR__);
 
     foreach ($finder as $file) {
-        // Print the absolute path
-        print $file->getRealpath()."\n";
+        // Dump the absolute path
+        dump($file->getRealpath());
 
-        // Print the relative path to the file, omitting the filename
-        print $file->getRelativePath()."\n";
+        // Dump the relative path to the file, omitting the filename
+        dump($file->getRelativePath());
 
-        // Print the relative path to the file
-        print $file->getRelativePathname()."\n";
+        // Dump the relative path to the file
+        dump($file->getRelativePathname());
     }
 
 The ``$file`` is an instance of :class:`Symfony\\Component\\Finder\\SplFileInfo`
@@ -121,9 +121,7 @@ And it also works with user-defined streams::
     $finder = new Finder();
     $finder->name('photos*')->size('< 100K')->date('since 1 hour ago');
     foreach ($finder->in('s3://bucket-name') as $file) {
-        // ... do something
-
-        print $file->getFilename()."\n";
+        // ... do something with the file
     }
 
 .. note::

--- a/components/form/introduction.rst
+++ b/components/form/introduction.rst
@@ -396,9 +396,9 @@ is created from the form factory.
             ->add('dueDate', 'date')
             ->getForm();
 
-        echo $twig->render('new.html.twig', array(
+        dump($twig->render('new.html.twig', array(
             'form' => $form->createView(),
-        ));
+        )));
 
     .. code-block:: php-symfony
 

--- a/components/form/introduction.rst
+++ b/components/form/introduction.rst
@@ -396,7 +396,7 @@ is created from the form factory.
             ->add('dueDate', 'date')
             ->getForm();
 
-        dump($twig->render('new.html.twig', array(
+        var_dump($twig->render('new.html.twig', array(
             'form' => $form->createView(),
         )));
 

--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -415,10 +415,10 @@ represented by a PHP callable instead of a string::
 
     $response = new StreamedResponse();
     $response->setCallback(function () {
-        echo 'Hello World';
+        dump('Hello World');
         flush();
         sleep(2);
-        echo 'Hello World';
+        dump('Hello World');
         flush();
     });
     $response->send();

--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -415,10 +415,10 @@ represented by a PHP callable instead of a string::
 
     $response = new StreamedResponse();
     $response->setCallback(function () {
-        dump('Hello World');
+        var_dump('Hello World');
         flush();
         sleep(2);
-        dump('Hello World');
+        var_dump('Hello World');
         flush();
     });
     $response->send();

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -217,7 +217,7 @@ This class currently only works with the `intl extension`_ installed::
     $reader = new BinaryBundleReader();
     $data = $reader->read('/path/to/bundle', 'en');
 
-    dump($data['Data']['entry1']);
+    var_dump($data['Data']['entry1']);
 
 PhpBundleReader
 ~~~~~~~~~~~~~~~
@@ -231,7 +231,7 @@ object::
     $reader = new PhpBundleReader();
     $data = $reader->read('/path/to/bundle', 'en');
 
-    dump($data['Data']['entry1']);
+    var_dump($data['Data']['entry1']);
 
 BufferedBundleReader
 ~~~~~~~~~~~~~~~~~~~~
@@ -272,10 +272,10 @@ returned::
     $data = $reader->read('/path/to/bundle', 'en');
 
     // Produces an error if the key "Data" does not exist
-    dump($data['Data']['entry1']);
+    var_dump($data['Data']['entry1']);
 
     // Returns null if the key "Data" does not exist
-    dump($reader->readEntry('/path/to/bundle', 'en', array('Data', 'entry1')));
+    var_dump($reader->readEntry('/path/to/bundle', 'en', array('Data', 'entry1')));
 
 Additionally, the
 :method:`Symfony\\Component\\Intl\\ResourceBundle\\Reader\\StructuredBundleReaderInterface::readEntry`
@@ -286,7 +286,7 @@ multi-valued entries (arrays), the values of the more specific and the fallback
 locale will be merged. In order to suppress this behavior, the last parameter
 ``$fallback`` can be set to ``false``::
 
-    dump($reader->readEntry(
+    var_dump($reader->readEntry(
         '/path/to/bundle',
         'en',
         array('Data', 'entry1'),

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -217,7 +217,7 @@ This class currently only works with the `intl extension`_ installed::
     $reader = new BinaryBundleReader();
     $data = $reader->read('/path/to/bundle', 'en');
 
-    echo $data['Data']['entry1'];
+    dump($data['Data']['entry1']);
 
 PhpBundleReader
 ~~~~~~~~~~~~~~~
@@ -231,7 +231,7 @@ object::
     $reader = new PhpBundleReader();
     $data = $reader->read('/path/to/bundle', 'en');
 
-    echo $data['Data']['entry1'];
+    dump($data['Data']['entry1']);
 
 BufferedBundleReader
 ~~~~~~~~~~~~~~~~~~~~
@@ -272,10 +272,10 @@ returned::
     $data = $reader->read('/path/to/bundle', 'en');
 
     // Produces an error if the key "Data" does not exist
-    echo $data['Data']['entry1'];
+    dump($data['Data']['entry1']);
 
     // Returns null if the key "Data" does not exist
-    echo $reader->readEntry('/path/to/bundle', 'en', array('Data', 'entry1'));
+    dump($reader->readEntry('/path/to/bundle', 'en', array('Data', 'entry1')));
 
 Additionally, the
 :method:`Symfony\\Component\\Intl\\ResourceBundle\\Reader\\StructuredBundleReaderInterface::readEntry`
@@ -286,12 +286,12 @@ multi-valued entries (arrays), the values of the more specific and the fallback
 locale will be merged. In order to suppress this behavior, the last parameter
 ``$fallback`` can be set to ``false``::
 
-    echo $reader->readEntry(
+    dump($reader->readEntry(
         '/path/to/bundle',
         'en',
         array('Data', 'entry1'),
         false
-    );
+    ));
 
 Accessing ICU Data
 ------------------

--- a/components/property_access/introduction.rst
+++ b/components/property_access/introduction.rst
@@ -68,8 +68,8 @@ You can also use multi dimensional arrays::
         )
     );
 
-    dump($accessor->getValue($persons, '[0][first_name]')); // 'Wouter'
-    dump($accessor->getValue($persons, '[1][first_name]')); // 'Ryan'
+    var_dump($accessor->getValue($persons, '[0][first_name]')); // 'Wouter'
+    var_dump($accessor->getValue($persons, '[1][first_name]')); // 'Ryan'
 
 Reading from Objects
 --------------------

--- a/components/property_access/introduction.rst
+++ b/components/property_access/introduction.rst
@@ -51,8 +51,8 @@ method. This is done using the index notation that is used in PHP::
         'first_name' => 'Wouter',
     );
 
-    echo $accessor->getValue($person, '[first_name]'); // 'Wouter'
-    echo $accessor->getValue($person, '[age]'); // null
+    dump($accessor->getValue($person, '[first_name]')); // 'Wouter'
+    dump($accessor->getValue($person, '[age]')); // null
 
 As you can see, the method will return ``null`` if the index does not exists.
 
@@ -68,8 +68,8 @@ You can also use multi dimensional arrays::
         )
     );
 
-    echo $accessor->getValue($persons, '[0][first_name]'); // 'Wouter'
-    echo $accessor->getValue($persons, '[1][first_name]'); // 'Ryan'
+    dump($accessor->getValue($persons, '[0][first_name]')); // 'Wouter'
+    dump($accessor->getValue($persons, '[1][first_name]')); // 'Ryan'
 
 Reading from Objects
 --------------------
@@ -86,13 +86,13 @@ To read from properties, use the "dot" notation::
     $person = new Person();
     $person->firstName = 'Wouter';
 
-    echo $accessor->getValue($person, 'firstName'); // 'Wouter'
+    dump($accessor->getValue($person, 'firstName')); // 'Wouter'
 
     $child = new Person();
     $child->firstName = 'Bar';
     $person->children = array($child);
 
-    echo $accessor->getValue($person, 'children[0].firstName'); // 'Bar'
+    dump($accessor->getValue($person, 'children[0].firstName')); // 'Bar'
 
 .. caution::
 
@@ -122,7 +122,7 @@ property name (``first_name`` becomes ``FirstName``) and prefixes it with
 
     $person = new Person();
 
-    echo $accessor->getValue($person, 'first_name'); // 'Wouter'
+    dump($accessor->getValue($person, 'first_name')); // 'Wouter'
 
 Using Hassers/Issers
 ~~~~~~~~~~~~~~~~~~~~
@@ -151,10 +151,10 @@ getters, this means that you can do something like this::
     $person = new Person();
 
     if ($accessor->getValue($person, 'author')) {
-        echo 'He is an author';
+        dump('He is an author');
     }
     if ($accessor->getValue($person, 'children')) {
-        echo 'He has children';
+        dump('He has children');
     }
 
 This will produce: ``He is an author``
@@ -179,7 +179,7 @@ The ``getValue`` method can also use the magic ``__get`` method::
 
     $person = new Person();
 
-    echo $accessor->getValue($person, 'Wouter'); // array(...)
+    dump($accessor->getValue($person, 'Wouter')); // array(...)
 
 Magic ``__call()`` Method
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -215,7 +215,7 @@ enable this feature by using :class:`Symfony\\Component\\PropertyAccess\\Propert
         ->enableMagicCall()
         ->getPropertyAccessor();
 
-    echo $accessor->getValue($person, 'wouter'); // array(...)
+    dump($accessor->getValue($person, 'wouter')); // array(...)
 
 .. versionadded:: 2.3
     The use of magic ``__call()`` method was introduced in Symfony 2.3.
@@ -239,9 +239,9 @@ method::
 
     $accessor->setValue($person, '[first_name]', 'Wouter');
 
-    echo $accessor->getValue($person, '[first_name]'); // 'Wouter'
+    dump($accessor->getValue($person, '[first_name]')); // 'Wouter'
     // or
-    // echo $person['first_name']; // 'Wouter'
+    // dump($person['first_name']); // 'Wouter'
 
 Writing to Objects
 ------------------
@@ -275,9 +275,9 @@ can use setters, the magic ``__set`` method or properties to set values::
     $accessor->setValue($person, 'lastName', 'de Jong');
     $accessor->setValue($person, 'children', array(new Person()));
 
-    echo $person->firstName; // 'Wouter'
-    echo $person->getLastName(); // 'de Jong'
-    echo $person->children; // array(Person());
+    dump($person->firstName); // 'Wouter'
+    dump($person->getLastName()); // 'de Jong'
+    dump($person->children); // array(Person());
 
 You can also use ``__call`` to set values but you need to enable the feature,
 see `Enable other Features`_.
@@ -313,7 +313,7 @@ see `Enable other Features`_.
 
     $accessor->setValue($person, 'wouter', array(...));
 
-    echo $person->getWouter(); // array(...)
+    dump($person->getWouter()); // array(...)
 
 Mixing Objects and Arrays
 -------------------------
@@ -345,7 +345,7 @@ You can also mix objects and arrays::
     $accessor->setValue($person, 'children[0].firstName', 'Wouter');
     // equal to $person->getChildren()[0]->firstName = 'Wouter'
 
-    echo 'Hello '.$accessor->getValue($person, 'children[0].firstName'); // 'Wouter'
+    dump('Hello '.$accessor->getValue($person, 'children[0].firstName')); // 'Wouter'
     // equal to $person->getChildren()[0]->firstName
 
 Enable other Features

--- a/components/property_access/introduction.rst
+++ b/components/property_access/introduction.rst
@@ -51,8 +51,8 @@ method. This is done using the index notation that is used in PHP::
         'first_name' => 'Wouter',
     );
 
-    dump($accessor->getValue($person, '[first_name]')); // 'Wouter'
-    dump($accessor->getValue($person, '[age]')); // null
+    var_dump($accessor->getValue($person, '[first_name]')); // 'Wouter'
+    var_dump($accessor->getValue($person, '[age]')); // null
 
 As you can see, the method will return ``null`` if the index does not exists.
 
@@ -86,13 +86,13 @@ To read from properties, use the "dot" notation::
     $person = new Person();
     $person->firstName = 'Wouter';
 
-    dump($accessor->getValue($person, 'firstName')); // 'Wouter'
+    var_dump($accessor->getValue($person, 'firstName')); // 'Wouter'
 
     $child = new Person();
     $child->firstName = 'Bar';
     $person->children = array($child);
 
-    dump($accessor->getValue($person, 'children[0].firstName')); // 'Bar'
+    var_dump($accessor->getValue($person, 'children[0].firstName')); // 'Bar'
 
 .. caution::
 
@@ -122,7 +122,7 @@ property name (``first_name`` becomes ``FirstName``) and prefixes it with
 
     $person = new Person();
 
-    dump($accessor->getValue($person, 'first_name')); // 'Wouter'
+    var_dump($accessor->getValue($person, 'first_name')); // 'Wouter'
 
 Using Hassers/Issers
 ~~~~~~~~~~~~~~~~~~~~
@@ -151,10 +151,10 @@ getters, this means that you can do something like this::
     $person = new Person();
 
     if ($accessor->getValue($person, 'author')) {
-        dump('He is an author');
+        var_dump('He is an author');
     }
     if ($accessor->getValue($person, 'children')) {
-        dump('He has children');
+        var_dump('He has children');
     }
 
 This will produce: ``He is an author``
@@ -179,7 +179,7 @@ The ``getValue`` method can also use the magic ``__get`` method::
 
     $person = new Person();
 
-    dump($accessor->getValue($person, 'Wouter')); // array(...)
+    var_dump($accessor->getValue($person, 'Wouter')); // array(...)
 
 Magic ``__call()`` Method
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -215,7 +215,7 @@ enable this feature by using :class:`Symfony\\Component\\PropertyAccess\\Propert
         ->enableMagicCall()
         ->getPropertyAccessor();
 
-    dump($accessor->getValue($person, 'wouter')); // array(...)
+    var_dump($accessor->getValue($person, 'wouter')); // array(...)
 
 .. versionadded:: 2.3
     The use of magic ``__call()`` method was introduced in Symfony 2.3.
@@ -239,9 +239,9 @@ method::
 
     $accessor->setValue($person, '[first_name]', 'Wouter');
 
-    dump($accessor->getValue($person, '[first_name]')); // 'Wouter'
+    var_dump($accessor->getValue($person, '[first_name]')); // 'Wouter'
     // or
-    // dump($person['first_name']); // 'Wouter'
+    // var_dump($person['first_name']); // 'Wouter'
 
 Writing to Objects
 ------------------
@@ -275,9 +275,9 @@ can use setters, the magic ``__set`` method or properties to set values::
     $accessor->setValue($person, 'lastName', 'de Jong');
     $accessor->setValue($person, 'children', array(new Person()));
 
-    dump($person->firstName); // 'Wouter'
-    dump($person->getLastName()); // 'de Jong'
-    dump($person->children); // array(Person());
+    var_dump($person->firstName); // 'Wouter'
+    var_dump($person->getLastName()); // 'de Jong'
+    var_dump($person->children); // array(Person());
 
 You can also use ``__call`` to set values but you need to enable the feature,
 see `Enable other Features`_.
@@ -313,7 +313,7 @@ see `Enable other Features`_.
 
     $accessor->setValue($person, 'wouter', array(...));
 
-    dump($person->getWouter()); // array(...)
+    var_dump($person->getWouter()); // array(...)
 
 Mixing Objects and Arrays
 -------------------------
@@ -345,7 +345,7 @@ You can also mix objects and arrays::
     $accessor->setValue($person, 'children[0].firstName', 'Wouter');
     // equal to $person->getChildren()[0]->firstName = 'Wouter'
 
-    dump('Hello '.$accessor->getValue($person, 'children[0].firstName')); // 'Wouter'
+    var_dump('Hello '.$accessor->getValue($person, 'children[0].firstName')); // 'Wouter'
     // equal to $person->getChildren()[0]->firstName
 
 Enable other Features

--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -186,8 +186,8 @@ first constructor argument::
 
     $role = new Role('ROLE_ADMIN');
 
-    // will echo 'ROLE_ADMIN'
-    echo $role->getRole();
+    // will show 'ROLE_ADMIN'
+    dump($role->getRole());
 
 .. note::
 
@@ -247,3 +247,4 @@ decision manager::
     if (!$securityContext->isGranted('ROLE_ADMIN')) {
         throw new AccessDeniedException();
     }
+

--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -187,7 +187,7 @@ first constructor argument::
     $role = new Role('ROLE_ADMIN');
 
     // will show 'ROLE_ADMIN'
-    dump($role->getRole());
+    var_dump($role->getRole());
 
 .. note::
 

--- a/components/translation/custom_formats.rst
+++ b/components/translation/custom_formats.rst
@@ -63,7 +63,7 @@ Once created, it can be used as any other loader::
 
     $translator->addResource('my_format', __DIR__.'/translations/messages.txt', 'fr_FR');
 
-    echo $translator->trans('welcome');
+    dump($translator->trans('welcome'));
 
 It will print *"accueil"*.
 
@@ -116,3 +116,4 @@ YAML file are dumped into a text file with the custom format::
 
     $dumper = new MyFormatDumper();
     $dumper->dump($catalogue, array('path' => __DIR__.'/dumps'));
+

--- a/components/translation/custom_formats.rst
+++ b/components/translation/custom_formats.rst
@@ -63,7 +63,7 @@ Once created, it can be used as any other loader::
 
     $translator->addResource('my_format', __DIR__.'/translations/messages.txt', 'fr_FR');
 
-    dump($translator->trans('welcome'));
+    var_dump($translator->trans('welcome'));
 
 It will print *"accueil"*.
 

--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -15,7 +15,7 @@ Imagine you want to translate the string *"Symfony is great"* into French::
         'Symfony is great!' => 'J\'aime Symfony!',
     ), 'fr_FR');
 
-    echo $translator->trans('Symfony is great!');
+    dump($translator->trans('Symfony is great!'));
 
 In this example, the message *"Symfony is great!"* will be translated into
 the locale set in the constructor (``fr_FR``) if the message exists in one of
@@ -31,7 +31,7 @@ Sometimes, a message containing a variable needs to be translated::
     // ...
     $translated = $translator->trans('Hello '.$name);
 
-    echo $translated;
+    dump($translated);
 
 However, creating a translation for this string is impossible since the translator
 will try to look up the exact message, including the variable portions
@@ -45,7 +45,7 @@ variable with a "placeholder"::
         array('%name%' => $name)
     );
 
-    echo $translated;
+    dump($translated);
 
 Symfony will now look for a translation of the raw message (``Hello %name%``)
 and *then* replace the placeholders with their values. Creating a translation

--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -15,7 +15,7 @@ Imagine you want to translate the string *"Symfony is great"* into French::
         'Symfony is great!' => 'J\'aime Symfony!',
     ), 'fr_FR');
 
-    dump($translator->trans('Symfony is great!'));
+    var_dump($translator->trans('Symfony is great!'));
 
 In this example, the message *"Symfony is great!"* will be translated into
 the locale set in the constructor (``fr_FR``) if the message exists in one of
@@ -31,7 +31,7 @@ Sometimes, a message containing a variable needs to be translated::
     // ...
     $translated = $translator->trans('Hello '.$name);
 
-    dump($translated);
+    var_dump($translated);
 
 However, creating a translation for this string is impossible since the translator
 will try to look up the exact message, including the variable portions
@@ -45,7 +45,7 @@ variable with a "placeholder"::
         array('%name%' => $name)
     );
 
-    dump($translated);
+    var_dump($translated);
 
 Symfony will now look for a translation of the raw message (``Hello %name%``)
 and *then* replace the placeholders with their values. Creating a translation

--- a/cookbook/bundles/remove.rst
+++ b/cookbook/bundles/remove.rst
@@ -79,7 +79,7 @@ can remove the ``Acme`` directory as well.
     :method:`Symfony\\Component\\HttpKernel\\Bundle\\BundleInterface::getPath` method
     to get the path of the bundle::
 
-        echo $this->container->get('kernel')->getBundle('AcmeDemoBundle')->getPath();
+        dump($this->container->get('kernel')->getBundle('AcmeDemoBundle')->getPath());
 
 3.1 Remove Bundle Assets
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cookbook/bundles/remove.rst
+++ b/cookbook/bundles/remove.rst
@@ -80,6 +80,7 @@ can remove the ``Acme`` directory as well.
     to get the path of the bundle::
 
         dump($this->container->get('kernel')->getBundle('AcmeDemoBundle')->getPath());
+        die();
 
 3.1 Remove Bundle Assets
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is a split of #5388 for the 2.3 branch.

Original description:

> | Q | A |
> | --- | --- |
> | Doc fix? | yes |
> | New docs? | no |
> | Applies to | all |
> | Fixed tickets | #5177 |
> 
> Original PR and discussion in https://github.com/symfony/symfony-docs/pull/5285
> 
> Change echo/print in examples to use:
> - `var_dump()` in components docs
> - `dump()` in framework docs
