### PR TITLE
[WSSE] - Using a PSR6 cache instead of file cache

### DIFF
--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -224,7 +224,7 @@ the ``PasswordDigest`` header value matches with the user's password.
         public function __construct(UserProviderInterface $userProvider, CacheItemPoolInterface $cachePool)
         {
             $this->userProvider = $userProvider;
-            $this->$cachePool     = $cachePool;
+            $this->cachePool     = $cachePool;
         }
 
         public function authenticate(TokenInterface $token)
@@ -259,7 +259,7 @@ the ``PasswordDigest`` header value matches with the user's password.
                 return false;
             }
 
-            $cacheItem = $this->cacheService->getItem(md5($nonce));
+            $cacheItem = $this->cachePool->getItem(md5($nonce));
             // Validate that the nonce is *not* used in the last 5 minutes
             // if it has, this could be a replay attack
             if ($cacheItem->isHit()) {
@@ -267,7 +267,7 @@ the ``PasswordDigest`` header value matches with the user's password.
             }
             // If cache directory does not exist we create it
             $cacheItem->set(null)->expiresAfter($this->lifetime - (time() - $created));
-            $this->cacheService->save($cacheItem);
+            $this->cachePool->save($cacheItem);
 
             // Validate Secret
             $expected = base64_encode(sha1(base64_decode($nonce).$created.$secret, true));

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -127,7 +127,7 @@ set an authenticated token in the token storage if successful.
 
         public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager)
         {
-            $this->tokenStorage = $tokenStorage;
+            $this->tokenStorage          = $tokenStorage;
             $this->authenticationManager = $authenticationManager;
         }
 
@@ -224,7 +224,7 @@ the ``PasswordDigest`` header value matches with the user's password.
         public function __construct(UserProviderInterface $userProvider, CacheItemPoolInterface $cachePool)
         {
             $this->userProvider = $userProvider;
-            $this->cachePool     = $cachePool;
+            $this->cachePool    = $cachePool;
         }
 
         public function authenticate(TokenInterface $token)

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -259,14 +259,17 @@ the ``PasswordDigest`` header value matches with the user's password.
                 return false;
             }
 
+            // Try to fetch the cache item from pool
             $cacheItem = $this->cachePool->getItem(md5($nonce));
-            // Validate that the nonce is *not* used in the last 5 minutes
-            // if it has, this could be a replay attack
+            
+            // Validate that the nonce is *not* in cache
+            // if it is, this could be a replay attack
             if ($cacheItem->isHit()) {
                 throw new NonceExpiredException('Previously used nonce detected');
             }
-            // If cache directory does not exist we create it
-            $cacheItem->set(null)->expiresAfter($this->lifetime - (time() - $created));
+            
+            // Store the item in cache for 5 minutes
+            $cacheItem->set(null)->expiresAfter(300);
             $this->cachePool->save($cacheItem);
 
             // Validate Secret

--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -127,7 +127,7 @@ set an authenticated token in the token storage if successful.
 
         public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager)
         {
-            $this->tokenStorage          = $tokenStorage;
+            $this->tokenStorage = $tokenStorage;
             $this->authenticationManager = $authenticationManager;
         }
 
@@ -224,7 +224,7 @@ the ``PasswordDigest`` header value matches with the user's password.
         public function __construct(UserProviderInterface $userProvider, CacheItemPoolInterface $cachePool)
         {
             $this->userProvider = $userProvider;
-            $this->cachePool    = $cachePool;
+            $this->cachePool = $cachePool;
         }
 
         public function authenticate(TokenInterface $token)
@@ -411,7 +411,7 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
                 class: AppBundle\Security\Authentication\Provider\WsseProvider
                 arguments:
                     - '' # User Provider
-                    - '@cache'
+                    - '@cache.app'
                 public: false
 
             wsse.security.authentication.listener:
@@ -433,7 +433,7 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
                     public="false"
                 >
                     <argument /> <!-- User Provider -->
-                    <argument type="service" id="cache"></argument>
+                    <argument type="service" id="cache.app"></argument>
                 </service>
 
                 <service id="wsse.security.authentication.listener"
@@ -456,7 +456,7 @@ to service ids that do not exist yet: ``wsse.security.authentication.provider`` 
             'AppBundle\Security\Authentication\Provider\WsseProvider',
             array(
                 '', // User Provider
-                new Reference('cache'),
+                new Reference('cache.app'),
             )
         );
         $definition->setPublic(false);


### PR DESCRIPTION
I rewrote the WSSE example to use a PSR-6 cache instead. I did this because Symfony got a fancy new CacheComponent now and because using file cache will eventually fill up your inodes. (I just removed 2 million inodes from my server.)

Note: Im not sure about the service name for a cache pool. Is it just `cache`?
