### PR TITLE
do not reference unused interface

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -431,7 +431,6 @@ interface only requires one method: ``loadUserByUsername($username)``::
     namespace AppBundle\Entity;
 
     use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
-    use Symfony\Component\Security\Core\User\UserInterface;
     use Doctrine\ORM\EntityRepository;
 
     class UserRepository extends EntityRepository implements UserLoaderInterface


### PR DESCRIPTION
In #5993 we removed the refreshUser() method which is no longer required
when implementing the new UserLoaderInterface. Thus, we no longer have
to reference the UserInterface too.
