### PR TITLE
Fixed yaml configuration of app.exception_controller

### DIFF
--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -233,8 +233,8 @@ In that case, you might want to override one or both of the ``showAction()`` and
             # app/config/services.yml
             services:
                 app.exception_controller:
-                  class: AppBundle\Controller\CustomExceptionController
-                  arguments: ['@twig', '%kernel.debug%']
+                    class: AppBundle\Controller\CustomExceptionController
+                    arguments: ['@twig', '%kernel.debug%']
 
         .. code-block:: xml
 

--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -233,8 +233,8 @@ In that case, you might want to override one or both of the ``showAction()`` and
             # app/config/services.yml
             services:
                 app.exception_controller:
-                class: AppBundle\Controller\CustomExceptionController
-                arguments: ['@twig', '%kernel.debug%']
+                  class: AppBundle\Controller\CustomExceptionController
+                  arguments: ['@twig', '%kernel.debug%']
 
         .. code-block:: xml
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | - |

Fixed yaml code-block for app.exception_controller service: indented lines with 'class' and 'arguments' configuration to make this example functional.
