### PR TITLE
Fix monolog line formatter in logging cookbook example.

### DIFF
--- a/cookbook/logging/monolog.rst
+++ b/cookbook/logging/monolog.rst
@@ -343,7 +343,7 @@ using a processor.
             monolog.formatter.session_request:
                 class: Monolog\Formatter\LineFormatter
                 arguments:
-                    - "[%%datetime%%] [%%extra.token%%] %%channel%%.%%level_name%%: %%message%%\n"
+                    - "[%%datetime%%] [%%extra.token%%] %%channel%%.%%level_name%%: %%message%% %%context%% %%extra%%\n"
 
             monolog.processor.session_request:
                 class: Acme\MyBundle\SessionRequestProcessor
@@ -375,7 +375,7 @@ using a processor.
                 <service id="monolog.formatter.session_request"
                     class="Monolog\Formatter\LineFormatter">
 
-                    <argument>[%%datetime%%] [%%extra.token%%] %%channel%%.%%level_name%%: %%message%%&#xA;</argument>
+                    <argument>[%%datetime%%] [%%extra.token%%] %%channel%%.%%level_name%%: %%message%% %%context%% %%extra%%&#xA;</argument>
                 </service>
 
                 <service id="monolog.processor.session_request"
@@ -405,7 +405,7 @@ using a processor.
                 'monolog.formatter.session_request',
                 'Monolog\Formatter\LineFormatter'
             )
-            ->addArgument('[%%datetime%%] [%%extra.token%%] %%channel%%.%%level_name%%: %%message%%\n');
+            ->addArgument('[%%datetime%%] [%%extra.token%%] %%channel%%.%%level_name%%: %%message%% %%context%% %%extra%%\n');
 
         $container
             ->register(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

After [Adding some extra Data in the Log Messages](http://symfony.com/doc/current/cookbook/logging/monolog.html#adding-some-extra-data-in-the-log-messages), logs were missing some detail (like missing translation tokens on translation.WARNING messages).

I've corrected the line formatter adding missing tokens taken from [Monolog/Formatter/LineFormatter.php](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Formatter/LineFormatter.php).

Example, log entries before adding extra data:

```
[2015-08-25 14:24:58] translation.WARNING: Translation not found. {"id":"GeoCountryReg.labels.imageFile1","domain":"messages","locale":"es"} []
```

And after:

```
[2015-08-25 14:27:29] [cutptr3q-f0d64b15] translation.WARNING: Translation not found.
```

Desired effect was:

```
[2015-08-25 14:36:18] [cutptr3q-3b0c7c83] translation.WARNING: Translation not found. {"id":"GeoCountryReg.labels.imageFile1","domain":"messages","locale":"es"} []
```
