### PR TITLE
Use a better escaping mechanism for data-prototype attr

### DIFF
--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -304,7 +304,7 @@ new "tag" forms. To render it, make the following change to your template:
 
     .. code-block:: html+twig
 
-        <ul class="tags" data-prototype="{{ form_widget(form.tags.vars.prototype)|e }}">
+        <ul class="tags" data-prototype="{{ form_widget(form.tags.vars.prototype)|e('html_attr') }}">
             ...
         </ul>
 


### PR DESCRIPTION
Twig defines the `html_attr` strategy to escape values to be included in HTML attributes. Let's use it instead of the generic strategy.
