### PR TITLE
Added php start tag to page_creation.rst

### DIFF
--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -36,6 +36,7 @@ Suppose you want to create a page - ``/lucky/number`` - that generates a
 lucky (well, random) number and prints it. To do that, create a class and
 a method inside of it that will be executed when someone goes to ``/lucky/number``::
 
+    <?php
     // src/AppBundle/Controller/LuckyController.php
     namespace AppBundle\Controller;
 
@@ -101,6 +102,7 @@ or the status code.
 Suppose you want to create a JSON endpoint that returns the lucky number.
 Just add a second method to ``LuckyController``::
 
+    <?php
     // src/AppBundle/Controller/LuckyController.php
     // ...
 
@@ -131,6 +133,7 @@ Try this out in your browser:
 
 You can even shorten this with the handy :class:`Symfony\\Component\\HttpFoundation\\JsonResponse`::
 
+    <?php
     // src/AppBundle/Controller/LuckyController.php
     // ...
 
@@ -167,6 +170,7 @@ at the end:
 
     .. code-block:: php-annotations
 
+        <?php
         // src/AppBundle/Controller/LuckyController.php
         // ...
 
@@ -221,6 +225,7 @@ Because of the ``{count}`` "placeholder", the URL to the page is *different*:
 it now works for URLs matching ``/lucky/number/*`` - for example ``/lucky/number/5``.
 The best part is that you can access this value and use it in your controller::
 
+    <?php
     // src/AppBundle/Controller/LuckyController.php
     // ...
 
@@ -273,6 +278,7 @@ So far, ``LuckyController`` doesn't extend any base class. The easiest way
 to use Twig - or many other tools in Symfony - is to extend Symfony's base
 :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller` class::
 
+    <?php
     // src/AppBundle/Controller/LuckyController.php
     // ...
 
@@ -295,6 +301,7 @@ Twig templates, another that can log messages and many more.
 
 To render a Twig template, use a service called ``templating``::
 
+    <?php
     // src/AppBundle/Controller/LuckyController.php
     // ...
 
@@ -328,6 +335,7 @@ and this has a ``render()`` method.
 But this can get even easier! By extending the ``Controller`` class, you
 also get a lot of shortcut methods, like ``render()``::
 
+    <?php
     // src/AppBundle/Controller/LuckyController.php
     // ...
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

I have added the php start tag `<?php` to the code fragments of the file `src/AppBundle/Controller/LuckyController.php` as newcomers can forget it.
