### PR TITLE
Twig reference: Add links from routing functions to special routing parameters

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -324,6 +324,10 @@ Returns the relative URL (without the scheme and host) for the given route.
 If ``relative`` is enabled, it'll create a path relative to the current
 path. More information in :ref:`templating-pages`.
 
+.. seealso::
+
+    Read :doc:`/routing` to learn more about the Routing component.
+
 url
 ~~~
 
@@ -341,6 +345,10 @@ url
 Returns the absolute URL (with scheme and host) for the given route. If
 ``schemeRelative`` is enabled, it'll create a scheme-relative URL. More
 information in :ref:`templating-pages`.
+
+.. seealso::
+
+    Read :doc:`/routing` to learn more about the Routing component.
 
 absolute_url
 ~~~~~~~~~~~~


### PR DESCRIPTION
The Twig reference doesn't explain what is the `parameters` parameter. I added a link to a section that explain the _Special Routing Parameters_.
