### PR TITLE
Changing field type in MySQL example

### DIFF
--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -189,7 +189,7 @@ MySQL
 .. code-block:: sql
 
     CREATE TABLE `sessions` (
-        `sess_id` VARBINARY(128) NOT NULL PRIMARY KEY,
+        `sess_id` VARCHAR(128) NOT NULL PRIMARY KEY,
         `sess_data` BLOB NOT NULL,
         `sess_time` INTEGER UNSIGNED NOT NULL,
         `sess_lifetime` MEDIUMINT NOT NULL


### PR DESCRIPTION
It seems inconsistent that the MySQL table as the sess_id as VARBINARY, when the PostgeSQL and Microsoft SQL server use VARCHAR (which makes more sense to me)