### PR TITLE
service_container : fix php Definition instance

### DIFF
--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -93,7 +93,7 @@ configure the service container to use the
 
         $container->register('app.newsletter_manager_factory', 'AppBundle\Email\NewsletterManagerFactory');
 
-        $newsletterManager = new Definition();
+        $newsletterManager = new Definition('AppBundle\Email\NewsletterManager');
 
         // call a method on the specified service
         $newsletterManager->setFactory(array(


### PR DESCRIPTION
Nothing really important ^^, just according YAML format with PHP format.

I have a question but I don't know where I can ask ^^ :
The doc says that $container->register is a shortcut of definition method [("shortcut for the previous method")](http://symfony.com/doc/current/service_container/definitions.html#getting-and-setting-service-definitions).

But for me definition method is not the same as directly register service in containerBuidler.
Is there a place where I can post my questions ?

EDIT: I think this is not a justified PR, if so, sorry for the time spent
