### PR TITLE
Update securing_services.rst

### DIFF
--- a/cookbook/security/securing_services.rst
+++ b/cookbook/security/securing_services.rst
@@ -234,7 +234,7 @@ documentation.
 
         .. code-block:: yaml
 
-            # app/config/services.yml
+            # app/config/config.yml
             jms_security_extra:
                 # ...
                 secure_all_services: true


### PR DESCRIPTION
I'm pretty sure the file mentioned in the last info box is `app/config/config.yml` and not `services.yml`;
there will probably be a similar issue in the other formats (XML and PHP) but I don't use them so I don't know for sure.

Also, it goes back all the way to the first version of the docs, for SF 2.3.
