### PR TITLE
Update "bootstrap.php.cache" to "autoload.php"

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -92,7 +92,7 @@ of your bundle::
     directory.
 
 Just like in your real application - autoloading is automatically enabled
-via the ``bootstrap.php.cache`` file (as configured by default in the
+via the ``autoload.php`` file (as configured by default in the
 ``app/phpunit.xml.dist`` file).
 
 Running tests for a given file or directory is also very easy:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8 |
| Fixed tickets |  |

Update `testing.rst` for version 2.8 accordingly after change https://github.com/symfony/symfony-standard/commit/747a384401edf803e985c52089c882edaebe467a#diff-d81c0bc884e8d2b4407434a5aef33c0a
