### PR TITLE
Completely re-reading the data transformers chapter

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -1141,6 +1141,8 @@ the choice is ultimately up to you.
 
         $form->get('dueDate')->setData(new \DateTime());
 
+.. _form-as-services:
+
 Defining your Forms as Services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -365,19 +365,20 @@ it's recognized as a custom field type:
 
     .. code-block:: yaml
 
+        # app/config/services.yml
         services:
             app.type.issue_selector:
                 class: AppBundle\Form\IssueSelectorType
-                arguments: ["@doctrine.orm.default_entity_manager"]
+                arguments: ["@doctrine.orm.entity_manager"]
                 tags:
                     - { name: form.type, alias: issue_selector }
 
 
     .. code-block:: xml
-        
+
         <service id="app.type.issue_selector"
             class="AppBundle\Form\IssueSelectorType">
-            <argument type="service" id="doctrine.orm.default_entity_manager"/>
+            <argument type="service" id="doctrine.orm.entity_manager"/>
             <tag name="form.type" alias="issue_selector" />
         </service>
 
@@ -391,7 +392,7 @@ it's recognized as a custom field type:
             ->setDefinition('app.type.issue_selector', new Definition(
                 'AppBundle\Form\IssueSelectorType'
                 ), array(
-                new Reference('doctrine.orm.default_entity_manager'),
+                new Reference('doctrine.orm.entity_manager'),
             ))
             ->addTag('form.type', array(
                 'alias' => 'issue_selector',

--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -100,8 +100,8 @@ in your code.
     :class:`Symfony\\Component\\Form\\DataTransformerInterface` - so you can create
     your own classes, instead of putting all the logic in the form (see the next section).
 
-Harder Examle: Transforming an Issue Number into an Issue Entity
-----------------------------------------------------------------
+Harder Example: Transforming an Issue Number into an Issue Entity
+-----------------------------------------------------------------
 
 Say you have a many-to-one relation from the Task entity to an Issue entity (i.e. each
 Task has an optional foreign key to its related Issue). Adding a listbox with all

--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -60,6 +60,7 @@ class::
     // src/AppBundle/Form/TaskType.php
 
     use Symfony\Component\Form\CallbackTransformer;
+    use Symfony\Component\Form\FormBuilderInterface;
     // ...
 
     class TaskType extends AbstractType

--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -100,6 +100,14 @@ in your code.
     :class:`Symfony\\Component\\Form\\DataTransformerInterface` - so you can create
     your own classes, instead of putting all the logic in the form (see the next section).
 
+You can also add the transformer, right when adding the field by changing the format
+slightly::
+
+    $builder->add(
+        $builder->create('description', 'textarea')
+            ->addModelTransformer(...)
+    );
+
 Harder Example: Transforming an Issue Number into an Issue Entity
 -----------------------------------------------------------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | #5307 |

**Note**: `setDefaultOptions()` -> `configureOptions()` in 2.7 after merge

Hi guys!

This follows after #5307, which helped update the article (but also added some new complexity). Data transformers are super cool, but I think we've over-complicated them in the past. Even for me, before re-writing this, I tried to avoid transformers because I thought they were hard :).

The code for this can be found here: https://github.com/weaverryan/docs-data-transformer/commits/finish, where each commit that starts with "[tuts-apply-diff]" is a "step" in the tutorial.

My goals:

1) Show an easy example using the CallbackTransformer in the beginning
2) Remove complexity related to any factories that were there before
3) Moved theoretical section to the bottom

Thanks!
