### PR TITLE
Do not use dynamic REQUEST_URI from $_SERVER as base url

### DIFF
--- a/components/routing/introduction.rst
+++ b/components/routing/introduction.rst
@@ -39,7 +39,7 @@ your autoloader to load the Routing component::
     $routes = new RouteCollection();
     $routes->add('route_name', $route);
 
-    $context = new RequestContext($_SERVER['REQUEST_URI']);
+    $context = new RequestContext('/');
 
     $matcher = new UrlMatcher($routes, $context);
 
@@ -207,7 +207,7 @@ a certain route::
     $routes = new RouteCollection();
     $routes->add('show_post', new Route('/show/{slug}'));
 
-    $context = new RequestContext($_SERVER['REQUEST_URI']);
+    $context = new RequestContext('/');
 
     $generator = new UrlGenerator($routes, $context);
 
@@ -327,7 +327,7 @@ automatically in the background if you want to use it. A basic example of the
 :class:`Symfony\\Component\\Routing\\Router` class would look like::
 
     $locator = new FileLocator(array(__DIR__));
-    $requestContext = new RequestContext($_SERVER['REQUEST_URI']);
+    $requestContext = new RequestContext('/');
 
     $router = new Router(
         new YamlFileLoader($locator),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets |  |

I am not sure why we use `$_SERVER['REQUEST_URI']` as a first parameter for `Symfony\Component\Routing\RequestContext` where it expects to get baseUrl.
`$_SERVER['REQUEST_URI']` is dynamic and shouldn't be used as a static value for baseUrl.

Probably better not to pass this parameter at all(default) or use `/`, what I propose.
I know that many people won't look that deeply into those examples but, in my opinion, `$_SERVER['REQUEST_URI']` is not base url.

Not sure what to do with the note about the request uri(the one with http foundation link/info).

Maybe the idea was to use `$_SERVER['REQUEST_URI']` in `->match()` examples ?
