### PR TITLE
incorrect: severity is an array key here and not a constant

### DIFF
--- a/cookbook/validation/severity.rst
+++ b/cookbook/validation/severity.rst
@@ -38,17 +38,17 @@ Use the ``payload`` option to configure the error level for each constraint:
         class User
         {
             /**
-             * @Assert\NotBlank(payload = {severity = "error"})
+             * @Assert\NotBlank(payload = {"severity" = "error"})
              */
             protected $username;
 
             /**
-             * @Assert\NotBlank(payload = {severity = "error"})
+             * @Assert\NotBlank(payload = {"severity" = "error"})
              */
             protected $password;
 
             /**
-             * @Assert\Iban(payload = {severity = "warning"})
+             * @Assert\Iban(payload = {"severity" = "warning"})
              */
             protected $bankAccountNumber;
         }


### PR DESCRIPTION
see http://stackoverflow.com/questions/31701947/how-to-use-symfony-2-6-validations-payload-with-annotation/32826742#comment53602501_32826742 for details
