### PR TITLE
Remove documentation of deprecated console shell

### DIFF
--- a/cookbook/console/usage.rst
+++ b/cookbook/console/usage.rst
@@ -32,34 +32,3 @@ but avoid the performance hit of collecting debug data:
 .. code-block:: bash
 
     $ php app/console list --no-debug
-
-There is an interactive shell which allows you to enter commands without having to
-specify ``php app/console`` each time, which is useful if you need to run several
-commands. To enter the shell run:
-
-.. code-block:: bash
-
-    $ php app/console --shell
-    $ php app/console -s
-
-You can now just run commands with the command name:
-
-.. code-block:: bash
-
-    Symfony > list
-
-When using the shell you can choose to run each command in a separate process:
-
-.. code-block:: bash
-
-    $ php app/console --shell --process-isolation
-    $ php app/console -s --process-isolation
-
-When you do this, the output will not be colorized and interactivity is not
-supported so you will need to pass all command parameters explicitly.
-
-.. note::
-
-    Unless you are using isolated processes, clearing the cache in the shell
-    will not have an effect on subsequent commands you run. This is because
-    the original cached files are still being used.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8 |
| Fixed tickets | #5729 |
