### PR TITLE
[WCM] Add documentation for the ChainNameConverter

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -437,6 +437,22 @@ processes::
     $anne = $normalizer->denormalize(array('first_name' => 'Anne'), 'Person');
     // Person object with firstName: 'Anne'
 
+.. _using-multiple-name-converters:
+
+Using multiple Name Converters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can combine multiple name converters by using the ``ChainNameConverter``::
+
+    use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+    use Symfony\Component\Serializer\NameConverter\ChainNameConverter;
+
+    $camelCaseNameConverter = new CamelCaseToSnakeCaseNameConverter();
+    $orgPrefixNameConverter = new OrgPrefixNameConverter();
+
+    $nameConverter = new ChainNameConverter(array($camelCaseNameConverter, $orgPrefixNameConverter));
+    $normalizer = new ObjectNormalizer(null, $nameConverter);
+
 Serializing Boolean Attributes
 ------------------------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes (symfony/symfony/pull/18182) |
| Applies to | master |
| Fixed tickets |  |

This adds a small section to the serializer page about a new `ChainNameConverter` introduced with symfony/symfony/pull/18182.

In the code example I am "using" the `OrgPrefixNameConverter` which was introduced at the beginning of the main section.

:octocat: 
