### PR TITLE
Using lower case on "Form"

### DIFF
--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -443,7 +443,7 @@ the base block by using the ``parent()`` Twig function:
 
 .. code-block:: html+twig
 
-    {# app/Resources/views/Form/fields.html.twig #}
+    {# app/Resources/views/form/fields.html.twig #}
     {% extends 'form_div_layout.html.twig' %}
 
     {% block integer_widget %}


### PR DESCRIPTION
To be coherent with other examples on this page