### PR TITLE
Added an example for a different method of verbosity level usage.

### DIFF
--- a/components/console/introduction.rst
+++ b/components/console/introduction.rst
@@ -229,6 +229,9 @@ level. For example::
         $output->writeln(...);
     }
 
+    // alternatively you can pass the verbosity level to writeln()
+    $output->writeln('...', OutputInterface::VERBOSITY_VERBOSE);
+
 There are also more semantic methods you can use to test for each of the
 verbosity levels::
 


### PR DESCRIPTION
Setting a message level like in the added example, was not yet documented. I just found out this method by looking into the code. I also tested with some dummy command that it really does what I thought:

```
protected function execute(InputInterface $input, OutputInterface $output) {
    $output->writeln('quiet', OutputInterface::VERBOSITY_QUIET);
    $output->writeln('normal', OutputInterface::VERBOSITY_NORMAL);
    $output->writeln('verbose', OutputInterface::VERBOSITY_VERBOSE);
    $output->writeln('very verbose', OutputInterface::VERBOSITY_VERY_VERBOSE);
    $output->writeln('debug', OutputInterface::VERBOSITY_DEBUG);
}
```
