### PR TITLE
Also mention "hasXXX" methods as validation targets

### DIFF
--- a/components/validator/metadata.rst
+++ b/components/validator/metadata.rst
@@ -36,8 +36,8 @@ Getters
 -------
 
 Constraints can also be applied to the value returned by any public *getter*
-method, which are the methods whose names start with ``get`` or ``is``. This
-feature allows to validate your objects dynamically.
+method, which are the methods whose names start with ``get``, ``has`` or ``is``.
+This feature allows to validate your objects dynamically.
 
 Suppose that, for security reasons, you want to validate that a password field
 doesn't match the first name of the user. First, create a public method called


### PR DESCRIPTION
At least in http://symfony.com/doc/current/validation.html, "hasXXX" methods are mentioned in addition to "getXXX" and "isXXX".
