### PR TITLE
Deprecated message with "true" parameter

### DIFF
--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -64,7 +64,7 @@ TwigBundle Configuration ("twig")
 
             <twig:config
                 auto-reload="%kernel.debug%"
-                autoescape="true"
+                autoescape="filename"
                 base-template-class="Twig_Template"
                 cache="%kernel.cache_dir%/twig"
                 charset="%kernel.charset%"
@@ -95,7 +95,7 @@ TwigBundle Configuration ("twig")
                  'pi'  => 3.14,
              ),
              'auto_reload'          => '%kernel.debug%',
-             'autoescape'           => true,
+             'autoescape'           => 'filename',
              'base_template_class'  => 'Twig_Template',
              'cache'                => '%kernel.cache_dir%/twig',
              'charset'              => '%kernel.charset%',
@@ -131,8 +131,7 @@ autoescape
 
 **type**: ``boolean`` or ``string`` **default**: ``'filename'``
 
-If set to ``true``, all template contents are escaped for HTML. If set to
-``false``, automatic escaping is disabled (you can still escape each content
+If set to ``false``, automatic escaping is disabled (you can still escape each content
 individually in the templates).
 
 .. caution::


### PR DESCRIPTION
With the "true" parameter you will get this message:
Using "true" as the default strategy is deprecated since version 1.21. Use "html" instead.

I replaced it with the default value.
