### PR TITLE
Improve specification explanation

### DIFF
--- a/http_cache/expiration.rst
+++ b/http_cache/expiration.rst
@@ -88,7 +88,7 @@ servers should not send ``Expires`` dates more than one year in the future."
 .. note::
 
     Accordingly with `RFC 7234 - Caching`_, the ``Expires`` header value is
-    ignored when a ``s-max-age`` or ``max-age`` directives are defined.
+    ignored when ``s-max-age`` or ``max-age`` directives are defined.
 
 
 .. _`expiration model`: http://tools.ietf.org/html/rfc2616#section-13.2

--- a/http_cache/expiration.rst
+++ b/http_cache/expiration.rst
@@ -88,9 +88,9 @@ servers should not send ``Expires`` dates more than one year in the future."
 .. note::
 
     Accordingly with `RFC 7234 - Caching`_, the ``Expires`` header value is
-    ignored when a ``s-max-age`` or ``max-age`` header is defined.
+    ignored when a ``s-max-age`` or ``max-age`` directives are defined.
 
 
 .. _`expiration model`: http://tools.ietf.org/html/rfc2616#section-13.2
 .. _`FrameworkExtraBundle documentation`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/cache.html
-.. _`RFC 7234 - Caching`: https://tools.ietf.org/html/rfc7234
+.. _`RFC 7234 - Caching`: https://tools.ietf.org/html/rfc7234#section-5.2

--- a/http_cache/expiration.rst
+++ b/http_cache/expiration.rst
@@ -93,4 +93,4 @@ servers should not send ``Expires`` dates more than one year in the future."
 
 .. _`expiration model`: http://tools.ietf.org/html/rfc2616#section-13.2
 .. _`FrameworkExtraBundle documentation`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/cache.html
-.. _`RFC 7234 - Caching`: https://tools.ietf.org/html/rfc7234#section-5.2
+.. _`RFC 7234 - Caching`: https://tools.ietf.org/html/rfc7234#section-4.2.1

--- a/http_cache/expiration.rst
+++ b/http_cache/expiration.rst
@@ -88,7 +88,7 @@ servers should not send ``Expires`` dates more than one year in the future."
 .. note::
 
     Accordingly with `RFC 7234 - Caching`_, the ``Expires`` header value is
-    ignored when ``s-max-age`` or ``max-age`` directives are defined.
+    ignored when ``s-maxage`` or ``max-age`` directives are defined.
 
 
 .. _`expiration model`: http://tools.ietf.org/html/rfc2616#section-13.2

--- a/http_cache/expiration.rst
+++ b/http_cache/expiration.rst
@@ -87,7 +87,8 @@ servers should not send ``Expires`` dates more than one year in the future."
 
 .. note::
 
-    Accordingly with `RFC 7234 - Caching`_, the `Expires` header value will be ignored by any recipient if a `s-max-age` or `max-age` header is defined.
+    Accordingly with `RFC 7234 - Caching`_, the ``Expires`` header value is
+    ignored when a ``s-max-age`` or ``max-age`` header is defined.
 
 
 .. _`expiration model`: http://tools.ietf.org/html/rfc2616#section-13.2

--- a/http_cache/expiration.rst
+++ b/http_cache/expiration.rst
@@ -85,5 +85,11 @@ the lifetime calculation vulnerable to clock skew. Another limitation
 of the ``Expires`` header is that the specification states that "HTTP/1.1
 servers should not send ``Expires`` dates more than one year in the future."
 
+.. note::
+
+    Accordingly with `RFC 7234 - Caching`_, the `Expires` header value will be ignored by any recipient if a `s-max-age` or `max-age` header is defined.
+
+
 .. _`expiration model`: http://tools.ietf.org/html/rfc2616#section-13.2
 .. _`FrameworkExtraBundle documentation`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/cache.html
+.. _`RFC 7234 - Caching`: https://tools.ietf.org/html/rfc7234


### PR DESCRIPTION
RFC 2616 and RFC 7234 define that a recipient MUST ignore Expires header if one of `s-max-age` or `max-age` header is defined.