### PR TITLE
Replace 'filters' by 'formatters'

### DIFF
--- a/components/dependency_injection/configurators.rst
+++ b/components/dependency_injection/configurators.rst
@@ -114,9 +114,9 @@ to create a configurator class to configure these instances::
         // ...
     }
 
-The ``EmailConfigurator``'s job is to inject the enabled filters into ``NewsletterManager``
+The ``EmailConfigurator``'s job is to inject the enabled formatters into ``NewsletterManager``
 and ``GreetingCardManager`` because they are not aware of where the enabled
-filters come from. In the other hand, the ``EmailFormatterManager`` holds
+formatters come from. In the other hand, the ``EmailFormatterManager`` holds
 the knowledge about the enabled formatters and how to load them, keeping
 the single responsibility principle.
 

--- a/components/dependency_injection/configurators.rst
+++ b/components/dependency_injection/configurators.rst
@@ -116,7 +116,7 @@ to create a configurator class to configure these instances::
 
 The ``EmailConfigurator``'s job is to inject the enabled formatters into ``NewsletterManager``
 and ``GreetingCardManager`` because they are not aware of where the enabled
-formatters come from. In the other hand, the ``EmailFormatterManager`` holds
+formatters come from. On the other hand, the ``EmailFormatterManager`` holds
 the knowledge about the enabled formatters and how to load them, keeping
 the single responsibility principle.
 


### PR DESCRIPTION
According to the context the correct word to use is "formatters" instead of "filters".
