### PR TITLE
[Console] Reword a subheading of console/logging.rst

### DIFF
--- a/console/logging.rst
+++ b/console/logging.rst
@@ -167,11 +167,13 @@ service configuration. Your method receives a
 :class:`Symfony\\Component\\Console\\Event\\ConsoleExceptionEvent` object,
 which has methods to get information about the event and the exception.
 
+.. _logging-non-0-exit-statuses:
+
 Logging Error Exit Statuses
 ---------------------------
 
 The logging capabilities of the console can be further extended by logging
-commands that return error exist statuses, which are any number different than
+commands that return error exit statuses, which are any number different than
 zero. This way you will know if a command had any errors, even if no exceptions
 were thrown.
 

--- a/console/logging.rst
+++ b/console/logging.rst
@@ -167,12 +167,13 @@ service configuration. Your method receives a
 :class:`Symfony\\Component\\Console\\Event\\ConsoleExceptionEvent` object,
 which has methods to get information about the event and the exception.
 
-Logging non-0 Exit Statuses
+Logging Error Exit Statuses
 ---------------------------
 
 The logging capabilities of the console can be further extended by logging
-non-0 exit statuses. This way you will know if a command had any errors, even
-if no exceptions were thrown.
+commands that return error exist statuses, which are any number different than
+zero. This way you will know if a command had any errors, even if no exceptions
+were thrown.
 
 First configure a listener for console terminate events in the service container:
 


### PR DESCRIPTION
Because of the typography we use, the "non-0 exit statuses" heading reads as "nono exit statuses" (instead of "non-zero ..."):

![console-heading](https://cloud.githubusercontent.com/assets/73419/21296011/99817e48-c561-11e6-86fb-429d6546e1c1.png)

I propose a minor reword to avoid this problem.
