### PR TITLE
Fix for #5783

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -28,9 +28,8 @@ Usage
 The :class:`Symfony\\Component\\DomCrawler\\Crawler` class provides methods
 to query and manipulate HTML and XML documents.
 
-An instance of the Crawler represents a set (:phpclass:`SplObjectStorage`)
-of :phpclass:`DOMElement` objects, which are basically nodes that you can
-traverse easily::
+An instance of the Crawler represents a set of :phpclass:`DOMElement` objects,
+which are basically nodes that you can traverse easily::
 
     use Symfony\Component\DomCrawler\Crawler;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8 |
| Fixed tickets | #5783 |

I can confirm, that this is the only place where the `SplStorageObject` and its methods which were marked as deprecated in symfony/symfony#15907 are referenced.
