### PR TITLE
Removed reference to remove HTTPS off from nginx configuration

### DIFF
--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -269,7 +269,6 @@ The **minimum configuration** to get your application running under Nginx is:
             fastcgi_split_path_info ^(.+\.php)(/.*)$;
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            fastcgi_param HTTPS off;
         }
         # PROD
         location ~ ^/app\.php(/|$) {
@@ -277,7 +276,6 @@ The **minimum configuration** to get your application running under Nginx is:
             fastcgi_split_path_info ^(.+\.php)(/.*)$;
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            fastcgi_param HTTPS off;
             # Prevents URIs that include the front controller. This will 404:
             # http://domain.tld/app.php/some-path
             # Remove the internal directive to allow URIs like this


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #5517 |

As explained and confirmed in #5517 the `https off` flag could be causing issues, in my opinion it's better to rely on the defaults distributions give.

An alternative would be to replace the lines with `HTTPS $https;`, [nginx will fill $https depending on current request](http://nginx.org/en/docs/http/ngx_http_core_module.html#var_https). But I think it's less confusing if we just let the lines out of the example.
