### PR TITLE
Fix adding custom extensions for unit testing

### DIFF
--- a/cookbook/form/unit_testing.rst
+++ b/cookbook/form/unit_testing.rst
@@ -188,6 +188,13 @@ allows you to return a list of extensions to register::
             $validator = $this->getMock('\Symfony\Component\Validator\Validator\ValidatorInterface');
             $validator->method('validate')->will($this->returnValue(new ConstraintViolationList()));
 
+            $metadata = $this->getMockBuilder('Symfony\Component\Validator\Mapping\ClassMetadata')
+                ->disableOriginalConstructor()
+                ->getMock();
+            $validator
+                ->method('getMetadataFor')
+                ->will($this->returnValue($metadata));
+
             return array(
                 new ValidatorExtension($validator),
             );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | - |

The previous version was generating the following error when running tests:

> Error: Call to a member function addConstraint() on null
> 
> /vagrant/blog/vendor/symfony/symfony/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php:39
> /vagrant/blog/tests/AppBundle/Form/Type/UserCreateTypeTest.php:87
> /vagrant/blog/vendor/symfony/symfony/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php:30
> /vagrant/blog/vendor/symfony/symfony/src/Symfony/Component/Form/Test/TypeTestCase.php:31
> /vagrant/blog/tests/AppBundle/Form/Type/UserCreateTypeTest.php:93

The changes for vesion 2.8+ should be a little different due to the refactoring that took place, but I would be happy to fix it once this gets merged.
