### PR TITLE
[Security][Guard] Completed start method signature

### DIFF
--- a/cookbook/security/guard-authentication.rst
+++ b/cookbook/security/guard-authentication.rst
@@ -418,7 +418,7 @@ Each authenticator needs the following methods:
     object that should be sent to the client. The ``$exception`` will tell you
     *what* went wrong during authentication.
 
-**start**
+**start(Request $request, AuthenticationException $authException = null)**
     This is called if the client accesses a URI/resource that requires authentication,
     but no authentication details were sent (i.e. you returned ``null`` from
     ``getCredentials()``). Your job is to return a


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8 |
| Fixed tickets |  |

The `start()` method did not have its signature but the other methods did.
