### PR TITLE
[#5388] change echo and print in examples

### DIFF
--- a/components/expression_language/caching.rst
+++ b/components/expression_language/caching.rst
@@ -56,7 +56,7 @@ Both ``evaluate()`` and ``compile()`` can handle ``ParsedExpression`` and
     // the parse() method returns a ParsedExpression
     $expression = $language->parse('1 + 4', array());
 
-    dump($language->evaluate($expression)); // prints 5
+    var_dump($language->evaluate($expression)); // prints 5
 
 .. code-block:: php
 
@@ -68,7 +68,7 @@ Both ``evaluate()`` and ``compile()`` can handle ``ParsedExpression`` and
         serialize($language->parse('1 + 4', array()))
     );
 
-    dump($language->evaluate($expression)); // prints 5
+    var_dump($language->evaluate($expression)); // prints 5
 
 .. _DoctrineBridge: https://github.com/symfony/DoctrineBridge
 .. _`doctrine cache library`: http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/caching.html

--- a/components/expression_language/caching.rst
+++ b/components/expression_language/caching.rst
@@ -56,7 +56,7 @@ Both ``evaluate()`` and ``compile()`` can handle ``ParsedExpression`` and
     // the parse() method returns a ParsedExpression
     $expression = $language->parse('1 + 4', array());
 
-    echo $language->evaluate($expression); // prints 5
+    dump($language->evaluate($expression)); // prints 5
 
 .. code-block:: php
 
@@ -68,7 +68,7 @@ Both ``evaluate()`` and ``compile()`` can handle ``ParsedExpression`` and
         serialize($language->parse('1 + 4', array()))
     );
 
-    echo $language->evaluate($expression); // prints 5
+    dump($language->evaluate($expression)); // prints 5
 
 .. _DoctrineBridge: https://github.com/symfony/DoctrineBridge
 .. _`doctrine cache library`: http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/caching.html

--- a/components/expression_language/extending.rst
+++ b/components/expression_language/extending.rst
@@ -44,7 +44,7 @@ This method has 3 arguments:
         return strtolower($str);
     });
 
-    dump($language->evaluate('lowercase("HELLO")'));
+    var_dump($language->evaluate('lowercase("HELLO")'));
 
 This will print ``hello``. Both the **compiler** and **evaluator** are passed
 an ``arguments`` variable as their first argument, which is equal to the

--- a/components/expression_language/extending.rst
+++ b/components/expression_language/extending.rst
@@ -44,7 +44,7 @@ This method has 3 arguments:
         return strtolower($str);
     });
 
-    echo $language->evaluate('lowercase("HELLO")');
+    dump($language->evaluate('lowercase("HELLO")'));
 
 This will print ``hello``. Both the **compiler** and **evaluator** are passed
 an ``arguments`` variable as their first argument, which is equal to the
@@ -126,3 +126,4 @@ or by using the second argument of the constructor::
                 parent::__construct($parser, $providers);
             }
         }
+

--- a/components/expression_language/introduction.rst
+++ b/components/expression_language/introduction.rst
@@ -68,9 +68,9 @@ The main class of the component is
 
     $language = new ExpressionLanguage();
 
-    echo $language->evaluate('1 + 2'); // displays 3
+    dump($language->evaluate('1 + 2')); // displays 3
 
-    echo $language->compile('1 + 2'); // displays (1 + 2)
+    dump($language->compile('1 + 2')); // displays (1 + 2)
 
 Expression Syntax
 -----------------
@@ -96,12 +96,12 @@ PHP type (including objects)::
     $apple = new Apple();
     $apple->variety = 'Honeycrisp';
 
-    echo $language->evaluate(
+    dump($language->evaluate(
         'fruit.variety',
         array(
             'fruit' => $apple,
         )
-    );
+    ));
 
 This will print "Honeycrisp". For more information, see the :doc:`/components/expression_language/syntax`
 entry, especially :ref:`component-expression-objects` and :ref:`component-expression-arrays`.

--- a/components/expression_language/introduction.rst
+++ b/components/expression_language/introduction.rst
@@ -68,9 +68,9 @@ The main class of the component is
 
     $language = new ExpressionLanguage();
 
-    dump($language->evaluate('1 + 2')); // displays 3
+    var_dump($language->evaluate('1 + 2')); // displays 3
 
-    dump($language->compile('1 + 2')); // displays (1 + 2)
+    var_dump($language->compile('1 + 2')); // displays (1 + 2)
 
 Expression Syntax
 -----------------
@@ -96,7 +96,7 @@ PHP type (including objects)::
     $apple = new Apple();
     $apple->variety = 'Honeycrisp';
 
-    dump($language->evaluate(
+    var_dump($language->evaluate(
         'fruit.variety',
         array(
             'fruit' => $apple,

--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -42,7 +42,7 @@ to JavaScript::
     $apple = new Apple();
     $apple->variety = 'Honeycrisp';
 
-    dump($language->evaluate(
+    var_dump($language->evaluate(
         'fruit.variety',
         array(
             'fruit' => $apple,
@@ -72,7 +72,7 @@ JavaScript::
 
     $robot = new Robot();
 
-    dump($language->evaluate(
+    var_dump($language->evaluate(
         'robot.sayHi(3)',
         array(
             'robot' => $robot,
@@ -93,7 +93,7 @@ constant::
 
     define('DB_USER', 'root');
 
-    dump($language->evaluate(
+    var_dump($language->evaluate(
         'constant("DB_USER")'
     ));
 
@@ -114,7 +114,7 @@ array keys, similar to JavaScript::
 
     $data = array('life' => 10, 'universe' => 10, 'everything' => 22);
 
-    dump($language->evaluate(
+    var_dump($language->evaluate(
         'data["life"] + data["universe"] + data["everything"]',
         array(
             'data' => $data,
@@ -230,7 +230,7 @@ String Operators
 
 For example::
 
-    dump($language->evaluate(
+    var_dump($language->evaluate(
         'firstName~" "~lastName',
         array(
             'firstName' => 'Arthur',

--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -42,12 +42,12 @@ to JavaScript::
     $apple = new Apple();
     $apple->variety = 'Honeycrisp';
 
-    echo $language->evaluate(
+    dump($language->evaluate(
         'fruit.variety',
         array(
             'fruit' => $apple,
         )
-    );
+    ));
 
 This will print out ``Honeycrisp``.
 
@@ -72,12 +72,12 @@ JavaScript::
 
     $robot = new Robot();
 
-    echo $language->evaluate(
+    dump($language->evaluate(
         'robot.sayHi(3)',
         array(
             'robot' => $robot,
         )
-    );
+    ));
 
 This will print out ``Hi Hi Hi!``.
 
@@ -93,9 +93,9 @@ constant::
 
     define('DB_USER', 'root');
 
-    echo $language->evaluate(
+    dump($language->evaluate(
         'constant("DB_USER")'
-    );
+    ));
 
 This will print out ``root``.
 
@@ -114,12 +114,12 @@ array keys, similar to JavaScript::
 
     $data = array('life' => 10, 'universe' => 10, 'everything' => 22);
 
-    echo $language->evaluate(
+    dump($language->evaluate(
         'data["life"] + data["universe"] + data["everything"]',
         array(
             'data' => $data,
         )
-    );
+    ));
 
 This will print out ``42``.
 
@@ -140,14 +140,14 @@ Arithmetic Operators
 
 For example::
 
-    echo $language->evaluate(
+    dump($language->evaluate(
         'life + universe + everything',
         array(
             'life' => 10,
             'universe' => 10,
             'everything' => 22,
         )
-    );
+    ));
 
 This will print out ``42``.
 
@@ -230,13 +230,13 @@ String Operators
 
 For example::
 
-    echo $language->evaluate(
+    dump($language->evaluate(
         'firstName~" "~lastName',
         array(
             'firstName' => 'Arthur',
             'lastName' => 'Dent',
         )
-    );
+    ));
 
 This would print out ``Arthur Dent``.
 

--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -140,7 +140,7 @@ Arithmetic Operators
 
 For example::
 
-    dump($language->evaluate(
+    var_dump($language->evaluate(
         'life + universe + everything',
         array(
             'life' => 10,

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -360,7 +360,7 @@ having unique identifiers::
     });
 
     $serializer = new Serializer(array($normalizer), array($encoder));
-    dump($serializer->serialize($org, 'json'));
+    var_dump($serializer->serialize($org, 'json'));
     // {"name":"Les-Tilleuls.coop","members":[{"name":"K\u00e9vin", organization: "Les-Tilleuls.coop"}]}
 
 JMSSerializer

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -360,7 +360,7 @@ having unique identifiers::
     });
 
     $serializer = new Serializer(array($normalizer), array($encoder));
-    echo $serializer->serialize($org, 'json');
+    dump($serializer->serialize($org, 'json'));
     // {"name":"Les-Tilleuls.coop","members":[{"name":"K\u00e9vin", organization: "Les-Tilleuls.coop"}]}
 
 JMSSerializer


### PR DESCRIPTION
A split of #5388 for the changes in the 2.6 branch.

Original description:

> | Q | A |
> | --- | --- |
> | Doc fix? | yes |
> | New docs? | no |
> | Applies to | all |
> | Fixed tickets | #5177 |
> 
> Original PR and discussion in https://github.com/symfony/symfony-docs/pull/5285
> 
> Change echo/print in examples to use:
> - `var_dump()` in components docs
> - `dump()` in framework docs
