### PR TITLE
Redirect /form to /forms for consistency

### DIFF
--- a/_build/redirection_map
+++ b/_build/redirection_map
@@ -324,3 +324,4 @@
 /components/yaml/index /components/yaml
 /deployment/tools /deployment
 /install/bundles /setup/bundles
+/form /forms


### PR DESCRIPTION
The main guide is called `/forms`, but the sub-guides are in `/form/...`. When restructuring the docs, we decided this was the correct naming, so we shouldn't change this.

However, I think it would be nice to redirect `/form` to `/forms` (I'm used to simply remove the sub-guide slug from the URL to visit the main guide).
