### PR TITLE
Fix missing function name

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -234,7 +234,7 @@ your controller::
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             // $form->getData() holds the submitted values
             // but, the original `$task` variable has also been updated
             $task = $form->getData();


### PR DESCRIPTION
Example in the 'Handling Form Submissions' section was invalid, as the name of a function to be called (isValid) was missing.
