### PR TITLE
Fixed wrong code examples for Isbn constraint

### DIFF
--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -57,8 +57,8 @@ on an  object that will contain an ISBN.
         {
             /**
              * @Assert\Isbn(
-             *     type = isbn10,
-             *     message: This value is not  valid.
+             *     type = "isbn10",
+             *     message: "This value is not  valid."
              * )
              */
             protected $isbn;
@@ -97,7 +97,7 @@ on an  object that will contain an ISBN.
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
                 $metadata->addPropertyConstraint('isbn', new Assert\Isbn(array(
-                    'type'    => isbn10,
+                    'type'    => 'isbn10',
                     'message' => 'This value is not valid.'
                 )));
             }

--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -58,7 +58,7 @@ on an  object that will contain an ISBN.
             /**
              * @Assert\Isbn(
              *     type = "isbn10",
-             *     message: "This value is not  valid."
+             *     message = "This value is not  valid."
              * )
              */
             protected $isbn;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5+ |
| Fixed tickets | n/a |

The example in the annotations code block causes an exception '[Semantical Error] Couldn't find constant isbn10'.
It happens because attribute values in annotation blocks must be quoted.
Additionally I fixed PHP code block to use quoted attribute also there
