### PR TITLE
Fix for #6625

### DIFF
--- a/book/testing.rst
+++ b/book/testing.rst
@@ -17,8 +17,9 @@ it has its own excellent `documentation`_.
 
 .. note::
 
-    It's recommended to use the latest stable PHPUnit version (you will have
-    to use version 4.2 or higher to test the Symfony core code itself).
+    It's recommended to use the latest stable PHPUnit version, `installed as
+    PHAR`_ (you will have to use version 4.2 or higher to test the Symfony core 
+    code itself).
 
 Each test - whether it's a unit test or a functional test - is a PHP class
 that should live in the ``tests/`` directory of your application. If you follow
@@ -910,3 +911,4 @@ Learn more
 
 .. _`$_SERVER`: http://php.net/manual/en/reserved.variables.server.php
 .. _`documentation`: https://phpunit.de/manual/current/en/
+.. _`installed as PHAR`: https://phpunit.de/manual/current/en/installation.html#installation.phar


### PR DESCRIPTION
This fix adds a recommendation of installing PHPUnit as a PHAR archive, as suggested in #6625.
