### PR TITLE
Use statement for InputOption added to example

### DIFF
--- a/console/input.rst
+++ b/console/input.rst
@@ -118,8 +118,8 @@ simply as a boolean flag without a value (e.g.  ``--yell``).
 For example, add a new option to the command that can be used to specify
 how many times in a row the message should be printed::
 
-    use Symfony\Component\Console\Input\InputOption;
     // ...
+    use Symfony\Component\Console\Input\InputOption;
 
     $this
         // ...

--- a/console/input.rst
+++ b/console/input.rst
@@ -118,6 +118,9 @@ simply as a boolean flag without a value (e.g.  ``--yell``).
 For example, add a new option to the command that can be used to specify
 how many times in a row the message should be printed::
 
+    use Symfony\Component\Console\Input\InputOption;
+    // ...
+
     $this
         // ...
         ->addOption(


### PR DESCRIPTION
Hi,

while reading in the docs today I was looking for the namespace of the `InputOption` class. Since it was missing on this page I added it.

Sam