### PR TITLE
[PHPUnitBridge] Fix versionadded notes

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -125,8 +125,8 @@ Disabling the Deprecation Helper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 3.1
-    The ability to disable the deprecation helper was introduced in version
-    3.1.
+    The ability to disable the deprecation helper was introduced in the 3.1 
+    version of this component
 
 Set the ``SYMFONY_DEPRECATIONS_HELPER`` environment variable to ``disabled`` to
 completely disable the deprecation helper. This is useful to make use of the
@@ -240,7 +240,8 @@ DNS-sensitive Tests
 -------------------
 
 .. versionadded:: 3.1
-    The mocks for DNS related functions were introduced in version 3.1.
+    The ability to disable the deprecation helper was introduced in the 3.1 
+    version of this component
 
 Tests that make network connections, for example to check the validity of a DNS
 record, can be slow to execute and unreliable due to the conditions of the
@@ -355,7 +356,8 @@ Modified PHPUnit script
 -----------------------
 
 .. versionadded:: 3.2
-    The modified PHPUnit script script was introduced in Symfony 3.2.
+    The ability to disable the deprecation helper was introduced in the 3.2 
+    version of this component
 
 This bridge provides a modified version of PHPUnit that you can call by using
 its ``bin/simple-phpunit`` command. It has the following features:

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -125,7 +125,7 @@ Disabling the Deprecation Helper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 3.1
-    The ability to disable the deprecation helper was introduced in Symfony
+    The ability to disable the deprecation helper was introduced in version
     3.1.
 
 Set the ``SYMFONY_DEPRECATIONS_HELPER`` environment variable to ``disabled`` to
@@ -240,7 +240,7 @@ DNS-sensitive Tests
 -------------------
 
 .. versionadded:: 3.1
-    The mocks for DNS related functions were introduced in Symfony 3.1.
+    The mocks for DNS related functions were introduced in version 3.1.
 
 Tests that make network connections, for example to check the validity of a DNS
 record, can be slow to execute and unreliable due to the conditions of the

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -126,7 +126,7 @@ Disabling the Deprecation Helper
 
 .. versionadded:: 3.1
     The ability to disable the deprecation helper was introduced in the 3.1 
-    version of this component
+    version of this component.
 
 Set the ``SYMFONY_DEPRECATIONS_HELPER`` environment variable to ``disabled`` to
 completely disable the deprecation helper. This is useful to make use of the
@@ -241,7 +241,7 @@ DNS-sensitive Tests
 
 .. versionadded:: 3.1
     The ability to disable the deprecation helper was introduced in the 3.1 
-    version of this component
+    version of this component.
 
 Tests that make network connections, for example to check the validity of a DNS
 record, can be slow to execute and unreliable due to the conditions of the
@@ -357,7 +357,7 @@ Modified PHPUnit script
 
 .. versionadded:: 3.2
     The ability to disable the deprecation helper was introduced in the 3.2 
-    version of this component
+    version of this component.
 
 This bridge provides a modified version of PHPUnit that you can call by using
 its ``bin/simple-phpunit`` command. It has the following features:


### PR DESCRIPTION
I was reading the docs and noted that those features were marked as present only from Symfony 3.1/2. The reality is that the version that includes that stuff is the bridge's, which is backward compatible!
So, as an example, I can use the bridge v3.2 on my Symfony 2.8 app.

I think it should be helpfull to specify that more clearly.