### PR TITLE
Improveme the apache/mod_php configuration example

### DIFF
--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -93,6 +93,14 @@ and increase web server performance:
         #     Options FollowSymlinks
         # </Directory>
 
+        # optionally disable the RewriteEngine for the asset directories
+        # which will allow apache to simply reply with a 404 when files are
+        # not found instead of passing the request into the full symfony stack
+        <Directory /var/www/project/web/bundles>
+            <IfModule mod_rewrite.c>
+                RewriteEngine Off
+            </IfModule>
+        </Directory>
         ErrorLog /var/log/apache2/project_error.log
         CustomLog /var/log/apache2/project_access.log combined
     </VirtualHost>


### PR DESCRIPTION
We recently had a project undergo a massive security scan. We had setup email error reporting, so symfony sent us ~15K emails all mostly route not found when the scanner was playing around in the bundles asset directory. In reality if a file isn't available in the bundles directory the server can simply return a 404 not found, and it is probably also slightly more secure and performant to not fire up the entire symfony framework in that case.
