### PR TITLE
Fixed code example

### DIFF
--- a/cookbook/session/locale_sticky_session.rst
+++ b/cookbook/session/locale_sticky_session.rst
@@ -53,8 +53,8 @@ how you determine the desired locale from the request::
         public static function getSubscribedEvents()
         {
             return array(
-                // must be registered before the default Locale listener
-                KernelEvents::REQUEST => array(array('onKernelRequest', 17)),
+                // must be registered after the default Locale listener
+                KernelEvents::REQUEST => array(array('onKernelRequest', 16)),
             );
         }
     }

--- a/cookbook/session/locale_sticky_session.rst
+++ b/cookbook/session/locale_sticky_session.rst
@@ -54,7 +54,7 @@ how you determine the desired locale from the request::
         {
             return array(
                 // must be registered after the default Locale listener
-                KernelEvents::REQUEST => array(array('onKernelRequest', 16)),
+                KernelEvents::REQUEST => array(array('onKernelRequest', 15)),
             );
         }
     }


### PR DESCRIPTION
The new subscriber must be called after the default listener. The default sets the locale as

``` php
$locale = $request->attributes->get('_locale');
$request->setLocale($locale);
```

which overwrites any local set before it.
