### PR TITLE
Re-introduced Validator component usage

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -111,6 +111,34 @@ following:
 .. index::
    single: Validation; Using the validator
 
+Retrieving a Validator instance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :class:`Symfony\\Component\\Validator\\Validator` class is the main access
+point of the Validator component. To create a new instance of this class, it
+is recommended to use the :class:`Symfony\\Component\\Validator\\Validation`
+class.
+
+You can get a very basic ``Validator`` by calling
+:method:`Validation::createValidator() <Symfony\\Component\\Validator\\Validation::createValidator>`::
+
+    use Symfony\Component\Validator\Validation;
+
+    $validator = Validation::createValidator();
+
+The created validator can be used to validate strings, arrays, numbers, but it
+can't validate classes. In order to achieve that, you have to configure the ``Validator``
+class. To do that, you can use the :class:`Symfony\\Component\\Validator\\ValidatorBuilder`.
+This class can be retrieved by using the
+:method:`Validation::createValidatorBuilder() <Symfony\\Component\\Validator\\Validation::createValidatorBuilder>`
+method::
+
+    use Symfony\Component\Validator\Validation;
+
+    $validator = Validation::createValidatorBuilder()
+        // ... build a custom instance of the Validator
+        ->getValidator();
+        
 Using the ``validator`` Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Hi, I just saw use of Validator component have been removed, probably a mistake (the initial pull request have changed so many times ^^).

This re-introduce the creation of a Validator instance, useful when you use it without use the full edition framework :)

Also, regarding the initial (second in fact) pull request (https://github.com/symfony/symfony-docs/pull/5661/files) why **Caching** and **Resources loading** sections have been removed ? 

Mickaël
