### PR TITLE
Fixed the YAML syntax for service references

### DIFF
--- a/cookbook/routing/custom_route_loader.rst
+++ b/cookbook/routing/custom_route_loader.rst
@@ -16,7 +16,7 @@ A custom route loader does not enable your bundle to inject routes
 without the need to modify the routing configuration
 (e.g. ``app/config/routing.yml``) manually.
 If your bundle provides routes, whether via a configuration file, like
-the `WebProfilerBundle` does, or via a custom route loader, like the 
+the `WebProfilerBundle` does, or via a custom route loader, like the
 `FOSRestBundle`_ does, an entry in the routing configuration is always
 necessary.
 
@@ -46,7 +46,7 @@ Take these lines from the ``routing.yml`` in the Symfony Standard Edition:
 
     # app/config/routing.yml
     app:
-        resource: @AppBundle/Controller/
+        resource: '@AppBundle/Controller/'
         type:     annotation
 
 When the main loader parses this, it tries all registered delegate loaders and calls

--- a/cookbook/routing/custom_route_loader.rst
+++ b/cookbook/routing/custom_route_loader.rst
@@ -46,7 +46,7 @@ Take these lines from the ``routing.yml`` in the Symfony Standard Edition:
 
     # app/config/routing.yml
     app:
-        resource: '@AppBundle/Controller/'
+        resource: "@AppBundle/Controller/"
         type:     annotation
 
 When the main loader parses this, it tries all registered delegate loaders and calls

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -35,7 +35,7 @@ TwigBundle Configuration ("twig")
 
             # The following were added in Symfony 2.3.
             # See http://twig.sensiolabs.org/doc/recipes.html#using-the-template-name-to-set-the-default-escaping-strategy
-            autoescape_service:        ~ # Example: '@my_service'
+            autoescape_service:        ~ # Example: "@my_service"
             autoescape_service_method: ~ # use in combination with autoescape_service option
             base_template_class:       ~ # Example: Twig_Template
             cache:                     "%kernel.cache_dir%/twig"

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -35,7 +35,7 @@ TwigBundle Configuration ("twig")
 
             # The following were added in Symfony 2.3.
             # See http://twig.sensiolabs.org/doc/recipes.html#using-the-template-name-to-set-the-default-escaping-strategy
-            autoescape_service:        ~ # Example: @my_service
+            autoescape_service:        ~ # Example: '@my_service'
             autoescape_service_method: ~ # use in combination with autoescape_service option
             base_template_class:       ~ # Example: Twig_Template
             cache:                     "%kernel.cache_dir%/twig"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

See https://github.com/symfony/symfony/pull/16285 and https://github.com/symfony/symfony/pull/16353 for context. I've just found two issues, but it's possible that this syntax is used in more places.
