### PR TITLE
[Config] Note about bundle priority for PrependExtensionInterface

### DIFF
--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -131,3 +131,8 @@ The above would be the equivalent of writing the following into the
             // ...
             'use_acme_goodbye' => false,
         ));
+
+More than one bundle using PrependExtensionInterface
+----------------------------------------------------
+
+When there is more than one bundle prepending the same extension and defining the same key, the bundle that is registered **first** will take priority and next bundles won't override this specific config setting.  


### PR DESCRIPTION
I've stumbled upon problem that my config setting wasn't prepended using PrependExtensionInterface. It was because I didn’t know that first bundle takes priority when it comes to overriding exactly the same config key. 
