### PR TITLE
Added "Require all granted" for Apache 2.4

### DIFF
--- a/cookbook/configuration/web_server_configuration.rst
+++ b/cookbook/configuration/web_server_configuration.rst
@@ -47,6 +47,7 @@ The **minimum configuration** to get your application running under Apache is:
             AllowOverride All
             Order Allow,Deny
             Allow from All
+            Require all granted
         </Directory>
 
         # uncomment the following lines if you install assets as symlinks
@@ -78,6 +79,7 @@ and increase web server performance:
             AllowOverride None
             Order Allow,Deny
             Allow from All
+            Require all granted
 
             <IfModule mod_rewrite.c>
                 Options -MultiViews
@@ -233,6 +235,7 @@ should look something like this:
             AllowOverride All
             Order Allow,Deny
             Allow from all
+            Require all granted
         </Directory>
 
         # uncomment the following lines if you install assets as symlinks


### PR DESCRIPTION
The following lines no longer work by default in Apache 2.4:

Order Allow,Deny
Allow from all

The way to do this in Apache 2.4 is with the line "Require all granted". The other two lines can be left there for compatibility with Apache 2.2, though I haven't tested if adding this new line breaks that old version of Apache...

More info at http://httpd.apache.org/docs/2.4/upgrading.html
