### PR TITLE
Document translation_domain for choice fields

### DIFF
--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -17,6 +17,7 @@ To use this field, you must specify *either* ``choices`` or ``choice_loader`` op
 |             | - `choice_loader`_                                                           |
 |             | - `choice_label`_                                                            |
 |             | - `choice_attr`_                                                             |
+|             | - `choice_translation_domain`_                                               |
 |             | - `placeholder`_                                                             |
 |             | - `expanded`_                                                                |
 |             | - `multiple`_                                                                |
@@ -41,6 +42,7 @@ To use this field, you must specify *either* ``choices`` or ``choice_loader`` op
 |             | - `mapped`_                                                                  |
 |             | - `read_only`_                                                               |
 |             | - `required`_                                                                |
+|             | - `translation_domain`_                                                      |
 +-------------+------------------------------------------------------------------------------+
 | Parent type | :doc:`form </reference/forms/types/form>`                                    |
 +-------------+------------------------------------------------------------------------------+
@@ -347,6 +349,8 @@ type:
 .. include:: /reference/forms/types/options/read_only.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/choice_type_translation_domain.rst.inc
 
 Field Variables
 ---------------

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -16,6 +16,8 @@ objects from the database.
 |             | - `choice_label`_                                                |
 |             | - `query_builder`_                                               |
 |             | - `em`_                                                          |
+|             | - `choice_translation_domain`_                                   |
+|             | - `translation_domain`_                                          |
 +-------------+------------------------------------------------------------------+
 | Overridden  | - `choices`_                                                     |
 | options     |                                                                  |
@@ -175,6 +177,26 @@ em
 
 If specified, this entity manager will be used to load the choices
 instead of the ``default`` entity manager.
+
+choice_translation_domain
+~~~~~~~~~~~~~
+
+.. versionadded:: 2.7
+    The ``choice_translation_domain`` option was introduced in Symfony 2.7.
+
+**type**: ``boolean``
+
+This option determines whether the translation of the data obtained will be informed domain ``translation_domain``.
+
+translation_domain
+~~~~~~~~~~~~~
+
+.. versionadded:: 2.7
+    The ``translation_domain`` option was introduced in Symfony 2.7.
+
+**type**: ``string``
+
+If specified, use translations of informed domain(e.g. ``AcmeStoreBundle`` to ``Acme\StoreBundle\Resources\translation`` files).
 
 
 Overridden Options

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -186,7 +186,7 @@ choice_translation_domain
 
 **type**: ``boolean`` | ``null`` | ``string``
 
-If specified ``null`` value, corresponds to parents translation_domain or default domain (messages). If the value is ``string``, corresponds to explicit domain(e.g. ``AcmeStoreBundle``). If the value is ``true``, reuse current ``translation_domain`` and ``false`` to disabled.
+If specified ``null`` value, corresponds to parents ``translation_domain`` or default domain (messages). If the value is ``string``, corresponds to explicit domain(e.g. ``AcmeStoreBundle``). If the value is ``true``, reuse current ``translation_domain`` and ``false`` to disabled.
 
 translation_domain
 ~~~~~~~~~~~~~~~~~~
@@ -196,7 +196,7 @@ translation_domain
 
 **type**: ``string``
 
-If specified, use translations of informed domain(e.g. ``AcmeStoreBundle`` to ``Acme\StoreBundle\Resources\translation`` files).
+When ``choice_translation_domain`` is ``true`` or ``null``, use translations of informed domain(e.g. ``AcmeStoreBundle`` to ``Acme\StoreBundle\Resources\translation`` files).
 
 
 Overridden Options

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -16,8 +16,6 @@ objects from the database.
 |             | - `choice_label`_                                                |
 |             | - `query_builder`_                                               |
 |             | - `em`_                                                          |
-|             | - `choice_translation_domain`_                                   |
-|             | - `translation_domain`_                                          |
 +-------------+------------------------------------------------------------------+
 | Overridden  | - `choices`_                                                     |
 | options     |                                                                  |
@@ -26,6 +24,7 @@ objects from the database.
 | options     |                                                                  |
 |             | - `placeholder`_                                                 |
 |             | - `choice_translation_domain`_                                   |
+|             | - `translation_domain`_                                          |
 |             | - `expanded`_                                                    |
 |             | - `multiple`_                                                    |
 |             | - `preferred_choices`_                                           |
@@ -178,27 +177,6 @@ em
 If specified, this entity manager will be used to load the choices
 instead of the ``default`` entity manager.
 
-choice_translation_domain
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 2.7
-    The ``choice_translation_domain`` option was introduced in Symfony 2.7.
-
-**type**: ``boolean`` | ``null`` | ``string``
-
-If specified ``null`` value, corresponds to parents ``translation_domain`` or default domain (messages). If the value is ``string``, corresponds to explicit domain(e.g. ``AcmeStoreBundle``). If the value is ``true``, reuse current ``translation_domain`` and ``false`` to disabled.
-
-translation_domain
-~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 2.7
-    The ``translation_domain`` option was introduced in Symfony 2.7.
-
-**type**: ``string``
-
-When ``choice_translation_domain`` is ``true`` or ``null``, use translations of informed domain(e.g. ``AcmeStoreBundle`` to ``Acme\StoreBundle\Resources\translation`` files).
-
-
 Overridden Options
 ------------------
 
@@ -220,6 +198,8 @@ type:
 .. include:: /reference/forms/types/options/placeholder.rst.inc
 
 .. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
+
+.. include:: /reference/forms/types/options/choice_type_translation_domain.rst.inc
 
 .. include:: /reference/forms/types/options/expanded.rst.inc
 

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -179,7 +179,7 @@ If specified, this entity manager will be used to load the choices
 instead of the ``default`` entity manager.
 
 choice_translation_domain
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.7
     The ``choice_translation_domain`` option was introduced in Symfony 2.7.
@@ -189,7 +189,7 @@ choice_translation_domain
 This option determines whether the translation of the data obtained will be informed domain ``translation_domain``.
 
 translation_domain
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.7
     The ``translation_domain`` option was introduced in Symfony 2.7.

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -184,9 +184,9 @@ choice_translation_domain
 .. versionadded:: 2.7
     The ``choice_translation_domain`` option was introduced in Symfony 2.7.
 
-**type**: ``boolean``
+**type**: ``boolean`` | ``null`` | ``string``
 
-This option determines whether the translation of the data obtained will be informed domain ``translation_domain``.
+If specified ``null`` value, corresponds to parents translation_domain or default domain (messages). If the value is ``string``, corresponds to explicit domain(e.g. ``AcmeStoreBundle``). If the value is ``true``, reuse current ``translation_domain`` and ``false`` to disabled.
 
 translation_domain
 ~~~~~~~~~~~~~~~~~~

--- a/reference/forms/types/options/choice_type_translation_domain.rst.inc
+++ b/reference/forms/types/options/choice_type_translation_domain.rst.inc
@@ -1,0 +1,8 @@
+translation_domain
+~~~~~~~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``messages``
+
+In case `choice_translation_domain`_ is set to ``true`` or ``null``, this
+configures the exact translation domain that will be used for any labels or
+options that are rendered for this field


### PR DESCRIPTION
It has a slightly different behaviour, I think it's interested to document it.

This finishes #5614.

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 2.7+ |
| Fixed tickets | - |
