### PR TITLE
Added note about the hash_equals polyfill

### DIFF
--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -289,6 +289,13 @@ the ``PasswordDigest`` header value matches with the user's password.
     provider for the given token. In the case of multiple providers, the
     authentication manager will then move to the next provider in the list.
 
+.. note::
+
+    While the :phpfunction:`hash_equals` function was introduced in PHP 5.6,
+    you are safe to use it with any PHP version in your Symfony application. In
+    PHP versions prior to 5.6, `Symfony Polyfill`_ (which is included in
+    Symfony) will define the function for you.
+
 The Factory
 -----------
 
@@ -666,3 +673,4 @@ in the factory and consumed or passed to the other classes in the container.
 .. _`WSSE`: http://www.xml.com/pub/a/2003/12/17/dive.html
 .. _`nonce`: https://en.wikipedia.org/wiki/Cryptographic_nonce
 .. _`timing attacks`: https://en.wikipedia.org/wiki/Timing_attack
+.. _`Symfony Polyfill`: https://github.com/symfony/polyfill

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -295,6 +295,11 @@ the ``PasswordDigest`` header value matches with the user's password.
     you are safe to use it with any PHP version in your Symfony application. In
     PHP versions prior to 5.6, `Symfony Polyfill`_ (which is included in
     Symfony) will define the function for you.
+    
+    .. versionadded:: 2.8
+        Symfony Polyfill is included by default since Symfony 2.8. Prior to Symfony 2.8,
+        you have to execute ``composer require symfony/polyfill-php56`` to be able to
+        use ``hash_equals`` on older PHP versions.
 
 The Factory
 -----------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes |
| Applies to | 2.8+ |
| Fixed tickets | - |

To not confuse the readers, I think we should tell them a polyfill is used in older PHP versions.
