### PR TITLE
[Finder] document array use for locations

### DIFF
--- a/components/finder.rst
+++ b/components/finder.rst
@@ -82,7 +82,8 @@ directory to use for the search::
 Search in several locations by chaining calls to
 :method:`Symfony\\Component\\Finder\\Finder::in`::
 
-    $finder->files()->in(__DIR__)->in('/elsewhere');
+    $finder->files()->in(array(__DIR__, '/elsewhere'));
+    $finder->in(__DIR__)->in('/elsewhere');
 
 Use wildcard characters to search in the directories matching a pattern::
 


### PR DESCRIPTION
Hi,

This pull request is valid from Symfony 2.7 to 3.2-dev.

The function `Finder::in()` accepts a string or array of string for look into multiple locations => https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Finder/Finder.php

The other way described is valid, but shouldn't be recommended/documented.

Mickaël
