### PR TITLE
[RFR] Fixing typo in Symfony version for ButtonType

### DIFF
--- a/best_practices/forms.rst
+++ b/best_practices/forms.rst
@@ -85,7 +85,7 @@ makes them easier to re-use later.
 
     Add buttons in the templates, not in the form classes or the controllers.
 
-Since Symfony 2.5, you can add buttons as fields on your form. This is a nice
+Since Symfony 2.3, you can add buttons as fields on your form. This is a nice
 way to simplify the template that renders your form. But if you add the buttons
 directly in your form class, this would effectively limit the scope of that form:
 


### PR DESCRIPTION
ButtonType was introduced in Symfony 2.3.

See : http://symfony.com/blog/new-in-symfony-2-3-buttons-support-in-forms
