### PR TITLE
Update event_dispatcher.rst for consistency

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -135,7 +135,7 @@ A call to the dispatcher's ``addListener()`` method associates any valid
 PHP callable to an event::
 
     $listener = new AcmeListener();
-    $dispatcher->addListener('acme.action', array($listener, 'onFooAction'));
+    $dispatcher->addListener('foo.action', array($listener, 'onFooAction'));
 
 The ``addListener()`` method takes up to three arguments:
 

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -135,7 +135,7 @@ A call to the dispatcher's ``addListener()`` method associates any valid
 PHP callable to an event::
 
     $listener = new AcmeListener();
-    $dispatcher->addListener('foo.action', array($listener, 'onFooAction'));
+    $dispatcher->addListener('acme.foo.action', array($listener, 'onFooAction'));
 
 The ``addListener()`` method takes up to three arguments:
 
@@ -161,12 +161,12 @@ The ``addListener()`` method takes up to three arguments:
 
         use Symfony\Component\EventDispatcher\Event;
 
-        $dispatcher->addListener('foo.action', function (Event $event) {
-            // will be executed when the foo.action event is dispatched
+        $dispatcher->addListener('acme.foo.action', function (Event $event) {
+            // will be executed when the acme.foo.action event is dispatched
         });
 
 Once a listener is registered with the dispatcher, it waits until the event
-is notified. In the above example, when the ``foo.action`` event is dispatched,
+is notified. In the above example, when the ``acme.foo.action`` event is dispatched,
 the dispatcher calls the ``AcmeListener::onFooAction()`` method and passes
 the ``Event`` object as the single argument::
 
@@ -216,7 +216,7 @@ determine which instance is passed.
         // register your event listener service
         $listener = new Definition(\AcmeListener::class);
         $listener->addTag('kernel.event_listener', array(
-            'event' => 'foo.action',
+            'event' => 'acme.foo.action',
             'method' => 'onFooAction',
         ));
         $containerBuilder->setDefinition('listener_service_id', $listener);


### PR DESCRIPTION
Improve event naming for example consistency with the what appends next.

The event is initially named `foo.action` that break the consistency with the lines 164 and 169 of the document.