### PR TITLE
Adjust Application use statement

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -216,7 +216,7 @@ console::
     namespace Tests\AppBundle\Command;
 
     use AppBundle\Command\CreateUserCommand;
-    use Symfony\Bundle\FrameworkBundle\Console\Application;
+    use Symfony\Component\Console\Application;
     use Symfony\Component\Console\Tester\CommandTester;
 
     class CreateUserCommandTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
The code example assumes the use of the Console Application (no kernel parameter) but the use statement is for the Frameworkbundle Console Application, which requires the kernel parameter. This is confusing, basically the example cannot work as it is.
