### PR TITLE
Fixed some wrong line number references in doctrine.rst

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -534,10 +534,10 @@ Take a look at the previous example in more detail:
   responsible for handling the process of persisting and fetching objects
   to and from the database.
 
-* **line 16** The ``persist()`` method tells Doctrine to "manage" the ``$product``
+* **line 17** The ``persist()`` method tells Doctrine to "manage" the ``$product``
   object. This does not actually cause a query to be made to the database (yet).
 
-* **line 17** When the ``flush()`` method is called, Doctrine looks through
+* **line 18** When the ``flush()`` method is called, Doctrine looks through
   all of the objects that it's managing to see if they need to be persisted
   to the database. In this example, the ``$product`` object has not been
   persisted yet, so the entity manager executes an ``INSERT`` query and a


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | none |

Some line numbers for the code example in section "Persisting Objects to the Database" were wrong.
