### PR TITLE
Rename "console tasks" to "console commands"

### DIFF
--- a/console/input.rst
+++ b/console/input.rst
@@ -134,7 +134,7 @@ Next, use this in the command to print the message multiple times::
         $output->writeln($text);
     }
 
-Now, when you run the task, you can optionally specify a ``--iterations``
+Now, when you run the command, you can optionally specify a ``--iterations``
 flag:
 
 .. code-block:: terminal

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -473,7 +473,7 @@ in your application. To do this, run:
     your entities) with how it *actually* looks, and executes the SQL statements
     needed to *update* the database schema to where it should be. In other
     words, if you add a new property with mapping metadata to ``Product``
-    and run this task, it will execute the "ALTER TABLE" statement needed
+    and run this command, it will execute the "ALTER TABLE" statement needed
     to add that new column to the existing ``product`` table.
 
     An even better way to take advantage of this functionality is via

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -18,7 +18,7 @@ the class for you.
         --entity="AppBundle:Category" \
         --fields="name:string(255)"
 
-This task generates the ``Category`` entity for you, with an ``id`` field,
+This command generates the ``Category`` entity for you, with an ``id`` field,
 a ``name`` field and the associated getter and setter functions.
 
 Relationship Mapping Metadata

--- a/doctrine/console.rst
+++ b/doctrine/console.rst
@@ -16,13 +16,13 @@ command:
 A list of available commands will print out. You can find out more information
 about any of these commands (or any Symfony command) by running the ``help``
 command. For example, to get details about the ``doctrine:database:create``
-task, run:
+command, run:
 
 .. code-block:: terminal
 
     $ php app/console help doctrine:database:create
 
-Some notable or interesting tasks include:
+Some notable or interesting commands include:
 
 * ``doctrine:ensure-production-settings`` - checks to see if the current
   environment is configured efficiently for production. This should always

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -489,7 +489,7 @@ kernel.cache_warmer
 process
 
 Cache warming occurs whenever you run the ``cache:warmup`` or ``cache:clear``
-task (unless you pass ``--no-warmup`` to ``cache:clear``). It is also run
+commands (unless you pass ``--no-warmup`` to ``cache:clear``). It is also run
 when handling the request, if it wasn't done by one of the commands yet.
 The purpose is to initialize any cache that will be needed by the application
 and prevent the first user from any significant "cache hit" where the cache

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -489,7 +489,7 @@ kernel.cache_warmer
 process
 
 Cache warming occurs whenever you run the ``cache:warmup`` or ``cache:clear``
-commands (unless you pass ``--no-warmup`` to ``cache:clear``). It is also run
+command (unless you pass ``--no-warmup`` to ``cache:clear``). It is also run
 when handling the request, if it wasn't done by one of the commands yet.
 The purpose is to initialize any cache that will be needed by the application
 and prevent the first user from any significant "cache hit" where the cache

--- a/security/acl.rst
+++ b/security/acl.rst
@@ -91,8 +91,8 @@ First, you need to configure the connection the ACL system is supposed to use:
     domain objects. You can use whatever mapper you like for your objects, be it
     Doctrine ORM, MongoDB ODM, Propel, raw SQL, etc. The choice is yours.
 
-After the connection is configured, you have to import the database structure.
-Fortunately, there is a task for this. Simply run the following command:
+After the connection is configured, you have to import the database structure
+running the following command:
 
 .. code-block:: terminal
 

--- a/testing.rst
+++ b/testing.rst
@@ -464,7 +464,7 @@ Injection Container::
     $container = $client->getContainer();
 
 For a list of services available in your application, use the ``debug:container``
-console task.
+command.
 
 .. versionadded:: 2.6
     Prior to Symfony 2.6, this command was called ``container:debug``.


### PR DESCRIPTION
In the past we used "console tasks" to refer to "console commands". There were still some occurrences of "console tasks" in the docs. This PR fixes them.