### PR TITLE
Fixed a syntax issue in custom_constraint article

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -167,7 +167,7 @@ Constraint Validators with Dependencies
 If your constraint validator has dependencies, such as a database connection,
 it will need to be configured as a service in the Dependency Injection
 Container. This service must include the ``validator.constraint_validator``
-tag so that the validation system knows about it::
+tag so that the validation system knows about it:
 
 .. configuration-block::
 


### PR DESCRIPTION
Here you can see how the render is broken: http://symfony.com/doc/current/validation/custom_constraint.html#constraint-validators-with-dependencies
