### PR TITLE
Update dependency-injection.rst

### DIFF
--- a/create_framework/dependency-injection.rst
+++ b/create_framework/dependency-injection.rst
@@ -157,6 +157,7 @@ The front controller is now only about wiring everything together::
 
     $request = Request::createFromGlobals();
 
+    $sc->get('context')->fromRequest($request);
     $response = $sc->get('framework')->handle($request);
 
     $response->send();


### PR DESCRIPTION
If you don't update the context then you can't use this framework to setup routes that require any thing else than GET. In other words if you try using this for a rest api it will just not work.
