### PR TITLE
Unify placeholders in documentation and code

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -24,7 +24,7 @@ First you need to create a Constraint class and extend :class:`Symfony\\Componen
      */
     class ContainsAlphanumeric extends Constraint
     {
-        public $message = 'The string "%string%" contains an illegal character: it can only contain letters or numbers.';
+        public $message = 'The string "{{ string }}" contains an illegal character: it can only contain letters or numbers.';
     }
 
 .. note::
@@ -67,14 +67,14 @@ The validator class is also simple, and only has one required method ``validate(
             if (!preg_match('/^[a-zA-Z0-9]+$/', $value, $matches)) {
                 // If you're using the new 2.5 validation API (you probably are!)
                 $this->context->buildViolation($constraint->message)
-                    ->setParameter('%string%', $value)
+                    ->setParameter('{{ string }}', $value)
                     ->addViolation();
 
                 // If you're using the old 2.4 validation API
                 /*
                 $this->context->addViolation(
                     $constraint->message,
-                    array('%string%' => $value)
+                    array('{{ string }}' => $value)
                 );
                 */
             }


### PR DESCRIPTION
Update validation documentation to unify approach with placeholders.

Constraints/Validators in code have `{{ value }}` placeholders, but documentation `%value%`.
It could confuse.

I propose to update documentation to use `{{ value }}` placeholders