### PR TITLE
Fix Cache Pools: SQLite3Cache constructor argument

### DIFF
--- a/components/cache/cache_pools.rst
+++ b/components/cache/cache_pools.rst
@@ -153,7 +153,8 @@ application as if they were Symfony Cache adapters::
     use Doctrine\Common\Cache\SQLite3Cache;
     use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 
-    $doctrineCache = new SQLite3Cache(__DIR__.'/cache/data.sqlite');
+    $sqliteDatabase = new \SQLite3(__DIR__.'/cache/data.sqlite');
+    $doctrineCache = new SQLite3Cache($sqliteDatabase, 'tableName');
     $symfonyCache = new DoctrineAdapter($doctrineCache);
 
 This adapter also defines two optional arguments called  ``namespace`` (default:


### PR DESCRIPTION
The first argument for SQLite3Cache should be of type SQLite3 instead of a string

https://github.com/doctrine/cache/blob/master/lib/Doctrine/Common/Cache/SQLite3Cache.php#L68 
