### PR TITLE
Added escaping tip

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1550,6 +1550,18 @@ a template helper function:
             Read this blog post.
         </a>
 
+.. tip::
+
+    If you are generating the route inside a script tag, you might need to properly escape it for Javascript
+
+    .. code-block:: javascript
+
+        <script>
+        var route = "{{ path('blog_show', {'slug': 'my-blog-post'})|escape('js') }}";
+        </script>
+
+    For more information, see the Twig documentation.
+
 .. index::
    single: Routing; Absolute URLs
 


### PR DESCRIPTION
Added a tip under the "Generating URLs from a Template" section to remind users of proper escaping if they are generating routes in a JS context
