### PR TITLE
Add a class specificity for SplFileInfo text

### DIFF
--- a/components/finder.rst
+++ b/components/finder.rst
@@ -41,7 +41,7 @@ directories::
     }
 
 The ``$file`` is an instance of :class:`Symfony\\Component\\Finder\\SplFileInfo`
-which extends :phpclass:`SplFileInfo` to provide methods to work with relative
+which extends PHP's own :phpclass:`\SplFileInfo` to provide methods to work with relative
 paths.
 
 The above code prints the names of all the files in the current directory

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -41,7 +41,7 @@ directories::
     }
 
 The ``$file`` is an instance of :class:`Symfony\\Component\\Finder\\SplFileInfo`
-which extends PHP's own :phpclass:`\SplFileInfo` to provide methods to work with relative
+which extends PHP's own :phpclass:`SplFileInfo` to provide methods to work with relative
 paths.
 
 The above code prints the names of all the files in the current directory


### PR DESCRIPTION
- update text to differentiate between PHP's SplFileInfo and Symfony's SplFileInfo
