### PR TITLE
Remove trailing slash: check for match

### DIFF
--- a/cookbook/routing/redirect_trailing_slash.rst
+++ b/cookbook/routing/redirect_trailing_slash.rst
@@ -29,9 +29,9 @@ new URL with a 301 response status code::
             $url = str_replace($pathInfo, rtrim($pathInfo, ' /'), $requestUri);
 
             try{
-              $this->get('router')->match(str_replace('/app_dev.php', '', $url))
+                $this->get('router')->match(str_replace('/app_dev.php', '', $url))
             }catch(ResourceNotFoundException $e){
-              throw $this->createNotFoundException();
+                throw $this->createNotFoundException();
             }
             return $this->redirect($url, 301);
         }

--- a/cookbook/routing/redirect_trailing_slash.rst
+++ b/cookbook/routing/redirect_trailing_slash.rst
@@ -28,6 +28,8 @@ new URL with a 301 response status code::
 
             $url = str_replace($pathInfo, rtrim($pathInfo, ' /'), $requestUri);
 
+            // send 404 if page doesn't exist. Google sees a 301 as a link and
+            // will mark destination as a not found error
             try{
                 $this->get('router')->match(str_replace('/app_dev.php', '', $url))
             }catch(ResourceNotFoundException $e){

--- a/cookbook/routing/redirect_trailing_slash.rst
+++ b/cookbook/routing/redirect_trailing_slash.rst
@@ -17,6 +17,7 @@ new URL with a 301 response status code::
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
     class RedirectingController extends Controller
     {
@@ -27,6 +28,11 @@ new URL with a 301 response status code::
 
             $url = str_replace($pathInfo, rtrim($pathInfo, ' /'), $requestUri);
 
+            try{
+              $this->get('router')->match(str_replace('/app_dev.php', '', $url))
+            }catch(ResourceNotFoundException $e){
+              throw $this->createNotFoundException();
+            }
             return $this->redirect($url, 301);
         }
     }


### PR DESCRIPTION
A 301 seems to imply that the redirect target exists.  Redirecting to a 404 page is all the same to a normal end user, but it seems Google will see it as a crawl error.  This change just makes sure that there is a route that will match the redirected URL; otherwise a 404 is thrown.
