### PR TITLE
List of supported branches for Platform.sh.

### DIFF
--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -268,7 +268,8 @@ The specific configuration files at the root of the Git repository:
 allow `Platform.sh`_ to build Pull Requests.
 
 .. note::
-    Only the following branches are supported for building Pull Requests: 2.3 (LTS), 2.6, 2.7, 2.8.
+    Only the following branches are supported for building Pull Requests: 2.3 (LTS), 
+    2.6, 2.7, 2.8.
 
 Minor Changes (e.g. Typos)
 --------------------------

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -263,11 +263,12 @@ changes.
 To access the `Platform.sh`_ environment URL, simply go to your Pull Request 
 page on GitHub and click on ``Details``.
 
-.. note::
+The specific configuration files at the root of the Git repository: 
+``.platform.app.yaml``, ``.platform/services.yaml`` and ``.platform/routes.yaml`` 
+allow `Platform.sh`_ to build Pull Requests.
 
-    The specific configuration files at the root of the Git repository: 
-    ``.platform.app.yaml``, ``.platform/services.yaml`` and 
-    ``.platform/routes.yaml`` allow `Platform.sh`_ to build Pull Requests.
+.. note::
+    Only the following branches are supported for building Pull Requests: 2.3 (LTS), 2.6, 2.7, 2.8.
 
 Minor Changes (e.g. Typos)
 --------------------------


### PR DESCRIPTION
It seems the configuration has not been added to legacy branches (2.0 => 2.5).
