### PR TITLE
don't ignore the _exts directory anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /_build
-/_exts
 *.pyc


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

As we don't have a Git submodule for the Sphinx extension anymore, there
is no reason to still keep an entry for the directory in our .gitignore
file.
