### PR TITLE
Fix wrong variable name in comment

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -169,7 +169,7 @@ The serializer can also be used to update an existing object::
     EOF;
 
     $serializer->deserialize($data, 'Acme\Person', 'xml', array('object_to_populate' => $person));
-    // $obj2 = Acme\Person(name: 'foo', age: '69', sportsman: true)
+    // $person = Acme\Person(name: 'foo', age: '69', sportsman: true)
 
 This is a common need when working with an ORM.
 


### PR DESCRIPTION
The object being updated via deserialize is $person, but in the comment it was wrongly referred to as $obj2
