### PR TITLE
Remove outdated reference

### DIFF
--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -99,7 +99,6 @@ To override the 404 error template for HTML pages, create a new
     {% block body %}
         <h1>Page not found</h1>
 
-        {# example security usage, see below #}
         {% if is_granted('IS_AUTHENTICATED_FULLY') %}
             {# ... #}
         {% endif %}


### PR DESCRIPTION
Finishes #6771 

Original description:

> In the example code of the custom error page, there was a comment reference to the `Avoiding Exceptions when Using Security Functions in Error Templates' section, that lived in the pre-2.8 documentation. That subsection is no longer there.
