### PR TITLE
Replace array with null

### DIFF
--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -188,7 +188,7 @@ into the client constructor::
     $cookieJar = new Cookie('flavor', 'chocolate', strtotime('+1 day'));
 
     // create a client and set the cookies
-    $client = new Client(array(), array(), $cookieJar);
+    $client = new Client(array(), null, $cookieJar);
     // ...
 
 History


### PR DESCRIPTION
Argument 2 passed to Symfony\Component\BrowserKit\Client::__construct() must be an instance of Symfony\Component\BrowserKit\History or null, array given