### PR TITLE
Fix missing constant usage for generating urls

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1479,7 +1479,9 @@ By default, the router will generate relative URLs (e.g. ``/blog``). From
 a controller, simply pass ``true`` to the third argument of the ``generateUrl()``
 method::
 
-    $this->generateUrl('blog_show', array('slug' => 'my-blog-post'), true);
+    use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+    $this->generateUrl('blog_show', array('slug' => 'my-blog-post'), UrlGeneratorInterface::ABSOLUTE_URL);
     // http://www.example.com/blog/my-blog-post
 
 From a template, in Twig, simply use the ``url()`` function (which generates an absolute URL)


### PR DESCRIPTION
This was forgotten in #5813 as reported in symfony/symfony#16991
