### PR TITLE
[HttpFoundation] ParameterBag::get() $deep param

### DIFF
--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -164,8 +164,8 @@ When PHP imports the request query, it handles request parameters like
     $request->query->get('foo');
     // returns array('bar' => 'bar')
 
-    $request->query->get('foo[bar]');
-    // returns null   
+    $request->query->get('foo')['bar'];
+    // returns 'bar'
 
 .. _component-foundation-attributes:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8+ |

Documentation replacement for `$deep` parameter of `ParameterBag::get()` since it was deprecated in 2.8 and removed in 3.0.

Because there's no need to show the legacy way of doing this. We just get an array back and that's all.
