### PR TITLE
Better explain the most common problems when testing emails

### DIFF
--- a/email/testing.rst
+++ b/email/testing.rst
@@ -66,8 +66,8 @@ to get information about the messages sent on the previous request::
 Troubleshooting
 ---------------
 
-Problem: The mail collector returns `null`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Problem: The collector object is `null`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The email collector is only available when the profiler is enabled and collects
 information, as explained in :doc:`/testing/profiling`.

--- a/email/testing.rst
+++ b/email/testing.rst
@@ -66,8 +66,14 @@ to get information about the messages sent on the previous request::
 Troubleshooting
 ---------------
 
+Problem: The mail collector returns `null`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 The email collector is only available when the profiler is enabled and collects
 information, as explained in :doc:`/testing/profiling`.
+
+Problem: The collector doesn't contain the email
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If a redirection is performed after sending the email (for example when you send
 an email after a form is processed and before redirecting to another page), make

--- a/email/testing.rst
+++ b/email/testing.rst
@@ -66,8 +66,8 @@ to get information about the messages sent on the previous request::
 Troubleshooting
 ---------------
 
-Problem: The collector object is `null`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Problem: The collector object is ``null``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The email collector is only available when the profiler is enabled and collects
 information, as explained in :doc:`/testing/profiling`.

--- a/email/testing.rst
+++ b/email/testing.rst
@@ -71,7 +71,7 @@ information, as explained in :doc:`/testing/profiling`.
 
 If the action that sends the email redirects to another page (for example when
 you send an email after a form is processed and before redirecting to another
-page) make sure that the test client doesn't follow the redirects, as explained
+page), make sure that the test client doesn't follow the redirects, as explained
 in :doc:`/testing`. Otherwise, the collector will lose the original email when
 redirecting to the new page.
 

--- a/email/testing.rst
+++ b/email/testing.rst
@@ -26,10 +26,6 @@ Start with an easy controller action that sends an email::
         return $this->render(...);
     }
 
-.. note::
-
-    Don't forget to enable the profiler as explained in :doc:`/testing/profiling`.
-
 In your functional test, use the ``swiftmailer`` collector on the profiler
 to get information about the messages sent on the previous request::
 
@@ -66,5 +62,17 @@ to get information about the messages sent on the previous request::
             );
         }
     }
+
+Troubleshooting
+---------------
+
+The email collector is only available when the profiler is enabled and collects
+information, as explained in :doc:`/testing/profiling`.
+
+If the action that sends the email redirects to another page (for example when
+you send an email after a form is processed and before redirecting to another
+page) make sure that the test client doesn't follow the redirects, as explained
+in :doc:`/testing`. Otherwise, the collector will lose the original email when
+redirecting to the new page.
 
 .. _`Swift Mailer`: http://swiftmailer.org/

--- a/email/testing.rst
+++ b/email/testing.rst
@@ -69,10 +69,10 @@ Troubleshooting
 The email collector is only available when the profiler is enabled and collects
 information, as explained in :doc:`/testing/profiling`.
 
-If the action that sends the email redirects to another page (for example when
-you send an email after a form is processed and before redirecting to another
-page), make sure that the test client doesn't follow the redirects, as explained
-in :doc:`/testing`. Otherwise, the collector will lose the original email when
-redirecting to the new page.
+If a redirection is performed after sending the email (for example when you send
+an email after a form is processed and before redirecting to another page), make
+sure that the test client doesn't follow the redirects, as explained in
+:doc:`/testing`. Otherwise, the collector will contain the information of the
+redirected page and the email won't be accessible.
 
 .. _`Swift Mailer`: http://swiftmailer.org/


### PR DESCRIPTION
Testing emails is simple but in the past I've suffered lots of problems related to this. In fact, a few minutes ago I fixed a long standing wrong test thanks to this comment about page redirections and collectors: https://github.com/symfony/symfony/issues/20282#event-848771951

I propose to create a new mini section to better explain the problems that you may face when testing emails.