### PR TITLE
Fixed a missing method name in example

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -234,7 +234,7 @@ your controller::
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             // $form->getData() holds the submitted values
             // but, the original `$task` variable has also been updated
             $task = $form->getData();


### PR DESCRIPTION
Probably something that went wrong merging somewhere. My best guess is that this should be `isValid`. This issue is present in all branches and can be merged upwards.

Thanks @devproco for reporting this issue
