### PR TITLE
Add Body tag to see the web debug toolbar

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -193,7 +193,7 @@ example, if you use annotations, create something like this::
          */
         public function adminAction()
         {
-            return new Response('Admin page!');
+            return new Response('<html><body>Admin page!</body></html>');
         }
     }
 


### PR DESCRIPTION
Add body tag on the response content to see the web debug toolbar.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | #5616 |
