### PR TITLE
Added caution notes about the removal of AsseticBundle in 2.8/3.0

### DIFF
--- a/best_practices/web-assets.rst
+++ b/best_practices/web-assets.rst
@@ -35,6 +35,16 @@ much more concise:
 Using Assetic
 -------------
 
+.. caution::
+
+    Starting from Symfony 2.8, Assetic is no longer included by default in the
+    Symfony Standard Edition. Before using any of its features, install the
+    AsseticBundle executing this command command in your project:
+
+    .. code-block:: cli
+
+        $ composer install symfony/assetic-bundle
+
 These days, you probably can't simply create static CSS and JavaScript files
 and include them in your template. Instead, you'll probably want to combine
 and minify these to improve client-side performance. You may also want to

--- a/best_practices/web-assets.rst
+++ b/best_practices/web-assets.rst
@@ -38,12 +38,8 @@ Using Assetic
 .. caution::
 
     Starting from Symfony 2.8, Assetic is no longer included by default in the
-    Symfony Standard Edition. Before using any of its features, install the
-    AsseticBundle executing this command command in your project:
-
-    .. code-block:: cli
-
-        $ composer install symfony/assetic-bundle
+    Symfony Standard Edition. Refer to :doc:`this article </cookbook/assetic/asset_management>`
+    to learn how to install and enable Assetic in your Symfony application.
 
 These days, you probably can't simply create static CSS and JavaScript files
 and include them in your template. Instead, you'll probably want to combine

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1130,9 +1130,9 @@ advantage of Symfony's template inheritance.
 .. tip::
 
     This section will teach you the philosophy behind including stylesheet
-    and JavaScript assets in Symfony. Symfony also packages another library,
-    called Assetic, which follows this philosophy but allows you to do much
-    more interesting things with those assets. For more information on
+    and JavaScript assets in Symfony. Symfony is also compatible with another
+    library, called Assetic, which follows this philosophy but allows you to do
+    much more interesting things with those assets. For more information on
     using Assetic see :doc:`/cookbook/assetic/asset_management`.
 
 Start by adding two blocks to your base template that will hold your assets:

--- a/cookbook/assetic/apply_to_option.rst
+++ b/cookbook/assetic/apply_to_option.rst
@@ -7,12 +7,8 @@ How to Apply an Assetic Filter to a specific File Extension
 .. caution::
 
     Starting from Symfony 2.8, Assetic is no longer included by default in the
-    Symfony Standard Edition. Before using any of its features, install the
-    AsseticBundle executing this command command in your project:
-
-    .. code-block:: cli
-
-        $ composer install symfony/assetic-bundle
+    Symfony Standard Edition. Refer to :doc:`this article </cookbook/assetic/asset_management>`
+    to learn how to install and enable Assetic in your Symfony application.
 
 Assetic filters can be applied to individual files, groups of files or even,
 as you'll see here, files that have a specific extension. To show you how

--- a/cookbook/assetic/apply_to_option.rst
+++ b/cookbook/assetic/apply_to_option.rst
@@ -4,6 +4,16 @@
 How to Apply an Assetic Filter to a specific File Extension
 ===========================================================
 
+.. caution::
+
+    Starting from Symfony 2.8, Assetic is no longer included by default in the
+    Symfony Standard Edition. Before using any of its features, install the
+    AsseticBundle executing this command command in your project:
+
+    .. code-block:: cli
+
+        $ composer install symfony/assetic-bundle
+
 Assetic filters can be applied to individual files, groups of files or even,
 as you'll see here, files that have a specific extension. To show you how
 to handle each option, suppose that you want to use Assetic's CoffeeScript

--- a/cookbook/assetic/asset_management.rst
+++ b/cookbook/assetic/asset_management.rst
@@ -4,6 +4,16 @@
 How to Use Assetic for Asset Management
 =======================================
 
+.. caution::
+
+    Starting from Symfony 2.8, Assetic is no longer included by default in the
+    Symfony Standard Edition. Before using any of its features, install the
+    AsseticBundle executing this command command in your project:
+
+    .. code-block:: cli
+
+        $ composer install symfony/assetic-bundle
+
 Assetic combines two major ideas: :ref:`assets <cookbook-assetic-assets>` and
 :ref:`filters <cookbook-assetic-filters>`. The assets are files such as CSS,
 JavaScript and image files. The filters are things that can be applied to

--- a/cookbook/assetic/asset_management.rst
+++ b/cookbook/assetic/asset_management.rst
@@ -10,9 +10,60 @@ How to Use Assetic for Asset Management
     Symfony Standard Edition. Before using any of its features, install the
     AsseticBundle executing this command command in your project:
 
-    .. code-block:: cli
+    .. code-block:: bash
 
-        $ composer install symfony/assetic-bundle
+        $ composer require symfony/assetic-bundle
+
+    Then, enable the bundle by adding the following configuration under the
+    ``asetic`` key:
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # app/config/config.yml
+            assetic:
+                debug:          "%kernel.debug%"
+                use_controller: false
+                filters:
+                    cssrewrite: ~
+
+            # ...
+
+        .. code-block:: xml
+
+            <!-- app/config/config.xml -->
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <container xmlns="http://symfony.com/schema/dic/services"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:framework="http://symfony.com/schema/dic/symfony"
+                xmlns:twig="http://symfony.com/schema/dic/twig"
+                xsi:schemaLocation="http://symfony.com/schema/dic/services
+                    http://symfony.com/schema/dic/services/services-1.0.xsd
+                    http://symfony.com/schema/dic/symfony
+                    http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+                <assetic:config debug="%kernel.debug%" use-controller="%kernel.debug%">
+                    <assetic:filters cssrewrite="null" />
+                </assetic:config>
+
+                <!-- ... -->
+            </container>
+
+        .. code-block:: php
+
+            // app/config/config.php
+
+            $container->loadFromExtension('assetic', array(
+                'debug' => '%kernel.debug%',
+                'use_controller' => '%kernel.debug%',
+                'filters' => array(
+                    'cssrewrite' => null,
+                ),
+                // ...
+            ));
+
+            // ...
 
 Assetic combines two major ideas: :ref:`assets <cookbook-assetic-assets>` and
 :ref:`filters <cookbook-assetic-filters>`. The assets are files such as CSS,

--- a/cookbook/assetic/asset_management.rst
+++ b/cookbook/assetic/asset_management.rst
@@ -8,7 +8,7 @@ How to Use Assetic for Asset Management
 
     Starting from Symfony 2.8, Assetic is no longer included by default in the
     Symfony Standard Edition. Before using any of its features, install the
-    AsseticBundle executing this command command in your project:
+    AsseticBundle executing this console command in your project:
 
     .. code-block:: bash
 

--- a/cookbook/assetic/asset_management.rst
+++ b/cookbook/assetic/asset_management.rst
@@ -4,66 +4,90 @@
 How to Use Assetic for Asset Management
 =======================================
 
-.. caution::
+Installing and Enabling Assetic
+-------------------------------
 
-    Starting from Symfony 2.8, Assetic is no longer included by default in the
-    Symfony Standard Edition. Before using any of its features, install the
-    AsseticBundle executing this console command in your project:
+Starting from Symfony 2.8, Assetic is no longer included by default in the
+Symfony Standard Edition. Before using any of its features, install the
+AsseticBundle executing this console command in your project:
 
     .. code-block:: bash
 
         $ composer require symfony/assetic-bundle
 
-    Then, enable the bundle by adding the following configuration under the
-    ``asetic`` key:
+Then, enable the bundle in the ``AppKernel`` file of your Symfony application::
 
-    .. configuration-block::
+    // app/AppKernel.php
 
-        .. code-block:: yaml
+    // ...
+    class AppKernel extends Kernel
+    {
+        // ...
 
-            # app/config/config.yml
-            assetic:
-                debug:          "%kernel.debug%"
-                use_controller: false
-                filters:
-                    cssrewrite: ~
-
-            # ...
-
-        .. code-block:: xml
-
-            <!-- app/config/config.xml -->
-            <?xml version="1.0" encoding="UTF-8" ?>
-            <container xmlns="http://symfony.com/schema/dic/services"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xmlns:framework="http://symfony.com/schema/dic/symfony"
-                xmlns:twig="http://symfony.com/schema/dic/twig"
-                xsi:schemaLocation="http://symfony.com/schema/dic/services
-                    http://symfony.com/schema/dic/services/services-1.0.xsd
-                    http://symfony.com/schema/dic/symfony
-                    http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
-                <assetic:config debug="%kernel.debug%" use-controller="%kernel.debug%">
-                    <assetic:filters cssrewrite="null" />
-                </assetic:config>
-
-                <!-- ... -->
-            </container>
-
-        .. code-block:: php
-
-            // app/config/config.php
-
-            $container->loadFromExtension('assetic', array(
-                'debug' => '%kernel.debug%',
-                'use_controller' => '%kernel.debug%',
-                'filters' => array(
-                    'cssrewrite' => null,
-                ),
+        public function registerBundles()
+        {
+            $bundles = array(
                 // ...
-            ));
+                new Symfony\Bundle\AsseticBundle\AsseticBundle(),
+            );
 
             // ...
+        }
+    }
+
+Finally, add the following minimal configuration to enable Assetic support in
+your application:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        assetic:
+            debug:          "%kernel.debug%"
+            use_controller: false
+            filters:
+                cssrewrite: ~
+
+        # ...
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xmlns:twig="http://symfony.com/schema/dic/twig"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony
+                http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+            <assetic:config debug="%kernel.debug%" use-controller="%kernel.debug%">
+                <assetic:filters cssrewrite="null" />
+            </assetic:config>
+
+            <!-- ... -->
+        </container>
+
+    .. code-block:: php
+
+        // app/config/config.php
+
+        $container->loadFromExtension('assetic', array(
+            'debug' => '%kernel.debug%',
+            'use_controller' => '%kernel.debug%',
+            'filters' => array(
+                'cssrewrite' => null,
+            ),
+            // ...
+        ));
+
+        // ...
+
+Introducing Assetic
+-------------------
 
 Assetic combines two major ideas: :ref:`assets <cookbook-assetic-assets>` and
 :ref:`filters <cookbook-assetic-filters>`. The assets are files such as CSS,

--- a/cookbook/assetic/index.rst
+++ b/cookbook/assetic/index.rst
@@ -1,6 +1,16 @@
 Assetic
 =======
 
+.. caution::
+
+    Starting from Symfony 2.8, Assetic is no longer included by default in the
+    Symfony Standard Edition. Before using any of its features, install the
+    AsseticBundle executing this command command in your project:
+
+    .. code-block:: cli
+
+        $ composer install symfony/assetic-bundle
+
 .. toctree::
     :maxdepth: 2
 

--- a/cookbook/assetic/index.rst
+++ b/cookbook/assetic/index.rst
@@ -4,12 +4,8 @@ Assetic
 .. caution::
 
     Starting from Symfony 2.8, Assetic is no longer included by default in the
-    Symfony Standard Edition. Before using any of its features, install the
-    AsseticBundle executing this command command in your project:
-
-    .. code-block:: cli
-
-        $ composer install symfony/assetic-bundle
+    Symfony Standard Edition. Refer to :doc:`this article </cookbook/assetic/asset_management>`
+    to learn how to install and enable Assetic in your Symfony application.
 
 .. toctree::
     :maxdepth: 2

--- a/cookbook/assetic/jpeg_optimize.rst
+++ b/cookbook/assetic/jpeg_optimize.rst
@@ -4,6 +4,16 @@
 How to Use Assetic for Image Optimization with Twig Functions
 =============================================================
 
+.. caution::
+
+    Starting from Symfony 2.8, Assetic is no longer included by default in the
+    Symfony Standard Edition. Before using any of its features, install the
+    AsseticBundle executing this command command in your project:
+
+    .. code-block:: cli
+
+        $ composer install symfony/assetic-bundle
+
 Among its many filters, Assetic has four filters which can be used for on-the-fly
 image optimization. This allows you to get the benefits of smaller file sizes
 without having to use an image editor to process each image. The results

--- a/cookbook/assetic/jpeg_optimize.rst
+++ b/cookbook/assetic/jpeg_optimize.rst
@@ -7,12 +7,8 @@ How to Use Assetic for Image Optimization with Twig Functions
 .. caution::
 
     Starting from Symfony 2.8, Assetic is no longer included by default in the
-    Symfony Standard Edition. Before using any of its features, install the
-    AsseticBundle executing this command command in your project:
-
-    .. code-block:: cli
-
-        $ composer install symfony/assetic-bundle
+    Symfony Standard Edition. Refer to :doc:`this article </cookbook/assetic/asset_management>`
+    to learn how to install and enable Assetic in your Symfony application.
 
 Among its many filters, Assetic has four filters which can be used for on-the-fly
 image optimization. This allows you to get the benefits of smaller file sizes

--- a/cookbook/assetic/php.rst
+++ b/cookbook/assetic/php.rst
@@ -7,12 +7,8 @@ Combining, Compiling and Minimizing Web Assets with PHP Libraries
 .. caution::
 
     Starting from Symfony 2.8, Assetic is no longer included by default in the
-    Symfony Standard Edition. Before using any of its features, install the
-    AsseticBundle executing this command command in your project:
-
-    .. code-block:: cli
-
-        $ composer install symfony/assetic-bundle
+    Symfony Standard Edition. Refer to :doc:`this article </cookbook/assetic/asset_management>`
+    to learn how to install and enable Assetic in your Symfony application.
 
 The official Symfony Best Practices recommend to use Assetic to
 :doc:`manage web assets </best_practices/web-assets>`, unless you are

--- a/cookbook/assetic/php.rst
+++ b/cookbook/assetic/php.rst
@@ -4,6 +4,16 @@
 Combining, Compiling and Minimizing Web Assets with PHP Libraries
 =================================================================
 
+.. caution::
+
+    Starting from Symfony 2.8, Assetic is no longer included by default in the
+    Symfony Standard Edition. Before using any of its features, install the
+    AsseticBundle executing this command command in your project:
+
+    .. code-block:: cli
+
+        $ composer install symfony/assetic-bundle
+
 The official Symfony Best Practices recommend to use Assetic to
 :doc:`manage web assets </best_practices/web-assets>`, unless you are
 comfortable with JavaScript-based front-end tools.

--- a/cookbook/assetic/uglifyjs.rst
+++ b/cookbook/assetic/uglifyjs.rst
@@ -4,6 +4,16 @@
 How to Minify CSS/JS Files (Using UglifyJS and UglifyCSS)
 =========================================================
 
+.. caution::
+
+    Starting from Symfony 2.8, Assetic is no longer included by default in the
+    Symfony Standard Edition. Before using any of its features, install the
+    AsseticBundle executing this command command in your project:
+
+    .. code-block:: cli
+
+        $ composer install symfony/assetic-bundle
+
 `UglifyJS`_ is a JavaScript parser/compressor/beautifier toolkit. It can be used
 to combine and minify JavaScript assets so that they require less HTTP requests
 and make your site load faster. `UglifyCSS`_ is a CSS compressor/beautifier

--- a/cookbook/assetic/uglifyjs.rst
+++ b/cookbook/assetic/uglifyjs.rst
@@ -7,12 +7,8 @@ How to Minify CSS/JS Files (Using UglifyJS and UglifyCSS)
 .. caution::
 
     Starting from Symfony 2.8, Assetic is no longer included by default in the
-    Symfony Standard Edition. Before using any of its features, install the
-    AsseticBundle executing this command command in your project:
-
-    .. code-block:: cli
-
-        $ composer install symfony/assetic-bundle
+    Symfony Standard Edition. Refer to :doc:`this article </cookbook/assetic/asset_management>`
+    to learn how to install and enable Assetic in your Symfony application.
 
 `UglifyJS`_ is a JavaScript parser/compressor/beautifier toolkit. It can be used
 to combine and minify JavaScript assets so that they require less HTTP requests

--- a/cookbook/assetic/yuicompressor.rst
+++ b/cookbook/assetic/yuicompressor.rst
@@ -10,6 +10,16 @@ How to Minify JavaScripts and Stylesheets with YUI Compressor
     **strongly advised to avoid using YUI utilities** unless strictly necessary.
     Read :doc:`/cookbook/assetic/uglifyjs` for a modern and up-to-date alternative.
 
+.. caution::
+
+    Starting from Symfony 2.8, Assetic is no longer included by default in the
+    Symfony Standard Edition. Before using any of its features, install the
+    AsseticBundle executing this command command in your project:
+
+    .. code-block:: cli
+
+        $ composer install symfony/assetic-bundle
+
 Yahoo! provides an excellent utility for minifying JavaScripts and stylesheets
 so they travel over the wire faster, the `YUI Compressor`_. Thanks to Assetic,
 you can take advantage of this tool very easily.

--- a/cookbook/assetic/yuicompressor.rst
+++ b/cookbook/assetic/yuicompressor.rst
@@ -13,12 +13,8 @@ How to Minify JavaScripts and Stylesheets with YUI Compressor
 .. caution::
 
     Starting from Symfony 2.8, Assetic is no longer included by default in the
-    Symfony Standard Edition. Before using any of its features, install the
-    AsseticBundle executing this command command in your project:
-
-    .. code-block:: cli
-
-        $ composer install symfony/assetic-bundle
+    Symfony Standard Edition. Refer to :doc:`this article </cookbook/assetic/asset_management>`
+    to learn how to install and enable Assetic in your Symfony application.
 
 Yahoo! provides an excellent utility for minifying JavaScripts and stylesheets
 so they travel over the wire faster, the `YUI Compressor`_. Thanks to Assetic,

--- a/reference/configuration/assetic.rst
+++ b/reference/configuration/assetic.rst
@@ -4,6 +4,16 @@
 AsseticBundle Configuration ("assetic")
 =======================================
 
+.. caution::
+
+    Starting from Symfony 2.8, Assetic is no longer included by default in the
+    Symfony Standard Edition. Before using any of its features, install the
+    AsseticBundle executing this command command in your project:
+
+    .. code-block:: cli
+
+        $ composer install symfony/assetic-bundle
+
 Full Default Configuration
 --------------------------
 

--- a/reference/configuration/assetic.rst
+++ b/reference/configuration/assetic.rst
@@ -7,12 +7,8 @@ AsseticBundle Configuration ("assetic")
 .. caution::
 
     Starting from Symfony 2.8, Assetic is no longer included by default in the
-    Symfony Standard Edition. Before using any of its features, install the
-    AsseticBundle executing this command command in your project:
-
-    .. code-block:: cli
-
-        $ composer install symfony/assetic-bundle
+    Symfony Standard Edition. Refer to :doc:`this article </cookbook/assetic/asset_management>`
+    to learn how to install and enable Assetic in your Symfony application.
 
 Full Default Configuration
 --------------------------

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -739,10 +739,7 @@ Those bundles can have other Twig extensions:
 
 * **Twig Extensions** includes some interesting extensions that do not belong
   to the Twig core. You can read more in `the official Twig Extensions
-  documentation`_;
-* **Assetic** adds the ``{% stylesheets %}``, ``{% javascripts %}`` and
-  ``{% image %}`` tags. You can read more about them in
-  :doc:`the Assetic Documentation </cookbook/assetic/asset_management>`.
+  documentation`_.
 
 .. _`Twig Reference`: http://twig.sensiolabs.org/documentation#reference
 .. _`the official Twig Extensions documentation`: http://twig.sensiolabs.org/doc/extensions/index.html


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8, 3.0 |
| Fixed tickets | https://github.com/symfony/symfony-docs/issues/5986 |

As expected, the removal of AsseticBundle is causing confusion among Symfony users. See for example http://stackoverflow.com/questions/34105114/assetic-not-found-in-symfony-2-8-and-3-0/34105138

This PR adds a lot of caution notes about AseticBundle removal and how to fix this issue.
