### PR TITLE
Changed extends double colon to single colon

### DIFF
--- a/templating/namespaced_paths.rst
+++ b/templating/namespaced_paths.rst
@@ -14,7 +14,7 @@ Take the following paths as an example:
 
 .. code-block:: twig
 
-    {% extends "AppBundle::layout.html.twig" %}
+    {% extends "AppBundle:layout.html.twig" %}
     {{ include('AppBundle:Foo:bar.html.twig') }}
 
 With namespaced paths, the following works as well:


### PR DESCRIPTION
When you use extends it will be a single colon instead of a double colon. If you generate a bundle you even need to add the Default folder like so:
```
{% extends "AppBundle:Default:layout.html.twig" %}
```