### PR TITLE
Fix assertion failure message meaning

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -264,7 +264,7 @@ document::
                 'Content-Type',
                 'application/json'
             ),
-            'the "Content-Type" header is "application/json"' // optional message shown on failure
+            'the "Content-Type" header is not "application/json"' // optional message shown on failure
         );
 
         // Assert that the response content contains a string


### PR DESCRIPTION
If the assertion fails it is because the "Content-Type" header is NOT "application/json"
