### PR TITLE
Fix the command for validating the schema

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -389,7 +389,7 @@ see the :ref:`doctrine-field-types` section.
 
     .. code-block:: terminal
 
-        $ php bin/console doctrine:schema:validate
+        $ php app/console doctrine:schema:validate
 
 .. _doctrine-generating-getters-and-setters:
 


### PR DESCRIPTION
It was basically the one for 3.1 and above in the page of the 2.8