### PR TITLE
Updated csrf_in_login_form.rst to include new labels

### DIFF
--- a/cookbook/security/csrf_in_login_form.rst
+++ b/cookbook/security/csrf_in_login_form.rst
@@ -182,7 +182,7 @@ After this, you have protected your login form against CSRF attacks.
                 ),
             ));
 
-versionadded:: 2.8
+.. versionadded:: 2.8
     The ``intention`` and ``csrf_token_generator`` options were introduced
     in Symfony 2.8. Prior, you had to use the ``csrf_token_id`` and ``csrf_provider``
     options.

--- a/cookbook/security/csrf_in_login_form.rst
+++ b/cookbook/security/csrf_in_login_form.rst
@@ -13,6 +13,10 @@ for CSRF. In this article you'll learn how you can use it in your login form.
     Login CSRF attacks are a bit less well-known. See `Forging Login Requests`_
     if you're curious about more details.
 
+.. note::
+
+    Since SF 2.8 ``intention`` has been depreciated, and removed in SF 3.0. It is now labeled as ``csrf_token_id``. ``csrf_provider`` was changed in SF 3.0 to ``csrf_token_generator``.
+    
 Configuring CSRF Protection
 ---------------------------
 
@@ -33,7 +37,9 @@ provider available in the Security component:
                     # ...
                     form_login:
                         # ...
-                        csrf_provider: security.csrf.token_manager
+                        # Use csrf_provider in SF <2.8
+                        # csrf_provider: security.csrf.token_manager
+                        csrf_token_generator: security.csrf.token_manager
 
     .. code-block:: xml
 
@@ -66,7 +72,9 @@ provider available in the Security component:
                     // ...
                     'form_login' => array(
                         // ...
-                        'csrf_provider' => 'security.csrf.token_manager',
+                        // Use csrf_provider in SF <2.8
+                        // 'csrf_provider' => 'security.csrf.token_manager',
+                        'csrf_token_generator' => 'security.csrf.token_manager',
                     ),
                 ),
             ),
@@ -124,7 +132,7 @@ After this, you have protected your login form against CSRF attacks.
 .. tip::
 
     You can change the name of the field by setting ``csrf_parameter`` and change
-    the token ID by setting ``intention`` in your configuration:
+    the token ID by setting  ``csrf_token_id`` ~~``intention``~~ in your configuration:
 
     .. configuration-block::
 
@@ -140,7 +148,8 @@ After this, you have protected your login form against CSRF attacks.
                         form_login:
                             # ...
                             csrf_parameter: _csrf_security_token
-                            intention: a_private_string
+                            # intention: a_private_string
+                            csrf_token_id: a_private_string
 
         .. code-block:: xml
 
@@ -158,7 +167,8 @@ After this, you have protected your login form against CSRF attacks.
                     <firewall name="secured_area">
                         <!-- ... -->
                         <form-login csrf-parameter="_csrf_security_token"
-                            intention="a_private_string"
+                            <!-- intention="a_private_string" -->
+                                 csrf_token_id="a_private_string"
                         />
                     </firewall>
                 </config>
@@ -176,7 +186,8 @@ After this, you have protected your login form against CSRF attacks.
                         'form_login' => array(
                             // ...
                             'csrf_parameter' => '_csrf_security_token',
-                            'intention'      => 'a_private_string',
+                            'csrf_token_id'     => 'a_private_string'
+                            // 'intention'      => 'a_private_string',
                         ),
                     ),
                 ),

--- a/cookbook/security/csrf_in_login_form.rst
+++ b/cookbook/security/csrf_in_login_form.rst
@@ -13,10 +13,6 @@ for CSRF. In this article you'll learn how you can use it in your login form.
     Login CSRF attacks are a bit less well-known. See `Forging Login Requests`_
     if you're curious about more details.
 
-.. note::
-
-    Since SF 2.8 ``intention`` has been depreciated, and removed in SF 3.0. It is now labeled as ``csrf_token_id``. ``csrf_provider`` was changed in SF 3.0 to ``csrf_token_generator``.
-    
 Configuring CSRF Protection
 ---------------------------
 
@@ -37,8 +33,6 @@ provider available in the Security component:
                     # ...
                     form_login:
                         # ...
-                        # Use csrf_provider in SF <2.8
-                        # csrf_provider: security.csrf.token_manager
                         csrf_token_generator: security.csrf.token_manager
 
     .. code-block:: xml
@@ -72,8 +66,6 @@ provider available in the Security component:
                     // ...
                     'form_login' => array(
                         // ...
-                        // Use csrf_provider in SF <2.8
-                        // 'csrf_provider' => 'security.csrf.token_manager',
                         'csrf_token_generator' => 'security.csrf.token_manager',
                     ),
                 ),
@@ -132,7 +124,7 @@ After this, you have protected your login form against CSRF attacks.
 .. tip::
 
     You can change the name of the field by setting ``csrf_parameter`` and change
-    the token ID by setting  ``csrf_token_id`` ~~``intention``~~ in your configuration:
+    the token ID by setting  ``csrf_token_id`` in your configuration:
 
     .. configuration-block::
 
@@ -148,7 +140,6 @@ After this, you have protected your login form against CSRF attacks.
                         form_login:
                             # ...
                             csrf_parameter: _csrf_security_token
-                            # intention: a_private_string
                             csrf_token_id: a_private_string
 
         .. code-block:: xml
@@ -167,7 +158,6 @@ After this, you have protected your login form against CSRF attacks.
                     <firewall name="secured_area">
                         <!-- ... -->
                         <form-login csrf-parameter="_csrf_security_token"
-                            <!-- intention="a_private_string" -->
                                  csrf_token_id="a_private_string"
                         />
                     </firewall>
@@ -187,11 +177,15 @@ After this, you have protected your login form against CSRF attacks.
                             // ...
                             'csrf_parameter' => '_csrf_security_token',
                             'csrf_token_id'     => 'a_private_string'
-                            // 'intention'      => 'a_private_string',
                         ),
                     ),
                 ),
             ));
+
+versionadded:: 2.8
+    The ``intention`` and ``csrf_token_generator`` options were introduced
+    in Symfony 2.8. Prior, you had to use the ``csrf_token_id`` and ``csrf_provider``
+    options.
 
 .. _`Cross-site request forgery`: https://en.wikipedia.org/wiki/Cross-site_request_forgery
 .. _`Forging Login Requests`: https://en.wikipedia.org/wiki/Cross-site_request_forgery#Forging_login_requests


### PR DESCRIPTION
Updated CSRF documentation to rename intention and csrf_provider. They were renamed in SF 3.0 to csrf_token_id and csrf_token_generator. In SF 2.8 intention is depreciated and in SF 2.8 csrf_provider is still being used.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 3.0 |
| Fixed tickets | #3059 |
