### PR TITLE
[minor] [2.8] Encourage use of tilde operator in version constraints

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -435,7 +435,7 @@ content:
 
     {
         "require": {
-            "symfony/symfony": "2.6.*"
+            "symfony/symfony": "~2.6"
         },
         "autoload": {
             "files": ["model.php","controllers.php"]

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -149,7 +149,7 @@ version as the second argument of the ``create-project`` command:
 
 .. code-block:: bash
 
-    $ composer create-project symfony/framework-standard-edition my_project_name "2.3.*"
+    $ composer create-project symfony/framework-standard-edition my_project_name "~2.3"
 
 .. tip::
 

--- a/components/form/introduction.rst
+++ b/components/form/introduction.rst
@@ -170,7 +170,7 @@ line to your ``composer.json`` file:
 
     {
         "require": {
-            "symfony/twig-bridge": "2.3.*"
+            "symfony/twig-bridge": "~2.3"
         }
     }
 
@@ -250,8 +250,8 @@ of each of these by adding the following to your ``composer.json`` file:
 
     {
         "require": {
-            "symfony/translation": "2.3.*",
-            "symfony/config": "2.3.*"
+            "symfony/translation": "~2.3",
+            "symfony/config": "~2.3"
         }
     }
 
@@ -301,7 +301,7 @@ install the latest 2.3 version, add this to your ``composer.json``:
 
     {
         "require": {
-            "symfony/validator": "2.3.*"
+            "symfony/validator": "~2.3"
         }
     }
 

--- a/cookbook/install/unstable_versions.rst
+++ b/cookbook/install/unstable_versions.rst
@@ -14,7 +14,7 @@ execute the following command:
 
 .. code-block:: bash
 
-    $ composer create-project symfony/framework-standard-edition my_project "2.7.*" --stability=dev
+    $ composer create-project symfony/framework-standard-edition my_project "~2.7" --stability=dev
 
 Once the command finishes its execution, you'll have a new Symfony project created
 in the ``my_project/`` directory and based on the most recent code found in the
@@ -25,7 +25,7 @@ option:
 
 .. code-block:: bash
 
-    $ composer create-project symfony/framework-standard-edition my_project "2.7.*" --stability=beta
+    $ composer create-project symfony/framework-standard-edition my_project "~2.7" --stability=beta
 
 Upgrading your Project to an Unstable Symfony Version
 -----------------------------------------------------
@@ -42,7 +42,7 @@ dependency as follows:
     {
         "require": {
             // ...
-            "symfony/symfony" : "2.7.*@dev"
+            "symfony/symfony" : "~2.7@dev"
         }
     }
 
@@ -53,8 +53,8 @@ following command to update your project dependencies:
 
     $ composer update symfony/symfony
 
-If you prefer to test a Symfony beta version, replace the ``"2.7.*@dev"`` constraint
-by ``"2.7.0-beta1"`` to install a specific beta number or ``2.7.*@beta`` to get
+If you prefer to test a Symfony beta version, replace the ``"~2.7@dev"`` constraint
+by ``"2.7.0-beta1"`` to install a specific beta number or ``~2.7@beta`` to get
 the most recent beta version.
 
 After upgrading the Symfony version, read the :doc:`Symfony Upgrading Guide </cookbook/upgrade/index>`

--- a/cookbook/upgrade/major_version.rst
+++ b/cookbook/upgrade/major_version.rst
@@ -33,7 +33,7 @@ it will be removed/changed in the future and that you should stop using it.
 When the major version is released (e.g. 3.0.0), all deprecated features and
 functionality are removed. So, as long as you've updated your code to stop
 using these deprecated features in the last version before the major (e.g.
-2.8.*), you should be able to upgrade without a problem.
+~2.8), you should be able to upgrade without a problem.
 
 To help you with this, the last minor releases will trigger deprecated notices.
 For example, 2.7 and 2.8 trigger deprecated notices. When visiting your
@@ -87,7 +87,7 @@ Composer by modifying your ``composer.json`` file:
         "...": "...",
 
         "require": {
-            "symfony/symfony": "3.0.*",
+            "symfony/symfony": "~3.0",
         },
         "...": "...",
     }

--- a/cookbook/upgrade/minor_version.rst
+++ b/cookbook/upgrade/minor_version.rst
@@ -30,7 +30,7 @@ to use the new version:
         "...": "...",
 
         "require": {
-            "symfony/symfony": "2.6.*",
+            "symfony/symfony": "~2.6",
         },
         "...": "...",
     }

--- a/cookbook/upgrade/patch_version.rst
+++ b/cookbook/upgrade/patch_version.rst
@@ -15,7 +15,7 @@ version is *really* easy:
 That's it! You should not encounter any backwards-compatibility breaks or
 need to change anything else in your code. That's because when you started
 your project, your ``composer.json`` included Symfony using a constraint
-like ``2.6.*``, where only the *last* version number will change when you
+like ``~2.6.0``, where only the *last* version number will change when you
 update.
 
 .. tip::

--- a/create_framework/separation-of-concerns.rst
+++ b/create_framework/separation-of-concerns.rst
@@ -83,9 +83,9 @@ be autoloaded, update the ``composer.json`` file:
 
     {
         "require": {
-            "symfony/http-foundation": "2.5.*",
-            "symfony/routing": "2.5.*",
-            "symfony/http-kernel": "2.5.*"
+            "symfony/http-foundation": "~2.5",
+            "symfony/routing": "~2.5",
+            "symfony/http-kernel": "~2.5"
         },
         "autoload": {
             "psr-0": { "Simplex\\": "src/", "Calendar\\": "src/" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to |  |
| Fixed tickets |  |

Before:

```
2.3.*
```

After

```
~2.3
```
