### PR TITLE
fix dumper default representation

### DIFF
--- a/components/yaml/introduction.rst
+++ b/components/yaml/introduction.rst
@@ -164,12 +164,15 @@ Array Expansion and Inlining
 ............................
 
 The YAML format supports two kind of representation for arrays, the expanded
-one, and the inline one. By default, the dumper uses the inline
+one, and the inline one. By default, the dumper uses the expanded
 representation:
 
 .. code-block:: yaml
 
-    { foo: bar, bar: { foo: bar, bar: baz } }
+    foo: bar
+    bar:
+        foo: bar
+        bar: baz
 
 The second argument of the :method:`Symfony\\Component\\Yaml\\Yaml::dump`
 method customizes the level at which the output switches from the expanded


### PR DESCRIPTION
Hi,

The default representation of dumper when using `Yaml` class is expanded:
`public static function dump($array, $inline = 2, $indent = 4, $flags = 0)`

May be i'm wrong because the `$inline` argument is different in `Yaml` (default inline=2 so expanded) and `Dumper` (default inline=0 so inline) class. So it depend to which class we refer to. 
