### PR TITLE
Forcing a version in twig asset has been removed

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -1057,30 +1057,6 @@ assets won't be loaded from cache after being deployed. For example, ``/images/l
 look like ``/images/logo.png?v2``. For more information, see the :ref:`reference-framework-assets-version`
 configuration option.
 
-.. _`book-templating-version-by-asset`:
-
-If you need to set a version for a specific asset, you can set the ``version`` argument
-if you are using Twig (or the fourth argument if you are using PHP) to the desired version:
-
-.. configuration-block::
-
-    .. code-block:: html+jinja
-
-        <img src="{{ asset('images/logo.png', version='3.0') }}" alt="Symfony!" />
-
-    .. code-block:: html+php
-
-        <img src="<?php echo $view['assets']->getUrl(
-            'images/logo.png',
-            null,
-            false,
-            '3.0'
-        ) ?>" alt="Symfony!" />
-
-If you don't give a version or pass ``null``, the default package version
-(from :ref:`reference-framework-assets-version`) will be used. If you pass ``false``,
-versioned URL will be deactivated for this asset.
-
 If you need absolute URLs for assets, you can use the ``absolute_url`` function
 if you are using Twig (or the third argument if you are using PHP) to ``true``:
 


### PR DESCRIPTION
Forcing a version with the Twig asset() function was deprecated in 2.7 and removed in 3.0
