### PR TITLE
[Validator] Add warning for null and blank values for minimum string length

### DIFF
--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -1,7 +1,7 @@
 Length
 ======
 
-Validates that a given string length is *between* some minimum and maximum
+Validates that a given string length is *between* some minimum (if is not null or blank, cf. the `min`_ option) and maximum
 value.
 
 +----------------+----------------------------------------------------------------------+


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | symfony/symfony#16157 |

As explained in the ticket, although the doc is very precise for the [min option of the string Length constraint](http://symfony.com/doc/current/reference/constraints/Length.html#min), the introducing line following the title is very misleading.

cc @jakzal 
