### PR TITLE
Mention HautelookAliceBundle in best practices

### DIFF
--- a/best_practices/tests.rst
+++ b/best_practices/tests.rst
@@ -113,8 +113,8 @@ pure JavaScript-based testing tools.
 Learn More about Functional Tests
 ---------------------------------
 
-Consider using `Faker`_, `Alice`_ or `HautelookAliceBundle`_ libraries to generate real-looking data
-for your test fixtures.
+Consider using the `HautelookAliceBundle`_ to generate real-looking data for
+your test fixtures using `Faker`_ and `Alice`_.
 
 .. _`Faker`: https://github.com/fzaninotto/Faker
 .. _`Alice`: https://github.com/nelmio/alice

--- a/best_practices/tests.rst
+++ b/best_practices/tests.rst
@@ -113,7 +113,7 @@ pure JavaScript-based testing tools.
 Learn More about Functional Tests
 ---------------------------------
 
-Consider using `Faker`_ and `Alice`_ libraries to generate real-looking data
+Consider using `Faker`_, `Alice`_ or `HautelookAliceBundle`_ libraries to generate real-looking data
 for your test fixtures.
 
 .. _`Faker`: https://github.com/fzaninotto/Faker
@@ -122,3 +122,4 @@ for your test fixtures.
 .. _`PhpSpec`: http://www.phpspec.net/
 .. _`Mink`: http://mink.behat.org
 .. _`smoke testing`: https://en.wikipedia.org/wiki/Smoke_testing_(software)
+.. _`HautelookAliceBundle`: https://github.com/hautelook/AliceBundle


### PR DESCRIPTION
Finishes #5773

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | all |
| Fixed tickets | - |

Reasons why I choosed HautelookAliceBundle over h4ccAliceFixturesBundle:
- It seems more active
- It supports Symfony 3
- It supports more database providers
