### PR TITLE
Added the missing namespace in example of a subscriber class

### DIFF
--- a/components/event_dispatcher/introduction.rst
+++ b/components/event_dispatcher/introduction.rst
@@ -393,6 +393,7 @@ subscribes to the ``kernel.response`` and ``store.order`` events::
 
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
     use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+    use Acme\StoreBundle\Event\FilterOrderEvent;
 
     class StoreSubscriber implements EventSubscriberInterface
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |
