### PR TITLE
Document the invalidate_session option

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -319,6 +319,19 @@ Redirecting after Login
 
 .. _reference-security-pbkdf2:
 
+Logout Configuration
+--------------------
+
+invalidate_session
+..................
+
+**type**: ``boolean`` **default**: ``true``
+
+By default, the session of the user is invalidated after the log out process.
+This means that the user will be logged out for all the firewalls defined in
+your application. Set this option to ``false`` to only log out from the current
+firewall.
+
 Using the PBKDF2 Encoder: Security and Speed
 --------------------------------------------
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -327,10 +327,13 @@ invalidate_session
 
 **type**: ``boolean`` **default**: ``true``
 
-By default, the session of the user is invalidated after the log out process.
-This means that the user will be logged out for all the firewalls defined in
-your application. Set this option to ``false`` to only log out from the current
-firewall.
+By default, when users log out from any firewall, their sessions are invalidated.
+This means that logging out from one firewall automatically logs them out from
+all the other firewalls.
+
+The ``invalidate_session`` option allows to redefine this behavior. Set this
+option to ``false`` in every firewall and the user will only be logged out from
+the current firewall and not the other ones.
 
 Using the PBKDF2 Encoder: Security and Speed
 --------------------------------------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | all |
| Fixed tickets | - |

I found this missing doc while closing https://github.com/symfony/symfony/issues/9543 and checking out the given reference to http://stackoverflow.com/questions/17129782/symfony2-logging-out-of-one-firewall
