### PR TITLE
Always use "main" as the default firewall name (to match Symfony Standard Edition)

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -216,7 +216,7 @@ the username and then check the password (more on passwords in a moment):
                         # manager_name: customer
 
             firewalls:
-                default:
+                main:
                     pattern:    ^/
                     http_basic: ~
                     provider: our_db_provider
@@ -244,7 +244,7 @@ the username and then check the password (more on passwords in a moment):
                     <entity class="AppBundle:User" property="username" />
                 </provider>
 
-                <firewall name="default" pattern="^/" provider="our_db_provider">
+                <firewall name="main" pattern="^/" provider="our_db_provider">
                     <http-basic />
                 </firewall>
 
@@ -273,7 +273,7 @@ the username and then check the password (more on passwords in a moment):
                 ),
             ),
             'firewalls' => array(
-                'default' => array(
+                'main' => array(
                     'pattern'    => '^/',
                     'http_basic' => null,
                     'provider'   => 'our_db_provider',

--- a/cookbook/security/form_login_setup.rst
+++ b/cookbook/security/form_login_setup.rst
@@ -27,7 +27,7 @@ First, enable form login under your firewall:
             # ...
 
             firewalls:
-                default:
+                main:
                     anonymous: ~
                     http_basic: ~
                     form_login:
@@ -45,7 +45,7 @@ First, enable form login under your firewall:
                 http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <config>
-                <firewall name="default">
+                <firewall name="main">
                     <anonymous />
                     <http-basic />
                     <form-login login-path="/login" check-path="/login_check" />
@@ -58,7 +58,7 @@ First, enable form login under your firewall:
         // app/config/security.php
         $container->loadFromExtension('security', array(
             'firewalls' => array(
-                'default' => array(
+                'main' => array(
                     'anonymous'  => null,
                     'http_basic' => null,
                     'form_login' => array(

--- a/cookbook/security/remember_me.rst
+++ b/cookbook/security/remember_me.rst
@@ -19,7 +19,7 @@ the session lasts using a cookie with the ``remember_me`` firewall option:
             # ...
 
             firewalls:
-                default:
+                main:
                     # ...
                     remember_me:
                         key:      "%secret%"
@@ -43,7 +43,7 @@ the session lasts using a cookie with the ``remember_me`` firewall option:
             <config>
                 <!-- ... -->
 
-                <firewall name="default">
+                <firewall name="main">
                     <!-- ... -->
 
                     <!-- 604800 is 1 week in seconds -->
@@ -65,7 +65,7 @@ the session lasts using a cookie with the ``remember_me`` firewall option:
             // ...
 
             'firewalls' => array(
-                'default' => array(
+                'main' => array(
                     // ...
                     'remember_me' => array(
                         'key'      => '%secret%',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #5878 |
