### PR TITLE
load() method definition from ExtensionInterface

### DIFF
--- a/cookbook/bundles/extension.rst
+++ b/cookbook/bundles/extension.rst
@@ -40,7 +40,7 @@ but usually you would simply extend the
 
     class AcmeHelloExtension extends Extension
     {
-        public function load(array $configs, ContainerBuilder $container)
+        public function load(array $config, ContainerBuilder $container)
         {
             // ... you'll load the files here later
         }


### PR DESCRIPTION
The `load` method definition seems to be wrong. In the `Symfony\Component\DependencyInjection\ContainerBuilder\ExtensionInterface`, the method definition is `public function load(array $config, ContainerBuilder $container);`
