### PR TITLE
Fix Authenticator Class (getCredentials) example

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -164,16 +164,15 @@ This requires you to implement six methods::
     class TokenAuthenticator extends AbstractGuardAuthenticator
     {
         /**
-         * Called on every request. Return whatever credentials you want, which
-         * will be passed to getUser().  Returning null skips all other authentication
-         * steps.  Throwing an AuthenticationException will cause authentication to fail, 
-         * calling onAuthenticationFailure().
+         * Called on every request. Return whatever credentials you want to
+         * be passed to getUser().  Returning null will cause authentication
+         * to be successful, skipping the rest of the authentication process.
          */
         public function getCredentials(Request $request)
         {
             if (!$token = $request->headers->get('X-AUTH-TOKEN')) {
-                // No token?  Cause authentication to fail.
-                throw new AuthenticationException();
+                // No token?
+                $token = null;
             }
 
             // What you return here will be passed to getUser() as $credentials

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -165,17 +165,14 @@ This requires you to implement six methods::
     {
         /**
          * Called on every request. Return whatever credentials you want to
-         * be passed to getUser().  Returning null will cause this authenticator
+         * be passed to getUser(). Returning null will cause this authenticator
          * to be skipped.
          */
         public function getCredentials(Request $request)
         {
             if (!$token = $request->headers->get('X-AUTH-TOKEN')) {
                 // No token?
-                // Throwing an exception will cause authentication
-                //   to fail and prevent other authenticators from
-                //   attempting to authenticate.
-                throw new AuthenticationException('No token provided.');
+                $token = null;
             }
 
             // What you return here will be passed to getUser() as $credentials

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -171,8 +171,11 @@ This requires you to implement six methods::
         public function getCredentials(Request $request)
         {
             if (!$token = $request->headers->get('X-AUTH-TOKEN')) {
-                // No token? 
-                $token = '';
+                // No token?
+                // Throwing an exception will cause authentication
+                //   to fail and prevent other authenticators from
+                //   attempting to authenticate.
+                throw new AuthenticationException('No token provided.');
             }
 
             // What you return here will be passed to getUser() as $credentials

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -165,14 +165,14 @@ This requires you to implement six methods::
     {
         /**
          * Called on every request. Return whatever credentials you want to
-         * be passed to getUser().  Returning null will cause authentication
-         * to be successful, skipping the rest of the authentication process.
+         * be passed to getUser().  Returning null will cause this authenticator
+         * to be skipped.
          */
         public function getCredentials(Request $request)
         {
             if (!$token = $request->headers->get('X-AUTH-TOKEN')) {
-                // No token?
-                $token = null;
+                // No token? 
+                $token = '';
             }
 
             // What you return here will be passed to getUser() as $credentials

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -164,14 +164,16 @@ This requires you to implement six methods::
     class TokenAuthenticator extends AbstractGuardAuthenticator
     {
         /**
-         * Called on every request. Return whatever credentials you want,
-         * or null to stop authentication.
+         * Called on every request. Return whatever credentials you want, which
+         * will be passed to getUser().  Returning null skips all other authentication
+         * steps.  Throwing an AuthenticationException will cause authentication to fail, 
+         * calling onAuthenticationFailure().
          */
         public function getCredentials(Request $request)
         {
             if (!$token = $request->headers->get('X-AUTH-TOKEN')) {
-                // no token? Return null and no other methods will be called
-                return;
+                // No token?  Cause authentication to fail.
+                throw new AuthenticationException();
             }
 
             // What you return here will be passed to getUser() as $credentials


### PR DESCRIPTION
The current wording surrounding the getCredentials is misleading.  Returning null does stop authentication, but it causes authentication to be successful.  The example implies that X-AUTH-TOKEN is required and should be correct.  For this behavior, either an AuthenticationException should be thrown or the credential variables should be initialized as empty and passed on to getUser().
