### PR TITLE
Fix CS for form templates locations

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -241,7 +241,7 @@ your controller::
             'form' => $form->createView(),
         ));
     }
-    
+
 .. caution::
 
     Be aware that the ``createView()`` method should be called *after* ``handleRequest``
@@ -686,7 +686,7 @@ the documentation for each type.
     is left blank. If you don't want this behavior, either
     :ref:`disable HTML5 validation <book-forms-html5-validation-disable>`
     or set the ``required`` option on your field to ``false``::
-    
+
         ->add('dueDate', 'date', array(
             'widget' => 'single_text',
             'required' => false
@@ -1711,7 +1711,7 @@ to define form output.
 PHP
 ...
 
-To automatically include the customized templates from the ``app/Resources/views/Form``
+To automatically include the customized templates from the ``app/Resources/views/form``
 directory created earlier in *all* templates, modify your application configuration
 file:
 
@@ -1724,7 +1724,7 @@ file:
             templating:
                 form:
                     resources:
-                        - 'Form'
+                        - ':form'
         # ...
 
     .. code-block:: xml
@@ -1740,7 +1740,7 @@ file:
             <framework:config>
                 <framework:templating>
                     <framework:form>
-                        <framework:resource>Form</framework:resource>
+                        <framework:resource>:form</framework:resource>
                     </framework:form>
                 </framework:templating>
                 <!-- ... -->
@@ -1754,14 +1754,14 @@ file:
             'templating' => array(
                 'form' => array(
                     'resources' => array(
-                        'Form',
+                        ':form',
                     ),
                 ),
             ),
             // ...
         ));
 
-Any fragments inside the ``app/Resources/views/Form`` directory are now used
+Any fragments inside the ``app/Resources/views/form`` directory are now used
 globally to define form output.
 
 .. index::

--- a/cookbook/form/form_customization.rst
+++ b/cookbook/form/form_customization.rst
@@ -451,7 +451,7 @@ the base block by using the ``parent()`` Twig function:
 
 .. code-block:: html+twig
 
-    {# app/Resources/views/Form/fields.html.twig #}
+    {# app/Resources/views/form/fields.html.twig #}
     {% extends 'form_div_layout.html.twig' %}
 
     {% block integer_widget %}
@@ -558,7 +558,7 @@ PHP
 ~~~
 
 By using the following configuration, any customized form fragments inside the
-``app/Resources/views/Form`` folder will be used globally when a
+``app/Resources/views/form`` folder will be used globally when a
 form is rendered.
 
 .. configuration-block::
@@ -570,7 +570,7 @@ form is rendered.
             templating:
                 form:
                     resources:
-                        - 'AppBundle:Form'
+                        - ':form'
             # ...
 
     .. code-block:: xml
@@ -579,7 +579,7 @@ form is rendered.
         <framework:config>
             <framework:templating>
                 <framework:form>
-                    <resource>AppBundle:Form</resource>
+                    <resource>:form</resource>
                 </framework:form>
             </framework:templating>
             <!-- ... -->
@@ -593,7 +593,7 @@ form is rendered.
             'templating' => array(
                 'form' => array(
                     'resources' => array(
-                        'AppBundle:Form',
+                        ':form',
                     ),
                 ),
              ),
@@ -685,7 +685,7 @@ customize the ``name`` field only:
 
         <?php echo $view['form']->widget($form['name']); ?>
 
-        <!-- app/Resources/views/Form/_product_name_widget.html.php -->
+        <!-- app/Resources/views/form/_product_name_widget.html.php -->
         <div class="text_widget">
             <?php echo $view['form']->block('form_widget_simple') ?>
         </div>
@@ -742,7 +742,7 @@ You can also override the markup for an entire field row using the same method:
 
         <?php echo $view['form']->row($form['name']); ?>
 
-        <!-- app/Resources/views/Form/_product_name_row.html.php -->
+        <!-- app/Resources/views/form/_product_name_row.html.php -->
         <div class="name_row">
             <?php echo $view['form']->label($form) ?>
             <?php echo $view['form']->errors($form) ?>


### PR DESCRIPTION
According to the best practices template lowercased snake_case should be used for all template directory and file names. This patch fixes some inconsistencies left from the previous such updates.
