### PR TITLE
Typo fix in tags.rst

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -195,7 +195,7 @@ Create a Compiler Pass
 ~~~~~~~~~~~~~~~~~~~~~~
 
 You can now use a :ref:`compiler pass <components-di-separate-compiler-passes>` to ask the
-container for any services with the ``acme_mailer.transport`` tag::
+container for any services with the ``app.mail_transport`` tag::
 
     // src/AppBundle/DependencyInjection/Compiler/MailTransportPass.php
     namespace AppBundle\DependencyInjection\Compiler;


### PR DESCRIPTION
I think there is a typo with acme_mailer.transport, this should be app.mail_transport since you are using the app.mail_transport on any other place.
