### PR TITLE
Update build documentation command

### DIFF
--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -280,7 +280,6 @@ purposes following these steps:
    .. code-block:: terminal
 
        # Linux and macOS
-       $ cd _build/
        $ make html
 
        # Windows


### PR DESCRIPTION
Updated contributing docs http://symfony.com/doc/2.7/contributing/documentation/overview.html#build-the-documentation-locally build documentation command. `_build` path on macOS and LNX do not exist by default. It will be created after `make html` and not before. Looks like removed line have no sense. 