### PR TITLE
Add missing getBoolean() method

### DIFF
--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -125,6 +125,9 @@ has some methods to filter the input values:
 :method:`Symfony\\Component\\HttpFoundation\\ParameterBag::getAlnum`
     Returns the alphabetic characters and digits of the parameter value;
 
+:method:`Symfony\\Component\\HttpFoundation\\ParameterBag::getBoolean`
+    Returns the parameter value converted to boolean;
+
 :method:`Symfony\\Component\\HttpFoundation\\ParameterBag::getDigits`
     Returns the digits of the parameter value;
 


### PR DESCRIPTION
According to the [Symfony\Component\HttpFoundation\ParameterBag::getBoolean()](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/ParameterBag.php#L187-L190).
