### PR TITLE
[components][expression_language] Fix the wrong constructor for SerializedParsedExpression

### DIFF
--- a/components/expression_language/caching.rst
+++ b/components/expression_language/caching.rst
@@ -65,7 +65,7 @@ Both ``evaluate()`` and ``compile()`` can handle ``ParsedExpression`` and
 
     $expression = new SerializedParsedExpression(
         '1 + 4',
-        serialize($language->parse('1 + 4', array()))
+        serialize($language->parse('1 + 4', array())->getNodes())
     );
 
     echo $language->evaluate($expression); // prints 5


### PR DESCRIPTION
SerializedParsedExpression

There is a bug in the code snippet for creating a
SerializedParsedExpression instance in chapter "Using Parsed and
Serialized Expressions"

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |
