### PR TITLE
HTML5 range documentation

### DIFF
--- a/reference/forms/types.rst
+++ b/reference/forms/types.rst
@@ -18,6 +18,7 @@ Form Types Reference
    types/percent
    types/search
    types/url
+   types/range
 
    types/choice
    types/entity

--- a/reference/forms/types/map.rst.inc
+++ b/reference/forms/types/map.rst.inc
@@ -11,6 +11,7 @@ Text Fields
 * :doc:`percent </reference/forms/types/percent>`
 * :doc:`search </reference/forms/types/search>`
 * :doc:`url </reference/forms/types/url>`
+* :doc:`url </reference/forms/types/range>`
 
 Choice Fields
 ~~~~~~~~~~~~~

--- a/reference/forms/types/map.rst.inc
+++ b/reference/forms/types/map.rst.inc
@@ -11,7 +11,7 @@ Text Fields
 * :doc:`percent </reference/forms/types/percent>`
 * :doc:`search </reference/forms/types/search>`
 * :doc:`url </reference/forms/types/url>`
-* :doc:`url </reference/forms/types/range>`
+* :doc:`range </reference/forms/types/range>`
 
 Choice Fields
 ~~~~~~~~~~~~~

--- a/reference/forms/types/range.rst
+++ b/reference/forms/types/range.rst
@@ -70,3 +70,5 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/label_attr.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/trim.rst.inc

--- a/reference/forms/types/range.rst
+++ b/reference/forms/types/range.rst
@@ -8,7 +8,7 @@ The ``range`` field is a slider that is rendered using the HTML5
 ``<input type="range" />`` tag.
 
 +-------------+---------------------------------------------------------------------+
-| Rendered as | ``input`` ``range`` field (slider in html5 supported browser)                              |
+| Rendered as | ``input`` ``range`` field (slider in HTML5 supported browser)       |
 +-------------+---------------------------------------------------------------------+
 | Inherited   | - `data`_                                                           |
 | options     | - `disabled`_                                                       |
@@ -18,8 +18,7 @@ The ``range`` field is a slider that is rendered using the HTML5
 |             | - `label`_                                                          |
 |             | - `label_attr`_                                                     |
 |             | - `mapped`_                                                         |
-|             | - `max`_                                                           |
-|             | - `min`_                                                           |
+|             | - `attr`_                                                           |
 |             | - `required`_                                                       |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`text </reference/forms/types/text>`                           |
@@ -30,6 +29,12 @@ The ``range`` field is a slider that is rendered using the HTML5
 Basic Usage
 -----------
 
+    $builder->add('name', 'range', array(
+        'attr' => array(
+            'min' => 5,
+            'max' => 50
+        )
+    ));
 
 Inherited Options
 -----------------

--- a/reference/forms/types/range.rst
+++ b/reference/forms/types/range.rst
@@ -10,16 +10,17 @@ The ``range`` field is a slider that is rendered using the HTML5
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``range`` field (slider in HTML5 supported browser)       |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | - `data`_                                                           |
-| options     | - `disabled`_                                                       |
+| Inherited   | - `attr`_                                                           |
+| options     | - `data`_                                                           |
+|             | - `disabled`_                                                       |
 |             | - `empty_data`_                                                     |
 |             | - `error_bubbling`_                                                 |
 |             | - `error_mapping`_                                                  |
 |             | - `label`_                                                          |
 |             | - `label_attr`_                                                     |
 |             | - `mapped`_                                                         |
-|             | - `attr`_                                                           |
 |             | - `required`_                                                       |
+|             | - `trim`_                                                           |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`text </reference/forms/types/text>`                           |
 +-------------+---------------------------------------------------------------------+
@@ -28,6 +29,8 @@ The ``range`` field is a slider that is rendered using the HTML5
 
 Basic Usage
 -----------
+
+.. code-block:: php
 
     $builder->add('name', 'range', array(
         'attr' => array(
@@ -44,7 +47,17 @@ type:
 
 .. include:: /reference/forms/types/options/attr.rst.inc
 
+.. include:: /reference/forms/types/options/data.rst.inc
+
 .. include:: /reference/forms/types/options/disabled.rst.inc
+
+.. include:: /reference/forms/types/options/empty_data.rst.inc
+    :end-before: DEFAULT_PLACEHOLDER
+
+The default value is ``''`` (the empty string).
+
+.. include:: /reference/forms/types/options/empty_data.rst.inc
+    :start-after: DEFAULT_PLACEHOLDER
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 
@@ -52,10 +65,8 @@ type:
 
 .. include:: /reference/forms/types/options/label.rst.inc
 
-.. include:: /reference/forms/types/options/label_attr.rst.inc
-
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
-.. include:: /reference/forms/types/options/read_only.rst.inc
+.. include:: /reference/forms/types/options/label_attr.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc

--- a/reference/forms/types/range.rst
+++ b/reference/forms/types/range.rst
@@ -65,9 +65,9 @@ The default value is ``''`` (the empty string).
 
 .. include:: /reference/forms/types/options/label.rst.inc
 
-.. include:: /reference/forms/types/options/mapped.rst.inc
-
 .. include:: /reference/forms/types/options/label_attr.rst.inc
+
+.. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
 

--- a/reference/forms/types/range.rst
+++ b/reference/forms/types/range.rst
@@ -1,0 +1,56 @@
+.. index::
+   single: Forms; Fields; range
+
+range Field Type
+================
+
+The ``range`` field is a slider that is rendered using the HTML5
+``<input type="range" />`` tag.
+
++-------------+---------------------------------------------------------------------+
+| Rendered as | ``input`` ``range`` field (slider in html5 supported browser)                              |
++-------------+---------------------------------------------------------------------+
+| Inherited   | - `data`_                                                           |
+| options     | - `disabled`_                                                       |
+|             | - `empty_data`_                                                     |
+|             | - `error_bubbling`_                                                 |
+|             | - `error_mapping`_                                                  |
+|             | - `label`_                                                          |
+|             | - `label_attr`_                                                     |
+|             | - `mapped`_                                                         |
+|             | - `max`_                                                           |
+|             | - `min`_                                                           |
+|             | - `required`_                                                       |
++-------------+---------------------------------------------------------------------+
+| Parent type | :doc:`text </reference/forms/types/text>`                           |
++-------------+---------------------------------------------------------------------+
+| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RangeType` |
++-------------+---------------------------------------------------------------------+
+
+Basic Usage
+-----------
+
+
+Inherited Options
+-----------------
+
+These options inherit from the :doc:`form </reference/forms/types/form>`
+type:
+
+.. include:: /reference/forms/types/options/attr.rst.inc
+
+.. include:: /reference/forms/types/options/disabled.rst.inc
+
+.. include:: /reference/forms/types/options/error_bubbling.rst.inc
+
+.. include:: /reference/forms/types/options/error_mapping.rst.inc
+
+.. include:: /reference/forms/types/options/label.rst.inc
+
+.. include:: /reference/forms/types/options/label_attr.rst.inc
+
+.. include:: /reference/forms/types/options/mapped.rst.inc
+
+.. include:: /reference/forms/types/options/read_only.rst.inc
+
+.. include:: /reference/forms/types/options/required.rst.inc


### PR DESCRIPTION
Hi, 

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | [#5439] |
| Code PR | [12607] |
| License | MIT |

I am trying to contribute to range added for the PR https://github.com/symfony/symfony/pull/12067 & https://github.com/symfony/symfony/issues/11979 which fixes https://github.com/symfony/symfony-docs/issues/5439 .

Need some help on moving for I am really new to the documentation. 

The current issues I feel is whether we need to add Basic usage or is that only reference ?

I had a look at http://symfony.com/doc/current/reference/forms/types/number.html which would have been similar, but that seems it referencing to choice seems more confusing.

I have looked into other types also and almost all are some what similar.

Any input is highly appreciated and will work on in the free time. If someone is interested please do take the PR or finish it .

Thank you.
