### PR TITLE
Update php_soap_extension.rst

### DIFF
--- a/cookbook/web_services/php_soap_extension.rst
+++ b/cookbook/web_services/php_soap_extension.rst
@@ -124,7 +124,7 @@ Below is an example calling the service using a `NuSOAP`_ client. This example
 assumes that the ``indexAction`` in the controller above is accessible via the
 route ``/soap``::
 
-    $client = new \Soapclient('http://example.com/app.php/soap?wsdl', true);
+    $client = new \Soapclient('http://example.com/app.php/soap?wsdl');
 
     $result = $client->call('hello', array('name' => 'Scott'));
 


### PR DESCRIPTION
 I think 
$client = new \Soapclient('http://example.com/app.php/soap?wsdl', true); 
doesn't accept "true" as a default second parameter anymore
