### PR TITLE
[reate_framework] Fix mock $matcher

### DIFF
--- a/create_framework/unit-testing.rst
+++ b/create_framework/unit-testing.rst
@@ -157,6 +157,11 @@ Response::
                 }
             )))
         ;
+        $matcher
+            ->expects($this->once())
+            ->method('getContext')
+            ->will($this->returnValue($this->getMock('Symfony\Component\Routing\RequestContext')))
+        ;
         $resolver = new ControllerResolver();
 
         $framework = new Framework($matcher, $resolver);


### PR DESCRIPTION
We need `getContext` method, otherwise we get:

> Fatal error: Call to a member function fromRequest() on a non-object in /Users/kenji/work/framework/src/Simplex/Framework.php on line 24

line 24:

``` php
$this->matcher->getContext()->fromRequest($request);
```
