### PR TITLE
Update console dialog helper documentation

### DIFF
--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -142,10 +142,13 @@ in the console, so it is a good practice to put some useful information in it. T
 function should also return the value of the user's input if the validation was successful.
 
 You can set the max number of times to ask in the ``$attempts`` argument.
-If you reach this max number it will use the default value.
 Using ``false`` means the amount of attempts is infinite.
 The user will be asked as long as they provide an invalid answer and will only
 be able to proceed if their input is valid.
+
+Each time the user is asked the question, if no answer is supplied, the default one is used
+and it's validated using the ``$validator`` callback.
+If the validator throws an exception on the last attempt, the exception is displayed to the user.
 
 Validating a Hidden Response
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -146,9 +146,10 @@ Using ``false`` means the amount of attempts is infinite.
 The user will be asked as long as they provide an invalid answer and will only
 be able to proceed if their input is valid.
 
-Each time the user is asked the question, if no answer is supplied, the default one is used
-and it's validated using the ``$validator`` callback.
-If the validator throws an exception on the last attempt, the exception is displayed to the user.
+Each time the user is asked the question, if no answer is supplied, the default
+one is used (and validated with the ``$validator`` callback) and the remaining
+number of attempts is displayed. If the last attempt is reached, the application
+throws an exception and ends its execution.
 
 Validating a Hidden Response
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`If you reach this max number it will use the default value.` is not always true, on the last attempt we can supply an answer and the default one is not used

Actually the default answer is used each time the user is asked the question if the user didn't specify any answer and it's validated using the `validator` callback 