### PR TITLE
Mention commiting only bower.json

### DIFF
--- a/cookbook/frontend/bower.rst
+++ b/cookbook/frontend/bower.rst
@@ -135,6 +135,11 @@ For more details, read the article `Checking in front-end dependencies`_.
 But, it's very possible that Bower will add a lock feature in the future
 (e.g. `bower/bower#1748`_).
 
+Bower.json
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Another option is to just commit your bower.json to git which holds the different dependencies. Then use `bower install` to install the required dependencies.
+
 .. _Bower: http://bower.io
 .. _`Node.js`: https://nodejs.org
 .. _BowerPHP: http://bowerphp.org/

--- a/cookbook/frontend/bower.rst
+++ b/cookbook/frontend/bower.rst
@@ -135,10 +135,11 @@ For more details, read the article `Checking in front-end dependencies`_.
 But, it's very possible that Bower will add a lock feature in the future
 (e.g. `bower/bower#1748`_).
 
-Bower.json
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Another option is to just commit your bower.json to git which holds the different dependencies. Then use `bower install` to install the required dependencies.
+If you don't care too much about having *exact* the same versions, you can only
+commit the ``bower.json`` file. Running ``bower install`` will give you the
+latest versions within the specified version range of each package in
+``bower.json``. Using strict version constraints (e.g. ``1.10.*``) is often
+enough to ensure only bringing in compatible versions.
 
 .. _Bower: http://bower.io
 .. _`Node.js`: https://nodejs.org


### PR DESCRIPTION
Replaces https://github.com/symfony/symfony-docs/pull/5778

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | all |
| Fixed tickets | - |

The section is called "Should I Git Ignore or Commit Bower Assets?", but we cover only the commit way and not the git ignore way, giving users a bit biased information. We should at least mention that people can also commit bower.json.

Thanks to @krike for providing the original patch!
