### PR TITLE
Explain the query_string ldap authentication provider configuration key

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -142,9 +142,10 @@ Each part will be explained in the next section.
                     http_basic:
                         provider: some_key_from_above
                     http_basic_ldap:
-                        provider:  some_key_from_above
-                        service:   ldap
-                        dn_string: '{username}'
+                        provider:     some_key_from_above
+                        service:      ldap
+                        dn_string:    '{username}'
+                        query_string: ~
                     http_digest:
                         provider: some_key_from_above
                     guard:
@@ -237,8 +238,9 @@ Each part will be explained in the next section.
                         # new in Symfony 2.3
                         require_previous_session: true
 
-                        service:   ~
-                        dn_string: '{username}'
+                        service:      ~
+                        dn_string:    '{username}'
+                        query_string: ~
 
                     remember_me:
                         token_provider: name

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -273,26 +273,24 @@ For example, if your users have DN strings in the form
 query_string
 ............
 
-**type**: ``string``
+**type**: ``string`` **default**: ``null``
 
-This (optional) key enables the user provider to search for a user and
-then use the DN found for the bind process. This is useful in environments
-with multiple LDAP user providers with a different ``base_dn``. As value
-a valid search string for should be used, e.g. ``uid="{username}"``. The
-placeholder value will be replaced by the actual username.
+This (optional) key makes the user provider search for a user and then use the
+found DN for the bind process. This is useful when using multiple LDAP user
+providers with different ``base_dn``. The value of this option must be a valid
+search string (e.g. ``uid="{username}"``). The placeholder value will be
+replaced by the actual username.
 
-When this key is used, ``dn_string`` has to be adjusted accordingly and
-should reflect a common denominator as base DN.
+When this option is used, ``dn_string`` has to be updated accordingly. Following
+the previous example, if your users have the following two DN:
+``dc=companyA,dc=example,dc=com`` and ``dc=companyB,dc=example,dc=com``, then
+``dn_string`` should be ``dc=example,dc=com``. If the ``query_string`` option is
+``uid="{username}"``, then the authentication provider can authenticate users
+from both DN.
 
-Extending the previous example: If Your users have two different DN in the
-form of ``dc=companyA,dc=example,dc=com`` and ``dc=companyB,dc=example,dc=com``,
-then ``dn_string`` should be ``dc=example,dc=com``. In conjunction with
-``uid="{username}"`` as ``query_string`` the authentication provider can
-authenticate user from both DN.
-
-Please bear in mind, that the usernames themselves have to be unique
-across both DN, as the authentication provider won't determine the
-correct user for the bind process if more than one are found.
+Bear in mind that usernames must be unique across both DN, as the authentication
+provider won't be able to select the correct user for the bind process if more
+than one is found.
 
 Examples are provided below, for both ``form_login_ldap`` and
 ``http_basic_ldap``.

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -270,6 +270,30 @@ For example, if your users have DN strings in the form
 ``uid=einstein,dc=example,dc=com``, then the ``dn_string`` will be
 ``uid={username},dc=example,dc=com``.
 
+query_string
+............
+
+**type**: ``string``
+
+This (optional) key enables the user provider to search for a user and
+then use the DN found for the bind process. This is useful in environments
+with multiple LDAP user providers with a different ``base_dn``. As value
+a valid search string for should be used, e.g. ``uid="{username}"``. The
+placeholder value will be replaced by the actual username.
+
+When this key is used, ``dn_string`` has to be adjusted accordingly and
+should reflect a common denominator as base DN.
+
+Extending the previous example: If Your users have two different DN in the
+form of ``dc=companyA,dc=example,dc=com`` and ``dc=companyB,dc=example,dc=com``,
+then ``dn_string`` should be ``dc=example,dc=com``. In conjunction with
+``uid="{username}"`` as ``query_string`` the authentication provider can
+authenticate user from both DN.
+
+Please bear in mind, that the usernames themselves have to be unique
+across both DN, as the authentication provider won't determine the
+correct user for the bind process if more than one are found.
+
 Examples are provided below, for both ``form_login_ldap`` and
 ``http_basic_ldap``.
 


### PR DESCRIPTION
@lsmith77 I hope the overall explanation suits you. The key isn't included in the examples at the bottom of the page, as they are currently quite concise. Since `dn_string` and `query_string` are somehow interconnected that might overcomplicate them - and hopefully the written explanation is enough for this rather advanced option.

Refs symfony/symfony#21402