### PR TITLE
Replace undefined argument with intended string argument

### DIFF
--- a/service_container/definitions.rst
+++ b/service_container/definitions.rst
@@ -29,7 +29,7 @@ There are some helpful methods for working with the service definitions::
     // get the "app.user_config_manager" definition
     $definition = $container->getDefinition('app.user_config_manager');
     // get the definition with the "app.user_config_manager" ID or alias
-    $definition = $container->findDefinition($serviceId);
+    $definition = $container->findDefinition('app.user_config_manager');
 
     // add a new "app.number_generator" definitions
     $definition = new Definition('AppBundle\NumberGenerator');


### PR DESCRIPTION
Since the comment mentions `app.user_config_manager`, I assume it was meant to be used as an argument here.