### PR TITLE
Added a note about coding standards and method arguments

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -160,6 +160,9 @@ Structure
   ``tearDown`` methods of PHPUnit tests, which should always be the first methods
   to increase readability;
 
+* Declare all the arguments in the same line as the method/function name, no
+  matter how many arguments there are;
+
 * Use parentheses when instantiating classes regardless of the number of
   arguments the constructor has;
 

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -153,8 +153,8 @@ Structure
   that are not intended to be instantiated from the outside and thus are not
   concerned by the `PSR-0`_ and `PSR-4`_ autoload standards;
 
-* Declare the class inheritance (if any) and all the implemented interfaces (if
-  any) in the same line as the class name;
+* Declare the class inheritance and all the implemented interfaces on the same
+  line as the class name;
 
 * Declare class properties before methods;
 

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -153,6 +153,9 @@ Structure
   that are not intended to be instantiated from the outside and thus are not
   concerned by the `PSR-0`_ and `PSR-4`_ autoload standards;
 
+* Declare the class inheritance (if any) and all the implemented interfaces (if
+  any) in the same line as the class name;
+
 * Declare class properties before methods;
 
 * Declare public methods first, then protected ones and finally private ones.

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -163,7 +163,7 @@ Structure
   ``tearDown`` methods of PHPUnit tests, which should always be the first methods
   to increase readability;
 
-* Declare all the arguments in the same line as the method/function name, no
+* Declare all the arguments on the same line as the method/function name, no
   matter how many arguments there are;
 
 * Use parentheses when instantiating classes regardless of the number of


### PR DESCRIPTION
This coding standard is optional in the PSR-2 standard, so we must explain our own convention. Related to https://github.com/symfony/symfony/issues/18890.
