### PR TITLE
Update custom_constraint.rst

### DIFF
--- a/cookbook/validation/custom_constraint.rst
+++ b/cookbook/validation/custom_constraint.rst
@@ -158,7 +158,7 @@ Constraint Validators with Dependencies
 If your constraint validator has dependencies, such as a database connection,
 it will need to be configured as a service in the Dependency Injection
 Container. This service must include the ``validator.constraint_validator``
-tag and may include an ``alias`` attribute:
+tag and *MUST* include an ``alias`` attribute:
 
 .. configuration-block::
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | >=2.3 |
| Fixed tickets |  |

You **MUST** specify an alias because

```php
//Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory.php
[...]
// $name will be a FQCN and will not be present in $this->validators array
$name = $constraint->validatedBy();

if (!isset($this->validators[$name])) {
    $this->validators[$name] = new $name(); //LOOK HERE; IF I DON'T SPECIFY THIS ALIAS, I WILL END HERE: NO SERVICE!
} elseif (is_string($this->validators[$name])) {
    $this->validators[$name] = $this->container->get($this->validators[$name]);
}

[...]
```

So if custom validator is a service that needs to be taken from `Container`, there is no valid alternative to `alias`: it should be mandatory (and should be reported onto documentation) as you can see from this factory.
