### PR TITLE
Fixed little typo with a twig example

### DIFF
--- a/cookbook/doctrine/registration_form.rst
+++ b/cookbook/doctrine/registration_form.rst
@@ -295,10 +295,10 @@ Next, create the template:
         {# app/Resources/views/registration/register.html.twig #}
 
         {{ form_start(form) }}
-            {{ form_row('form.username') }}
-            {{ form_row('form.email') }}
-            {{ form_row('form.plainPassword.first') }}
-            {{ form_row('form.plainPassword.second') }}
+            {{ form_row(form.username) }}
+            {{ form_row(form.email) }}
+            {{ form_row(form.plainPassword.first) }}
+            {{ form_row(form.plainPassword.second) }}
 
             <button type="submit">Register!</button>
         {{ form_end(form) }}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7 |

Was stuck with this throw:

```
 Twig_Error_Runtime: An exception has been thrown during the rendering of a template ("Catchable Fatal Error: Argument 1 passed to Symfony\Component\Form\FormRenderer::searchAndRenderBlock() must be an instance of Symfony\Component\Form\FormView, string given, called in....
```
