### PR TITLE
Add tip for when returning `null` from `createToken()`

### DIFF
--- a/cookbook/security/api_key_authentication.rst
+++ b/cookbook/security/api_key_authentication.rst
@@ -128,6 +128,11 @@ will cause authentication to fail. You might want to return ``null`` instead
 to just skip the authentication, so Symfony can fallback to another authentication
 method, if any.
 
+.. caution::
+
+    In case you return ``null`` from your ``createToken()`` method, be sure to enable
+    ``anonymous`` in you firewall. This way you'll be able to get an ``AnonymousToken``.
+
 2. supportsToken
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #5264 |
