### PR TITLE
Added a note about not using the ClassLoader component

### DIFF
--- a/components/class_loader.rst
+++ b/components/class_loader.rst
@@ -10,7 +10,7 @@ The ClassLoader Component
 .. caution::
 
     The ClassLoader component was deprecated in Symfony 3.3 and it will be
-    removed in 4.0. Alternatively, use the Composer's class loading mechanism.
+    removed in 4.0. Alternatively, use Composer's class loading mechanism.
 
 Usage
 -----

--- a/components/class_loader.rst
+++ b/components/class_loader.rst
@@ -7,14 +7,13 @@ The ClassLoader Component
     The ClassLoader component provides tools to autoload your classes and
     cache their locations for performance.
 
-Usage
------
-
 .. caution::
 
-    If your application uses Composer's class loading mechanism and PHP 7 caching
-    features, there's no need to use this component to load classes. That's why
-    this component may be deprecated anytime soon.
+    The ClassLoader component was deprecated in Symfony 3.3 and it will be
+    removed in 4.0. Alternatively, use the Composer's class loading mechanism.
+
+Usage
+-----
 
 Whenever you reference a class that has not been required or included yet,
 PHP uses the `autoloading mechanism`_ to delegate the loading of a file

--- a/components/class_loader.rst
+++ b/components/class_loader.rst
@@ -10,6 +10,12 @@ The ClassLoader Component
 Usage
 -----
 
+.. caution::
+
+    If your application uses Composer's class loading mechanism and PHP 7 caching
+    features, there's no need to use this component to load classes. That's why
+    this component may be deprecated anytime soon.
+
 Whenever you reference a class that has not been required or included yet,
 PHP uses the `autoloading mechanism`_ to delegate the loading of a file
 defining the class. Symfony provides three autoloaders, which are able to


### PR DESCRIPTION
This fixes #5949.

The component will be deprecated soon, so I guess it's OK to start warning our users.