### PR TITLE
use examples with hour, minute, second array keys for time placeholder

### DIFF
--- a/reference/forms/types/options/time_placeholder.rst.inc
+++ b/reference/forms/types/options/time_placeholder.rst.inc
@@ -1,0 +1,50 @@
+placeholder
+~~~~~~~~~~~
+
+.. versionadded:: 2.6
+    The ``placeholder`` option was introduced in Symfony 2.6 in favor of
+    ``empty_value``, which is available prior to 2.6.
+
+.. versionadded:: 2.3
+    Since Symfony 2.3, empty values are also supported if the ``expanded``
+    option is set to true.
+
+**type**: ``string`` or ``boolean``
+
+This option determines whether or not a special "empty" option (e.g. "Choose
+an option") will appear at the top of a select widget. This option only
+applies if the ``multiple`` option is set to false.
+
+* Add empty values with "Select hour", "Select minute" and "Select second" as the text::
+
+    $builder->add('startTime', 'time', array(
+        'input'  => 'datetime',
+        'widget' => 'choice',
+        'placeholder' => array(
+            'hour'   => 'Select hour',
+            'minute' => 'Select minute',
+            'second' => 'Select second',
+        )
+    ));
+
+* Guarantee that no "empty" value option is displayed::
+
+    $builder->add('startTime', 'time', array(
+        'input'  => 'datetime',
+        'widget' => 'choice',
+        'placeholder' => array(
+            'hour'   => false,
+            'minute' => false,
+            'second' => false,
+        )
+    ));
+
+If you leave the ``placeholder`` option unset, then a blank (with no text)
+option will automatically be added if and only if the ``required`` option
+is false::
+
+    $builder->add('startTime', 'time', array(
+        'input'    => 'datetime',
+        'widget'   => 'choice',
+        'required' => false
+    ));

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -76,7 +76,7 @@ values.
 Field Options
 -------------
 
-.. include:: /reference/forms/types/options/placeholder.rst.inc
+.. include:: /reference/forms/types/options/time_placeholder.rst.inc
 
 .. include:: /reference/forms/types/options/hours.rst.inc
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes |
| Applies to | 2.6+ |
| Fixed tickets | #6178 |

Documentation will also be needed for the DateTime type with a very similar example adding day, month and year.

I'm not sure if the new placeholder include file is needed as it will probably not be reused.
