### PR TITLE
Fix Varnish 4 code example

### DIFF
--- a/http_cache/varnish.rst
+++ b/http_cache/varnish.rst
@@ -32,7 +32,7 @@ header:
 .. code-block:: varnish4
 
     sub vcl_recv {
-        remove req.http.Forwarded;
+        unset req.http.Forwarded;
     }
 
 If you do not have access to your Varnish configuration, you can instead


### PR DESCRIPTION
Finishes https://github.com/symfony/symfony-docs/pull/6770

Original description:

> remove word in vcl_recv doesnt exist in varnish 4.*
