### PR TITLE
Fix redundant command line sample

### DIFF
--- a/cookbook/upgrade/major_version.rst
+++ b/cookbook/upgrade/major_version.rst
@@ -134,7 +134,7 @@ Next, use Composer to download new versions of the libraries:
 
 .. code-block:: bash
 
-    $ composer update --with-dependencies symfony/symfony
+    $ composer update symfony/symfony
 
 .. include:: /cookbook/upgrade/_update_dep_errors.rst.inc
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #6189 |

Removed option `--with-dependencies` from the first command line example for composer upgrade.
