### PR TITLE
Add third column to specific emplacements table describing relationship

### DIFF
--- a/cookbook/bundles/best_practices.rst
+++ b/cookbook/bundles/best_practices.rst
@@ -117,20 +117,20 @@ files are going to be part of the repository.
 
 The following classes and files have specific emplacements:
 
-===============================  ============================= ================
-Type                             Directory                     Location
-===============================  ============================= ================
-Commands                         ``Command/``                  Mandatory
-Controllers                      ``Controller/``               Mandatory
-Service Container Extensions     ``DependencyInjection/``      Mandatory
-Event Listeners                  ``EventListener/``            Convention
-Model classes [1]                ``Model/``                    Convention
-Configuration                    ``Resources/config/``         Mandatory
-Web Resources (CSS, JS, images)  ``Resources/public/``         Mandatory
-Translation files                ``Resources/translations/``   Mandatory
-Templates                        ``Resources/views/``          Mandatory
-Unit and Functional Tests        ``Tests/``                    Mandatory
-===============================  ============================= ================
+===============================  =============================  ================
+Type                             Directory                      Location
+===============================  =============================  ================
+Commands                         ``Command/``                   Mandatory
+Controllers                      ``Controller/``                Mandatory
+Service Container Extensions     ``DependencyInjection/``       Mandatory
+Event Listeners                  ``EventListener/``             Convention
+Model classes [1]                ``Model/``                     Convention
+Configuration                    ``Resources/config/``          Mandatory
+Web Resources (CSS, JS, images)  ``Resources/public/``          Mandatory
+Translation files                ``Resources/translations/``    Mandatory
+Templates                        ``Resources/views/``           Mandatory
+Unit and Functional Tests        ``Tests/``                     Mandatory
+===============================  =============================  ================
 
 [1] See :doc:`/cookbook/doctrine/mapping_model_classes` for how to handle the
 mapping with a compiler pass.

--- a/cookbook/bundles/best_practices.rst
+++ b/cookbook/bundles/best_practices.rst
@@ -118,7 +118,7 @@ files are going to be part of the repository.
 The following classes and files have specific emplacements:
 
 ===============================  ============================= ================
-Type                             Directory                     Relationship
+Type                             Directory                     Location
 ===============================  ============================= ================
 Commands                         ``Command/``                  Mandatory
 Controllers                      ``Controller/``               Mandatory
@@ -129,7 +129,7 @@ Configuration                    ``Resources/config/``         Mandatory
 Web Resources (CSS, JS, images)  ``Resources/public/``         Mandatory
 Translation files                ``Resources/translations/``   Mandatory
 Templates                        ``Resources/views/``          Mandatory
-Unit and Functional Tests        ``Tests/``                    Convention
+Unit and Functional Tests        ``Tests/``                    Mandatory
 ===============================  ============================= ================
 
 [1] See :doc:`/cookbook/doctrine/mapping_model_classes` for how to handle the

--- a/cookbook/bundles/best_practices.rst
+++ b/cookbook/bundles/best_practices.rst
@@ -117,20 +117,20 @@ files are going to be part of the repository.
 
 The following classes and files have specific emplacements:
 
-===============================  =============================
-Type                             Directory
-===============================  =============================
-Commands                         ``Command/``
-Controllers                      ``Controller/``
-Service Container Extensions     ``DependencyInjection/``
-Event Listeners                  ``EventListener/``
-Model classes [1]                ``Model/``
-Configuration                    ``Resources/config/``
-Web Resources (CSS, JS, images)  ``Resources/public/``
-Translation files                ``Resources/translations/``
-Templates                        ``Resources/views/``
-Unit and Functional Tests        ``Tests/``
-===============================  =============================
+===============================  ============================= ================
+Type                             Directory                     Relationship
+===============================  ============================= ================
+Commands                         ``Command/``                  Mandatory
+Controllers                      ``Controller/``               Mandatory
+Service Container Extensions     ``DependencyInjection/``      Mandatory
+Event Listeners                  ``EventListener/``            Convention
+Model classes [1]                ``Model/``                    Convention
+Configuration                    ``Resources/config/``         Mandatory
+Web Resources (CSS, JS, images)  ``Resources/public/``         Mandatory
+Translation files                ``Resources/translations/``   Mandatory
+Templates                        ``Resources/views/``          Mandatory
+Unit and Functional Tests        ``Tests/``                    Convention
+===============================  ============================= ================
 
 [1] See :doc:`/cookbook/doctrine/mapping_model_classes` for how to handle the
 mapping with a compiler pass.


### PR DESCRIPTION
The standard Symfony2 framework has mandatory requirements about specific emplacements, and then others that are considered best practice by convention. This commit makes the documentation clearer in order to provide a developer with reasonable expectations about the consequences of altering the default directory structure. Additionally, newer developers may be less intimidated and concerned by whether they are compromising any auto-wiring functionality by deviating from the information provided.

Fixes #5502
