### PR TITLE
Replace property_accessor by property_access

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -85,7 +85,7 @@ Configuration
     * :ref:`enabled <reference-translator-enabled>`
     * `fallbacks`_
     * `logging`_
-* `property_accessor`_
+* `property_access`_
     * `magic_call`_
     * `throw_exception_on_invalid_index`_
 * `validation`_
@@ -1268,7 +1268,7 @@ for a given key. The logs are made to the ``translation`` channel and at the
 ``debug`` for level for keys where there is a translation in the fallback
 locale and the ``warning`` level if there is no translation to use at all.
 
-property_accessor
+property_access
 ~~~~~~~~~~~~~~~~~
 
 magic_call

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1269,7 +1269,7 @@ for a given key. The logs are made to the ``translation`` channel and at the
 locale and the ``warning`` level if there is no translation to use at all.
 
 property_access
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 magic_call
 ..........


### PR DESCRIPTION
Property accessor service name is `property_accessor` but configuration key is `property_access`.
IMHO, to avoid confusion both should be the same. But for the moment, I amend the documentation to reflect the actual mapping.
