### PR TITLE
Added a caution note about the LDAP injection attacks

### DIFF
--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -167,6 +167,13 @@ use the ``ldap`` user provider.
             ),
         );
 
+.. caution::
+
+    The Security component escapes values provided when binding against an LDAP
+    server (likewise for the user provider). However, the LDAP component does
+    not provide any other escaping, so it's your responsibility to prevent
+    the LDAP injection attacks.
+
 The ``ldap`` user provider supports many different configuration options:
 
 service


### PR DESCRIPTION
After reading [this comment](https://github.com/symfony/symfony-docs/issues/6795#issuecomment-248075845) by @csarrazi I'm not sure which protection does the LDAP component offer and which one it doesn't ... so please, review this carefully. Thanks!