### PR TITLE
Moved comment to the right place

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -196,9 +196,10 @@ expression or a CSS selector, then use the client to click on it. For example::
     $link = $crawler
         ->filter('a:contains("Greet")') // find all links with the text "Greet"
         ->eq(1) // select the second link in the list
-        ->link() // and click it
+        ->link()
     ;
-
+    
+    // and click it
     $crawler = $client->click($link);
 
 Submitting a form is very similar: select a form button, optionally override


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | >= 2.3 afaik |
| Fixed tickets | none |

I think this move is required because we can think at this moment that the function `link()` send the click that is wrong (link() function create a Link object from the selector or throw an exception).
