### PR TITLE
[CreateFramework] don't override existing variables

### DIFF
--- a/create_framework/templating.rst
+++ b/create_framework/templating.rst
@@ -41,7 +41,7 @@ rendered::
 
     function render_template($request)
     {
-        extract($request->attributes->all());
+        extract($request->attributes->all(), EXTR_SKIP);
         ob_start();
         include sprintf(__DIR__.'/../src/pages/%s.php', $_route);
 
@@ -110,7 +110,7 @@ Here is the updated and improved version of our framework::
 
     function render_template($request)
     {
-        extract($request->attributes->all());
+        extract($request->attributes->all(), EXTR_SKIP);
         ob_start();
         include sprintf(__DIR__.'/../src/pages/%s.php', $_route);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #5568 |

When extracting the request attributes, existing variables must not be
overridden so that the `$request` variable is passed to the template as
is.
