### PR TITLE
Removed info about reducing visibility for private

### DIFF
--- a/contributing/code/bc.rst
+++ b/contributing/code/bc.rst
@@ -236,7 +236,6 @@ Change return type                                  No
 Add private method                                  Yes
 Remove private method                               Yes
 Change name                                         Yes
-Reduce visibility                                   Yes
 Add argument without a default value                Yes
 Add argument with a default value                   Yes
 Remove argument                                     Yes


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.3+ |
| Fixed tickets | n/a |

It makes no sense to reduce visibility of private methods as soon as it is minimal visibility.
I removed this table line in order to not confuse readers.
