### PR TITLE
Add a note about needing to install proxy-manager

### DIFF
--- a/components/dependency_injection/lazy_services.rst
+++ b/components/dependency_injection/lazy_services.rst
@@ -100,9 +100,9 @@ your lazy loaded services are working.
 
 .. note::
 
-    If you don't install the `ProxyManager bridge`_, the container will
-    just skip over the ``lazy`` flag and simply instantiate the service
-    as it would normally do.
+    If you don't install the `ProxyManager bridge`_ and the
+    `ocramius/proxy-manager`_, the container will just skip over the ``lazy``
+    flag and simply instantiate the service as it would normally do.
 
 The proxy gets initialized and the actual service is instantiated as soon
 as you interact in any way with this object.
@@ -117,3 +117,4 @@ in the `documentation of ProxyManager`_.
 .. _`ProxyManager bridge`: https://github.com/symfony/symfony/tree/master/src/Symfony/Bridge/ProxyManager
 .. _`proxy`: https://en.wikipedia.org/wiki/Proxy_pattern
 .. _`documentation of ProxyManager`: https://github.com/Ocramius/ProxyManager/blob/master/docs/lazy-loading-value-holder.md
+.. _`ocramius/proxy-manager`: https://github.com/Ocramius/ProxyManager


### PR DESCRIPTION
When using symfony/symfony it 'provides' `symfony/proxy-manager-bridge` but it doesn't install `ocramius/proxy-manager`.
This means that when you install the bridge you still don't get the proxy-manager and lazy services are not lazy.
