### PR TITLE
[DependencyInjection][Improve] Constant YAML with expression language

### DIFF
--- a/service_container/parameters.rst
+++ b/service_container/parameters.rst
@@ -253,6 +253,15 @@ key and define the type as ``constant``.
         imports:
             - { resource: parameters.xml }
 
+It's also possible to use PHP constants in YAML files using expression language.
+To learn more about the expression language syntax, see :doc:`/components/expression_language/syntax`.
+
+.. code-block:: yaml
+
+    parameters:
+    global.constant.value: "@=constant('GLOBAL_CONSTANT')"
+    my_class.constant.value: "@=constant('My_Class::CONSTANT_NAME')"
+
 PHP Keywords in XML
 -------------------
 

--- a/service_container/parameters.rst
+++ b/service_container/parameters.rst
@@ -225,6 +225,12 @@ key and define the type as ``constant``.
 
 .. configuration-block::
 
+    .. code-block:: yaml
+
+        parameters:
+            global.constant.value: "@=constant('GLOBAL_CONSTANT')"
+            my_class.constant.value: "@=constant('My_Class::CONSTANT_NAME')"
+
     .. code-block:: xml
 
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -243,6 +249,12 @@ key and define the type as ``constant``.
         $container->setParameter('global.constant.value', GLOBAL_CONSTANT);
         $container->setParameter('my_class.constant.value', My_Class::CONSTANT_NAME);
 
+.. caution::
+
+    It's also possible to use PHP constants in YAML files using expression language.
+    You must have :doc:`/components/expression_language` installed.
+    To learn more about the expression language syntax, see :doc:`/components/expression_language/syntax`.
+
 .. tip::
 
     If you're using YAML, you can :doc:`import an XML file </service_container/import>`
@@ -253,14 +265,10 @@ key and define the type as ``constant``.
         imports:
             - { resource: parameters.xml }
 
-It's also possible to use PHP constants in YAML files using expression language.
-To learn more about the expression language syntax, see :doc:`/components/expression_language/syntax`.
+.. note::
 
-.. code-block:: yaml
+    In Symfony 3.2 YAML support PHP constants.
 
-    parameters:
-    global.constant.value: "@=constant('GLOBAL_CONSTANT')"
-    my_class.constant.value: "@=constant('My_Class::CONSTANT_NAME')"
 
 PHP Keywords in XML
 -------------------


### PR DESCRIPTION
Hi here,

Ï notice two things about this documentation.
http://symfony.com/doc/current/service_container/parameters.html#constants-as-parameters

- The first is that it is possible to retrieve a constant in a YAML with language expression since version 2.4 and that this solution is not indicated.
- The second is that since version 3.2 there is a new way to do it, see http://symfony.com/blog/new-in-symfony-3-2-php-constants-in-yaml-files

@javiereguiluz Is it an oversight or is there a reason that is not specified ?
Can I add this documentation that you have indicated in your news ?

Regards,


