### PR TITLE
Edit tests in unit-testing.rst to fix error

### DIFF
--- a/create_framework/unit-testing.rst
+++ b/create_framework/unit-testing.rst
@@ -91,6 +91,12 @@ We are now ready to write our first test::
         protected function getFrameworkForException($exception)
         {
             $matcher = $this->getMock('Symfony\Component\Routing\Matcher\UrlMatcherInterface');
+            $context = $this->getMock('Symfony\Component\Routing\RequestContext');
+            $matcher
+                ->expects($this->once())
+                ->method('getContext')
+                ->willReturn($context)
+            ;
             $matcher
                 ->expects($this->once())
                 ->method('match')
@@ -141,6 +147,12 @@ Response::
     public function testControllerResponse()
     {
         $matcher = $this->getMock('Symfony\Component\Routing\Matcher\UrlMatcherInterface');
+        $context = $this->getMock('Symfony\Component\Routing\RequestContext');
+        $matcher
+            ->expects($this->once())
+            ->method('getContext')
+            ->willReturn($context)
+        ;
         $matcher
             ->expects($this->once())
             ->method('match')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7 |
| Fixed tickets | NA? |

In symfony-docs/create_framework/unit-testing.rst, in the
tutorial's "FrameworkTest" class, make following changes to
protected method named "getFrameworkForException" and to test
method named "testControllerResponse":
    (i)  add mock RequestContext, and
    (ii) add to mock URLMatcherInterface the expectation that its
"getContext" method will be called and will return the mock
RequestContext.

Reason: Prior to these changes, running phpunit while following the
unit-testing.rst tutorial causes php error with message:
  "Fatal error: Call to a member function fromRequest() on null in
  [path/to/]example.com/src/Simplex/Framework.php on line 24"

The line 24 referred to in the foregoing error message is the first
line of the "handle" method of the tutorial's "Framework" class:
    "$this->matcher->getContext()->fromRequest($request);"
