### PR TITLE
[CS] Avoid using useless expressions

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -175,6 +175,9 @@ Structure
   switched to opt-in via ``@`` operator.
   Read more at :ref:`contributing-code-conventions-deprecations`.
 
+* Do not use ``else``, ``elseif``, ``break`` after ``if`` and ``case`` conditions
+  which return or throw something.
+
 Naming Conventions
 ------------------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes |
| Applies to | all |
| Fixed tickets | N/A |

Do not use `else`, `elseif`, `break` after `if` and `case` conditions
which returns or throws something.
