### PR TITLE
Replace form.type_extension tag

### DIFF
--- a/cookbook/form/create_form_type_extension.rst
+++ b/cookbook/form/create_form_type_extension.rst
@@ -95,7 +95,7 @@ Registering your Form Type Extension as a Service
 -------------------------------------------------
 
 The next step is to make Symfony aware of your extension. All you
-need to do is to declare it as a service by using the ``form.type_extension``
+need to do is to declare it as a service by using the ``extended_type`` or ``extended-type``
 tag:
 
 .. configuration-block::


### PR DESCRIPTION
As declared in the migrate document [UPGRADE FROM 2.x to 3.0](https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md) "The alias option of the form.type_extension tag was removed in favor of the extended_type/extended-type option.". In the current examples the `extended_type` is already used.

This PR fixes the create form type extension documentation that was still using the `form.type_extension` tag
