### PR TITLE
[DependencyInjection] Add Autowiring keyword

### DIFF
--- a/components/dependency_injection/autowiring.rst
+++ b/components/dependency_injection/autowiring.rst
@@ -1,8 +1,8 @@
 .. index::
     single: DependencyInjection; Autowiring
 
-Defining Services Dependencies Automatically
-============================================
+Defining Services Dependencies Automatically (Autowiring)
+=========================================================
 
 .. versionadded:: 2.8
     Support for autowiring services was introduced in Symfony 2.8.
@@ -76,7 +76,7 @@ service is marked as autowired:
             <services>
                 <service id="twitter_client" class="AppBundle\TwitterClient" autowire="true" />
             </services>
-        </services>
+        </container>
 
     .. code-block:: php
 
@@ -218,7 +218,7 @@ subsystem isn't able to find itself the interface implementation to register::
                 <service id="rot13_transformer" class="AppBundle\Rot13Transformer" />
                 <service id="twitter_client" class="AppBundle\TwitterClient" autowire="true" />
             </services>
-        </services>
+        </container>
 
     .. code-block:: php
 
@@ -356,7 +356,7 @@ and a Twitter client using it::
                     <argument type="service" id="uppercase_rot13_transformer" />
                 </service>
             </services>
-        </services>
+        </container>
 
     .. code-block:: php
 


### PR DESCRIPTION
Add the autowiring keyword: although unfamiliar too many, `autowiring` is still the word being used in the doc and also in the service configuration. In other words, even though not very descriptive at first, it is _the_ keyword to describe this feature. As a result, it should appear in the title to make it more searchable.

Also a fix in the XML config. ~~I'm also experimenting an issue with the doc block (you can see `configuraiton-block` and the code blocks are indented as comments), but unsure of what the issue actually is:~~

<img width="754" alt="screen shot 2016-03-02 at 20 10 06" src="https://cloud.githubusercontent.com/assets/5175937/13473782/cde4ad8e-e0b2-11e5-934a-0aaf145d6fb0.png">

[Page on platform.sh](http://pr-6323-6qmocelev2lwe.eu.platform.sh/components/dependency_injection/autowiring.html)
