### PR TITLE
Error in CSRF example code snippet

### DIFF
--- a/components/form.rst
+++ b/components/form.rst
@@ -134,7 +134,7 @@ The following snippet adds CSRF protection to the form factory::
 
     $formFactory = Forms::createFormFactoryBuilder()
         // ...
-        ->addExtension(new CsrfExtension($csrfStorage))
+        ->addExtension(new CsrfExtension($csrfManager))
         ->getFormFactory();
 
 Internally, this extension will automatically add a hidden field to every


### PR DESCRIPTION
Something's wrong when I tried this code:

```
$session = new Session();

$csrfGenerator = new UriSafeTokenGenerator();
$csrfStorage = new SessionTokenStorage($session);
$csrfManager = new CsrfTokenManager($csrfGenerator, $csrfStorage);

$formFactory = Forms::createFormFactoryBuilder()
    // ...
    ->addExtension(new CsrfExtension($csrfStorage))
    ->getFormFactory();
```

Constructing a `CsrfExtension` requires a `CsrfTokenManagerInterface` as an argument (see symfony/form/Extension/Csrf/CsrfExtension.php, line 47).

The `$csrfStorage` in `addExtension(new CsrfExtension($csrfStorage)`, has a class that implements `TokenStorageInterface` (see symfony/security-csrf/TokenStorage/SessionStorageToken.php,  line 22).

So I replaced it with `$csrfManager` that has class that implements `CsrfTokenManagerInterface`. (see symfony/security-csrf/CsrfTokenManager.php, line 24)
