### PR TITLE
[FormComponent] Fix typos

### DIFF
--- a/form/form_dependencies.rst
+++ b/form/form_dependencies.rst
@@ -1,7 +1,7 @@
 How to Access Services or Config from Inside a Form
 ===================================================
 
-Sometimes, you may need to access a :doc:`services </service_container>` or other
+Sometimes, you may need to access a :doc:`service </service_container>` or other
 configuration from inside of your form class. To do this, you have 2 options:
 
 1) Pass Options to your Form
@@ -45,7 +45,7 @@ create your form::
     }
 
 Finally, the ``entity_manager`` option is accessible in the ``$options`` argument
-if your ``buildForm`` method::
+of your ``buildForm`` method::
 
     // src/AppBundle/Form/TaskType.php
     // ...


### PR DESCRIPTION
- fix typo from services to service in the first paragraph
- fix typo from "if your buildForm" to "of your buildForm"
