### PR TITLE
Routes should be just imported, not mounted

### DIFF
--- a/cookbook/configuration/micro-kernel-trait.rst
+++ b/cookbook/configuration/micro-kernel-trait.rst
@@ -194,15 +194,12 @@ to hold the kernel. Now it looks like this::
         {
             // import the WebProfilerRoutes, only if the bundle is enabled
             if (isset($this->bundles['WebProfilerBundle'])) {
-                $routes->mount('/_wdt', $routes->import('@WebProfilerBundle/Resources/config/routing/wdt.xml'));
-                $routes->mount('/_profiler', $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml'));
+                $routes->import('@WebProfilerBundle/Resources/config/routing/wdt.xml', '/_wdt');
+                $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml', '/_profiler');
             }
 
             // load the annotation routes
-            $routes->mount(
-                '/',
-                $routes->import(__DIR__.'/../src/App/Controller/', 'annotation')
-            );
+            $routes->import($routes->import(__DIR__.'/../src/App/Controller/', '/', 'annotation'));
         }
     }
 


### PR DESCRIPTION
It just causes me headache to figure out why the routes behave so weirdly even if you follow the cookbook 1:1 :-).

When calling `mount()` on already imported routes (what is stated in the cookbook), the router behaves a bit weirdly and mounts the routes in this way:

```
-------------------------- -------- -------- ------ --------------------------------------------- 
  Name                       Method   Scheme   Host   Path                                         
 -------------------------- -------- -------- ------ --------------------------------------------- 
  _wdt                       ANY      ANY      ANY    /_wdt/_wdt/{token}                           
  _profiler_home             ANY      ANY      ANY    /_profiler/_profiler/                        
  _profiler_search           ANY      ANY      ANY    /_profiler/_profiler/search                  
  _profiler_search_bar       ANY      ANY      ANY    /_profiler/_profiler/search_bar              
...
```

Basically the prefixes are doubled, what is definitely not intended. While the behavior of the `RouteCollectionBuilder` is kinda weird, I rather think this is a just misuse of the `mount()` method - which is not needed and is probably not expected to be called on already imported and mounted routes.

Moreover, the import of annotation routes works just by coincidence - the second parameter of `import()` is prefix, not type, so the routes are added with prefix "/annotation" and only because the mount is used, they appears as mounted to "/" prefix.

Cc @weaverryan 
