### PR TITLE
--dev is default and causes a warning

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -45,7 +45,7 @@ the follow command:
 
 .. code-block:: bash
 
-    $ composer --dev update
+    $ composer update
 
 Running
 -------


### PR DESCRIPTION
--dev causes a warning:

```
$ composer --dev update
You are using the deprecated option "dev". Dev packages are installed by default now.
```
