### PR TITLE
Added comment about SVG height property

### DIFF
--- a/cookbook/profiler/data_collector.rst
+++ b/cookbook/profiler/data_collector.rst
@@ -182,7 +182,8 @@ block and set the value of two variables called ``icon`` and ``text``:
 
         {{ include('@App/data_collector/icon.svg') }}
 
-    You are encouraged to use the latter technique for your own toolbar panels.
+    You are encouraged to use the latter technique for your own toolbar panels. Make
+    sure the svg file has the ``height`` property set to ``24``. 
 
 If the toolbar panel includes extended web profiler information, the Twig template
 must also define additional blocks:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | none |

When you use a .svg file for the toolbar icon it must have `height="24"` or the toolbar will render strangely. The attached images will show an example of this render error. 

![screen shot 2016-01-11 at 10 19 40](https://cloud.githubusercontent.com/assets/1275206/12229997/3c9b7d04-b84d-11e5-9a8f-51143dfe5cd3.png)
![screen shot 2016-01-11 at 10 19 18](https://cloud.githubusercontent.com/assets/1275206/12229998/3c9df070-b84d-11e5-879b-36837f2ff10a.png)
