### PR TITLE
[Cookbook][Session] fix default expiry field name

### DIFF
--- a/cookbook/doctrine/mongodb_session_storage.rst
+++ b/cookbook/doctrine/mongodb_session_storage.rst
@@ -165,7 +165,7 @@ From the `MongoDB shell`_:
 .. code-block:: sql
 
     use session_db
-    db.session.ensureIndex( { "expireAt": 1 }, { expireAfterSeconds: 0 } )
+    db.session.ensureIndex( { "expires_at": 1 }, { expireAfterSeconds: 0 } )
 
 .. _installed and configured a MongoDB server: http://docs.mongodb.org/manual/installation/
 .. _MongoDB shell: http://docs.mongodb.org/v2.2/tutorial/getting-started-with-the-mongo-shell/


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

As @stevenmusumeche noted in https://github.com/symfony/symfony-docs/pull/5478#issuecomment-124630107, the [default expiry field name is expires_at](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php#L86).
