### PR TITLE
Update performance.rst - "Caching the Autoloader with APC" section

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -71,21 +71,21 @@ Caching the Autoloader with APC
 Another solution is to cache the location of each class after it's located
 the first time. Symfony comes with a class - :class:`Symfony\\Component\\ClassLoader\\ApcClassLoader` -
 that does exactly this. To use it, just adapt your front controller file.
-If you're using the Standard Distribution, this code should already be available
-as comments in this file::
+If you're using the Standard Distribution, make the following changes::
 
     // app.php
     // ...
+    
+    use Symfony\Component\ClassLoader\ApcClassLoader;
 
-    $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
+    $loader = require __DIR__.'/../app/autoload.php';
+    include_once __DIR__.'/../app/bootstrap.php.cache';
 
     // Use APC for autoloading to improve performance
     // Change 'sf2' by the prefix you want in order
     // to prevent key conflict with another application
-    /*
     $loader = new ApcClassLoader('sf2', $loader);
     $loader->register(true);
-    */
 
     // ...
 


### PR DESCRIPTION
The example provided under "Caching the Autoloader with APC" is not in sync with the content of the 'app.php' file in Symfony 2.8:
- the comment hint was removed in https://github.com/symfony/symfony-standard/pull/964
- the autoloader was extracted from bootstrap: https://github.com/symfony/symfony-standard/commit/747a384401edf803e985c52089c882edaebe467a

Even on PHP 5.6 with built-in OPcache, I still see a performance boost from enabling the ApcClassLoader.
