### PR TITLE
Added callable validation_groups example

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -616,6 +616,11 @@ Now the form will skip your validation constraints. It will still validate
 basic integrity constraints, such as checking whether an uploaded file was too
 large or whether you tried to submit text in a number field.
 
+.. seealso::
+
+    To see how to use a service with dependencies to resolve ``validation_groups``
+    checkout cookbook article :doc:`/cookbook/validation/validation-group-service-resolver`.
+
 .. index::
    single: Forms; Built-in field types
 

--- a/cookbook/map.rst.inc
+++ b/cookbook/map.rst.inc
@@ -249,6 +249,7 @@
 
   * :doc:`/cookbook/validation/custom_constraint`
   * :doc:`/cookbook/validation/severity`
+  * :doc:`/cookbook/validation/validation-group-service-resolver`
 
 * :doc:`/cookbook/web_server/index`
 

--- a/cookbook/validation/index.rst
+++ b/cookbook/validation/index.rst
@@ -6,3 +6,4 @@ Validation
 
     custom_constraint
     severity
+    validation-group-service-resolver

--- a/cookbook/validation/validation-group-service-resolver.rst
+++ b/cookbook/validation/validation-group-service-resolver.rst
@@ -1,0 +1,71 @@
+How to Dynamically Configure Validation Groups
+==============================================
+
+Sometimes you need advanced logic to determine the validation groups. If this
+can't be determined by a simple callback, you can use a service. Create a
+service that implements ``__invoke`` which accepts a ``FormInterface`` as a
+parameter.
+
+.. code-block:: php
+
+    namespace AppBundle\Validation;
+
+    use Symfony\Component\Form\FormInterface;
+
+    class ValidationGroupResolver
+    {
+        private $service1;
+
+        private $service2;
+
+        public function __construct($service1, $service2)
+        {
+            $this->service1 = $service1;
+            $this->service2 = $service2;
+        }
+
+        /**
+         * @param FormInterface $form
+         * @return array
+         */
+        public function __invoke(FormInterface $form)
+        {
+            $groups = array();
+
+            // ... determine which groups to apply and return an array
+
+            return $groups;
+        }
+    }
+
+Then in your form, inject the resolver and set it as the ``validation_groups``.
+
+.. code-block:: php
+
+    use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    use Symfony\Component\Form\AbstractType
+    use AppBundle\Validator\ValidationGroupResolver;
+
+    class MyClassType extends AbstractType
+    {
+        /**
+         * @var ValidationGroupResolver
+         */
+        private $groupResolver;
+
+        public function __construct(ValidationGroupResolver $groupResolver)
+        {
+            $this->groupResolver = $groupResolver;
+        }
+
+        // ...
+        public function setDefaultOptions(OptionsResolverInterface $resolver)
+        {
+            $resolver->setDefaults(array(
+                'validation_groups' => $this->groupResolver,
+            ));
+        }
+    }
+
+This will result in the form validator invoking your group resolver to set the
+validation groups returned when validating.


### PR DESCRIPTION
Recently I had a need to dynamically set the validation_groups of a small set of forms based on the user that was logged in. In digging about the FormValidator::resolveValidationGroups and saw I could use a class that implements the __invoke method. Figured I might as well write something about it and see if you'd want to add it to the docs.
