### PR TITLE
[Security] Warn for implementing `eraseCredentials`

### DIFF
--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -169,6 +169,12 @@ forces the class to have the five following methods:
 
 To learn more about each of these, see :class:`Symfony\\Component\\Security\\Core\\User\\UserInterface`.
 
+.. caution::
+
+    Do not actually implement ``eraseCredentials`` when you load your users directly
+    from Doctrine, as changes will be flushed when a user tries to login. As example,
+    setting ``password`` to ``null`` will be flushed with every login attempt.
+
 What do the serialize and unserialize Methods do?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -171,9 +171,10 @@ To learn more about each of these, see :class:`Symfony\\Component\\Security\\Cor
 
 .. caution::
 
-    Do not actually implement ``eraseCredentials`` when you load your users directly
-    from Doctrine, as changes will be flushed when a user tries to login. As example,
-    setting ``password`` to ``null`` will be flushed with every login attempt.
+    Do not actually implement ``eraseCredentials()`` when loading the users
+    directly from Doctrine, as changes will be flushed when a user tries to
+    login. For example, setting ``password`` to ``null`` will be flushed with
+    every login attempt.
 
 What do the serialize and unserialize Methods do?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -171,10 +171,10 @@ To learn more about each of these, see :class:`Symfony\\Component\\Security\\Cor
 
 .. caution::
 
-    Do not actually implement ``eraseCredentials()`` when loading the users
-    directly from Doctrine, as changes will be flushed when a user tries to
-    login. For example, setting ``password`` to ``null`` will be flushed with
-    every login attempt.
+    The ``eraseCredentials()`` method is only meant to clean up possibly stored 
+    plain text passwords (or similar credentials). Be careful what to erase 
+    if your user class is also mapped to a database as the modified object 
+    will likely be persisted during the request.
 
 What do the serialize and unserialize Methods do?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
... as implementing `eraseCredentials` on a Doctrine entity will be flushed. Setting `password` to `null` will actually be saved at every login attempt.

This might also could be a warning with the `UserInterface` docblock directly (?)