### PR TITLE
Explain sample configuration parameter usage

### DIFF
--- a/cookbook/bundles/configuration.rst
+++ b/cookbook/bundles/configuration.rst
@@ -223,7 +223,12 @@ thrown)::
         $configuration = new Configuration();
 
         $config = $this->processConfiguration($configuration, $configs);
-        // ...
+        
+        // Example configuration parameter usage: Set configuration variables as 
+        // parameters in the container.
+        $container->setParameter('twitter.client_id', $config['twitter']['client_id']);
+        $container->setParameter('twitter.client_secret', $config['twitter']['client_secret']);
+
     }
 
 The ``processConfiguration()`` method uses the configuration tree you've defined


### PR DESCRIPTION
The "Processing the `$configs` Array" section explains how to define parameters within the Configuration class and process them in the Extension. In my opinion, it doesn't take the example to a logical conclusion. People reading this file want to learn how to create configuration within a Bundle. It would be helpful to explain how the configuration can be used. Since the example uses parameters, I propose showing how the parameters can be loaded into the container. With these code changes, the `twitter.client_id` and `twitter.client_secret` are now available through use throughout the application.
