### PR TITLE
Remove colloquialism "hold on"

### DIFF
--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -32,8 +32,8 @@ take a look at the :doc:`Form Events </form/events>` documentation.
 Customizing your Form Based on the Underlying Data
 --------------------------------------------------
 
-Before jumping right into dynamic form generation, hold on and recall what
-a bare form class looks like::
+Before jumping right into dynamic form generation, recall what
+a bare form class looks like:
 
     // src/AppBundle/Form/Type/ProductType.php
     namespace AppBundle\Form\Type;


### PR DESCRIPTION
I'm of the thought that documentation should balance between conversational grammar and formal grammar. Hold on pushes that over the conversational boundary, in my opinion. Thoughts?
