### PR TITLE
Clarify signed requests in the ESI renderer

### DIFF
--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -1207,6 +1207,12 @@ One great advantage of the ESI renderer is that you can make your application
 as dynamic as needed and at the same time, hit the application as little as
 possible.
 
+.. caution::
+
+    The fragment listener only responds to signed requests. Requests are only
+    signed when using the fragment renderer and the ``render_esi`` Twig
+    function.
+
 .. note::
 
     Once you start using ESI, remember to always use the ``s-maxage``


### PR DESCRIPTION
I think this clarification makes things more clear to readers. It also explains why something might not work when people don't use the `render_esi` helper function.
