### PR TITLE
Replace "chapter" by "article" where appropriate

### DIFF
--- a/components/yaml/yaml_format.rst
+++ b/components/yaml/yaml_format.rst
@@ -8,7 +8,7 @@ According to the official `YAML`_ website, YAML is "a human friendly data
 serialization standard for all programming languages".
 
 Even if the YAML format can describe complex nested data structure, this
-chapter only describes the minimum set of features needed to use YAML as a
+article only describes the minimum set of features needed to use YAML as a
 configuration file format.
 
 YAML is a simple language that describes data. As PHP, it has a syntax for

--- a/configuration.rst
+++ b/configuration.rst
@@ -95,7 +95,7 @@ specific bundle (i.e. ``FrameworkBundle`` and ``TwigBundle``).
 
 .. sidebar:: Configuration Formats
 
-    Throughout the chapters, all configuration examples will be shown in
+    Throughout the documentation, all configuration examples will be shown in
     three formats (YAML, XML and PHP). YAML is used by default, but you can
     choose whatever you like best. There is no performance difference:
 

--- a/configuration/external_parameters.rst
+++ b/configuration/external_parameters.rst
@@ -4,11 +4,11 @@
 How to Set external Parameters in the Service Container
 =======================================================
 
-In the chapter :doc:`/configuration`, you learned how to manage your application
-configuration. At times, it may benefit your application
-to store certain credentials outside of your project code. Database configuration
-is one such example. The flexibility of the Symfony service container allows
-you to easily do this.
+In the article :doc:`/configuration`, you learned how to manage your application
+configuration. At times, it may benefit your application to store certain
+credentials outside of your project code. Database configuration is one such
+example. The flexibility of the Symfony service container allows you to easily
+do this.
 
 Environment Variables
 ---------------------

--- a/configuration/front_controllers_and_kernel.rst
+++ b/configuration/front_controllers_and_kernel.rst
@@ -144,7 +144,7 @@ This method is responsible for loading the application's
 configuration from the right *environment*.
 
 Environments have been covered extensively
-:doc:`in the previous chapter </configuration/environments>`,
+:doc:`in the previous article </configuration/environments>`,
 and you probably remember that the Symfony Standard Edition comes with three
 of them - ``dev``, ``prod`` and ``test``.
 

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -126,9 +126,9 @@ memorable name for the new branch (if you are fixing a reported issue, use
 
 .. code-block:: terminal
 
-    $ git checkout -b improve_install_chapter upstream/2.7
+    $ git checkout -b improve_install_article upstream/2.7
 
-In this example, the name of the branch is ``improve_install_chapter`` and the
+In this example, the name of the branch is ``improve_install_article`` and the
 ``upstream/2.7`` value tells Git to create this branch based on the ``2.7``
 branch of the ``upstream`` remote, which is the original Symfony Docs repository.
 
@@ -151,10 +151,10 @@ even remove any content and do your best to comply with the
 
 .. code-block:: terminal
 
-    $ git push origin improve_install_chapter
+    $ git push origin improve_install_article
 
 The ``origin`` value is the name of the Git remote that corresponds to your
-forked repository and ``improve_install_chapter`` is the name of the branch you
+forked repository and ``improve_install_article`` is the name of the branch you
 created previously.
 
 **Step 7.** Everything is now ready to initiate a **pull request**. Go to your
@@ -171,7 +171,7 @@ changes should be applied:
 In this example, the **base fork** should be ``symfony/symfony-docs`` and
 the **base** branch should be the ``2.7``, which is the branch that you selected
 to base your changes on. The **head fork** should be your forked copy
-of ``symfony-docs`` and the **compare** branch should be ``improve_install_chapter``,
+of ``symfony-docs`` and the **compare** branch should be ``improve_install_article``,
 which is the name of the branch you created and where you made your changes.
 
 .. _pull-request-format:
@@ -192,7 +192,7 @@ changes and push the new changes:
 .. code-block:: terminal
 
     $ cd projects/symfony-docs/
-    $ git checkout improve_install_chapter
+    $ git checkout improve_install_article
 
     # ... do your changes
 

--- a/controller.rst
+++ b/controller.rst
@@ -184,12 +184,12 @@ and ``redirect()`` methods::
     The ``redirectToRoute()`` method was introduced in Symfony 2.6. Previously (and still now), you
     could use ``redirect()`` and ``generateUrl()`` together for this.
 
-For more information, see the :doc:`Routing chapter </routing>`.
+For more information, see the :doc:`Routing article </routing>`.
 
 .. caution::
 
-    The ``redirect()`` method does not check its destination in any way. If you 
-    redirect to some URL provided by the end-users, your application may be open 
+    The ``redirect()`` method does not check its destination in any way. If you
+    redirect to some URL provided by the end-users, your application may be open
     to the `unvalidated redirects security vulnerability`_.
 
 
@@ -230,7 +230,7 @@ creating unnecessarily deep structures::
     ));
 
 The Symfony templating system and Twig are explained more in the
-:doc:`Creating and Using Templates chapter </templating>`.
+:doc:`Creating and Using Templates article </templating>`.
 
 .. index::
    single: Controller; Accessing services
@@ -266,7 +266,7 @@ console command:
 .. versionadded:: 2.6
     Prior to Symfony 2.6, this command was called ``container:debug``.
 
-For more information, see the :doc:`/service_container` chapter.
+For more information, see the :doc:`/service_container` article.
 
 .. tip::
 
@@ -548,7 +548,7 @@ A) Shortcut methods (like ``render()`` and ``redirectToRoute()``);
 B) Access to *all* of the useful objects (services) in the system via the
    :ref:`get() <controller-accessing-services>` method.
 
-In other chapters, you'll learn how to use specific services from inside your controller
+In other articles, you'll learn how to use specific services from inside your controller
 that will help you persist and fetch objects from a database, process form submissions,
 handle caching and more.
 

--- a/doctrine/registration_form.rst
+++ b/doctrine/registration_form.rst
@@ -290,7 +290,7 @@ encoder in the security configuration:
                 <encoder class="AppBundle\Entity\User">bcrypt</encoder>
             </config>
         </srv:container>
-        
+
     .. code-block:: php
 
         // app/config/security.php
@@ -302,9 +302,8 @@ encoder in the security configuration:
             ),
         ));
 
-In this case the recommended ``bcrypt`` algorithm is used. To learn more
-about how to encode the users password have a look into the
-:ref:`security chapter <security-encoding-user-password>`.
+In this case the recommended ``bcrypt`` algorithm is used. If needed, check out
+the :ref:`user password encoding <security-encoding-user-password>` article.
 
 .. note::
 

--- a/form/csrf_protection.rst
+++ b/form/csrf_protection.rst
@@ -11,7 +11,7 @@ using a CSRF token inside your forms.
 
 The good news is that, by default, Symfony embeds and validates CSRF tokens
 automatically for you. This means that you can take advantage of the CSRF
-protection without doing anything. In fact, every form in this chapter has
+protection without doing anything. In fact, every form in this article has
 taken advantage of the CSRF protection!
 
 CSRF protection works by adding a hidden field to your form - called ``_token``

--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -67,7 +67,7 @@ a bare form class looks like::
 .. note::
 
     If this particular section of code isn't already familiar to you, you
-    probably need to take a step back and first review the :doc:`Forms chapter </forms>`
+    probably need to take a step back and first review the :doc:`Forms article </forms>`
     before proceeding.
 
 Assume for a moment that this form utilizes an imaginary "Product" class

--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -795,7 +795,7 @@ Customizing Error Output
    The Form component only handles *how* the validation errors are rendered,
    and not the actual validation error messages. The error messages themselves
    are determined by the validation constraints you apply to your objects.
-   For more information, see the chapter on :doc:`validation </validation>`.
+   For more information, see the article on :doc:`validation </validation>`.
 
 There are many different ways to customize how errors are rendered when a
 form is submitted with errors. The error messages for a field are rendered

--- a/form/without_class.rst
+++ b/form/without_class.rst
@@ -6,7 +6,7 @@ How to Use a Form without a Data Class
 
 In most cases, a form is tied to an object, and the fields of the form get
 and store their data on the properties of that object. This is exactly what
-you've seen so far in this chapter with the `Task` class.
+you've seen so far in this article with the `Task` class.
 
 But sometimes, you may just want to use a form without a class, and get back
 an array of the submitted data. This is actually really easy::
@@ -76,7 +76,7 @@ simple array of your submitted data, how can you add constraints to the data of
 your form?
 
 The answer is to setup the constraints yourself, and attach them to the individual
-fields. The overall approach is covered a bit more in the :doc:`validation chapter </validation/raw_values>`,
+fields. The overall approach is covered a bit more in :doc:`this validation article </validation/raw_values>`,
 but here's a short example:
 
 .. code-block:: php

--- a/forms.rst
+++ b/forms.rst
@@ -6,7 +6,7 @@ Forms
 
 Dealing with HTML forms is one of the most common - and challenging - tasks for
 a web developer. Symfony integrates a Form component that makes dealing with
-forms easy. In this chapter, you'll build a complex form from the ground up,
+forms easy. In this article, you'll build a complex form from the ground up,
 learning the most important features of the form library along the way.
 
 .. note::
@@ -59,7 +59,7 @@ going to need to build a form. But before you begin, first focus on the generic
 This class is a "plain-old-PHP-object" because, so far, it has nothing
 to do with Symfony or any other library. It's quite simply a normal PHP object
 that directly solves a problem inside *your* application (i.e. the need to
-represent a task in your application). Of course, by the end of this chapter,
+represent a task in your application). Of course, by the end of this article,
 you'll be able to submit data to a ``Task`` instance (via an HTML form), validate
 its data, and persist it to the database.
 
@@ -252,7 +252,7 @@ your controller::
             'form' => $form->createView(),
         ));
     }
-    
+
 .. caution::
 
     Be aware that the ``createView()`` method should be called *after* ``handleRequest()``
@@ -400,7 +400,7 @@ That's it! If you re-submit the form with invalid data, you'll see the
 corresponding errors printed out with the form.
 
 Validation is a very powerful feature of Symfony and has its own
-:doc:`dedicated chapter </validation>`.
+:doc:`dedicated article </validation>`.
 
 .. _forms-html5-validation-disable:
 
@@ -479,7 +479,7 @@ the documentation for each type.
     is left blank. If you don't want this behavior, either
     :ref:`disable HTML5 validation <forms-html5-validation-disable>`
     or set the ``required`` option on your field to ``false``::
-    
+
         ->add('dueDate', 'date', array(
             'widget' => 'single_text',
             'required' => false

--- a/http_cache/varnish.rst
+++ b/http_cache/varnish.rst
@@ -102,7 +102,7 @@ configuration of PHP, your session cookie has the name ``PHPSESSID``:
                 set req.http.Cookie = regsuball(req.http.Cookie, ";(PHPSESSID)=", "; \1=");
                 set req.http.Cookie = regsuball(req.http.Cookie, ";[^ ][^;]*", "");
                 set req.http.Cookie = regsuball(req.http.Cookie, "^[; ]+|[; ]+$", "");
-    
+
                 if (req.http.Cookie == "") {
                     // If there are no more cookies, remove the header to get page cached.
                     unset req.http.Cookie;
@@ -120,7 +120,7 @@ configuration of PHP, your session cookie has the name ``PHPSESSID``:
                 set req.http.Cookie = regsuball(req.http.Cookie, ";(PHPSESSID)=", "; \1=");
                 set req.http.Cookie = regsuball(req.http.Cookie, ";[^ ][^;]*", "");
                 set req.http.Cookie = regsuball(req.http.Cookie, "^[; ]+|[; ]+$", "");
-    
+
                 if (req.http.Cookie == "") {
                     // If there are no more cookies, remove the header to get page cached.
                     remove req.http.Cookie;
@@ -168,7 +168,7 @@ using Varnish 3:
 Enable Edge Side Includes (ESI)
 -------------------------------
 
-As explained in the :doc:`Edge Side Includes chapter </http_cache/esi>`, Symfony
+As explained in the :doc:`Edge Side Includes article </http_cache/esi>`, Symfony
 detects whether it talks to a reverse proxy that understands ESI or not. When
 you use the Symfony reverse proxy, you don't need to do anything. But to make
 Varnish instead of Symfony resolve the ESI tags, you need some configuration

--- a/introduction/from_flat_php_to_symfony2.rst
+++ b/introduction/from_flat_php_to_symfony2.rst
@@ -10,11 +10,11 @@ Symfony versus Flat PHP
 
 If you've never used a PHP framework, aren't familiar with the
 `Model-View-Controller`_ (MVC) philosophy, or just wonder what all the *hype*
-is around Symfony, this chapter is for you. Instead of *telling* you that
+is around Symfony, this article is for you. Instead of *telling* you that
 Symfony allows you to develop faster and better software than with flat PHP,
 you'll see for yourself.
 
-In this chapter, you'll write a simple application in flat PHP, and then
+In this article, you'll write a simple application in flat PHP, and then
 refactor it to be more organized. You'll travel through time, seeing the
 decisions behind why web development has evolved over the past several years
 to where it is now.
@@ -25,7 +25,7 @@ let you take back control of your code.
 A Simple Blog in Flat PHP
 -------------------------
 
-In this chapter, you'll build the token blog application using only flat PHP.
+In this article, you'll build the token blog application using only flat PHP.
 To begin, create a single page that displays blog entries that have been
 persisted to the database. Writing in flat PHP is quick and dirty:
 
@@ -717,14 +717,14 @@ And rewriting ``layout.html.php`` template in Twig would look like this:
 
 Twig is well-supported in Symfony. And while PHP templates will always
 be supported in Symfony, the many advantages of Twig will continue to
-be discussed. For more information, see the :doc:`templating chapter </templating>`.
+be discussed. For more information, see the :doc:`templating article </templating>`.
 
 Where Symfony Delivers
 ----------------------
 
-In the upcoming chapters, you'll learn more about how each piece of Symfony
-works and how you can organize your project. For now, celebrate at how migrating
-the blog from flat PHP to Symfony has improved life:
+In the rest of documentation articles, you'll learn more about how each piece of
+Symfony works and how you can organize your project. For now, celebrate at how
+migrating the blog from flat PHP to Symfony has improved life:
 
 * Your application now has **clear and consistently organized code** (though
   Symfony doesn't force you into this). This promotes **reusability** and
@@ -746,7 +746,7 @@ the blog from flat PHP to Symfony has improved life:
 
 * Symfony's HTTP-centric architecture gives you access to powerful tools
   such as **HTTP caching** powered by **Symfony's internal HTTP cache** or
-  more powerful tools such as `Varnish`_. This is covered in a later chapter
+  more powerful tools such as `Varnish`_. This is covered in another article
   all about :doc:`caching </http_cache>`.
 
 And perhaps best of all, by using Symfony, you now have access to a whole

--- a/introduction/http_fundamentals.rst
+++ b/introduction/http_fundamentals.rst
@@ -10,7 +10,7 @@ Great news! While you're learning Symfony, you're *also* learning the fundamenta
 of the *web*. Symfony is closely modeled after the HTTP Request-Response flow: that
 *fundamental* paradigm that's behind almost *all* communication on the web.
 
-In this chapter, you'll walk through the HTTP fundamentals and find out how these
+In this article, you'll walk through the HTTP fundamentals and find out how these
 are applied throughout Symfony.
 
 Requests and Responses in HTTP

--- a/introduction/symfony1.rst
+++ b/introduction/symfony1.rst
@@ -10,7 +10,7 @@ at its core, the skills used to master a symfony1 project continue to be
 very relevant when developing in Symfony2. Sure, ``app.yml`` is gone, but
 routing, controllers and templates all remain.
 
-This chapter walks through the differences between symfony1 and Symfony2.
+This article walks through the differences between symfony1 and Symfony2.
 As you'll see, many tasks are tackled in a slightly different way. You'll
 come to appreciate these minor differences as they promote stable, predictable,
 testable and decoupled code in your Symfony2 applications.
@@ -359,7 +359,7 @@ You can now access this from a controller, for example::
 
 In reality, the Symfony2 configuration is much more powerful and is used
 primarily to configure objects that you can use. For more information, see
-the chapter titled ":doc:`/service_container`".
+the article titled ":doc:`/service_container`".
 
 .. _`Composer`: https://getcomposer.org
 .. _`Symfony Standard Edition`: https://github.com/symfony/symfony-standard

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -32,7 +32,7 @@ Creating a Page: Route and Controller
 .. tip::
 
     Before continuing, make sure you've read the :doc:`Setup </setup>`
-    chapter and can access your new Symfony app in the browser.
+    article and can access your new Symfony app in the browser.
 
 Suppose you want to create a page - ``/lucky/number`` - that generates a lucky (well,
 random) number and prints it. To do that, create a "Controller class" and a
@@ -149,7 +149,7 @@ to get your *new* lucky number!
 
     http://localhost:8000/lucky/number
 
-In the :doc:`/templating` chapter, you'll learn all about Twig: how to loop, render
+In the :doc:`/templating` article, you'll learn all about Twig: how to loop, render
 other templates and leverage its powerful layout inheritance system.
 
 Checking out the Project Structure
@@ -214,7 +214,7 @@ That exists!
 
 You can control how your bundles behave via the ``app/config/config.yml`` file.
 That file - and other details like environments & parameters - are discussed in
-the :doc:`/configuration` chapter.
+the :doc:`/configuration` article.
 
 What's Next?
 ------------
@@ -222,7 +222,7 @@ What's Next?
 Congrats! You're already starting to master Symfony and learn a whole new
 way of building beautiful, functional, fast and maintainable apps.
 
-Ok, time to finish mastering the fundamentals by reading these chapters:
+Ok, time to finish mastering the fundamentals by reading these articles:
 
 * :doc:`/routing`
 * :doc:`/controller`

--- a/performance.rst
+++ b/performance.rst
@@ -5,7 +5,7 @@ Performance
 ===========
 
 Symfony is fast, right out of the box. Of course, if you really need speed,
-there are many ways that you can make Symfony even faster. In this chapter,
+there are many ways that you can make Symfony even faster. In this article,
 you'll explore some of the ways to make your Symfony application even faster.
 
 .. index::

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1157,7 +1157,7 @@ resources
 
 A list of all resources for form theming in PHP. This setting is not required
 if you're using the Twig format for your templates, in that case refer to
-:ref:`the form chapter <forms-theming-twig>`.
+:ref:`the form article <forms-theming-twig>`.
 
 Assume you have custom global form themes in
 ``src/WebsiteBundle/Resources/views/Form``, you can configure this like:

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -7,7 +7,7 @@ service that you would like to register as a listener to one of Symfony's
 core events, you can flag it with the ``kernel.event_listener`` tag.
 
 You can learn a little bit more about "tags" by reading the ":doc:`/service_container/tags`"
-section of the Service Container chapter.
+article.
 
 Below is information about all of the tags available inside Symfony. There
 may also be tags in other bundles you use that aren't listed here.

--- a/routing.rst
+++ b/routing.rst
@@ -14,7 +14,7 @@ hunt down and update to make the change? If you're using Symfony's router,
 the change is simple.
 
 The Symfony router lets you define creative URLs that you map to different
-areas of your application. By the end of this chapter, you'll be able to:
+areas of your application. By the end of this article, you'll be able to:
 
 * Create complex routes that map to controllers
 * Generate URLs inside templates and controllers
@@ -652,7 +652,7 @@ But if you pass extra ones, they will be added to the URI as a query string::
 Generating URLs from a Template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To generate URLs inside Twig, see the templating chapter: :ref:`templating-pages`.
+To generate URLs inside Twig, see the templating article: :ref:`templating-pages`.
 If you also need to generate URLs in JavaScript, see :doc:`/routing/generate_url_javascript`.
 
 .. index::

--- a/security.rst
+++ b/security.rst
@@ -5,13 +5,13 @@ Security
 ========
 
 Symfony's security system is incredibly powerful, but it can also be confusing
-to set up. In this chapter, you'll learn how to set up your application's security
+to set up. In this article, you'll learn how to set up your application's security
 step-by-step, from configuring your firewall and how you load users to denying
 access and fetching the User object. Depending on what you need, sometimes
 the initial setup can be tough. But once it's done, Symfony's security system
 is both flexible and (hopefully) fun to work with.
 
-Since there's a lot to talk about, this chapter is organized into a few big
+Since there's a lot to talk about, this article is organized into a few big
 sections:
 
 #. Initial ``security.yml`` setup (*authentication*);
@@ -902,7 +902,7 @@ the built-in helper function:
 
 If you use this function and you are *not* behind a firewall, an exception will
 be thrown. Again, it's almost always a good idea to have a main firewall that
-covers all URLs (as shown before in this chapter).
+covers all URLs (as shown before in this article).
 
 .. caution::
 

--- a/security/acl_advanced.rst
+++ b/security/acl_advanced.rst
@@ -4,7 +4,7 @@
 How to Use advanced ACL Concepts
 ================================
 
-The aim of this chapter is to give a more in-depth view of the ACL system, and
+The aim of this article is to give a more in-depth view of the ACL system, and
 also explain some of the design decisions behind it.
 
 Design Concepts
@@ -83,7 +83,7 @@ Access control entries can have different scopes in which they apply. In
 Symfony, there are basically two different scopes:
 
 - Class-Scope: These entries apply to all objects with the same class.
-- Object-Scope: This was the scope solely used in the previous chapter, and
+- Object-Scope: This was the scope solely used in the previous article, and
   it only applies to one specific object.
 
 Sometimes, you will find the need to apply an ACE only to a specific field of

--- a/security/custom_authentication_provider.rst
+++ b/security/custom_authentication_provider.rst
@@ -15,9 +15,9 @@ How to Create a custom Authentication Provider
     * To authenticate via OAuth using a third-party service such as Google, Facebook
       or Twitter, try using the `HWIOAuthBundle`_ community bundle.
 
-If you have read the chapter on :doc:`/security`, you understand the
+If you have read the article on :doc:`/security`, you understand the
 distinction Symfony makes between authentication and authorization in the
-implementation of security. This chapter discusses the core classes involved
+implementation of security. This article discusses the core classes involved
 in the authentication process, and how to implement a custom authentication
 provider. Because authentication and authorization are separate concepts,
 this extension will be user-provider agnostic, and will function with your
@@ -27,7 +27,7 @@ wherever else you choose to store them.
 Meet WSSE
 ---------
 
-The following chapter demonstrates how to create a custom authentication
+The following article demonstrates how to create a custom authentication
 provider for WSSE authentication. The security protocol for WSSE provides
 several security benefits:
 
@@ -48,7 +48,7 @@ password digest.
 .. note::
 
     WSSE also supports application key validation, which is useful for web
-    services, but is outside the scope of this chapter.
+    services, but is outside the scope of this article.
 
 The Token
 ---------
@@ -371,7 +371,7 @@ requires the following methods:
 ``addConfiguration()``
     Method which is used to define the configuration
     options underneath the configuration key in your security configuration.
-    Setting configuration options are explained later in this chapter.
+    Setting configuration options are explained later in this article.
 
 .. note::
 

--- a/security/securing_services.rst
+++ b/security/securing_services.rst
@@ -5,7 +5,7 @@
 How to Secure any Service or Method in your Application
 =======================================================
 
-In the security chapter, you can see how to
+In the security article, you can see how to
 :ref:`secure a controller <security-securing-controller>` by requesting
 the ``security.authorization_checker`` service from the Service Container and
 checking the current user's role::

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -13,7 +13,7 @@ which are like simple conditional statements.
 
     Take a look at the
     :doc:`authorization </components/security/authorization>`
-    chapter for an even deeper understanding on voters.
+    article for an even deeper understanding on voters.
 
 How Symfony Uses Voters
 -----------------------

--- a/service_container.rst
+++ b/service_container.rst
@@ -12,7 +12,7 @@ your product inventory, or another object that processes data from a third-party
 API. The point is that a modern application does many things and is organized
 into many objects that handle each task.
 
-This chapter is about a special PHP object in Symfony that helps
+This article is about a special PHP object in Symfony that helps
 you instantiate, organize and retrieve the many objects of your application.
 This object, called a service container, will allow you to standardize and
 centralize the way objects are constructed in your application. The container
@@ -23,14 +23,14 @@ in Symfony. In large part, the service container is the biggest contributor
 to the speed and extensibility of Symfony.
 
 Finally, configuring and using the service container is easy. By the end
-of this chapter, you'll be comfortable creating your own objects via the
+of this article, you'll be comfortable creating your own objects via the
 container and customizing objects from any third-party bundle. You'll begin
 writing code that is more reusable, testable and decoupled, simply because
 the service container makes writing good code so easy.
 
 .. tip::
 
-    If you want to know a lot more after reading this chapter, check out
+    If you want to know a lot more after reading this article, check out
     the :doc:`DependencyInjection component documentation </components/dependency_injection>`.
 
 .. index::

--- a/setup/_vendor_deps.rst.inc
+++ b/setup/_vendor_deps.rst.inc
@@ -12,7 +12,7 @@ you need for each.
 By default, these libraries are downloaded by running a ``composer install``
 "downloader" binary. This ``composer`` file is from a library called `Composer`_
 and you can read more about installing it in the :ref:`Installation <installation-updating-vendors>`
-chapter.
+article.
 
 The ``composer`` command reads from the ``composer.json`` file at the root
 of your project. This is an JSON-formatted file, which holds a list of each

--- a/setup/new_project_git.rst
+++ b/setup/new_project_git.rst
@@ -20,7 +20,7 @@ Initial Project Setup
 ---------------------
 
 To get started, you'll need to download Symfony and get things running. See
-the :doc:`/setup` chapter for details.
+the :doc:`/setup` article for details.
 
 Once your project is running, just follow these simple steps:
 
@@ -63,7 +63,7 @@ At this point, you have a fully-functional Symfony project that's correctly
 committed to Git. You can immediately begin development, committing the new
 changes to your Git repository.
 
-You can continue to follow along with the :doc:`/page_creation` chapter
+You can continue to follow along with the :doc:`/page_creation` article
 to learn more about how to configure and develop inside your application.
 
 .. tip::

--- a/setup/new_project_svn.rst
+++ b/setup/new_project_svn.rst
@@ -48,7 +48,7 @@ Initial Project Setup
 
 To get started, you'll need to download Symfony and get the basic Subversion setup.
 First, download and get your Symfony project running by following the
-:doc:`Installation </setup>` chapter.
+:doc:`Installation </setup>` article.
 
 Once you have your new project directory and things are working, follow along
 with these steps:
@@ -105,7 +105,7 @@ At this point, you have a fully-functional Symfony project stored in your
 Subversion repository. The development can start with commits in the Subversion
 repository.
 
-You can continue to follow along with the :doc:`/page_creation` chapter
+You can continue to follow along with the :doc:`/page_creation` article
 to learn more about how to configure and develop inside your application.
 
 .. tip::

--- a/templating.rst
+++ b/templating.rst
@@ -9,7 +9,7 @@ handling each request that comes into a Symfony application. In reality,
 the controller delegates most of the heavy work to other places so that
 code can be tested and reused. When a controller needs to generate HTML,
 CSS or any other content, it hands the work off to the templating engine.
-In this chapter, you'll learn how to write powerful templates that can be
+In this article, you'll learn how to write powerful templates that can be
 used to return content to the user, populate email bodies, and more. You'll
 learn shortcuts, clever ways to extend templates and how to reuse template
 code.
@@ -114,7 +114,7 @@ with alternating ``odd``, ``even`` classes:
         </div>
     {% endfor %}
 
-Throughout this chapter, template examples will be shown in both Twig and PHP.
+Throughout this article, template examples will be shown in both Twig and PHP.
 
 .. sidebar:: Why Twig?
 

--- a/templating/formats.rst
+++ b/templating/formats.rst
@@ -33,8 +33,8 @@ The ``getRequestFormat()`` on the ``Request`` object defaults to ``html``,
 but can return any other format based on the format requested by the user.
 The request format is most often managed by the routing, where a route can
 be configured so that ``/contact`` sets the request format to ``html`` while
-``/contact.xml`` sets the format to ``xml``. For more information, see the
-:ref:`Advanced Example in the Routing chapter <advanced-routing-example>`.
+``/contact.xml`` sets the format to ``xml``. For more information, see this
+:ref:`Advanced Routing Example <advanced-routing-example>`.
 
 To create links that include the format parameter, include a ``_format``
 key in the parameter hash:

--- a/testing.rst
+++ b/testing.rst
@@ -12,7 +12,7 @@ The PHPUnit Testing Framework
 -----------------------------
 
 Symfony integrates with an independent library - called PHPUnit - to give
-you a rich testing framework. This chapter won't cover PHPUnit itself, but
+you a rich testing framework. This article won't cover PHPUnit itself, but
 it has its own excellent `documentation`_.
 
 .. note::

--- a/translation.rst
+++ b/translation.rst
@@ -28,7 +28,7 @@ into the language of the user::
     *language* code, an underscore (``_``), then the `ISO 3166-1 alpha-2`_
     *country* code (e.g. ``fr_FR`` for French/France) is recommended.
 
-In this chapter, you'll learn how to use the Translation component in the
+In this article, you'll learn how to use the Translation component in the
 Symfony Framework. You can read the
 :doc:`Translation component documentation </components/translation/usage>`
 to learn even more. Overall, the process has several steps:
@@ -412,8 +412,8 @@ checks translation resources for several locales:
 
 .. note::
 
-    When Symfony doesn't find a translation in the given locale, it will 
-    add the missing translation to the log file. For details, 
+    When Symfony doesn't find a translation in the given locale, it will
+    add the missing translation to the log file. For details,
     see :ref:`reference-framework-translator-logging`.
 
 Handling the User's Locale


### PR DESCRIPTION
Symfony Docs are no longer divided into books and chapters, so let's replace `chapter` by `article`.

I've maintained the `chapter` references in the "Best Practices" book, the "Crete your Own Framework" book and "The Quick Tour".