### PR TITLE
change translation getMessages() to getCatalogue()

### DIFF
--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -378,6 +378,9 @@ messages. Just specify the required locale::
 
     $catalogue = $translator->getCatalogue('fr_FR');
     $messages = $catalogue->all();
+    while ($catalogue = $catalogue->getFallbackCatalogue()) {
+        $messages = array_replace_recursive($catalogue->all(), $messages);
+    }
 
 The ``$messages`` variable will have the following structure::
 

--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -376,7 +376,8 @@ In case you want to use the same translation catalogue outside your application
 (e.g. use translation on the client side), it's possible to fetch raw translation
 messages. Just specify the required locale::
 
-    $messages = $translator->getMessages('fr_FR');
+    $catalogue = $translator->getCatalogue('fr_FR');
+    $messages = $catalogue->all();
 
 The ``$messages`` variable will have the following structure::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | 2.8 |
| Fixed tickets | #6137 |

I'm assuming here that the structure of the `$messages` variable didn't change.
