### PR TITLE
Changed RFC links from drafts to proposed standarts

### DIFF
--- a/http_cache.rst
+++ b/http_cache.rst
@@ -361,7 +361,7 @@ Learn more
 .. _`Things Caches Do`: http://2ndscale.com/writings/things-caches-do
 .. _`Cache Tutorial`: http://www.mnot.net/cache_docs/
 .. _`Varnish`: https://www.varnish-cache.org/
-.. _`Squid in reverse proxy mode`: http://wiki.squid-cache.org/SquidFaq/ReverseProxy7
+.. _`Squid in reverse proxy mode`: http://wiki.squid-cache.org/SquidFaq/ReverseProxy
 .. _`HTTP Bis`: http://tools.ietf.org/wg/httpbis/
 .. _`RFC 7234 - Caching`: https://tools.ietf.org/html/rfc7234
 .. _`RFC 7232 - Conditional Requests`: https://tools.ietf.org/html/rfc7232

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -192,9 +192,8 @@ These four headers are used to help cache your responses via *two* different mod
 
     All of the HTTP headers you'll read about are *not* invented by Symfony! They're
     part of an HTTP specification that's used by sites all over the web. To dig deeper
-    into HTTP Caching, check out the original `RFC 2616`_ document, or these two
-    other pieces: `P4 - Conditional Requests`_ and `P6 -
-    Caching: Browser and intermediary caches`_.
+    into HTTP Caching, check out the original documents `RFC 7234 - Caching`_ and 
+    `RFC 7232 - Conditional Requests`_.
 
     As a web developer, you are strongly urged to read the specification. Its
     clarity and power - even more than fifteen years after its creation - is
@@ -362,10 +361,9 @@ Learn more
 .. _`Things Caches Do`: http://2ndscale.com/writings/things-caches-do
 .. _`Cache Tutorial`: http://www.mnot.net/cache_docs/
 .. _`Varnish`: https://www.varnish-cache.org/
-.. _`Squid in reverse proxy mode`: http://wiki.squid-cache.org/SquidFaq/ReverseProxy
-.. _`RFC 2616`: http://tools.ietf.org/html/rfc2616
+.. _`Squid in reverse proxy mode`: http://wiki.squid-cache.org/SquidFaq/ReverseProxy7
 .. _`HTTP Bis`: http://tools.ietf.org/wg/httpbis/
-.. _`P4 - Conditional Requests`: http://tools.ietf.org/html/draft-ietf-httpbis-p4-conditional
-.. _`P6 - Caching: Browser and intermediary caches`: http://tools.ietf.org/html/draft-ietf-httpbis-p6-cache
+.. _`RFC 7234 - Caching`: https://tools.ietf.org/html/rfc7234
+.. _`RFC 7232 - Conditional Requests`: https://tools.ietf.org/html/rfc7232
 .. _`FOSHttpCacheBundle`: http://foshttpcachebundle.readthedocs.org/
 .. _`HTTP specification`: http://www.w3.org/Protocols/rfc2616/rfc2616.html

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -192,7 +192,7 @@ These four headers are used to help cache your responses via *two* different mod
 
     All of the HTTP headers you'll read about are *not* invented by Symfony! They're
     part of an HTTP specification that's used by sites all over the web. To dig deeper
-    into HTTP Caching, check out the original documents `RFC 7234 - Caching`_ and 
+    into HTTP Caching, check out the documents `RFC 7234 - Caching`_ and 
     `RFC 7232 - Conditional Requests`_.
 
     As a web developer, you are strongly urged to read the specification. Its


### PR DESCRIPTION
First 'HTTP Cache' documentation page had been created in May 2013 when RFC 7232 and 7234 were still drafts.
I think it makes sense now to change links from drafts to proposed standards and remove the reference to old good RFC 2616 which is already obsolete.
