### PR TITLE
Update HttpFoundation note after recent changes in routing component

### DIFF
--- a/components/routing/introduction.rst
+++ b/components/routing/introduction.rst
@@ -48,9 +48,8 @@ your autoloader to load the Routing component::
 
 .. note::
 
-    Be careful when using ``$_SERVER['REQUEST_URI']``, as it may include
-    any query parameters on the URL, which will cause problems with route
-    matching. An easy way to solve this is to use the HttpFoundation component
+    Althought to populate parameters for :class: Symfony\\Component\\Routing\\RequestContext
+    you can use variables from ``$_SERVER``, easier way is to use HttpFoundation component
     as explained :ref:`below <components-routing-http-foundation>`.
 
 You can add as many routes as you like to a

--- a/components/routing/introduction.rst
+++ b/components/routing/introduction.rst
@@ -48,9 +48,9 @@ your autoloader to load the Routing component::
 
 .. note::
 
-    Althought to populate parameters for :class: Symfony\\Component\\Routing\\RequestContext
-    you can use variables from ``$_SERVER``, easier way is to use HttpFoundation component
-    as explained :ref:`below <components-routing-http-foundation>`.
+    The :class:`Symfony\\Component\\Routing\\RequestContext` parameters can be populated
+    with the values stored in ``$_SERVER``, but it's easier to use the HttpFoundation
+    component as explained :ref:`below <components-routing-http-foundation>`.
 
 You can add as many routes as you like to a
 :class:`Symfony\\Component\\Routing\\RouteCollection`.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets |  |

Update HttpFoundation note to reflect changes in https://github.com/symfony/symfony-docs/pull/5652.
We do not longer use `$_SERVER['REQUEST_URI']` in examples so keeping the reference in note doesn't have much value.
I updated it to make it more generic and reflect current examples.
