### PR TITLE
[Process] Add explanation on how to make the Process survive a response

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -135,6 +135,14 @@ are done doing other stuff::
     advantage of the ``kernel.terminate`` event, and run your command **synchronuously**
     inside this event. Be aware that ``kernel.terminate`` is called only if you run ``PHP-FPM``.
 
+.. caution::
+
+    Beware also that if you do that, the said php process won't available to serve
+    any new request until the subprocess is finished, which means you can block your
+    FPM pool quickly if you're not careful enough.
+    That's why it generally way better to not do any fancy thing even after the request is sent
+    but prefer using a job queue.
+
 :method:`Symfony\\Component\\Process\\Process::wait` takes one optional argument:
 a callback that is called repeatedly whilst the process is still running, passing
 in the output and its type::

--- a/components/process.rst
+++ b/components/process.rst
@@ -125,14 +125,15 @@ are done doing other stuff::
     process is completed.
 
 .. note::
-    If a `Response` is sent **before** what `Process` is running had a chance to complete,
+
+    If a ``Response`` is sent **before** what ``Process`` is running had a chance to complete,
     the server process will be killed (depending on your OS). It means that your task
-    will be stopped right away.
-    Running an asynchronous process is not the same than running a processing surviving yourselves.
+    will be stopped right away. Running an asynchronous process is not the same than running
+    a processing surviving yourselves.
 
     If you want your process to survive the request/response cycle, you could take
-    advantage of the `kernel.terminate` event, and run your command **synchronuously**
-    inside this event. Be aware that `kernel.terminate` is called only if you run `PHP-FPM`.
+    advantage of the ``kernel.terminate`` event, and run your command **synchronuously**
+    inside this event. Be aware that ``kernel.terminate`` is called only if you run ``PHP-FPM``.
 
 :method:`Symfony\\Component\\Process\\Process::wait` takes one optional argument:
 a callback that is called repeatedly whilst the process is still running, passing

--- a/components/process.rst
+++ b/components/process.rst
@@ -124,6 +124,16 @@ are done doing other stuff::
     which means that your code will halt at this line until the external
     process is completed.
 
+.. note::
+    If a `Response` is sent **before** what `Process` is running had a chance to complete,
+    the server process will be killed (depending on your OS). It means that your task
+    will be stopped right away.
+    Running an asynchronous process is not the same than running a processing surviving yourselves.
+
+    If you want your process to survive the request/response cycle, you could take
+    advantage of the `kernel.terminate` event, and run your command **synchronuously**
+    inside this event. Be aware that `kernel.terminate` is called only if you run `PHP-FPM`.
+
 :method:`Symfony\\Component\\Process\\Process::wait` takes one optional argument:
 a callback that is called repeatedly whilst the process is still running, passing
 in the output and its type::


### PR DESCRIPTION
Fixes #7151

It clarifies the situation for users that could be tempted to use the asynchronous `Process` feature to achieve long running task after the Response is sent which won't work.

It goes from no code execution (if you send a Response really fast) to partial code execution.