### PR TITLE
Removed tip that was meant for the 2.x versions

### DIFF
--- a/controller/service.rst
+++ b/controller/service.rst
@@ -336,12 +336,6 @@ controller:
 
         return new StreamedResponse($callback);
 
-.. tip::
-
-    ``getRequest()`` has been deprecated. Instead, have an argument to your
-    controller action method called ``Request $request``. The order of the
-    parameters is not important, but the typehint must be provided.
-
 .. _`Controller class source code`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
 .. _`base Controller class`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
 .. _`FrameworkExtraBundle documentation`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/routing.html#controller-as-service


### PR DESCRIPTION
`getRequest()` was removed from the Controller class back in 3.0 already. I could not find a reference on this page to `getRequest` either way so I think it's safe to remove this tip completely.