### PR TITLE
Update options_resolver.rst

### DIFF
--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -430,7 +430,7 @@ if you need to use other options during normalization::
         {
             // ...
             $resolver->setNormalizer('host', function (Options $options, $value) {
-                if (!in_array(substr($value, 0, 7), array('http://', 'https://'))) {
+                if ('http://' !== substr($value, 0, 7) && 'https://' !== substr($value, 0, 8)) {
                     if ('ssl' === $options['encryption']) {
                         $value = 'https://'.$value;
                     } else {


### PR DESCRIPTION
The old code will not work as expected if the `host` option starts with `https`, the `substr` function will return `https:/` and not `https://`.

``` php
$resolver = new Symfony\Component\OptionsResolver\OptionsResolver;

$resolver->setDefined(['host', 'encryption']);
$resolver->setNormalizer('host', function (Options $options, $value) {

     if (!in_array(substr($value, 0, 7), array('http://', 'https://'))) {
        if ('ssl' === $options['encryption']) {
            $value = 'https://'.$value;
        } else {
            $value = 'http://'.$value;
        }
    }

    return $value;
});;


$options = $resolver->resolve(array(
    'host'       => 'https://symfony.com/',
    'encryption' => 'ssl'
));

echo $options['host'];
// Expected value : https://symfony.com/
// Result         : https://https://symfony.com/
```
