### PR TITLE
[create_framework] Add $context->fromRequest($request);

### DIFF
--- a/create_framework/separation-of-concerns.rst
+++ b/create_framework/separation-of-concerns.rst
@@ -65,6 +65,7 @@ And update ``example.com/web/front.php`` accordingly::
     $routes = include __DIR__.'/../src/app.php';
 
     $context = new Routing\RequestContext();
+    $context->fromRequest($request);
     $matcher = new Routing\Matcher\UrlMatcher($routes, $context);
     $resolver = new HttpKernel\Controller\ControllerResolver();
 


### PR DESCRIPTION
See http://symfony.com/doc/2.3/create_framework/http-kernel-controller-resolver.html

``` php
$context = new Routing\RequestContext();
$context->fromRequest($request);
$matcher = new Routing\Matcher\UrlMatcher($routes, $context);
$resolver = new HttpKernel\Controller\ControllerResolver();
```

The line `$context->fromRequest($request);` is missing on this page.
