### PR TITLE
change the third (wrong description) to the fourth

### DIFF
--- a/components/translation/introduction.rst
+++ b/components/translation/introduction.rst
@@ -200,7 +200,7 @@ loaded like this::
     );
 
 When translating strings that are not in the default domain (``messages``),
-you must specify the domain as the third argument of ``trans()``::
+you must specify the domain as the fourth argument of ``trans()``::
 
     $translator->trans('Symfony is great', array(), 'admin');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | ~ |

Is the `domain`  the fourth argument( rather than the third) of the `$translator->trans()` ?

Correct me please If I'm wrong.Sorry about my poor English.
