### PR TITLE
[Finder] Fixed typo in RealPath method on SplFileInfo class

### DIFF
--- a/components/finder.rst
+++ b/components/finder.rst
@@ -31,7 +31,7 @@ directories::
 
     foreach ($finder as $file) {
         // Dump the absolute path
-        var_dump($file->getRealpath());
+        var_dump($file->getRealPath());
 
         // Dump the relative path to the file, omitting the filename
         var_dump($file->getRelativePath());
@@ -163,7 +163,7 @@ You can also define your own sorting algorithm with ``sort()`` method::
 
     $sort = function (\SplFileInfo $a, \SplFileInfo $b)
     {
-        return strcmp($a->getRealpath(), $b->getRealpath());
+        return strcmp($a->getRealPath(), $b->getRealPath());
     };
 
     $finder->sort($sort);


### PR DESCRIPTION
The getRealPath method in SplFileInfo has a capital letter for getReal**p**ath. See [SplFileInfo::getRealPath](http://php.net/manual/en/splfileinfo.getrealpath.php)

Found this typo when implementing the finder component and copying the example .
