### PR TITLE
[Form] [Cookbook] Correctly setup unit tests with dependencies

### DIFF
--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -128,6 +128,8 @@ make sure the ``FormRegistry`` uses the created instance::
         {
             // mock any dependencies
             $this->entityManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+
+            parent::setUp();
         }
 
         protected function getExtensions()


### PR DESCRIPTION
Among other things, `parent::setUp()` will call `getExtensions()` that uses the private variables.
