### PR TITLE
[Book][Templating] Update absolute URL asset to match 2.7

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1098,7 +1098,7 @@ if you are using Twig (or the third argument if you are using PHP) to ``true``:
 
     .. code-block:: html+jinja
 
-        <img src="{{ asset('images/logo.png', absolute=true) }}" alt="Symfony!" />
+        <img src="{{ absolute_url(asset('images/logo.png')) }}" alt="Symfony!" />
 
     .. code-block:: html+php
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7+ |
| Fixed tickets | N/A |

As mentionned in http://symfony.com/blog/new-in-symfony-2-7-the-new-asset-component, the Right Way:tm: to generate absolute url assets is now through `absolute_url(assset(...))`...
