### PR TITLE
Routing: add explanation for the "_fragment" parameter

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -465,7 +465,7 @@ Special Routing Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As you've seen, each routing parameter or default value is eventually available
-as an argument in the controller method. Additionally, there are three parameters
+as an argument in the controller method. Additionally, there are four parameters
 that are special: each adds a unique piece of functionality inside your application:
 
 ``_controller``
@@ -476,6 +476,10 @@ that are special: each adds a unique piece of functionality inside your applicat
     Used to set the request format (:ref:`read more <routing-format-param>`).
 
 ``_fragment``
+
+ .. versionadded:: 3.2
+    The ``_fragment`` parameter was introduced in Symfony 3.2.
+
     Used to set the fragment identifier, the optional last part of a URL that
     starts with a ``#`` character and is used to identify a portion of a document.
 

--- a/routing.rst
+++ b/routing.rst
@@ -475,6 +475,10 @@ that are special: each adds a unique piece of functionality inside your applicat
 ``_format``
     Used to set the request format (:ref:`read more <routing-format-param>`).
 
+``_fragment``
+    Used to set the fragment identifier, the optional last part of a URL that
+    starts with a ``#`` character and is used to identify a portion of a document.
+
 ``_locale``
     Used to set the locale on the request (:ref:`read more <translation-locale-url>`).
 


### PR DESCRIPTION
Add explanation about this PR: https://github.com/symfony/symfony/pull/12979

Presented in http://symfony.com/blog/new-in-symfony-3-2-routing-improvements

I copy-pasted the start of the announcement as the explanation since I couldn't have found a better explanation. I hope that won't be a problem.
