### PR TITLE
Updated the condition to display console name

### DIFF
--- a/components/console/usage.rst
+++ b/components/console/usage.rst
@@ -101,7 +101,7 @@ to get this information output:
 
     Acme Console Application version 1.2
 
-If you do not provide both arguments then it will just output:
+If you do not provide a console name then it will just output:
 
 .. code-block:: text
 


### PR DESCRIPTION
Before `3.1` we need both console name and version in order to display the console name instead of `console tool`, now we only need to setup the name.

See https://github.com/symfony/console/commit/56eb96de859a443d87606a6193224c92a01086da
