### PR TITLE
Update bundles directory structure

### DIFF
--- a/bundles.rst
+++ b/bundles.rst
@@ -143,7 +143,7 @@ between all Symfony bundles. Take a look at AcmeDemoBundle, as it contains some
 of the most common elements of a bundle:
 
 ``Controller/``
-    Contains the controllers of the bundle (e.g. ``RandomController.php``).
+    Contains the controllers of the bundle (e.g. ``HelloController.php``).
 
 ``DependencyInjection/``
     Holds certain Dependency Injection Extension classes, which may import service


### PR DESCRIPTION
In directory structure we have 

```
Resources/views/
Holds templates organized by controller name (e.g. Hello/index.html.twig).
```

In my opinion it would be more consistent to connect this controller name also in the first element in list "Controller".