### PR TITLE
replace dirname() call with ..

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -199,13 +199,13 @@ to hold the kernel. Now it looks like this::
         // optional, to use the standard Symfony cache directory
         public function getCacheDir()
         {
-            return dirname(__DIR__).'/var/cache/'.$this->getEnvironment();
+            return __DIR__.'/../var/cache/'.$this->getEnvironment();
         }
 
         // optional, to use the standard Symfony logs directory
         public function getLogDir()
         {
-            return dirname(__DIR__).'/var/logs';
+            return __DIR__.'/../var/logs';
         }
     }
 


### PR DESCRIPTION
Using `dirname(__DIR__)` is less readable than using `__DIR__.'/..'`. Also, this is in line with what we use above in `configureRoutes()`.
