### PR TITLE
[3.0] First round of Form deprecation removals

### DIFF
--- a/best_practices/forms.rst
+++ b/best_practices/forms.rst
@@ -42,14 +42,10 @@ form in its own PHP class::
                 'data_class' => 'AppBundle\Entity\Post'
             ));
         }
-
-        public function getName()
-        {
-            return 'post';
-        }
     }
 
-To use the class, use ``createForm`` and instantiate the new class::
+To use the class, pass the fully qualified class name to the ``createForm()``
+method::
 
     use AppBundle\Form\PostType;
     // ...
@@ -57,7 +53,7 @@ To use the class, use ``createForm`` and instantiate the new class::
     public function newAction(Request $request)
     {
         $post = new Post();
-        $form = $this->createForm(new PostType(), $post);
+        $form = $this->createForm(PostType::class, $post);
 
         // ...
     }
@@ -91,13 +87,16 @@ directly in your form class, this would effectively limit the scope of that form
 
 .. code-block:: php
 
+    // ...
+    use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+
     class PostType extends AbstractType
     {
         public function buildForm(FormBuilderInterface $builder, array $options)
         {
             $builder
                 // ...
-                ->add('save', 'submit', array('label' => 'Create Post'))
+                ->add('save', SubmitType::class, array('label' => 'Create Post'))
             ;
         }
 
@@ -111,6 +110,7 @@ some developers configure form buttons in the controller::
     namespace AppBundle\Controller\Admin;
 
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\Form\Extension\Core\Type\SubmitType;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use AppBundle\Entity\Post;
     use AppBundle\Form\PostType;
@@ -122,8 +122,8 @@ some developers configure form buttons in the controller::
         public function newAction(Request $request)
         {
             $post = new Post();
-            $form = $this->createForm(new PostType(), $post);
-            $form->add('submit', 'submit', array(
+            $form = $this->createForm(PostType::class, $post);
+            $form->add('submit', SubmitType::class, array(
                 'label' => 'Create',
                 'attr'  => array('class' => 'btn btn-default pull-right')
             ));
@@ -178,7 +178,7 @@ Handling a form submit usually follows a similar template:
 
     public function newAction(Request $request)
     {
-        // build the form ...
+        // ... build the form
 
         $form->handleRequest($request);
 
@@ -193,7 +193,7 @@ Handling a form submit usually follows a similar template:
             ));
         }
 
-        // render the template
+        // ... render the template
     }
 
 There are really only two notable things here. First, we recommend that you
@@ -207,21 +207,3 @@ Second, we recommend using ``$form->isSubmitted()`` in the ``if`` statement
 for clarity. This isn't technically needed, since ``isValid()`` first calls
 ``isSubmitted()``. But without this, the flow doesn't read well as it *looks*
 like the form is *always* processed (even on the GET request).
-
-Custom Form Field Types
------------------------
-
-.. best-practice::
-
-    Add the ``app_`` prefix to your custom form field types to avoid collisions.
-
-Custom form field types inherit from the ``AbstractType`` class, which defines the
-``getName()`` method to configure the name of that form type. These names must
-be unique in the application.
-
-If a custom form type uses the same name as any of the Symfony's built-in form
-types, it will override it. The same happens when the custom form type matches
-any of the types defined by the third-party bundles installed in your application.
-
-Add the ``app_`` prefix to your custom form field types to avoid name collisions
-that can lead to hard to debug errors.

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -80,6 +80,7 @@ from inside a controller::
     use AppBundle\Entity\Task;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\Form\Extension\Core\Type;
 
     class DefaultController extends Controller
     {
@@ -91,9 +92,11 @@ from inside a controller::
             $task->setDueDate(new \DateTime('tomorrow'));
 
             $form = $this->createFormBuilder($task)
-                ->add('task', 'text')
-                ->add('dueDate', 'date')
-                ->add('save', 'submit', array('label' => 'Create Task'))
+                ->add('task', Type\TextType::class)
+                ->add('dueDate', Type\DateType::class)
+                ->add('save', Type\SubmitType::class, array(
+                    'label' => 'Create Task'
+                ))
                 ->getForm();
 
             return $this->render('default/new.html.twig', array(
@@ -116,8 +119,9 @@ building the form.
 
 In this example, you've added two fields to your form - ``task`` and ``dueDate`` -
 corresponding to the ``task`` and ``dueDate`` properties of the ``Task`` class.
-You've also assigned each a "type" (e.g. ``text``, ``date``), which, among
-other things, determines which HTML form tag(s) is rendered for that field.
+You've also assigned each a "type": text (``TextType::class``) and date
+(``DateType::class``), which, among other things, determines which HTML form
+element is rendered for that field.
 
 Finally, you added a submit button with a custom label for submitting the form to
 the server.
@@ -146,7 +150,7 @@ helper functions:
 
         {# app/Resources/views/default/new.html.twig #}
         {{ form_start(form) }}
-        {{ form_widget(form) }}
+            {{ form_widget(form) }}
         {{ form_end(form) }}
 
     .. code-block:: html+php
@@ -224,9 +228,9 @@ controller::
         $task = new Task();
 
         $form = $this->createFormBuilder($task)
-            ->add('task', 'text')
-            ->add('dueDate', 'date')
-            ->add('save', 'submit', array('label' => 'Create Task'))
+            ->add('task', Type\TextType::class)
+            ->add('dueDate', Type\DateType::class)
+            ->add('save', Type\SubmitType::class, array('label' => 'Create Task'))
             ->getForm();
 
         $form->handleRequest($request);
@@ -254,7 +258,7 @@ controller::
     to the ``submit`` method - a strategy which is deprecated and will be
     removed in Symfony 3.0. For details on that method, see :ref:`cookbook-form-submit-request`.
 
-This controller follows a common pattern for handling forms, and has three
+This controller follows a common pattern for handling forms and has three
 possible paths:
 
 #. When initially loading the page in a browser, the form is simply created and
@@ -309,11 +313,13 @@ When your form contains more than one submit button, you will want to check
 which of the buttons was clicked to adapt the program flow in your controller.
 To do this, add a second button with the caption "Save and add" to your form::
 
+    // ...
+
     $form = $this->createFormBuilder($task)
-        ->add('task', 'text')
-        ->add('dueDate', 'date')
-        ->add('save', 'submit', array('label' => 'Create Task'))
-        ->add('saveAndAdd', 'submit', array('label' => 'Save and Add'))
+        ->add('task', Type\TextType::class)
+        ->add('dueDate', Type\DateType::class)
+        ->add('save', Type\SubmitType::class, array('label' => 'Create Task'))
+        ->add('saveAndAdd', Type\SubmitType::class, array('label' => 'Save and Add'))
         ->getForm();
 
 In your controller, use the button's
@@ -618,10 +624,11 @@ the data of the form should be saved, but not validated.
 
 First, we need to add the two buttons to the form::
 
+    // ...
     $form = $this->createFormBuilder($task)
         // ...
-        ->add('nextStep', 'submit')
-        ->add('previousStep', 'submit')
+        ->add('nextStep', Type\SubmitType::class)
+        ->add('previousStep', Type\SubmitType::class)
         ->getForm();
 
 Then, we configure the button for returning to the previous step to run
@@ -630,7 +637,7 @@ so we set its ``validation_groups`` option to false::
 
     $form = $this->createFormBuilder($task)
         // ...
-        ->add('previousStep', 'submit', array(
+        ->add('previousStep', Type\SubmitType::class, array(
             'validation_groups' => false,
         ))
         ->getForm();
@@ -667,7 +674,7 @@ boxes. However, the :doc:`date field </reference/forms/types/date>` can be
 configured to be rendered as a single text box (where the user would enter
 the date as a string in the box)::
 
-    ->add('dueDate', 'date', array('widget' => 'single_text'))
+    ->add('dueDate', Type\DateType::class, array('widget' => 'single_text'))
 
 .. image:: /images/book/form-simple2.png
     :align: center
@@ -699,7 +706,7 @@ the documentation for each type.
     The label for the form field can be set using the ``label`` option,
     which can be applied to any field::
 
-        ->add('dueDate', 'date', array(
+        ->add('dueDate', Type\DateType, array(
             'widget' => 'single_text',
             'label'  => 'Due Date',
         ))
@@ -720,7 +727,7 @@ Now that you've added validation metadata to the ``Task`` class, Symfony
 already knows a bit about your fields. If you allow it, Symfony can "guess"
 the type of your field and set it up for you. In this example, Symfony can
 guess from the validation rules that both the ``task`` field is a normal
-``text`` field and the ``dueDate`` field is a ``date`` field::
+text field and the ``dueDate`` field is a date field::
 
     public function newAction()
     {
@@ -729,7 +736,7 @@ guess from the validation rules that both the ``task`` field is a normal
         $form = $this->createFormBuilder($task)
             ->add('task')
             ->add('dueDate', null, array('widget' => 'single_text'))
-            ->add('save', 'submit')
+            ->add('save', Type\SubmitType::class)
             ->getForm();
     }
 
@@ -990,9 +997,9 @@ ways. If you build your form in the controller, you can use ``setAction()`` and
     $form = $this->createFormBuilder($task)
         ->setAction($this->generateUrl('target_route'))
         ->setMethod('GET')
-        ->add('task', 'text')
-        ->add('dueDate', 'date')
-        ->add('save', 'submit')
+        ->add('task', Type\TextType::class)
+        ->add('dueDate', Type\DateType::class)
+        ->add('save', Type\SubmitType::class)
         ->getForm();
 
 .. note::
@@ -1004,7 +1011,7 @@ In :ref:`book-form-creating-form-classes` you will learn how to move the
 form building code into separate classes. When using an external form class
 in the controller, you can pass the action and method as form options::
 
-    $form = $this->createForm(new TaskType(), $task, array(
+    $form = $this->createForm(TaskType::class, $task, array(
         'action' => $this->generateUrl('target_route'),
         'method' => 'GET',
     ));
@@ -1054,6 +1061,7 @@ that will house the logic for building the task form::
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 
     class TaskType extends AbstractType
     {
@@ -1062,23 +1070,10 @@ that will house the logic for building the task form::
             $builder
                 ->add('task')
                 ->add('dueDate', null, array('widget' => 'single_text'))
-                ->add('save', 'submit')
+                ->add('save', SubmitType::class)
             ;
         }
-
-        public function getName()
-        {
-            return 'task';
-        }
     }
-
-.. caution::
-
-    The ``getName()`` method returns the identifier of this form "type". These
-    identifiers must be unique in the application. Unless you want to override
-    a built-in type, they should be different from the default Symfony types
-    and from any type defined by a third-party bundle installed in your application.
-    Consider prefixing your types with ``app_`` to avoid identifier collisions.
 
 This new class contains all the directions needed to create the task form. It can
 be used to quickly build a form object in the controller::
@@ -1091,7 +1086,7 @@ be used to quickly build a form object in the controller::
     public function newAction()
     {
         $task = ...;
-        $form = $this->createForm(new TaskType(), $task);
+        $form = $this->createForm(TaskType::class, $task);
 
         // ...
     }
@@ -1132,13 +1127,14 @@ the choice is ultimately up to you.
     object, you need to set the ``mapped`` option to ``false``::
 
         use Symfony\Component\Form\FormBuilderInterface;
+        use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 
         public function buildForm(FormBuilderInterface $builder, array $options)
         {
             $builder
                 ->add('task')
                 ->add('dueDate', null, array('mapped' => false))
-                ->add('save', 'submit')
+                ->add('save', SubmitType::class)
             ;
         }
 
@@ -1176,7 +1172,7 @@ easy to use in your application.
             app.form.type.task:
                 class: AppBundle\Form\Type\TaskType
                 tags:
-                    - { name: form.type, alias: task }
+                    - { name: form.type }
 
     .. code-block:: xml
 
@@ -1188,7 +1184,7 @@ easy to use in your application.
 
             <services>
                 <service id="app.form.type.task" class="AppBundle\Form\Type\TaskType">
-                    <tag name="form.type" alias="task" />
+                    <tag name="form.type" />
                 </service>
             </services>
         </container>
@@ -1201,20 +1197,22 @@ easy to use in your application.
                 'app.form.type.task',
                 'AppBundle\Form\Type\TaskType'
             )
-            ->addTag('form.type', array(
-                'alias' => 'task',
-            ))
+            ->addTag('form.type')
         ;
 
-That's it! Now you can use your form type directly in a controller::
+That's it! Now, when using the task type, the Form component will use the
+service instead of creating a new instance itself::
 
     // src/AppBundle/Controller/DefaultController.php
-    // ...
 
+    // ...
+    use AppBundle\Form\Type\TaskType;
+
+    // ...
     public function newAction()
     {
         $task = ...;
-        $form = $this->createForm('task', $task);
+        $form = $this->createForm(TaskType::class, $task);
 
         // ...
     }
@@ -1222,15 +1220,18 @@ That's it! Now you can use your form type directly in a controller::
 or even use from within the form type of another form::
 
     // src/AppBundle/Form/Type/ListType.php
-    // ...
 
+    // ...
+    use AppBundle\Form\Type\TaskType;
+
+    // ...
     class ListType extends AbstractType
     {
         public function buildForm(FormBuilderInterface $builder, array $options)
         {
             // ...
 
-            $builder->add('someTask', 'task');
+            $builder->add('someTask', TaskType::class);
         }
     }
 
@@ -1358,19 +1359,12 @@ create a form class so that a ``Category`` object can be modified by the user::
                 'data_class' => 'AppBundle\Entity\Category',
             ));
         }
-
-        public function getName()
-        {
-            return 'category';
-        }
     }
 
 The end goal is to allow the ``Category`` of a ``Task`` to be modified right
 inside the task form itself. To accomplish this, add a ``category`` field
 to the ``TaskType`` object whose type is an instance of the new ``CategoryType``
-class:
-
-.. code-block:: php
+class::
 
     use Symfony\Component\Form\FormBuilderInterface;
 
@@ -1378,7 +1372,7 @@ class:
     {
         // ...
 
-        $builder->add('category', new CategoryType());
+        $builder->add('category', CategoryType::class);
     }
 
 The fields from ``CategoryType`` can now be rendered alongside those from
@@ -1549,15 +1543,17 @@ Each fragment name follows the same basic pattern and is broken up into two piec
 separated by a single underscore character (``_``). A few examples are:
 
 * ``form_row`` - used by ``form_row`` to render most fields;
-* ``textarea_widget`` - used by ``form_widget`` to render a ``textarea`` field
+* ``textarea_widget`` - used by ``form_widget`` to render a textarea field
   type;
 * ``form_errors`` - used by ``form_errors`` to render errors for a field;
 
-Each fragment follows the same basic pattern: ``type_part``. The ``type`` portion
-corresponds to the field *type* being rendered (e.g. ``textarea``, ``checkbox``,
-``date``, etc) whereas the ``part`` portion corresponds to *what* is being
-rendered (e.g. ``label``, ``widget``, ``errors``, etc). By default, there
-are 4 possible *parts* of a form that can be rendered:
+Each fragment follows the same basic pattern: ``block-prefix_part``. The
+``block-prefix`` portion defaults to the underscored version of the field class
+name (e.g. ``textarea`` for the ``TextareaType``, ``checkbox`` for the
+``CheckboxType``, ``task`` for the ``TaskType``, etc.), whereas the ``part``
+portion corresponds to *what* is being rendered (e.g. ``label``, ``widget``,
+``errors``, etc). By default, there are four possible *parts* of a form that can
+be rendered:
 
 +-------------+--------------------------+---------------------------------------------------------+
 | ``label``   | (e.g. ``form_label``)    | renders the field's label                               |
@@ -1595,9 +1591,9 @@ type (the parent type of ``textarea`` is ``text``, its parent is ``form``),
 and Symfony uses the fragment for the parent type if the base fragment doesn't
 exist.
 
-So, to override the errors for *only* ``textarea`` fields, copy the
-``form_errors`` fragment, rename it to ``textarea_errors`` and customize it. To
-override the default error rendering for *all* fields, copy and customize the
+So, to *only* override the errors for textarea fields, copy the ``form_errors``
+fragment, rename it to ``textarea_errors`` and customize it. To override the
+default error rendering for *all* fields, copy and customize the
 ``form_errors`` fragment directly.
 
 .. tip::
@@ -1843,22 +1839,23 @@ an array of the submitted data. This is actually really easy::
 
     // make sure you've imported the Request namespace above the class
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\Form\Extension\Core\Type;
     // ...
 
     public function contactAction(Request $request)
     {
         $defaultData = array('message' => 'Type your message here');
         $form = $this->createFormBuilder($defaultData)
-            ->add('name', 'text')
-            ->add('email', 'email')
-            ->add('message', 'textarea')
-            ->add('send', 'submit')
+            ->add('name', Type\TextType::class)
+            ->add('email', Type\EmailType::class)
+            ->add('message', Type\TextareaType::class)
+            ->add('send', Type\SubmitType::class)
             ->getForm();
 
         $form->handleRequest($request);
 
         if ($form->isValid()) {
-            // data is an array with "name", "email", and "message" keys
+            // data is an array with "name", "email" and "message" keys
             $data = $form->getData();
         }
 
@@ -1913,12 +1910,13 @@ but here's a short example:
 
     use Symfony\Component\Validator\Constraints\Length;
     use Symfony\Component\Validator\Constraints\NotBlank;
+    use Symfony\Component\Form\Extension\Core\Type;
 
     $builder
-       ->add('firstName', 'text', array(
+       ->add('firstName', Type\TextType::class, array(
            'constraints' => new Length(array('min' => 3)),
        ))
-       ->add('lastName', 'text', array(
+       ->add('lastName', Type\TextType::class, array(
            'constraints' => array(
                new NotBlank(),
                new Length(array('min' => 3)),
@@ -1929,12 +1927,12 @@ but here's a short example:
 .. tip::
 
     If you are using validation groups, you need to either reference the
-    ``Default`` group when creating the form, or set the correct group on
+    ``Default`` group when creating the form or set the correct group on
     the constraint you are adding.
 
-.. code-block:: php
+    .. code-block:: php
 
-    new NotBlank(array('groups' => array('create', 'update'))
+        new NotBlank(array('groups' => array('create', 'update'))
 
 Final Thoughts
 --------------

--- a/components/form/form_events.rst
+++ b/components/form/form_events.rst
@@ -288,10 +288,11 @@ Creating and binding an event listener to the form is very easy::
 
     use Symfony\Component\Form\FormEvent;
     use Symfony\Component\Form\FormEvents;
+    use Symfony\Component\Form\Extension\Core\Type;
 
     $form = $formFactory->createBuilder()
-        ->add('username', 'text')
-        ->add('show_email', 'checkbox')
+        ->add('username', Type\TextType::class)
+        ->add('show_email', Type\CheckboxType::class)
         ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $user = $event->getData();
             $form = $event->getForm();
@@ -323,8 +324,8 @@ callback for better readability::
     {
         public function buildForm(FormBuilderInterface $builder, array $options)
         {
-            $builder->add('username', 'text');
-            $builder->add('show_email', 'checkbox');
+            $builder->add('username', Type\TextType::class);
+            $builder->add('show_email', Type\CheckboxType::class);
             $builder->addEventListener(
                 FormEvents::PRE_SET_DATA,
                 array($this, 'onPreSetData')
@@ -351,6 +352,7 @@ Event subscribers have different uses:
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
     use Symfony\Component\Form\FormEvent;
     use Symfony\Component\Form\FormEvents;
+    use Symfony\Component\Form\Extension\Core\Type\EmailType;
 
     class AddEmailFieldListener implements EventSubscriberInterface
     {
@@ -370,7 +372,7 @@ Event subscribers have different uses:
             // Check whether the user from the initial data has chosen to
             // display his email or not.
             if (true === $user->isShowEmail()) {
-                $form->add('email', 'email');
+                $form->add('email', EmailType::class);
             }
         }
 
@@ -387,7 +389,7 @@ Event subscribers have different uses:
             // If the data was submitted previously, the additional value that
             // is included in the request variables needs to be removed.
             if (true === $user['show_email']) {
-                $form->add('email', 'email');
+                $form->add('email', EmailType::class);
             } else {
                 unset($user['email']);
                 $event->setData($user);
@@ -400,8 +402,8 @@ To register the event subscriber, use the addEventSubscriber() method::
     // ...
 
     $form = $formFactory->createBuilder()
-        ->add('username', 'text')
-        ->add('show_email', 'checkbox')
+        ->add('username', Type\TextType::class)
+        ->add('show_email', Type\CheckboxType::class)
         ->addEventSubscriber(new AddEmailFieldListener())
         ->getForm();
 

--- a/components/form/introduction.rst
+++ b/components/form/introduction.rst
@@ -391,9 +391,11 @@ is created from the form factory.
 
     .. code-block:: php-standalone
 
+        use Symfony\Component\Form\Extension\Core\Type;
+
         $form = $formFactory->createBuilder()
-            ->add('task', 'text')
-            ->add('dueDate', 'date')
+            ->add('task', TextType::class)
+            ->add('dueDate', DateType::class)
             ->getForm();
 
         var_dump($twig->render('new.html.twig', array(
@@ -407,6 +409,7 @@ is created from the form factory.
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
         use Symfony\Component\HttpFoundation\Request;
+        use Symfony\Component\Form\Extension\Core\Type;
 
         class DefaultController extends Controller
         {
@@ -415,8 +418,8 @@ is created from the form factory.
                 // createFormBuilder is a shortcut to get the "form factory"
                 // and then call "createBuilder()" on it
                 $form = $this->createFormBuilder()
-                    ->add('task', 'text')
-                    ->add('dueDate', 'date')
+                    ->add('task', TextType::class)
+                    ->add('dueDate', DateType::class)
                     ->getForm();
 
                 return $this->render('AcmeTaskBundle:Default:new.html.twig', array(
@@ -444,13 +447,14 @@ builder:
 
     .. code-block:: php-standalone
 
+        // ...
         $defaults = array(
             'dueDate' => new \DateTime('tomorrow'),
         );
 
         $form = $formFactory->createBuilder('form', $defaults)
-            ->add('task', 'text')
-            ->add('dueDate', 'date')
+            ->add('task', Type\TextType::class)
+            ->add('dueDate', Type\DateType::class)
             ->getForm();
 
     .. code-block:: php-symfony
@@ -460,8 +464,8 @@ builder:
         );
 
         $form = $this->createFormBuilder($defaults)
-            ->add('task', 'text')
-            ->add('dueDate', 'date')
+            ->add('task', Type\TextType::class)
+            ->add('dueDate', Type\DateType::class)
             ->getForm();
 
 .. tip::
@@ -546,12 +550,13 @@ method:
 
     .. code-block:: php-standalone
 
+        // ...
         use Symfony\Component\HttpFoundation\Request;
         use Symfony\Component\HttpFoundation\RedirectResponse;
 
         $form = $formFactory->createBuilder()
-            ->add('task', 'text')
-            ->add('dueDate', 'date')
+            ->add('task', Type\TextType::class)
+            ->add('dueDate', Type\DateType::class)
             ->getForm();
 
         $request = Request::createFromGlobals();
@@ -578,8 +583,8 @@ method:
         public function newAction(Request $request)
         {
             $form = $this->createFormBuilder()
-                ->add('task', 'text')
-                ->add('dueDate', 'date')
+                ->add('task', TextType::class)
+                ->add('dueDate', DateType::class)
                 ->getForm();
 
             $form->handleRequest($request);
@@ -624,12 +629,13 @@ option when building each field:
 
         use Symfony\Component\Validator\Constraints\NotBlank;
         use Symfony\Component\Validator\Constraints\Type;
+        use Symfony\Component\Form\Extension\Core\Type;
 
         $form = $formFactory->createBuilder()
-            ->add('task', 'text', array(
+            ->add('task', Type\TextType::class, array(
                 'constraints' => new NotBlank(),
             ))
-            ->add('dueDate', 'date', array(
+            ->add('dueDate', Type\DateType::class, array(
                 'constraints' => array(
                     new NotBlank(),
                     new Type('\DateTime'),
@@ -641,12 +647,13 @@ option when building each field:
 
         use Symfony\Component\Validator\Constraints\NotBlank;
         use Symfony\Component\Validator\Constraints\Type;
+        use Symfony\Component\Form\Extension\Core\Type;
 
         $form = $this->createFormBuilder()
-            ->add('task', 'text', array(
+            ->add('task', Type\TextType::class, array(
                 'constraints' => new NotBlank(),
             ))
-            ->add('dueDate', 'date', array(
+            ->add('dueDate', Type\DateType::class, array(
                 'constraints' => array(
                     new NotBlank(),
                     new Type('\DateTime'),


### PR DESCRIPTION
Forms has changed a lot, so it'll take many rounds and much time to get things right for 3.0. Let's start with this PR and create new PRs based on this.

I propose to only apply the deprecation of field types to the 3.0 version of the docs. In this version, PHP 5.5 is the minimum PHP version, so we can use the much nicer `::class` constant instead of passing a 40+ long string each time.

I just did a quick review & change round for the best practices, book and component docs. It's very likely that some other text still needs to be updated in these articles and the cookbook and references needs changes as well. I think it's better to do these things in separate PRs to avoid big PRs with lots of merge conflicts.

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 3.0+ |
| Fixed tickets | - |
