### PR TITLE
rename $input to $greetInput

### DIFF
--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -504,8 +504,8 @@ Calling a command from another one is straightforward::
             '--yell'  => true,
         );
 
-        $input = new ArrayInput($arguments);
-        $returnCode = $command->run($input, $output);
+        $greetInput = new ArrayInput($arguments);
+        $returnCode = $command->run($greetInput, $output);
 
         // ...
     }


### PR DESCRIPTION
Not a good practice to set/abuse a variable that was passed as an argument
