### PR TITLE
Add an other method to disable validation on Form

### DIFF
--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -735,3 +735,5 @@ all of this, use a listener::
 
     By doing this, you may accidentally disable something more than just form
     validation, since the ``POST_SUBMIT`` event may have other listeners.
+
+An other solution is to set ``group_validation`` with an unknown group like ``disable_validation``.

--- a/cookbook/form/dynamic_form_modification.rst
+++ b/cookbook/form/dynamic_form_modification.rst
@@ -736,4 +736,4 @@ all of this, use a listener::
     By doing this, you may accidentally disable something more than just form
     validation, since the ``POST_SUBMIT`` event may have other listeners.
 
-An other solution is to set ``group_validation`` with an unknown group like ``disable_validation``.
+Another solution is to set ``group_validation`` with an unknown group like ``disable_validation``.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

Hi,
I think this method can be usefull for disable the group_validation. 
The important question, is why set a unknow group on the group validation disable all validation, but set to `false` does not work?
What did you think?
