### PR TITLE
Anonymous parameter security must set to false

### DIFF
--- a/cookbook/security/guard-authentication.rst
+++ b/cookbook/security/guard-authentication.rst
@@ -294,7 +294,7 @@ Finally, configure your ``firewalls`` key in ``security.yml`` to use this authen
                 # ...
 
                 main:
-                    anonymous: ~
+                    anonymous: false
                     logout: ~
 
                     guard:


### PR DESCRIPTION
In order to use curl command, must set false to anonymous parameter in security.yml
