### PR TITLE
Added annotations example to Linking to Pages examples

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -872,7 +872,7 @@ configuration:
         // src/AppBundle/Controller/WelcomeController.php
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
         use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-        
+
         class WelcomeController extends Controller
         {
             /**
@@ -940,7 +940,7 @@ route:
         // src/AppBundle/Controller/ArticleController.php
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
         use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-        
+
         class ArticleController extends Controller
         {
             /**

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -870,6 +870,8 @@ configuration:
     .. code-block:: php-annotations
 
         // src/AppBundle/Controller/WelcomeController.php
+        namespace AppBundle\Controller;
+
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
         use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 
@@ -938,6 +940,8 @@ route:
     .. code-block:: php-annotations
 
         // src/AppBundle/Controller/ArticleController.php
+        namespace AppBundle\Controller;
+
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
         use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -870,6 +870,9 @@ configuration:
     .. code-block:: php-annotations
 
         // src/AppBundle/Controller/WelcomeController.php
+        use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        
         class WelcomeController extends Controller
         {
             /**
@@ -935,6 +938,9 @@ route:
     .. code-block:: php-annotations
 
         // src/AppBundle/Controller/ArticleController.php
+        use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        
         class ArticleController extends Controller
         {
             /**

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -867,6 +867,20 @@ configuration:
 
 .. configuration-block::
 
+    .. code-block:: php-annotations
+
+        // src/AppBundle/Controller/WelcomeController.php
+        class WelcomeController extends Controller
+        {
+            /**
+             * @Route("/", name="_welcome")
+             */
+            public function indexAction()
+            {
+                // ...
+            }
+        }
+
     .. code-block:: yaml
 
         # app/config/routing.yml
@@ -917,6 +931,20 @@ As expected, this will generate the URL ``/``. Now, for a more complicated
 route:
 
 .. configuration-block::
+
+    .. code-block:: php-annotations
+
+        // src/AppBundle/Controller/ArticleController.php
+        class ArticleController extends Controller
+        {
+            /**
+             * @Route("/article/{slug}", name="article_show")
+             */
+            public function showAction($slug)
+            {
+                // ...
+            }
+        }
 
     .. code-block:: yaml
 


### PR DESCRIPTION
In the routing examples for the Linking to Pages section there were no annotations examples (which is what most people use). I have added these examples
