### PR TITLE
Added jQuery symfony-collection plugin to Form collection docs

### DIFF
--- a/cookbook/form/form_collections.rst
+++ b/cookbook/form/form_collections.rst
@@ -739,5 +739,13 @@ the relationship between the removed ``Tag`` and ``Task`` object.
     updated (whether you're adding new tags or removing existing tags) on
     each Tag object itself.
 
+.. sidebar:: Form collection jQuery plugin
+
+    The jQuery plugin  `symfony-collection`_ helps with ``collection`` form elements,
+    by providing the JavaScript functionality needed to add, edit and delete
+    elements of the collection. More advanced functionality like moving or duplicating
+    an element in the collection and customizing the buttons is also possible.
+
 .. _`Owning Side and Inverse Side`: http://docs.doctrine-project.org/en/latest/reference/unitofwork-associations.html
 .. _`JSFiddle`: http://jsfiddle.net/847Kf/4/
+.. _`symfony-collection`: https://github.com/ninsuo/symfony-collection


### PR DESCRIPTION
Issue #6943.

I've added a few lines in the form cookbook about form collections. I have placed the content at the bottom because the whole document is concerned.

If another branch must be targeted I will rebase the changes. 
