### PR TITLE
[Fix][httpKernel] Wrong links

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -124,9 +124,9 @@ For general information on adding listeners to the events below, see
 
 .. caution::
 
-    As of 3.1 the :class:`Symfony\\Component\\Httpkernel\\HttpKernel` accepts a
+    As of 3.1 the :class:`Symfony\\Component\\HttpKernel` accepts a
     fourth argument, which must be an instance of
-    :class:`Symfony\\Component\\Httpkernel\\Controller\\ArgumentResolverInterface`.
+    :class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverInterface`.
     In 4.0 this argument will become mandatory.
 
 .. seealso::

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -124,7 +124,7 @@ For general information on adding listeners to the events below, see
 
 .. caution::
 
-    As of 3.1 the :class:`Symfony\\Component\\HttpKernel` accepts a
+    As of 3.1 the :class:`Symfony\\Component\\HttpKernel\\HttpKernel` accepts a
     fourth argument, which must be an instance of
     :class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverInterface`.
     In 4.0 this argument will become mandatory.


### PR DESCRIPTION
Hello here,

### Problem
Fixes bad links pointing to the HttpKernel api.
http://symfony.com/doc/current/components/http_kernel.html#the-kernel-request-event

Happy New Year !