### PR TITLE
[Requirements] Clarify what are JSON and ctype

### DIFF
--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -57,5 +57,5 @@ you need to have the PDO driver installed for the database server you want
 to use.
 
 .. _`Requirements section of the README`: https://github.com/symfony/symfony/blob/2.7/README.md#requirements
-.. _`JSON extension`: http://php.net/manual/book.json.php
-.. _`ctype extension`: http://php.net/manual/book.ctype.php
+.. _`JSON extension`: https://php.net/manual/book.json.php
+.. _`ctype extension`: https://php.net/manual/book.ctype.php

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -22,8 +22,8 @@ Required
 --------
 
 * PHP needs to be a minimum version of PHP 5.3.9
-* JSON needs to be enabled
-* ctype needs to be enabled
+* `JSON extension`_ needs to be enabled
+* `ctype extension`_ needs to be enabled
 * Your ``php.ini`` needs to have the ``date.timezone`` setting
 
 .. caution::
@@ -57,3 +57,5 @@ you need to have the PDO driver installed for the database server you want
 to use.
 
 .. _`Requirements section of the README`: https://github.com/symfony/symfony/blob/2.7/README.md#requirements
+.. _`JSON extension`: http://php.net/manual/book.json.php
+.. _`ctype extension`: http://php.net/manual/book.ctype.php


### PR DESCRIPTION
On: http://symfony.com/doc/2.7/reference/requirements.html#required

I found “*JSON needs to be enabled*” and “*ctype needs to be enabled*” ambiguous, the first may be misinterpreted as a browser need and the second as a C dependency.

I added “*extension*” and links to the official PHP documentation.

After the update, these items will look like this:

> - [JSON extension](http://php.net/manual/book.json.php) needs to be enabled
> - [ctype extension](http://php.net/manual/book.ctype.php) needs to be enabled