### PR TITLE
[cookbook New project] Fix symfony version and initial add

### DIFF
--- a/cookbook/workflow/new_project_svn.rst
+++ b/cookbook/workflow/new_project_svn.rst
@@ -75,7 +75,7 @@ with these steps:
    .. code-block:: bash
 
         $ cd myproject/
-        $ svn add --depth=empty app var/cache var/logs app/config web
+        $ svn add --depth=empty app var var/cache var/logs app/config web
 
         $ svn propset svn:ignore "vendor" .
         $ svn propset svn:ignore "bootstrap*" var/
@@ -92,7 +92,7 @@ with these steps:
    .. code-block:: bash
 
         $ svn add --force .
-        $ svn ci -m "add basic Symfony Standard 2.X.Y"
+        $ svn ci -m "add basic Symfony Standard 3.X.Y"
 
 That's it! Since the ``app/config/parameters.yml`` file is ignored, you can
 store machine-specific settings like database passwords here without committing


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 3.0 |
| Fixed tickets |  |

Also add var dir, so that var/cache and var/logs can be added too.
Commit "add basic Symfony Standard 3.X.Y" instead of "add basic Symfony Standard 2.X.Y".
