### PR TITLE
Add little caution to add service id for @Route annotation

### DIFF
--- a/cookbook/controller/service.rst
+++ b/cookbook/controller/service.rst
@@ -76,13 +76,6 @@ Then you can define it as a service as follows:
             'AppBundle\Controller\HelloController'
         ));
 
-.. caution::
-
-    If you are managing your routes with PHP annotation, you may need to add an
-    ``@Route`` annotation to the controller-class which specifies its service
-    ID. If you don't, the system may try to construct your controller without
-    any arguments. See the `FrameworkExtraBundle documentation`_ for details.
-
 Referring to the Service
 ------------------------
 
@@ -126,7 +119,8 @@ the route ``_controller`` value:
 .. tip::
 
     You can also use annotations to configure routing using a controller
-    defined as a service. See the `FrameworkExtraBundle documentation`_ for
+    defined as a service. Make sure you specify the service ID in the
+    ``@Route`` annotation. See the `FrameworkExtraBundle documentation`_ for
     details.
 
 .. tip::
@@ -345,4 +339,4 @@ controller:
 
 .. _`Controller class source code`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
 .. _`base Controller class`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
-.. _`FrameworkExtraBundle documentation`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/routing.html
+.. _`FrameworkExtraBundle documentation`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/routing.html#controller-as-service

--- a/cookbook/controller/service.rst
+++ b/cookbook/controller/service.rst
@@ -76,6 +76,13 @@ Then you can define it as a service as follows:
             'AppBundle\Controller\HelloController'
         ));
 
+.. caution::
+
+    If you are managing your routes with PHP annotation, you may need to add an
+    ``@Route`` annotation to the controller-class which specifies its service
+    ID. If you don't, the system may try to construct your controller without
+    any arguments. See the `FrameworkExtraBundle documentation`_ for details.
+
 Referring to the Service
 ------------------------
 


### PR DESCRIPTION
Finishes #6258

Original PR description:

> I just ran into this problem and it took me a while. Without the `@Route(service="myid")` annotation, the controller was _always_ being instantiated without any arguments, completely ignoring my service-definition.
> 
> Not sure how far back/forward this applies to other versions.
