### PR TITLE
Remove suggestion to change the `.class` parameters

### DIFF
--- a/bundles/override.rst
+++ b/bundles/override.rst
@@ -40,7 +40,7 @@ Services & Configuration
 If you want to modify service definitions of another bundle, you can use a compiler
 pass to change the class of the service or to modify method calls. In the following
 example, the implementing class for the ``original-service-id`` is changed to 
-``Acme\DemoBundle\YourService`.
+``Acme\DemoBundle\YourService``.
 
     // src/Acme/DemoBundle/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
     namespace Acme\DemoBundle\DependencyInjection\Compiler;

--- a/bundles/override.rst
+++ b/bundles/override.rst
@@ -40,7 +40,7 @@ Services & Configuration
 If you want to modify service definitions of another bundle, you can use a compiler
 pass to change the class of the service or to modify method calls. In the following
 example, the implementing class for the ``original-service-id`` is changed to 
-``Acme\DemoBundle\YourService``.
+``Acme\DemoBundle\YourService``::
 
     // src/Acme/DemoBundle/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
     namespace Acme\DemoBundle\DependencyInjection\Compiler;

--- a/bundles/override.rst
+++ b/bundles/override.rst
@@ -37,39 +37,10 @@ If the controller is a service, see the next section on how to override it.
 Services & Configuration
 ------------------------
 
-In order to override/extend a service, there are two options. First, you can
-set the parameter holding the service's class name to your own class by setting
-it in ``app/config/config.yml``. This of course is only possible if the class name is
-defined as a parameter in the service config of the bundle containing the
-service. For example, to override the class used for Symfony's ``translator``
-service, you would override the ``translator.class`` parameter. Knowing exactly
-which parameter to override may take some research. For the translator, the
-parameter is defined and used in the ``Resources/config/translation.xml`` file
-in the core FrameworkBundle:
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # app/config/config.yml
-        parameters:
-            translator.class: Acme\HelloBundle\Translation\Translator
-
-    .. code-block:: xml
-
-        <!-- app/config/config.xml -->
-        <parameters>
-            <parameter key="translator.class">Acme\HelloBundle\Translation\Translator</parameter>
-        </parameters>
-
-    .. code-block:: php
-
-        // app/config/config.php
-        $container->setParameter('translator.class', 'Acme\HelloBundle\Translation\Translator');
-
-Secondly, if the class is not available as a parameter, you want to make sure the
-class is always overridden when your bundle is used or if you need to modify
-something beyond just the class name, you should use a compiler pass::
+If you want to modify service definitions of another bundle, you can use a compiler
+pass to change the class of the service or to modify method calls. In the following
+example, the implementing class for the ``original-service-id`` is changed to 
+``Acme\DemoBundle\YourService`.
 
     // src/Acme/DemoBundle/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
     namespace Acme\DemoBundle\DependencyInjection\Compiler;
@@ -86,12 +57,7 @@ something beyond just the class name, you should use a compiler pass::
         }
     }
 
-In this example you fetch the service definition of the original service, and set
-its class name to your own class.
-
-See :doc:`/service_container/compiler_passes` for information on how to use
-compiler passes. If you want to do something beyond just overriding the class,
-like adding a method call, you can only use the compiler pass method.
+For more information on compiler passes, see :doc:`/service_container/compiler_passes`.
 
 Entities & Entity Mapping
 -------------------------


### PR DESCRIPTION
To my knowledge, this practice has been discouraged and the corresponding configuration hooks have been dropped in Symfony 3.0.
