### PR TITLE
Fix web/front.php

### DIFF
--- a/create_framework/http_kernel_controller_resolver.rst
+++ b/create_framework/http_kernel_controller_resolver.rst
@@ -185,9 +185,6 @@ Let's conclude with the new version of our framework::
     $controllerResolver = new HttpKernel\Controller\ControllerResolver();
     $argumentResolver = new HttpKernel\Controller\ArgumentResolver();
 
-    $controller = $controllerResolver->getController($request);
-    $arguments = $argumentResolver->getArguments($request, $controller);
-
     try {
         $request->attributes->add($matcher->match($request->getPathInfo()));
 


### PR DESCRIPTION
## $controller always return false.

```
$controller = $controllerResolver->getController($request);
$arguments = $argumentResolver->getArguments($request, $controller);
```

The two lines before the `try ... catch` should run after:

```
$request->attributes->add($matcher->match($request->getPathInfo()));
```

The three lines already exist inside the `try ... catch` which works fine and properly after removed those two lines.

([http://symfony.com/doc/master/create_framework/http_kernel_controller_resolver.html](http://symfony.com/doc/master/create_framework/http_kernel_controller_resolver.html))
