### PR TITLE
Corrected model folder inside bundle

### DIFF
--- a/cookbook/bundles/best_practices.rst
+++ b/cookbook/bundles/best_practices.rst
@@ -122,7 +122,7 @@ Commands                         ``Command/``
 Controllers                      ``Controller/``
 Service Container Extensions     ``DependencyInjection/``
 Event Listeners                  ``EventListener/``
-Model classes [1]                ``Model/``
+Model classes [1]                ``Entity/`` (Doctrine ORM) or ``Document/`` (an ODM) 
 Configuration                    ``Resources/config/``
 Web Resources (CSS, JS, images)  ``Resources/public/``
 Translation files                ``Resources/translations/``


### PR DESCRIPTION
According to the best practices, I believe that Entity or Document folders should be used.
