### PR TITLE
Fixed the way flash messages are retrieved in the template

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -427,14 +427,14 @@ read any flash messages from the session:
         {# app/Resources/views/base.html.twig #}
 
         {# you can read and display just one flash message type... #}
-        {% for flash_message in app.session.flash('notice') %}
+        {% for flash_message in app.session.flashBag.get('notice') %}
             <div class="flash-notice">
                 {{ flash_message }}
             </div>
         {% endfor %}
 
         {# ...or you can read and display every flash message available #}
-        {% for type, flash_messages in app.session.flashes %}
+        {% for type, flash_messages in app.session.flashBag.all %}
             {% for flash_message in flash_messages %}
                 <div class="flash-{{ type }}">
                     {{ flash_message }}


### PR DESCRIPTION
In #7432 I changed the code of the templates to get the flash messages. I don't know why I did that ... because it's completely wrong 😵

In #7555 @lerox pointed this issue and I can confirm it:

![symfony_error](https://cloud.githubusercontent.com/assets/73419/23469257/6e423134-fea3-11e6-8d08-e56b01839404.png)

So, let's revert it.