### PR TITLE
Fixed a minor indentation issue

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -321,42 +321,42 @@ Keep the following guidelines in mind while you develop.
 
 #. **The order of the controller arguments does not matter**
 
-    Symfony matches the parameter **names** from the route to the variable
-    **names** of the controller. The arguments of the controller could be
-    totally reordered and still work perfectly::
+   Symfony matches the parameter **names** from the route to the variable
+   **names** of the controller. The arguments of the controller could be
+   totally reordered and still work perfectly::
 
-        public function indexAction($lastName, $firstName)
-        {
-            // ...
-        }
+       public function indexAction($lastName, $firstName)
+       {
+           // ...
+       }
 
 #. **Each required controller argument must match up with a routing parameter**
 
-    The following would throw a ``RuntimeException`` because there is no
-    ``foo`` parameter defined in the route::
+   The following would throw a ``RuntimeException`` because there is no
+   ``foo`` parameter defined in the route::
 
-        public function indexAction($firstName, $lastName, $foo)
-        {
-            // ...
-        }
+       public function indexAction($firstName, $lastName, $foo)
+       {
+           // ...
+       }
 
-    Making the argument optional, however, is perfectly ok. The following
-    example would not throw an exception::
+   Making the argument optional, however, is perfectly ok. The following
+   example would not throw an exception::
 
-        public function indexAction($firstName, $lastName, $foo = 'bar')
-        {
-            // ...
-        }
+       public function indexAction($firstName, $lastName, $foo = 'bar')
+       {
+           // ...
+       }
 
 #. **Not all routing parameters need to be arguments on your controller**
 
-    If, for example, the ``lastName`` weren't important for your controller,
-    you could omit it entirely::
+   If, for example, the ``lastName`` weren't important for your controller,
+   you could omit it entirely::
 
-        public function indexAction($firstName)
-        {
-            // ...
-        }
+       public function indexAction($firstName)
+       {
+           // ...
+       }
 
 .. tip::
 


### PR DESCRIPTION
Lists are always tricky because you must indent with 3 white spaces instead of 4:
### Before

![before_syntax](https://cloud.githubusercontent.com/assets/73419/14988687/4e8322cc-1155-11e6-923d-cf961898eda8.png)
### After

![after_syntax](https://cloud.githubusercontent.com/assets/73419/14988689/514154fc-1155-11e6-985c-160fa8570fcb.png)
