### PR TITLE
[book] Updated link to Translatable Extension

### DIFF
--- a/book/translation.rst
+++ b/book/translation.rst
@@ -717,5 +717,5 @@ steps:
 .. _`i18n`: https://en.wikipedia.org/wiki/Internationalization_and_localization
 .. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-.. _`Translatable Extension`: https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/translatable.md
+.. _`Translatable Extension`: http://atlantic18.github.io/DoctrineExtensions/doc/translatable.html
 .. _`Translatable Behavior`: https://github.com/KnpLabs/DoctrineBehaviors

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -717,5 +717,5 @@ steps:
 .. _`i18n`: https://en.wikipedia.org/wiki/Internationalization_and_localization
 .. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-.. _`Translatable Extension`: https://github.com/l3pp4rd/DoctrineExtensions
+.. _`Translatable Extension`: https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/translatable.md
 .. _`Translatable Behavior`: https://github.com/KnpLabs/DoctrineBehaviors


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | n/a |

Since l3pp4rd project was moved it is better to provide link to the new project. Moreover, I think it is better to show the exact page of Translatable Extension instead of a list of extensions.
