### PR TITLE
Fixed the signature of prepend method in the code example

### DIFF
--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -292,7 +292,7 @@ method is called by implementing
     {
         // ...
 
-        public function prepend()
+        public function prepend(ContainerBuilder $container)
         {
             // ...
 


### PR DESCRIPTION
`PrependExtensionInterface::prepend` has one parameter: `$container`. From the current example it is not clear how `$container` appeared in the method body. Anyway, it is better to have here correct code examples.