### PR TITLE
add missing options `choice_value`, `choice_name` and `choice_attr` to `EntityType`

### DIFF
--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -22,6 +22,9 @@ objects from the database.
 +-------------+------------------------------------------------------------------+
 | Inherited   | from the :doc:`choice </reference/forms/types/choice>` type:     |
 | options     |                                                                  |
+|             | - `choice_value`_                                                |
+|             | - `choice_name`_                                                 |
+|             | - `choice_attr`_                                                 |
 |             | - `placeholder`_                                                 |
 |             | - `choice_translation_domain`_                                   |
 |             | - `translation_domain`_                                          |
@@ -194,6 +197,12 @@ Inherited Options
 
 These options inherit from the :doc:`choice </reference/forms/types/choice>`
 type:
+
+.. include:: /reference/forms/types/options/choice_value.rst.inc
+
+.. include:: /reference/forms/types/options/choice_name.rst.inc
+
+.. include:: /reference/forms/types/options/choice_attr.rst.inc
 
 .. include:: /reference/forms/types/options/placeholder.rst.inc
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no (& yes symfony/symfony#17694) |
| Applies to | 2.7+ |
| Fixed tickets | #6259 |
