### PR TITLE
Misplaced paragraph about placeholders in routing.rst

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -591,10 +591,6 @@ sees our annotation routes:
 For more details on loading routes, including how to prefix the paths of loaded routes,
 see :doc:`/routing/external_resources`.
 
-The path will *not*, however, match simply ``/blog``. That's because,
-by default, all placeholders are required. This can be changed by adding
-a placeholder value to the ``defaults`` array.
-
 .. index::
    single: Routing; Generating URLs
 


### PR DESCRIPTION
It looks that this paragraph was only a misplaced duplicate of [this block](https://github.com/symfony/symfony-docs/blame/c72dde0a8e90ec9fb90b31e472b2c1e0fac35a37/routing.rst#L259-L262)

As you can see on [this commit](https://github.com/symfony/symfony-docs/commit/6e48ceee6ed96364fa9000fe2c6fa1f792e86971?short_path=51326f5#diff-3b3b9409bff44f4b31ba1f933dbf0001L338) the paragraph was originally added to the [Giving {placeholders} a Default Value](https://github.com/symfony/symfony-docs/blob/2.7/routing.rst#giving-placeholders-a-default-value) part.
