### PR TITLE
Add views example to MicroKernelTrait description

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -276,6 +276,18 @@ Template files should live in the ``Resources/views`` directory of whatever dire
 your *kernel* lives in. Since ``AppKernel`` lives in ``app/``, this template lives
 at ``app/Resources/views/micro/random.html.twig``.
 
+.. code-block:: html+twig
+
+    <!DOCTYPE html>
+    <html>
+        <head>
+            <title>Random action</title>
+        </head>
+        <body>
+            <p>{{ number }}</p>
+        </body>
+    </html>
+
 Finally, you need a front controller to boot and run the application. Create a
 ``web/index.php``::
 
@@ -305,7 +317,6 @@ this:
     │  ├─ logs/
     │  └─ Resources
     |     └─ views
-    |        ├─ base.html.twig
     |        └─ micro
     |           └─ random.html.twig
     ├─ src/


### PR DESCRIPTION
PR after [issue #7348](https://github.com/symfony/symfony-docs/issues/7348) reported by @olberger.
To make [Building your own Framework with the MicroKernelTrait](http://symfony.com/doc/current/configuration/micro_kernel_trait.html) fully described mentioned `base.html.twig` and `micro/random.html.twig` should be presented.