### PR TITLE
[Contributing][Code] remove PHPUnit requirement

### DIFF
--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -14,8 +14,7 @@ Before working on Symfony, setup a friendly environment with the following
 software:
 
 * Git;
-* PHP version 5.3.9 or above;
-* `PHPUnit`_ 4.2 or above.
+* PHP version 5.3.9 or above.
 
 .. caution::
 
@@ -365,4 +364,3 @@ before merging.
 .. _`fabbot`: http://fabbot.io
 .. _`PSR-1`: http://www.php-fig.org/psr/psr-1/
 .. _`PSR-2`: http://www.php-fig.org/psr/psr-2/
-.. _PHPUnit: https://phpunit.de/manual/current/en/installation.html


### PR DESCRIPTION
PHPUnit is no longer a requirement to test patches for the Symfony core
as we ship a wrapper script that will take care to install the required
PHPUnit version matching the user's environment and must be used to run
Symfony's test suite.
