### PR TITLE
Remove double spaces in some YAML configuration

### DIFF
--- a/console/commands_as_services.rst
+++ b/console/commands_as_services.rst
@@ -30,7 +30,7 @@ with ``console.command``:
             app.command.my_command:
                 class: AppBundle\Command\MyCommand
                 tags:
-                    -  { name: console.command }
+                    - { name: console.command }
 
     .. code-block:: xml
 
@@ -137,7 +137,7 @@ inject the ``command.default_name`` parameter:
                 class: AppBundle\Command\MyCommand
                 arguments: ["%command.default_name%"]
                 tags:
-                    -  { name: console.command }
+                    - { name: console.command }
 
     .. code-block:: xml
 

--- a/security/securing_services.rst
+++ b/security/securing_services.rst
@@ -157,7 +157,7 @@ the :ref:`sidebar <securing-services-annotations-sidebar>` below):
             newsletter_manager:
                 class: AppBundle\Newsletter\NewsletterManager
                 tags:
-                    -  { name: security.secure_service }
+                    - { name: security.secure_service }
 
     .. code-block:: xml
 

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -20,7 +20,7 @@ to be used for a specific purpose. Take the following example:
                 class: AppBundle\Extension\FooExtension
                 public: false
                 tags:
-                    -  { name: twig.extension }
+                    - { name: twig.extension }
 
     .. code-block:: xml
 
@@ -146,12 +146,12 @@ For example, you may add the following transports as services:
                 class: \Swift_SmtpTransport
                 arguments: ['%mailer_host%']
                 tags:
-                    -  { name: app.mail_transport }
+                    - { name: app.mail_transport }
 
             app.sendmail_transport:
                 class: \Swift_SendmailTransport
                 tags:
-                    -  { name: app.mail_transport }
+                    - { name: app.mail_transport }
 
     .. code-block:: xml
 
@@ -290,12 +290,12 @@ To answer this, change the service declaration:
                 class: \Swift_SmtpTransport
                 arguments: ['%mailer_host%']
                 tags:
-                    -  { name: app.mail_transport, alias: foo }
+                    - { name: app.mail_transport, alias: foo }
 
             app.sendmail_transport:
                 class: \Swift_SendmailTransport
                 tags:
-                    -  { name: app.mail_transport, alias: bar }
+                    - { name: app.mail_transport, alias: bar }
 
     .. code-block:: xml
 


### PR DESCRIPTION
That makes things easier when copying and pasting ;)

There will be some conflicts when merging on the master branch. I can rebase and open an other PR on an other branch if needed.
