### PR TITLE
Fix all broken links/permanent redirects/removed anchors

### DIFF
--- a/best_practices/business-logic.rst
+++ b/best_practices/business-logic.rst
@@ -333,7 +333,7 @@ were defined by the PHP community. You can learn more about
 use the `PHP-CS-Fixer`_, which is a command-line utility that can fix the
 coding standards of an entire codebase in a matter of seconds.
 
-.. _`full definition`: http://en.wikipedia.org/wiki/Business_logic
+.. _`full definition`: https://en.wikipedia.org/wiki/Business_logic
 .. _`Doctrine project`: http://www.doctrine-project.org/
 .. _`fixture class`: https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html#writing-simple-fixtures
 .. _`PSR-1`: http://www.php-fig.org/psr/psr-1/

--- a/best_practices/configuration.rst
+++ b/best_practices/configuration.rst
@@ -180,5 +180,5 @@ that you store them outside the Symfony project and make them available
 through environment variables. Learn how to do it in the following article:
 :doc:`/cookbook/configuration/external_parameters`
 
-.. _`feature toggles`: http://en.wikipedia.org/wiki/Feature_toggle
+.. _`feature toggles`: https://en.wikipedia.org/wiki/Feature_toggle
 .. _`constant() function`: http://twig.sensiolabs.org/doc/functions/constant.html

--- a/best_practices/creating-the-project.rst
+++ b/best_practices/creating-the-project.rst
@@ -177,4 +177,4 @@ the Symfony directory structure.
 .. _`Get Started`: https://getcomposer.org/doc/00-intro.md
 .. _`Composer download page`: https://getcomposer.org/download/
 .. _`public checksums repository`: https://github.com/sensiolabs/checksums
-.. _`these steps`: http://fabien.potencier.org/article/73/signing-project-releases
+.. _`these steps`: http://fabien.potencier.org/signing-project-releases.html

--- a/best_practices/tests.rst
+++ b/best_practices/tests.rst
@@ -121,4 +121,4 @@ for your test fixtures.
 .. _`PhpUnit`: https://phpunit.de/
 .. _`PhpSpec`: http://www.phpspec.net/
 .. _`Mink`: http://mink.behat.org
-.. _`smoke testing`: http://en.wikipedia.org/wiki/Smoke_testing_(software)
+.. _`smoke testing`: https://en.wikipedia.org/wiki/Smoke_testing_(software)

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -362,7 +362,7 @@ see the :ref:`book-doctrine-field-types` section.
     `Reserved SQL keywords documentation`_ on how to properly escape these
     names. Alternatively, if you're free to choose your database schema,
     simply map to a different table name or column name. See Doctrine's
-    `Persistent classes`_ and `Property Mapping`_ documentation.
+    `Creating Classes for the Database`_ and `Property Mapping`_ documentation.
 
 .. note::
 
@@ -1429,7 +1429,7 @@ For more information about Doctrine, see the *Doctrine* section of the
 .. _`Property Mapping`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html#property-mapping
 .. _`Lifecycle Events documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/events.html#lifecycle-events
 .. _`Reserved SQL keywords documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html#quoting-reserved-words
-.. _`Persistent classes`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html#persistent-classes
+.. _`Creating Classes for the Database`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html#creating-classes-for-the-database
 .. _`DoctrineMongoDBBundle`: https://symfony.com/doc/current/bundles/DoctrineMongoDBBundle/index.html
 .. _`migrations`: https://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html
 .. _`DoctrineFixturesBundle`: https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -1420,7 +1420,7 @@ For more information about Doctrine, see the *Doctrine* section of the
 * `DoctrineMongoDBBundle`_
 
 .. _`Doctrine`: http://www.doctrine-project.org/
-.. _`MongoDB`: http://www.mongodb.org/
+.. _`MongoDB`: https://www.mongodb.org/
 .. _`Basic Mapping Documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html
 .. _`Query Builder`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/query-builder.html
 .. _`Doctrine Query Language`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/dql-doctrine-query-language.html

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -1963,5 +1963,5 @@ Learn more from the Cookbook
 .. _`DateTime`: http://php.net/manual/en/class.datetime.php
 .. _`Twig Bridge`: https://github.com/symfony/symfony/tree/2.3/src/Symfony/Bridge/Twig
 .. _`form_div_layout.html.twig`: https://github.com/symfony/symfony/blob/2.3/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
-.. _`Cross-site request forgery`: http://en.wikipedia.org/wiki/Cross-site_request_forgery
+.. _`Cross-site request forgery`: https://en.wikipedia.org/wiki/Cross-site_request_forgery
 .. _`view on GitHub`: https://github.com/symfony/symfony/tree/2.3/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form

--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -320,6 +320,8 @@ As it stands now, that code would need to be added to every controller file.
 If you forget to include something in one file, hopefully it doesn't relate
 to security...
 
+.. _book-from_flat_php-front-controller:
+
 A "Front Controller" to the Rescue
 ----------------------------------
 

--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -627,7 +627,7 @@ doing so much work.
 
     Symfony also supports weak ETags by passing ``true`` as the second
     argument to the
-    :method:`Symfony\\Component\\HttpFoundation\\Response::setETag` method.
+    :method:`Symfony\\Component\\HttpFoundation\\Response::setEtag` method.
 
 .. index::
    single: Cache; Last-Modified header

--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -1244,7 +1244,7 @@ Learn more from the Cookbook
 
 * :doc:`/cookbook/cache/varnish`
 
-.. _`Things Caches Do`: http://tomayko.com/writings/things-caches-do
+.. _`Things Caches Do`: http://2ndscale.com/writings/things-caches-do
 .. _`Cache Tutorial`: http://www.mnot.net/cache_docs/
 .. _`Varnish`: https://www.varnish-cache.org/
 .. _`Squid in reverse proxy mode`: http://wiki.squid-cache.org/SquidFaq/ReverseProxy

--- a/book/http_fundamentals.rst
+++ b/book/http_fundamentals.rst
@@ -578,6 +578,6 @@ sensible defaults. For more advanced users, the sky is the limit.
 .. _`Live HTTP Headers`: https://addons.mozilla.org/en-US/firefox/addon/live-http-headers/
 .. _`List of HTTP status codes`: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
 .. _`List of HTTP header fields`: https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
-.. _`List of common media types`: https://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types
+.. _`List of common media types`: https://www.iana.org/assignments/media-types/media-types.xhtml
 .. _`Validator`: https://github.com/symfony/Validator
 .. _`Swift Mailer`: http://swiftmailer.org/

--- a/book/http_fundamentals.rst
+++ b/book/http_fundamentals.rst
@@ -576,8 +576,8 @@ sensible defaults. For more advanced users, the sky is the limit.
 .. _`HTTP 1.1 RFC`: http://www.w3.org/Protocols/rfc2616/rfc2616.html
 .. _`HTTP Bis`: http://datatracker.ietf.org/wg/httpbis/
 .. _`Live HTTP Headers`: https://addons.mozilla.org/en-US/firefox/addon/live-http-headers/
-.. _`List of HTTP status codes`: http://en.wikipedia.org/wiki/List_of_HTTP_status_codes
-.. _`List of HTTP header fields`: http://en.wikipedia.org/wiki/List_of_HTTP_header_fields
-.. _`List of common media types`: http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types
+.. _`List of HTTP status codes`: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+.. _`List of HTTP header fields`: https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
+.. _`List of common media types`: https://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types
 .. _`Validator`: https://github.com/symfony/Validator
 .. _`Swift Mailer`: http://swiftmailer.org/

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -394,7 +394,7 @@ need in your new application.
 Be sure to also check out the :doc:`Cookbook </cookbook/index>`, which contains
 a wide variety of articles about solving specific problems with Symfony.
 
-.. _`explained in this post`: http://fabien.potencier.org/article/73/signing-project-releases
+.. _`explained in this post`: http://fabien.potencier.org/signing-project-releases.html
 .. _`Composer`: https://getcomposer.org/
 .. _`Composer download page`: https://getcomposer.org/download/
 .. _`Apache`: http://httpd.apache.org/docs/current/mod/core.html#documentroot

--- a/book/performance.rst
+++ b/book/performance.rst
@@ -139,8 +139,8 @@ file since there will be fewer files to monitor for changes. Of course if this
 feature is disabled in the byte code cache (e.g. ``apc.stat=0`` in APC), there
 is no longer a reason to use a bootstrap file.
 
-.. _`byte code caches`: http://en.wikipedia.org/wiki/List_of_PHP_accelerators
+.. _`byte code caches`: https://en.wikipedia.org/wiki/List_of_PHP_accelerators
 .. _`OPcache`: http://php.net/manual/en/book.opcache.php
 .. _`APC`: http://php.net/manual/en/book.apc.php
 .. _`autoload.php`: https://github.com/symfony/symfony-standard/blob/master/app/autoload.php
-.. _`bootstrap file`: https://github.com/sensio/SensioDistributionBundle/blob/master/Composer/ScriptHandler.php
+.. _`bootstrap file`: https://github.com/sensiolabs/SensioDistributionBundle/blob/master/Composer/ScriptHandler.php

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -1020,4 +1020,4 @@ Learn more
 * :doc:`/cookbook/service_container/compiler_passes`
 * :doc:`/components/dependency_injection/advanced`
 
-.. _`service-oriented architecture`: http://wikipedia.org/wiki/Service-oriented_architecture
+.. _`service-oriented architecture`: https://en.wikipedia.org/wiki/Service-oriented_architecture

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1025,9 +1025,9 @@ but Symfony provides a more dynamic option via the ``asset`` Twig function:
         <link href="<?php echo $view['assets']->getUrl('css/blog.css') ?>" rel="stylesheet" />
 
 The ``asset`` function's main purpose is to make your application more portable.
-If your application lives at the root of your host (e.g. http://example.com),
+If your application lives at the root of your host (e.g. ``http://example.com``),
 then the rendered paths should be ``/images/logo.png``. But if your application
-lives in a subdirectory (e.g. http://example.com/my_app), each asset path
+lives in a subdirectory (e.g. ``http://example.com/my_app``), each asset path
 should render with the subdirectory (e.g. ``/my_app/images/logo.png``). The
 ``asset`` function takes care of this by determining how your application is
 being used and generating the correct paths accordingly.

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1640,12 +1640,12 @@ Learn more from the Cookbook
 
 .. _`Twig`: http://twig.sensiolabs.org
 .. _`KnpBundles.com`: http://knpbundles.com
-.. _`Cross Site Scripting`: http://en.wikipedia.org/wiki/Cross-site_scripting
+.. _`Cross Site Scripting`: https://en.wikipedia.org/wiki/Cross-site_scripting
 .. _`Output Escaping`: http://twig.sensiolabs.org/doc/api.html#escaper-extension
 .. _`tags`: http://twig.sensiolabs.org/doc/tags/index.html
 .. _`filters`: http://twig.sensiolabs.org/doc/filters/index.html
 .. _`add your own extensions`: http://twig.sensiolabs.org/doc/advanced.html#creating-an-extension
-.. _`hinclude.js`: http://mnot.github.com/hinclude/
+.. _`hinclude.js`: http://mnot.github.io/hinclude/
 .. _`with_context`: http://twig.sensiolabs.org/doc/functions/include.html
 .. _`include() function`: http://twig.sensiolabs.org/doc/functions/include.html
 .. _`{% include %} tag`: http://twig.sensiolabs.org/doc/tags/include.html

--- a/book/testing.rst
+++ b/book/testing.rst
@@ -866,4 +866,4 @@ Learn more
 * :doc:`/cookbook/testing/bootstrap`
 
 .. _`$_SERVER`: http://php.net/manual/en/reserved.variables.server.php
-.. _`documentation`: http://phpunit.de/manual/current/en/
+.. _`documentation`: https://phpunit.de/manual/current/en/

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -714,8 +714,8 @@ steps:
 * Manage the user's locale, which is stored on the request, but can also
   be set on the user's session.
 
-.. _`i18n`: http://en.wikipedia.org/wiki/Internationalization_and_localization
-.. _`ISO 3166-1 alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
-.. _`ISO 639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+.. _`i18n`: https://en.wikipedia.org/wiki/Internationalization_and_localization
+.. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
+.. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 .. _`Translatable Extension`: https://github.com/l3pp4rd/DoctrineExtensions
 .. _`Translatable Behavior`: https://github.com/KnpLabs/DoctrineBehaviors

--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -121,9 +121,9 @@ Numeric Node Constraints
     The numeric (float and integer) nodes were introduced in Symfony 2.2.
 
 Numeric nodes (float and integer) provide two extra constraints -
-:method:`Symfony\\Component\\Config\\Definition\\Builder::min` and
-:method:`Symfony\\Component\\Config\\Definition\\Builder::max` -
-allowing to validate the value::
+:method:`Symfony\\Component\\Config\\Definition\\Builder\\IntegerNodeDefinition::min`
+and :method:`Symfony\\Component\\Config\\Definition\\Builder\\IntegerNodeDefinition::max`
+- allowing to validate the value::
 
     $rootNode
         ->children()

--- a/components/dependency_injection/lazy_services.rst
+++ b/components/dependency_injection/lazy_services.rst
@@ -115,5 +115,5 @@ in the `documentation of ProxyManager`_.
 
 
 .. _`ProxyManager bridge`: https://github.com/symfony/symfony/tree/master/src/Symfony/Bridge/ProxyManager
-.. _`proxy`: http://en.wikipedia.org/wiki/Proxy_pattern
+.. _`proxy`: https://en.wikipedia.org/wiki/Proxy_pattern
 .. _`documentation of ProxyManager`: https://github.com/Ocramius/ProxyManager/blob/master/docs/lazy-loading-value-holder.md

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -385,5 +385,5 @@ directly::
     // submit that form
     $crawler = $client->submit($form);
 
-.. _`Goutte`:  https://github.com/fabpot/goutte
+.. _`Goutte`: https://github.com/FriendsOfPHP/Goutte
 .. _Packagist: https://packagist.org/packages/symfony/dom-crawler

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -188,7 +188,7 @@ The crawler supports multiple ways of adding the content::
 .. note::
 
     When dealing with character sets other than ISO-8859-1, always add HTML
-    content using the :method:`Symfony\\Component\\DomCrawler\\Crawler::addHTMLContent`
+    content using the :method:`Symfony\\Component\\DomCrawler\\Crawler::addHtmlContent`
     method where you can specify the second parameter to be your target character
     set.
 

--- a/components/event_dispatcher/introduction.rst
+++ b/components/event_dispatcher/introduction.rst
@@ -652,7 +652,7 @@ with 2 other dispatchers:
 * :doc:`/components/event_dispatcher/container_aware_dispatcher`
 * :doc:`/components/event_dispatcher/immutable_dispatcher`
 
-.. _Mediator: http://en.wikipedia.org/wiki/Mediator_pattern
+.. _Mediator: https://en.wikipedia.org/wiki/Mediator_pattern
 .. _Closures: http://php.net/manual/en/functions.anonymous.php
 .. _PHP callable: http://www.php.net/manual/en/language.pseudo-types.php#language.types.callback
 .. _Packagist: https://packagist.org/packages/symfony/event-dispatcher

--- a/components/form/introduction.rst
+++ b/components/form/introduction.rst
@@ -63,7 +63,7 @@ factory.
 
 .. tip::
 
-    For a working example, see https://github.com/bschussek/standalone-forms
+    For a working example, see https://github.com/webmozart/standalone-forms
 
 Request Handling
 ~~~~~~~~~~~~~~~~
@@ -692,5 +692,5 @@ object::
     an error was originally attached to.
 
 .. _Packagist: https://packagist.org/packages/symfony/form
-.. _Twig:      http://twig.sensiolabs.org
+.. _Twig: http://twig.sensiolabs.org
 .. _`Twig Configuration`: http://twig.sensiolabs.org/doc/intro.html

--- a/components/http_foundation/session_testing.rst
+++ b/components/http_foundation/session_testing.rst
@@ -21,16 +21,16 @@ The mock storage drivers do not read or write the system globals
 ``session_id()`` or ``session_name()``. Methods are provided to simulate this if
 required:
 
-* :method:`Symfony\\Component\\HttpFoundation\\Session\\SessionStorageInterface::getId`: Gets the
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\SessionStorageInterface::getId`: Gets the
   session ID.
 
-* :method:`Symfony\\Component\\HttpFoundation\\Session\\SessionStorageInterface::setId`: Sets the
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\SessionStorageInterface::setId`: Sets the
   session ID.
 
-* :method:`Symfony\\Component\\HttpFoundation\\Session\\SessionStorageInterface::getName`: Gets the
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\SessionStorageInterface::getName`: Gets the
   session name.
 
-* :method:`Symfony\\Component\\HttpFoundation\\Session\\SessionStorageInterface::setName`: Sets the
+* :method:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\SessionStorageInterface::setName`: Sets the
   session name.
 
 Unit Testing

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -226,9 +226,6 @@ has a simple API
 :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::has`
     Returns true if the attribute exists.
 
-:method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::keys`
-    Returns an array of stored attribute keys.
-
 :method:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface::replace`
     Sets multiple attributes at once: takes a keyed array and sets each key => value pair.
 

--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -118,11 +118,11 @@ See ":ref:`http-kernel-working-example`" for a more concrete implementation.
 For general information on adding listeners to the events below, see
 :ref:`http-kernel-creating-listener`.
 
-.. tip::
+.. seealso::
 
-    Fabien Potencier also wrote a wonderful series on using the HttpKernel
-    component and other Symfony components to create your own framework. See
-    `Create your own framework... on top of the Symfony2 Components`_.
+    There is a wonderful tutorial series on using the HttpKernel component and
+    other Symfony components to create your own framework. See
+    :doc:`/create_framework/introduction`.
 
 .. _component-http-kernel-kernel-request:
 

--- a/components/process.rst
+++ b/components/process.rst
@@ -265,7 +265,7 @@ You can access the `pid`_ of a running process with the
 
 .. _`Symfony Issue#5759`: https://github.com/symfony/symfony/issues/5759
 .. _`PHP Bug#39992`: https://bugs.php.net/bug.php?id=39992
-.. _`exec`: http://en.wikipedia.org/wiki/Exec_(operating_system)
-.. _`pid`: http://en.wikipedia.org/wiki/Process_identifier
+.. _`exec`: https://en.wikipedia.org/wiki/Exec_(operating_system)
+.. _`pid`: https://en.wikipedia.org/wiki/Process_identifier
 .. _`PHP Documentation`: http://php.net/manual/en/pcntl.constants.php
 .. _Packagist: https://packagist.org/packages/symfony/process

--- a/components/process.rst
+++ b/components/process.rst
@@ -158,7 +158,7 @@ To make your code work better on all platforms, you might want to use the
     method was introduced in Symfony 2.3.
 
 In case you are building a binary driver, you can use the
-:method:`Symfony\\Component\\Process\\Process::setPrefix` method to prefix all
+:method:`Symfony\\Component\\Process\\ProcessBuilder::setPrefix` method to prefix all
 the generated process commands.
 
 The following example will generate two process commands for a tar binary
@@ -194,7 +194,7 @@ timeout (in seconds)::
     $process->run();
 
 If the timeout is reached, a
-:class:`Symfony\\Process\\Exception\\RuntimeException` is thrown.
+:class:`Symfony\\Component\\Process\\Exception\\RuntimeException` is thrown.
 
 For long running commands, it is your responsibility to perform the timeout
 check regularly::

--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -101,7 +101,7 @@ Each provider (since it implements
 has a method :method:`Symfony\\Component\\Security\\Core\\Authentication\\Provider\\AuthenticationProviderInterface::supports`
 by which the ``AuthenticationProviderManager``
 can determine if it supports the given token. If this is the case, the
-manager then calls the provider's method :class:`Symfony\\Component\\Security\\Core\\Authentication\\Provider\\AuthenticationProviderInterface::authenticate`.
+manager then calls the provider's method :method:`Symfony\\Component\\Security\\Core\\Authentication\\Provider\\AuthenticationProviderInterface::authenticate`.
 This method should return an authenticated token or throw an
 :class:`Symfony\\Component\\Security\\Core\\Exception\\AuthenticationException`
 (or any other exception extending it).

--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -177,7 +177,7 @@ Roles
 
 Roles are objects that give expression to a certain right the user has.
 The only requirement is that they implement :class:`Symfony\\Component\\Security\\Core\\Role\\RoleInterface`,
-which means they should also have a :method:`Symfony\\Component\\Security\\Core\\Role\\Role\\RoleInterface::getRole`
+which means they should also have a :method:`Symfony\\Component\\Security\\Core\\Role\\RoleInterface::getRole`
 method that returns a string representation of the role itself. The default
 :class:`Symfony\\Component\\Security\\Core\\Role\\Role` simply returns its
 first constructor argument::

--- a/components/security/secure_tools.rst
+++ b/components/security/secure_tools.rst
@@ -67,4 +67,4 @@ to work correctly. Just pass a file name to enable it::
     solution is to hash the value returned by ``nextBytes()`` (to do that, you
     can use a simple ``md5()`` PHP function).
 
-.. _`Timing attack`: http://en.wikipedia.org/wiki/Timing_attack
+.. _`Timing attack`: https://en.wikipedia.org/wiki/Timing_attack

--- a/components/translation/introduction.rst
+++ b/components/translation/introduction.rst
@@ -215,5 +215,5 @@ Usage
 Read how to use the Translation component in :doc:`/components/translation/usage`.
 
 .. _Packagist: https://packagist.org/packages/symfony/translation
-.. _`ISO 3166-1 alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
-.. _`ISO 639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+.. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
+.. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -369,5 +369,5 @@ use for translation::
         'fr_FR'
     );
 
-.. _`L10n`: http://en.wikipedia.org/wiki/Internationalization_and_localization
-.. _`ISO 31-11`: http://en.wikipedia.org/wiki/Interval_(mathematics)#Notations_for_intervals
+.. _`L10n`: https://en.wikipedia.org/wiki/Internationalization_and_localization
+.. _`ISO 31-11`: https://en.wikipedia.org/wiki/Interval_(mathematics)#Notations_for_intervals

--- a/contributing/code/license.rst
+++ b/contributing/code/license.rst
@@ -36,4 +36,4 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-.. _Wikipedia: http://en.wikipedia.org/wiki/MIT_License
+.. _Wikipedia: https://en.wikipedia.org/wiki/MIT_License

--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -383,16 +383,16 @@ convert many commits to one commit. This is no longer necessary today, because
 Symfony project uses a proprietary tool which automatically squashes all commits
 before merging.
 
-.. _ProGit:                                http://git-scm.com/book
-.. _GitHub:                                https://github.com/signup/free
-.. _`GitHub's Documentation`:              https://help.github.com/articles/ignoring-files
-.. _Symfony repository:                    https://github.com/symfony/symfony
-.. _dev mailing-list:                      http://groups.google.com/group/symfony-devs
-.. _travis-ci.org:                         https://travis-ci.org/
-.. _`travis-ci.org status icon`:           http://about.travis-ci.org/docs/user/status-images/
+.. _ProGit: http://git-scm.com/book
+.. _GitHub: https://github.com/join
+.. _`GitHub's Documentation`: https://help.github.com/articles/ignoring-files
+.. _Symfony repository: https://github.com/symfony/symfony
+.. _dev mailing-list: http://groups.google.com/group/symfony-devs
+.. _travis-ci.org: https://travis-ci.org/
+.. _`travis-ci.org status icon`: http://about.travis-ci.org/docs/user/status-images/
 .. _`travis-ci.org Getting Started Guide`: http://about.travis-ci.org/docs/user/getting-started/
-.. _`documentation repository`:            https://github.com/symfony/symfony-docs
-.. _`fabbot`:                              http://fabbot.io
-.. _`PSR-1`:                               http://www.php-fig.org/psr/psr-1/
-.. _`PSR-2`:                               http://www.php-fig.org/psr/psr-2/
-.. _PHPUnit:                               https://phpunit.de/manual/current/en/installation.html
+.. _`documentation repository`: https://github.com/symfony/symfony-docs
+.. _`fabbot`: http://fabbot.io
+.. _`PSR-1`: http://www.php-fig.org/psr/psr-1/
+.. _`PSR-2`: http://www.php-fig.org/psr/psr-2/
+.. _PHPUnit: https://phpunit.de/manual/current/en/installation.html

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -195,5 +195,5 @@ License
 .. _`PSR-1`: http://www.php-fig.org/psr/psr-1/
 .. _`PSR-2`: http://www.php-fig.org/psr/psr-2/
 .. _`PSR-4`: http://www.php-fig.org/psr/psr-4/
-.. _`identical comparison`: https://php.net/manual/en/language.operators.comparison.php
+.. _`identical comparison`: http://php.net/manual/en/language.operators.comparison.php
 .. _`Yoda conditions`: https://en.wikipedia.org/wiki/Yoda_conditions

--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -174,8 +174,8 @@ In addition, documentation follows these rules:
 
 .. _`the Sphinx documentation`: http://sphinx-doc.org/rest.html#source-code
 .. _`Twig Coding Standards`: http://twig.sensiolabs.org/doc/coding_standards.html
-.. _`American English`: http://en.wikipedia.org/wiki/American_English
+.. _`American English`: https://en.wikipedia.org/wiki/American_English
 .. _`American English Oxford Dictionary`: http://www.oxforddictionaries.com/definition/american_english/
-.. _`headings and titles`: http://en.wikipedia.org/wiki/Letter_case#Headings_and_publication_titles
-.. _`Serial (Oxford) Commas`: http://en.wikipedia.org/wiki/Serial_comma
-.. _`nosism`: http://en.wikipedia.org/wiki/Nosism
+.. _`headings and titles`: https://en.wikipedia.org/wiki/Letter_case#Headings_and_publication_titles
+.. _`Serial (Oxford) Commas`: https://en.wikipedia.org/wiki/Serial_comma
+.. _`nosism`: https://en.wikipedia.org/wiki/Nosism

--- a/contributing/documentation/translations.rst
+++ b/contributing/documentation/translations.rst
@@ -89,4 +89,4 @@ repository and apply changes to the translated documents as soon as possible.
     repositories as obsolete documentation is dangerous.
 
 .. _`an ongoing discussion`: https://github.com/symfony/symfony-docs/issues/4078
-.. _Symfony docs mailing-list: http://groups.google.com/group/symfony-docs
+.. _Symfony docs mailing-list: https://groups.google.com/forum/#!forum/symfony-docs

--- a/contributing/documentation/translations.rst
+++ b/contributing/documentation/translations.rst
@@ -16,9 +16,6 @@ Contributing
 First, become familiar with the :doc:`markup language </contributing/documentation/format>`
 used by the documentation.
 
-Then, subscribe to the `Symfony docs mailing-list`_, as collaboration happens
-there.
-
 Finally, find the *master* repository for the language you want to contribute
 for. Here is the list of the official *master* repositories:
 
@@ -39,7 +36,6 @@ Joining the Translation Team
 If you want to help translating some documents for your language or fix some
 bugs, consider joining us; it's a very easy process:
 
-* Introduce yourself on the `Symfony docs mailing-list`_;
 * *(optional)* Ask which documents you can work on;
 * Fork the *master* repository for your language (click the "Fork" button on
   the GitHub page);
@@ -59,8 +55,8 @@ Adding a new Language
 This section gives some guidelines for starting the translation of the
 Symfony documentation for a new language.
 
-As starting a translation is a lot of work, talk about your plan on the
-`Symfony docs mailing-list`_ and try to find motivated people willing to help.
+As starting a translation is a lot of work,  try to find motivated people
+willing to help.
 
 When the team is ready, nominate a team manager; they will be responsible for
 the *master* repository.
@@ -89,4 +85,3 @@ repository and apply changes to the translated documents as soon as possible.
     repositories as obsolete documentation is dangerous.
 
 .. _`an ongoing discussion`: https://github.com/symfony/symfony-docs/issues/4078
-.. _Symfony docs mailing-list: https://groups.google.com/forum/#!forum/symfony-docs

--- a/cookbook/assetic/uglifyjs.rst
+++ b/cookbook/assetic/uglifyjs.rst
@@ -297,6 +297,6 @@ not in debug mode.
 
 .. _`UglifyJS`: https://github.com/mishoo/UglifyJS
 .. _`UglifyCSS`: https://github.com/fmarcia/UglifyCSS
-.. _`Node.js`: http://nodejs.org/
-.. _`install Node.js`: http://nodejs.org/
-.. _`package.json`: http://package.json.nodejitsu.com/
+.. _`Node.js`: https://nodejs.org/
+.. _`install Node.js`: https://nodejs.org/
+.. _`package.json`: http://browsenpm.org/package.json

--- a/cookbook/assetic/yuicompressor.rst
+++ b/cookbook/assetic/yuicompressor.rst
@@ -163,6 +163,6 @@ apply this filter when debug mode is off.
     common config file. For details on applying filters by file extension,
     see :ref:`cookbook-assetic-apply-to`.
 
-.. _`YUI Compressor`: http://developer.yahoo.com/yui/compressor/
+.. _`YUI Compressor`: http://yui.github.io/yuicompressor/
 .. _`Download the JAR`: https://github.com/yui/yuicompressor/releases
-.. _`no longer maintained by Yahoo`: http://www.yuiblog.com/blog/2013/01/24/yui-compressor-has-a-new-owner/
+.. _`no longer maintained by Yahoo`: http://yuiblog.com/blog/2013/01/24/yui-compressor-has-a-new-owner/

--- a/cookbook/bundles/configuration.rst
+++ b/cookbook/bundles/configuration.rst
@@ -396,5 +396,5 @@ Assume the XSD file is called ``hello-1.0.xsd``, the schema location will be
 
 .. _`FrameworkBundle Configuration`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
 .. _`TwigBundle Configuration`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
-.. _`XML namespace`: http://en.wikipedia.org/wiki/XML_namespace
-.. _`XML schema`: http://en.wikipedia.org/wiki/XML_schema
+.. _`XML namespace`: https://en.wikipedia.org/wiki/XML_namespace
+.. _`XML schema`: https://en.wikipedia.org/wiki/XML_schema

--- a/cookbook/bundles/configuration.rst
+++ b/cookbook/bundles/configuration.rst
@@ -353,7 +353,7 @@ In order to use the schema, the XML configuration file must provide an
 ``xsi:schemaLocation`` attribute pointing to the XSD file for a certain XML
 namespace. This location always starts with the XML namespace. This XML
 namespace is then replaced with the XSD validation base path returned from
-:method:`Extension::getXsdValidationBasePath() <Symfony\\Component\\DependencyInjection\\ExtensionInterface::getXsdValidationBasePath>`
+:method:`Extension::getXsdValidationBasePath() <Symfony\\Component\\DependencyInjection\\Extension\\ExtensionInterface::getXsdValidationBasePath>`
 method. This namespace is then followed by the rest of the path from the base
 path to the file itself.
 

--- a/cookbook/configuration/front_controllers_and_kernel.rst
+++ b/cookbook/configuration/front_controllers_and_kernel.rst
@@ -158,12 +158,12 @@ loading the ``app/config/config_*environment*.yml`` file. You are, of course,
 free to implement this method differently if you need a more sophisticated
 way of loading your configuration.
 
-.. _front controller: http://en.wikipedia.org/wiki/Front_Controller_pattern
+.. _front controller: https://en.wikipedia.org/wiki/Front_Controller_pattern
 .. _Symfony Standard Edition: https://github.com/symfony/symfony-standard
 .. _app.php: https://github.com/symfony/symfony-standard/blob/master/web/app.php
 .. _app_dev.php: https://github.com/symfony/symfony-standard/blob/master/web/app_dev.php
 .. _app/console: https://github.com/symfony/symfony-standard/blob/master/app/console
 .. _AppKernel: https://github.com/symfony/symfony-standard/blob/master/app/AppKernel.php
-.. _decorate: http://en.wikipedia.org/wiki/Decorator_pattern
+.. _decorate: https://en.wikipedia.org/wiki/Decorator_pattern
 .. _RewriteRule shipped with the Symfony Standard Edition: https://github.com/symfony/symfony-standard/blob/master/web/.htaccess
-.. _template methods: http://en.wikipedia.org/wiki/Template_method_pattern
+.. _template methods: https://en.wikipedia.org/wiki/Template_method_pattern

--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -305,6 +305,6 @@ The **minimum configuration** to get your application running under Nginx is:
 For advanced Nginx configuration options, read the official `Nginx documentation`_.
 
 .. _`Apache documentation`: http://httpd.apache.org/docs/
-.. _`does not support Unix sockets`: https://issues.apache.org/bugzilla/show_bug.cgi?id=54101
+.. _`does not support Unix sockets`: https://bz.apache.org/bugzilla/show_bug.cgi?id=54101
 .. _`FastCgiExternalServer`: http://www.fastcgi.com/mod_fastcgi/docs/mod_fastcgi.html#FastCgiExternalServer
 .. _`Nginx documentation`: http://wiki.nginx.org/Symfony

--- a/cookbook/controller/service.rst
+++ b/cookbook/controller/service.rst
@@ -324,7 +324,6 @@ controller:
     controller action method called ``Request $request``. The order of the
     parameters is not important, but the typehint must be provided.
 
-
 .. _`Controller class source code`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
 .. _`base Controller class`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
 .. _`FrameworkExtraBundle documentation`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/routing.html

--- a/cookbook/controller/upload_file.rst
+++ b/cookbook/controller/upload_file.rst
@@ -156,8 +156,9 @@ There are some important things to consider in the code of the above controller:
    provides methods for the most common operations when dealing with uploaded files.
 #. A well-known security best practice is to never trust the input provided by
    users. This also applies to the files uploaded by your visitors. The ``Uploaded``
-   class provides methods to get the original file extension (:method:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile::getExtension`),
-   the original file size (:method:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile::getSize`)
+   class provides methods to get the original file extension
+   (:method:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile::getExtension`),
+   the original file size (:method:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile::getClientSize`)
    and the original file name (:method:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile::getClientOriginalName`).
    However, they are considered *not safe* because a malicious user could tamper
    that information. That's why it's always better to generate a unique name and

--- a/cookbook/deployment/heroku.rst
+++ b/cookbook/deployment/heroku.rst
@@ -326,7 +326,7 @@ This is also very useful to build assets on the production system, e.g. with Ass
 
 .. _`the original article`: https://devcenter.heroku.com/articles/getting-started-with-symfony2
 .. _`sign up with Heroku`: https://signup.heroku.com/signup/dc
-.. _`Heroku Toolbelt`: https://devcenter.heroku.com/articles/getting-started-with-php#local-workstation-setup
+.. _`Heroku Toolbelt`: https://devcenter.heroku.com/articles/getting-started-with-php#set-up
 .. _`getting Started with PHP on Heroku`: https://devcenter.heroku.com/articles/getting-started-with-php
 .. _`ephemeral file system`: https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem
 .. _`Logplex`: https://devcenter.heroku.com/articles/logplex

--- a/cookbook/deployment/heroku.rst
+++ b/cookbook/deployment/heroku.rst
@@ -336,7 +336,7 @@ This is also very useful to build assets on the production system, e.g. with Ass
 .. _`custom compile steps`: https://devcenter.heroku.com/articles/php-support#custom-compile-step
 .. _`custom Composer command`: https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands
 .. _`Heroku buildpacks`: https://devcenter.heroku.com/articles/buildpacks
-.. _`multiple buildpack`: https://github.com/ddollar/heroku-buildpack-multi.git
+.. _`multiple buildpack`: https://github.com/ddollar/heroku-buildpack-multi
 .. _`Grunt`: http://gruntjs.com
 .. _`gulp`: http://gulpjs.com
 .. _`Heroku documentation`: https://devcenter.heroku.com/articles/custom-php-settings#nginx

--- a/cookbook/form/data_transformers.rst
+++ b/cookbook/form/data_transformers.rst
@@ -48,7 +48,7 @@ Suppose you have a Task form with a description ``textarea`` type::
 But, there are two complications:
 
 #. Your users are allowed to use *some* HTML tags, but not others: you need a way
-   to call :phpfunction:`striptags` after the form is submitted;
+   to call :phpfunction:`strip_tags` after the form is submitted;
 
 #. To be friendly, you want to convert ``<br/>`` tags into line breaks (``\n``) before
    rendering the field so the text is easier to edit.

--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -263,4 +263,4 @@ easily testing against multiple sets of data.
 You can also pass another argument, such as a boolean if the form has to
 be synchronized with the given set of data or not etc.
 
-.. _`data providers`: http://www.phpunit.de/manual/current/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers
+.. _`data providers`: https://phpunit.de/manual/current/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers

--- a/cookbook/routing/redirect_in_config.rst
+++ b/cookbook/routing/redirect_in_config.rst
@@ -17,7 +17,7 @@ Redirecting Using a Path
 
 Assume there is no default controller for the ``/`` path of your application
 and you want to redirect these requests to ``/app``. You will need to use the
-:method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController::urlRedirect`
+:method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController::urlRedirectAction`
 action to redirect to this new url:
 
 .. configuration-block::
@@ -97,7 +97,7 @@ Redirecting Using a Route
 Assume you are migrating your website from WordPress to Symfony, you want to
 redirect ``/wp-admin`` to the route ``sonata_admin_dashboard``. You don't know
 the path, only the route name. This can be achieved using the
-:method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController::redirect`
+:method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController::redirectAction`
 action:
 
 .. configuration-block::

--- a/cookbook/security/csrf_in_login_form.rst
+++ b/cookbook/security/csrf_in_login_form.rst
@@ -180,5 +180,5 @@ After this, you have protected your login form against CSRF attacks.
                 ),
             ));
 
-.. _`Cross-site request forgery`: http://en.wikipedia.org/wiki/Cross-site_request_forgery
-.. _`Forging Login Requests`: http://en.wikipedia.org/wiki/Cross-site_request_forgery#Forging_login_requests
+.. _`Cross-site request forgery`: https://en.wikipedia.org/wiki/Cross-site_request_forgery
+.. _`Forging Login Requests`: https://en.wikipedia.org/wiki/Cross-site_request_forgery#Forging_login_requests

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -668,5 +668,5 @@ in the factory and consumed or passed to the other classes in the container.
 
 .. _`HWIOAuthBundle`: https://github.com/hwi/HWIOAuthBundle
 .. _`WSSE`: http://www.xml.com/pub/a/2003/12/17/dive.html
-.. _`nonce`: http://en.wikipedia.org/wiki/Cryptographic_nonce
-.. _`timing attacks`: http://en.wikipedia.org/wiki/Timing_attack
+.. _`nonce`: https://en.wikipedia.org/wiki/Cryptographic_nonce
+.. _`timing attacks`: https://en.wikipedia.org/wiki/Timing_attack

--- a/cookbook/templating/PHP.rst
+++ b/cookbook/templating/PHP.rst
@@ -353,4 +353,4 @@ instance, to output something in a JavaScript script, use the ``js`` context::
 
     <?php echo $view->escape($var, 'js') ?>
 
-.. _`@Template`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/view`
+.. _`@Template`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/view

--- a/cookbook/web_server/built_in.rst
+++ b/cookbook/web_server/built_in.rst
@@ -74,4 +74,4 @@ you have to pass the correct location using the ``--docroot`` option:
     $ php app/console server:run --docroot=public_html
 
 .. _`built-in web server`: http://www.php.net/manual/en/features.commandline.webserver.php
-.. _`php.net`: http://php.net/manual/en/features.commandline.webserver.php#example-401
+.. _`php.net`: http://php.net/manual/en/features.commandline.webserver.php#example-411

--- a/cookbook/workflow/new_project_git.rst
+++ b/cookbook/workflow/new_project_git.rst
@@ -101,4 +101,4 @@ manage this is `Gitolite`_.
 .. _`Gitolite`: https://github.com/sitaramc/gitolite
 .. _`GitHub .gitignore`: https://help.github.com/articles/ignoring-files
 .. _`Bitbucket`: https://bitbucket.org/
-.. _`comparison of hosting services`: http://en.wikipedia.org/wiki/Comparison_of_open-source_software_hosting_facilities
+.. _`comparison of hosting services`: https://en.wikipedia.org/wiki/Comparison_of_open-source_software_hosting_facilities

--- a/create_framework/dependency-injection.rst
+++ b/create_framework/dependency-injection.rst
@@ -239,5 +239,5 @@ micro-framework, and especially its `Application`_ class.
 Have fun!
 
 .. _`Pimple`: https://github.com/fabpot/Pimple
-.. _`Silex`: https://silex.sensiolabs.org/
+.. _`Silex`: http://silex.sensiolabs.org/
 .. _`Application`: https://github.com/fabpot/Silex/blob/master/src/Silex/Application.php

--- a/create_framework/event-dispatcher.rst
+++ b/create_framework/event-dispatcher.rst
@@ -302,5 +302,5 @@ to make it more awesome out of the box, add more listeners. Again, this book
 is not about creating a generic framework, but one that is tailored to your
 needs. Stop whenever you see fit, and further evolve the code from there.
 
-.. _`WSGI`: http://www.python.org/dev/peps/pep-0333/#middleware-components-that-play-both-sides
+.. _`WSGI`: https://www.python.org/dev/peps/pep-0333/#middleware-components-that-play-both-sides
 .. _`Rack`: http://rack.rubyforge.org/

--- a/create_framework/front-controller.rst
+++ b/create_framework/front-controller.rst
@@ -71,7 +71,7 @@ routing all client requests to a single PHP script.
 .. tip::
 
     Exposing a single PHP script to the end user is a design pattern called
-    the "`front controller`_".
+    the ":ref:`front controller <book-from_flat_php-front-controller>`".
 
 Such a script might look like the following::
 
@@ -237,5 +237,3 @@ variable.
 
     If you decide to stop here, you can probably enhance your framework by
     extracting the URL map to a configuration file.
-
-.. _`front controller`: http://symfony.com/doc/current/book/from_flat_php_to_symfony2.html#a-front-controller-to-the-rescue

--- a/create_framework/http-foundation.rst
+++ b/create_framework/http-foundation.rst
@@ -301,7 +301,7 @@ component is the start of better interoperability between all frameworks and
 applications using it (like `Symfony`_, `Drupal 8`_, `phpBB 4`_, `ezPublish
 5`_, `Laravel`_, `Silex`_, and `more`_).
 
-.. _`Twig`: http://twig.sensiolabs.com/
+.. _`Twig`: http://twig.sensiolabs.org/
 .. _`Symfony versus Flat PHP`: http://symfony.com/doc/current/book/from_flat_php_to_symfony2.html
 .. _`HTTP specification`: http://tools.ietf.org/wg/httpbis/
 .. _`audited`: http://symfony.com/blog/symfony2-security-audit

--- a/create_framework/http-foundation.rst
+++ b/create_framework/http-foundation.rst
@@ -78,8 +78,8 @@ unit test for the above code::
 .. note::
 
     If our application were just slightly bigger, we would have been able to
-    find even more problems. If you are curious about them, read the `Symfony
-    versus Flat PHP`_ chapter of the Symfony documentation.
+    find even more problems. If you are curious about them, read the
+    :doc:`/book/from_flat_php_to_symfony2` chapter of the book.
 
 At this point, if you are not convinced that security and testing are indeed
 two very good reasons to stop writing code the old way and adopt a framework
@@ -302,7 +302,6 @@ applications using it (like `Symfony`_, `Drupal 8`_, `phpBB 4`_, `ezPublish
 5`_, `Laravel`_, `Silex`_, and `more`_).
 
 .. _`Twig`: http://twig.sensiolabs.org/
-.. _`Symfony versus Flat PHP`: http://symfony.com/doc/current/book/from_flat_php_to_symfony2.html
 .. _`HTTP specification`: http://tools.ietf.org/wg/httpbis/
 .. _`audited`: http://symfony.com/blog/symfony2-security-audit
 .. _`Symfony`: http://symfony.com/

--- a/create_framework/http-foundation.rst
+++ b/create_framework/http-foundation.rst
@@ -306,8 +306,8 @@ applications using it (like `Symfony`_, `Drupal 8`_, `phpBB 4`_, `ezPublish
 .. _`HTTP specification`: http://tools.ietf.org/wg/httpbis/
 .. _`audited`: http://symfony.com/blog/symfony2-security-audit
 .. _`Symfony`: http://symfony.com/
-.. _`Drupal 8`: http://drupal.org/
-.. _`phpBB 4`: http://www.phpbb.com/
+.. _`Drupal 8`: https://drupal.org/
+.. _`phpBB 4`: https://www.phpbb.com/
 .. _`ezPublish 5`: http://ez.no/
 .. _`Laravel`: http://laravel.com/
 .. _`Silex`: http://silex.sensiolabs.org/

--- a/create_framework/http-kernel-controller-resolver.rst
+++ b/create_framework/http-kernel-controller-resolver.rst
@@ -142,7 +142,8 @@ method is not defined, an argument has no matching attribute, ...).
     With the great flexibility of the default controller resolver, you might
     wonder why someone would want to create another one (why would there be an
     interface if not?). Two examples: in Symfony, ``getController()`` is
-    enhanced to support `controllers as services`_; and in
+    enhanced to support
+    :doc:`controllers as services </cookbook/controller/service>`; and in
     `FrameworkExtraBundle`_, ``getArguments()`` is enhanced to support
     parameter converters, where request attributes are converted to objects
     automatically.

--- a/create_framework/http-kernel-httpkernel-class.rst
+++ b/create_framework/http-kernel-httpkernel-class.rst
@@ -122,9 +122,9 @@ And in your controller, return a ``StreamedResponse`` instance instead of a
 
 .. tip::
 
-    Read the `Internals`_ chapter of the Symfony documentation to learn more
-    about the events dispatched by HttpKernel and how they allow you to change
-    the flow of a request.
+    Read the :doc:`/reference/events` reference to learn more about the events
+    dispatched by HttpKernel and how they allow you to change the flow of a
+    request.
 
 Now, let's create a listener, one that allows a controller to return a string
 instead of a full Response object::
@@ -200,5 +200,3 @@ worlds: a custom framework, tailored to your needs, but based on a rock-solid
 and well maintained low-level architecture that has been proven to work for
 many websites; a code that has been audited for security issues and that has
 proven to scale well.
-
-.. _`Internals`: http://symfony.com/doc/current/book/internals.html#events

--- a/create_framework/http-kernel-httpkernelinterface.rst
+++ b/create_framework/http-kernel-httpkernelinterface.rst
@@ -186,5 +186,5 @@ the many features built into the HttpKernel component; HTTP caching being just
 one of them but an important one as it can make your applications fly!
 
 .. _`HTTP caching`: http://symfony.com/doc/current/book/http_cache.html
-.. _`ESI`: http://en.wikipedia.org/wiki/Edge_Side_Includes
+.. _`ESI`: https://en.wikipedia.org/wiki/Edge_Side_Includes
 .. _`Varnish`: https://www.varnish-cache.org/

--- a/create_framework/http-kernel-httpkernelinterface.rst
+++ b/create_framework/http-kernel-httpkernelinterface.rst
@@ -40,7 +40,7 @@ Update your framework so that it implements this interface::
     }
 
 Even if this change looks trivial, it brings us a lot! Let's talk about one of
-the most impressive one: transparent `HTTP caching`_ support.
+the most impressive one: transparent :doc:`HTTP caching </book/http_cache>` support.
 
 The ``HttpCache`` class implements a fully-featured reverse proxy, written in
 PHP; it implements ``HttpKernelInterface`` and wraps another

--- a/create_framework/introduction.rst
+++ b/create_framework/introduction.rst
@@ -121,6 +121,5 @@ In the next chapter, we are going to introduce the HttpFoundation Component
 and see what it brings us.
 
 .. _`Symfony`: http://symfony.com/
-.. _`documentation`: http://symfony.com/doc
 .. _`Silex`: http://silex.sensiolabs.org/
 .. _`Composer`: http://packagist.org/about-composer

--- a/create_framework/routing.rst
+++ b/create_framework/routing.rst
@@ -78,10 +78,12 @@ of default values for route attributes (``array('name' => 'World')``).
 
 .. note::
 
-    Read the official `documentation`_ for the Routing component to learn more
-    about its many features like URL generation, attribute requirements, HTTP
-    method enforcements, loaders for YAML or XML files, dumpers to PHP or
-    Apache rewrite rules for enhanced performance, and much more.
+    Read the
+    :doc:`Routing component documentation </components/routing/introduction>` to
+    learn more about its many features like URL generation, attribute
+    requirements, HTTP method enforcements, loaders for YAML or XML files,
+    dumpers to PHP or Apache rewrite rules for enhanced performance, and much
+    more.
 
 Based on the information stored in the ``RouteCollection`` instance, a
 ``UrlMatcher`` instance can match URL paths::
@@ -218,5 +220,3 @@ generate absolute URLs::
         $dumper = new Routing\Matcher\Dumper\PhpMatcherDumper($routes);
 
         echo $dumper->dump();
-
-.. _`documentation`: http://symfony.com/doc/current/components/routing.html

--- a/create_framework/unit-testing.rst
+++ b/create_framework/unit-testing.rst
@@ -195,6 +195,6 @@ Symfony code.
 Now that we are confident (again) about the code we have written, we can
 safely think about the next batch of features we want to add to our framework.
 
-.. _`PHPUnit`: http://phpunit.de/manual/current/en/index.html
-.. _`test doubles`: http://phpunit.de/manual/current/en/test-doubles.html
+.. _`PHPUnit`: https://phpunit.de/manual/current/en/index.html
+.. _`test doubles`: https://phpunit.de/manual/current/en/test-doubles.html
 .. _`XDebug`: http://xdebug.org/

--- a/glossary.rst
+++ b/glossary.rst
@@ -126,6 +126,6 @@ Glossary
         chapter.
 
 
-.. _`service-oriented architecture`: http://wikipedia.org/wiki/Service-oriented_architecture
-.. _`HTTP Wikipedia`: http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
+.. _`service-oriented architecture`: https://wikipedia.org/wiki/Service-oriented_architecture
+.. _`HTTP Wikipedia`: https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
 .. _`HTTP 1.1 RFC`: http://www.w3.org/Protocols/rfc2616/rfc2616.html

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -311,7 +311,7 @@ instance), the host might have been manipulated by an attacker.
     You can read "`HTTP Host header attacks`_" for more information about
     these kinds of attacks.
 
-The Symfony :method:`Request::getHost() <Symfony\\Component\\HttpFoundation\\Request:getHost>`
+The Symfony :method:`Request::getHost() <Symfony\\Component\\HttpFoundation\\Request::getHost>`
 method might be vulnerable to some of these attacks because it depends on
 the configuration of your web server. One simple solution to avoid these
 attacks is to whitelist the hosts that your Symfony application can respond

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -512,5 +512,5 @@ To use HTTP-Digest authentication you need to provide a realm and a key:
             ),
         ));
 
-.. _`PBKDF2`: http://en.wikipedia.org/wiki/PBKDF2
+.. _`PBKDF2`: https://en.wikipedia.org/wiki/PBKDF2
 .. _`ircmaxell/password-compat`: https://packagist.org/packages/ircmaxell/password-compat

--- a/reference/constraints/CardScheme.rst
+++ b/reference/constraints/CardScheme.rst
@@ -131,4 +131,4 @@ message
 
 The message shown when the value does not pass the ``CardScheme`` check.
 
-.. _`Wikipedia: Issuer identification number (IIN)`: http://en.wikipedia.org/wiki/Bank_card_number#Issuer_identification_number_.28IIN.29
+.. _`Wikipedia: Issuer identification number (IIN)`: https://en.wikipedia.org/wiki/Bank_card_number#Issuer_identification_number_.28IIN.29

--- a/reference/constraints/Country.rst
+++ b/reference/constraints/Country.rst
@@ -82,4 +82,4 @@ message
 
 This message is shown if the string is not a valid country code.
 
-.. _`ISO 3166-1 alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
+.. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes

--- a/reference/constraints/Currency.rst
+++ b/reference/constraints/Currency.rst
@@ -88,4 +88,4 @@ message
 
 This is the message that will be shown if the value is not a valid currency.
 
-.. _`3-letter ISO 4217`: http://en.wikipedia.org/wiki/ISO_4217
+.. _`3-letter ISO 4217`: https://en.wikipedia.org/wiki/ISO_4217

--- a/reference/constraints/Iban.rst
+++ b/reference/constraints/Iban.rst
@@ -102,4 +102,4 @@ message
 
 The default message supplied when the value does not pass the Iban check.
 
-.. _`International Bank Account Number (IBAN)`: http://en.wikipedia.org/wiki/International_Bank_Account_Number
+.. _`International Bank Account Number (IBAN)`: https://en.wikipedia.org/wiki/International_Bank_Account_Number

--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -145,4 +145,4 @@ bothIsbnMessage
 The message that will be shown if both the `isbn10`_ and `isbn13`_ options
 are true and the given value does not pass the ISBN-13 nor the ISBN-13 check.
 
-.. _`International Standard Book Number (ISBN)`: http://en.wikipedia.org/wiki/Isbn
+.. _`International Standard Book Number (ISBN)`: https://en.wikipedia.org/wiki/Isbn

--- a/reference/constraints/Issn.rst
+++ b/reference/constraints/Issn.rst
@@ -104,5 +104,4 @@ requireHyphen
 The validator will allow non hyphenated ISSN values by default. When switching
 this to ``true``, the validator requires a hyphenated ISSN value.
 
-.. _`International Standard Serial Number (ISSN)`: http://en.wikipedia.org/wiki/Issn
-
+.. _`International Standard Serial Number (ISSN)`: https://en.wikipedia.org/wiki/Issn

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -87,5 +87,5 @@ message
 
 This message is shown if the string is not a valid locale.
 
-.. _`ISO 639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-.. _`ISO 3166-1 alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
+.. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+.. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes

--- a/reference/constraints/Luhn.rst
+++ b/reference/constraints/Luhn.rst
@@ -97,4 +97,4 @@ message
 
 The default message supplied when the value does not pass the Luhn check.
 
-.. _`Luhn algorithm`: http://en.wikipedia.org/wiki/Luhn_algorithm
+.. _`Luhn algorithm`: https://en.wikipedia.org/wiki/Luhn_algorithm

--- a/reference/forms/types/currency.rst
+++ b/reference/forms/types/currency.rst
@@ -98,4 +98,4 @@ The actual default value of this option depends on other field options:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 
-.. _`3-letter ISO 4217`: http://en.wikipedia.org/wiki/ISO_4217
+.. _`3-letter ISO 4217`: https://en.wikipedia.org/wiki/ISO_4217

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -111,5 +111,5 @@ The actual default value of this option depends on other field options:
 
 .. include:: /reference/forms/types/options/required.rst.inc
 
-.. _`ISO 639-1`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-.. _`ISO 3166-1 alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
+.. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+.. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -136,4 +136,4 @@ Variable       Type        Usage
 money_pattern  ``string``  The format to use to display the money, including the currency.
 =============  ==========  ===============================================================
 
-.. _`3 letter ISO 4217 code`: http://en.wikipedia.org/wiki/ISO_4217
+.. _`3 letter ISO 4217 code`: https://en.wikipedia.org/wiki/ISO_4217


### PR DESCRIPTION
Today, I discovered that Sphinx has a built-in link checker. I couldn't resist running it and fixing everything it found.

It turns out that we had a lot of broken/permanently redirected links.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | - |
