### PR TITLE
[Workflow] Improve configuration example text indents

### DIFF
--- a/workflow/state-machines.rst
+++ b/workflow/state-machines.rst
@@ -32,17 +32,17 @@ Below is the configuration for the pull request state machine.
         framework:
             workflows:
                 pull_request:
-                   type: 'state_machine'
-                   supports:
+                    type: 'state_machine'
+                    supports:
                         - AppBundle\Entity\PullRequest
-                   places:
+                    places:
                         - start
                         - coding
                         - travis
                         - review
                         - merged
                         - closed
-                   transitions:
+                    transitions:
                         submit:
                             from: start
                             to: travis


### PR DESCRIPTION
To be _"pixel perfect"_ indents should be 4 spaces.