### PR TITLE
Show label & set correct value in Symfony 3.X

### DIFF
--- a/cookbook/form/create_custom_field_type.rst
+++ b/cookbook/form/create_custom_field_type.rst
@@ -35,7 +35,8 @@ for form fields, which is ``<BundleName>\Form\Type``. Make sure the field extend
                 'choices' => array(
                     'Male' => 'm',
                     'Female' => 'f',
-                )
+                ),
+                'choices_as_values' => true,
             ));
         }
 

--- a/cookbook/form/create_custom_field_type.rst
+++ b/cookbook/form/create_custom_field_type.rst
@@ -33,8 +33,8 @@ for form fields, which is ``<BundleName>\Form\Type``. Make sure the field extend
         {
             $resolver->setDefaults(array(
                 'choices' => array(
-                    'm' => 'Male',
-                    'f' => 'Female',
+                    'Male' => 'm',
+                    'Female' => 'f',
                 )
             ));
         }


### PR DESCRIPTION
At some point in Symfony history the key/value pairs switched orders, so the friendly label now has to be the key of the array. This change fixes the example.
