### PR TITLE
Remove Yaml doctrine metadata examples

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -251,7 +251,7 @@ PHP classes.
 You'll provide this mapping information in the form of "metadata", a collection
 of rules that tells Doctrine exactly how the ``Product`` class and its
 properties should be *mapped* to a specific database table. This metadata
-can be specified in a number of different formats, including YAML, XML or
+can be specified in a number of different formats, including XML, or
 directly inside the ``Product`` class via DocBlock annotations:
 
 .. configuration-block::
@@ -292,26 +292,6 @@ directly inside the ``Product`` class via DocBlock annotations:
             private $description;
         }
 
-    .. code-block:: yaml
-
-        # src/AppBundle/Resources/config/doctrine/Product.orm.yml
-        AppBundle\Entity\Product:
-            type: entity
-            table: product
-            id:
-                id:
-                    type: integer
-                    generator: { strategy: AUTO }
-            fields:
-                name:
-                    type: string
-                    length: 100
-                price:
-                    type: decimal
-                    scale: 2
-                description:
-                    type: text
-
     .. code-block:: xml
 
         <!-- src/AppBundle/Resources/config/doctrine/Product.orm.xml -->
@@ -334,7 +314,7 @@ directly inside the ``Product`` class via DocBlock annotations:
 .. note::
 
     A bundle can accept only one metadata definition format. For example, it's
-    not possible to mix YAML metadata definitions with annotated PHP entity
+    not possible to mix XML metadata definitions with annotated PHP entity
     class definitions.
 
 .. tip::

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -56,20 +56,6 @@ property on the ``Product`` class, annotated as follows:
             private $category;
         }
 
-    .. code-block:: yaml
-
-        # src/AppBundle/Resources/config/doctrine/Product.orm.yml
-        AppBundle\Entity\Product:
-            type: entity
-            # ...
-            manyToOne:
-                category:
-                    targetEntity: Category
-                    inversedBy: products
-                    joinColumn:
-                        name: category_id
-                        referencedColumnName: id
-
     .. code-block:: xml
 
         <!-- src/AppBundle/Resources/config/doctrine/Product.orm.xml -->
@@ -123,19 +109,6 @@ to hold those associated objects.
                 $this->products = new ArrayCollection();
             }
         }
-
-    .. code-block:: yaml
-
-        # src/AppBundle/Resources/config/doctrine/Category.orm.yml
-        AppBundle\Entity\Category:
-            type: entity
-            # ...
-            oneToMany:
-                products:
-                    targetEntity: Product
-                    mappedBy: category
-        # Don't forget to initialize the collection in
-        # the __construct() method of the entity
 
     .. code-block:: xml
 

--- a/doctrine/lifecycle_callbacks.rst
+++ b/doctrine/lifecycle_callbacks.rst
@@ -11,7 +11,7 @@ stages of the lifecycle of an entity (e.g. the entity is inserted, updated,
 deleted, etc).
 
 If you're using annotations for your metadata, start by enabling the lifecycle
-callbacks. This is not necessary if you're using YAML or XML for your mapping.
+callbacks. This is not necessary if you're using XML for your mapping.
 
 .. code-block:: php-annotations
 
@@ -41,15 +41,6 @@ the current date, only when the entity is first persisted (i.e. inserted):
         {
             $this->createdAt = new \DateTime();
         }
-
-    .. code-block:: yaml
-
-        # src/AppBundle/Resources/config/doctrine/Product.orm.yml
-        AppBundle\Entity\Product:
-            type: entity
-            # ...
-            lifecycleCallbacks:
-                prePersist: [setCreatedAtValue]
 
     .. code-block:: xml
 

--- a/doctrine/repository.rst
+++ b/doctrine/repository.rst
@@ -28,14 +28,6 @@ To do this, add the repository class name to your entity's mapping definition:
             //...
         }
 
-    .. code-block:: yaml
-
-        # src/AppBundle/Resources/config/doctrine/Product.orm.yml
-        AppBundle\Entity\Product:
-            type: entity
-            repositoryClass: AppBundle\Entity\ProductRepository
-            # ...
-
     .. code-block:: xml
 
         <!-- src/AppBundle/Resources/config/doctrine/Product.orm.xml -->

--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -505,17 +505,6 @@ you will learn about next!).
              */
             protected $tags;
 
-        .. code-block:: yaml
-
-            # src/AppBundle/Resources/config/doctrine/Task.orm.yml
-            AppBundle\Entity\Task:
-                type: entity
-                # ...
-                oneToMany:
-                    tags:
-                        targetEntity: Tag
-                        cascade:      [persist]
-
         .. code-block:: xml
 
             <!-- src/AppBundle/Resources/config/doctrine/Task.orm.xml -->


### PR DESCRIPTION
Doctrine 3 is dropping Yaml support. Let's make the docs future proof by not suggesting Yaml anymore. This will avoid new people to start writing Yaml metadata and having to rewrite all them when updating to Doctrine 3 in a few months.
