### PR TITLE
Improved code example of `prepend` method

### DIFF
--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -56,6 +56,7 @@ The following example illustrates how to prepend
 a configuration setting in multiple bundles as well as disable a flag in multiple bundles
 in case a specific other bundle is not registered::
 
+    // src/Acme/HelloBundle/DependencyInjection/AcmeHelloExtension.php
     public function prepend(ContainerBuilder $container)
     {
         // get all bundles
@@ -69,8 +70,10 @@ in case a specific other bundle is not registered::
                     case 'acme_something':
                     case 'acme_other':
                         // set use_acme_goodbye to false in the config of
-                        // acme_something and acme_other note that if the user manually
-                        // configured use_acme_goodbye to true in the app/config/config.yml
+                        // acme_something and acme_other
+                        //
+                        // note that if the user manually configured
+                        // use_acme_goodbye to true in the app/config/config.yml
                         // then the setting would in the end be true and not false
                         $container->prependExtensionConfig($name, $config);
                         break;

--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -73,7 +73,7 @@ in case a specific other bundle is not registered::
                         // acme_something and acme_other
                         //
                         // note that if the user manually configured
-                        // use_acme_goodbye to true in the app/config/config.yml
+                        // use_acme_goodbye to true in app/config/config.yml
                         // then the setting would in the end be true and not false
                         $container->prependExtensionConfig($name, $config);
                         break;


### PR DESCRIPTION
- Split the comment into readable parts. At the moment 2 different sentences combined in one without a comma or a dot. It is difficult to catch a sense of '...acme_something and acme_other note that if the user...' 
- Additionally, added a comment with a file path to put reader in the context of this example