### PR TITLE
Fix bootstrap class name help-block

### DIFF
--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -1055,7 +1055,7 @@ form, modify the ``use`` tag and add the following:
         {{ block('base_form_widget_simple') }}
 
         {% if help is defined %}
-            <span class="help">{{ help }}</span>
+            <span class="help-block">{{ help }}</span>
         {% endif %}
     {% endblock %}
 
@@ -1070,7 +1070,7 @@ the following:
         {{ parent() }}
 
         {% if help is defined %}
-            <span class="help">{{ help }}</span>
+            <span class="help-block">{{ help }}</span>
         {% endif %}
     {% endblock %}
 


### PR DESCRIPTION
I checked the [bootstrap documentation](http://getbootstrap.com/css/#forms-example) as well as the bootstrap source code, there is no such class as `help`. Example from the docs:

``` html
<div class="form-group">
  <label for="exampleInputFile">File input</label>
  <input type="file" id="exampleInputFile">
  <p class="help-block">Example block-level help text here.</p>
</div>
```
