### PR TITLE
Update cache_pools.rst

### DIFF
--- a/components/cache/cache_pools.rst
+++ b/components/cache/cache_pools.rst
@@ -282,7 +282,7 @@ item in the cache immediately (it returns ``true`` if the item was saved or
 ``false`` if some error occurred)::
 
     // ...
-    $userFriends = $cache->get('user_'.$userId.'_friends');
+    $userFriends = $cache->getItem('user_'.$userId.'_friends');
     $userFriends->set($user->getFriends());
     $isSaved = $cache->save($userFriends);
 


### PR DESCRIPTION
When retrieving an item from cache you have to use `getItem()` and not `get()`

The `Psr\Cache\CacheItemPoolInterface` doesn't declare the `get` method