### PR TITLE
fix YAML syntax highlighting

### DIFF
--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -140,11 +140,11 @@ by adding the ``delivery_whitelist`` option:
             delivery_whitelist:
                # all email addresses matching this regex will *not* be
                # redirected to dev@example.com
-               - "/@specialdomain\.com$/"
+               - '/@specialdomain\.com$/'
 
                # all emails sent to admin@mydomain.com won't
                # be redirected to dev@example.com too
-               - "/^admin@mydomain\.com$/"
+               - '/^admin@mydomain\.com$/'
 
     .. code-block:: xml
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #5684 |

In YAML, double quoted strings can contain escape sequences. Thus, we would have to escape the backslash if we wanted to use them instead of single quotes (see the Platform.sh build to spot the difference now).
