### PR TITLE
[Component][ClassLoader]Remove invalid note

### DIFF
--- a/components/class_loader/class_loader.rst
+++ b/components/class_loader/class_loader.rst
@@ -33,11 +33,6 @@ is straightforward::
 
     $loader->register();
 
-.. note::
-
-    The autoloader is automatically registered in a Symfony application
-    (see ``app/autoload.php``).
-
 Use :method:`Symfony\\Component\\ClassLoader\\ClassLoader::addPrefix` or
 :method:`Symfony\\Component\\ClassLoader\\ClassLoader::addPrefixes` to register
 your classes::


### PR DESCRIPTION
- remove the note mentioning that a class loader from this component is registered in app/autoload.php because in fact it loads Composer's autoloader
