### PR TITLE
Link: Macro to Customize a Collection Prototype

### DIFF
--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -799,6 +799,11 @@ Part of the Form  Block Name
 ``row``           ``_tasks_entry_row``
 ================  =======================
 
+If you want to avoid duplicating the template code for the prototype, use the
+macro approach described by Maximilian Beck in his
+`Custom form collection prototype <http://glumb.de/en/custom-form-collection-prototype-in-symfony2>`
+blog post.
+
 Other common Customizations
 ---------------------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

Maximilian Beck has a much better approach for customizing a form collection prototype than the one outlined in the current docs (which I can’t even get to work).

His blog post: http://glumb.de/en/custom-form-collection-prototype-in-symfony2
