### PR TITLE
[2.8] Remove 2.6 versionaddeds as version reached eom

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -441,10 +441,6 @@ If you want to redirect the user to another page, use the ``redirectToRoute()`` 
         // return $this->redirect($this->generateUrl('homepage'), 301);
     }
 
-.. versionadded:: 2.6
-    The ``redirectToRoute()`` method was introduced in Symfony 2.6. Previously (and still now), you
-    could use ``redirect()`` and ``generateUrl()`` together for this (see the example above).
-
 Or, if you want to redirect externally, just use ``redirect()`` and pass it the URL::
 
     public function indexAction()
@@ -535,9 +531,6 @@ console command:
 .. code-block:: bash
 
     $ php app/console debug:container
-
-.. versionadded:: 2.6
-    Prior to Symfony 2.6, this command was called ``container:debug``.
 
 For more information, see the :doc:`/book/service_container` chapter.
 
@@ -825,16 +818,10 @@ method to check the CSRF token::
         // ... do something, like deleting an object
     }
 
-.. versionadded:: 2.6
-    The ``isCsrfTokenValid()`` shortcut method was introduced in Symfony 2.6.
-    It is equivalent to executing the following code:
-
-    .. code-block:: php
-
-        use Symfony\Component\Security\Csrf\CsrfToken;
-
-        $this->get('security.csrf.token_manager')
-            ->isTokenValid(new CsrfToken('token_id', 'TOKEN'));
+    // isCsrfTokenValid() is equivalent to:
+    // $this->get('security.csrf.token_manager')->isTokenValid()
+    //     new \Symfony\Component\Security\Csrf\CsrfToken\CsrfToken('token_id', $token)
+    // );
 
 Final Thoughts
 --------------

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1403,9 +1403,6 @@ the command by running the following from the root of your project.
 
     $ php app/console debug:router
 
-.. versionadded:: 2.6
-    Prior to Symfony 2.6, this command was called ``router:debug``.
-
 This command will print a helpful list of *all* the configured routes in
 your application:
 

--- a/book/security.rst
+++ b/book/security.rst
@@ -846,15 +846,6 @@ You can easily deny access from inside a controller::
         // ...
     }
 
-.. versionadded:: 2.6
-    The ``denyAccessUnlessGranted()`` method was introduced in Symfony 2.6. Previously (and
-    still now), you could check access directly and throw the ``AccessDeniedException`` as shown
-    in the example above).
-
-.. versionadded:: 2.6
-    The ``security.authorization_checker`` service was introduced in Symfony 2.6. Prior
-    to Symfony 2.6, you had to use the ``isGranted()`` method of the ``security.context`` service.
-
 In both cases, a special
 :class:`Symfony\\Component\\Security\\Core\\Exception\\AccessDeniedException`
 is thrown, which ultimately triggers a 403 HTTP response inside Symfony.
@@ -1018,10 +1009,6 @@ shown above.
 
 Retrieving the User Object
 --------------------------
-
-.. versionadded:: 2.6
-     The ``security.token_storage`` service was introduced in Symfony 2.6. Prior
-     to Symfony 2.6, you had to use the ``getToken()`` method of the ``security.context`` service.
 
 After authentication, the ``User`` object of the current user can be accessed
 via the ``security.token_storage`` service. From inside a controller, this will
@@ -1222,9 +1209,6 @@ in the following way from a controller::
     $encoded = $encoder->encodePassword($user, $plainPassword);
 
     $user->setPassword($encoded);
-
-.. versionadded:: 2.6
-    The ``security.password_encoder`` service was introduced in Symfony 2.6.
 
 In order for this to work, just make sure that you have the encoder for your
 user class (e.g. ``AppBundle\Entity\User``) configured under the ``encoders``

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -1150,9 +1150,6 @@ console. To show all services and the class for each service, run:
 
     $ php app/console debug:container
 
-.. versionadded:: 2.6
-    Prior to Symfony 2.6, this command was called ``container:debug``.
-
 By default, only public services are shown, but you can also view private services:
 
 .. code-block:: bash

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1269,12 +1269,6 @@ automatically:
             <p>Application Environment: <?php echo $app->getEnvironment() ?></p>
         <?php endif ?>
 
-.. versionadded:: 2.6
-    The global ``app.security`` variable (or the ``$app->getSecurity()``
-    method in PHP templates) is deprecated as of Symfony 2.6. Use ``app.user``
-    (``$app->getUser()``) and ``is_granted()`` (``$view['security']->isGranted()``)
-    instead.
-
 .. tip::
 
     You can add your own global template variables. See the cookbook example

--- a/book/testing.rst
+++ b/book/testing.rst
@@ -472,9 +472,6 @@ Be warned that this does not work if you insulate the client or if you use an
 HTTP layer. For a list of services available in your application, use the
 ``debug:container`` console task.
 
-.. versionadded:: 2.6
-    Prior to Symfony 2.6, this command was called ``container:debug``.
-
 .. tip::
 
     If the information you need to check is available from the profiler, use

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -452,9 +452,6 @@ checks translation resources for several locales:
 #. If the translation still isn't found, Symfony uses the ``fallbacks`` configuration
    parameter, which defaults to ``en`` (see `Configuration`_).
 
-.. versionadded:: 2.6
-    The ability to log missing translations was introduced in Symfony 2.6.
-
 .. note::
 
     When Symfony doesn't find a translation in the given locale, it will 
@@ -745,9 +742,6 @@ For more information, see the documentation for these libraries.
 
 Debugging Translations
 ----------------------
-
-.. versionadded:: 2.6
-    Prior to Symfony 2.6, this command was called ``translation:debug``.
 
 When maintaining a bundle, you may use or remove the usage of a translation
 message without updating all message catalogues. The ``debug:translation``

--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -421,10 +421,6 @@ method.
 The info will be printed as a comment when dumping the configuration tree
 with the ``config:dump-reference`` command.
 
-.. versionadded:: 2.6
-    Since Symfony 2.6, the info will also be added to the exception message
-    when an invalid type is given.
-
 Optional Sections
 -----------------
 

--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -59,9 +59,6 @@ dispatched. Listeners receive a
 Disable Commands inside Listeners
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 2.6
-    Disabling commands inside listeners was introduced in Symfony 2.6.
-
 Using the
 :method:`Symfony\\Component\\Console\\Event\\ConsoleCommandEvent::disableCommand`
 method, you can disable a command inside a listener. The application

--- a/components/console/helpers/debug_formatter.rst
+++ b/components/console/helpers/debug_formatter.rst
@@ -4,9 +4,6 @@
 Debug Formatter Helper
 ======================
 
-.. versionadded:: 2.6
-    The Debug Formatter helper was introduced in Symfony 2.6.
-
 The :class:`Symfony\\Component\\Console\\Helper\\DebugFormatterHelper` provides
 functions to output debug information when running an external program, for
 instance a process or HTTP request. For example, if you used it to output

--- a/components/console/helpers/processhelper.rst
+++ b/components/console/helpers/processhelper.rst
@@ -4,9 +4,6 @@
 Process Helper
 ==============
 
-.. versionadded:: 2.6
-    The Process Helper was introduced in Symfony 2.6.
-
 The Process Helper shows processes as they're running and reports
 useful information about process status.
 

--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -40,14 +40,6 @@ Instead of advancing the bar by a number of steps (with the
 you can also set the current progress by calling the
 :method:`Symfony\\Component\\Console\\Helper\\ProgressBar::setProgress` method.
 
-.. versionadded:: 2.6
-    The ``setProgress()`` method was called ``setCurrent()`` prior to Symfony 2.6.
-
-.. caution::
-
-    Prior to version 2.6, the progress bar only works if your platform
-    supports ANSI codes; on other platforms, no output is generated.
-
 .. tip::
 
     If your platform doesn't support ANSI codes, updates to the progress
@@ -56,9 +48,6 @@ you can also set the current progress by calling the
     :method:`Symfony\\Component\\Console\\Helper\\ProgressBar::setRedrawFrequency`
     accordingly. By default, when using a ``max``, the redraw frequency
     is set to *10%* of your ``max``.
-
-    .. versionadded:: 2.6
-        The ``setRedrawFrequency()`` method was introduced in Symfony 2.6.
 
 If you don't know the number of steps in advance, just omit the steps argument
 when creating the :class:`Symfony\\Component\\Console\\Helper\\ProgressBar`
@@ -306,9 +295,6 @@ that displays the number of remaining steps::
             return $bar->getMaxSteps() - $bar->getProgress();
         }
     );
-
-.. versionadded:: 2.6
-    The ``getProgress()`` method was called ``getStep()`` prior to Symfony 2.6.
 
 Custom Messages
 ~~~~~~~~~~~~~~~

--- a/components/dependency_injection/factories.rst
+++ b/components/dependency_injection/factories.rst
@@ -12,11 +12,6 @@ For this situation, you can use a factory to create the object and tell
 the service container to call a method on the factory rather than directly
 instantiating the class.
 
-.. versionadded:: 2.6
-    The new :method:`Symfony\\Component\\DependencyInjection\\Definition::setFactory`
-    method was introduced in Symfony 2.6. Refer to older versions for the
-    syntax for factories prior to 2.6.
-
 Suppose you have a factory that configures and returns a new ``NewsletterManager``
 object::
 

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -190,10 +190,6 @@ Get all the child or parent nodes::
 Accessing Node Values
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 2.6
-    The :method:`Symfony\\Component\\DomCrawler\\Crawler::nodeName`
-    method was introduced in Symfony 2.6.
-
 Access the node name (HTML tag name) of the first node of the current selection (eg. "p" or "div")::
 
     // will return the node name (HTML tag name) of the first child element under <body>

--- a/components/event_dispatcher/introduction.rst
+++ b/components/event_dispatcher/introduction.rst
@@ -628,10 +628,6 @@ and so on...
 Event Name Introspection
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 2.4
-    Before Symfony 2.4, the event name and the event dispatcher had to be
-    requested from the ``Event`` instance. These methods are now deprecated.
-
 The ``EventDispatcher`` instance, as well as the name of the event that
 is dispatched, are passed as arguments to the listener::
 

--- a/components/expression_language/extending.rst
+++ b/components/expression_language/extending.rst
@@ -56,9 +56,6 @@ evaluating or the "names" if compiling).
 Using Expression Providers
 --------------------------
 
-.. versionadded:: 2.6
-    Expression providers were introduced in Symfony 2.6.
-
 When you use the ``ExpressionLanguage`` class in your library, you often want
 to add custom functions. To do so, you can create a new expression provider by
 creating a class that implements

--- a/components/filesystem/lock_handler.rst
+++ b/components/filesystem/lock_handler.rst
@@ -1,9 +1,6 @@
 LockHandler
 ===========
 
-.. versionadded:: 2.6
-    The lock handler feature was introduced in Symfony 2.6
-
 What is a Lock?
 ---------------
 

--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -512,9 +512,6 @@ You can still set the ``Content-Type`` of the sent file, or change its ``Content
         'filename.txt'
     );
 
-.. versionadded:: 2.6
-    The ``deleteFileAfterSend()`` method was introduced in Symfony 2.6.
-
 It is possible to delete the file after the request is sent with the
 :method:`Symfony\\Component\\HttpFoundation\\BinaryFileResponse::deleteFileAfterSend` method.
 Please note that this will not work when the ``X-Sendfile`` header is set.

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -22,11 +22,6 @@ You can install the component in 2 different ways:
 Notes on Previous Versions
 --------------------------
 
-.. versionadded:: 2.6
-    This documentation was written for Symfony 2.6 and later. If you use an older
-    version, please `read the Symfony 2.5 documentation`_. For a list of changes,
-    see the `CHANGELOG`_.
-
 Usage
 -----
 
@@ -222,10 +217,6 @@ For example, to make the ``host`` option required, you can do::
         }
     }
 
-.. versionadded:: 2.6
-    As of Symfony 2.6, ``setRequired()`` accepts both an array of options or a
-    single option. Prior to 2.6, you could only pass arrays.
-
 If you omit a required option, a
 :class:`Symfony\\Component\\OptionsResolver\\Exception\\MissingOptionsException`
 will be thrown::
@@ -250,11 +241,6 @@ one required option::
         }
     }
 
-.. versionadded:: 2.6
-    The methods :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::isRequired`
-    and :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::getRequiredOptions`
-    were introduced in Symfony 2.6.
-
 Use :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::isRequired` to find
 out if an option is required. You can use
 :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::getRequiredOptions` to
@@ -274,11 +260,6 @@ retrieve the names of all required options::
             $requiredOptions = $resolver->getRequiredOptions();
         }
     }
-
-.. versionadded:: 2.6
-    The methods :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::isMissing`
-    and :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::getMissingOptions`
-    were introduced in Symfony 2.6.
 
 If you want to check whether a required option is still missing from the default
 options, you can use :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::isMissing`.
@@ -362,11 +343,6 @@ is thrown::
 In sub-classes, you can use :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::addAllowedTypes`
 to add additional allowed types without erasing the ones already set.
 
-.. versionadded:: 2.6
-    Before Symfony 2.6, ``setAllowedTypes()`` and ``addAllowedTypes()`` expected
-    the values to be given as an array mapping option names to allowed types:
-    ``$resolver->setAllowedTypes(array('port' => array('null', 'int')));``
-
 Value Validation
 ~~~~~~~~~~~~~~~~
 
@@ -413,11 +389,6 @@ returns ``true`` for acceptable values and ``false`` for invalid values::
 In sub-classes, you can use :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::addAllowedValues`
 to add additional allowed values without erasing the ones already set.
 
-.. versionadded:: 2.6
-    Before Symfony 2.6, ``setAllowedValues()`` and ``addAllowedValues()`` expected
-    the values to be given as an array mapping option names to allowed values:
-    ``$resolver->setAllowedValues(array('transport' => array('sendmail', 'mail', 'smtp')));``
-
 Option Normalization
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -447,11 +418,6 @@ option. You can configure a normalizer by calling
             });
         }
     }
-
-.. versionadded:: 2.6
-    The method :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::setNormalizer`
-    was introduced in Symfony 2.6. Before, you had to use
-    :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::setNormalizers`.
 
 The normalizer receives the actual ``$value`` and returns the normalized form.
 You see that the closure also takes an ``$options`` parameter. This is useful
@@ -587,11 +553,6 @@ comes from the default::
         }
     }
 
-.. versionadded:: 2.6
-    The method :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::setDefined`
-    was introduced in Symfony 2.6. Before, you had to use
-    :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::setOptional`.
-
 You can use :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::setDefined`
 to define an option without setting a default value. Then the option will only
 be included in the resolved options if it was actually passed to
@@ -642,11 +603,6 @@ options in one go::
             $resolver->setDefined(array('port', 'encryption'));
         }
     }
-
-.. versionadded:: 2.6
-    The method :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::isDefined`
-    and :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::getDefinedOptions`
-    were introduced in Symfony 2.6.
 
 The methods :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::isDefined`
 and :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::getDefinedOptions`

--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -4,11 +4,6 @@
 Authentication
 ==============
 
-.. versionadded:: 2.6
-    The ``TokenStorageInterface`` was introduced in Symfony 2.6. Prior, you
-    had to use the ``getToken()`` method of the
-    :class:`Symfony\\Component\\Security\\Core\\SecurityContextInterface`.
-
 When a request points to a secured area, and one of the listeners from the
 firewall map is able to extract the user's credentials from the current
 :class:`Symfony\\Component\\HttpFoundation\\Request` object, it should create

--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -29,11 +29,6 @@ An authorization decision will always be based on a few things:
     Any object for which access control needs to be checked, like
     an article or a comment object.
 
-.. versionadded:: 2.6
-    The ``TokenStorageInterface`` was introduced in Symfony 2.6. Prior, you
-    had to use the ``setToken()`` method of the
-    :class:`Symfony\\Component\\Security\\Core\\SecurityContextInterface`.
-
 .. _components-security-access-decision-manager:
 
 Access Decision Manager

--- a/components/security/firewall.rst
+++ b/components/security/firewall.rst
@@ -34,11 +34,6 @@ certain action or resource of the application::
         throw new AccessDeniedException();
     }
 
-.. versionadded:: 2.6
-    As of Symfony 2.6, the :class:`Symfony\\Component\\Security\\Core\\SecurityContext` class was split
-    in the :class:`Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationChecker` and
-    :class:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorage` classes.
-
 .. note::
 
     Read the dedicated sections to learn more about :doc:`/components/security/authentication`

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -529,20 +529,12 @@ There are several types of normalizers available:
 
     Objects are normalized to a map of property names to property values.
 
-.. versionadded:: 2.6
-    The :class:`Symfony\\Component\\Serializer\\Normalizer\\PropertyNormalizer`
-    class was introduced in Symfony 2.6.
-
 .. versionadded:: 2.7
     The :class:`Symfony\\Component\\Serializer\\Normalizer\\ObjectNormalizer`
     class was introduced in Symfony 2.7.
 
 Handling Circular References
 ----------------------------
-
-.. versionadded:: 2.6
-    Handling of circular references was introduced in Symfony 2.6. In previous
-    versions of Symfony, circular references led to infinite loops.
 
 Circular references are common when dealing with entity relations::
 

--- a/components/var_dumper/introduction.rst
+++ b/components/var_dumper/introduction.rst
@@ -9,9 +9,6 @@ The VarDumper Component
     arbitrary PHP variable. Built on top, it provides a better ``dump()``
     function that you can use instead of :phpfunction:`var_dump`.
 
-.. versionadded:: 2.6
-    The VarDumper component was introduced in Symfony 2.6.
-
 Installation
 ------------
 
@@ -79,7 +76,7 @@ DebugBundle and Twig Integration
 
 The DebugBundle allows greater integration of the component into the Symfony
 full-stack framework. It is enabled by default in the *dev* and *test*
-environment of the standard edition since version 2.6.
+environment of the Symfony Standard Edition.
 
 Since generating (even debug) output in the controller or in the model
 of your application may just break it by e.g. sending HTTP headers or

--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -136,10 +136,6 @@ what it looks like and debug it?
 Fortunately, the default ``ExceptionController`` allows you to preview your
 *error* pages during development.
 
-.. versionadded:: 2.6
-    This feature was introduced in Symfony 2.6. Before, the third-party
-    `WebfactoryExceptionsBundle`_ could be used for the same purpose.
-
 To use this feature, you need to have a definition in your
 ``routing_dev.yml`` file like so:
 

--- a/cookbook/controller/service.rst
+++ b/cookbook/controller/service.rst
@@ -127,9 +127,6 @@ the route ``_controller`` value:
     If your controller implements the ``__invoke()`` method, you can simply
     refer to the service id (``app.hello_controller``).
 
-    .. versionadded:: 2.6
-        Support for ``__invoke()`` was introduced in Symfony 2.6.
-
 Alternatives to base Controller Methods
 ---------------------------------------
 

--- a/cookbook/doctrine/mapping_model_classes.rst
+++ b/cookbook/doctrine/mapping_model_classes.rst
@@ -23,12 +23,6 @@ register the mappings for your model classes.
     compiler pass since the `CouchDB Mapping Compiler Pass pull request`_
     was merged.
 
-.. versionadded:: 2.6
-    Support for defining namespace aliases was introduced in Symfony 2.6.
-    It is safe to define the aliases with older versions of Symfony as
-    the aliases are the last argument to ``createXmlMappingDriver`` and
-    are ignored by PHP if that argument doesn't exist.
-
 In your bundle class, write the following code to register the compiler pass.
 This one is written for the CmfRoutingBundle, so parts of it will need to
 be adapted for your case::

--- a/cookbook/doctrine/pdo_session_storage.rst
+++ b/cookbook/doctrine/pdo_session_storage.rst
@@ -4,12 +4,6 @@
 How to Use PdoSessionHandler to Store Sessions in the Database
 ==============================================================
 
-.. caution::
-
-    There was a backwards-compatibility break in Symfony 2.6: the database
-    schema changed slightly. See :ref:`Symfony 2.6 Changes <pdo-session-handle-26-changes>`
-    for details.
-
 The default Symfony session storage writes the session information to files.
 Most medium to large websites use a database to store the session values
 instead of files, because databases are easier to use and scale in a
@@ -122,10 +116,6 @@ a second array argument to ``PdoSessionHandler``:
         ));
         $container->setDefinition('session.handler.pdo', $storageDefinition);
 
-.. versionadded:: 2.6
-    The ``db_lifetime_col`` was introduced in Symfony 2.6. Prior to 2.6,
-    this column did not exist.
-
 These are parameters that you must configure:
 
 ``db_table`` (default ``sessions``):
@@ -192,24 +182,6 @@ Preparing the Database to Store Sessions
 Before storing sessions in the database, you must create the table that stores
 the information. The following sections contain some examples of the SQL statements
 you may use for your specific database engine.
-
-.. _pdo-session-handle-26-changes:
-
-.. sidebar:: Schema Changes needed when Upgrading to Symfony 2.6
-
-    If you use the ``PdoSessionHandler`` prior to Symfony 2.6 and upgrade, you'll
-    need to make a few changes to your session table:
-
-    * A new session lifetime (``sess_lifetime`` by default) integer column
-      needs to be added;
-    * The data column (``sess_data`` by default) needs to be changed to a
-      BLOB type.
-
-    Check the SQL statements below for more details.
-
-    To keep the old (2.5 and earlier) functionality, change your class name
-    to use ``LegacyPdoSessionHandler`` instead of ``PdoSessionHandler`` (the
-    legacy class was added in Symfony 2.6.2).
 
 MySQL
 ~~~~~

--- a/cookbook/event_dispatcher/event_listener.rst
+++ b/cookbook/event_dispatcher/event_listener.rst
@@ -266,9 +266,6 @@ there are some minor advantages for each of them:
 Debugging Event Listeners
 -------------------------
 
-.. versionadded:: 2.6
-    The ``debug:event-dispatcher`` command was introduced in Symfony 2.6.
-
 You can find out what listeners are registered in the event dispatcher
 using the console. To show all events and their listeners, run:
 

--- a/cookbook/form/create_custom_field_type.rst
+++ b/cookbook/form/create_custom_field_type.rst
@@ -259,10 +259,6 @@ But this only works because the ``GenderType`` is very simple. What if
 the gender codes were stored in configuration or in a database? The next
 section explains how more complex field types solve this problem.
 
-.. versionadded:: 2.6
-    The ``placeholder`` option was introduced in Symfony 2.6 in favor of
-    ``empty_value``, which is available prior to 2.6.
-
 .. _form-cookbook-form-field-service:
 
 Creating your Field Type as a Service

--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -333,11 +333,6 @@ and fill in the listener logic::
         // ...
     }
 
-.. versionadded:: 2.6
-    The :class:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface` was
-    introduced in Symfony 2.6. Prior, you had to use the ``getToken()`` method of
-    :class:`Symfony\\Component\\Security\\Core\\SecurityContextInterface`.
-
 .. note::
 
     The ``multiple`` and ``expanded`` form options will default to false
@@ -464,10 +459,6 @@ sport like this::
 
         // ...
     }
-
-.. versionadded:: 2.6
-    The ``placeholder`` option was introduced in Symfony 2.6 in favor of
-    ``empty_value``, which is available prior to 2.6.
 
 When you're building this form to display to the user for the first time,
 then this example works perfectly.

--- a/cookbook/profiler/matchers.rst
+++ b/cookbook/profiler/matchers.rst
@@ -102,11 +102,6 @@ matcher::
         }
     }
 
-.. versionadded:: 2.6
-    The :class:`Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationCheckerInterface` was
-    introduced in Symfony 2.6. Prior, you had to use the ``isGranted`` method of
-    :class:`Symfony\\Component\\Security\\Core\\SecurityContextInterface`.
-
 Then, configure a new service and set it as ``private`` because the application
 won't use it directly:
 
@@ -143,10 +138,6 @@ won't use it directly:
         $definition->setPublic(false);
 
         $container->setDefinition('app.super_admin_matcher', $definition);
-
-.. versionadded:: 2.6
-    The ``security.authorization_checker`` service was introduced in Symfony 2.6. Prior
-    to Symfony 2.6, you had to use the ``isGranted()`` method of the ``security.context`` service.
 
 Once the service is registered, the only thing left to do is configure the
 profiler to use this service as the matcher:

--- a/cookbook/security/custom_password_authenticator.rst
+++ b/cookbook/security/custom_password_authenticator.rst
@@ -10,16 +10,11 @@ How to Create a Custom Form Password Authenticator
     flexible way to accomplish custom authentication tasks like this.
 
 Imagine you want to allow access to your website only between 2pm and 4pm
-UTC. Before Symfony 2.4, you had to create a custom token, factory, listener
-and provider. In this entry, you'll learn how to do this for a login form
-(i.e. where your user submits their username and password).
-Before Symfony 2.6, you had to use the password encoder to authenticate the user password.
+UTC. In this entry, you'll learn how to do this for a login form (i.e. where
+your user submits their username and password).
 
 The Password Authenticator
 --------------------------
-
-.. versionadded:: 2.6
-    The ``UserPasswordEncoderInterface`` interface was introduced in Symfony 2.6.
 
 .. versionadded:: 2.8
     The ``SimpleFormAuthenticatorInterface`` interface was moved to the

--- a/cookbook/security/form_login_setup.rst
+++ b/cookbook/security/form_login_setup.rst
@@ -186,11 +186,6 @@ form::
         );
     }
 
-.. versionadded:: 2.6
-    The ``security.authentication_utils`` service and the
-    :class:`Symfony\\Component\\Security\\Http\\Authentication\\AuthenticationUtils`
-    class were introduced in Symfony 2.6.
-
 Don't let this controller confuse you. As you'll see in a moment, when the
 user submits the form, the security system automatically handles the form
 submission for you. If the user had submitted an invalid username or password,

--- a/cookbook/security/pre_authenticated.rst
+++ b/cookbook/security/pre_authenticated.rst
@@ -92,9 +92,6 @@ in the x509 firewall configuration respectively.
 REMOTE_USER Based Authentication
 --------------------------------
 
-.. versionadded:: 2.6
-    REMOTE_USER pre authenticated firewall was introduced in Symfony 2.6.
-
 A lot of authentication modules, like ``auth_kerb`` for Apache provide the username
 using the ``REMOTE_USER`` environment variable. This variable can be trusted by
 the application since the authentication happened before the request reached it.

--- a/cookbook/validation/severity.rst
+++ b/cookbook/validation/severity.rst
@@ -21,9 +21,6 @@ The process to achieve this behavior consists of two steps:
 1. Assigning the Error Level
 ----------------------------
 
-.. versionadded:: 2.6
-    The ``payload`` option was introduced in Symfony 2.6.
-
 Use the ``payload`` option to configure the error level for each constraint:
 
 .. configuration-block::
@@ -130,10 +127,6 @@ Use the ``payload`` option to configure the error level for each constraint:
 
 2. Customize the Error Message Template
 ---------------------------------------
-
-.. versionadded:: 2.6
-    The ``getConstraint()`` method in the ``ConstraintViolation`` class was
-    introduced in Symfony 2.6.
 
 When validation of the ``User`` object fails, you can retrieve the constraint
 that caused a particular failure using the

--- a/cookbook/web_server/built_in.rst
+++ b/cookbook/web_server/built_in.rst
@@ -4,10 +4,6 @@
 How to Use PHP's built-in Web Server
 ====================================
 
-.. versionadded:: 2.6
-    The ability to run the server as a background process was introduced
-    in Symfony 2.6.
-
 Since PHP 5.4 the CLI SAPI comes with a `built-in web server`_. It can be used
 to run your PHP applications locally during development, for testing or for
 application demonstrations. This way, you don't have to bother configuring

--- a/reference/configuration/debug.rst
+++ b/reference/configuration/debug.rst
@@ -10,9 +10,6 @@ Symfony full-stack framework and can be configured under the ``debug`` key
 in your application configuration. When using XML, you must use the
 ``http://symfony.com/schema/dic/debug`` namespace.
 
-.. versionadded::
-    The DebugBundle was introduced in Symfony 2.6.
-
 .. tip::
 
    The XSD schema is available at

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -526,11 +526,6 @@ profiler
 enabled
 .......
 
-.. versionadded:: 2.2
-    The ``enabled`` option was introduced in Symfony 2.2. Prior to Symfony
-    2.2, the profiler could only be disabled by omitting the ``framework.profiler``
-    configuration entirely.
-
 **type**: ``boolean`` **default**: ``false``
 
 The profiler can be enabled by setting this option to ``true``. When you
@@ -1321,9 +1316,6 @@ found.
 logging
 .......
 
-.. versionadded:: 2.6
-    The ``logging`` option was introduced in Symfony 2.6.
-
 **default**: ``true`` when the debug mode is enabled, ``false`` otherwise.
 
 When ``true``, a log entry is made whenever the translator cannot find a translation
@@ -1404,9 +1396,6 @@ error messages.
 strict_email
 ............
 
-.. versionadded:: 2.5
-    The ``strict_email`` option was introduced in Symfony 2.5.
-
 **type**: ``Boolean`` **default**: ``false``
 
 If this option is enabled, the `egulias/email-validator`_ library will be
@@ -1415,9 +1404,6 @@ the validator uses a simple regular expression to validate email addresses.
 
 api
 ...
-
-.. versionadded:: 2.5
-    The ``api`` option was introduced in Symfony 2.5.
 
 **type**: ``string``
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -13,10 +13,6 @@ Full Default Configuration
 The following is the full default configuration for the security system.
 Each part will be explained in the next section.
 
-.. versionadded:: 2.5
-    Support for restricting security firewalls to specific http methods was introduced in
-    Symfony 2.5.
-
 .. configuration-block::
 
     .. code-block:: yaml

--- a/reference/constraints/Expression.rst
+++ b/reference/constraints/Expression.rst
@@ -216,12 +216,6 @@ more about the expression language syntax, see
                 // ...
             }
 
-    .. versionadded:: 2.6
-        In Symfony 2.6, the Expression constraint *is* executed if the value
-        is ``null``. Before 2.6, if the value was ``null``, the expression
-        was never executed and the value was considered valid (unless you
-        also had a constraint like ``NotBlank`` on the property).
-
 For more information about the expression and what variables are available
 to you, see the :ref:`expression <reference-constraint-expression-option>`
 option details below.

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -156,9 +156,6 @@ Options
 maxSize
 ~~~~~~~
 
-.. versionadded:: 2.6
-    The suffixes ``Ki`` and ``Mi`` were introduced in Symfony 2.6.
-
 **type**: ``mixed``
 
 If set, the size of the underlying file must be below this file size in
@@ -184,9 +181,6 @@ see `Wikipedia: Binary prefix`_.
 
 binaryFormat
 ~~~~~~~~~~~~
-
-.. versionadded:: 2.6
-    The ``binaryFormat`` option was introduced in Symfony 2.6.
 
 **type**: ``boolean`` **default**: ``null``
 
@@ -226,10 +220,6 @@ per the `mimeTypes`_ option.
 
 disallowEmptyMessage
 ~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 2.6
-    The ``disallowEmptyMessage`` option was introduced in Symfony 2.6. Prior to 2.6,
-    if the user uploaded an empty file, no validation error occurred.
 
 **type**: ``string`` **default**: ``An empty file is not allowed.``
 

--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -93,9 +93,6 @@ If you want to ensure that the ``age`` of a ``Person`` class is greater than
 Comparing Dates
 ---------------
 
-.. versionadded:: 2.6
-    The feature to compare dates was introduced in Symfony 2.6.
-
 This constraint can be used to compare ``DateTime`` objects against any date
 string `accepted by the DateTime constructor`_. For example, you could check
 that a date must at least be the next day:

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -92,9 +92,6 @@ or equal to ``18``, you could do the following:
 Comparing Dates
 ---------------
 
-.. versionadded:: 2.6
-    The feature to compare dates was introduced in Symfony 2.6.
-
 This constraint can be used to compare ``DateTime`` objects against any date
 string `accepted by the DateTime constructor`_. For example, you could check
 that a date must at least be the current day:

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -93,9 +93,6 @@ If you want to ensure that the ``age`` of a ``Person`` class is less than
 Comparing Dates
 ---------------
 
-.. versionadded:: 2.6
-    The feature to compare dates was introduced in Symfony 2.6.
-
 This constraint can be used to compare ``DateTime`` objects against any date
 string `accepted by the DateTime constructor`_. For example, you could check
 that a date must be in the past like this:

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -92,9 +92,6 @@ equal to ``80``, you could do the following:
 Comparing Dates
 ---------------
 
-.. versionadded:: 2.6
-    The feature to compare dates was introduced in Symfony 2.6.
-
 This constraint can be used to compare ``DateTime`` objects against any date
 string `accepted by the DateTime constructor`_. For example, you could check
 that a date must be today or in the past like this:

--- a/reference/constraints/_payload-option.rst.inc
+++ b/reference/constraints/_payload-option.rst.inc
@@ -3,9 +3,6 @@ payload
 
 **type**: ``mixed`` **default**: ``null``
 
-.. versionadded:: 2.6
-    The ``payload`` option was introduced in Symfony 2.6.
-
 This option can be used to attach arbitrary domain-specific data to a constraint.
 The configured payload is not used by the Validator component, but its processing
 is completely up to you.

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -876,10 +876,6 @@ For more information, see :doc:`/cookbook/routing/custom_route_loader`.
 routing.expression_language_provider
 ------------------------------------
 
-.. versionadded:: 2.6
-    The ``routing.expression_language_provider`` tag was introduced in Symfony
-    2.6.
-
 **Purpose**: Register a provider for expression language functions in routing
 
 This tag is used to automatically register
@@ -889,10 +885,6 @@ functions to the routing expression language.
 
 security.expression_language_provider
 -------------------------------------
-
-.. versionadded:: 2.6
-    The ``security.expression_language_provider`` tag was introduced in Symfony
-    2.6.
 
 **Purpose**: Register a provider for expression language functions in security
 

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -90,10 +90,6 @@ Field Options
 placeholder
 ~~~~~~~~~~~
 
-.. versionadded:: 2.6
-    The ``placeholder`` option was introduced in Symfony 2.6 in favor of
-    ``empty_value``, which is available prior to 2.6.
-
 **type**: ``string`` or ``array``
 
 If your widget option is set to ``choice``, then this field will be represented

--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -56,9 +56,6 @@ Field Options
 allow_extra_fields
 ~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 2.6
-    The ``allow_extra_fields`` option was introduced in Symfony 2.6.
-
 **type**: ``boolean`` **default**: ``false``
 
 Usually, if you submit extra fields that aren't configured in your form,

--- a/reference/forms/types/options/html5.rst.inc
+++ b/reference/forms/types/options/html5.rst.inc
@@ -1,9 +1,6 @@
 html5
 ~~~~~
 
-.. versionadded:: 2.6
-    The ``html5`` option was introduced in Symfony 2.6.
-
 **type**: ``boolean`` **default**: ``true``
 
 If this is set to ``true`` (the default), it'll use the HTML5 type (date, time

--- a/reference/forms/types/options/placeholder.rst.inc
+++ b/reference/forms/types/options/placeholder.rst.inc
@@ -1,10 +1,6 @@
 placeholder
 ~~~~~~~~~~~
 
-.. versionadded:: 2.6
-    The ``placeholder`` option was introduced in Symfony 2.6 in favor of
-    ``empty_value``, which is available prior to 2.6.
-
 .. versionadded:: 2.3
     Since Symfony 2.3, empty values are also supported if the ``expanded``
     option is set to true.

--- a/reference/map.rst.inc
+++ b/reference/map.rst.inc
@@ -13,7 +13,7 @@
   * :doc:`twig </reference/configuration/twig>`
   * :doc:`monolog </reference/configuration/monolog>`
   * :doc:`web_profiler </reference/configuration/web_profiler>`
-  * :doc:`debug </reference/configuration/debug>` (new in 2.6)
+  * :doc:`debug </reference/configuration/debug>`
 
 * :doc:`Configuring the Kernel (e.g. AppKernel) </reference/configuration/kernel>`
 

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -361,9 +361,6 @@ information in :ref:`book-templating-pages`.
 absolute_url
 ~~~~~~~~~~~~
 
-.. versionadded:: 2.6
-     The ``absolute_url`` function was introduced in Symfony 2.7
-
 .. code-block:: jinja
 
     {{ absolute_url(path) }}
@@ -380,9 +377,6 @@ an existing path:
 
 relative_path
 ~~~~~~~~~~~~~
-
-.. versionadded:: 2.6
-     The ``relative_path`` function was introduced in Symfony 2.7
 
 .. code-block:: jinja
 
@@ -725,11 +719,6 @@ The available attributes are:
 * ``app.environment``
 * ``app.debug``
 * ``app.security`` (deprecated as of 2.6)
-
-.. caution::
-
-     The ``app.security`` global is deprecated as of 2.6. The user is already
-     available as ``app.user`` and ``is_granted()`` is registered as function.
 
 Symfony Standard Edition Extensions
 -----------------------------------


### PR DESCRIPTION
2.6 has reached eom today, so 2.8 should no longer contain the versionadded directives for 2.6 according to our upgrade process.

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | 2.8+ |
| Fixed tickets | - |
