### PR TITLE
Fix file_permissions.rst.

### DIFF
--- a/setup/file_permissions.rst
+++ b/setup/file_permissions.rst
@@ -31,8 +31,8 @@ needed permissions:
 
 .. code-block:: bash
 
-    $ rm -rf app/cache/*
-    $ rm -rf app/logs/*
+    $ rm -rf var/cache/*
+    $ rm -rf var/logs/*
 
     $ HTTPDUSER=`ps axo user,comm | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1`
     $ sudo chmod -R +a "$HTTPDUSER allow delete,write,append,file_inherit,directory_inherit" var


### PR DESCRIPTION
Cache and logs folders were not pointing to the path for the 3.x version.
