### PR TITLE
Removed superfluous use statement in documentation

### DIFF
--- a/console/style.rst
+++ b/console/style.rst
@@ -357,7 +357,6 @@ of your commands to change their appearance::
     use AppBundle\Console\CustomStyle;
     use Symfony\Component\Console\Input\InputInterface;
     use Symfony\Component\Console\Output\OutputInterface;
-    use Symfony\Component\Console\Style\SymfonyStyle;
 
     class GreetCommand extends ContainerAwareCommand
     {


### PR DESCRIPTION
It would appear that SymfonyStyle is no longer being used. It shouldn't remain as being used.