### PR TITLE
Minor rewording for the security:checker article

### DIFF
--- a/security/security_checker.rst
+++ b/security/security_checker.rst
@@ -27,7 +27,7 @@ FriendsOfPHP organization.
 .. note::
 
     To enable the ``security:check`` command, make sure the
-    `SensioDistributionBundle`_ is enabled in your application.
+    `SensioDistributionBundle`_ is installed and enabled in your application.
 
 .. _`security advisories database`: https://github.com/FriendsOfPHP/security-advisories
-.. _`SensioDistributionBundle`: https://packagist.org/packages/sensio/distribution-bundle
+.. _`SensioDistributionBundle`: https://github.com/sensiolabs/SensioDistributionBundle

--- a/security/security_checker.rst
+++ b/security/security_checker.rst
@@ -27,11 +27,7 @@ FriendsOfPHP organization.
 .. note::
 
     To enable the ``security:check`` command, make sure the
-    `SensioDistributionBundle`_ is installed.
-
-    .. code-block:: terminal
-
-        $ composer require 'sensio/distribution-bundle'
+    `SensioDistributionBundle`_ is enabled in your application.
 
 .. _`security advisories database`: https://github.com/FriendsOfPHP/security-advisories
 .. _`SensioDistributionBundle`: https://packagist.org/packages/sensio/distribution-bundle


### PR DESCRIPTION
Installing the bundle is not enough ... you must enable it also.
