### PR TITLE
Fixed an array notation in comment (serializer.rst)

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -300,7 +300,7 @@ You are now able to serialize only attributes in the groups you want::
     $serializer = new Serializer(array($normalizer));
 
     $data = $serializer->normalize($obj, null, array('groups' => array('group1')));
-    // $data = ['foo' => 'foo'];
+    // $data = array('foo' => 'foo');
 
     $obj2 = $serializer->denormalize(
         array('foo' => 'foo', 'bar' => 'bar'),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | https://github.com/symfony/symfony-docs/pull/6422#discussion_r59129292 |

Fixed against the right branch, reverted from other pr. The other pr is against 2.3, this was not in 2.3 yet.
