### PR TITLE
TYPO: missing closing parantheses of the array

### DIFF
--- a/cookbook/serializer.rst
+++ b/cookbook/serializer.rst
@@ -169,7 +169,7 @@ to your class and choose which groups to use when serializing::
     $serializer = $this->get('serializer');
     $json = $serializer->serialize(
         $someObject,
-        'json', array('groups' => array('group1')
+        'json', array('groups' => array('group1'))
     );
 
 .. _cookbook-serializer-enabling-metadata-cache:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7 |

Fix typo: minor typo, the array was missing its closing parentheses in the code block.
