### PR TITLE
Callback Validation Constraint: Remove reference to deprecated option

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -193,7 +193,7 @@ You can then use the following configuration to invoke this validator:
         use Symfony\Component\Validator\Constraints as Assert;
 
         /**
-         * @Assert\Callback({"AppBundle\MyStaticValidatorClass", "isAuthorValid"})
+         * @Assert\Callback({"Vendor\Package\Validator", "validate"})
          */
         class Author
         {
@@ -201,36 +201,30 @@ You can then use the following configuration to invoke this validator:
 
     .. code-block:: yaml
 
-	# src/AppBundle/Resources/config/validation.yml
-	AppBundle\Entity\Author:
-	    constraints:
-		- Callback:
-		    methods:
-			-    [AppBundle\MyStaticValidatorClass, isAuthorValid]
+        # src/AppBundle/Resources/config/validation.yml
+        AppBundle\Entity\Author:
+            constraints:
+                - Callback: [Vendor\Package\Validator, validate]
 
     .. code-block:: xml
 
-	<!-- src/AppBundle/Resources/config/validation.xml -->
-	<?xml version="1.0" encoding="UTF-8" ?>
-	<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
-	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+        <!-- src/AppBundle/Resources/config/validation.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
 
-	    <class name="AppBundle\Entity\Author">
-		<constraint name="Callback">
-		    <option name="methods">
-			<value>
-			    <value>AppBundle\MyStaticValidatorClass</value>
-			    <value>isAuthorValid</value>
-			</value>
-		    </option>
-		</constraint>
-	    </class>
-	</constraint-mapping>
+            <class name="AppBundle\Entity\Author">
+                <constraint name="Callback">
+                    <value>Vendor\Package\Validator</value>
+                    <value>validate</value>
+                </constraint>
+            </class>
+        </constraint-mapping>
 
     .. code-block:: php
 
-	// src/AppBundle/Entity/Author.php
+        // src/AppBundle/Entity/Author.php
         namespace AppBundle\Entity;
 
         use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -238,18 +232,12 @@ You can then use the following configuration to invoke this validator:
 
         class Author
         {
-	    public $name;
-
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
-		$metadata->addConstraint(new Callback(array(
-		    'methods' => array(
-			array(
-			    'AppBundle\MyStaticValidatorClass',
-			    'isAuthorValid',
-			),
-		    ),
-		)));
+                $metadata->addConstraint(new Assert\Callback(array(
+                    'Vendor\Package\Validator',
+                    'validate',
+                )));
             }
         }
 
@@ -267,8 +255,9 @@ constructor of the Callback constraint::
     // src/AppBundle/Entity/Author.php
     namespace AppBundle\Entity;
 
-    use Symfony\Component\Validator\ExecutionContextInterface;
-    use AppBundle\Entity\Author;
+    use Symfony\Component\Validator\Context\ExecutionContextInterface;
+    // if you're using the older 2.4 validation API, you'll need this instead
+    // use Symfony\Component\Validator\ExecutionContextInterface;
 
     use Symfony\Component\Validator\Mapping\ClassMetadata;
     use Symfony\Component\Validator\Constraints as Assert;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7 |
| Fixed tickets | / |

Regression from 2.6: http://symfony.com/doc/2.6/reference/constraints/Callback.html#external-callbacks-and-closures
The examples were still using the old, deprecated syntax... And even calling a method not defined anymore (`isAuthorValid` instead of `validate`)
