### PR TITLE
refs #5898 Fix updates of testing.rst for 3.0

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -63,7 +63,7 @@ called ``Calculator`` in the ``Util/`` directory of the app bundle::
     }
 
 To test this, create a ``CalculatorTest`` file in the ``tests/AppBundle/Util`` directory
-of your bundle::
+of your application::
 
     // tests/AppBundle/Util/CalculatorTest.php
     namespace Tests\AppBundle\Util;
@@ -84,13 +84,13 @@ of your bundle::
 
 .. note::
 
-    By convention, the ``Tests/AppBundle`` directory should replicate the directory
+    By convention, the ``tests/AppBundle`` directory should replicate the directory
     of your bundle for unit tests. So, if you're testing a class in the
-    ``AppBundle/Util/`` directory, put the test in the ``tests/AppBundle/Util/``
+    ``src/AppBundle/Util/`` directory, put the test in the ``tests/AppBundle/Util/``
     directory.
 
 Just like in your real application - autoloading is automatically enabled
-via the ``autoload.php`` file (as configured by default in the
+via the ``app/autoload.php`` file (as configured by default in the
 ``phpunit.xml.dist`` file).
 
 Running tests for a given file or directory is also very easy:
@@ -790,7 +790,7 @@ PHPUnit Configuration
 
 Each application has its own PHPUnit configuration, stored in the
 ``phpunit.xml.dist`` file. You can edit this file to change the defaults or
-create an ``phpunit.xml`` file to set up a configuration for your local machine
+create a ``phpunit.xml`` file to set up a configuration for your local machine
 only.
 
 .. tip::
@@ -825,7 +825,7 @@ configuration adds tests from a custom ``lib/tests`` directory:
         <testsuites>
             <testsuite name="Project Test Suite">
                 <!-- ... --->
-                <directory>../lib/tests</directory>
+                <directory>lib/tests</directory>
             </testsuite>
         </testsuites>
         <!-- ... --->
@@ -842,10 +842,10 @@ section:
         <filter>
             <whitelist>
                 <!-- ... -->
-                <directory>../lib</directory>
+                <directory>lib</directory>
                 <exclude>
                     <!-- ... -->
-                    <directory>../lib/tests</directory>
+                    <directory>lib/tests</directory>
                 </exclude>
             </whitelist>
         </filter>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 3.0+ |
| Fixed tickets | part of #5898 |

As a consequence of the following changes:

> - `app/phpunit.xml.dist` -> `phpunit.xml.dist`

https://github.com/symfony/symfony-docs/commit/1461bdcf4e7ac8d7a0304ad30782e1987a03443b#diff-6e8b9a935e200194f4cdab04f31032a2

> - `src/AppBundle/Tests/...` -> `tests/AppBundle/...`

https://github.com/symfony/symfony-docs/commit/3083e90a560af5dd3134b568a4d8a5de9babd183#diff-6e8b9a935e200194f4cdab04f31032a2
