### PR TITLE
Docs do not match functionality

### DIFF
--- a/cookbook/bundles/configuration.rst
+++ b/cookbook/bundles/configuration.rst
@@ -294,8 +294,7 @@ The ``config:dump-reference`` command dumps the default configuration of a
 bundle in the console using the Yaml format.
 
 As long as your bundle's configuration is located in the standard location
-(``YourBundle\DependencyInjection\Configuration``) and does not require
-arguments to be passed to the constructor it will work automatically. If you
+(``YourBundle\DependencyInjection\Configuration``) and does not override the constructor it will work automatically. If you
 have something different, your ``Extension`` class must override the
 :method:`Extension::getConfiguration() <Symfony\\Component\\HttpKernel\\DependencyInjection\\Extension::getConfiguration>`
 method and return an instance of your ``Configuration``.


### PR DESCRIPTION
The _Dump the configuration_ section specifies that one of the requirements that need to be met to automatically dump configuration is the constructor not requiring parameters.

The code that handles this though does not match this description:

```
/**
 * {@inheritdoc}
 */
public function getConfiguration(array $config, ContainerBuilder $container)
{
    $reflected = new \ReflectionClass($this);
    $namespace = $reflected->getNamespaceName();

    $class = $namespace.'\\Configuration';
    if (class_exists($class)) {
        $r = new \ReflectionClass($class);
        $container->addResource(new FileResource($r->getFileName()));

        // Notice here that it just checks if the __construct method exists,
        // the arguments are irrelevant
        if (!method_exists($class, '__construct')) {
            $configuration = new $class();

            return $configuration;
        }
    }
}
```
