### PR TITLE
[MicroKernel] Fixed the display of a code block

### DIFF
--- a/cookbook/configuration/micro-kernel-trait.rst
+++ b/cookbook/configuration/micro-kernel-trait.rst
@@ -280,7 +280,7 @@ your *kernel* lives in. Since ``AppKernel`` lives in ``app/``, this template liv
 at ``app/Resources/views/micro/random.html.twig``.
 
 Finally, you need a front controller to boot and run the application. Create a
-``web/index.php``:
+``web/index.php``::
 
     // web/index.php
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8 |
| Fixed tickets |  |

The display of a php code block was a quote.
