### PR TITLE
fixed the component name

### DIFF
--- a/components/expression_language/index.rst
+++ b/components/expression_language/index.rst
@@ -1,5 +1,5 @@
-Expression Language
-===================
+ExpressionLanguage
+==================
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |

This fixes the component name which is "ExpressionLanguage" without a space (this is by the way consistent with the other components).
