### PR TITLE
[Fix][Console] Missing autoloading by Composer

### DIFF
--- a/components/console/usage.rst
+++ b/components/console/usage.rst
@@ -16,6 +16,8 @@ built-in options as well as a couple of built-in commands for the Console compon
         <?php
         // application.php
 
+        require __DIR__.'/vendor/autoload.php';
+
         use Symfony\Component\Console\Application;
 
         $application = new Application();


### PR DESCRIPTION
Hello,

The good practice is to use the autoloading mechanism provided by composer, except I notice that on this documentation it lacks the essential to make the example work.

- See http://symfony.com/doc/current/components/console/usage.html#using-console-commands-shortcuts-and-built-in-commands

I note that there is the call of the autoload in the other documents, for example:

- http://symfony.com/doc/current/components/console/single_command_tool.html


Regards,