### PR TITLE
Added note about using the Validator TypeTestCase in form unit testing

### DIFF
--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -158,7 +158,7 @@ before creating the parent form using the ``PreloadedExtension`` class::
     testing but to its children.
 
 Forms Using Validation
-------------------------------------
+----------------------
 
 If your forms uses the ``invalid_message`` or ``constraints`` option for validation, you need to
 register the validation extension which provides this options.

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -124,7 +124,7 @@ To create your form correctly, you need to make the type available to the
 form factory in your test. The easiest way is to register it manually
 before creating the parent form using the ``PreloadedExtension`` class::
 
-    // src/AppBundle/Tests/Form/Type/TestedTypeTests.php
+    // src/AppBundle/Tests/Form/Type/TestedTypeTest.php
     namespace AppBundle\Tests\Form\Type;
 
     use AppBundle\Form\Type\TestedType;
@@ -167,7 +167,7 @@ In order to have these options registered, your test needs to extend the
 :class:`Symfony\\Component\\Form\\Tests\\Extension\\Validator\\Type\\TypeTestCase`
 class::
 
-    // tests/AppBundle/Form/Type/TestedTypeTests.php
+    // tests/AppBundle/Form/Type/TestedTypeTest.php
     namespace Tests\AppBundle\Form\Type;
 
     use Symfony\Component\Form\Tests\Extension\Validator\Type\TypeTestCase;
@@ -188,7 +188,7 @@ will be raised if you try to test a class that depends on other extensions.
 The :method:`Symfony\\Component\\Form\\Test\\TypeTestCase::getExtensions` method
 allows you to return a list of extensions to register::
 
-    // src/AppBundle/Tests/Form/Type/TestedTypeTests.php
+    // src/AppBundle/Tests/Form/Type/TestedTypeTest.php
     namespace AppBundle\Tests\Form\Type;
 
     use AppBundle\Form\Type\TestedType;
@@ -215,16 +215,13 @@ allows you to return a list of extensions to register::
         // ... your tests
     }
 
-It is also possible to load custom form types, form type extensions or type guessers using the
-``getTypedExtensions``, ``getTypes`` and ``getTypeGuessers`` methods.
-
 Testing against Different Sets of Data
 --------------------------------------
 
 If you are not familiar yet with PHPUnit's `data providers`_, this might be
 a good opportunity to use them::
 
-    // src/AppBundle/Tests/Form/Type/TestedTypeTests.php
+    // src/AppBundle/Tests/Form/Type/TestedTypeTest.php
     namespace AppBundle\Tests\Form\Type;
 
     use AppBundle\Form\Type\TestedType;

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -157,24 +157,6 @@ before creating the parent form using the ``PreloadedExtension`` class::
     be getting errors that are not related to the form you are currently
     testing but to its children.
 
-Forms Using Validation
-----------------------
-
-If your form uses the ``invalid_message`` or ``constraints`` option for validation, you need to
-register the validation extension which provides these options.
-Luckily Symfony provides a base test class which takes care of it, just extend
-``Symfony\Component\Form\Tests\Extension\Validator\Type\TypeTestCase``::
-
-    // tests/AppBundle/Form/Type/TestedTypeTest.php
-    namespace Tests\AppBundle\Form\Type;
-
-    use Symfony\Component\Form\Tests\Extension\Validator\Type\TypeTestCase;
-
-    class TestedTypeTest extends TypeTestCase
-    {
-        // ...
-    }
-
 Adding Custom Extensions
 ------------------------
 

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -157,12 +157,31 @@ before creating the parent form using the ``PreloadedExtension`` class::
     be getting errors that are not related to the form you are currently
     testing but to its children.
 
+Forms Using Validation
+------------------------------------
+
+If your forms uses the ``invalid_message`` or ``constraints`` option for validation, you need to
+register the validation extension which provides this options.
+Luckily Symfony provides a custom test class which does this for you.
+In order to have this option registered, your test needs to extend from the
+:class:`Symfony\\Component\\Form\\Tests\\Extension\\Validator\\Type\\TypeTestCase`
+class::
+
+    // tests/AppBundle/Form/Type/TestedTypeTests.php
+    namespace Tests\AppBundle\Form\Type;
+
+    use Symfony\Component\Form\Tests\Extension\Validator\Type\TypeTestCase;
+
+    class TestedTypeTest extends TypeTestCase
+    {
+        // ...
+    }
+
 Adding Custom Extensions
 ------------------------
 
 It often happens that you use some options that are added by
-:doc:`form extensions </form/create_form_type_extension>`. One of the
-cases may be the ``ValidatorExtension`` with its ``invalid_message`` option.
+:doc:`form extensions </form/create_form_type_extension>`.
 The ``TypeTestCase`` only loads the core form extension, which means an
 :class:`Symfony\\Component\\OptionsResolver\\Exception\\InvalidOptionsException`
 will be raised if you try to test a class that depends on other extensions.
@@ -173,36 +192,31 @@ allows you to return a list of extensions to register::
     namespace AppBundle\Tests\Form\Type;
 
     use AppBundle\Form\Type\TestedType;
-    use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
     use Symfony\Component\Form\Form;
     use Symfony\Component\Form\Forms;
     use Symfony\Component\Form\FormBuilder;
     use Symfony\Component\Form\Test\TypeTestCase;
-    use Symfony\Component\Validator\ConstraintViolationList;
     use Symfony\Component\Validator\Mapping\ClassMetadata;
-    use Symfony\Component\Validator\Validator\ValidatorInterface;
 
     class TestedTypeTest extends TypeTestCase
     {
         protected function getExtensions()
         {
-            $validator = $this->createMock(ValidatorInterface::class);
             // use getMock() on PHPUnit 5.3 or below
             // $validator = $this->getMock(ValidatorInterface::class);
             $validator
-                ->method('validate')
-                ->will($this->returnValue(new ConstraintViolationList()));
-            $validator
                 ->method('getMetadataFor')
                 ->will($this->returnValue(new ClassMetadata(Form::class)));
-
             return array(
-                new ValidatorExtension($validator),
+                new MyFormExtension(),
             );
         }
 
         // ... your tests
     }
+
+It is also possible to load custom form types, form type extensions or type guessers using the
+``getTypedExtensions``, ``getTypes`` and ``getTypeGuessers`` methods.
 
 Testing against Different Sets of Data
 --------------------------------------

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -163,7 +163,7 @@ Forms Using Validation
 If your forms uses the ``invalid_message`` or ``constraints`` option for validation, you need to
 register the validation extension which provides this options.
 Luckily Symfony provides a custom test class which does this for you.
-In order to have this option registered, your test needs to extend from the
+In order to have these options registered, your test needs to extend the
 :class:`Symfony\\Component\\Form\\Tests\\Extension\\Validator\\Type\\TypeTestCase`
 class::
 

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -160,11 +160,10 @@ before creating the parent form using the ``PreloadedExtension`` class::
 Forms Using Validation
 ----------------------
 
-If your forms uses the ``invalid_message`` or ``constraints`` option for validation, you need to
-register the validation extension which provides this options.
-Luckily Symfony provides a custom test class which does this for you.
-In order to have these options registered, your test needs to extend the
-:class:`Symfony\\Component\\Form\\Tests\\Extension\\Validator\\Type\\TypeTestCase`
+If your form uses the ``invalid_message`` or ``constraints`` option for validation, you need to
+register the validation extension which provides these options.
+Luckily Symfony provides a base test class which takes care of it, just extend
+``Symfony\Component\Form\Tests\Extension\Validator\Type\TypeTestCase``
 class::
 
     // tests/AppBundle/Form/Type/TestedTypeTest.php

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -163,8 +163,7 @@ Forms Using Validation
 If your form uses the ``invalid_message`` or ``constraints`` option for validation, you need to
 register the validation extension which provides these options.
 Luckily Symfony provides a base test class which takes care of it, just extend
-``Symfony\Component\Form\Tests\Extension\Validator\Type\TypeTestCase``
-class::
+``Symfony\Component\Form\Tests\Extension\Validator\Type\TypeTestCase``::
 
     // tests/AppBundle/Form/Type/TestedTypeTest.php
     namespace Tests\AppBundle\Form\Type;

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -195,6 +195,7 @@ allows you to return a list of extensions to register::
             $validator
                 ->method('getMetadataFor')
                 ->will($this->returnValue(new ClassMetadata(Form::class)));
+
             return array(
                 new ValidatorExtension($validator),
             );

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -161,7 +161,8 @@ Adding Custom Extensions
 ------------------------
 
 It often happens that you use some options that are added by
-:doc:`form extensions </form/create_form_type_extension>`.
+:doc:`form extensions </form/create_form_type_extension>`. One of the
+cases may be the ``ValidatorExtension`` with its ``invalid_message`` option.
 The ``TypeTestCase`` only loads the core form extension, which means an
 :class:`Symfony\\Component\\OptionsResolver\\Exception\\InvalidOptionsException`
 will be raised if you try to test a class that depends on other extensions.
@@ -172,23 +173,30 @@ allows you to return a list of extensions to register::
     namespace AppBundle\Tests\Form\Type;
 
     use AppBundle\Form\Type\TestedType;
+    use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
     use Symfony\Component\Form\Form;
     use Symfony\Component\Form\Forms;
     use Symfony\Component\Form\FormBuilder;
     use Symfony\Component\Form\Test\TypeTestCase;
+    use Symfony\Component\Validator\ConstraintViolationList;
     use Symfony\Component\Validator\Mapping\ClassMetadata;
+    use Symfony\Component\Validator\Validator\ValidatorInterface;
 
     class TestedTypeTest extends TypeTestCase
     {
         protected function getExtensions()
         {
+            $validator = $this->createMock(ValidatorInterface::class);
             // use getMock() on PHPUnit 5.3 or below
             // $validator = $this->getMock(ValidatorInterface::class);
+            $validator
+                ->method('validate')
+                ->will($this->returnValue(new ConstraintViolationList()));
             $validator
                 ->method('getMetadataFor')
                 ->will($this->returnValue(new ClassMetadata(Form::class)));
             return array(
-                new MyFormExtension(),
+                new ValidatorExtension($validator),
             );
         }
 


### PR DESCRIPTION
This update ads the usage of the validator TypeTestCase class to use for testing when validation is required.