### PR TITLE
[load_balancer_reverse_proxy ] Always use 127.0.0.1 as a trusted proxy

### DIFF
--- a/cookbook/request/load_balancer_reverse_proxy.rst
+++ b/cookbook/request/load_balancer_reverse_proxy.rst
@@ -83,7 +83,7 @@ In this case, you'll need to - *very carefully* - trust *all* proxies.
        // web/app.php
 
        // ...
-       Request::setTrustedProxies(array($request->server->get('REMOTE_ADDR')));
+       Request::setTrustedProxies(array('127.0.0.1', $request->server->get('REMOTE_ADDR')));
 
        $response = $kernel->handle($request);
        // ...


### PR DESCRIPTION
Apparently the behaviour changed in Symfony 2.7. Before, the solution just worked perfectly with a Amazon ELB. After upgrading to Symfony 2.7 the subrequests weren't trusted anymore because they set the `REMOTE_ADDR` to `127.0.0.1`
