### PR TITLE
Fix incorrect callback validation example

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -59,7 +59,7 @@ Configuration
         # src/AppBundle/Resources/config/validation.yml
         AppBundle\Entity\Author:
             constraints:
-                - Callback: [validate]
+                - Callback: validate
 
     .. code-block:: xml
 


### PR DESCRIPTION
Current example in documentation leads into an exception:

> Uncaught PHP Exception Symfony\Component\Validator\Exception\ConstraintDefinitionException: "["validate"] targeted by Callback constraint is not a valid callable"
