### PR TITLE
[WIP] Added caution notes about the deprecation of container scopes

### DIFF
--- a/cookbook/console/console_command.rst
+++ b/cookbook/console/console_command.rst
@@ -82,6 +82,11 @@ for details.
 Getting Services from the Service Container
 -------------------------------------------
 
+.. caution::
+
+    The "container scopes" concept explained in this section has been deprecated
+    in Symfony 2.8 and it will be removed in Symfony 3.0.
+
 By using :class:`Symfony\\Bundle\\FrameworkBundle\\Command\\ContainerAwareCommand`
 as the base class for the command (instead of the more basic
 :class:`Symfony\\Component\\Console\\Command\\Command`), you have access to the

--- a/cookbook/service_container/scopes.rst
+++ b/cookbook/service_container/scopes.rst
@@ -4,6 +4,11 @@
 How to Work with Scopes
 =======================
 
+.. caution::
+
+    The "container scopes" concept explained in this article has been deprecated
+    in Symfony 2.8 and it will be removed in Symfony 3.0.
+
 This article is all about scopes, a somewhat advanced topic related to the
 :doc:`/book/service_container`. If you've ever gotten an error mentioning
 "scopes" when creating services, then this article is for you.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8+ |
| Fixed tickets | #5436 |

This is a first proposal related to scopes deprecation. Questions:
- Should we expand the "caution notes" to explain why we did that and the alternatives provided?
- Should we rewrite the `cookbook/service_container/scopes.rst` article to explain the new scopes + shared flag and add a note about the old scopes which were available in the past Symfony versions?
