### PR TITLE
Missing step after new command file is created.

### DIFF
--- a/cookbook/console/console_command.rst
+++ b/cookbook/console/console_command.rst
@@ -64,7 +64,14 @@ want to extend the AppBundle to greet you from the command line, create
         }
     }
 
-This command will now automatically be available to run:
+In the console file, you need to add the new command file path into it and add a line of code "$application->add(new Commands\GiftUpdateCommand());" after the new application object is created, so that the console file knows that you added a new command. It should look as below.
+  //other code in the console file
+  $kernel = new AppKernel($env, $debug);
+  $application = new Application($kernel);
+  $application->add(new Command\GiftUpdateCommand()); // the newly added code
+  $application->run($input);
+
+This command will now be available to run:
 
 .. code-block:: bash
 


### PR DESCRIPTION
The new command will not automatically be available to run.
It requires the proper configuration in the console file, without this step, this document is very hard for people to figure out why the new command won't work after the command file is created.
