### PR TITLE
Fix example for isNotModified

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -420,12 +420,12 @@ conditional value specified in the client Request, use the
 :method:`Symfony\\Component\\HttpFoundation\\Response::isNotModified`
 method::
 
-    if ($response->isNotModified($request)) {
+    if (!$response->isNotModified($request)) {
         $response->send();
     }
 
 If the Response is not modified, it sets the status code to 304 and removes the
-actual response content.
+actual response content. If the response *is* modified, the response should be sent.
 
 .. _redirect-response:
 


### PR DESCRIPTION
Response::isNotModified returns true if the content is not modified, and false if the content is modified (that is, not not modified). Accordingly, the test for whether the response should be sent needs to be changed. It's an unfortunate double-negative, but the existing example was wrong.