### PR TITLE
Change example of ignoring dependencies for yaml

### DIFF
--- a/service_container/optional_dependencies.rst
+++ b/service_container/optional_dependencies.rst
@@ -76,7 +76,8 @@ call if the service exists and remove the method call if it does not:
         services:
             app.newsletter_manager:
                 class:     AppBundle\Newsletter\NewsletterManager
-                arguments: ['@?app.mailer']
+                calls:
+                    - [setMailer, ['@?app.mailer']]
 
     .. code-block:: xml
 


### PR DESCRIPTION
Change constructor injection to setter injection (the same as in examples for xml and php), so it is clear what method call is ignored
