### PR TITLE
About Templating Naming Pattern

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -492,8 +492,8 @@ The Symfony templating engine is explained in great detail in the
 .. sidebar:: Templating Naming Pattern
 
     You can also put templates in the ``Resources/views`` directory of a bundle and
-    reference them with a special shortcut syntax like ``@AppBundle/Hello/index.html.twig``
-    or ``@AppBundle/layout.html.twig``. These would live in at ``Resources/views/Hello/index.html.twig``
+    reference them with a special shortcut syntax like ``@App/Hello/index.html.twig``
+    or ``@App/layout.html.twig``. These would live in at ``Resources/views/Hello/index.html.twig``
     and ``Resources/views/layout.html.twig`` inside the bundle respectively.
 
 .. index::


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

If I'm not wrong, the correct way to use the namespaced syntax is omitting the word "Bundle".

This work for me: 
`@App/Hello/index.html.twig`

However this doesn't:
`@AppBundle/Hello/index.html.twig`
