### PR TITLE
[File Uploads] Check if the entity contains the files

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -444,13 +444,13 @@ controller.
                 $entity = $args->getEntity();
                 
                 if (!$entity instanceof Product) {
-                  return;
+                    return;
                 }
 
                 if ($entity->getBrochure()) {
-                  $fileName = $entity->getBrochure();
+                    $fileName = $entity->getBrochure();
                   
-                  $entity->setBrochure(new File($this->targetPath.'/'.$fileName));
+                    $entity->setBrochure(new File($this->targetPath.'/'.$fileName));
                 }
             }
         }

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -443,8 +443,7 @@ controller.
             {
                 $entity = $args->getEntity();
                 
-                // Only for tests purpose and proper object validation
-                if (!$entity instanceof ObjectWanted) {
+                if (!$entity instanceof Product) {
                   return;
                 }
 

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -442,10 +442,17 @@ controller.
             public function postLoad(LifecycleEventArgs $args)
             {
                 $entity = $args->getEntity();
+                
+                // Only for tests purpose and proper object validation
+                if (!$entity instanceof ObjectWanted) {
+                  return;
+                }
 
-                $fileName = $entity->getBrochure();
-
-                $entity->setBrochure(new File($this->targetPath.'/'.$fileName));
+                if ($entity->getBrochure()) {
+                  $fileName = $entity->getBrochure();
+                  
+                  $entity->setBrochure(new File($this->targetPath.'/'.$fileName));
+                }
             }
         }
 

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -447,9 +447,7 @@ controller.
                     return;
                 }
 
-                if ($entity->getBrochure()) {
-                    $fileName = $entity->getBrochure();
-                  
+                if ($fileName = $entity->getBrochure()) {
                     $entity->setBrochure(new File($this->targetPath.'/'.$fileName));
                 }
             }


### PR DESCRIPTION
After many tests, it seems that if the entity does not contains the files, the event throw a Exception, by checking the presence of files, the exception isn't thrown and the process can continue, this can be usefull if the entity isn't linked with file or if the file was stored into an array but not needed at this time.

The return isn't needed after the if statement.