### PR TITLE
Clarify the mappings that require no method prefix.

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -639,9 +639,9 @@ Now, create the ``isPasswordLegal()`` method and include the logic you need::
 .. note::
 
     The keen-eyed among you will have noticed that the prefix of the getter
-    ("get", "is" or "has") is omitted in the mappings for YAML, XML and PHP.
-    This allows you to move the constraint to a property with the same name
-    later (or vice versa) without changing your validation logic.
+    ("get", "is" or "has") is omitted in the mappings for the YAML, XML and PHP
+    formats. This allows you to move the constraint to a property with the same
+    name later (or vice versa) without changing your validation logic.
 
 .. _validation-class-target:
 

--- a/validation.rst
+++ b/validation.rst
@@ -639,9 +639,9 @@ Now, create the ``isPasswordLegal()`` method and include the logic you need::
 .. note::
 
     The keen-eyed among you will have noticed that the prefix of the getter
-    ("get", "is" or "has") is omitted in the mapping. This allows you to move
-    the constraint to a property with the same name later (or vice versa)
-    without changing your validation logic.
+    ("get", "is" or "has") is omitted in the mappings for YAML, XML and PHP.
+    This allows you to move the constraint to a property with the same name
+    later (or vice versa) without changing your validation logic.
 
 .. _validation-class-target:
 


### PR DESCRIPTION
On the Validation page, there is a section about "getter" constraints. In the note it wasn't clear about where the prefix should be dropped, given that the example annotation constraints doesn't include any method specifics. This PR clarifies that.