### PR TITLE
[Email] Add caution related to deprecate mail transport

### DIFF
--- a/email.rst
+++ b/email.rst
@@ -86,6 +86,11 @@ The following configuration attributes are available:
 * ``delivery_addresses`` (an array of email addresses where to send ALL emails)
 * ``disable_delivery`` (set to true to disable delivery completely)
 
+.. caution::
+
+    Starting from Swift Mailer 5.4.5, ``mail`` transport is deprecated. It will be removed 
+    in version 6. Consider using other transport as ``smtp``, ``sendmail`` or ``gmail``.
+
 Sending Emails
 --------------
 


### PR DESCRIPTION
For current stable Symfony standard edition `swiftmailer/swiftmailer` version v5.4.6 is used. Since this one `mail` transport is deprecated. I think it's worth to mentioning this deprecation.

https://github.com/swiftmailer/swiftmailer/issues/866

>User Deprecated: The Swift_Transport_MailTransport class is deprecated since version 5.4.5 and will  be removed in 6.0. Use the Sendmail or SMTP transport instead.