### PR TITLE
Removed 'html' from the component description

### DIFF
--- a/components/form/introduction.rst
+++ b/components/form/introduction.rst
@@ -5,8 +5,7 @@
 The Form Component
 ==================
 
-    The Form component allows you to easily create, process and reuse HTML
-    forms.
+    The Form component allows you to easily create, process and reuse forms.
 
 The Form component is a tool to help you solve the problem of allowing end-users
 to interact with the data and modify the data in your application. And though


### PR DESCRIPTION
Removed a single word from the component description, to clarify that `symfony/form` is not responsible for rendering html forms (it's `symfony/twig-bundle` that does this).

This comes from a discussion, here: https://www.reddit.com/r/PHP/comments/4oj05y/symfony_rest_api_validating_data_that_will_be/d4e7fuq?context=3
