### PR TITLE
Clarify example for SUBMIT form event

### DIFF
--- a/components/form/form_events.rst
+++ b/components/form/form_events.rst
@@ -178,10 +178,9 @@ View data        Same as in ``FormEvents::POST_SET_DATA``
 
 .. sidebar:: ``FormEvents::SUBMIT`` in the Form component
 
-    The ``Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener``
-    subscribes to the ``FormEvents::SUBMIT`` event in order to remove the
-    fields that need to be removed whenever manipulating a collection of forms
-    for which ``allow_delete`` has been enabled.
+    The ``Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener``
+    subscribes to the ``FormEvents::SUBMIT`` event in order to prepend a default
+    protocol to URL field data that was submitted without a protocol.
 
 C) The ``FormEvents::POST_SUBMIT`` Event
 ........................................


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | #5990 |

It's indicated in the docs that form field cannot be added/removed by listeners of the SUBMIT form event, but the example provided was removing fields. While it's possible to do so, it's not recommended since it has little effect. Replaced with a different example implementation.
