### PR TITLE
[Workflow] Add missing semicolon to workflow usage code block

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -140,7 +140,7 @@ like this:
         // This property is used by the marking store
         public $currentPlace;
         public $title;
-        public $content
+        public $content;
     }
 
 .. note::


### PR DESCRIPTION
Fix second code block example on: http://symfony.com/doc/current/workflow/usage.html
```
class BlogPost
{
    // This property is used by the marking store
    public $currentPlace;
    public $title;
    public $content     // missing ;
}
```