### PR TITLE
Update parent_services for tip consistency

### DIFF
--- a/service_container/parent_services.rst
+++ b/service_container/parent_services.rst
@@ -31,7 +31,7 @@ you may have multiple repository classes which need the
         // ...
     }
 
-Your child service class may look like::
+Your child service classes may look like::
 
     // src/AppBundle/Repository/DoctrineUserRepository.php
     namespace AppBundle\Repository;

--- a/service_container/parent_services.rst
+++ b/service_container/parent_services.rst
@@ -31,7 +31,7 @@ you may have multiple repository classes which need the
         // ...
     }
 
-Your childs service class may look like::
+Your child service class may look like::
 
     // src/AppBundle/Repository/DoctrineUserRepository.php
     namespace AppBundle\Repository;

--- a/service_container/parent_services.rst
+++ b/service_container/parent_services.rst
@@ -31,6 +31,30 @@ you may have multiple repository classes which need the
         // ...
     }
 
+Your childs service class may look like::
+
+    // src/AppBundle/Repository/DoctrineUserRepository.php
+    namespace AppBundle\Repository;
+    
+    use AppBundle\Repository\BaseDoctrineRepository
+
+    // ...
+    class DoctrineUserRepository extends BaseDoctrineRepository
+    {
+        // ...
+    }
+    
+    // src/AppBundle/Repository/DoctrinePostRepository.php
+    namespace AppBundle\Repository;
+    
+    use AppBundle\Repository\BaseDoctrineRepository
+
+    // ...
+    class DoctrinePostRepository extends BaseDoctrineRepository
+    {
+        // ...
+    }
+
 Just as you use PHP inheritance to avoid duplication in your PHP code, the
 service container allows you to extend parent services in order to avoid
 duplicated service definitions:


### PR DESCRIPTION
Currently the first page tip explain that the created service class extends the BaseDoctrineRepository but it is not represented by the code samples. Simply adding class declaration example for tip consistency and user reading improvement.