### PR TITLE
Update class names to QCN in examples instead of FQCN

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1109,14 +1109,14 @@ The controller might look like this::
 Notice that Symfony adds the string ``Controller`` to the class name (``Blog``
 => ``BlogController``) and ``Action`` to the method name (``show`` => ``showAction``).
 
-You could also refer to this controller using its fully-qualified class name
+You could also refer to this controller using its qualified class name
 and method: ``AppBundle\Controller\BlogController::showAction``. But if you
 follow some simple conventions, the logical name is more concise and allows
 more flexibility.
 
 .. note::
 
-   In addition to using the logical name or the fully-qualified class name,
+   In addition to using the logical name or the qualified class name,
    Symfony supports a third way of referring to a controller. This method
    uses just one colon separator (e.g. ``service_name:indexAction``) and
    refers to the controller as a service (see :doc:`/cookbook/controller/service`).

--- a/cookbook/assetic/php.rst
+++ b/cookbook/assetic/php.rst
@@ -116,7 +116,7 @@ First, configure a new ``scssphp`` Assetic filter:
             ),
         ));
 
-The value of the ``formatter`` option is the fully qualified class name of the
+The value of the ``formatter`` option is the qualified class name of the
 formatter used by the filter to produce the compiled CSS file. Using the
 compressed formatter will minimize the resulting file, regardless of whether
 the original files are regular CSS files or SCSS files.

--- a/cookbook/bundles/best_practices.rst
+++ b/cookbook/bundles/best_practices.rst
@@ -138,7 +138,7 @@ Classes
 
 The bundle directory structure is used as the namespace hierarchy. For
 instance, a ``ContentController`` controller is stored in
-``Acme/BlogBundle/Controller/ContentController.php`` and the fully qualified
+``Acme/BlogBundle/Controller/ContentController.php`` and the qualified
 class name is ``Acme\BlogBundle\Controller\ContentController``.
 
 All classes and files must follow the :doc:`Symfony coding standards </contributing/code/standards>`.

--- a/cookbook/doctrine/mapping_model_classes.rst
+++ b/cookbook/doctrine/mapping_model_classes.rst
@@ -139,7 +139,7 @@ Annotations, XML, Yaml, PHP and StaticPHP. The arguments are:
         }
 
     Now place your mapping file into ``/Resources/config/doctrine-base`` with the
-    fully qualified class name, separated by ``.`` instead of ``\``, for example
+    qualified class name, separated by ``.`` instead of ``\``, for example
     ``Other.Namespace.Model.Name.orm.xml``. You may not mix the two as otherwise
     the ``SymfonyFileLocator`` will get confused.
 

--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -170,14 +170,14 @@ tag and an ``alias`` attribute:
         # app/config/services.yml
         services:
             validator.unique.your_validator_name:
-                class: Fully\Qualified\Validator\Class\Name
+                class: Qualified\Validator\Class\Name
                 tags:
                     - { name: validator.constraint_validator, alias: alias_name }
 
     .. code-block:: xml
 
         <!-- app/config/services.xml -->
-        <service id="validator.unique.your_validator_name" class="Fully\Qualified\Validator\Class\Name">
+        <service id="validator.unique.your_validator_name" class="Qualified\Validator\Class\Name">
             <argument type="service" id="doctrine.orm.default_entity_manager" />
             <tag name="validator.constraint_validator" alias="alias_name" />
         </service>
@@ -186,7 +186,7 @@ tag and an ``alias`` attribute:
 
         // app/config/services.php
         $container
-            ->register('validator.unique.your_validator_name', 'Fully\Qualified\Validator\Class\Name')
+            ->register('validator.unique.your_validator_name', 'Qualified\Validator\Class\Name')
             ->addTag('validator.constraint_validator', array('alias' => 'alias_name'));
 
 Your constraint class should now use this alias to reference the appropriate

--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -96,7 +96,7 @@ type
 
 **type**: ``string`` [:ref:`default option <validation-default-option>`]
 
-This required option is the fully qualified class name or one of the PHP
+This required option is the qualified class name or one of the PHP
 datatypes as determined by PHP's ``is_`` functions.
 
 * :phpfunction:`array <is_array>`

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -508,7 +508,7 @@ configuration and tag it with ``kernel.event_subscriber``:
 
         services:
             kernel.subscriber.your_subscriber_name:
-                class: Fully\Qualified\Subscriber\Class\Name
+                class: Qualified\Subscriber\Class\Name
                 tags:
                     - { name: kernel.event_subscriber }
 
@@ -522,7 +522,7 @@ configuration and tag it with ``kernel.event_subscriber``:
             <services>
                 <service
                     id="kernel.subscriber.your_subscriber_name"
-                    class="Fully\Qualified\Subscriber\Class\Name">
+                    class="Qualified\Subscriber\Class\Name">
 
                     <tag name="kernel.event_subscriber" />
                 </service>
@@ -534,7 +534,7 @@ configuration and tag it with ``kernel.event_subscriber``:
         $container
             ->register(
                 'kernel.subscriber.your_subscriber_name',
-                'Fully\Qualified\Subscriber\Class\Name'
+                'Qualified\Subscriber\Class\Name'
             )
             ->addTag('kernel.event_subscriber')
         ;
@@ -576,7 +576,7 @@ channel when injecting the logger in a service.
 
         services:
             my_service:
-                class: Fully\Qualified\Loader\Class\Name
+                class: Qualified\Loader\Class\Name
                 arguments: ['@logger']
                 tags:
                     - { name: monolog.logger, channel: acme }
@@ -589,7 +589,7 @@ channel when injecting the logger in a service.
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="my_service" class="Fully\Qualified\Loader\Class\Name">
+                <service id="my_service" class="Qualified\Loader\Class\Name">
                     <argument type="service" id="logger" />
                     <tag name="monolog.logger" channel="acme" />
                 </service>
@@ -598,7 +598,7 @@ channel when injecting the logger in a service.
 
     .. code-block:: php
 
-        $definition = new Definition('Fully\Qualified\Loader\Class\Name', array(
+        $definition = new Definition('Qualified\Loader\Class\Name', array(
             new Reference('logger'),
         ));
         $definition->addTag('monolog.logger', array('channel' => 'acme'));
@@ -751,7 +751,7 @@ of your configuration and tag it with ``routing.loader``:
 
         services:
             routing.loader.your_loader_name:
-                class: Fully\Qualified\Loader\Class\Name
+                class: Qualified\Loader\Class\Name
                 tags:
                     - { name: routing.loader }
 
@@ -765,7 +765,7 @@ of your configuration and tag it with ``routing.loader``:
             <services>
                 <service
                     id="routing.loader.your_loader_name"
-                    class="Fully\Qualified\Loader\Class\Name">
+                    class="Qualified\Loader\Class\Name">
 
                     <tag name="routing.loader" />
                 </service>
@@ -775,7 +775,7 @@ of your configuration and tag it with ``routing.loader``:
     .. code-block:: php
 
         $container
-            ->register('routing.loader.your_loader_name', 'Fully\Qualified\Loader\Class\Name')
+            ->register('routing.loader.your_loader_name', 'Qualified\Loader\Class\Name')
             ->addTag('routing.loader')
         ;
 
@@ -870,7 +870,7 @@ templates):
 
         services:
             templating.helper.your_helper_name:
-                class: Fully\Qualified\Helper\Class\Name
+                class: Qualified\Helper\Class\Name
                 tags:
                     - { name: templating.helper, alias: alias_name }
 
@@ -884,7 +884,7 @@ templates):
             <services>
                 <service
                     id="templating.helper.your_helper_name"
-                    class="Fully\Qualified\Helper\Class\Name">
+                    class="Qualified\Helper\Class\Name">
 
                     <tag name="templating.helper" alias="alias_name" />
                 </service>
@@ -894,7 +894,7 @@ templates):
     .. code-block:: php
 
         $container
-            ->register('templating.helper.your_helper_name', 'Fully\Qualified\Helper\Class\Name')
+            ->register('templating.helper.your_helper_name', 'Qualified\Helper\Class\Name')
             ->addTag('templating.helper', array('alias' => 'alias_name'))
         ;
 
@@ -1135,7 +1135,7 @@ configuration and tag it with ``twig.extension``:
 
         services:
             twig.extension.your_extension_name:
-                class: Fully\Qualified\Extension\Class\Name
+                class: Qualified\Extension\Class\Name
                 tags:
                     - { name: twig.extension }
 
@@ -1149,7 +1149,7 @@ configuration and tag it with ``twig.extension``:
             <services>
                 <service
                     id="twig.extension.your_extension_name"
-                    class="Fully\Qualified\Extension\Class\Name">
+                    class="Qualified\Extension\Class\Name">
 
                     <tag name="twig.extension" />
                 </service>
@@ -1161,7 +1161,7 @@ configuration and tag it with ``twig.extension``:
         $container
             ->register(
                 'twig.extension.your_extension_name',
-                'Fully\Qualified\Extension\Class\Name'
+                'Qualified\Extension\Class\Name'
             )
             ->addTag('twig.extension')
         ;

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -109,7 +109,7 @@ class
 **type**: ``string`` **required**
 
 The class of your entity (e.g. ``AcmeStoreBundle:Category``). This can be
-a fully-qualified class name (e.g. ``Acme\StoreBundle\Entity\Category``)
+a qualified class name (e.g. ``Acme\StoreBundle\Entity\Category``)
 or the short alias name (as shown prior).
 
 .. include:: /reference/forms/types/options/data_class.rst.inc


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | N/A |

Name resolution used in whole codebase and examples are based on Qualified Class
Names instead of Fully Qualified ones.

Ref: http://php.net/manual/en/language.namespaces.rules.php
