### PR TITLE
Update 'ide' example in framework.rst

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -214,14 +214,14 @@ ide
 Symfony turns file paths seen in variable dumps and exception messages into
 links that open those files right inside your browser. If you prefer to open
 those files in your favorite IDE or text editor, set this option to any of the
-following values: ``phpstorm``, ``phpstorm-mac``, ``sublime``,
+following values: ``phpstorm``, ``phpstorm-core``, ``sublime``,
 ``textmate``, ``macvim`` and ``emacs``.
 
 .. note::
 
     The ``phpstorm`` option requires `PhpStormProtocol`_ for Windows,
     or `phpstorm-url-handler`_ for Linux.  PhpStorm for the Mac provides
-    built-in support for the ``phpstorm-mac`` option.
+    built-in support for the ``phpstorm-core`` option.
 
 If you use another editor, the expected configuration value is a URL template
 that contains an ``%f`` placeholder where the file path is expected and ``%l``

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -214,14 +214,14 @@ ide
 Symfony turns file paths seen in variable dumps and exception messages into
 links that open those files right inside your browser. If you prefer to open
 those files in your favorite IDE or text editor, set this option to any of the
-following values: ``phpstorm``, ``phpstorm-core``, ``sublime``,
+following values: ``phpstorm``, ``phpstorm-protocol``, ``sublime``,
 ``textmate``, ``macvim`` and ``emacs``.
 
 .. note::
 
-    The ``phpstorm`` option requires `PhpStormProtocol`_ for Windows,
-    or `phpstorm-url-handler`_ for Linux.  PhpStorm for the Mac provides
-    built-in support for the ``phpstorm-core`` option.
+    PhpStorm for the Mac provides built-in support for the ``phpstorm`` option.
+    The ``phpstorm-protocol`` option requires `PhpStormProtocol`_ for Windows,
+    or `phpstorm-url-handler`_ for Linux.
 
 If you use another editor, the expected configuration value is a URL template
 that contains an ``%f`` placeholder where the file path is expected and ``%l``

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -214,13 +214,14 @@ ide
 Symfony turns file paths seen in variable dumps and exception messages into
 links that open those files right inside your browser. If you prefer to open
 those files in your favorite IDE or text editor, set this option to any of the
-following values: ``phpstorm``, ``sublime``,
+following values: ``phpstorm``, ``phpstorm-mac``, ``sublime``,
 ``textmate``, ``macvim`` and ``emacs``.
 
 .. note::
 
-    PhpStorm for the Mac provides built-in support for the ``phpstorm`` protocol.
-    Windows requires `PhpStormProtocol`_.  Linux requires `phpstorm-url-handler`_.
+    The ``phpstorm`` option requires `PhpStormProtocol`_ for Windows,
+    or `phpstorm-url-handler`_ for Linux.  PhpStorm for the Mac provides
+    built-in support for the ``phpstorm-mac`` option.
 
 If you use another editor, the expected configuration value is a URL template
 that contains an ``%f`` placeholder where the file path is expected and ``%l``

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -214,14 +214,14 @@ ide
 Symfony turns file paths seen in variable dumps and exception messages into
 links that open those files right inside your browser. If you prefer to open
 those files in your favorite IDE or text editor, set this option to any of the
-following values: ``phpstorm``, ``phpstorm-protocol``, ``sublime``,
+following values: ``phpstorm``, ``sublime``,
 ``textmate``, ``macvim`` and ``emacs``.
 
 .. note::
 
-    PhpStorm for the Mac provides built-in support for the ``phpstorm`` option.
-    The ``phpstorm-protocol`` option requires `PhpStormProtocol`_ for Windows,
-    or `phpstorm-url-handler`_ for Linux.
+    The ``phpstorm`` option is supported natively by PhpStorm on MacOS,
+    Windows requires `PhpStormProtocol`_,
+    and Linux requires `phpstorm-url-handler`_.
 
 If you use another editor, the expected configuration value is a URL template
 that contains an ``%f`` placeholder where the file path is expected and ``%l``

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -214,8 +214,7 @@ ide
 Symfony turns file paths seen in variable dumps and exception messages into
 links that open those files right inside your browser. If you prefer to open
 those files in your favorite IDE or text editor, set this option to any of the
-following values: ``phpstorm``, ``sublime``,
-``textmate``, ``macvim`` and ``emacs``.
+following values: ``phpstorm``, ``sublime``, ``textmate``, ``macvim`` and ``emacs``.
 
 .. note::
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -214,8 +214,13 @@ ide
 Symfony turns file paths seen in variable dumps and exception messages into
 links that open those files right inside your browser. If you prefer to open
 those files in your favorite IDE or text editor, set this option to any of the
-following values: ``phpstorm`` (requires `PhpStormProtocol`_), ``sublime``,
+following values: ``phpstorm``, ``sublime``,
 ``textmate``, ``macvim`` and ``emacs``.
+
+.. note::
+
+    PhpStorm for the Mac provides built-in support for the ``phpstorm`` protocol.
+    Windows requires `PhpStormProtocol`_.  Linux requires `phpstorm-url-handler`_.
 
 If you use another editor, the expected configuration value is a URL template
 that contains an ``%f`` placeholder where the file path is expected and ``%l``
@@ -228,7 +233,7 @@ doubling them to prevent Symfony from interpreting them as container parameters)
 
         # app/config/config.yml
         framework:
-            ide: 'phpstorm://open?url=file://%%f&line=%%l'
+            ide: 'myide://open?url=file://%%f&line=%%l'
 
     .. code-block:: xml
 
@@ -240,14 +245,14 @@ doubling them to prevent Symfony from interpreting them as container parameters)
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-            <framework:config ide="phpstorm://open?url=file://%%f&line=%%l" />
+            <framework:config ide="myide://open?url=file://%%f&line=%%l" />
         </container>
 
     .. code-block:: php
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
-            'ide' => 'phpstorm://open?url=file://%%f&line=%%l',
+            'ide' => 'myide://open?url=file://%%f&line=%%l',
         ));
 
 Since every developer uses a different IDE, the recommended way to enable this
@@ -1656,4 +1661,5 @@ Full Default Configuration
 .. _`Doctrine Cache`: http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/caching.html
 .. _`egulias/email-validator`: https://github.com/egulias/EmailValidator
 .. _`PhpStormProtocol`: https://github.com/aik099/PhpStormProtocol
+.. _`phpstorm-url-handler`: https://github.com/sanduhrs/phpstorm-url-handler
 .. _`blue/green deployment`: http://martinfowler.com/bliki/BlueGreenDeployment.html

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -228,7 +228,7 @@ doubling them to prevent Symfony from interpreting them as container parameters)
 
         # app/config/config.yml
         framework:
-            ide: 'phpstorm://open?file=%%f&line=%%l'
+            ide: 'phpstorm://open?url=file://%%f&line=%%l'
 
     .. code-block:: xml
 
@@ -240,14 +240,14 @@ doubling them to prevent Symfony from interpreting them as container parameters)
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-            <framework:config ide="phpstorm://open?file=%%f&line=%%l" />
+            <framework:config ide="phpstorm://open?url=file://%%f&line=%%l" />
         </container>
 
     .. code-block:: php
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
-            'ide' => 'phpstorm://open?file=%%f&line=%%l',
+            'ide' => 'phpstorm://open?url=file://%%f&line=%%l',
         ));
 
 Since every developer uses a different IDE, the recommended way to enable this


### PR DESCRIPTION
The example 'ide' configuration was different from the actual format required for PhpStorm.  See README at https://github.com/aik099/PhpStormProtocol to verify the correct format as 

> phpstorm://open?url=file://%f&line=%l