### PR TITLE
removed unnecessary exception from repository

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -430,29 +430,18 @@ interface only requires one method: ``loadUserByUsername($username)``::
 
     use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
     use Symfony\Component\Security\Core\User\UserInterface;
-    use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
     use Doctrine\ORM\EntityRepository;
 
     class UserRepository extends EntityRepository implements UserLoaderInterface
     {
         public function loadUserByUsername($username)
         {
-            $user = $this->createQueryBuilder('u')
+            return $this->createQueryBuilder('u')
                 ->where('u.username = :username OR u.email = :email')
                 ->setParameter('username', $username)
                 ->setParameter('email', $username)
                 ->getQuery()
                 ->getOneOrNullResult();
-
-            if (null === $user) {
-                $message = sprintf(
-                    'Unable to find an active admin AppBundle:User object identified by "%s".',
-                    $username
-                );
-                throw new UsernameNotFoundException($message);
-            }
-
-            return $user;
         }
     }
 


### PR DESCRIPTION
removed `UsernameNotFoundException` form repository as this logic does not belong to repository and also it is duplicated. exception is already thrown on proper place if no user is found:
https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php#L60
