### PR TITLE
Update Doctrine UTF8 docs

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -131,10 +131,6 @@ for you:
         $ php bin/console doctrine:database:drop --force
         $ php bin/console doctrine:database:create
 
-    There's no way to configure these defaults inside Doctrine, as it tries to be
-    as agnostic as possible in terms of environment configuration. One way to solve
-    this problem is to configure server-level defaults.
-
     Setting UTF8 defaults for MySQL is as simple as adding a few lines to
     your configuration file  (typically ``my.cnf``):
 
@@ -144,6 +140,55 @@ for you:
         # Version 5.5.3 introduced "utf8mb4", which is recommended
         collation-server     = utf8mb4_general_ci # Replaces utf8_general_ci
         character-set-server = utf8mb4            # Replaces utf8
+
+    You can also change the defaults for Doctrine so that the generated SQL
+    uses the correct character set.
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # app/config/config.yml
+            doctrine:
+                charset: utf8mb4
+                dbal:
+                    default_table_options:
+                        charset: utf8mb4
+                        collate: utf8mb4_unicode_ci
+
+        .. code-block:: xml
+
+            <!-- app/config/config.xml -->
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <container xmlns="http://symfony.com/schema/dic/services"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
+                xsi:schemaLocation="http://symfony.com/schema/dic/services
+                    http://symfony.com/schema/dic/services/services-1.0.xsd
+                    http://symfony.com/schema/dic/doctrine
+                    http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+                <doctrine:config>
+                    <doctrine:dbal
+                        charset="utf8mb4">
+                            <doctrine:default-table-option name="charset">utf8mb4</doctrine:default-table-option>
+                            <doctrine:default-table-option name="collate">utf8mb4_unicode_ci</doctrine:default-table-option>
+                    </doctrine:dbal>
+                </doctrine:config>
+            </container>
+
+        .. code-block:: php
+
+            // app/config/config.php
+            $configuration->loadFromExtension('doctrine', array(
+                'dbal' => array(
+                    'charset' => 'utf8mb4',
+                    'default_table_options' => array(
+                        'charset' => 'utf8mb4'
+                        'collate' => 'utf8mb4_unicode_ci'
+                    )
+                ),
+            ));
 
     We recommend against MySQL's ``utf8`` character set, since it does not
     support 4-byte unicode characters, and strings containing them will be


### PR DESCRIPTION
Since its now possible (https://github.com/doctrine/DoctrineBundle/pull/420) to set the default character set for all tables using DoctrineBundle it can be mentioned in the docs
