### PR TITLE
fixing $formatLevelMap array values

### DIFF
--- a/components/console/logger.rst
+++ b/components/console/logger.rst
@@ -98,8 +98,8 @@ constructor::
 
     // ...
     $formatLevelMap = array(
-        LogLevel::CRITICAL => ConsoleLogger::INFO,
-        LogLevel::DEBUG    => ConsoleLogger::ERROR,
+        LogLevel::CRITICAL => ConsoleLogger::ERROR,
+        LogLevel::DEBUG    => ConsoleLogger::INFO,
     );
     $logger = new ConsoleLogger($output, array(), $formatLevelMap);
 


### PR DESCRIPTION
Logically the values of `$formatLevelMap` array were switched,
`LogLevel::CRITICAL` key should have value `ConsoleLogger::ERROR` and
`LogLevel::DEBUG` key should have value `ConsoleLogger::INFO`
