### PR TITLE
Correcting reference to `isSuccessful` method for Process

### DIFF
--- a/components/console/helpers/debug_formatter.rst
+++ b/components/console/helpers/debug_formatter.rst
@@ -122,7 +122,7 @@ notify this to the users::
         $debugFormatter->stop(
             spl_object_hash($process),
             'Some command description',
-            $process->isSuccessfull()
+            $process->isSuccessful()
         )
     );
 


### PR DESCRIPTION
Stumbled across this misnamed method when doing some copying and pasting. "Successful" vs. "successfull" always gets me too.
