### PR TITLE
use the message argument of assertX functions

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -259,7 +259,8 @@ document::
             $client->getResponse()->headers->contains(
                 'Content-Type',
                 'application/json'
-            )
+            ),
+            '"Content-Type" header is NOT "application/json"' // optional message shown on failure
         );
 
         // Assert that the response content contains a string
@@ -268,7 +269,9 @@ document::
         $this->assertRegExp('/foo(bar)?/', $client->getResponse()->getContent());
 
         // Assert that the response status code is 2xx
-        $this->assertTrue($client->getResponse()->isSuccessful());
+        $this->assertTrue($client->getResponse()->isSuccessful(),
+                          'response status code is NOT 2xx'
+                          );
         // Assert that the response status code is 404
         $this->assertTrue($client->getResponse()->isNotFound());
         // Assert a specific 200 status code
@@ -279,7 +282,8 @@ document::
 
         // Assert that the response is a redirect to /demo/contact
         $this->assertTrue(
-            $client->getResponse()->isRedirect('/demo/contact')
+            $client->getResponse()->isRedirect('/demo/contact'),
+            'response is NOT a redirect to /demo/contact'
         );
         // ...or simply check that the response is a redirect to any URL
         $this->assertTrue($client->getResponse()->isRedirect());


### PR DESCRIPTION
Assert functions from PHPUnit do have an optional message argument. This is especially usefull for assertTrue because the message printed on failure does not (and can not) contain any details. Demonstrate this possibility
