### PR TITLE
[Reference] add back the option's description

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -596,6 +596,8 @@ username
 
 **type**: ``string`` **default**: ``''``
 
+When needed, the username for the profiling storage.
+
 password
 ........
 


### PR DESCRIPTION
This was accidentally removed in #6908 when the deprecation warnings were added.
