### PR TITLE
[Cookbook][Debugging] reflect behavior changes in cache generation

### DIFF
--- a/cookbook/debugging.rst
+++ b/cookbook/debugging.rst
@@ -21,10 +21,9 @@ Disabling the Bootstrap File and Class Caching
 
 And to make the production environment as fast as possible, Symfony creates
 big PHP files in your cache containing the aggregation of PHP classes your
-project needs for every request. However, this behavior can confuse your IDE
-or your debugger. This recipe shows you how you can tweak this caching
-mechanism to make it friendlier when you need to debug code that involves
-Symfony classes.
+project needs for every request. However, this behavior can confuse your
+debugger. This recipe shows you how you can tweak this caching mechanism
+to make it friendlier when you need to debug code that involves Symfony classes.
 
 The ``app_dev.php`` front controller reads as follows by default::
 
@@ -37,9 +36,9 @@ The ``app_dev.php`` front controller reads as follows by default::
     $kernel->loadClassCache();
     $request = Request::createFromGlobals();
 
-To make your debugger happier, disable all PHP class caches by removing the
-call to ``loadClassCache()`` and by replacing the require statements like
-below::
+To make your debugger happier, disable the loading of all PHP class caches
+by removing the call to ``loadClassCache()`` and by replacing the require
+statements like below::
 
     // ...
 
@@ -57,7 +56,5 @@ below::
     session.
 
 Some IDEs do not like the fact that some classes are stored in different
-locations. To avoid problems, you can either tell your IDE to ignore the PHP
-cache files, or you can change the extension used by Symfony for these files::
-
-    $kernel->loadClassCache('classes', '.php.cache');
+locations. To avoid problems, you can tell your IDE to ignore the PHP cache
+file.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8+ |
| Fixed tickets | #6169 |

Starting with Symfony 2.8, the class cache is generated when the cache
is warmed up. This means that you cannot prevent the cache from being
generated, but you must simply not load it to ease debugging. Also, this
means that you have to ignore the cache files in your IDE now if it
cannot deal with them properly.
