### PR TITLE
[ClassLoader] Add missed link to the external PSR-4 specification

### DIFF
--- a/components/class_loader/introduction.rst
+++ b/components/class_loader/introduction.rst
@@ -19,7 +19,7 @@ load your classes:
   the `PSR-0`_ class naming standard;
 
 * :doc:`/components/class_loader/psr4_class_loader`: loads classes that follow
-  the `PSR-4` class naming standard;
+  the `PSR-4`_ class naming standard;
 
 * :doc:`/components/class_loader/map_class_loader`: loads classes using
   a static map from class name to file path.
@@ -45,5 +45,6 @@ You can install the component in 2 different ways:
 .. include:: /components/require_autoload.rst.inc
 
 .. _PSR-0: http://www.php-fig.org/psr/psr-0/
+.. _PSR-4: http://www.php-fig.org/psr/psr-4/
 .. _`autoloading mechanism`: http://php.net/manual/en/language.oop5.autoload.php
 .. _Packagist: https://packagist.org/packages/symfony/class-loader

--- a/components/var_dumper/introduction.rst
+++ b/components/var_dumper/introduction.rst
@@ -104,6 +104,11 @@ original value. You can configure the limits in terms of:
 * maximum number of items to dump,
 * maximum string length before truncation.
 
+Since dumping into the toolbar is not always possible - e.g. when working on a
+JSON API - you can have an alternate output destination for dumps. This is
+configurable with the ``debug.dump_destination`` option, that you can typically
+set to ``php://stderr``.
+
 .. configuration-block::
 
     .. code-block:: yaml
@@ -111,6 +116,7 @@ original value. You can configure the limits in terms of:
         debug:
            max_items: 250
            max_string_length: -1
+           dump_destination: ~
 
     .. code-block:: xml
 
@@ -119,8 +125,16 @@ original value. You can configure the limits in terms of:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/debug http://symfony.com/schema/dic/debug/debug-1.0.xsd">
 
-            <config max-items="250" max-string-length="-1" />
+            <config max-items="250" max-string-length="-1" dump-destination="null" />
         </container>
+
+    .. code-block:: php
+
+        $container->loadFromExtension('debug', array(
+           'max_items' => 250,
+           'max_string_length' => -1,
+           'dump_destination' => null,
+        ));
 
 Dump Examples and Output
 ------------------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.6+ |
| Fixed tickets | N/A |

There is already the link to the external PSR-0 specification, but for PSR-4 this link is missed. So I added it. 
