### PR TITLE
Caution about impersonation not compatible with pre authenticated

### DIFF
--- a/cookbook/security/impersonating_user.rst
+++ b/cookbook/security/impersonating_user.rst
@@ -6,8 +6,17 @@ How to Impersonate a User
 
 Sometimes, it's useful to be able to switch from one user to another without
 having to log out and log in again (for instance when you are debugging or trying
-to understand a bug a user sees that you can't reproduce). This can be easily
-done by activating the ``switch_user`` firewall listener:
+to understand a bug a user sees that you can't reproduce).
+
+.. caution::
+
+    User impersonation is not compatible with
+    :doc:`pre Authenticated firewalls</cookbook/security/pre_authenticated>`. The
+    reason is that impersonation requires the authentication state to be maintained
+    server-side but pre Authenticated information (``SSL_CLIENT_S_DN_Email``,
+    ``REMOTE_USER`` or other) is sent in each request.
+
+This can be easily done by activating the ``switch_user`` firewall listener:
 
 .. configuration-block::
 

--- a/cookbook/security/impersonating_user.rst
+++ b/cookbook/security/impersonating_user.rst
@@ -13,7 +13,7 @@ to understand a bug a user sees that you can't reproduce).
     User impersonation is not compatible with
     :doc:`pre Authenticated firewalls</cookbook/security/pre_authenticated>`. The
     reason is that impersonation requires the authentication state to be maintained
-    server-side but pre Authenticated information (``SSL_CLIENT_S_DN_Email``,
+    server-side but pre-authenticated information (``SSL_CLIENT_S_DN_Email``,
     ``REMOTE_USER`` or other) is sent in each request.
 
 This can be easily done by activating the ``switch_user`` firewall listener:

--- a/cookbook/security/pre_authenticated.rst
+++ b/cookbook/security/pre_authenticated.rst
@@ -11,6 +11,14 @@ box, Symfony supports most authentication mechanisms.
 These requests are called *pre authenticated* requests because the user is already
 authenticated when reaching your application.
 
+.. caution::
+
+    :doc:`User impersonation </cookbook/security/impersonating_user>` is not
+    compatible with pre Authenticated firewalls. The reason is that
+    impersonation requires the authentication state to be maintained server-side
+    but pre Authenticated information (``SSL_CLIENT_S_DN_Email``, ``REMOTE_USER``
+    or other) is sent in each request.
+
 X.509 Client Certificate Authentication
 ---------------------------------------
 
@@ -152,9 +160,3 @@ key in the ``remote_user`` firewall configuration.
     See :ref:`the previous note <cookbook-security-pre-authenticated-user-provider-note>`
     for more information.
 
-.. caution::
-
-    :doc:`User impersonation </cookbook/security/impersonating_user>` is not
-    compatible with ``REMOTE_USER`` based authentication. The reason is that
-    impersonation requires the authentication state to be maintained server-side
-    but ``REMOTE_USER`` information is sent by the browser in each request.

--- a/cookbook/security/pre_authenticated.rst
+++ b/cookbook/security/pre_authenticated.rst
@@ -14,9 +14,9 @@ authenticated when reaching your application.
 .. caution::
 
     :doc:`User impersonation </cookbook/security/impersonating_user>` is not
-    compatible with pre Authenticated firewalls. The reason is that
+    compatible with pre-authenticated firewalls. The reason is that
     impersonation requires the authentication state to be maintained server-side
-    but pre Authenticated information (``SSL_CLIENT_S_DN_Email``, ``REMOTE_USER``
+    but pre-authenticated information (``SSL_CLIENT_S_DN_Email``, ``REMOTE_USER``
     or other) is sent in each request.
 
 X.509 Client Certificate Authentication


### PR DESCRIPTION
Caution added to close Symfony issue #2172 according to @fabpot comment in the Symfony #19059 PR.
I also improved the similar caution about REMOTE_USER to make it global.
