### PR TITLE
Remove isSubmitted call

### DIFF
--- a/cookbook/doctrine/registration_form.rst
+++ b/cookbook/doctrine/registration_form.rst
@@ -220,7 +220,7 @@ controller for displaying the registration form::
 
             // 2) handle the submit (will only happen on POST)
             $form->handleRequest($request);
-            if ($form->isValid() && $form->isSubmitted()) {
+            if ($form->isValid()) {
                 // 3) Encode the password (you could also do this via Doctrine listener)
                 $password = $this->get('security.password_encoder')
                     ->encodePassword($user, $user->getPlainPassword());

--- a/cookbook/doctrine/registration_form.rst
+++ b/cookbook/doctrine/registration_form.rst
@@ -220,7 +220,7 @@ controller for displaying the registration form::
 
             // 2) handle the submit (will only happen on POST)
             $form->handleRequest($request);
-            if ($form->isValid()) {
+            if ($form->isSubmitted() && $form->isValid()) {
                 // 3) Encode the password (you could also do this via Doctrine listener)
                 $password = $this->get('security.password_encoder')
                     ->encodePassword($user, $user->getPlainPassword());


### PR DESCRIPTION
Streamline with http://symfony.com/doc/current/book/forms.html#handling-form-submissions
There is no need for `isSubmitted` as this is done inside `isValid`
