### PR TITLE
Link to inversedBy/mappedBy documentation

### DIFF
--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -168,7 +168,7 @@ own a collection of its related ``Product`` objects.
 
 .. note::
 
-    The code in the constructor is important.  Rather than being instantiated
+    The code in the constructor is important. Rather than being instantiated
     as a traditional ``array``, the ``$products`` property must be of a type
     that implements Doctrine's ``Collection`` interface. In this case, an
     ``ArrayCollection`` object is used. This object looks and acts almost
@@ -183,10 +183,10 @@ own a collection of its related ``Product`` objects.
 
 .. tip::
 
-   The targetEntity value in the metadata used above can reference any entity
-   with a valid namespace, not just entities defined in the same namespace. To
-   relate to an entity defined in a different class or bundle, enter a full
-   namespace as the targetEntity.
+    The targetEntity value in the metadata used above can reference any entity
+    with a valid namespace, not just entities defined in the same namespace. To
+    relate to an entity defined in a different class or bundle, enter a full
+    namespace as the targetEntity.
 
 Now that you've added new properties to both the ``Product`` and ``Category``
 classes, tell Doctrine to generate the missing getter and setter methods for you:

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -176,6 +176,11 @@ own a collection of its related ``Product`` objects.
     you uncomfortable, don't worry. Just imagine that it's an ``array``
     and you'll be in good shape.
 
+.. seealso::
+
+    To understand ``inversedBy`` and ``mappedBy`` usage, see Doctrine's
+    `Association Updates` documentation.
+
 .. tip::
 
    The targetEntity value in the metadata used above can reference any entity
@@ -407,3 +412,4 @@ Doctrine's `Association Mapping Documentation`_.
     statement, which *imports* the ``ORM`` annotations prefix.
 
 .. _`Association Mapping Documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/association-mapping.html
+.. _`Association Updates`: http://docs.doctrine-project.org/en/latest/reference/unitofwork-associations.html


### PR DESCRIPTION
Finishes https://github.com/symfony/symfony-docs/pull/6769

Original description:

> Note for «see doctrine's documentation» just in section where `inversedBy` and `mappedBy` first appeared
> 
> I know that five sections away there is a [More Information on Associations](https://symfony.com/doc/2.7/book/doctrine.html#more-information-on-associations) section, that has a reference to this (if you dig enough: it's linked in the page linked in that section), but that's not enough. It's too general and too late.
> 
> When you're reading this (my case, as a newcomer right now) and get to this `inversedBy` and `mappedBy` in [Relationship Mapping Metadata](https://symfony.com/doc/2.7/book/doctrine.html#relationship-mapping-metadata) section, and there isn't any direct mention about it, you felt lost. Can't understand why that's used and what it means. And you scroll and see no direct reference about that. It breaks your learning rhythm. I had to search about this, till I found the Doctrine's documentation that I linked in the added note. That cleared out the doubt. So I can continue learning. Five sections away there's a general «Read more about associations». That's OK. I will read more then. But at that moment, you need, at least, to understand why that parameters are there.
