### PR TITLE
Fix doc for 2.6+, `server:start` replace `...:run`

### DIFF
--- a/cookbook/web_server/built_in.rst
+++ b/cookbook/web_server/built_in.rst
@@ -37,7 +37,7 @@ can change the socket passing an IP address and a port as a command-line argumen
 
 .. code-block:: bash
 
-    $ php app/console server:run 192.168.0.1:8080
+    $ php app/console server:start 192.168.0.1:8080
 
 .. note::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.6 |
| Fixed tickets | - |
