### PR TITLE
Add a warning about routes parameters names limitations

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -468,7 +468,7 @@ a slash. URLs matching this route might look like:
 
 .. caution::
 
-    A route parameter name cannot start with a digit and cannot be longer than 32 characters.
+    A route placeholder name cannot start with a digit and cannot be longer than 32 characters.
 
 Special Routing Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/routing.rst
+++ b/routing.rst
@@ -466,6 +466,10 @@ a slash. URLs matching this route might look like:
     Symfony provides you with a way to do this by leveraging service container
     parameters. Read more about this in ":doc:`/routing/service_container_parameters`".
 
+.. caution::
+
+    A route parameter name cannot start with a digit and cannot be longer than 32 characters.
+
 Special Routing Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
@wouterj @xabbuh 

I'm sorry guys I had to do a new branch and a new PR because I failed in the old one. I shouldn't have used the fast GitHub edit method.

I fixed the indentation to 4 spaces.

Also I thought this kind of information fitted more in the "advanced" area along with the special parameters than in the basic examples.

Follow up to #7133 