### PR TITLE
path() explanation inside templating + Minor formatting changes

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1461,7 +1461,7 @@ system. Take the ``blog_show`` example route from earlier::
     // /blog/my-blog-post
 
 To generate a URL, you need to specify the name of the route (e.g. ``blog_show``)
-and any wildcards (e.g. ``slug = my-blog-post``) used in the path for that
+and any wildcards (e.g. ``slug`` = ``my-blog-post``) used in the path for that
 route. With this information, any URL can easily be generated::
 
     class MainController extends Controller
@@ -1500,7 +1500,7 @@ In an upcoming section, you'll learn how to generate URLs from inside templates.
 
         var url = Routing.generate(
             'blog_show',
-            {"slug": 'my-blog-post'}
+            {'slug': 'my-blog-post'}
         );
 
     For more information, see the documentation for that bundle.
@@ -1546,6 +1546,8 @@ a template helper function:
 .. versionadded:: 2.8
     The ``path()`` PHP templating helper was introduced in Symfony 2.8. Prior
     to 2.8, you had to use the ``generate()`` helper method.
+
+The ``path()`` method generates relative URLs.
 
 .. index::
    single: Routing; Absolute URLs

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1162,11 +1162,11 @@ each separated by a colon:
 
 For example, a ``_controller`` value of ``AppBundle:Blog:show`` means:
 
-=========  ==================  ==============
-Bundle     Controller Class    Method Name
-=========  ==================  ==============
-AppBundle  ``BlogController``  ``showAction``
-=========  ==================  ==============
+=============  ==================  ==============
+Bundle         Controller Class    Method Name
+=============  ==================  ==============
+``AppBundle``  ``BlogController``  ``showAction``
+=============  ==================  ==============
 
 The controller might look like this::
 


### PR DESCRIPTION
Mention that "path()" generates relative URLs.
Take out an "=" sign out of code syntax.
Single quotes instead of double ones in javascript example.
Format "AppBundle" inside the example table for controller short names.
