### PR TITLE
Update installation.rst

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -334,10 +334,27 @@ of the Symfony Installer anywhere in your system:
     # Windows
     c:\projects\> php symfony demo
 
+.. note::
+
+    Apart from the :doc:`usual Symfony application requirements </reference/requirements>`,
+    the Symfony Demo application needs the PDO-SQLite PHP extension to be enabled.
+
 Once downloaded, enter into the ``symfony_demo/`` directory and run the PHP's
 built-in web server executing the ``php app/console server:run`` command. Access
 to the ``http://localhost:8000`` URL in your browser to start using the Symfony
 Demo application.
+
+.. tip::
+
+    The application will run with the lastest version available of Symfony. If we
+    want to run it with a previous version, we should change the Symfony dependency.
+
+    For example, for using Symfony 2.8.0 we would proceed as follows:
+
+    .. code-block:: bash
+
+        $ cd symfony_demo
+        $ composer require symfony/symfony:2.8.0
 
 .. _installing-a-symfony2-distribution:
 


### PR DESCRIPTION
Update section **Installing the Symfony Demo Application**, with a pair of notes, because I would have appreciated having that info previously.
1. The Demo Application needs the PDO-SQLite extension enabled. You realize that when you run the server and try to browse the Public section of the demo. It generates an huge error page. This is only mentioned in the [symfony-demo repository](https://github.com/symfony/symfony-demo), but it should be here too. This way, it will be friendly for newcomers (as me). Plus, the `symfony-demo` repository itself isn't mentioned in the document neither, so...
2. I'm reading the book because I need to prepare to a position where the team is using Symfony 2.8. I followed the tutorial and the `demo` application generated was using the last Symfony version available... And I wanted, obviously, to use Symfony 2.8. I searched the internet and, after a precious amount of time, finally got the solution, indirectly, in the [official announcement of the Demo Application](http://symfony.com/blog/introducing-the-symfony-demo-application).

So, I thought that this notes will be useful to  future users like me.
