### PR TITLE
Update dynamic_form_modification.rst

### DIFF
--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -307,7 +307,7 @@ and fill in the listener logic::
 
                     $formOptions = array(
                         'class'         => User::class,
-                        'property'      => 'fullName',
+                        'choice_label'  => 'fullName',
                         'query_builder' => function (EntityRepository $er) use ($user) {
                             // build a custom query
                             // return $er->createQueryBuilder('u')->addOrderBy('fullName', 'DESC');


### PR DESCRIPTION
Option 'property' is deprecated since 2.7 in favor of 'choice_label'
http://symfony.com/doc/2.7/reference/forms/types/entity.html#choice-label