### PR TITLE
Update standards to match actual practices

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -198,7 +198,8 @@ Service Naming Conventions
 Documentation
 -------------
 
-* Add PHPDoc blocks for all classes, methods, and functions;
+* Add PHPDoc blocks for all classes, methods, and functions, except when the
+  comments are trivial (e.g. basic getter and setter methods);
 
 * Omit the ``@return`` tag if the method does not return anything;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets |  |

We don't add phpdoc if it doesn't add any meaningful information, so i removed the line saying all methods should be documented. Maybe we should replace it by a phrase explaining what should be documented ?
