### PR TITLE
Add details about chmod +a vs setfacl

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -259,7 +259,10 @@ If there are any issues, correct them now before moving on.
 
     If this doesn't work, try adding ``-n`` option.
 
-    Note: setfacl isn't available on NFS mount points. However, setting cache and logs over NFS is strongly not recommanded for performance.
+    .. note::
+
+        setfacl isn't available on NFS mount points. However, setting cache and logs over NFS is strongly not recommanded for performance.
+
 
     **4. Without using ACL**
 

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -229,10 +229,9 @@ If there are any issues, correct them now before moving on.
     its user to be the same as your CLI user (e.g. for Apache, update the ``User``
     and ``Group`` values).
 
-    **2. Using ACL on a system that supports chmod +a**
+    **2. Using ACL on a system that supports chmod +a (MacOS X)**
 
-    Many systems allow you to use the ``chmod +a`` command. Try this first,
-    and if you get an error - try the next method. This uses a command to
+    MacOS X allows you to use the ``chmod +a`` command. This uses a command to
     try to determine your web server user and set it as ``HTTPDUSER``:
 
     .. code-block:: bash
@@ -244,12 +243,11 @@ If there are any issues, correct them now before moving on.
         $ sudo chmod +a "$HTTPDUSER allow delete,write,append,file_inherit,directory_inherit" app/cache app/logs
         $ sudo chmod +a "`whoami` allow delete,write,append,file_inherit,directory_inherit" app/cache app/logs
 
+    **3. Using ACL on a system that supports setfacl (most Linux/BSD)**
 
-    **3. Using ACL on a system that does not support chmod +a**
-
-    Some systems don't support ``chmod +a``, but do support another utility
+    Most Linux and BSD distributions don't support ``chmod +a``, but do support another utility
     called ``setfacl``. You may need to `enable ACL support`_ on your partition
-    and install setfacl before using it (as is the case with Ubuntu). This
+    and install setfacl before using it (as is the case with old versions of Ubuntu). This
     uses a command to try to determine your web server user and set it as
     ``HTTPDUSER``:
 
@@ -260,6 +258,8 @@ If there are any issues, correct them now before moving on.
         $ sudo setfacl -dR -m u:"$HTTPDUSER":rwX -m u:`whoami`:rwX app/cache app/logs
 
     If this doesn't work, try adding ``-n`` option.
+
+    Note: setfacl isn't available on NFS mount points. However, setting cache and logs over NFS is strongly not recommanded for performance.
 
     **4. Without using ACL**
 

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -245,11 +245,10 @@ If there are any issues, correct them now before moving on.
 
     **3. Using ACL on a system that supports setfacl (most Linux/BSD)**
 
-    Most Linux and BSD distributions don't support ``chmod +a``, but do support another utility
-    called ``setfacl``. You may need to `enable ACL support`_ on your partition
-    and install setfacl before using it (as is the case with old versions of Ubuntu). This
-    uses a command to try to determine your web server user and set it as
-    ``HTTPDUSER``:
+    Most Linux and BSD distributions don't support ``chmod +a``, but do support
+    another utility called ``setfacl``. You may need to `enable ACL support`_
+    on your partition and install setfacl before using it. This uses a command
+    to try to determine your web server user and set it as ``HTTPDUSER``:
 
     .. code-block:: bash
 

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -261,8 +261,8 @@ If there are any issues, correct them now before moving on.
 
     .. note::
 
-        setfacl isn't available on NFS mount points. However, setting cache and logs over NFS is strongly not recommended for performance.
-
+        setfacl isn't available on NFS mount points. However, setting cache
+        and logs over NFS is strongly not recommended for performance.
 
     **4. Without using ACL**
 

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -261,7 +261,7 @@ If there are any issues, correct them now before moving on.
 
     .. note::
 
-        setfacl isn't available on NFS mount points. However, setting cache and logs over NFS is strongly not recommanded for performance.
+        setfacl isn't available on NFS mount points. However, setting cache and logs over NFS is strongly not recommended for performance.
 
 
     **4. Without using ACL**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | no |

chmod +a seems to be a MacOS X non standard feature so it's useless to ask everyone to try it before setfacl. Linux users should directly go for it (Internet is full of comments of people asking how to chmod +a on Ubuntu or CentOS).
Add also informations about NFS and setfacl: it's a common issue when deploying on production.
