### PR TITLE
To use annotations, files must be removed

### DIFF
--- a/cookbook/doctrine/reverse_engineering.rst
+++ b/cookbook/doctrine/reverse_engineering.rst
@@ -101,8 +101,10 @@ execute the second command only.
 
 .. tip::
 
-    If you want to use annotations, you can safely delete the XML (or YAML) files
-    after running these two commands.
+    If you want to use annotations, you must remove the XML (or YAML) files
+    after running these two commands. It is `not possible to mix XML/YAML metadata
+    definitions with annotated PHP entity class definitions 
+    <http://symfony.com/doc/current/book/doctrine.html#add-mapping-information>`_.
 
 For example, the newly created ``BlogComment`` entity class looks as follow::
 

--- a/cookbook/doctrine/reverse_engineering.rst
+++ b/cookbook/doctrine/reverse_engineering.rst
@@ -102,9 +102,8 @@ execute the second command only.
 .. tip::
 
     If you want to use annotations, you must remove the XML (or YAML) files
-    after running these two commands. It is `not possible to mix XML/YAML metadata
-    definitions with annotated PHP entity class definitions 
-    <http://symfony.com/doc/current/book/doctrine.html#add-mapping-information>`_.
+    after running these two commands. This is necessary as
+    :ref:`it is not possible to mix mapping configuration formats <book-doctrine-adding-mapping>`
 
 For example, the newly created ``BlogComment`` entity class looks as follow::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | Tested on 3.0 |
| Fixed tickets | N/A |

I'm proposing this change after spending an hour trying to work out why my Repository class wasn't loading.

Thanks to `ysor123` on IRC, we diagnosed the problem was the XML mapping files generated when reverse engineering my database, which I hadn't deleted.

This is obliquely referred to at http://symfony.com/doc/current/book/doctrine.html#add-mapping-information:

> A bundle can accept only one metadata definition format. For example, it's not possible to mix YAML metadata definitions with annotated PHP entity class definitions.

It'd be great to clarify this for future readers.
