### PR TITLE
Adds bin folder creation instruction

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -22,6 +22,7 @@ executable that needs to be installed on your system only once:
 .. code-block:: bash
 
     # Linux and macOS systems
+    $ sudo mkdir -p /usr/local/bin
     $ sudo curl -LsS https://symfony.com/installer -o /usr/local/bin/symfony
     $ sudo chmod a+x /usr/local/bin/symfony
 


### PR DESCRIPTION
On some cases, after OS installation, the user/local/bin folder does not exists. Adding this instruction will avoid curl issues.
