### PR TITLE
Change file name comment to default one

### DIFF
--- a/create_framework/front-controller.rst
+++ b/create_framework/front-controller.rst
@@ -191,7 +191,7 @@ the ``setContent()`` directly from the front controller script::
 
 And the ``hello.php`` script can now be converted to a template::
 
-    <!-- example.com/src/pages/hello.php -->
+    // example.com/src/pages/hello.php
 
     <?php $name = $request->get('name', 'World') ?>
 

--- a/create_framework/routing.rst
+++ b/create_framework/routing.rst
@@ -33,7 +33,7 @@ framework just a little to make templates even more readable::
 As we now extract the request query parameters, simplify the ``hello.php``
 template as follows::
 
-    <!-- example.com/src/pages/hello.php -->
+    // example.com/src/pages/hello.php
 
     Hello <?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8') ?>
 
@@ -166,7 +166,7 @@ There are a few new things in the code::
 
 * Request attributes are extracted to keep our templates simple::
 
-      <!-- example.com/src/pages/hello.php -->
+      // example.com/src/pages/hello.php
 
       Hello <?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8') ?>
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | ~ |

`<!--` comment was not used before.
In doc we are rather see `//`
