### PR TITLE
DumpFile() third argument is deprecated and doesn't exists anymore

### DIFF
--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -252,8 +252,6 @@ complete new file (but never a partially-written file)::
 
 The ``file.txt`` file contains ``Hello World`` now.
 
-A desired file mode can be passed as the third argument.
-
 Error Handling
 --------------
 


### PR DESCRIPTION
see https://github.com/symfony/symfony-docs/pull/6906

nl;dr; `dumpFile()` third argument is deprecated and removed in 3.x, we shouldn't document it.
