### PR TITLE
Note to create a service if you extend ExceptionController

### DIFF
--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -269,7 +269,7 @@ In that case, you might want to override one or both of the ``showAction()`` and
               arguments: [ "@twig", "%kernel.debug%" ]
           
           twig:
-              exception_controller:  my_custom_exception_controller_service:showAction
+              exception_controller:  app.extension_controller:showAction
 
 .. tip::
 

--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -251,7 +251,25 @@ will be passed two parameters:
 Instead of creating a new exception controller from scratch you can, of course,
 also extend the default :class:`Symfony\\Bundle\\TwigBundle\\Controller\\ExceptionController`.
 In that case, you might want to override one or both of the ``showAction()`` and
-``findTemplate()`` methods. The latter one locates the template to be used.
+``findTemplate()`` methods. The latter one locates the template to be used. 
+
+.. note::
+  
+  In case of extending the :class:`Symfony\\Bundle\\TwigBundle\\Controller\\ExceptionController` 
+  you may configure a service to pass the twig-Environment and the debug-Flag to the constructor. 
+  
+  .. configuration-block::
+  
+      .. code-block:: yaml
+  
+          # app/config/config.yml
+          services:
+            my_custom_exception_controller_service:
+              class: AppBundle\CustomExceptionController
+              arguments: [ "@twig", "%kernel.debug%" ]
+          
+          twig:
+              exception_controller:  my_custom_exception_controller_service:showAction
 
 .. tip::
 

--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -256,7 +256,7 @@ In that case, you might want to override one or both of the ``showAction()`` and
 .. note::
   
   In case of extending the :class:`Symfony\\Bundle\\TwigBundle\\Controller\\ExceptionController` 
-  you may configure a service to pass the twig-Environment and the debug-Flag to the constructor. 
+  you may configure a service to pass the Twig environment and the ``debug`` flag to the constructor. 
   
   .. configuration-block::
   
@@ -264,7 +264,7 @@ In that case, you might want to override one or both of the ``showAction()`` and
   
           # app/config/config.yml
           services:
-            my_custom_exception_controller_service:
+            app.extension_controller:
               class: AppBundle\CustomExceptionController
               arguments: [ "@twig", "%kernel.debug%" ]
           


### PR DESCRIPTION
I had some trouble to get the custom exception handling with inheritance of ExceptionController working, because I hadn't a clue to make a service out of the ExceptionController of the TwigBundle.
