### PR TITLE
Added new links to the Symfony screencast series at KnpU

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -4,9 +4,16 @@
 Installing and Configuring Symfony
 ==================================
 
-The goal of this chapter is to get you up and running with a working application
-built on top of Symfony. In order to simplify the process of creating new
-applications, Symfony provides an installer application.
+Welcome to Symfony! Starting a new Symfony project is easy. In fact, you'll have
+your first working Symfony application up and running in just a few short minutes.
+
+.. seealso::
+
+    Do you prefer video tutorials? Check out the `Joyful Development with Symfony`_
+    screencast series from KnpUniversity.
+
+To make creating new applications even simpler, Symfony provides an installer.
+Downloading it is your first step.
 
 Installing the Symfony Installer
 --------------------------------
@@ -412,6 +419,7 @@ need in your new application.
 Be sure to also check out the :doc:`Cookbook </cookbook/index>`, which contains
 a wide variety of articles about solving specific problems with Symfony.
 
+.. _`Joyful Development with Symfony`: http://knpuniversity.com/screencast/symfony
 .. _`explained in this post`: http://fabien.potencier.org/signing-project-releases.html
 .. _`Composer`: https://getcomposer.org/
 .. _`Composer download page`: https://getcomposer.org/download/

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -21,6 +21,11 @@ simple two-step process:
 Just like on the web, every interaction is initiated by an HTTP request.
 Your job is pure and simple: understand that request and return a response.
 
+.. seealso::
+
+    Do you prefer video tutorials? Check out the `Joyful Development with Symfony`_
+    screencast series from KnpUniversity.
+
 .. index::
    single: Page creation; Example
 
@@ -585,6 +590,7 @@ There's also a :doc:`Cookbook </cookbook/index>` *packed* with more advanced
 
 Have fun!
 
+.. _`Joyful Development with Symfony`: http://knpuniversity.com/screencast/symfony/first-page
 .. _`app/Resources/views/base.html.twig`: https://github.com/symfony/symfony-standard/blob/2.7/app/Resources/views/base.html.twig
 .. _`Composer`: https://getcomposer.org
 .. _`find open source bundles`: http://knpbundles.com


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 3.0+ |
| Fixed tickets | - |

KnpU has just published a new (and free) screencast series about Symfony 3 (http://knpuniversity.com/screencast/symfony). I propose to link to it from two book chapters: installation and "create your first page".

These chapters are critical for us because they are the starting point for most Symfony newcomers. We must do as much as we can do to "engage" them and lots of developers love video tutorials.
