### PR TITLE
Avoid confusion

### DIFF
--- a/book/translation.rst
+++ b/book/translation.rst
@@ -482,7 +482,7 @@ need it::
             $request = $event->getRequest();
 
             // some logic to determine the $locale
-            $request->getSession()->set('_locale', $locale);
+            $request->setLocale($locale);
         }
 
 Read :doc:`/cookbook/session/locale_sticky_session` for more on the topic.


### PR DESCRIPTION
To me it was a bit confusing why the locale was set on the session and not the request. Further more, reading the linked article shows extra code is needed to make this work at all.

Since the linked article explains in more detail how to make the locale sticky, I suggest just setting it on the request in this code sample.
