### PR TITLE
[components][expression_language] Add doc for backslashes

### DIFF
--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -181,6 +181,28 @@ Comparison Operators
     You must use parenthesis because the unary operator ``not`` has precedence
     over the binary operator ``matches``.
 
+    A backslash(``\``) must be escaped by 4 backslashes(``\\\\``) in a string and
+    8 backslashes(``\\\\\\\\``) in a regex::
+
+        $language->evaluate('"\\\\"');
+        // returns \
+
+        $language->evaluate('"a\\\\b" matches "/^a\\\\\\\\b$/"');
+        // returns true
+
+    Control characters must be defined as the escaped form of their escape sequences.
+    Otherwise, they will be replaced by spaces and ignored::
+
+        $language->evaluate('"a\nb"');
+        // returns a b
+
+        $language->evaluate('"a\\nb"');
+        // returns a\nb
+
+    This is because the backslashes in a string will be stripped by the
+    ``stripcslashes()`` function and the stripped slashes in a regex will be
+    stripped again by the regex engine.
+
 Examples::
 
     $ret1 = $language->evaluate(


### PR DESCRIPTION
Additional backslashes are required to escape a backslash(`\`)
in a string or regex because a string will be stripped by the lexer.
This should be documented here, otherwise, user may feel confused about
the unexpected behavior.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | ~2.4 |
| Fixed tickets | n/a |
