### PR TITLE
Added ldap to the list of user providers

### DIFF
--- a/cookbook/security/custom_provider.rst
+++ b/cookbook/security/custom_provider.rst
@@ -9,7 +9,8 @@ When a user submits a username and password, the authentication layer asks
 the configured user provider to return a user object for a given username.
 Symfony then checks whether the password of this user is correct and generates
 a security token so the user stays authenticated during the current session.
-Out of the box, Symfony has an "in_memory" and an "entity" user provider.
+Out of the box, Symfony has four user providers: ``in_memory``, ``entity``, 
+``ldap`` and ``chain``.
 In this entry you'll see how you can create your own user provider, which
 could be useful if your users are accessed via a custom database, a file,
 or - as shown in this example - a web service.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.8+ |
| Fixed tickets | n/a |

Ldap is the new user provider in  Symfony 2.8, so it would be good to mention it in the list of all user providers.
