### PR TITLE
Fixed a typo in the choice_label code example

### DIFF
--- a/reference/forms/types/options/choice_label.rst.inc
+++ b/reference/forms/types/options/choice_label.rst.inc
@@ -49,7 +49,7 @@ If your choice values are objects, then ``choice_label`` can also be a
         'choices' => array(
             new Status(Status::YES),
             new Status(Status::NO),
-            new Status::(Status::MAYBE),
+            new Status(Status::MAYBE),
         ),
         'choices_as_values' => true,
         'choice_label' => 'displayName',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | Yes |
| New docs? | No |
| Applies to | >=2.7 |
| Fixed tickets |  |
