### PR TITLE
Improve cookbook form unit testing.

### DIFF
--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -39,7 +39,6 @@ The simplest ``TypeTestCase`` implementation looks like the following::
     // tests/AppBundle/Form/Type/TestedTypeTest.php
     namespace Tests\AppBundle\Form\Type;
 
-    use AppBundle\Form\Type\TestedType;
     use AppBundle\Model\TestObject;
     use Symfony\Component\Form\Test\TypeTestCase;
 
@@ -52,7 +51,7 @@ The simplest ``TypeTestCase`` implementation looks like the following::
                 'test2' => 'test2',
             );
 
-            $type = new TestedType();
+            $type = 'AppBundle\Form\Type\TestedType';
             $form = $this->factory->create($type);
 
             $object = TestObject::fromArray($formData);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | #6203 |

I tweak this example from cookbook, and receive error:

```
Symfony\Component\Form\Exception\UnexpectedTypeException: Expected argument of type "string", "AppBundle\Form\CategoryType" given
```

and i just fix it like in this pr - and all become ok.
