### PR TITLE
Fix var_dumper advanced usage link

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -64,7 +64,7 @@ current PHP SAPI:
 .. note::
 
     If you want to catch the dump output as a string, please read the
-    `advanced documentation <advanced>`_ which contains examples of it.
+    :doc:`advanced documentation </components/var_dumper/advanced>` which contains examples of it.
     You'll also learn how to change the format or redirect the output to
     wherever you want.
 


### PR DESCRIPTION
Fixes the "advanced usages" link from the http://symfony.com/doc/current/components/var_dumper.html#the-dump-function section's note.

I've performed a quick search for similar errors in other documents, but was unable to find any other. 😃  
