### PR TITLE
Fix typo in Workflow docs (form -> from)

### DIFF
--- a/workflow/state-machines.rst
+++ b/workflow/state-machines.rst
@@ -158,31 +158,31 @@ Below is the configuration for the pull request state machine.
                   ),
                   'transitions' => array(
                     'start'=> array(
-                      'form' => 'start',
+                      'from' => 'start',
                       'to' => 'travis',
                     ),
                     'update'=> array(
-                      'form' => array('coding','travis','review'),
+                      'from' => array('coding','travis','review'),
                       'to' => 'travis',
                     ),
                     'wait_for_reivew'=> array(
-                      'form' => 'travis',
+                      'from' => 'travis',
                       'to' => 'review',
                     ),
                     'request_change'=> array(
-                      'form' => 'review',
+                      'from' => 'review',
                       'to' => 'coding',
                     ),
                     'accept'=> array(
-                      'form' => 'review',
+                      'from' => 'review',
                       'to' => 'merged',
                     ),
                     'reject'=> array(
-                      'form' => 'review',
+                      'from' => 'review',
                       'to' => 'closed',
                     ),
                     'reopen'=> array(
-                      'form' => 'start',
+                      'from' => 'start',
                       'to' => 'review',
                     ),
                   ),

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -117,15 +117,15 @@ like this:
                           ),
                           'transitions' => array(
                             'to_review'=> array(
-                              'form' => 'draft',
+                              'from' => 'draft',
                               'to' => 'review',
                             ),
                             'publish'=> array(
-                              'form' => 'review',
+                              'from' => 'review',
                               'to' => 'published',
                             ),
                             'reject'=> array(
-                              'form' => 'review',
+                              'from' => 'review',
                               'to' => 'rejected',
                             ),
                           ),


### PR DESCRIPTION
In the PHP code samples *from* is misspelled as *form*.