### PR TITLE
fix link role syntax

### DIFF
--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -179,7 +179,7 @@ own a collection of its related ``Product`` objects.
 .. seealso::
 
     To understand ``inversedBy`` and ``mappedBy`` usage, see Doctrine's
-    `Association Updates` documentation.
+    `Association Updates`_ documentation.
 
 .. tip::
 


### PR DESCRIPTION
Without the trailing underscore no link would be created, but the text
would be displayed as is.
