### PR TITLE
File loaders can now set the type to load explicitly

### DIFF
--- a/components/config/resources.rst
+++ b/components/config/resources.rst
@@ -87,8 +87,16 @@ the resource::
     $loaderResolver = new LoaderResolver(array(new YamlUserLoader($locator)));
     $delegatingLoader = new DelegatingLoader($loaderResolver);
 
-    $delegatingLoader->load(__DIR__.'/users.yml');
-    /*
-    The YamlUserLoader will be used to load this resource,
+    // YamlUserLoader is used to load this resource because it supports
+    // files with the '.yml' extension
     since it supports files with a "yml" extension
-    */
+    $delegatingLoader->load(__DIR__.'/users.yml');
+
+.. tip::
+
+    If your application uses unconventional file extensions (for example, your
+    YAML files have a ``.res`` extension) you can pass the file type as the
+    second optional parameter of the ``load()`` method::
+
+      // ...
+      $delegatingLoader->load(__DIR__.'/users.res', 'yml');

--- a/components/config/resources.rst
+++ b/components/config/resources.rst
@@ -91,12 +91,3 @@ the resource::
     // files with the '.yml' extension
     since it supports files with a "yml" extension
     $delegatingLoader->load(__DIR__.'/users.yml');
-
-.. tip::
-
-    If your application uses unconventional file extensions (for example, your
-    YAML files have a ``.res`` extension) you can pass the file type as the
-    second optional parameter of the ``load()`` method::
-
-      // ...
-      $delegatingLoader->load(__DIR__.'/users.res', 'yml');

--- a/components/config/resources.rst
+++ b/components/config/resources.rst
@@ -89,5 +89,4 @@ the resource::
 
     // YamlUserLoader is used to load this resource because it supports
     // files with the '.yml' extension
-    since it supports files with a "yml" extension
     $delegatingLoader->load(__DIR__.'/users.yml');

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -222,8 +222,8 @@ Loading a YAML config file::
     XML files have a ``.config`` extension) you can pass the file type as the
     second optional parameter of the ``load()`` method::
 
-      // ...
-      $loader->load('services.config', 'xml');
+        // ...
+        $loader->load('services.config', 'xml');
 
 If you *do* want to use PHP to create the services then you can move this
 into a separate config file and load it in a similar way::

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -216,6 +216,15 @@ Loading a YAML config file::
     If you want to load YAML config files then you will also need to install
     :doc:`the Yaml component </components/yaml>`.
 
+.. tip::
+
+    If your application uses unconventional file extensions (for example, your
+    XML files have a ``.config`` extension) you can pass the file type as the
+    second optional parameter of the ``load()`` method::
+
+      // ...
+      $loader->load('services.config', 'xml');
+
 If you *do* want to use PHP to create the services then you can move this
 into a separate config file and load it in a similar way::
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -181,6 +181,48 @@ The ``imports`` key works a lot like the PHP ``include()`` function: the content
 ``parameters.yml``, ``security.yml`` and ``services.yml`` are read and loaded. You
 can also load XML files or PHP files.
 
+.. tip::
+
+    If your application uses unconventional file extensions (for example, your
+    YAML files have a ``.res`` extension) you can set the file type explicitly
+    with the ``type`` option:
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # app/config/config.yml
+            imports:
+                - { resource: parameters.res, type: yml }
+                # ...
+
+        .. code-block:: xml
+
+            <!-- app/config/config.xml -->
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <container xmlns="http://symfony.com/schema/dic/services"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:framework="http://symfony.com/schema/dic/symfony"
+                xmlns:twig="http://symfony.com/schema/dic/twig"
+                xsi:schemaLocation="http://symfony.com/schema/dic/services
+                    http://symfony.com/schema/dic/services/services-1.0.xsd
+                    http://symfony.com/schema/dic/symfony
+                    http://symfony.com/schema/dic/symfony/symfony-1.0.xsd
+                    http://symfony.com/schema/dic/twig
+                    http://symfony.com/schema/dic/twig/twig-1.0.xsd">
+
+                <imports>
+                    <import resource="parameters.res" type="yml" />
+                    <!-- ... -->
+                </imports>
+            </container>
+
+        .. code-block:: php
+
+            // app/config/config.php
+            $this->import('parameters.res', 'yml');
+            // ...
+
 .. _config-parameter-intro:
 
 The parameters Key: Parameters (Variables)


### PR DESCRIPTION
This fixes #7352.
I propose to document this in a subtle manner because this is rarely needed by users.
Ping @ogizanagi because he was the original author of the related PR. Thanks!