### PR TITLE
Fixed a typo in "define commands as service"

### DIFF
--- a/console/commands_as_services.rst
+++ b/console/commands_as_services.rst
@@ -11,7 +11,7 @@ Symfony will even inject the container.
 While making life easier, this has some limitations:
 
 * Your command must live in the ``Command`` directory;
-* There's no way to conditionally register your service based on the environment
+* There's no way to conditionally register your command based on the environment
   or availability of some dependencies;
 * You can't access the container in the ``configure()`` method (because
   ``setContainer`` hasn't been called yet);


### PR DESCRIPTION
In the introduction of this chapter, we are explaining the restrictions of the "normal" way to register commands, before showing that defining them as services can solve these problems, so at this point we don't talk about a service but a basic command.