### PR TITLE
Update dependency_injection.rst because it has an error.

### DIFF
--- a/create_framework/dependency_injection.rst
+++ b/create_framework/dependency_injection.rst
@@ -100,10 +100,11 @@ Create a new file to host the dependency injection container configuration::
     $sc->register('matcher', 'Symfony\Component\Routing\Matcher\UrlMatcher')
         ->setArguments(array($routes, new Reference('context')))
     ;
+    $sc->register('request_stack', 'Symfony\Component\HttpFoundation\RequestStack');
     $sc->register('resolver', 'Symfony\Component\HttpKernel\Controller\ControllerResolver');
 
     $sc->register('listener.router', 'Symfony\Component\HttpKernel\EventListener\RouterListener')
-        ->setArguments(array(new Reference('matcher')))
+        ->setArguments(array(new Reference('matcher'), new Reference('request_stack')))
     ;
     $sc->register('listener.response', 'Symfony\Component\HttpKernel\EventListener\ResponseListener')
         ->setArguments(array('UTF-8'))


### PR DESCRIPTION
The line:
    $sc->register('listener.router', 'Symfony\Component\HttpKernel\EventListener\RouterListener')
        ->setArguments(array(new Reference('matcher')))
    ;
is wrong, because the Symfony\Component\HttpKernel\EventListener\ResponseListener has two mandatory arguments; an instance of Symfony\Component\Routing\Matcher\UrlMatcher (or RequestMatcher), and an instance of RequestStack; so, we need to add the line:

$sc->register('request_stack', 'Symfony\Component\HttpFoundation\RequestStack');

And change the registration of listener.router on this form:

```
$sc->register('listener.router', 'Symfony\Component\HttpKernel\EventListener\RouterListener')
    ->setArguments(array(new Reference('matcher'), new Reference('request_stack')))
;
```
