### PR TITLE
Mentioned the new GitHub topics to find Symfony bundles

### DIFF
--- a/assetic/jpeg_optimize.rst
+++ b/assetic/jpeg_optimize.rst
@@ -306,4 +306,4 @@ file:
     `LiipImagineBundle`_ community bundle.
 
 .. _`Jpegoptim`: http://www.kokkonen.net/tjko/projects.html
-.. _`LiipImagineBundle`: http://knpbundles.com/liip/LiipImagineBundle
+.. _`LiipImagineBundle`: https://github.com/liip/LiipImagineBundle

--- a/bundles.rst
+++ b/bundles.rst
@@ -181,4 +181,4 @@ Learn more
 
     bundles/*
 
-_`third-party bundles`: http://knpbundles.com
+_`third-party bundles`: https://github.com/search?q=topic%3Asymfony-bundle&type=Repositories

--- a/bundles/installation.rst
+++ b/bundles/installation.rst
@@ -26,8 +26,7 @@ the bundle on the `Packagist.org`_ site.
 
 .. tip::
 
-    Looking for bundles? Try searching at `KnpBundles.com`_: the unofficial
-    archive of Symfony Bundles.
+    Looking for bundles? Try searching for `symfony-bundle topic on GitHub`_.
 
 2) Install the Bundle via Composer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -142,5 +141,5 @@ what to do next. Have fun!
 .. _their documentation: https://getcomposer.org/doc/00-intro.md
 .. _Packagist.org:       https://packagist.org
 .. _FOSUserBundle:       https://github.com/FriendsOfSymfony/FOSUserBundle
-.. _KnpBundles.com:      http://knpbundles.com/
 .. _`composer require`:  https://getcomposer.org/doc/03-cli.md#require
+.. _`symfony-bundle topic on GitHub`: https://github.com/search?q=topic%3Asymfony-bundle&type=Repositories

--- a/contributing/community/other.rst
+++ b/contributing/community/other.rst
@@ -12,4 +12,4 @@ these additional resources:
 .. _pull requests:         https://github.com/symfony/symfony/pulls
 .. _commits:               https://github.com/symfony/symfony/commits/master
 .. _bugs and enhancements: https://github.com/symfony/symfony/issues
-.. _bundles:               http://knpbundles.com/
+.. _bundles:               https://github.com/search?q=topic%3Asymfony-bundle&type=Repositories

--- a/deployment.rst
+++ b/deployment.rst
@@ -203,7 +203,7 @@ other potential things like pushing assets to a CDN (see `Common Post-Deployment
 .. _`Fabric`: http://www.fabfile.org/
 .. _`Magallanes`: https://github.com/andres-montanez/Magallanes
 .. _`Ant`: http://blog.sznapka.pl/deploying-symfony2-applications-with-ant
-.. _`bundles that add deployment features`: http://knpbundles.com/search?q=deploy
+.. _`bundles that add deployment features`: https://github.com/search?utf8=✓&q=topic%3Asymfony-bundle+topic%3Adeploy&type=Repositories&ref=searchresults
 .. _`Memcached`: http://memcached.org/
 .. _`Redis`: http://redis.io/
 .. _`Symfony plugin`: https://github.com/capistrano/symfony/

--- a/introduction/from_flat_php_to_symfony2.rst
+++ b/introduction/from_flat_php_to_symfony2.rst
@@ -751,7 +751,7 @@ the blog from flat PHP to Symfony has improved life:
 
 And perhaps best of all, by using Symfony, you now have access to a whole
 set of **high-quality open source tools developed by the Symfony community**!
-A good selection of Symfony community tools can be found on `KnpBundles.com`_.
+A good selection of `Symfony community tools`_ can be found on GitHub.
 
 .. _`Model-View-Controller`: https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller
 .. _`Doctrine`: http://www.doctrine-project.org
@@ -760,5 +760,5 @@ A good selection of Symfony community tools can be found on `KnpBundles.com`_.
 .. _`download Composer`: https://getcomposer.org/download/
 .. _`Validator`: https://github.com/symfony/validator
 .. _`Varnish`: https://www.varnish-cache.org/
-.. _`KnpBundles.com`: http://knpbundles.com/
 .. _`Twig`: http://twig.sensiolabs.org
+.. _`Symfony community tools`: https://github.com/search?q=topic%3Asymfony-bundle&type=Repositories


### PR DESCRIPTION
Sadly, KnpBundles stopped updating a few months ago. Let's switch to GitHub Topics as the official resource to fund Symfony bundles.