### PR TITLE
[HttpFoundation] Fix typo for ParameterBag getters

### DIFF
--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -140,7 +140,7 @@ has some methods to filter the input values:
 :method:`Symfony\\Component\\HttpFoundation\\ParameterBag::filter`
     Filters the parameter by using the PHP :phpfunction:`filter_var` function.
 
-All getters takes up to three arguments: the first one is the parameter name
+All getters take up to two arguments: the first one is the parameter name
 and the second one is the default value to return if the parameter does not
 exist::
 

--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -140,9 +140,9 @@ has some methods to filter the input values:
 :method:`Symfony\\Component\\HttpFoundation\\ParameterBag::filter`
     Filters the parameter by using the PHP :phpfunction:`filter_var` function.
 
-All getters take up to three arguments: the first one is the parameter name, 
+All getters take up to three arguments: the first one is the parameter name and 
 the second one is the default value to return if the parameter does not
-exist and the third one is a boolean to allow for a deep search::
+exist::
 
     // the query string is '?foo=bar'
 
@@ -155,9 +155,6 @@ exist and the third one is a boolean to allow for a deep search::
     $request->query->get('bar', 'bar');
     // returns 'bar'
   
-    //a path like foo[bar] will find deeper items
-    //the query string is '?foo[bar]=baz'
-    $request->query->get('foo[bar]', 'foobar', true);
 
 When PHP imports the request query, it handles request parameters like
 ``foo[bar]=bar`` in a special way as it creates an array. So you can get the

--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -140,9 +140,9 @@ has some methods to filter the input values:
 :method:`Symfony\\Component\\HttpFoundation\\ParameterBag::filter`
     Filters the parameter by using the PHP :phpfunction:`filter_var` function.
 
-All getters take up to two arguments: the first one is the parameter name
-and the second one is the default value to return if the parameter does not
-exist::
+All getters take up to three arguments: the first one is the parameter name, 
+the second one is the default value to return if the parameter does not
+exist and the third one is a boolean to allow for a deep search::
 
     // the query string is '?foo=bar'
 
@@ -154,6 +154,10 @@ exist::
 
     $request->query->get('bar', 'bar');
     // returns 'bar'
+  
+    //a path like foo[bar] will find deeper items
+    //the query string is '?foo[bar]=baz'
+    $request->query->get('foo[bar]', 'foobar', true);
 
 When PHP imports the request query, it handles request parameters like
 ``foo[bar]=bar`` in a special way as it creates an array. So you can get the


### PR DESCRIPTION
[HttpFoundation] Fix typo for max number of arguments for ParameterBag getters

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7 |
| Fixed tickets | ~ |
