### PR TITLE
Testing the use of a "diff" view for some code samples

### DIFF
--- a/_build/conf.py
+++ b/_build/conf.py
@@ -21,6 +21,7 @@ sys.path.append(os.path.abspath('_theme/_exts'))
 # adding PhpLexer
 from sphinx.highlighting import lexers
 from pygments.lexers.compiled import CLexer
+from pygments.lexers.diff import DiffLexer
 from pygments.lexers.special import TextLexer
 from pygments.lexers.text import RstLexer
 from pygments.lexers.web import PhpLexer
@@ -110,6 +111,7 @@ lexers['rst'] = RstLexer()
 lexers['varnish3'] = CLexer()
 lexers['varnish4'] = CLexer()
 lexers['terminal'] = TerminalLexer()
+lexers['diff'] = DiffLexer()
 
 config_block = {
     'markdown': 'Markdown',

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -57,8 +57,8 @@ so this is passed into the constructor:
     {
         private $transport;
 
--       public function __construct()
-+       public function __construct($transport)
+    -   public function __construct()
+    +   public function __construct($transport)
         {
             $this->transport = $transport;
         }
@@ -75,7 +75,7 @@ Then you can set the choice of transport in the container:
     $container = new ContainerBuilder();
     $container
         ->register('mailer', 'Mailer')
-+       ->addArgument('sendmail');
+    +   ->addArgument('sendmail');
 
 This class is now much more flexible as you have separated the choice of
 transport out of the implementation and into the container.
@@ -90,10 +90,10 @@ the ``Mailer`` service's constructor argument:
     use Symfony\Component\DependencyInjection\ContainerBuilder;
 
     $container = new ContainerBuilder();
-+   $container->setParameter('mailer.transport', 'sendmail');
+    +$container->setParameter('mailer.transport', 'sendmail');
     $container
         ->register('mailer', 'Mailer')
-+       ->addArgument('%mailer.transport%');
+    +   ->addArgument('%mailer.transport%');
 
 Now that the ``mailer`` service is in the container you can inject it as
 a dependency of other classes. If you have a ``NewsletterManager`` class

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -49,13 +49,16 @@ You can register this in the container as a service::
 
 An improvement to the class to make it more flexible would be to allow
 the container to set the ``transport`` used. If you change the class
-so this is passed into the constructor::
+so this is passed into the constructor:
+
+.. code-block:: diff
 
     class Mailer
     {
         private $transport;
 
-        public function __construct($transport)
+-       public function __construct()
++       public function __construct($transport)
         {
             $this->transport = $transport;
         }
@@ -63,14 +66,16 @@ so this is passed into the constructor::
         // ...
     }
 
-Then you can set the choice of transport in the container::
+Then you can set the choice of transport in the container:
+
+.. code-block:: diff
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
 
     $container = new ContainerBuilder();
     $container
         ->register('mailer', 'Mailer')
-        ->addArgument('sendmail');
++       ->addArgument('sendmail');
 
 This class is now much more flexible as you have separated the choice of
 transport out of the implementation and into the container.
@@ -78,15 +83,17 @@ transport out of the implementation and into the container.
 Which mail transport you have chosen may be something other services need
 to know about. You can avoid having to change it in multiple places by making
 it a parameter in the container and then referring to this parameter for
-the ``Mailer`` service's constructor argument::
+the ``Mailer`` service's constructor argument:
+
+.. code-block:: diff
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
 
     $container = new ContainerBuilder();
-    $container->setParameter('mailer.transport', 'sendmail');
++   $container->setParameter('mailer.transport', 'sendmail');
     $container
         ->register('mailer', 'Mailer')
-        ->addArgument('%mailer.transport%');
++       ->addArgument('%mailer.transport%');
 
 Now that the ``mailer`` service is in the container you can inject it as
 a dependency of other classes. If you have a ``NewsletterManager`` class

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -53,7 +53,7 @@ so this is passed into the constructor:
 
 .. code-block:: diff
 
-    class Mailer
+    @@ -2,7 +2,7 @@ class Mailer
     {
         private $transport;
 

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -53,7 +53,7 @@ so this is passed into the constructor:
 
 .. code-block:: diff
 
-    @@ -2,7 +2,7 @@ class Mailer
+    class Mailer
     {
         private $transport;
 


### PR DESCRIPTION
@weaverryan pointed out that some docs use the `diff` view for code samples (e.g. https://webpack.js.org/guides/code-splitting-css/#using-extracttextwebpackplugin)  This is a test to see if this could work for us too. If it works, it'd be used selectively and only when it really makes sense.