### PR TITLE
Update formats.rst

### DIFF
--- a/templating/formats.rst
+++ b/templating/formats.rst
@@ -21,15 +21,21 @@ isn't actually rendered differently based on its format.
 In many cases, you may want to allow a single controller to render multiple
 different formats based on the "request format". For that reason, a common
 pattern is to do the following::
-    /**
-     * @Route("/{_format}", name="article_show", defaults={"_format": "html"}, requirements={"_format": "html|pdf"}
-     */
-    public function indexAction(Request $request)
-    {
-        $format = $request->getRequestFormat();
 
-        return $this->render('article/index.'.$format.'.twig');
-    }
+.. configuration-block::
+
+  .. code-block:: php-annotations
+  
+      /**
+       * @Route("/{_format}", name="article_show", defaults={"_format": "html"}, requirements={"_format": "html|pdf"}
+       */
+      public function indexAction(Request $request)
+      {
+          $format = $request->getRequestFormat();
+
+          return $this->render('article/index.'.$format.'.twig');
+      }
+    
 
 The ``getRequestFormat`` on the ``Request`` object defaults to ``html``,
 but can return any other format based on the format requested by the user.
@@ -41,7 +47,7 @@ be configured so that ``/contact`` sets the request format to ``html`` while
 To create links that include the format parameter, include a ``_format``
 key in the parameter hash:
 
-.. configuration-block::
+.. configuration-block::  
 
     .. code-block:: html+twig
 

--- a/templating/formats.rst
+++ b/templating/formats.rst
@@ -27,7 +27,7 @@ pattern is to do the following::
   .. code-block:: php-annotations
   
       /**
-       * @Route("{_format}", name="contact_list", defaults={"_format": "html"}, requirements={"_format": "html|xml|pdf"})
+       * @Route("/{_format}", name="contact_list", defaults={"_format": "html"}, requirements={"_format": "html|xml|pdf"})
        *
        * @param Request $request       
        *

--- a/templating/formats.rst
+++ b/templating/formats.rst
@@ -47,7 +47,7 @@ be configured so that ``/contact`` sets the request format to ``html`` while
 To create links that include the format parameter, include a ``_format``
 key in the parameter hash:
 
-.. configuration-block::  
+.. configuration-block::
 
     .. code-block:: html+twig
 

--- a/templating/formats.rst
+++ b/templating/formats.rst
@@ -9,10 +9,10 @@ most cases you'll use templates to render HTML content, a template can just
 as easily generate JavaScript, CSS, XML or any other format you can dream of.
 
 For example, the same "resource" is often rendered in several formats.
-To render an article index page in XML, simply include the format in the
+To render a contact index page in XML, simply include the format in the
 template name:
 
-* *XML template name*: ``article/index.xml.twig``
+* *XML template name*: ``contact/index.xml.twig``
 * *XML template filename*: ``index.xml.twig``
 
 In reality, this is nothing more than a naming convention and the template
@@ -27,13 +27,17 @@ pattern is to do the following::
   .. code-block:: php-annotations
   
       /**
-       * @Route("/{_format}", name="article_show", defaults={"_format": "html"}, requirements={"_format": "html|pdf"}
+       * @Route("{_format}", name="contact_list", defaults={"_format": "html"}, requirements={"_format": "html|xml|pdf"})
+       *
+       * @param Request $request       
+       *
+       * @return Response
        */
       public function indexAction(Request $request)
       {
           $format = $request->getRequestFormat();
 
-          return $this->render('article/index.'.$format.'.twig');
+          return $this->render('contact/index.'.$format.'.twig');
       }
     
 
@@ -41,7 +45,7 @@ The ``getRequestFormat`` on the ``Request`` object defaults to ``html``,
 but can return any other format based on the format requested by the user.
 The request format is most often managed by the routing, where a route can
 be configured so that ``/contact`` sets the request format to ``html`` while
-``/contact.xml`` sets the format to ``xml``. For more information, see the
+``/contact/xml`` sets the format to ``xml``. For more information, see the
 :ref:`Advanced Example in the Routing chapter <advanced-routing-example>`.
 
 To create links that include the format parameter, include a ``_format``
@@ -51,7 +55,7 @@ key in the parameter hash:
 
     .. code-block:: html+twig
 
-        <a href="{{ path('article_show', {'id': 123, '_format': 'pdf'}) }}">
+        <a href="{{ path('contact_list', {'_format': 'pdf'}) }}">
             PDF Version
         </a>
 
@@ -59,9 +63,6 @@ key in the parameter hash:
 
         <!-- The path() method was introduced in Symfony 2.8. Prior to 2.8, you
              had to use generate(). -->
-        <a href="<?php echo $view['router']->path('article_show', array(
-            'id' => 123,
-            '_format' => 'pdf',
-        )) ?>">
+        <a href="<?php echo $view['router']->path('contact_list', ['_format' => 'pdf']) ?>">
             PDF Version
         </a>

--- a/templating/formats.rst
+++ b/templating/formats.rst
@@ -21,7 +21,9 @@ isn't actually rendered differently based on its format.
 In many cases, you may want to allow a single controller to render multiple
 different formats based on the "request format". For that reason, a common
 pattern is to do the following::
-
+    /**
+     * @Route("/{_format}", name="article_show", defaults={"_format": "html"}, requirements={"_format": "html|pdf"}
+     */
     public function indexAction(Request $request)
     {
         $format = $request->getRequestFormat();


### PR DESCRIPTION
In this case the $request->getRequestFormat() will give back "html" as default value. Possible solution is set _format as parameter in the route to overwrite the format. In my example without _format parameter it will render the article/index.html.twig and with pdf _format it will render the article/index.pdf.twig.