### PR TITLE
Added minor clarification

### DIFF
--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -500,7 +500,8 @@ if it should::
 
     BinaryFileResponse::trustXSendfileTypeHeader();
 
-You can still set the ``Content-Type`` of the sent file, or change its ``Content-Disposition``::
+With the ``BinaryFileResponse``, you can still set the ``Content-Type`` of the sent file,
+or change its ``Content-Disposition``::
 
     $response->headers->set('Content-Type', 'text/plain');
     $response->setContentDisposition(


### PR DESCRIPTION
It was not clear if the following code applies to BinaryFileResponse only or to all file responses.

Since the following two paragraphs ("It is possible to delete ..." and "If you just created...") also apply to BinaryFileResponse only, it would be even better to have a separate heading for BinaryFileResponse, but I don't know how to create another sub-heading at this level.
