### PR TITLE
unused use instructions

### DIFF
--- a/cookbook/event_dispatcher/event_listener.rst
+++ b/cookbook/event_dispatcher/event_listener.rst
@@ -141,9 +141,7 @@ listen to the same ``kernel.exception`` event::
     namespace AppBundle\EventSubscriber;
 
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
-    use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
     class ExceptionSubscriber implements EventSubscriberInterface
     {


### PR DESCRIPTION
removed excess use instructions, that not used in example
