### PR TITLE
[Validator] Fixed incorrect xml constraint example

### DIFF
--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -72,7 +72,7 @@ This will check if ``firstName`` is of type ``string`` and that ``age`` is an
             <class name="AppBundle\Entity\Author">
                 <property name="firstName">
                     <constraint name="Type">
-                        <type>string</type>
+                        <option name="type">string</option>
                     </constraint>
                 </property>
                 <property name="age">


### PR DESCRIPTION
I've fixed an incorrect xml example for the type constraint. See image for validation error in phpstorm

![example_bug](https://cloud.githubusercontent.com/assets/1374857/20151627/1b845fc0-a6bb-11e6-94d6-589cf117b8d1.png)
