### PR TITLE
Fix Build Framework documentation in controller resolver part

### DIFF
--- a/create_framework/http_kernel_controller_resolver.rst
+++ b/create_framework/http_kernel_controller_resolver.rst
@@ -10,7 +10,7 @@ class::
 
     class LeapYearController
     {
-        public function indexAction($request)
+        public function indexAction(Request $request)
         {
             if (is_leap_year($request->attributes->get('year'))) {
                 return new Response('Yep, this is a leap year!');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

In Controller Resolver part of the "Create your own framework" documentation, we must create a controller with the Request parameter but the parameter is not typed so the controller resolver cannot determine that is the Request object.
