### PR TITLE
typo fix in pre authenticated

### DIFF
--- a/cookbook/security/pre_authenticated.rst
+++ b/cookbook/security/pre_authenticated.rst
@@ -149,5 +149,5 @@ key in the ``remote_user`` firewall configuration.
 .. note::
 
     Just like for X509 authentication, you will need to configure a "user provider".
-    See :ref:`the note previous note <cookbook-security-pre-authenticated-user-provider-note>`
+    See :ref:`the previous note <cookbook-security-pre-authenticated-user-provider-note>`
     for more information.


### PR DESCRIPTION
Simple typo in pre_auth cookbook entry
