### PR TITLE
Fixed a typo in configuration-block

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -260,7 +260,7 @@ to ``$name``. Just make sure they the name of the placeholder is the
 same as the name of the argument variable.
 
 Take the following more-interesting example, where the controller has two
-arguments::
+arguments:
 
 .. configuration-block::
 


### PR DESCRIPTION
It is not rendered properly right now (https://symfony.com/doc/current/book/controller.html#route-parameters-as-controller-arguments)

I think this should fix it
