### PR TITLE
[Ldap] Updated Ldap component documentation for 3.1

### DIFF
--- a/components/ldap.rst
+++ b/components/ldap.rst
@@ -39,7 +39,8 @@ using the following options:
     Your encryption mechanism (``ssl``, ``tls`` or ``none``)
 
 ``connection_string``
-    You may use this option instead of
+    You may use this option instead of ``host`` and ``port`` to connect to the
+    LDAP server
 
 ``optReferrals``
     Specifies whether to automatically follow referrals
@@ -96,11 +97,11 @@ array, you may use the
 
     // Do something with the results array
 
-Creating or updating entries
+Creating or Updating Entries
 ----------------------------
 
-Since version 3.1, The Ldap component provides means to create
-new LDAP entries, update or even delete existing ones::
+The Ldap component provides means to create new LDAP entries, update or even
+delete existing ones::
 
     use Symfony\Component\Ldap\Ldap;
     use Symfony\Component\Ldap\Entry;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | 3.1, 3.2 |
| Fixed tickets | #5756 |

Unfortunately, I didn't have the time to update the docs since I have been pretty busy these last months, but like people say, better late than never!
The documentation has been updated for version 3.1 of the Ldap component, which no longer uses the same class, and now provides an LdapManager which can create new LDAP entries, or manipulate existing ones (update or delete).

I didn't add a documentation section regarding the legacy classes, but I figure that they should no longer be described as the main entry points for the Ldap component.
