### PR TITLE
Do not pass object without __toString for token generator

### DIFF
--- a/cookbook/security/custom_password_authenticator.rst
+++ b/cookbook/security/custom_password_authenticator.rst
@@ -65,6 +65,9 @@ the user::
                     );
                 }
 
+                // CAUTION: implement __toString method for $user object
+                // or pass the username (like a nickname, email address, etc.) instead $user
+                // otherwise you get a redirect error
                 return new UsernamePasswordToken(
                     $user,
                     $user->getPassword(),


### PR DESCRIPTION
May be it's good for those who implements that receipt from cookbook to prevent them from this trap.
