### PR TITLE
[Cookbook][Console] change API doc class name

### DIFF
--- a/cookbook/console/style.rst
+++ b/cookbook/console/style.rst
@@ -83,14 +83,14 @@ helper methods that cover the most common interactions performed by console comm
 Titling Methods
 ~~~~~~~~~~~~~~~
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::title`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::title`
     It displays the given string as the command title. This method is meant to
     be used only once in a given command, but nothing prevents you to use it
     repeatedly::
 
         $io->title('Lorem ipsum dolor sit amet');
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::section`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::section`
     It displays the given string as the title of some command section. This is
     only needed in complex commands which want to better separate their contents::
 
@@ -105,7 +105,7 @@ Titling Methods
 Content Methods
 ~~~~~~~~~~~~~~~
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::text`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::text`
     It displays the given string or array of strings as regular text. This is
     useful to render help messages and instructions for the user running the
     command::
@@ -122,7 +122,7 @@ Content Methods
             'Aenean sit amet arcu vitae sem faucibus porta',
         ));
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::listing`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::listing`
     It displays an unordered list of elements passed as an array::
 
         $io->listing(array(
@@ -131,7 +131,7 @@ Content Methods
             'Element #3 Lorem ipsum dolor sit amet',
         ));
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::table`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::table`
     It displays the given array of headers and rows as a compact table::
 
         $io->table(
@@ -143,7 +143,7 @@ Content Methods
             )
         );
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::newLine`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::newLine`
     It displays a blank line in the command output. Although it may seem useful,
     most of the times you won't need it at all. The reason is that every helper
     already adds their own blank lines, so you don't have to care about the
@@ -158,7 +158,7 @@ Content Methods
 Admonition Methods
 ~~~~~~~~~~~~~~~~~~
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::note`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::note`
     It displays the given string or array of strings as a highlighted admonition.
     Use this helper sparingly to avoid cluttering command's output::
 
@@ -174,7 +174,7 @@ Admonition Methods
             'Aenean sit amet arcu vitae sem faucibus porta',
         ));
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::caution`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::caution`
     Similar to the ``note()`` helper, but the contents are more prominently
     highlighted. The resulting contents resemble an error message, so you should
     avoid using this helper unless strictly necessary::
@@ -194,7 +194,7 @@ Admonition Methods
 Progress Bar Methods
 ~~~~~~~~~~~~~~~~~~~~
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::progressStart`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::progressStart`
     It displays a progress bar with a number of steps equal to the argument passed
     to the method (don't pass any value if the length of the progress bar is
     unknown)::
@@ -205,7 +205,7 @@ Progress Bar Methods
         // displays a 100-step length progress bar
         $io->progressStart(100);
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::progressAdvance`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::progressAdvance`
     It makes the progress bar advance the given number of steps (or ``1`` step
     if no argument is passed)::
 
@@ -215,7 +215,7 @@ Progress Bar Methods
         // advances the progress bar 10 steps
         $io->progressAdvance(10);
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::progressFinish`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::progressFinish`
     It finishes the progress bar (filling up all the remaining steps when its
     length is known)::
 
@@ -224,7 +224,7 @@ Progress Bar Methods
 User Input Methods
 ~~~~~~~~~~~~~~~~~~
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::ask`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::ask`
     It asks the user to provide some value::
 
         $io->ask('What is your name?');
@@ -245,7 +245,7 @@ User Input Methods
             return $number;
         });
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::askHidden`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::askHidden`
     It's very similar to the ``ask()`` method but the user's input will be hidden
     and it cannot define a default value. Use it when asking for sensitive information::
 
@@ -260,7 +260,7 @@ User Input Methods
             return $password;
         });
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::confirm`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::confirm`
     It asks a Yes/No question to the user and it only returns ``true`` or ``false``::
 
         $io->confirm('Restart the web server?');
@@ -270,7 +270,7 @@ User Input Methods
 
         $io->confirm('Restart the web server?', true);
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::choice`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::choice`
     It asks a question whose answer is constrained to the given list of valid
     answers::
 
@@ -284,7 +284,7 @@ User Input Methods
 Result Methods
 ~~~~~~~~~~~~~~
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::success`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::success`
     It displays the given string or array of strings highlighted as a successful
     message (with a green background and the ``[OK]`` label). It's meant to be
     used once to display the final result of executing the given command, but you
@@ -301,7 +301,7 @@ Result Methods
             'Consectetur adipiscing elit',
         ));
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::warning`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::warning`
     It displays the given string or array of strings highlighted as a warning
     message (with a read background and the ``[WARNING]`` label). It's meant to be
     used once to display the final result of executing the given command, but you
@@ -318,7 +318,7 @@ Result Methods
             'Consectetur adipiscing elit',
         ));
 
-:method:`Symfony\\Component\\Console\\Style\\StyleInterface::error`
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::error`
     It displays the given string or array of strings highlighted as an error
     message (with a read background and the ``[ERROR]`` label). It's meant to be
     used once to display the final result of executing the given command, but you


### PR DESCRIPTION
The article describes the methods of the `SymfonyStyle` class and not
the `StyleInterface` (new methods can only be added to the class but not
to the interface before Symfony 4.0).
