### PR TITLE
configureOptions(...) : protected => public

### DIFF
--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -173,7 +173,7 @@ It's a good practice to split the option configuration into a separate method::
             $this->options = $resolver->resolve($options);
         }
 
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setDefaults(array(
                 'host'       => 'smtp.example.org',
@@ -192,7 +192,7 @@ than processing options. Second, sub-classes may now override the
     // ...
     class GoogleMailer extends Mailer
     {
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             parent::configureOptions($resolver);
 
@@ -215,7 +215,7 @@ For example, to make the ``host`` option required, you can do::
     {
         // ...
 
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
             $resolver->setRequired('host');
@@ -243,7 +243,7 @@ one required option::
     {
         // ...
 
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
             $resolver->setRequired(array('host', 'username', 'password'));
@@ -263,7 +263,7 @@ retrieve the names of all required options::
     // ...
     class GoogleMailer extends Mailer
     {
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             parent::configureOptions($resolver);
 
@@ -291,7 +291,7 @@ been set::
     {
         // ...
 
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
             $resolver->setRequired('host');
@@ -301,7 +301,7 @@ been set::
     // ...
     class GoogleMailer extends Mailer
     {
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             parent::configureOptions($resolver);
 
@@ -336,7 +336,7 @@ correctly. To validate the types of the options, call
     {
         // ...
 
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
             $resolver->setAllowedTypes('host', 'string');
@@ -381,7 +381,7 @@ to verify that the passed option contains one of these values::
     {
         // ...
 
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
             $resolver->setDefault('transport', 'sendmail');
@@ -432,7 +432,7 @@ option. You can configure a normalizer by calling
     {
         // ...
 
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
 
@@ -459,7 +459,7 @@ if you need to use other options during normalization::
     class Mailer
     {
         // ...
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
             $resolver->setNormalizer('host', function ($options, $value) {
@@ -493,7 +493,7 @@ these options, you can return the desired default value::
     class Mailer
     {
         // ...
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
             $resolver->setDefault('encryption', null);
@@ -525,7 +525,7 @@ the closure::
     class Mailer
     {
         // ...
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
             $resolver->setDefaults(array(
@@ -537,7 +537,7 @@ the closure::
 
     class GoogleMailer extends Mailer
     {
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             parent::configureOptions($resolver);
 
@@ -568,7 +568,7 @@ comes from the default::
     class Mailer
     {
         // ...
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
             $resolver->setDefault('port', 25);
@@ -600,7 +600,7 @@ be included in the resolved options if it was actually passed to
     {
         // ...
 
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
             $resolver->setDefined('port');
@@ -634,7 +634,7 @@ options in one go::
     class Mailer
     {
         // ...
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
             $resolver->setDefined(array('port', 'encryption'));
@@ -655,7 +655,7 @@ let you find out which options are defined::
     {
         // ...
 
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             parent::configureOptions($resolver);
 
@@ -701,7 +701,7 @@ can change your code to do the configuration only once per class::
             $this->options = self::$resolversByClass[$class]->resolve($options);
         }
 
-        protected function configureOptions(OptionsResolver $resolver)
+        public function configureOptions(OptionsResolver $resolver)
         {
             // ...
         }


### PR DESCRIPTION
As in Symfony\Component\Form\AbstractType the method is public, overrides should be public too.

/**
     \* Configures the options for this type.
     *
     \* @param OptionsResolver $resolver The resolver for the options.
     */
    public function configureOptions(OptionsResolver $resolver)
    {
    }
