### PR TITLE
Added a new section to the page templating/global_vars using a EVListener

### DIFF
--- a/templating/global_variables.rst
+++ b/templating/global_variables.rst
@@ -143,7 +143,7 @@ Using an Event Listener Together with the @Template Annotation
 
 If you're using the `@Template`_ annotation from `SensioFrameworkExtraBundle`_ you can hook
 into ``kernel.view`` right before the template listener kicks in, take a look at the
-dedicated page about :doc:`Event Listeners </event_dispatcher.html>`.
+dedicated page about :doc:`Event Listeners </event_dispatcher>`.
 
 Here is an example of changing the parameters when you have your listener set up:
 

--- a/templating/global_variables.rst
+++ b/templating/global_variables.rst
@@ -133,3 +133,25 @@ If the global variable you want to set is more complicated - say an object -
 then you won't be able to use the above method. Instead, you'll need to create
 a :ref:`Twig Extension <reference-dic-tags-twig-extension>` and return the
 global variable as one of the entries in the ``getGlobals`` method.
+
+.. note::
+``getGlobals`` is deprecated as of Twig v1.23 and removed in v2.0.
+
+Using an Event Listener Together with the @Template Annotation
+--------------------------------------------------------------
+
+If you're using the :doc:`@Template </bundles/SensioFrameworkExtraBundle/annotations/view.html>`
+annotation from the :doc:`/bundles/SensioFrameworkExtraBundle` you can hook
+into `kernel.view` right before the template listener kicks in, take a look at the
+dedicated page about :doc:`Event Listeners </event_dispatcher.html>`.
+
+Here is an example of changing the parameters when you have your listener set up:
+
+.. code-block:: php
+
+  public function onKernelView(GetResponseForControllerResultEvent $event)
+  {
+      $params = $event->getControllerResult();
+      $params['sadface'] = 'You need me everywhere!';
+      $event->setControllerResult($params);
+  }

--- a/templating/global_variables.rst
+++ b/templating/global_variables.rst
@@ -141,10 +141,10 @@ global variable as one of the entries in the ``getGlobals`` method.
 Using an Event Listener Together with the @Template Annotation
 --------------------------------------------------------------
 
-If you're using the :doc:`@Template <http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/annotations/view.html>`
-annotation from :doc:`SensioFrameworkExtraBundle <http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/index.html>` you can hook
+If you're using the `@Template <http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/annotations/view.html>`_
+annotation from `SensioFrameworkExtraBundle <http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/index.html>`_ you can hook
 into `kernel.view` right before the template listener kicks in, take a look at the
-dedicated page about :doc:`Event Listeners </event_dispatcher.html>`.
+dedicated page about :doc:`Event Listeners </event_dispatcher.html>`_.
 
 Here is an example of changing the parameters when you have your listener set up:
 

--- a/templating/global_variables.rst
+++ b/templating/global_variables.rst
@@ -125,36 +125,3 @@ This should feel familiar, as it's the same syntax you use in service configurat
                  'user_management' => '@app.user_management',
              ),
         ));
-
-Using a Twig Extension
-----------------------
-
-If the global variable you want to set is more complicated - say an object -
-then you won't be able to use the above method. Instead, you'll need to create
-a :ref:`Twig Extension <reference-dic-tags-twig-extension>` and return the
-global variable as one of the entries in the ``getGlobals`` method.
-
-.. note::
-
-    ``getGlobals`` is deprecated as of Twig v1.23 and removed in v2.0.
-
-Using an Event Listener Together with the @Template Annotation
---------------------------------------------------------------
-
-If you're using the `@Template`_ annotation from `SensioFrameworkExtraBundle`_ you can hook
-into ``kernel.view`` right before the template listener kicks in, take a look at the
-dedicated page about :doc:`Event Listeners </event_dispatcher>`.
-
-Here is an example of changing the parameters when you have your listener set up:
-
-.. code-block:: php
-
-  public function onKernelView(GetResponseForControllerResultEvent $event)
-  {
-      $params = $event->getControllerResult();
-      $params['sadface'] = 'You need me everywhere!';
-      $event->setControllerResult($params);
-  }
-
-.. _`@Template`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/view
-.. _`SensioFrameworkExtraBundle`: http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html#annotations-for-controllers

--- a/templating/global_variables.rst
+++ b/templating/global_variables.rst
@@ -135,7 +135,8 @@ a :ref:`Twig Extension <reference-dic-tags-twig-extension>` and return the
 global variable as one of the entries in the ``getGlobals`` method.
 
 .. note::
-``getGlobals`` is deprecated as of Twig v1.23 and removed in v2.0.
+
+    ``getGlobals`` is deprecated as of Twig v1.23 and removed in v2.0.
 
 Using an Event Listener Together with the @Template Annotation
 --------------------------------------------------------------

--- a/templating/global_variables.rst
+++ b/templating/global_variables.rst
@@ -141,8 +141,8 @@ global variable as one of the entries in the ``getGlobals`` method.
 Using an Event Listener Together with the @Template Annotation
 --------------------------------------------------------------
 
-If you're using the :doc:`@Template </bundles/SensioFrameworkExtraBundle/annotations/view.html>`
-annotation from the :doc:`/bundles/SensioFrameworkExtraBundle` you can hook
+If you're using the :doc:`@Template <http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/annotations/view.html>`
+annotation from :doc:`SensioFrameworkExtraBundle <http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/index.html>` you can hook
 into `kernel.view` right before the template listener kicks in, take a look at the
 dedicated page about :doc:`Event Listeners </event_dispatcher.html>`.
 

--- a/templating/global_variables.rst
+++ b/templating/global_variables.rst
@@ -142,7 +142,7 @@ Using an Event Listener Together with the @Template Annotation
 --------------------------------------------------------------
 
 If you're using the `@Template`_ annotation from `SensioFrameworkExtraBundle`_ you can hook
-into `kernel.view` right before the template listener kicks in, take a look at the
+into ``kernel.view`` right before the template listener kicks in, take a look at the
 dedicated page about :doc:`Event Listeners </event_dispatcher.html>`_.
 
 Here is an example of changing the parameters when you have your listener set up:

--- a/templating/global_variables.rst
+++ b/templating/global_variables.rst
@@ -141,8 +141,7 @@ global variable as one of the entries in the ``getGlobals`` method.
 Using an Event Listener Together with the @Template Annotation
 --------------------------------------------------------------
 
-If you're using the `@Template <http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/annotations/view.html>`_
-annotation from `SensioFrameworkExtraBundle <http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/index.html>`_ you can hook
+If you're using the `@Template`_ annotation from `SensioFrameworkExtraBundle`_ you can hook
 into `kernel.view` right before the template listener kicks in, take a look at the
 dedicated page about :doc:`Event Listeners </event_dispatcher.html>`_.
 
@@ -156,3 +155,6 @@ Here is an example of changing the parameters when you have your listener set up
       $params['sadface'] = 'You need me everywhere!';
       $event->setControllerResult($params);
   }
+
+.. _`@Template`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/view
+.. _`SensioFrameworkExtraBundle`: http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle

--- a/templating/global_variables.rst
+++ b/templating/global_variables.rst
@@ -143,7 +143,7 @@ Using an Event Listener Together with the @Template Annotation
 
 If you're using the `@Template`_ annotation from `SensioFrameworkExtraBundle`_ you can hook
 into ``kernel.view`` right before the template listener kicks in, take a look at the
-dedicated page about :doc:`Event Listeners </event_dispatcher.html>`_.
+dedicated page about :doc:`Event Listeners </event_dispatcher.html>`.
 
 Here is an example of changing the parameters when you have your listener set up:
 
@@ -157,4 +157,4 @@ Here is an example of changing the parameters when you have your listener set up
   }
 
 .. _`@Template`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/view
-.. _`SensioFrameworkExtraBundle`: http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle
+.. _`SensioFrameworkExtraBundle`: http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html#annotations-for-controllers


### PR DESCRIPTION
Added another option for injecting variables into templates through the use of a event listener, also added a DC/removal notice on twigs getGlobals
