### PR TITLE
[Workflow] Improve code block for workflow as state machine

### DIFF
--- a/workflow/state-machines.rst
+++ b/workflow/state-machines.rst
@@ -32,17 +32,21 @@ Below is the configuration for the pull request state machine.
         framework:
             workflows:
                 pull_request:
-                   type: 'state_machine'
-                   supports:
+                    type: 'state_machine'
+                    supports:
                         - AppBundle\Entity\PullRequest
-                   places:
+                    marking_store:
+                        type: 'single_state'
+                        arguments:
+                            - 'currentPlace'
+                    places:
                         - start
                         - coding
                         - travis
                         - review
                         - merged
                         - closed
-                   transitions:
+                    transitions:
                         submit:
                             from: start
                             to: travis


### PR DESCRIPTION
In http://symfony.com/doc/current/workflow/state-machines.html#example-of-a-state-machine configuration example `marking_store` section is missing. This section is required to run workflow. After merge proposed PR configuration example will be fully working version also copy&paste ready.

Fixed also indents for `places`, `transitions` and `type` by adding missing space.