### PR TITLE
Added a note about case-insensitiveness of service ids

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -154,6 +154,12 @@ later how you can configure a service that has multiple instances in the
     ``get()`` method to locate and retrieve the ``app.mailer`` service from
     the service container.
 
+.. note::
+
+    Service identifiers are case-insensitive (``app.mailer`` and ``APP.Mailer``
+    for example refer to the same service). This behavior was deprecated in
+    Symfony 3.3 and it will no longer work in Symfony 4.0.
+
 .. _service-container-parameters:
 
 Service Parameters

--- a/service_container.rst
+++ b/service_container.rst
@@ -154,7 +154,7 @@ later how you can configure a service that has multiple instances in the
     ``get()`` method to locate and retrieve the ``app.mailer`` service from
     the service container.
 
-.. note::
+.. caution::
 
     Service identifiers are case-insensitive (``app.mailer`` and ``APP.Mailer``
     for example refer to the same service). This behavior was deprecated in


### PR DESCRIPTION
This fixes #7367. I propose to add just a small note because my guess it that the case-insensitive behavior is unused by 99.99% of developers and most of them are even unaware of it.