### PR TITLE
[DX] Form Types location contradicts Best Practices

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -992,7 +992,7 @@ In :ref:`book-form-creating-form-classes` you will learn how to move the
 form building code into separate classes. When using an external form class
 in the controller, you can pass the action and method as form options::
 
-    use AppBundle\Form\Type\TaskType;
+    use AppBundle\Form\TaskType;
     // ...
 
     $form = $this->createForm(TaskType::class, $task, array(
@@ -1040,8 +1040,8 @@ However, a better practice is to build the form in a separate, standalone PHP
 class, which can then be reused anywhere in your application. Create a new class
 that will house the logic for building the task form::
 
-    // src/AppBundle/Form/Type/TaskType.php
-    namespace AppBundle\Form\Type;
+    // src/AppBundle/Form/TaskType.php
+    namespace AppBundle\Form;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
@@ -1063,7 +1063,7 @@ This new class contains all the directions needed to create the task form. It ca
 be used to quickly build a form object in the controller::
 
     // src/AppBundle/Controller/DefaultController.php
-    use AppBundle\Form\Type\TaskType;
+    use AppBundle\Form\TaskType;
 
     public function newAction()
     {
@@ -1147,8 +1147,8 @@ type as a service, and inject all dependencies you need.
 You might want to use a service defined as ``app.my_service`` in your form
 type. Create a constructor to your form type to receive the service::
 
-    // src/AppBundle/Form/Type/TaskType.php
-    namespace AppBundle\Form\Type;
+    // src/AppBundle/Form/TaskType.php
+    namespace AppBundle\Form;
 
     use App\Utility\MyService;
     use Symfony\Component\Form\AbstractType;
@@ -1184,7 +1184,7 @@ Define your form type as a service.
         # src/AppBundle/Resources/config/services.yml
         services:
             app.form.type.task:
-                class: AppBundle\Form\Type\TaskType
+                class: AppBundle\Form\TaskType
                 arguments: ["@app.my_service"]
                 tags:
                     - { name: form.type }
@@ -1198,7 +1198,7 @@ Define your form type as a service.
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="app.form.type.task" class="AppBundle\Form\Type\TaskType">
+                <service id="app.form.type.task" class="AppBundle\Form\TaskType">
                     <tag name="form.type" />
                     <argument type="service" id="app.my_service"></argument>
                 </service>
@@ -1210,7 +1210,7 @@ Define your form type as a service.
         // src/AppBundle/Resources/config/services.php
         use Symfony\Component\DependencyInjection\Reference;
 
-        $container->register('app.form.type.task', 'AppBundle\Form\Type\TaskType')
+        $container->register('app.form.type.task', 'AppBundle\Form\TaskType')
             ->addArgument(new Reference('app.my_service'))
             ->addTag('form.type')
 
@@ -1318,8 +1318,8 @@ Next, add a new ``category`` property to the ``Task`` class::
 Now that your application has been updated to reflect the new requirements,
 create a form class so that a ``Category`` object can be modified by the user::
 
-    // src/AppBundle/Form/Type/CategoryType.php
-    namespace AppBundle\Form\Type;
+    // src/AppBundle/Form/CategoryType.php
+    namespace AppBundle\Form;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
@@ -1348,7 +1348,7 @@ class:
 .. code-block:: php
 
     use Symfony\Component\Form\FormBuilderInterface;
-    use AppBundle\Form\Type\CategoryType;
+    use AppBundle\Form\CategoryType;
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {


### PR DESCRIPTION
I wondered why I always put form definitions in `AppBundle/Form/Type`, and whether we were meant to put something else in `AppBundle/Form`. While Googling for an answer I came across the [Forms Best Practice](http://symfony.com/doc/current/best_practices/forms.html) guide, which says the new best practice is to put the form types (which I guess are usually form definitions, so the change makes sense) directly in `AppBundle/Form`.

This PR updates the [main documentation](http://symfony.com/doc/current/book/forms.html#book-form-creating-form-classes) to reflect the best practices. If anyone can point me to discussions clarifying the difference between form types, form definitions and how the Symfony view has changed (reflected in the change of location) I'd greatly appreciate it.
