### PR TITLE
Update introduction.rst

### DIFF
--- a/components/var_dumper/introduction.rst
+++ b/components/var_dumper/introduction.rst
@@ -17,6 +17,9 @@ You can install the component in 2 different ways:
 * :doc:`Install it via Composer </components/using_components>` (``symfony/var-dumper`` on `Packagist`_);
 * Use the official Git repository (https://github.com/symfony/var-dumper).
 
+.. note::
+Make sure the bundle is added in your ``app/AppKernel.php``
+
 .. _components-var-dumper-dump:
 
 The dump() Function


### PR DESCRIPTION
the docs are missing important info that the var_dumper component needs to added as a bundle to the appkernel
