### PR TITLE
[WCM][Routing] Update default attributes example for annotations

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -277,7 +277,7 @@ So how can you make ``blog_list`` once again match when the user visits
         class BlogController extends Controller
         {
             /**
-             * @Route("/blog/{page}", name="blog_list", requirements={"page": "\d+"})
+             * @Route("/blog/{page}", name="blog_list", defaults={"page": 1}, requirements={"page": "\d+"})
              */
             public function listAction($page = 1)
             {


### PR DESCRIPTION
https://github.com/symfony/symfony/pull/21333 removed the autowiring of request attributes based on method arguments default values when using the `@Route` annotation.
This feature was causing an annoying bug on argument resolvers and was inconsistent with other configuration formats which force to define the attributes explicitly.

This fixes the corresponding routing example. On hold until https://github.com/symfony/symfony/pull/21377 is merged.