### PR TITLE
Removed True and False constraints from reference

### DIFF
--- a/reference/constraints.rst
+++ b/reference/constraints.rst
@@ -9,11 +9,8 @@ Validation Constraints Reference
    constraints/Blank
    constraints/NotNull
    constraints/IsNull
-   constraints/Null
    constraints/IsTrue
-   constraints/True
    constraints/IsFalse
-   constraints/False
    constraints/Type
 
    constraints/Email

--- a/reference/constraints/False.rst
+++ b/reference/constraints/False.rst
@@ -1,8 +1,0 @@
-False
-=====
-
-.. caution::
-
-    The ``False`` constraint is deprecated since Symfony 2.7 and removed in
-    Symfony 3.0. Use the :doc:`/reference/constraints/IsFalse` constraint
-    instead.

--- a/reference/constraints/Null.rst
+++ b/reference/constraints/Null.rst
@@ -1,8 +1,0 @@
-Null
-====
-
-.. caution::
-
-    The ``Null`` constraint is deprecated since Symfony 2.7 and removed in
-    Symfony 3.0. Use the :doc:`/reference/constraints/IsNull` constraint
-    instead.

--- a/reference/constraints/True.rst
+++ b/reference/constraints/True.rst
@@ -1,8 +1,0 @@
-True
-====
-
-.. caution::
-
-    The ``True`` constraint is deprecated since Symfony 2.7 and removed in
-    Symfony 3.0. Use the :doc:`/reference/constraints/IsTrue` constraint
-    instead.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 3.0+ |
| Fixed tickets |  |

This PR simply removes _True_, _False_, _Null_ constraints from reference list.
