### PR TITLE
Remove a caution note about StringUtils::equals() which is no longer true

### DIFF
--- a/components/security/secure_tools.rst
+++ b/components/security/secure_tools.rst
@@ -21,11 +21,6 @@ algorithm; you can use the same strategy in your own code thanks to the
     // is some known string (e.g. password) equal to some user input?
     $bool = StringUtils::equals($knownString, $userInput);
 
-.. caution::
-
-    To avoid timing attacks, the known string must be the first argument
-    and the user-entered string the second.
-
 Generating a Secure random Number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #5618 |
