### PR TITLE
Use getParameter method in controllers

### DIFF
--- a/book/controller.rst
+++ b/book/controller.rst
@@ -540,6 +540,14 @@ console command:
 
 For more information, see the :doc:`/book/service_container` chapter.
 
+.. tip::
+
+    To get a container configuration parameter in controller you can use the
+    :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::getParameter`
+    method::
+
+        $from = $this->getParameter('app.mailer.from');
+
 .. index::
    single: Controller; Managing errors
    single: Controller; 404 pages

--- a/cookbook/controller/upload_file.rst
+++ b/cookbook/controller/upload_file.rst
@@ -140,7 +140,7 @@ Finally, you need to update the code of the controller that handles the form::
 
                 // Move the file to the directory where brochures are stored
                 $file->move(
-                    $this->container->getParameter('brochures_directory'),
+                    $this->getParameter('brochures_directory'),
                     $fileName
                 );
 
@@ -408,7 +408,7 @@ Now, register this class as a Doctrine listener:
 
         // app/config/services.php
         use Symfony\Component\DependencyInjection\Reference;
-        
+
         // ...
         $definition = new Definition(
             'AppBundle\EventListener\BrochureUploaderListener',


### PR DESCRIPTION
Since Symfony 2.7 there is `getParameter()` method available for accessing container configuration parameters.
