### PR TITLE
Mac OS X 10.11.6 grep adds line number

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -248,7 +248,7 @@ If there are any issues, correct them now before moving on.
 
         $ rm -rf var/cache/* var/logs/* var/sessions/*
 
-        $ HTTPDUSER=`ps axo user,comm | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1`
+        $ HTTPDUSER=`ps axo user,comm | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1 | cut -d: -f3`
         $ sudo chmod -R +a "$HTTPDUSER allow delete,write,append,file_inherit,directory_inherit" var
         $ sudo chmod -R +a "`whoami` allow delete,write,append,file_inherit,directory_inherit" var
 


### PR DESCRIPTION
It looks like Mac OS X 10.11.6 `grep` adds the line number output by default and the command used to find the http server user name fails:

```
$ ps axo user,comm | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx'| grep -v root | head -1 | cut -d\  -f1
2:211:username
```

I haven't found an option to explicitly remove the line number output with `grep` so I've just added another `cut` command on the pipe. I've checked and it still works for Mac OS X 10.9.5.
