### PR TITLE
[Contributing][Documentation] replace EOL with EOM

### DIFF
--- a/contributing/documentation/format.rst
+++ b/contributing/documentation/format.rst
@@ -194,8 +194,8 @@ how the behavior has changed:
 Whenever a new minor version of Symfony is released (e.g. 2.4, 2.5, etc),
 a new branch of the documentation is created from the ``master`` branch.
 At this point, all the ``versionadded`` tags for Symfony versions that have
-reached end-of-life will be removed. For example, if Symfony 2.5 were released
-today, and 2.2 had recently reached its end-of-life, the 2.2 ``versionadded``
+reached end-of-maintenance will be removed. For example, if Symfony 2.5 were
+released today, and 2.2 had recently reached its end-of-life, the 2.2 ``versionadded``
 tags would be removed from the new ``2.5`` branch.
 
 Testing Documentation


### PR DESCRIPTION
IIRC with end-of-life we usually refer to the time when a Symfony
release does not receive Security fixes anymore. But we remove all the
`versionadded` directives when a Symfony version does not receive bug
fixes anymore.
