### PR TITLE
Clarify documentation on serving files

### DIFF
--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -483,6 +483,9 @@ abstracts the hard work behind a simple API::
 
     $response->headers->set('Content-Disposition', $d);
 
+Then you must set the file's content as usual, for example by using
+:method:`Symfony\\Component\\HttpFoundation\\Response::setContent`.
+
 Alternatively, if you are serving a static file, you can use a
 :class:`Symfony\\Component\\HttpFoundation\\BinaryFileResponse`::
 


### PR DESCRIPTION
For a beginner, the "Serving Files" documentation was a little bit ambiguous on whether the makeDisposition method only adds the header or deals with sending the content as well. This change tries to make that explicit.
