### PR TITLE
Mention that requests matchers are now lazy loaded in FirewallMap

### DIFF
--- a/components/security/firewall.rst
+++ b/components/security/firewall.rst
@@ -67,6 +67,11 @@ the user::
 
     $map->add($requestMatcher, $listeners, $exceptionListener);
 
+.. note::
+
+    Starting from Symfony 3.3, the request matchers passed to the ``FirewallMap``
+    class are "lazy loaded" to improve the application performance.
+
 The firewall map will be given to the firewall as its first argument, together
 with the event dispatcher that is used by the :class:`Symfony\\Component\\HttpKernel\\HttpKernel`::
 


### PR DESCRIPTION
This fixes #7474.

This is the only place where we mention FirewallMap, so maybe we could add this note. If you don't agree, let's close it as "won't fix". Thanks!