### PR TITLE
[Workflow] Add tip for workflow configuration default values

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -151,9 +151,9 @@ like this:
     
 .. tip::
 
-    Workflow configuration ``type`` and ``arguments`` in ``marking_store`` section 
-    are optional. You can skip one or both when you use default values. Default value
-    for ``type`` is "single_state". Default value for ``arguments`` is "marking".
+    The ``type`` (default value ``single_state``) and ``arguments`` (default value ``marking``)
+    attributes of the ``marking_store`` option are optional. If omitted, their default values
+    will be used.
 
 With this workflow named ``blog_publishing``, you can get help to decide
 what actions that are allowed on a blog post. ::

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -151,9 +151,9 @@ like this:
     
 .. tip::
 
-    You can skip ``arguments`` in configuration if your properties, used 
-    by the marking store, have argument "marking". As this is default value. 
-    For ``type`` default one is "single_state".
+    Workflow configuration ``type`` and ``arguments`` in ``marking_store`` section 
+    are optional. You can skip one or both when you use default values. Default value
+    for ``type`` is "single_state". Default value for ``arguments`` is "marking".
 
 With this workflow named ``blog_publishing``, you can get help to decide
 what actions that are allowed on a blog post. ::

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -148,6 +148,12 @@ like this:
     The marking store type could be "multiple_state" or "single_state".
     A single state marking store does not support a model being on multiple places
     at the same time.
+    
+.. tip::
+
+    You can skip ``arguments`` in configuration if your properties, used 
+    by the marking store, have argument "marking". As this is default value. 
+    For ``type`` default one is "single_state".
 
 With this workflow named ``blog_publishing``, you can get help to decide
 what actions that are allowed on a blog post. ::


### PR DESCRIPTION
Added tip for http://symfony.com/doc/current/workflow/usage.html configuration.

Tested and based on great examples provided by @lyrixx in: https://github.com/lyrixx/SFLive-Paris2016-Workflow/blob/master/app/config/workflow.yml#L3 and
https://github.com/lyrixx/SFLive-Paris2016-Workflow/blob/master/src/AppBundle/Entity/Article.php#L24