### PR TITLE
Process: callbacks now allowed when output disabled

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -302,9 +302,14 @@ Use :method:`Symfony\\Component\\Process\\Process::disableOutput` and
     You can not enable or disable the output while the process is running.
 
     If you disable the output, you cannot access ``getOutput``,
-    ``getIncrementalOutput``, ``getErrorOutput`` or ``getIncrementalErrorOutput``.
-    Moreover, you could not pass a callback to the ``start``, ``run`` or ``mustRun``
-    methods or use ``setIdleTimeout``.
+    ``getIncrementalOutput``, ``getErrorOutput``, ``getIncrementalErrorOutput`` or
+    ``setIdleTimeout``.
+
+    However, it is possible to pass a callback to the ``start``, ``run`` or ``mustRun``
+    methods to handle process output in a streaming fashion.
+
+.. versionadded:: 3.1
+    The ability to pass a callback to these methods when output is disabled was added in Symfony 3.1.
 
 .. _`Symfony Issue#5759`: https://github.com/symfony/symfony/issues/5759
 .. _`PHP Bug#39992`: https://bugs.php.net/bug.php?id=39992


### PR DESCRIPTION
This is a recent change in 3.1 added by @romainneutron

Callbacks are allowed even if output is disabled

Related issue: symfony/symfony#17427
