### PR TITLE
[reference] [constraints] added missing colon character for Image constraint documentation in YAML format.

### DIFF
--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -89,7 +89,7 @@ that it is between a certain size, add the following:
     .. code-block:: yaml
 
         # src/AppBundle/Resources/config/validation.yml
-        AppBundle\Entity\Author
+        AppBundle\Entity\Author:
             properties:
                 headshot:
                     - Image:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | ~ |
