### PR TITLE
fix README requirements link

### DIFF
--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -56,4 +56,4 @@ If you want to use Doctrine, you will need to have PDO installed. Additionally,
 you need to have the PDO driver installed for the database server you want
 to use.
 
-.. _`Requirements section of the README`: https://github.com/symfony/symfony#requirements
+.. _`Requirements section of the README`: https://github.com/symfony/symfony/blob/2.8/README.md#requirements


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8, 2.7, 2.3 |
| Fixed tickets |  |

The "requirements" secion is not in README anymore, so we need to point to specific version
