### PR TITLE
Fixed a broken link to FastCgiExternalServer directive documentation

### DIFF
--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -306,7 +306,7 @@ The **minimum configuration** to get your application running under Nginx is:
             # Remove the internal directive to allow URIs like this
             internal;
         }
-        
+
         # return 404 for all other php files not matching the front controller
         # this prevents access to other php files you don't want to be accessible.
         location ~ \.php$ {
@@ -339,5 +339,5 @@ The **minimum configuration** to get your application running under Nginx is:
 For advanced Nginx configuration options, read the official `Nginx documentation`_.
 
 .. _`Apache documentation`: http://httpd.apache.org/docs/
-.. _`FastCgiExternalServer`: http://www.fastcgi.com/mod_fastcgi/docs/mod_fastcgi.html#FastCgiExternalServer
+.. _`FastCgiExternalServer`: http://docs.oracle.com/cd/B31017_01/web.1013/q20204/mod_fastcgi.html#FastCgiExternalServer
 .. _`Nginx documentation`: http://wiki.nginx.org/Symfony


### PR DESCRIPTION
This fixes #7080.

---

The previous official website (`fastcgi.com`) is down and I can't find this doc on the official Apache website. This is the only link that I found.
