### PR TITLE
Replace Capifony with Capistrano/symfony

### DIFF
--- a/cookbook/deployment/tools.rst
+++ b/cookbook/deployment/tools.rst
@@ -66,9 +66,10 @@ Using Build Scripts and other Tools
 There are also tools to help ease the pain of deployment. Some of them have been
 specifically tailored to the requirements of Symfony.
 
-`Capifony`_
-    This Ruby-based tool provides a specialized set of tools on top of
-    `Capistrano`_, tailored specifically to Symfony projects.
+`Capistrano`_/`symphony`_
+    `Capistrano`_ is a remote server automation and deployment tool written in Ruby. 
+    `symphony`_ is a plugin to ease symphony related tasks, inspired by `Capifony`_
+    (works only with Capistrano 2 )
 
 `sf2debpkg`_
     Helps you build a native Debian package for your Symfony project.
@@ -198,3 +199,4 @@ other potential things like pushing assets to a CDN (see `Common Post-Deployment
 .. _`bundles that add deployment features`: http://knpbundles.com/search?q=deploy
 .. _`Memcached`: http://memcached.org/
 .. _`Redis`: http://redis.io/
+.. _`symfony`: https://github.com/capistrano/symfony/

--- a/cookbook/deployment/tools.rst
+++ b/cookbook/deployment/tools.rst
@@ -66,10 +66,10 @@ Using Build Scripts and other Tools
 There are also tools to help ease the pain of deployment. Some of them have been
 specifically tailored to the requirements of Symfony.
 
-`Capistrano`_/`symphony`_
+`Capistrano`_ with `symfony plugin`_
     `Capistrano`_ is a remote server automation and deployment tool written in Ruby. 
-    `symphony`_ is a plugin to ease symphony related tasks, inspired by `Capifony`_
-    (works only with Capistrano 2 )
+    `symfony plugin`_ is a plugin to ease symphony related tasks, inspired by `Capifony`_
+    (which works only with Capistrano 2 )
 
 `sf2debpkg`_
     Helps you build a native Debian package for your Symfony project.
@@ -199,4 +199,5 @@ other potential things like pushing assets to a CDN (see `Common Post-Deployment
 .. _`bundles that add deployment features`: http://knpbundles.com/search?q=deploy
 .. _`Memcached`: http://memcached.org/
 .. _`Redis`: http://redis.io/
-.. _`symfony`: https://github.com/capistrano/symfony/
+.. _`symfony plugin`: https://github.com/capistrano/symfony/
+

--- a/cookbook/deployment/tools.rst
+++ b/cookbook/deployment/tools.rst
@@ -66,9 +66,9 @@ Using Build Scripts and other Tools
 There are also tools to help ease the pain of deployment. Some of them have been
 specifically tailored to the requirements of Symfony.
 
-`Capistrano`_ with `symfony plugin`_
+`Capistrano`_ with `Symfony plugin`_
     `Capistrano`_ is a remote server automation and deployment tool written in Ruby. 
-    `symfony plugin`_ is a plugin to ease symphony related tasks, inspired by `Capifony`_
+    `Symfony plugin`_ is a plugin to ease Symfony related tasks, inspired by `Capifony`_
     (which works only with Capistrano 2 )
 
 `sf2debpkg`_
@@ -199,5 +199,5 @@ other potential things like pushing assets to a CDN (see `Common Post-Deployment
 .. _`bundles that add deployment features`: http://knpbundles.com/search?q=deploy
 .. _`Memcached`: http://memcached.org/
 .. _`Redis`: http://redis.io/
-.. _`symfony plugin`: https://github.com/capistrano/symfony/
+.. _`Symfony plugin`: https://github.com/capistrano/symfony/
 


### PR DESCRIPTION
Since Capifony only works with Capistrano 2 (https://github.com/everzet/capifony/blob/master/README.md) and Capistrano 3 is the current version, its probably better to advice using the newer alternative.
