### PR TITLE
Accept only array in TagAwareAdapter::invalidateTags()

### DIFF
--- a/components/cache/cache_invalidation.rst
+++ b/components/cache/cache_invalidation.rst
@@ -40,7 +40,7 @@ If ``$cache`` implements :class:`Symfony\\Component\\Cache\\TagAwareAdapterInter
 you can invalidate the cached items by calling
 :method:`Symfony\\Component\\Cache\\TagAwareAdapterInterface::invalidateTags`::
 
-    // or invalidate all items related to `tag_1` or `tag_3`
+    // invalidate all items related to `tag_1` or `tag_3`
     $cache->invalidateTags(array('tag_1', 'tag_3'));
 
     // if you know the cache key, you can of course delete directly

--- a/components/cache/cache_invalidation.rst
+++ b/components/cache/cache_invalidation.rst
@@ -40,9 +40,6 @@ If ``$cache`` implements :class:`Symfony\\Component\\Cache\\TagAwareAdapterInter
 you can invalidate the cached items by calling
 :method:`Symfony\\Component\\Cache\\TagAwareAdapterInterface::invalidateTags`::
 
-    // invalidate all items related to `tag_2`
-    $cache->invalidateTags('tag_2');
-
     // or invalidate all items related to `tag_1` or `tag_3`
     $cache->invalidateTags(array('tag_1', 'tag_3'));
 


### PR DESCRIPTION
Reflect changes introduced in https://github.com/symfony/symfony/pull/20172
