### PR TITLE
Compatibility with Sphinx 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 cache:
   directories: [$HOME/.cache/pip]
 
-install: pip install sphinx~=1.3.0 git+https://github.com/fabpot/sphinx-php.git
+install: pip install -q -r --upgrade requirements.txt
 
 script: sphinx-build -nW -c _build/ -b html -d _build/doctrees . _build/html
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 cache:
   directories: [$HOME/.cache/pip]
 
-install: pip install -q -r --upgrade requirements.txt
+install: pip install --upgrade -q -r requirements.txt
 
 script: sphinx-build -nW -c _build/ -b html -d _build/doctrees . _build/html
 

--- a/_build/conf.py
+++ b/_build/conf.py
@@ -34,7 +34,7 @@ from symfonycom.sphinx.lexer import TerminalLexer
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo',
+    'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinxcontrib.phpdomain',
     'sensio.sphinx.refinclude', 'sensio.sphinx.configurationblock', 'sensio.sphinx.phpcode', 'sensio.sphinx.bestpractice', 'sensio.sphinx.codeblock',
     'symfonycom.sphinx'
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ requests==2.12.5
 six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.5.2
-git+https://github.com/fabpot/sphinx-php.git@7312eccce9465640752e51373a480da700e02345#egg_name=sphinx-php
-
+git+https://github.com/fabpot/sphinx-php.git@master#egg_name=sphinx-php
+sphinxcontrib-phpdomain==0.2.1


### PR DESCRIPTION
Depends on https://github.com/fabpot/sphinx-php/pull/36
`master` should be replaced with the tag before merge to `fabpot/sphinx-php@tag`

https://travis-ci.org/symfony/symfony-docs/builds/196216027
http://pr-7425-i6sje5i-6qmocelev2lwe.eu.platform.sh/