### PR TITLE
Re-added notes about previous versions in OptionsResolver component

### DIFF
--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -22,6 +22,11 @@ You can install the component in 2 different ways:
 Notes on Previous Versions
 --------------------------
 
+.. versionadded:: 2.6
+    This documentation was written for Symfony 2.6 and later. If you use an older
+    version, please `read the Symfony 2.5 documentation`_. For a list of changes,
+    see the `CHANGELOG`_.
+    
 Usage
 -----
 


### PR DESCRIPTION
On `OptionsResolver` component documentation, we have a `Notes on previous versions` section after Symfony 2.6.

Since Symfony 2.8 docs, this section is empty, so I suggest to remove it for version 3.x and probably re-add it in 2.8.
