### PR TITLE
Hard values for the driver option

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -43,7 +43,6 @@ information. By convention, this information is usually configured in an
 
     # app/config/parameters.yml
     parameters:
-        database_driver:    pdo_mysql
         database_host:      localhost
         database_name:      test_project
         database_user:      root
@@ -64,7 +63,7 @@ information. By convention, this information is usually configured in an
             # app/config/config.yml
             doctrine:
                 dbal:
-                    driver:   '%database_driver%'
+                    driver:   pdo_mysql
                     host:     '%database_host%'
                     dbname:   '%database_name%'
                     user:     '%database_user%'
@@ -84,7 +83,7 @@ information. By convention, this information is usually configured in an
 
                 <doctrine:config>
                     <doctrine:dbal
-                        driver="%database_driver%"
+                        driver="pdo_mysql"
                         host="%database_host%"
                         dbname="%database_name%"
                         user="%database_user%"
@@ -97,7 +96,7 @@ information. By convention, this information is usually configured in an
             // app/config/config.php
             $configuration->loadFromExtension('doctrine', array(
                 'dbal' => array(
-                    'driver'   => '%database_driver%',
+                    'driver'   => 'pdo_mysql',
                     'host'     => '%database_host%',
                     'dbname'   => '%database_name%',
                     'user'     => '%database_user%',

--- a/cookbook/doctrine/multiple_entity_managers.rst
+++ b/cookbook/doctrine/multiple_entity_managers.rst
@@ -27,7 +27,7 @@ The following configuration code shows how you can configure two entity managers
                 default_connection: default
                 connections:
                     default:
-                        driver:   '%database_driver%'
+                        driver:   pdo_mysql
                         host:     '%database_host%'
                         port:     '%database_port%'
                         dbname:   '%database_name%'
@@ -35,7 +35,7 @@ The following configuration code shows how you can configure two entity managers
                         password: '%database_password%'
                         charset:  UTF8
                     customer:
-                        driver:   '%database_driver2%'
+                        driver:   pdo_mysql
                         host:     '%database_host2%'
                         port:     '%database_port2%'
                         dbname:   '%database_name2%'
@@ -68,7 +68,7 @@ The following configuration code shows how you can configure two entity managers
             <config>
                 <dbal default-connection="default">
                     <connection name="default"
-                        driver="%database_driver%"
+                        driver="pdo_mysql"
                         host="%database_host%"
                         port="%database_port%"
                         dbname="%database_name%"
@@ -78,7 +78,7 @@ The following configuration code shows how you can configure two entity managers
                     />
 
                     <connection name="customer"
-                        driver="%database_driver2%"
+                        driver="pdo_mysql"
                         host="%database_host2%"
                         port="%database_port2%"
                         dbname="%database_name2%"
@@ -108,7 +108,7 @@ The following configuration code shows how you can configure two entity managers
                 'default_connection' => 'default',
                 'connections' => array(
                     'default' => array(
-                        'driver'   => '%database_driver%',
+                        'driver'   => 'pdo_mysql',
                         'host'     => '%database_host%',
                         'port'     => '%database_port%',
                         'dbname'   => '%database_name%',
@@ -117,7 +117,7 @@ The following configuration code shows how you can configure two entity managers
                         'charset'  => 'UTF8',
                     ),
                     'customer' => array(
-                        'driver'   => '%database_driver2%',
+                        'driver'   => 'pdo_mysql',
                         'host'     => '%database_host2%',
                         'port'     => '%database_port2%',
                         'dbname'   => '%database_name2%',


### PR DESCRIPTION
Fixes symfony/symfony#19196.

As the drivers are not different per environment, but rather always the same, it shouldn't be a parameter.
