### PR TITLE
[DependencyInjection][Fix] Missing RequestStack

### DIFF
--- a/create_framework/dependency_injection.rst
+++ b/create_framework/dependency_injection.rst
@@ -20,15 +20,16 @@ to it::
         {
             $context = new Routing\RequestContext();
             $matcher = new Routing\Matcher\UrlMatcher($routes, $context);
+            $requestStack = new RequestStack();
 
             $controllerResolver = new HttpKernel\Controller\ControllerResolver();
             $argumentResolver = new HttpKernel\Controller\ArgumentResolver();
 
             $dispatcher = new EventDispatcher();
-            $dispatcher->addSubscriber(new HttpKernel\EventListener\RouterListener($matcher));
+            $dispatcher->addSubscriber(new HttpKernel\EventListener\RouterListener($matcher, $requestStack));
             $dispatcher->addSubscriber(new HttpKernel\EventListener\ResponseListener('UTF-8'));
 
-            parent::__construct($dispatcher, $controllerResolver, new RequestStack(), $argumentResolver);
+            parent::__construct($dispatcher, $controllerResolver, $requestStack, $argumentResolver);
         }
     }
 


### PR DESCRIPTION
Hello,

Since the 2.8 the RouterListener object needs the RequestStack object for the second argument.
It was optional until version 3.0, eg:
- http://api.symfony.com/2.8/Symfony/Component/HttpKernel/EventListener/RouterListener.html
- http://api.symfony.com/3.0/Symfony/Component/HttpKernel/EventListener/RouterListener.html

As you can see, it lacks in the following example and causes a significant error:
- http://symfony.com/doc/current/create_framework/dependency_injection.html

Regards,