### PR TITLE
Fix escaping of backtick inside double back-quotes

### DIFF
--- a/components/yaml/yaml_format.rst
+++ b/components/yaml/yaml_format.rst
@@ -50,7 +50,7 @@ can use double quotes, for these characters it is more convenient to use single
 quotes, which avoids having to escape any backslash ``\``:
 
 * ``:``, ``{``, ``}``, ``[``, ``]``, ``,``, ``&``, ``*``, ``#``, ``?``, ``|``,
-  ``-``, ``<``, ``>``, ``=``, ``!``, ``%``, ``@``, ``\```
+  ``-``, ``<``, ``>``, ``=``, ``!``, ``%``, ``@``, `````
 
 The double-quoted style provides a way to express arbitrary strings, by
 using ``\`` to escape characters and sequences. For instance, it is very useful


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

This PR removes the backslash before the backtick inside a double-back-quoted inline code block, because there it is interpreted literally (and displayed too) instead of as an escaping character.
