### PR TITLE
Remove app_dev as build-in server is used

### DIFF
--- a/book/configuration.rst
+++ b/book/configuration.rst
@@ -87,8 +87,8 @@ format you prefer:
 
 .. note::
 
-   You'll learn exactly how to load each file/format in the next section
-   `Environments`_.
+    You'll learn exactly how to load each file/format in the next section
+    `Environments`_.
 
 Each top-level entry like ``framework`` or ``twig`` defines the configuration
 for a particular bundle. For example, the ``framework`` key defines the configuration
@@ -122,13 +122,13 @@ FrameworkBundle configuration:
 
 .. code-block:: bash
 
-    $ app/console config:dump-reference FrameworkBundle
+    $ php app/console config:dump-reference FrameworkBundle
 
 The extension alias (configuration key) can also be used:
 
 .. code-block:: bash
 
-    $ app/console config:dump-reference framework
+    $ php app/console config:dump-reference framework
 
 .. note::
 
@@ -194,6 +194,12 @@ cached files and allow them to rebuild:
     The ``test`` environment is used when running automated tests and cannot
     be accessed directly through the browser. See the :doc:`testing chapter </book/testing>`
     for more details.
+
+.. tip::
+
+    When using the ``server:run`` command to start a server,
+    ``http://localhost:8000/`` will use the dev front controller of your
+    application.
 
 .. index::
    single: Environments; Configuration

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -63,7 +63,8 @@ Before diving into this, test it out!
 
 .. tip::
 
-    If you setup a proper virtual host in :doc:`Apache or Nginx </cookbook/configuration/web_server_configuration>`,
+    If you setup a proper virtual host in
+    :doc:`Apache or Nginx </cookbook/configuration/web_server_configuration>`,
     replace ``http://localhost:8000`` with your host name - like
     ``http://symfony.dev/app_dev.php/lucky/number``.
 
@@ -79,22 +80,6 @@ The method below the annotation - ``numberAction`` - is called the *controller*
 and is where you build the page. The only rule is that a controller *must*
 return a Symfony :ref:`Response <component-http-foundation-response>` object
 (and you'll even learn to bend this rule eventually).
-
-.. sidebar:: What's the ``app_dev.php`` in the URL?
-
-    Great question! By including ``app_dev.php`` in the URL, you're executing
-    Symfony through a file - ``web/app_dev.php`` - that boots it in the ``dev``
-    environment. This enables great debugging tools and rebuilds cached
-    files automatically. For production, you'll use clean URLs - like
-    ``http://symfony.dev/lucky/number`` - that execute a different file -
-    ``app.php`` - that's optimized for speed.
-
-    When you visit the ``http://localhost:8000`` URL in your browser, you're
-    executing your Symfony application in the ``dev`` environment. To visit
-    your application in the ``prod`` environment, visit the ``http://localhost:8000/app.php``
-    URL instead.
-
-    To learn more about this and environments, see :ref:`book-page-creation-prod-cache-clear`.
 
 Creating a JSON Response
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -132,7 +117,7 @@ Just add a second method to ``LuckyController``::
 
 Try this out in your browser:
 
-    http://localhost:8000/app_dev.php/api/lucky/number
+    http://localhost:8000/api/lucky/number
 
 You can even shorten this with the handy :class:`Symfony\\Component\\HttpFoundation\\JsonResponse`::
 
@@ -253,7 +238,7 @@ The best part is that you can access this value and use it in your controller::
 
 Try it by going to ``/lucky/number/XX`` - replacing XX with *any* number:
 
-    http://localhost:8000/app_dev.php/lucky/number/7
+    http://localhost:8000/lucky/number/7
 
 You should see *7* lucky numbers printed out! You can get the value of any
 ``{placeholder}`` in your route by adding a ``$placeholder`` argument to
@@ -410,7 +395,7 @@ to put the content into the middle of the ``base.html.twig`` layout.
 
 Refresh to see your template in action!
 
-    http://localhost:8000/app_dev.php/lucky/number/9
+    http://localhost:8000/lucky/number/9
 
 If you view the source code, you now have a basic HTML structure thanks to
 ``base.html.twig``.

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -59,7 +59,7 @@ a method inside of it that will be executed when someone goes to ``/lucky/number
 
 Before diving into this, test it out!
 
-    http://localhost:8000/app_dev.php/lucky/number
+    http://localhost:8000/lucky/number
 
 .. tip::
 
@@ -86,9 +86,15 @@ return a Symfony :ref:`Response <component-http-foundation-response>` object
     Symfony through a file - ``web/app_dev.php`` - that boots it in the ``dev``
     environment. This enables great debugging tools and rebuilds cached
     files automatically. For production, you'll use clean URLs - like
-    ``http://localhost:8000/lucky/number`` - that execute a different file -
-    ``app.php`` - that's optimized for speed. To learn more about this and
-    environments, see :ref:`book-page-creation-prod-cache-clear`.
+    ``http://symfony.dev/lucky/number`` - that execute a different file -
+    ``app.php`` - that's optimized for speed.
+
+    When you visit the ``http://localhost:8000`` URL in your browser, you're
+    executing your Symfony application in the ``dev`` environment. To visit
+    your application in the ``prod`` environment, visit the ``http://localhost:8000/app.php``
+    URL instead.
+
+    To learn more about this and environments, see :ref:`book-page-creation-prod-cache-clear`.
 
 Creating a JSON Response
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Finishes/replaces https://github.com/symfony/symfony-docs/pull/5612

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | #5611 |
