### PR TITLE
[HttpFoundation] Fix typo for ParameterBag getters - 3.0

### DIFF
--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -140,7 +140,7 @@ has some methods to filter the input values:
 :method:`Symfony\\Component\\HttpFoundation\\ParameterBag::filter`
     Filters the parameter by using the PHP :phpfunction:`filter_var` function.
 
-All getters takes up to three arguments: the first one is the parameter name
+All getters take up to two arguments: the first one is the parameter name
 and the second one is the default value to return if the parameter does not
 exist::
 


### PR DESCRIPTION
[HttpFoundation] Fix typo for max number of arguments for ParameterBag getters for the 3.0 branch

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 3.0 |
| Fixed tickets | ~ |
