### PR TITLE
[2.8][Form] entry_type option: replace "in favor" misuses

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -312,7 +312,7 @@ entry_type
 ~~~~~~~~~~
 
 .. versionadded:: 2.8
-    The ``entry_type`` option was introduced in Symfony 2.8 in favor of
+    The ``entry_type`` option was introduced in Symfony 2.8 and replaces
     ``type``, which is available prior to 2.8.
 
 **type**: ``string`` or :class:`Symfony\\Component\\Form\\FormTypeInterface` **required**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8+ |
| Fixed tickets | - |
#6013 do the same for the `placeholder` option.
