### PR TITLE
fixed wrong secret string in array examples

### DIFF
--- a/cookbook/bundles/configuration.rst
+++ b/cookbook/bundles/configuration.rst
@@ -139,7 +139,7 @@ For the configuration example in the previous section, the array passed to your
         array(
             'twitter' => array(
                 'client_id' => 123,
-                'client_secret' => '$secret',
+                'client_secret' => 'your_secret',
             ),
         ),
     )
@@ -155,7 +155,7 @@ beneath it, the incoming array might look like this::
         array(
             'twitter' => array(
                 'client_id' => 123,
-                'client_secret' => '$secret',
+                'client_secret' => 'your_secret',
             ),
         ),
         // values from config_dev.yml


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7+ |
| Fixed tickets | -- |

Looks like this is a copy paste error from older doc versions where the string `$ecret` was used.

This needs to be applied to all branches from 2.7 on

Check the old version of the docs here where the `$ecret` string is used:
http://symfony.com/doc/2.6/cookbook/bundles/configuration.html
