### PR TITLE
Added hints to spool config section

### DIFF
--- a/cookbook/email/spool.rst
+++ b/cookbook/email/spool.rst
@@ -55,13 +55,15 @@ swiftmailer with the memory option, use the following configuration:
             'spool' => array('type' => 'memory')
         ));
 
+.. _spool-using-a-file:
+
 Spool Using Files
 ------------------
 
 When you use the filesystem for spooling, Symfony creates a folder in the given 
 path for each mail service (e.g. "default" for the default service). This folder
 will contain files for each email in the spool. So make sure this directory is 
-writable by symfony (or your webserver/php)!
+writable by Symfony (or your webserver/php)!
 
 In order to use the spool with files, use the following configuration:
 

--- a/cookbook/email/spool.rst
+++ b/cookbook/email/spool.rst
@@ -55,10 +55,15 @@ swiftmailer with the memory option, use the following configuration:
             'spool' => array('type' => 'memory')
         ));
 
-Spool Using a File
+Spool Using Files
 ------------------
 
-In order to use the spool with a file, use the following configuration:
+When you use the filesystem for spooling, Symfony creates a folder in the given 
+path for each mail service (e.g. "default" for the default service). This folder
+will contain files for each email in the spool. So make sure this directory is 
+writable by symfony (or your webserver/php)!
+
+In order to use the spool with files, use the following configuration:
 
 .. configuration-block::
 
@@ -69,7 +74,7 @@ In order to use the spool with a file, use the following configuration:
             # ...
             spool:
                 type: file
-                path: /path/to/spool
+                path: /path/to/spooldir
 
     .. code-block:: xml
 
@@ -84,7 +89,7 @@ In order to use the spool with a file, use the following configuration:
             <swiftmailer:config>
                 <swiftmailer:spool
                     type="file"
-                    path="/path/to/spool"
+                    path="/path/to/spooldir"
                 />
             </swiftmailer:config>
         </container>
@@ -97,7 +102,7 @@ In order to use the spool with a file, use the following configuration:
 
             'spool' => array(
                 'type' => 'file',
-                'path' => '/path/to/spool',
+                'path' => '/path/to/spooldir',
             ),
         ));
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

The former explanation suggests that a single file is used for spooling, which is not the case of course. But I ran into that problem and since Symfony falls back to memory if the dir is not writable (as it seems) with no error message, this addition might help some people to get spools running.
