### PR TITLE
Update extension.rst - added caution box for people trying to remove the default file with services definitions

### DIFF
--- a/cookbook/bundles/extension.rst
+++ b/cookbook/bundles/extension.rst
@@ -113,6 +113,12 @@ Other available loaders are the ``YamlFileLoader``, ``PhpFileLoader`` and
     The ``IniFileLoader`` can only be used to load parameters and it can only
     load them as strings.
 
+.. caution::
+
+    If you removed the default file with services definitions (i.e.
+    ``app/config/services.yml``), make sure to also remove it from the
+    ``imports`` key in ``app/config/config.yml``.
+
 Using Configuration to Change the Services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Following steps from the original article isn't enough, because config.yml still tries to import services.yml from the original location.
