### PR TITLE
[Doctrine] Exception note about functions with named managers

### DIFF
--- a/doctrine/custom_dql_functions.rst
+++ b/doctrine/custom_dql_functions.rst
@@ -69,4 +69,23 @@ In Symfony, you can register your custom DQL functions as follows:
             ),
         ));
 
+.. note::
+
+    In case the ``entity_managers`` were named explicitly, configuring the functions with the
+    orm directly will trigger the exception `Unrecognized option "dql" under "doctrine.orm"`.
+    The `dql` configuration block must be defined under the named entity manager.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    doctrine:
+        orm:
+            # ...
+            entity_managers:
+                example_manager:
+                    # Place your functions here
+                    dql:
+                        datetime_functions:
+                            test_datetime: AppBundle\DQL\DatetimeFunction
+
 .. _`DQL User Defined Functions`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/cookbook/dql-user-defined-functions.html


### PR DESCRIPTION
In case the managers were defined/named explicitly, the DQL functions should also be defined over there.
