### PR TITLE
Add apcu cache driver to doctrine config reference

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -294,7 +294,7 @@ certain classes, but those are for very advanced use-cases only.
 Caching Drivers
 ~~~~~~~~~~~~~~~
 
-For the caching drivers you can specify the values ``array``, ``apc``, ``memcache``,
+For the caching drivers you can specify the values ``array``, ``apc``, ``apcu``, ``memcache``,
 ``memcached``, ``redis``, ``wincache``, ``zenddata``, ``xcache`` or ``service``.
 
 The following example shows an overview of the caching configurations:


### PR DESCRIPTION
apcu cache driver was added in doctrine/cache 1.6:
https://github.com/doctrine/cache/releases/tag/v1.6.0

doctrine/cache version 1.6 was first used in symfony 3.0