### PR TITLE
Explain what happens if `flush()` fails

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -555,6 +555,11 @@ Take a look at the previous example in more detail:
     ``Product`` objects and then subsequently call ``flush()``, Doctrine will
     execute 100 ``INSERT`` queries using a single prepared statement object.
 
+.. note::
+
+    If ``flush()`` fails, an exception is thrown, which you can catch by wrapping
+    the ``flush()`` method in a ``try...catch`` block.
+
 Whether creating or updating objects, the workflow is always the same. In
 the next section, you'll see how Doctrine is smart enough to automatically
 issue an ``UPDATE`` query if the entity already exists in the database.

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -557,8 +557,9 @@ Take a look at the previous example in more detail:
 
 .. note::
 
-    If ``flush()`` fails, an exception is thrown, which you can catch by wrapping
-    the ``flush()`` method in a ``try...catch`` block.
+    If the ``flush()`` call fails, a ``Doctrine\ORM\ORMException`` exception
+    is thrown, which you can catch by wrapping the ``flush()`` method in a
+    ``try...catch`` block.
 
 Whether creating or updating objects, the workflow is always the same. In
 the next section, you'll see how Doctrine is smart enough to automatically


### PR DESCRIPTION
It should be mentioned _somewhere_ in this chapter, how to verify that the entity has really been persisted. What's the best practice here? try...catch? Or (for INSERT) check if $entity->getId() does exist? => Please expand on that.
Also, you could list all possible types of exceptions explicitly.
