### PR TITLE
[WIP] [2.7+] explicit differences between 'data' & 'empty_data' options in FormType

### DIFF
--- a/reference/forms/types/options/data.rst.inc
+++ b/reference/forms/types/options/data.rst.inc
@@ -20,3 +20,5 @@ the form or any nested field, you can set it in the data option::
     The default values for form fields are taken directly from the underlying
     data structure matching the field's name with a property of an object or a
     key of an array. The ``data`` option overrides this default value.
+    It means that when the data passed to the form is an object you want to
+    edit, the `data` option will also override the value already set.

--- a/reference/forms/types/options/data.rst.inc
+++ b/reference/forms/types/options/data.rst.inc
@@ -1,12 +1,12 @@
 data
 ~~~~
 
-**type**: ``mixed`` **default**: Defaults to field of the underlying object (if there is one)
+**type**: ``mixed`` **default**: Defaults to field of the underlying structure.
 
-When you create a form, each field initially displays the value of the
-corresponding property of the form's domain object (if an object is bound
-to the form). If you want to override the initial value for the form or
-just an individual field, you can set it in the data option::
+When you attach a form type to a form, it becomes a field that initially maps
+the value of the corresponding property or key of the form's domain data. If
+you want to override the initial value which will be rendered in the view for
+the form or any field, you can set it in the data option::
 
     $builder->add('token', 'hidden', array(
         'data' => 'abcdef',
@@ -15,5 +15,5 @@ just an individual field, you can set it in the data option::
 .. note::
 
     The default values for form fields are taken directly from the underlying
-    data structure (e.g. an entity or an array). The ``data`` option overrides
-    this default value.
+    data structure matching the field name with a property of an object or a
+    key of an array. The ``data`` option overrides this default value.

--- a/reference/forms/types/options/data.rst.inc
+++ b/reference/forms/types/options/data.rst.inc
@@ -6,14 +6,17 @@ data
 When you attach a form type to a form, it becomes a field that initially maps
 the value of the corresponding property or key of the form's domain data. If
 you want to override the initial value which will be rendered in the view for
-the form or any field, you can set it in the data option::
+the form or any nested field, you can set it in the data option::
 
     $builder->add('token', 'hidden', array(
         'data' => 'abcdef',
     ));
 
+    // Is the same as
+    $resolver->setDefault('data' => array('token' => 'abcdef'));
+
 .. note::
 
     The default values for form fields are taken directly from the underlying
-    data structure matching the field name with a property of an object or a
+    data structure matching the field's name with a property of an object or a
     key of an array. The ``data`` option overrides this default value.

--- a/reference/forms/types/options/empty_data.rst.inc
+++ b/reference/forms/types/options/empty_data.rst.inc
@@ -1,7 +1,7 @@
 empty_data
 ~~~~~~~~~~
 
-**type**: ``mixed``
+**type**: ``string`` or ``array`` when the form is compound
 
 .. This file should only be included with start-after or end-before that's
    set to this placeholder value. Its purpose is to let us include only
@@ -14,18 +14,29 @@ value is empty. It does not set an initial value if none is provided when
 the form is rendered in a view (see ``data`` or ``placeholder`` options).
 
 It helps you handling form submission and you can customize this to your needs.
-For example, if you want the ``gender`` choice field to be explicitly set to ``null``
+For example, if you want the ``gender`` choice field to be explicitly set to ``Male``
 when no value is selected, you can do it like this::
 
     $builder->add('gender', 'choice', array(
         'choices' => array(
             'm' => 'Male',
-            'f' => 'Female'
+            'f' => 'Female',
         ),
         'required'    => false,
         'empty_value' => 'Choose your gender',
-        'empty_data'  => null
+        'empty_data'  => 'm',
     ));
+
+If a form is compound, you can set ``empty_data`` as an array with fields names
+as keys and submitted values as string values (or arrays if nested fields are
+also compound).
+
+.. caution::
+
+    In this example, the choice field is not set as ``multiple``. If it was
+    ``empty_data`` option should be an array of submitted string values::
+
+        'empty_data' => array('m'),
 
 .. note::
 

--- a/reference/forms/types/options/empty_data.rst.inc
+++ b/reference/forms/types/options/empty_data.rst.inc
@@ -10,35 +10,31 @@ empty_data
 DEFAULT_PLACEHOLDER
 
 This option determines what value the field will return when the submitted
-value is empty. It does not set an initial value if none is provided when
-the form is rendered in a view (see ``data`` or ``placeholder`` options).
+value is empty (or missing). It does not set an initial value if none is
+provided when the form is rendered in a view (see ``data`` or ``placeholder``
+options).
 
 It helps you handling form submission and you can customize this to your needs.
-For example, if you want the ``gender`` choice field to be explicitly set to ``Male``
+For example, if you want the ``name`` field to be explicitly set to ``John Doe``
 when no value is selected, you can do it like this::
 
-    $builder->add('gender', 'choice', array(
-        'choices' => array(
-            'm' => 'Male',
-            'f' => 'Female',
-        ),
+    $builder->add('name', null, array(
         'required'    => false,
-        'empty_value' => 'Choose your gender',
-        'empty_data'  => 'm',
+        'empty_data'  => 'John Doe',
     ));
 
-If a form is compound, you can set ``empty_data`` as an array with fields names
+If a form is compound, you can set ``empty_data`` as an array with field names
 as keys and submitted values as string values (or arrays if nested fields are
 also compound).
-
-.. caution::
-
-    In this example, the choice field is not set as ``multiple``. If it was
-    ``empty_data`` option should be an array of submitted string values::
-
-        'empty_data' => array('m'),
 
 .. note::
 
     If you want to set the ``empty_data`` option for your entire form class,
     see the cookbook article :doc:`/cookbook/form/use_empty_data`.
+
+.. caution::
+
+    When using `empty_data` as an empty string, the form will always return
+    ``null``. If you need to get an empty string to be returned, you should
+    use a data transformer, see the cookbook article
+    :doc:`cookbook/form/data_transformers`.

--- a/reference/forms/types/options/empty_data.rst.inc
+++ b/reference/forms/types/options/empty_data.rst.inc
@@ -11,7 +11,7 @@ DEFAULT_PLACEHOLDER
 
 This option determines what value the field will return when the submitted
 value is empty. It does not set an initial value if none is provided when
-the form is rendered in a view (see `Data` or `Placeholder` options).
+the form is rendered in a view (see ``data`` or ``placeholder`` options).
 
 It helps you handling form submission and you can customize this to your needs.
 For example, if you want the ``gender`` choice field to be explicitly set to ``null``

--- a/reference/forms/types/options/empty_data.rst.inc
+++ b/reference/forms/types/options/empty_data.rst.inc
@@ -10,11 +10,12 @@ empty_data
 DEFAULT_PLACEHOLDER
 
 This option determines what value the field will return when the submitted
-value is empty.
+value is empty. It does not set an initial value if none is provided when
+the form is rendered in a view (see `Data` or `Placeholder` options).
 
-But you can customize this to your needs. For example, if you want the
-``gender`` choice field to be explicitly set to ``null`` when no value is
-selected, you can do it like this::
+It helps you handling form submission and you can customize this to your needs.
+For example, if you want the ``gender`` choice field to be explicitly set to ``null``
+when no value is selected, you can do it like this::
 
     $builder->add('gender', 'choice', array(
         'choices' => array(


### PR DESCRIPTION
It seems to be some confusion between two options `data` and empty_data` in regard of these two old symfony issues I read yesterday (symfony/symfony#14579, symfony/symfony#16530).

Probably because of their name and the fact that they both are some kind of "placeholder" in different step of the form cycle.

@jakzal advise me to open a PR here for that matter.

IMO both of their descriptions are already pretty clear.

You can see in this PR an attempt to explicit and focus on the context in which they are requested.

Any idea or suggestions are welcome.
