### PR TITLE
[Book] [Routing] Fix third param true to UrlGeneratorInterface::ABSOLUTE_URI

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1477,7 +1477,7 @@ Generating Absolute URLs
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, the router will generate relative URLs (e.g. ``/blog``). From
-a controller, simply pass ``true`` to the third argument of the ``generateUrl()``
+a controller, simply pass ``UrlGeneratorInterface::ABSOLUTE_URL`` to the third argument of the ``generateUrl()``
 method::
 
     use Symfony\Component\Routing\Generator\UrlGeneratorInterface;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | https://github.com/symfony/symfony/issues/16991 |

This was forgotten in https://github.com/symfony/symfony-docs/pull/6009
