### PR TITLE
Removed empty `Notes on previous versions`

### DIFF
--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -19,9 +19,6 @@ You can install the component in 2 different ways:
 
 .. include:: /components/require_autoload.rst.inc
 
-Notes on Previous Versions
---------------------------
-
 Usage
 -----
 


### PR DESCRIPTION
On `OptionsResolver` component documentation, we have a `Notes on previous versions` section after Symfony 2.6.

Since Symfony 2.8 docs, this section is empty, so I suggest to remove it for version 3.x and probably re-add it in 2.8.

> This pull request should be applied in 3.0, 3.1, 3.2 **and 2.8** cf @WouterJ comment
