### PR TITLE
[Form] fix `choice_label` values

### DIFF
--- a/reference/forms/types/options/choice_label.rst.inc
+++ b/reference/forms/types/options/choice_label.rst.inc
@@ -4,7 +4,7 @@ choice_label
 .. versionadded:: 2.7
     The ``choice_label`` option was introduced in Symfony 2.7.
 
-**type**: ``callable`` or ``string`` **default**: ``null``
+**type**: ``string``, ``bool``, ``callable`` or ``PropertyPath`` **default**: ``null``
 
 Normally, the array key of each item in the ``choices`` option is used as the
 text that's shown to the user. The ``choice_label`` option allows you to take
@@ -48,3 +48,7 @@ If your choice values are objects, then ``choice_label`` can also be a
         'choices_as_values' => true,
         'choice_label' => 'displayName',
     ));
+
+If set to ``false``, all the tag labels will be discarded for radio or checkbox
+inputs. You can also return ``false`` from the callable to discard only the label
+of the processed tag.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | kind of |
| Applies to | 2.7+ |
| Fixed tickets | n/a |

This PR is a complement of symfony/symfony#17798, which allows handling `false` as `choice_label` value in `ChoiceType` and its inheritance.

Not sure about the phrasing but this is the idea, suggestions are welcome !
