### PR TITLE
Remove reference to profiler lifetime property that was removed in 3.x

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -42,8 +42,6 @@ Configuration
     * `only_exceptions`_
     * `only_master_requests`_
     * `dsn`_
-    * `username`_
-    * `password`_
     * `matcher`_
         * `ip`_
         * :ref:`path <reference-profiler-matcher-path>`
@@ -554,20 +552,6 @@ The DSN where to store the profiling information.
 
     See :doc:`/profiler/storage` for more information about the
     profiler storage.
-
-username
-........
-
-**type**: ``string`` **default**: ``''``
-
-When needed, the username for the profiling storage.
-
-password
-........
-
-**type**: ``string`` **default**: ``''``
-
-When needed, the password for the profiling storage.
 
 matcher
 .......
@@ -1465,8 +1449,6 @@ Full Default Configuration
                 only_exceptions:      false
                 only_master_requests: false
                 dsn:                  file:%kernel.cache_dir%/profiler
-                username:
-                password:
                 matcher:
                     ip:                   ~
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -44,7 +44,6 @@ Configuration
     * `dsn`_
     * `username`_
     * `password`_
-    * `lifetime`_
     * `matcher`_
         * `ip`_
         * :ref:`path <reference-profiler-matcher-path>`
@@ -569,14 +568,6 @@ password
 **type**: ``string`` **default**: ``''``
 
 When needed, the password for the profiling storage.
-
-lifetime
-........
-
-**type**: ``integer`` **default**: ``86400``
-
-The lifetime of the profiling storage in seconds. The data will be deleted
-when the lifetime is expired.
 
 matcher
 .......
@@ -1476,7 +1467,6 @@ Full Default Configuration
                 dsn:                  file:%kernel.cache_dir%/profiler
                 username:
                 password:
-                lifetime:             86400
                 matcher:
                     ip:                   ~
 


### PR DESCRIPTION
Fixes #6889
