### PR TITLE
Use preferred spelling for "cannot"

### DIFF
--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -156,7 +156,7 @@ You can also ask and validate a hidden response::
 
     $validator = function ($value) {
         if ('' === trim($value)) {
-            throw new \Exception('The password can not be empty');
+            throw new \Exception('The password cannot be empty');
         }
 
         return $value;

--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -299,7 +299,7 @@ You can also use a validator with a hidden question::
         $question = new Question('Please enter your password');
         $question->setValidator(function ($value) {
             if (trim($value) == '') {
-                throw new \Exception('The password can not be empty');
+                throw new \Exception('The password cannot be empty');
             }
 
             return $value;

--- a/components/process.rst
+++ b/components/process.rst
@@ -323,7 +323,7 @@ Use :method:`Symfony\\Component\\Process\\Process::disableOutput` and
 
 .. caution::
 
-    You can not enable or disable the output while the process is running.
+    You cannot enable or disable the output while the process is running.
 
     If you disable the output, you cannot access ``getOutput()``,
     ``getIncrementalOutput()``, ``getErrorOutput()`` or ``getIncrementalErrorOutput()``.

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -91,7 +91,7 @@ of your application may just break it by e.g. sending HTTP headers or
 corrupting your view, the bundle configures the ``dump()`` function so that
 variables are dumped in the web debug toolbar.
 
-But if the toolbar can not be displayed because you e.g. called ``die``/``exit``
+But if the toolbar cannot be displayed because you e.g. called ``die``/``exit``
 or a fatal error occurred, then dumps are written on the regular output.
 
 In a Twig template, two constructs are available for dumping a variable.

--- a/controller/soap_web_service.rst
+++ b/controller/soap_web_service.rst
@@ -8,7 +8,7 @@ How to Create a SOAP Web Service in a Symfony Controller
 
 Setting up a controller to act as a SOAP server is simple with a couple
 tools. You must, of course, have the `PHP SOAP`_ extension installed.
-As the PHP SOAP extension can not currently generate a WSDL, you must either
+As the PHP SOAP extension cannot currently generate a WSDL, you must either
 create one from scratch or use a 3rd party generator.
 
 .. note::

--- a/doctrine/event_listeners_subscribers.rst
+++ b/doctrine/event_listeners_subscribers.rst
@@ -207,7 +207,7 @@ interface and have an event method for each event it subscribes to::
 
 .. tip::
 
-    Doctrine event subscribers can not return a flexible array of methods to
+    Doctrine event subscribers cannot return a flexible array of methods to
     call for the events like the :ref:`Symfony event subscriber <event_dispatcher-using-event-subscribers>`
     can. Doctrine event subscribers must return a simple array of the event
     names they subscribe to. Doctrine will then expect methods on the subscriber

--- a/reference/forms/types/button.rst
+++ b/reference/forms/types/button.rst
@@ -29,7 +29,7 @@ The following options are defined in the
 :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\BaseType` class.
 The ``BaseType`` class is the parent class for both the ``button`` type
 and the :doc:`form type </reference/forms/types/form>`, but it is not part
-of the form type tree (i.e. it can not be used as a form type on its own).
+of the form type tree (i.e. it cannot be used as a form type on its own).
 
 .. include:: /reference/forms/types/options/button_attr.rst.inc
 

--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -150,7 +150,7 @@ The following options are defined in the
 :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\BaseType` class.
 The ``BaseType`` class is the parent class for both the ``form`` type and
 the :doc:`button type </reference/forms/types/button>`, but it is not part
-of the form type tree (i.e. it can not be used as a form type on its own).
+of the form type tree (i.e. it cannot be used as a form type on its own).
 
 .. include:: /reference/forms/types/options/attr.rst.inc
 


### PR DESCRIPTION
"can not" is technically correct (see
http://www.dailywritingtips.com/cannot-or-can-not/), but less
recommended, it seems.