### PR TITLE
PHPDoc alignment is off

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -48,7 +48,7 @@ example containing most features described below:
         }
 
         /**
-         * @param string $dummy Some argument description
+         * @param string $dummy   Some argument description
          * @param array  $options
          *
          * @return string|null Transformed input


### PR DESCRIPTION
All items of the `@param`, `@throws`, `@return`, `@var`, and `@type` phpdoc tags must be aligned vertically.

`@see`: https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master
