### PR TITLE
Typo fix in the Serializer deserialization example for existing object

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -169,7 +169,7 @@ The serializer can also be used to update an existing object::
     EOF;
 
     $serializer->deserialize($data, 'Acme\Person', 'xml', array('object_to_populate' => $person));
-    // $obj2 = Acme\Person(name: 'foo', age: '99', sportsman: true)
+    // $obj2 = Acme\Person(name: 'foo', age: '69', sportsman: true)
 
 This is a common need when working with an ORM.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.7+ |
| Fixed tickets | N/A |

Just found a small typo in the comment with result values of deserialization. As the init value of the `age` of the `person` is 99, then after deserializing the existing `person` object it is 69. But in comment it is still 99 `// $jsonContent contains {"name":"foo","age":99,"sportsman":false}`
