### PR TITLE
[create_framework] Add missing extract() 2nd arg

### DIFF
--- a/create_framework/http-kernel-controller-resolver.rst
+++ b/create_framework/http-kernel-controller-resolver.rst
@@ -160,7 +160,7 @@ Let's conclude with the new version of our framework::
 
     function render_template(Request $request)
     {
-        extract($request->attributes->all());
+        extract($request->attributes->all(), EXTR_SKIP);
         ob_start();
         include sprintf(__DIR__.'/../src/pages/%s.php', $_route);
 


### PR DESCRIPTION
See previous page: http://symfony.com/doc/2.3/create_framework/templating.html

The code is `extract($request->attributes->all(), EXTR_SKIP);`.

In this page, suddenly `EXTR_SKIP` is missing. I don't know why.
