### PR TITLE
Update 'query_builder' option

### DIFF
--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -191,6 +191,13 @@ The value of this option can either be a ``QueryBuilder`` object, a Closure or
 passed the ``EntityRepository`` of the entity as the only argument and should
 return a ``QueryBuilder``.
 
+.. caution::
+
+    The entity used in the ``FROM`` clause of `query_builder`_ option
+    will always be validated against the class which you have specified with the form's `class`_ option.
+    If you return another entity instead of the one used in your ``FROM`` clause
+    (for instance if you return an entity from a joined table) it will break validation.
+    
 Overridden Options
 ------------------
 


### PR DESCRIPTION
The entity used in 'FROM' clause of 'query_builder' option will always be validated against the class which you have specified in form field option 'class'. If you return another entity instead of the one used in your FROM clause, for instance SELECT an entity from a joined table, it will break validation.

Closes #4331