### PR TITLE
Small fix twig_extension.rst in the English version

### DIFF
--- a/cookbook/templating/twig_extension.rst
+++ b/cookbook/templating/twig_extension.rst
@@ -73,7 +73,7 @@ Now you must let the Service Container know about your newly created Twig Extens
         # app/config/services.yml
         services:
             app.twig_extension:
-                class: AppBundle\Twig\AppExtension
+                class: Acme\AppBundle\Twig\AppExtension
                 public: false
                 tags:
                     - { name: twig.extension }
@@ -83,7 +83,7 @@ Now you must let the Service Container know about your newly created Twig Extens
         <!-- app/config/services.xml -->
         <services>
             <service id="app.twig_extension"
-                class="AppBundle\Twig\AppExtension"
+                class="Acme\AppBundle\Twig\AppExtension"
                 public="false">
                 <tag name="twig.extension" />
             </service>
@@ -95,7 +95,7 @@ Now you must let the Service Container know about your newly created Twig Extens
         use Symfony\Component\DependencyInjection\Definition;
 
         $container
-            ->register('app.twig_extension', '\AppBundle\Twig\AppExtension')
+            ->register('app.twig_extension', 'Acme\AppBundle\Twig\AppExtension')
             ->setPublic(false)
             ->addTag('twig.extension');
 


### PR DESCRIPTION
Just added Acme\ before AppBundle\Twig\AppExtension as it fired a :
Attempted to load class "AppExtension" from namespace "AppBundle\Twig".
Did you forget a "use" statement for another namespace?
500 Internal Server Error - ClassNotFoundException 
without it. (It looks like it's a little bug in the English version of this documentation, the French version writes it ok)
