### PR TITLE
Adding a description for the use_microseconds parameter introduced in MonologBundle v2.11

### DIFF
--- a/cookbook/logging/monolog.rst
+++ b/cookbook/logging/monolog.rst
@@ -26,60 +26,6 @@ The ``logger`` service has different methods for different logging levels.
 See :class:`Symfony\\Component\\HttpKernel\\Log\\LoggerInterface` for details
 on which methods are available.
 
-Since version `2.11 of MonologBundle <https://github.com/symfony/monolog-bundle/releases/tag/2.11.0>`
-an extra parameter for disabling the microsecond precision is available. This is
-kind of a micro optimization but could speed up log generation, specially if you log
-a lot of debug messages.
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # app/config/config.yml
-        monolog:
-            use_microseconds: false
-            handlers:
-                applog:
-                    type: stream
-                    path: /var/log/symfony.log
-                    level: error
-
-    .. code-block:: xml
-
-        <!-- app/config/config.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:monolog="http://symfony.com/schema/dic/monolog"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services
-                http://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/monolog
-                http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
-
-            <monolog:config use_microseconds="false">
-                <monolog:handler
-                    name="applog"
-                    type="stream"
-                    path="/var/log/symfony.log"
-                    level="error"
-                />
-            </monolog:config>
-        </container>
-
-    .. code-block:: php
-
-        // app/config/config.php
-        $container->loadFromExtension('monolog', array(
-            'use_microseconds' => false
-            'handlers' => array(
-                'applog' => array(
-                    'type'  => 'stream',
-                    'path'  => '/var/log/symfony.log',
-                    'level' => 'error',
-                ),
-            ),
-        ));
-
 Handlers and Channels: Writing Logs to different Locations
 ----------------------------------------------------------
 
@@ -339,6 +285,67 @@ option of your handler to ``rotating_file``:
                     // max number of log files to keep
                     // defaults to zero, which means infinite files
                     'max_files' => 10,
+                ),
+            ),
+        ));
+
+How to Disable Microseconds Precision
+-------------------------------------
+
+.. versionadded:: 2.11
+    The ``use_microseconds`` option was introduced in MonologBundle 2.11.
+
+Setting the parameter ``use_microseconds`` to ``false`` forces the logger to reduce
+the precision in the ``datetime`` field of the log messages from microsecond to second,
+avoiding a call to the ``microtime(true)`` function and the subsequent parsing.
+Disabling the use of microseconds can provide a small performance gain speeding up the
+log generation. This is recommended for systems that generate a large number of log events.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        monolog:
+            use_microseconds: false
+            handlers:
+                applog:
+                    type: stream
+                    path: /var/log/symfony.log
+                    level: error
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:monolog="http://symfony.com/schema/dic/monolog"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/monolog
+                http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+            <monolog:config use_microseconds="false">
+                <monolog:handler
+                    name="applog"
+                    type="stream"
+                    path="/var/log/symfony.log"
+                    level="error"
+                />
+            </monolog:config>
+        </container>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container->loadFromExtension('monolog', array(
+            'use_microseconds' => false,
+            'handlers' => array(
+                'applog' => array(
+                    'type'  => 'stream',
+                    'path'  => '/var/log/symfony.log',
+                    'level' => 'error',
                 ),
             ),
         ));

--- a/cookbook/logging/monolog.rst
+++ b/cookbook/logging/monolog.rst
@@ -26,6 +26,60 @@ The ``logger`` service has different methods for different logging levels.
 See :class:`Symfony\\Component\\HttpKernel\\Log\\LoggerInterface` for details
 on which methods are available.
 
+Since version `2.11 of MonologBundle <https://github.com/symfony/monolog-bundle/releases/tag/2.11.0>`
+an extra parameter for disabling the microsecond precision is available. This is
+kind of a micro optimization but could speed up log generation, specially if you log
+a lot of debug messages.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        monolog:
+            use_microseconds: false
+            handlers:
+                applog:
+                    type: stream
+                    path: /var/log/symfony.log
+                    level: error
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:monolog="http://symfony.com/schema/dic/monolog"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/monolog
+                http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+            <monolog:config use_microseconds="false">
+                <monolog:handler
+                    name="applog"
+                    type="stream"
+                    path="/var/log/symfony.log"
+                    level="error"
+                />
+            </monolog:config>
+        </container>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container->loadFromExtension('monolog', array(
+            'use_microseconds' => false
+            'handlers' => array(
+                'applog' => array(
+                    'type'  => 'stream',
+                    'path'  => '/var/log/symfony.log',
+                    'level' => 'error',
+                ),
+            ),
+        ));
+
 Handlers and Channels: Writing Logs to different Locations
 ----------------------------------------------------------
 


### PR DESCRIPTION
This adds a small paragraph bellow the usage section with an explanation and an example block.

| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | >= 2.3 |
| Fixed tickets | #6466 |
