### PR TITLE
Reorder arguments: $request as the first argument

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -331,7 +331,7 @@ object. To get it in your controller, just add it as an argument and
 
     use Symfony\Component\HttpFoundation\Request;
 
-    public function indexAction($firstName, $lastName, Request $request)
+    public function indexAction(Request $request, $firstName, $lastName)
     {
         $page = $request->query->get('page', 1);
 


### PR DESCRIPTION
The `Request` argument should be the first one due to it can't be optional, but other arguments can.
