### PR TITLE
[Contributing] [Standards] Do not use spaces inside/around offset accessors

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -176,7 +176,9 @@ Structure
   Read more at :ref:`contributing-code-conventions-deprecations`;
 
 * Do not use ``else``, ``elseif``, ``break`` after ``if`` and ``case`` conditions
-  which return or throw something.
+  which return or throw something;
+
+* Do not use spaces inside/around offset accessors;
 
 Naming Conventions
 ------------------

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -178,7 +178,7 @@ Structure
 * Do not use ``else``, ``elseif``, ``break`` after ``if`` and ``case`` conditions
   which return or throw something;
 
-* Do not use spaces inside/around offset accessors.
+* Do not use spaces around ``[`` offset accessor and before ``]`` offset accessor.
 
 Naming Conventions
 ------------------

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -178,7 +178,7 @@ Structure
 * Do not use ``else``, ``elseif``, ``break`` after ``if`` and ``case`` conditions
   which return or throw something;
 
-* Do not use spaces inside/around offset accessors;
+* Do not use spaces inside/around offset accessors.
 
 Naming Conventions
 ------------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes |
| Applies to | all |
| Fixed tickets | N/A |

Ref: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2089
