### PR TITLE
Fixed directory name typo

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -139,7 +139,7 @@ variable so we can render that::
         }
     }
 
-Finally, template files should live in the ``app/Resources/view`` directory. Create
+Finally, template files should live in the ``app/Resources/views`` directory. Create
 a new ``app/Resources/views/lucky`` directory with a new ``number.html.twig`` file
 inside:
 


### PR DESCRIPTION
My Symfony 3.1 fresh install has a `app/Resources/views` dir, not `app/Resources/view`.
