### PR TITLE
[FormComponent]Fix wrong mention in side note

### DIFF
--- a/form/events.rst
+++ b/form/events.rst
@@ -228,8 +228,7 @@ View data        Normalized data transformed using a view transformer
     information about the forms.
     The ``Symfony\Component\Form\Extension\Validator\EventListener\ValidationListener``
     subscribes to the ``FormEvents::POST_SUBMIT`` event in order to
-    automatically validate the denormalized object and to update the normalized
-    representation as well as the view representations.
+    automatically validate the denormalized object.
 
 Registering Event Listeners or Event Subscribers
 ------------------------------------------------


### PR DESCRIPTION
- fix wrong mention in side note for ValidationListener. It mentioned that the ValidationListener will also update the normalized representation as well as the view representations actions which it doesn't perform. The listener's only role is to validate the updated object
