### PR TITLE
Documented the ArgumentResolver along the ControllerResolver

### DIFF
--- a/components/http_kernel/introduction.rst
+++ b/components/http_kernel/introduction.rst
@@ -90,6 +90,8 @@ to the events discussed below::
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpKernel\HttpKernel;
     use Symfony\Component\EventDispatcher\EventDispatcher;
+    use Symfony\Component\HttpFoundation\RequestStack;
+    use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
     use Symfony\Component\HttpKernel\Controller\ControllerResolver;
 
     // create the Request object
@@ -98,10 +100,12 @@ to the events discussed below::
     $dispatcher = new EventDispatcher();
     // ... add some event listeners
 
-    // create your controller resolver
-    $resolver = new ControllerResolver();
+    // create your controller and argument resolvers
+    $controllerResolver = new ControllerResolver();
+    $argumentResolver = new ArgumentResolver();
+
     // instantiate the kernel
-    $kernel = new HttpKernel($dispatcher, $resolver);
+    $kernel = new HttpKernel($dispatcher, $controllerResolver, new RequestStack(), $argumentResolver);
 
     // actually execute the kernel, which turns the request into a response
     // by dispatching events, calling a controller, and returning the response
@@ -117,6 +121,14 @@ See ":ref:`http-kernel-working-example`" for a more concrete implementation.
 
 For general information on adding listeners to the events below, see
 :ref:`http-kernel-creating-listener`.
+
+
+.. caution::
+
+    As of 3.1 the :class:`Symfony\\Component\\Httpkernel\\HttpKernel` accepts a fourth argument, which
+    must be an instance of :class:`Symfony\\Component\\Httpkernel\\Controller\\ArgumentResolverInterface`.
+    In 4.0 this argument will become mandatory and the :class:`Symfony\\Component\\Httpkernel\\HttpKernel`
+    will no longer be able to fall back to the :class:`Symfony\\Component\\Httpkernel\\Controller\\ControllerResolver`.
 
 .. seealso::
 
@@ -225,13 +237,21 @@ This implementation is explained more in the sidebar below::
         public function getArguments(Request $request, $controller);
     }
 
+.. caution::
+
+    The ``getArguments()`` method in the :class:`Symfony\\Component\\Httpkernel\\Controller\\ControllerResolver`
+    and respective interface :class:`Symfony\\Component\\Httpkernel\\Controller\\ControllerResolverInterface`
+    are deprecated as of 3.1 and will be removed in 4.0. You can use the
+    :class:`Symfony\\Component\\Httpkernel\\Controller\\ArgumentResolver` which uses the
+    :class:`Symfony\\Component\\Httpkernel\\Controller\\ArgumentResolverInterface` instead.
+
 Internally, the ``HttpKernel::handle`` method first calls
 :method:`Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface::getController`
 on the controller resolver. This method is passed the ``Request`` and is responsible
 for somehow determining and returning a PHP callable (the controller) based
 on the request's information.
 
-The second method, :method:`Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface::getArguments`,
+The second method, :method:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverInterface::getArguments`,
 will be called after another event - ``kernel.controller`` - is dispatched.
 
 .. sidebar:: Resolving the Controller in the Symfony Framework
@@ -310,11 +330,11 @@ on the event object that's passed to listeners on this event.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Next, ``HttpKernel::handle`` calls
-:method:`Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface::getArguments`.
+:method:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverInterface::getArguments`.
 Remember that the controller returned in ``getController`` is a callable.
 The purpose of ``getArguments`` is to return the array of arguments that
 should be passed to that controller. Exactly how this is done is completely
-up to your design, though the built-in :class:`Symfony\\Component\\HttpKernel\\Controller\\ControllerResolver`
+up to your design, though the built-in :class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolver`
 is a good example.
 
 .. image:: /images/components/http_kernel/07-controller-arguments.png
@@ -326,7 +346,7 @@ of arguments that should be passed when executing that callable.
 .. sidebar:: Getting the Controller Arguments in the Symfony Framework
 
     Now that you know exactly what the controller callable (usually a method
-    inside a controller object) is, the ``ControllerResolver`` uses `reflection`_
+    inside a controller object) is, the ``ArgumentResolver`` uses `reflection`_
     on the callable to return an array of the *names* of each of the arguments.
     It then iterates over each of these arguments and uses the following tricks
     to determine which value should be passed for each argument:
@@ -338,8 +358,19 @@ of arguments that should be passed when executing that callable.
        from the ``RouterListener``).
 
     b) If the argument in the controller is type-hinted with Symfony's
-       :class:`Symfony\\Component\\HttpFoundation\\Request` object, then the
-       ``Request`` is passed in as the value.
+       :class:`Symfony\\Component\\HttpFoundation\\Request` object, the
+       ``Request`` is passed in as the value. If you have a custom ``Request``
+       class, it will be injected as long as you extend the Symfony ``Request``.
+
+    c) If the function or method argument is `variadic`_ and the ``Request``
+       ``attributes`` bag contains and array for that argument, they will all be
+       available through the `variadic`_ argument.
+
+    This functionality is provided by resolvers implementing the
+    :class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentValueResolverInterface`.
+    There are four implementations which provide the default behavior of Symfony but
+    customization is the key here. By implementing the ``ArgumentValueResolverInterface``
+    yourself and passing this to the ``ArgumentResolver``, you can extend this functionality.
 
 .. _component-http-kernel-calling-controller:
 
@@ -612,47 +643,52 @@ A full Working Example
 ----------------------
 
 When using the HttpKernel component, you're free to attach any listeners
-to the core events and use any controller resolver that implements the
-:class:`Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface`.
-However, the HttpKernel component comes with some built-in listeners and
-a built-in ControllerResolver that can be used to create a working example::
+to the core events, use any controller resolver that implements the
+:class:`Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface` and
+use any argument resolver that implements the
+:class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverInterface`.
+However, the HttpKernel component comes with some built-in listeners and everything
+else that can be used to create a working example::
 
-    use Symfony\Component\HttpFoundation\Request;
-    use Symfony\Component\HttpFoundation\RequestStack;
-    use Symfony\Component\HttpFoundation\Response;
-    use Symfony\Component\HttpKernel\HttpKernel;
-    use Symfony\Component\EventDispatcher\EventDispatcher;
-    use Symfony\Component\HttpKernel\Controller\ControllerResolver;
-    use Symfony\Component\HttpKernel\EventListener\RouterListener;
-    use Symfony\Component\Routing\RouteCollection;
-    use Symfony\Component\Routing\Route;
-    use Symfony\Component\Routing\Matcher\UrlMatcher;
-    use Symfony\Component\Routing\RequestContext;
+   use Symfony\Component\EventDispatcher\EventDispatcher;
+   use Symfony\Component\HttpFoundation\Request;
+   use Symfony\Component\HttpFoundation\RequestStack;
+   use Symfony\Component\HttpFoundation\Response;
+   use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+   use Symfony\Component\HttpKernel\Controller\ControllerResolver;
+   use Symfony\Component\HttpKernel\EventListener\RouterListener;
+   use Symfony\Component\HttpKernel\HttpKernel;
+   use Symfony\Component\Routing\Matcher\UrlMatcher;
+   use Symfony\Component\Routing\RequestContext;
+   use Symfony\Component\Routing\Route;
+   use Symfony\Component\Routing\RouteCollection;
 
-    $routes = new RouteCollection();
-    $routes->add('hello', new Route('/hello/{name}', array(
-            '_controller' => function (Request $request) {
-                return new Response(
-                    sprintf("Hello %s", $request->get('name'))
-                );
-            }
-        )
-    ));
+   $routes = new RouteCollection();
+   $routes->add('hello', new Route('/hello/{name}', array(
+       '_controller' => function (Request $request) {
+           return new Response(
+               sprintf("Hello %s", $request->get('name'))
+           );
+       })
+   ));
 
-    $request = Request::createFromGlobals();
+   $request = Request::createFromGlobals();
 
-    $matcher = new UrlMatcher($routes, new RequestContext());
+   $matcher = new UrlMatcher($routes, new RequestContext());
 
-    $dispatcher = new EventDispatcher();
-    $dispatcher->addSubscriber(new RouterListener($matcher, new RequestStack()));
+   $dispatcher = new EventDispatcher();
+   $dispatcher->addSubscriber(new RouterListener($matcher, new RequestStack()));
 
-    $resolver = new ControllerResolver();
-    $kernel = new HttpKernel($dispatcher, $resolver);
+   $controllerResolver = new ControllerResolver();
+   $argumentResolver = new ArgumentResolver();
 
-    $response = $kernel->handle($request);
-    $response->send();
+   $kernel = new HttpKernel($dispatcher, $controllerResolver, new RequestStack(), $argumentResolver);
 
-    $kernel->terminate($request, $response);
+   $response = $kernel->handle($request);
+   $response->send();
+
+   $kernel->terminate($request, $response);
+
 
 .. _http-kernel-sub-requests:
 
@@ -716,3 +752,4 @@ look like this::
 .. _`@ParamConverter`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
 .. _`@Template`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/view.html
 .. _`EmailSenderListener`: https://github.com/symfony/swiftmailer-bundle/blob/master/EventListener/EmailSenderListener.php
+.. _variadic: http://php.net/manual/en/functions.arguments.php

--- a/create_framework/event_dispatcher.rst
+++ b/create_framework/event_dispatcher.rst
@@ -36,24 +36,27 @@ the Response instance::
     // example.com/src/Simplex/Framework.php
     namespace Simplex;
 
+    use Symfony\Component\EventDispatcher\EventDispatcher;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
-    use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
-    use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+    use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
     use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
-    use Symfony\Component\EventDispatcher\EventDispatcher;
+    use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+    use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 
     class Framework
     {
-        private $matcher;
-        private $resolver;
         private $dispatcher;
+        private $matcher;
+        private $controllerResolver;
+        private $argumentResolver;
 
-        public function __construct(EventDispatcher $dispatcher, UrlMatcherInterface $matcher, ControllerResolverInterface $resolver)
+        public function __construct(EventDispatcher $dispatcher, UrlMatcherInterface $matcher, ControllerResolverInterface $controllerResolver, ArgumentResolverInterface $argumentResolver)
         {
-            $this->matcher = $matcher;
-            $this->resolver = $resolver;
             $this->dispatcher = $dispatcher;
+            $this->matcher = $matcher;
+            $this->controllerResolver = $controllerResolver;
+            $this->argumentResolver = $argumentResolver;
         }
 
         public function handle(Request $request)
@@ -63,8 +66,8 @@ the Response instance::
             try {
                 $request->attributes->add($this->matcher->match($request->getPathInfo()));
 
-                $controller = $this->resolver->getController($request);
-                $arguments = $this->resolver->getArguments($request, $controller);
+                $controller = $this->controllerResolver->getController($request);
+                $arguments = $this->argumentResolver->getArguments($request, $controller);
 
                 $response = call_user_func_array($controller, $arguments);
             } catch (ResourceNotFoundException $e) {

--- a/create_framework/separation_of_concerns.rst
+++ b/create_framework/separation_of_concerns.rst
@@ -2,7 +2,7 @@ The Separation of Concerns
 ==========================
 
 One down-side of our framework right now is that we need to copy and paste the
-code in ``front.php`` each time we create a new website. 40 lines of code is
+code in ``front.php`` each time we create a new website. 60 lines of code is
 not that much, but it would be nice if we could wrap this code into a proper
 class. It would bring us better *reusability* and easier testing to name just
 a few benefits.
@@ -20,19 +20,22 @@ request handling logic into its own ``Simplex\\Framework`` class::
 
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
-    use Symfony\Component\Routing\Matcher\UrlMatcher;
-    use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+    use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
     use Symfony\Component\HttpKernel\Controller\ControllerResolver;
+    use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+    use Symfony\Component\Routing\Matcher\UrlMatcher;
 
     class Framework
     {
         protected $matcher;
-        protected $resolver;
+        protected $controllerResolver;
+        protected $argumentResolver;
 
-        public function __construct(UrlMatcher $matcher, ControllerResolver $resolver)
+        public function __construct(UrlMatcher $matcher, ControllerResolver $controllerResolver, ArgumentResolver $argumentResolver)
         {
             $this->matcher = $matcher;
-            $this->resolver = $resolver;
+            $this->controllerResolver = $controllerResolver;
+            $this->argumentResolver = $argumentResolver;
         }
 
         public function handle(Request $request)
@@ -42,8 +45,8 @@ request handling logic into its own ``Simplex\\Framework`` class::
             try {
                 $request->attributes->add($this->matcher->match($request->getPathInfo()));
 
-                $controller = $this->resolver->getController($request);
-                $arguments = $this->resolver->getArguments($request, $controller);
+                $controller = $this->controllerResolver->getController($request);
+                $arguments = $this->argumentResolver->getArguments($request, $controller);
 
                 return call_user_func_array($controller, $arguments);
             } catch (ResourceNotFoundException $e) {
@@ -64,9 +67,11 @@ And update ``example.com/web/front.php`` accordingly::
 
     $context = new Routing\RequestContext();
     $matcher = new Routing\Matcher\UrlMatcher($routes, $context);
-    $resolver = new HttpKernel\Controller\ControllerResolver();
 
-    $framework = new Simplex\Framework($matcher, $resolver);
+    $controllerResolver = new ControllerResolver();
+    $argumentResolver = new ArgumentResolver();
+
+    $framework = new Simplex\Framework($matcher, $controllerResolver, new RequestStack(), $argumentResolver);
     $response = $framework->handle($request);
 
     $response->send();
@@ -142,7 +147,7 @@ To sum up, here is the new file layout:
 
     example.com
     ├── composer.json
-    ├── composer.lock    
+    ├── composer.lock
     ├── src
     │   ├── app.php
     │   └── Simplex

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -24,6 +24,7 @@ Tag Name                                  Usage
 `assetic.templating.twig`_                Remove this service if Twig templating is disabled
 `auto_alias`_                             Define aliases based on the value of container parameters
 `console.command`_                        Add a command
+`controller.argument_value_resolver`_     Register a value resolver for controller arguments such as ``Request``
 `data_collector`_                         Create a class that collects custom data for the profiler
 `doctrine.event_listener`_                Add a Doctrine event listener
 `doctrine.event_subscriber`_              Add a Doctrine event subscriber
@@ -349,6 +350,15 @@ console.command
 
 For details on registering your own commands in the service container, read
 :ref:`the cookbook article<cookbook-console-dic>`.
+
+controller.argument_value_resolver
+----------------------------------
+
+**Purpose**: Register a value resolver for controller arguments such as ``Request``
+
+Value resolvers implement the :class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentValueResolverInterface`
+and are used to resolve argument values for controllers as described here:
+:doc:`/cookbook/controller/argument_value_resolver`.
 
 data_collector
 --------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no ~ symfony/symfony#18308 |
| Applies to | 3.1 |
| Fixed tickets | ~ |

The ArgumentResolver is used now instead of the ControllerResolver. I have yet to document the extension point but first I want to have this page mention it.
