### PR TITLE
RequestStack parameter is required since 3.0

### DIFF
--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -616,6 +616,7 @@ However, the HttpKernel component comes with some built-in listeners and
 a built-in ControllerResolver that can be used to create a working example::
 
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HttpFoundation\RequestStack;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\HttpKernel;
     use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -641,7 +642,7 @@ a built-in ControllerResolver that can be used to create a working example::
     $matcher = new UrlMatcher($routes, new RequestContext());
 
     $dispatcher = new EventDispatcher();
-    $dispatcher->addSubscriber(new RouterListener($matcher));
+    $dispatcher->addSubscriber(new RouterListener($matcher, new RequestStack()));
 
     $resolver = new ControllerResolver();
     $kernel = new HttpKernel($dispatcher, $resolver);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 3.0 |
| Fixed tickets | N/A |
