### PR TITLE
Twig Extension does no longer need getName() method

### DIFF
--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -51,11 +51,12 @@ As an example you'll create a price filter to format a given number into price::
         }
     }
 
-.. note::
+.. note::.. note::
  
-    Prior to Twig 1.26, your extension had to provide an additional ``getName`` method that 
-    returned the extension's internal name. When your extension needs to be compatible
-    with Twig versions before 1.26, include this method which is omitted in the example 
+    Prior to Twig 1.26, your extension had to define an additional ``getName()``
+    method that returned a string with the extension's internal name (e.g.
+    ``app.my_extension``). When your extension needs to be compatible with Twig
+    versions before 1.26, include this method which is omitted in the example 
     above.
     
 .. tip::

--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -53,7 +53,7 @@ As an example you'll create a price filter to format a given number into price::
 
 .. note::
  
-    Prior to Twig 1.26, your extension had to provide an additional `getName` method that 
+    Prior to Twig 1.26, your extension had to provide an additional ``getName`` method that 
     returned the extension's internal name. When your extension needs to be compatible
     with Twig versions before 1.26, include this method which is omitted in the example 
     above.

--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -49,13 +49,15 @@ As an example you'll create a price filter to format a given number into price::
 
             return $price;
         }
-
-        public function getName()
-        {
-            return 'app_extension';
-        }
     }
 
+.. note::
+ 
+    Prior to Twig 1.26, your extension had to provide an additional `getName` method that 
+    returned the extension's internal name. When your extension needs to be compatible
+    with Twig versions before 1.26, include this method which is omitted in the example 
+    above.
+    
 .. tip::
 
     Along with custom filters, you can also add custom `functions`_ and register

--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -51,7 +51,7 @@ As an example you'll create a price filter to format a given number into price::
         }
     }
 
-.. note::.. note::
+.. note::
  
     Prior to Twig 1.26, your extension had to define an additional ``getName()``
     method that returned a string with the extension's internal name (e.g.


### PR DESCRIPTION
This has been deprecated as of Twig 1.26, see https://github.com/twigphp/Twig/blob/v1.26.0/CHANGELOG#L7