### PR TITLE
[Process] use ProcessFailedException instead of RuntimeException.

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -24,13 +24,14 @@ The :class:`Symfony\\Component\\Process\\Process` class allows you to execute
 a command in a sub-process::
 
     use Symfony\Component\Process\Process;
+    use Symfony\Component\Process\Exception\ProcessFailedException;
 
     $process = new Process('ls -lsa');
     $process->run();
 
     // executes after the command finishes
     if (!$process->isSuccessful()) {
-        throw new \RuntimeException($process->getErrorOutput());
+        throw new ProcessFailedException($process);
     }
 
     echo $process->getOutput();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | https://github.com/symfony/symfony/pull/16269 |
