### PR TITLE
[Console] Fix wrong quotes in QuestionHelper::setInputStream()

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -294,7 +294,7 @@ from the command line, you need to set the helper input stream::
         $commandTester = new CommandTester($command);
 
         $helper = $command->getHelper('question');
-        $helper->setInputStream($this->getInputStream('Test\\n'));
+        $helper->setInputStream($this->getInputStream("Test\n"));
         // Equals to a user inputting "Test" and hitting ENTER
         // If you need to enter a confirmation, "yes\n" will work
 


### PR DESCRIPTION
As pointed by [this Stack Overflow question](http://stackoverflow.com/questions/37709966/symfony-interactive-command-test-ends-with-runtimeexception/37712073), the code example showing how to test a command that interacts with the user is wrong.

The reason is that `\n` between simple quotes are [not considered as break lines](http://stackoverflow.com/questions/2531969/print-newline-in-php-in-single-quotes) in PHP, even escaped with an additional `\`.
