### PR TITLE
Remove extra quotes from ExprBuilder::thenInvalid() usage

### DIFF
--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -726,7 +726,7 @@ The builder is used for adding advanced validation rules to node definitions, li
                         ->isRequired()
                         ->validate()
                         ->ifNotInArray(array('mysql', 'sqlite', 'mssql'))
-                            ->thenInvalid('Invalid database driver "%s"')
+                            ->thenInvalid('Invalid database driver %s')
                         ->end()
                     ->end()
                 ->end()


### PR DESCRIPTION
The given example gives extra quotes (`Invalid database driver ""value""` instead of (`Invalid database driver "value"`), because the value is automatically quoted due to the use of `json_encode`.
