### PR TITLE
[Form] remove the getName() function as it is deprecated

### DIFF
--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -57,11 +57,6 @@ a bare form class looks like::
                 'data_class' => 'AppBundle\Entity\Product'
             ));
         }
-
-        public function getName()
-        {
-            return 'product';
-        }
     }
 
 .. note::


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8+ |
| Fixed tickets | none |
