### PR TITLE
Removed the use of ContainerAware class

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1397,25 +1397,14 @@ route. With this information, any URL can easily be generated::
 
 .. note::
 
-    In controllers that don't extend Symfony's base
-    :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller`,
-    you can use the ``router`` service's
-    :method:`Symfony\\Component\\Routing\\Router::generate` method::
+    The ``generateUrl()`` method defined in the base
+    :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller` class is
+    just a shortcut for this code::
 
-        use Symfony\Component\DependencyInjection\ContainerAware;
-
-        class MainController extends ContainerAware
-        {
-            public function showAction($slug)
-            {
-                // ...
-
-                $url = $this->container->get('router')->generate(
-                    'blog_show',
-                    array('slug' => 'my-blog-post')
-                );
-            }
-        }
+        $url = $this->container->get('router')->generate(
+            'blog_show',
+            array('slug' => 'my-blog-post')
+        );
 
 In an upcoming section, you'll learn how to generate URLs from inside templates.
 

--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -416,24 +416,25 @@ it with :ref:`dic-tags-form-type`.
             array('security.context')
         );
 
-If you wish to create it from within a controller or any other service that has
-access to the form factory, you then use::
+If you wish to create it from within a service that has access to the form factory,
+you then use::
 
-    use Symfony\Component\DependencyInjection\ContainerAware;
+    $form = $formFactory->create('friend_message');
 
-    class FriendMessageController extends ContainerAware
+In a controller that extends the :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller`
+class, you can simply call::
+
+    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+    class FriendMessageController extends Controller
     {
         public function newAction(Request $request)
         {
-            $form = $this->get('form.factory')->create('friend_message');
+            $form = $this->createForm('friend_message');
 
             // ...
         }
     }
-
-If you extend the ``Symfony\Bundle\FrameworkBundle\Controller\Controller`` class, you can simply call::
-
-    $form = $this->createForm('friend_message');
 
 You can also easily embed the form type into another form::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #5884 |

Removing the use of `ContainerAware` in these examples required a heavy rewording. Please, review them. Thanks!
