### PR TITLE
Fix typo in url for PHPUnit test coverage report

### DIFF
--- a/create_framework/unit-testing.rst
+++ b/create_framework/unit-testing.rst
@@ -173,7 +173,7 @@ coverage feature (you need to enable `XDebug`_ first):
 
     $ phpunit --coverage-html=cov/
 
-Open ``example.com/cov/src_Simplex_Framework.php.html`` in a browser and check
+Open ``example.com/cov/src/Simplex/Framework.php.html`` in a browser and check
 that all the lines for the Framework class are green (it means that they have
 been visited when the tests were executed).
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7 |
| Fixed tickets | NA? |

In symfony-docs/create_framework/unit-testing.rst, on topic of using
PHPUnit to create a test coverage report, it appears the path to the
report should be "example.com/cov/src/Simplex/Framework.php.html"
instead of "example.com/cov/src_Simplex_Framework.php.html".
