### PR TITLE
Updated the configuration for Symfony >3

### DIFF
--- a/best_practices/web-assets.rst
+++ b/best_practices/web-assets.rst
@@ -74,6 +74,19 @@ matter of wrapping all the assets with a single Twig tag:
         <script src="{{ asset_url }}"></script>
     {% endjavascripts %}
 
+
+
+As far as from Symfony 3, the Assetic is not included by default, you also need to add configuration to config.yml:
+
+.. code-block:: yaml
+assetic:
+    debug: "%kernel.debug%"
+    use_controller: "%kernel.debug%"
+    bundles: []
+    filters:
+        cssrewrite: ~
+
+
 Frontend-Based Applications
 ---------------------------
 


### PR DESCRIPTION
We need to configure the bundle if we work with Symfony 3 and higher. Otherwise, the error "There is no "cssrewrite" filter." we get. So, I added propose to add these changes.