### PR TITLE
[Form] fixed CollectionType needless option

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -56,8 +56,7 @@ address as its own input text box::
         'type'   => 'email',
         // these options are passed to each "email" type
         'options'  => array(
-            'required'  => false,
-            'attr'      => array('class' => 'email-box')
+            'attr' => array('class' => 'email-box')
         ),
     ));
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3+ |
| Doc fix | yes |

Define the `required` option in `(entry_)options` is useless as it is overridden by the collection option.
