### PR TITLE
Pin Python dependencies and install them in a virtualenv

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -46,10 +46,15 @@ disk: 512
 # Build time dependencies.
 dependencies:
   python:
-    sphinx: "1.3.6"
+    virtualenv: 15.1.0
 
 # The hooks that will be performed when the package is deployed.
 hooks:
     build: |
-      pip install git+https://github.com/fabpot/sphinx-php.git
+      virtualenv .virtualenv
+      . .virtualenv/bin/activate
+      # Platform.sh currently sets PIP_USER=1.
+      export PIP_USER=
+      pip install pip==9.0.1 wheel==0.29.0
+      pip install -r requirements.txt
       make -C _build html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+alabaster==0.7.9
+Babel==2.3.4
+docutils==0.13.1
+imagesize==0.7.1
+Jinja2==2.9.4
+MarkupSafe==0.23
+Pygments==2.2.0
+pytz==2016.10
+requests==2.12.5
+six==1.10.0
+snowballstemmer==1.2.1
+Sphinx==1.5.2
+git+https://github.com/fabpot/sphinx-php.git@7312eccce9465640752e51373a480da700e02345#egg_name=sphinx-php
+


### PR DESCRIPTION
(Alternative version from #7403)

Installing `sphinx` started to fail about a week ago, with `pip` incorrectly trying to remove a Python package shipped at the system level in Platform.sh environment.

It looks like it started failing because of a bug in the older version of `pip` that ships with Debian Jessie. We (Platform.sh) install global Python dependencies as user-site packages (using `pip --user`). We also ship system-site packages that we use for our own benefit.

So two issues here:

 * First, that older version of `pip`. We are going to look into upgrading it (a new batch of images based on Debian Stretch are cooking);
 * The build dependencies of the Symfony Docs are not pinned, which makes the build non-repeatable. I'm guessing that in this case it broke [when jinja2 ended up requiring markupsafe>=0.23][jinja2-commit] (but that's just a guess).

Fix the issue for good by installing in a `virtualenv` and pinning all the dependencies via `pip freeze`.

[jinja2-commit]: https://github.com/pallets/jinja/commit/5453db1711eeb33c68ed1126764ab691b81d1472