### PR TITLE
Fix build documentation for Windows environments

### DIFF
--- a/_build/make.bat
+++ b/_build/make.bat
@@ -5,8 +5,8 @@ REM Command file for Sphinx documentation
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
-set BUILDDIR=_build
-set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
+set BUILDDIR=.
+set ALLSPHINXOPTS=-c %BUILDDIR% -d %BUILDDIR%/doctrees %SPHINXOPTS% ..
 set I18NSPHINXOPTS=%SPHINXOPTS% .
 if NOT "%PAPER%" == "" (
 	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -279,12 +279,8 @@ purposes following these steps:
 
    .. code-block:: terminal
 
-       # Linux and macOS
        $ cd _build/
        $ make html
-
-       # Windows
-       $ _build\make html
 
 The generated documentation is available in the ``_build/html`` directory.
 


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/7548 Now there should be no differences between environments when we build the documentation locally.