### PR TITLE
Remove references to API tagging

### DIFF
--- a/contributing/code/_api_tagging.rst.inc
+++ b/contributing/code/_api_tagging.rst.inc
@@ -1,7 +1,0 @@
-.. note::
-
-    If you think that one of our regular classes should have an ``@api`` tag,
-    put your request into a `new ticket on GitHub`_. We will then evaluate
-    whether we can add the tag or not.
-
-.. _new ticket on GitHub: https://github.com/symfony/symfony/issues/new

--- a/contributing/code/bc.rst
+++ b/contributing/code/bc.rst
@@ -74,8 +74,6 @@ backwards compatibility promise:
 | Add a default value to an argument            | Yes                         |
 +-----------------------------------------------+-----------------------------+
 
-.. include:: _api_tagging.rst.inc
-
 Using our Classes
 ~~~~~~~~~~~~~~~~~
 
@@ -133,8 +131,6 @@ covered by our backwards compatibility promise:
 +-----------------------------------------------+-----------------------------+
 | Access a private property (via Reflection)    | No                          |
 +-----------------------------------------------+-----------------------------+
-
-.. include:: _api_tagging.rst.inc
 
 Working on Symfony Code
 -----------------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3 |
| Fixed tickets | n/a |

Related to symfony/symfony#15977 and symfony/symfony#15979.
