### PR TITLE
custom error pages - Reference to security functions warning is no more

### DIFF
--- a/cookbook/controller/error_pages.rst
+++ b/cookbook/controller/error_pages.rst
@@ -95,7 +95,6 @@ To override the 404 error template for HTML pages, create a new
     {% block body %}
         <h1>Page not found</h1>
 
-        {# example security usage, see below #}
         {% if is_granted('IS_AUTHENTICATED_FULLY') %}
             {# ... #}
         {% endif %}


### PR DESCRIPTION
Reference to security functions warning is no longer needed in > 2.8.

In the example code of the custom error page, there was a comment reference to the `Avoiding Exceptions when Using Security Functions in Error Templates' section, that lived in the pre-2.8 documentation. That subsection is no longer there.
