### PR TITLE
Fixed misspelling of human in glossary.rst YAML

### DIFF
--- a/glossary.rst
+++ b/glossary.rst
@@ -121,7 +121,7 @@ Glossary
 
    YAML
         *YAML* is a recursive acronym for "YAML Ain't a Markup Language". It's a
-        lightweight, humane data serialization language used extensively in
+        lightweight, human data serialization language used extensively in
         Symfony's configuration files. See the :doc:`/components/yaml/introduction`
         chapter.
 

--- a/glossary.rst
+++ b/glossary.rst
@@ -121,7 +121,7 @@ Glossary
 
    YAML
         *YAML* is a recursive acronym for "YAML Ain't a Markup Language". It's a
-        lightweight, human data serialization language used extensively in
+        lightweight, human friendly data serialization language used extensively in
         Symfony's configuration files. See the :doc:`/components/yaml/introduction`
         chapter.
 


### PR DESCRIPTION
There is a misspelling in the YAML section of the glossary.rst. 

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
