### PR TITLE
Add a note about enabling DebugBundle to use VarDumper inside Symfony

### DIFF
--- a/components/var_dumper/introduction.rst
+++ b/components/var_dumper/introduction.rst
@@ -18,7 +18,9 @@ You can install the component in 2 different ways:
 * Use the official Git repository (https://github.com/symfony/var-dumper).
 
 .. note::
-Make sure the bundle is added in your ``app/AppKernel.php``
+
+    If using it inside a Symfony application, make sure that the
+    DebugBundle is enabled in your ``app/AppKernel.php`` file.
 
 .. _components-var-dumper-dump:
 

--- a/components/var_dumper/introduction.rst
+++ b/components/var_dumper/introduction.rst
@@ -17,6 +17,9 @@ You can install the component in 2 different ways:
 * :doc:`Install it via Composer </components/using_components>` (``symfony/var-dumper`` on `Packagist`_);
 * Use the official Git repository (https://github.com/symfony/var-dumper).
 
+.. note::
+Make sure the bundle is added in your ``app/AppKernel.php``
+
 .. _components-var-dumper-dump:
 
 The dump() Function


### PR DESCRIPTION
This supersedes #6165 tweaking the proposed note contents.
