### PR TITLE
Update testing.rst

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -445,9 +445,7 @@ You can also get the objects related to the latest request::
 
     $crawler = $client->getCrawler();
 
-If your requests are not insulated, you can also access the ``Container`` and
-the ``Kernel``::
-
+    // you can also retrieve Container and Kernel instances
     $container = $client->getContainer();
     $kernel = $client->getKernel();
 


### PR DESCRIPTION
Hello, I'm working with some test in a Symfony 2.3 application. Reading the docs, they say that "If your requests are not insulated, you can also access the Container and the Kernel", but I can access kernel and container even in an insulated $client doing this:

```
    $client = $this->createClient();
    $client->insulate(true);
    $crawler = $client->request('GET', '/');

    $container = $client->getContainer();
    $kernel = $client->getKernel();
    var_dump($kernel->getBundles());
```
