### PR TITLE
Clarify Process::wait() callback behaviour

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -130,12 +130,12 @@ are done doing other stuff::
 
     $process = new Process('ls -lsa');
     $process->start();
-    
+
     // ... do other things
     
     $process->wait();
     
-    // do things after the process has finished
+    // ... do things after the process has finished
 
 .. note::
 

--- a/components/process.rst
+++ b/components/process.rst
@@ -130,9 +130,26 @@ are done doing other stuff::
 
     $process = new Process('ls -lsa');
     $process->start();
-
+    
     // ... do other things
+    
+    $process->wait();
+    
+    // do things after the process has finished
 
+.. note::
+
+    The :method:`Symfony\\Component\\Process\\Process::wait` method is blocking,
+    which means that your code will halt at this line until the external
+    process is completed.
+
+:method:`Symfony\\Component\\Process\\Process::wait` takes one optional argument:
+a callback that is called repeatedly whilst the process is still running, passing
+in the output and its type::
+
+    $process = new Process('ls -lsa');
+    $process->start();
+    
     $process->wait(function ($type, $buffer) {
         if (Process::ERR === $type) {
             echo 'ERR > '.$buffer;
@@ -140,12 +157,6 @@ are done doing other stuff::
             echo 'OUT > '.$buffer;
         }
     });
-
-.. note::
-
-    The :method:`Symfony\\Component\\Process\\Process::wait` method is blocking,
-    which means that your code will halt at this line until the external
-    process is completed.
 
 Streaming to the Standard Input of a Process
 --------------------------------------------


### PR DESCRIPTION
There was no clear description of when the Process::wait() callback was triggered and it seemed like it would be called once the process was complete which is incorrect.

I lost several hours after misunderstanding how this works and then trying to figure out why my 'after process' code was being triggered before the process had finished. Hopefully this change makes it clearer.
