### PR TITLE
Update doctrine.rst

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -1066,6 +1066,10 @@ it will likely be convenient for each ``Category`` object to automatically
 own a collection of its related ``Product`` objects.
 
 .. note::
+    To understand ``inversedBy`` and ``mappedBy`` usage, see Doctrine's
+    `Association Updates`_ documentation.
+
+.. note::
 
     The code in the constructor is important.  Rather than being instantiated
     as a traditional ``array``, the ``$products`` property must be of a type
@@ -1447,6 +1451,7 @@ For more information about Doctrine, see the *Doctrine* section of the
 .. _`Basic Mapping Documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html
 .. _`Query Builder`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/query-builder.html
 .. _`Doctrine Query Language`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/dql-doctrine-query-language.html
+.. _`Association Updates`: http://docs.doctrine-project.org/en/latest/reference/unitofwork-associations.html
 .. _`Association Mapping Documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/association-mapping.html
 .. _`Mapping Types Documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html#property-mapping
 .. _`Property Mapping`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html#property-mapping

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -1066,6 +1066,7 @@ it will likely be convenient for each ``Category`` object to automatically
 own a collection of its related ``Product`` objects.
 
 .. note::
+
     To understand ``inversedBy`` and ``mappedBy`` usage, see Doctrine's
     `Association Updates`_ documentation.
 


### PR DESCRIPTION
Note for «see doctrine's documentation» just in section where `inversedBy` and `mappedBy` first appeared

I know that five sections away there is a [More Information on Associations](https://symfony.com/doc/2.7/book/doctrine.html#more-information-on-associations) section, that has a reference to this (if you dig enough: it's linked in the page linked in that section), but that's not enough. It's too general and too late.

When you're reading this (my case, as a newcomer right now) and get to this `inversedBy` and `mappedBy` in [Relationship Mapping Metadata](https://symfony.com/doc/2.7/book/doctrine.html#relationship-mapping-metadata) section, and there isn't any direct mention about it, you felt lost. Can't understand why that's used and what it means. And you scroll and see no direct reference about that. It breaks your learning rhythm. I had to search about this, till I found the Doctrine's documentation that I linked in the added note. That cleared out the doubt. So I can continue learning. Five sections away there's a general «Read more about associations». That's OK. I will read more then. But at that moment, you need, at least, to understand why that parameters are there.
