### PR TITLE
Documented the new Inflector component

### DIFF
--- a/components/index.rst
+++ b/components/index.rst
@@ -21,6 +21,7 @@ The Components
     form/index
     http_foundation/index
     http_kernel/index
+    inflector
     intl
     options_resolver
     phpunit_bridge

--- a/components/inflector.rst
+++ b/components/inflector.rst
@@ -1,0 +1,53 @@
+.. index::
+   single: Inflector
+   single: Components; Inflector
+
+The Inflector Component
+=======================
+
+    The Inflector component converts English words between singular and plural forms.
+
+Installation
+------------
+
+You can install the component in two different ways:
+
+* :doc:`Install it via Composer</components/using_components>` (``symfony/inflector`` on `Packagist`_);
+* Use the official Git repository (https://github.com/symfony/inflector).
+
+.. include:: /components/require_autoload.rst.inc
+
+Usage
+-----
+
+The Inflector component provides an easy and consistent way to convert English
+words between singular and plural forms. The static ``singularize()`` method
+defined by :class:`Symfony\\Component\\Inflector\\Inflector` class returns the
+singular form of the given word::
+
+    use Symfony\Component\Inflector\Inflector;
+
+    $word = Inflector::singularize('cars');
+    // $word = 'car'
+
+Besides the regular singular-plural conversions, this component supports most of
+the arbitrary pluralization rules defined by the English language:
+
+    use Symfony\Component\Inflector\Inflector;
+
+    Inflector::singularize('alumni');  // 'alumnus'
+    Inflector::singularize('knives');  // 'knife'
+    Inflector::singularize('mice');    // 'mouse'
+    Inflector::singularize('stories'); // 'story'
+    Inflector::singularize('women');   // 'woman'
+
+In some edge cases, it's not possible to determine a unique singular form for
+the given word. In those cases, the ``singularize()`` method returns an array
+with all the compatible singular forms::
+
+    use Symfony\Component\Inflector\Inflector;
+
+    Inflector::singularize('indices'); // array('index', 'indix', 'indice')
+    Inflector::singularize('leaves');  // array('leaf', 'leave', 'leaff')
+
+.. _Packagist: https://packagist.org/packages/symfony/inflector

--- a/components/inflector.rst
+++ b/components/inflector.rst
@@ -41,9 +41,9 @@ the arbitrary pluralization rules defined by the English language:
     Inflector::singularize('stories'); // 'story'
     Inflector::singularize('women');   // 'woman'
 
-In some edge cases, it's not possible to determine a unique singular form for
-the given word. In those cases, the ``singularize()`` method returns an array
-with all the compatible singular forms::
+Sometimes it's not possible to determine a unique singular form for the given
+word. In those edge cases, the ``singularize()`` method returns an array with
+all the compatible singular forms::
 
     use Symfony\Component\Inflector\Inflector;
 

--- a/components/inflector.rst
+++ b/components/inflector.rst
@@ -31,7 +31,7 @@ singular form of the given word::
     // $word = 'car'
 
 Besides the regular singular-plural conversions, this component supports most of
-the arbitrary pluralization rules defined by the English language:
+the arbitrary pluralization rules defined by the English language::
 
     use Symfony\Component\Inflector\Inflector;
 

--- a/components/inflector.rst
+++ b/components/inflector.rst
@@ -5,7 +5,7 @@
 The Inflector Component
 =======================
 
-    The Inflector component converts English words between singular and plural forms.
+    The Inflector component converts English words from plural to singular.
 
 Installation
 ------------
@@ -22,8 +22,8 @@ Usage
 
 The Inflector component provides an easy and consistent way to convert English
 words between singular and plural forms. The static ``singularize()`` method
-defined by :class:`Symfony\\Component\\Inflector\\Inflector` class returns the
-singular form of the given word::
+defined by the :class:`Symfony\\Component\\Inflector\\Inflector` class returns
+the singular form of the given word::
 
     use Symfony\Component\Inflector\Inflector;
 

--- a/components/map.rst.inc
+++ b/components/map.rst.inc
@@ -112,6 +112,10 @@
 
   * :doc:`/components/intl`
 
+* **Inflector**
+
+  * :doc:`/components/inflector`
+
 * **OptionsResolver**
 
   * :doc:`/components/options_resolver`


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | master (3.1+) |
| Fixed tickets | #6417 |

Excuse me if this question is stupid, but while documenting this component I wondered why there isn't a reverse `pluralize()` method.
