### PR TITLE
Fix binary directory for demo application

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -347,7 +347,7 @@ of the Symfony Installer anywhere in your system:
     c:\projects\> php symfony demo
 
 Once downloaded, enter into the ``symfony_demo/`` directory and run the PHP's
-built-in web server executing the ``php bin/console server:run`` command. Access
+built-in web server executing the ``php app/console server:run`` command. Access
 to the ``http://localhost:8000`` URL in your browser to start using the Symfony
 Demo application.
 


### PR DESCRIPTION
Hello,

While trying to install the Symfony Demo application following the documentation on http://symfony.com/doc/master/book/installation.html#installing-the-symfony-demo-application, I had a problem as `php bin/console server:run` does not work.

I understood in https://github.com/symfony/symfony-docs/pull/6182 that the demo application uses Symfony 2.8 and therefore uses `php app/console` but I also noticed the regression of this PR in https://github.com/symfony/symfony-docs/commit/68650b807fc1dc380a3e8a1c6c10de5e58f35f6a.

This PR fixes this.
