### PR TITLE
Added app.token to the list of global variables

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -715,11 +715,13 @@ needed objects and values. It is an instance of
 
 The available attributes are:
 
-* ``app.user``
-* ``app.request``
-* ``app.session``
-* ``app.environment``
-* ``app.debug``
+* ``app.user`` (a PHP object representing the current user)
+* ``app.token`` (a :class:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\TokenInterface`
+  object representing the security token)
+* ``app.request`` (a :class:``Symfony\\Component\\HttpFoundation\\Request`` object)
+* ``app.session`` (a :class:``Symfony\\Component\\HttpFoundation\\Session\\Session`` object)
+* ``app.environment`` (a string with the name of the execution environment)
+* ``app.debug`` (a boolean telling whether the debug mode is enabled in the app)
 
 Symfony Standard Edition Extensions
 -----------------------------------


### PR DESCRIPTION
This fixes #7167.

---

Two questions:

1) do you agree adding a short description to each global variable? `request` and `session`are so obvious ... but others may not be so obvious to the reader.

2) The paragraph above this states that:

```
The ``app`` variable is available everywhere and gives access to many commonly
 needed objects and values. It is an instance of
 :class:`Symfony\\Bundle\\FrameworkBundle\\Templating\\GlobalVariables`.
```

Are we sure about that class? Shouldn't it be `Symfony\Bridge\Twig\AppVariable` instead?

Thanks!