### PR TITLE
Trusted proxies were removed when URL signing took over

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -1198,11 +1198,6 @@ One great advantage of the ESI renderer is that you can make your application
 as dynamic as needed and at the same time, hit the application as little as
 possible.
 
-.. tip::
-
-    The listener only responds to local IP addresses or
-    :doc:`trusted proxies </cookbook/request/load_balancer_reverse_proxy>`.
-
 .. note::
 
     Once you start using ESI, remember to always use the ``s-maxage``

--- a/cookbook/request/load_balancer_reverse_proxy.rst
+++ b/cookbook/request/load_balancer_reverse_proxy.rst
@@ -85,7 +85,7 @@ In this case, you'll need to - *very carefully* - trust *all* proxies.
        $response = $kernel->handle($request);
        // ...
 
-#. Ensure that the trusted_proxies setting in your ``app/config/config.yml`` 
+#. Ensure that the trusted_proxies setting in your ``app/config/config.yml``
    is not set or it will overwrite the ``setTrustedProxies`` call above.
 
 That's it! It's critical that you prevent traffic from all non-trusted sources.


### PR DESCRIPTION
Since: https://github.com/symfony/http-kernel/commit/fa8f4f8137444d267c087a404bc5532b14f10463
