### PR TITLE
remove 'placeholder' from empty-data example

### DIFF
--- a/reference/forms/types/options/empty_data.rst.inc
+++ b/reference/forms/types/options/empty_data.rst.inc
@@ -25,7 +25,6 @@ selected, you can do it like this::
             'f' => 'Female'
         ),
         'required'    => false,
-        'placeholder' => 'Choose your gender',
         'empty_data'  => null
     ));
 


### PR DESCRIPTION
This snippet is also included on the [TextType Field] page (http://symfony.com/doc/current/reference/forms/types/text.html) and might trick novice Symfony dev's into using the placeholder for the TextType as well. I think the placeholder can be removed here making the example even more to the point. 

![image](https://cloud.githubusercontent.com/assets/1330668/21541894/67cc3f44-cdba-11e6-9d16-10ffc5316984.png)
