### PR TITLE
Change type of arguments min and max

### DIFF
--- a/reference/constraints/Count.rst
+++ b/reference/constraints/Count.rst
@@ -38,8 +38,8 @@ you might add the following:
         {
             /**
              * @Assert\Count(
-             *      min = "1",
-             *      max = "5",
+             *      min = 1,
+             *      max = 5,
              *      minMessage = "You must specify at least one email",
              *      maxMessage = "You cannot specify more than {{ limit }} emails"
              * )


### PR DESCRIPTION
Min and max arguments are of type integers but passed as strings in the annotation example.