### PR TITLE
Added an opening PHP tag for the first example of "Symfony Page Creation"

### DIFF
--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -36,6 +36,8 @@ Suppose you want to create a page - ``/lucky/number`` - that generates a
 lucky (well, random) number and prints it. To do that, create a class and
 a method inside of it that will be executed when someone goes to ``/lucky/number``::
 
+    <?php
+
     // src/AppBundle/Controller/LuckyController.php
     namespace AppBundle\Controller;
 


### PR DESCRIPTION
If accepted, this fixes #6116.

---

This article is linked from the "Welcome to Symfony" page you see after installing Symfony. This is one of the most popular pages for Symfony newcomers. This little change can make a big difference because it's the first example you copy+paste and it should always work.
