### PR TITLE
Fix setting permission for var subdirectories

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -252,8 +252,8 @@ If there are any issues, correct them now before moving on.
         $ rm -rf var/cache/* var/logs/* var/sessions/*
 
         $ HTTPDUSER=`ps axo user,comm | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1`
-        $ sudo chmod +a "$HTTPDUSER allow delete,write,append,file_inherit,directory_inherit" var
-        $ sudo chmod +a "`whoami` allow delete,write,append,file_inherit,directory_inherit" var
+        $ sudo chmod -R +a "$HTTPDUSER allow delete,write,append,file_inherit,directory_inherit" var
+        $ sudo chmod -R +a "`whoami` allow delete,write,append,file_inherit,directory_inherit" var
 
 
     **3. Using ACL on a system that does not support chmod +a**


### PR DESCRIPTION
Subdirectories are created before the chmod command is executed, so ACL wouldn't be set on them an webserver would complain that it cant write to them.

Bug introduced in https://github.com/symfony/symfony-docs/commit/14d2afbdc2d1cf2486da36c270b70dd71b12d6bf
