### PR TITLE
Added paths options in Framework::translator configuration

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -85,6 +85,7 @@ Configuration
     * :ref:`enabled <reference-translator-enabled>`
     * `fallbacks`_
     * `logging`_
+    * `paths`_
 * `property_access`_
     * `magic_call`_
     * `throw_exception_on_invalid_index`_
@@ -1264,6 +1265,13 @@ for a given key. The logs are made to the ``translation`` channel and at the
 ``debug`` for level for keys where there is a translation in the fallback
 locale and the ``warning`` level if there is no translation to use at all.
 
+paths
+.....
+
+**type**: ``array`` **default**: ``[]``
+
+This option allows to define an array of paths where the component will look for translation files.
+
 property_access
 ~~~~~~~~~~~~~~~
 
@@ -1555,6 +1563,7 @@ Full Default Configuration
                 enabled:              false
                 fallbacks:            [en]
                 logging:              "%kernel.debug%"
+                paths:                []
 
             # validation configuration
             validation:


### PR DESCRIPTION
Hi,

Note this option is already documented in Translator docs, and a blog post mention it too: http://symfony.com/blog/new-in-symfony-2-8-translator-improvements#add-option-to-specify-additional-translation-loading-paths

Mickaël
