### PR TITLE
Update dev_environment.rst

### DIFF
--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -187,8 +187,8 @@ by adding the ``delivery_whitelist`` option:
         ));
 
 In the above example all email messages will be redirected to ``dev@example.com``,
-except messages sent to the ``admin@mydomain.com`` address or to any email
-address belonging to the domain ``specialdomain.com``, which will be delivered as normal.
+and messages sent to the ``admin@mydomain.com`` address or to any email
+address belonging to the domain ``specialdomain.com`` will be delivered as normal.
 
 Viewing from the Web Debug Toolbar
 ----------------------------------


### PR DESCRIPTION
As per the config docs:
delivery_whitelist: Used in combination with delivery_address. If set, emails matching any of these patterns will be delivered like normal, as well as being sent to delivery_address.
