### PR TITLE
[Routing] Fix a route path in a routing example

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -333,7 +333,7 @@ By adding a *default* value:
 
         return $collection;
 
-Now, when the user goes to ``/page``, the ``blog_list`` route will match and ``$page``
+Now, when the user goes to ``/blog``, the ``blog_list`` route will match and ``$page``
 will default to a value of ``1``.
 
 .. index::


### PR DESCRIPTION
Hello,

I found a little issue in the Routing documentation, like this example, the route path is not correct, the **blog_list** route will match when the user goes to **/blog**.
This PR fixes the issue.

![routing](https://cloud.githubusercontent.com/assets/6014143/17735160/1851cc9c-6481-11e6-9c6e-942d4b3411e5.png)
