### PR TITLE
Minor text fix - wrong submit button label (Forms)

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -96,7 +96,7 @@ from inside a controller::
             $form = $this->createFormBuilder($task)
                 ->add('task', TextType::class)
                 ->add('dueDate', DateType::class)
-                ->add('save', SubmitType::class, array('label' => 'Create Task'))
+                ->add('save', SubmitType::class, array('label' => 'Create Post'))
                 ->getForm();
 
             return $this->render('default/new.html.twig', array(


### PR DESCRIPTION
The screenshot of the rendered view below [(Form)](http://symfony.com/doc/current/_images/simple-form.png) shows the submit button with "Create Post". 

