### PR TITLE
File System Security Issue in Custom Auth Article

### DIFF
--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -134,7 +134,7 @@ set an authenticated token in the token storage if successful.
         {
             $request = $event->getRequest();
 
-            $wsseRegex = '/UsernameToken Username="([^"]+)", PasswordDigest="([^"]+)", Nonce="([a-zA-Z+/]+={0,2})", Created="([^"]+)"/';
+            $wsseRegex = '/UsernameToken Username="([^"]+)", PasswordDigest="([^"]+)", Nonce="([a-zA-Z0-9+/]+={0,2})", Created="([^"]+)"/';
             if (!$request->headers->has('x-wsse') || 1 !== preg_match($wsseRegex, $request->headers->get('x-wsse'), $matches)) {
                 return;
             }

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -134,7 +134,7 @@ set an authenticated token in the token storage if successful.
         {
             $request = $event->getRequest();
 
-            $wsseRegex = '/UsernameToken Username="([^"]+)", PasswordDigest="([^"]+)", Nonce="([^"]+)", Created="([^"]+)"/';
+            $wsseRegex = '/UsernameToken Username="([^"]+)", PasswordDigest="([^"]+)", Nonce="([a-zA-Z+/]+={0,2})", Created="([^"]+)"/';
             if (!$request->headers->has('x-wsse') || 1 !== preg_match($wsseRegex, $request->headers->get('x-wsse'), $matches)) {
                 return;
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #5845 |

I hope to address this security concern: If `$token->nonce` is set to [ANY USER INPUT] and later we run `file_put_contents($token->nonce, time())` are we allowing hackers to destroy any www-writable file in the system?

I did notice that `$nonce` is run through `base64_decode($nonce)` later in the article, implying nonce needs to be a Base64 string. Could this Regex be updated to only accept a Base64 string `[a-zA-Z+/]+={0,2}` for the nonce?

At the same time, Base64 allows `/` characters, so `file_put_contents()` would fail in those cases, so even this change, while secure, seems flawed. Replace [+/] with [-_]?
