### PR TITLE
Remove redundant verb

### DIFF
--- a/service_container/definitions.rst
+++ b/service_container/definitions.rst
@@ -96,7 +96,7 @@ fetched from the container::
 .. caution::
 
     Don't use ``get()`` to get a service that you want to inject as constructor
-    argument, the service is not yet availabe. Instead, use inject a
+    argument, the service is not yet availabe. Instead, use a
     ``Reference`` instance as shown above.
 
 Method Calls


### PR DESCRIPTION
Just removes an extra verb that was not really necessary.
