### PR TITLE
Remove choices as values in 3.0

### DIFF
--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -19,7 +19,7 @@ To use this field, you must specify *either* ``choices`` or ``choice_loader`` op
 |             | - `choice_name`_                                                             |
 |             | - `choice_translation_domain`_                                               |
 |             | - `choice_value`_                                                            |
-|             | - `choices_as_values`_                                                       |
+|             | - `choices_as_values`_ (deprecated)                                          |
 |             | - `expanded`_                                                                |
 |             | - `group_by`_                                                                |
 |             | - `multiple`_                                                                |
@@ -167,8 +167,6 @@ is the item's label and the array value is the item's value::
 
     $builder->add('inStock', ChoiceType::class, array(
         'choices' => array('In Stock' => true, 'Out of Stock' => false),
-        // always include this
-        'choices_as_values' => true,
     ));
 
 .. include:: /reference/forms/types/options/choice_attr.rst.inc
@@ -195,39 +193,8 @@ would replace the ``choices`` option.
 choices_as_values
 ~~~~~~~~~~~~~~~~~
 
-**type**: ``boolean`` **default**: false
-
-The ``choices_as_values`` option was added to keep backward compatibility with the
-*old* way of handling the ``choices`` option. When set to ``false`` (or omitted),
-the choice keys are used as the underlying value and the choice values are shown
-to the user.
-
-* Before 2.7 (and deprecated now)::
-
-    $builder->add('gender', 'choice', array(
-        // Shows "Male" to the user, returns "m" when selected
-        'choices'  => array('m' => 'Male', 'f' => 'Female'),
-        // before 2.7, this option didn't actually exist, but the
-        // behavior was equivalent to setting this to false in 2.7.
-        'choices_as_values' => false,
-    ));
-
-* Since 2.7::
-
-    $builder->add('gender', ChoiceType::class, array(
-        // Shows "Male" to the user, returns "m" when selected
-        'choices' => array('Male' => 'm', 'Female' => 'f'),
-        'choices_as_values' => true,
-    ));
-
-In Symfony 3.0, the ``choices_as_values`` option doesn't exist, but the ``choice``
-type behaves as if it were set to true:
-
-* Default for 3.0::
-
-    $builder->add('gender', ChoiceType::class, array(
-        'choices' => array('Male' => 'm', 'Female' => 'f'),
-    ));
+This option is deprecated and you should remove it from your 3.x projects (removing
+it will have *no* effect). For its purpose in 2.x, see the 2.7 documentation.
 
 .. include:: /reference/forms/types/options/expanded.rst.inc
 

--- a/reference/forms/types/options/choice_attr.rst.inc
+++ b/reference/forms/types/options/choice_attr.rst.inc
@@ -18,7 +18,6 @@ If an array, the keys of the ``choices`` array must be used as keys::
             'No' => false,
             'Maybe' => null,
         ),
-        'choices_as_values' => true,
         'choice_attr' => function($val, $key, $index) {
             // adds a class like attending_yes, attending_no, etc
             return ['class' => 'attending_'.strtolower($key)];

--- a/reference/forms/types/options/choice_label.rst.inc
+++ b/reference/forms/types/options/choice_label.rst.inc
@@ -16,7 +16,6 @@ more control::
             'no' => false,
             'maybe' => null,
         ),
-        'choices_as_values' => true,
         'choice_label' => function ($value, $key, $index) {
             if ($value == true) {
                 return 'Definitely!';
@@ -48,7 +47,6 @@ If your choice values are objects, then ``choice_label`` can also be a
             new Status(Status::NO),
             new Status(Status::MAYBE),
         ),
-        'choices_as_values' => true,
         'choice_label' => 'displayName',
     ));
 

--- a/reference/forms/types/options/group_by.rst.inc
+++ b/reference/forms/types/options/group_by.rst.inc
@@ -22,7 +22,6 @@ Take the following example::
             '1 week' => new \DateTime('+1 week'),
             '1 month' => new \DateTime('+1 month')
         ),
-        'choices_as_values' => true,
         'group_by' => function($val, $key, $index) {
             if ($val <= new \DateTime('+3 days')) {
                 return 'Soon';

--- a/reference/forms/types/options/preferred_choices.rst.inc
+++ b/reference/forms/types/options/preferred_choices.rst.inc
@@ -17,7 +17,6 @@ you can list the most popular on top, like Bork Bork and Pirate::
             'Bork'   => 'muppets',
             'Pirate' => 'arr'
         ),
-        'choices_as_values' => true,
         'preferred_choices' => array('muppets', 'arr')
     ));
 
@@ -34,7 +33,6 @@ be especially useful if your values are objects::
             '1 week' => new \DateTime('+1 week'),
             '1 month' => new \DateTime('+1 month')
         ),
-        'choices_as_values' => true,
         'preferred_choices' => function ($val, $key) {
             // prefer options within 3 days
             return $val <= new \DateTime('+3 days');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 3.0+ |
| Fixed tickets | n/a |

I think we must have just forgotten to remove this option!
