### PR TITLE
Update form_login_setup.rst

### DIFF
--- a/cookbook/security/form_login_setup.rst
+++ b/cookbook/security/form_login_setup.rst
@@ -394,7 +394,7 @@ for the login page:
         firewalls:
             # order matters! This must be before the ^/ firewall
             login_firewall:
-                pattern:   ^/login$
+                pattern:   ^/login/$
                 anonymous: ~
             secured_area:
                 pattern:    ^/


### PR DESCRIPTION
Line 397: added / to pattern.

Otherwise auth will not work with this example anymore. The user will be redirected to the login_form as anonymous, although his authetication data might have been correct.
