### PR TITLE
Warn on issue with controllers-as-services versus @Route annotation

### DIFF
--- a/cookbook/controller/service.rst
+++ b/cookbook/controller/service.rst
@@ -76,6 +76,13 @@ Then you can define it as a service as follows:
             'AppBundle\Controller\HelloController'
         ));
 
+.. caution::
+
+    If you are managing your routes with PHP annotation, you may need to add an
+    ``@Route`` annotation to the controller-class which specifies its service
+    ID. If you don't, the system may try to construct your controller without
+    any arguments. See the `FrameworkExtraBundle documentation`_ for details.
+
 Referring to the Service
 ------------------------
 


### PR DESCRIPTION
I just ran into this problem and it took me a while. Without the `@Route(service="myid")` annotation, the controller was _always_ being instantiated without any arguments, completely ignoring my service-definition.

Not sure how far back/forward this applies to other versions.
