### PR TITLE
Typo in default session save_path

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -800,7 +800,7 @@ start and depends on `gc_divisor`_ and `gc_probability`_.
 save_path
 .........
 
-**type**: ``string`` **default**: ``%kernel.cache.dir%/sessions``
+**type**: ``string`` **default**: ``%kernel.cache_dir%/sessions``
 
 This determines the argument to be passed to the save handler. If you choose
 the default file handler, this is the path where the session files are created.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

The %kernel.cache.dir% parameter does not exist, %kernel.cache_dir% does.
