### PR TITLE
Missing --no-interaction flag?

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -904,7 +904,7 @@ you can let Doctrine create the class for you.
 
 .. code-block:: bash
 
-    $ php app/console doctrine:generate:entity \
+    $ php app/console doctrine:generate:entity --no-interaction \
         --entity="AppBundle:Category" \
         --fields="name:string(255)"
 


### PR DESCRIPTION
Running 
php app/console doctrine:generate:entity --entity="AppBundle:Category" --fields="name:string(255)"
does not automatically generate the entity. 

Needs the --no-interaction flag set or it enters the interactive generator.
