### PR TITLE
Clarify by_reference use

### DIFF
--- a/reference/forms/types/options/by_reference.rst.inc
+++ b/reference/forms/types/options/by_reference.rst.inc
@@ -5,7 +5,7 @@ by_reference
 
 In most cases, if you have a ``name`` field, then you expect ``setName()``
 to be called on the underlying object. In some cases, however, ``setName()``
-may *not* be called. Setting ``by_reference`` ensures that the setter is
+may *not* be called. Setting ``by_reference=false`` ensures that the setter is
 called in all cases.
 
 To explain this further, here's a simple example::

--- a/reference/forms/types/options/by_reference.rst.inc
+++ b/reference/forms/types/options/by_reference.rst.inc
@@ -3,9 +3,9 @@ by_reference
 
 **type**: ``boolean`` **default**: ``true``
 
-In most cases, if you have a ``name`` field, then you expect ``setName()``
-to be called on the underlying object. In some cases, however, ``setName()``
-may *not* be called. Setting ``by_reference=false`` ensures that the setter is
+In most cases, if you have an ``author`` field, then you expect ``setAuthor()``
+to be called on the underlying object. In some cases, however, ``setAuthor()``
+may *not* be called. Setting ``by_reference`` to ``false`` ensures that the setter is
 called in all cases.
 
 To explain this further, here's a simple example::


### PR DESCRIPTION
I'd like to make it clear that `by_reference` must be set to `false` if the developer requires that an entity's setter method be called.
