### PR TITLE
Fixed a syntax issue in Doctrine article

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -385,7 +385,7 @@ see the :ref:`doctrine-field-types` section.
 .. tip::
 
     After creating your entities you should validate the mappings with the
-    following command::
+    following command:
 
     .. code-block:: terminal
 


### PR DESCRIPTION
This fixes https://github.com/symfony/symfony-docs/commit/27aa549dbdc13d5789eaf9db7d1c17daa9b5193a