### PR TITLE
NullOutput should be passed to $command->run()

### DIFF
--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -548,7 +548,7 @@ returns the returned code from the command (return value from command's
 
     If you want to suppress the output of the executed command, pass a
     :class:`Symfony\\Component\\Console\\Output\\NullOutput` as the second
-    argument to ``$command->execute()``.
+    argument to ``$command->run()``.
 
 .. caution::
 


### PR DESCRIPTION
as $command#execute() is protected, the NullOutput should be passed to $command#run() as that's the public method being invoked when calling an existing command.
