### PR TITLE
Remove deprecated StringUtils from WSSE custom auth provider

### DIFF
--- a/components/security/secure_tools.rst
+++ b/components/security/secure_tools.rst
@@ -1,25 +1,9 @@
-Securely Comparing Strings and Generating Random Numbers
-========================================================
+Securely Generating Random Numbers
+==================================
 
 The Symfony Security component comes with a collection of nice utilities
 related to security. These utilities are used by Symfony, but you should
 also use them if you want to solve the problem they address.
-
-Comparing Strings
-~~~~~~~~~~~~~~~~~
-
-The time it takes to compare two strings depends on their differences. This
-can be used by an attacker when the two strings represent a password for
-instance; it is known as a `Timing attack`_.
-
-Internally, when comparing two passwords, Symfony uses a constant-time
-algorithm; you can use the same strategy in your own code thanks to the
-:class:`Symfony\\Component\\Security\\Core\\Util\\StringUtils` class::
-
-    use Symfony\Component\Security\Core\Util\StringUtils;
-
-    // is some known string (e.g. password) equal to some user input?
-    $bool = StringUtils::equals($knownString, $userInput);
 
 Generating a Secure random Number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -214,7 +214,6 @@ the ``PasswordDigest`` header value matches with the user's password.
     use Symfony\Component\Security\Core\Exception\NonceExpiredException;
     use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
     use AppBundle\Security\Authentication\Token\WsseUserToken;
-    use Symfony\Component\Security\Core\Util\StringUtils;
 
     class WsseProvider implements AuthenticationProviderInterface
     {
@@ -273,7 +272,7 @@ the ``PasswordDigest`` header value matches with the user's password.
             // Validate Secret
             $expected = base64_encode(sha1(base64_decode($nonce).$created.$secret, true));
 
-            return StringUtils::equals($expected, $digest);
+            return hash_equals($expected, $digest);
         }
 
         public function supports(TokenInterface $token)
@@ -289,14 +288,6 @@ the ``PasswordDigest`` header value matches with the user's password.
     method, which tells the authentication manager whether or not to use this
     provider for the given token. In the case of multiple providers, the
     authentication manager will then move to the next provider in the list.
-
-.. note::
-
-    The comparison of the expected and the provided digests uses a constant
-    time comparison provided by the
-    :method:`Symfony\\Component\\Security\\Core\\Util\\StringUtils::equals`
-    method of the ``StringUtils`` class. It is used to mitigate possible
-    `timing attacks`_.
 
 The Factory
 -----------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | >=2.8 |
| Fixed tickets | N/A |
