### PR TITLE
[cookbook] Made list of form types more consistent

### DIFF
--- a/cookbook/form/create_form_type_extension.rst
+++ b/cookbook/form/create_form_type_extension.rst
@@ -329,7 +329,7 @@ Generic Form Type Extensions
 
 You can modify several form types at once by specifying their common parent
 (:doc:`/reference/forms/types`). For example, several form types natively
-available in Symfony inherit from the ``TextType`` form type (such as ``email``,
+available in Symfony inherit from the ``TextType`` form type (such as ``EmailType``,
 ``SearchType``, ``UrlType``, etc.). A form type extension applying to ``TextType``
 (i.e. whose ``getExtendedType`` method returns ``TextType::class``) would apply
 to all of these form types.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8+ |
| Fixed tickets | n/a |

Fixed content of inline code block 'email' to 'EmailType' accordingly to other form types in the list.
