### PR TITLE
use literals for external class names

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1487,7 +1487,7 @@ cache
 **type**: ``string``
 
 The service that is used to persist class metadata in a cache. The service
-has to implement the :class:`Doctrine\\Common\\Cache\\Cache` interface.
+has to implement the ``Doctrine\Common\Cache\Cache`` interface.
 
 .. seealso::
 


### PR DESCRIPTION
The `class` role does not work for classes whose API documentation is
not rendered on symfony.com.
