### PR TITLE
Fix missing key for time-sensitive tests

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -232,7 +232,7 @@ the mocked namespaces in the ``phpunit.xml`` file, as done for example in the
             <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
                 <arguments>
                     <array>
-                        <element><string>Symfony\Component\HttpFoundation</string></element>
+                        <element key="time-sensitive"><string>Symfony\Component\HttpFoundation</string></element>
                     </array>
                 </arguments>
             </listener>


### PR DESCRIPTION
The Symfony test listener [prints a warning](https://github.com/symfony/symfony/blob/4491eb64633f1945537e8a6a07adbb3ef5c1f802/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php#L66) when numeric keys are used to configure mocked namespaces.

As the specification of multiple namespaces might be a bit intuitive (I can't add multiple `<element key="time-sensitive">`), maybe the following example would be better:
```xml
<listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
    <arguments>
        <array>
            <element key="time-sensitive">
                <array>
                    <element><string>Symfony\Component\HttpFoundation</string></element>
                </array>
            </element>
        </array>
    </arguments>
</listener>
```