### PR TITLE
Fixed typo

### DIFF
--- a/cookbook/event_dispatcher/event_listener.rst
+++ b/cookbook/event_dispatcher/event_listener.rst
@@ -248,8 +248,10 @@ or a "sub request"::
 Certain things, like checking information on the *real* request, may not need to
 be done on the sub-request listeners.
 
+.. _events-or-subscribers:
+
 Listeners or Subscribers
----------------------
+------------------------
 
 Listeners and subscribers can be used in the same application indistinctly. The
 decision to use either of them is usually a matter of personal taste. However,

--- a/cookbook/event_dispatcher/event_listener.rst
+++ b/cookbook/event_dispatcher/event_listener.rst
@@ -248,7 +248,7 @@ or a "sub request"::
 Certain things, like checking information on the *real* request, may not need to
 be done on the sub-request listeners.
 
-Events or Subscribers
+Listeners or Subscribers
 ---------------------
 
 Listeners and subscribers can be used in the same application indistinctly. The


### PR DESCRIPTION
Comparing events to subscribers doesn't make much sense, so I figured it must be a typo.
