### PR TITLE
Update 'date' to DateType::class in form.rst

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -694,7 +694,7 @@ the documentation for each type.
     :ref:`disable HTML5 validation <book-forms-html5-validation-disable>`
     or set the ``required`` option on your field to ``false``::
     
-        ->add('dueDate', 'date', array(
+        ->add('dueDate', DateType::class, array(
             'widget' => 'single_text',
             'required' => false
         ))


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8+ |
| Fixed tickets | ~ |

A small patch for a small issue. This patch should be merged upwards as 3.0 also has the old notation.
