### PR TITLE
add warning about `auto_alias` is not enabled by default

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -351,6 +351,11 @@ wrapping their names with ``%`` characters).
     sense most of the times to prevent accessing those services directly instead
     of using the generic service alias.
 
+.. note::
+
+    You need to manually add the ``Symfony\Component\DependencyInjection\Compiler\AutoAliasServicePass``
+    compiler pass to the container for this feature to work.
+
 console.command
 ---------------
 


### PR DESCRIPTION
The `auto_alias` feature is described as if it were enabled out of the box

refs https://github.com/symfony/symfony/issues/21321