### PR TITLE
Update locale_sticky_session.rst

### DIFF
--- a/session/locale_sticky_session.rst
+++ b/session/locale_sticky_session.rst
@@ -202,13 +202,14 @@ Then register the listener:
 
         // app/config/services.php
         use AppBundle\EventListener\UserLocaleListener;
+        use Symfony\Component\DependencyInjection\Reference;
 
         $container
             ->register('app.user_locale_listener', UserLocaleListener::class)
-            ->addArgument('session')
+            ->addArgument(new Reference('session'))
             ->addTag(
                 'kernel.event_listener',
-                array('event' => 'security.interactive_login', 'method' => 'onInteractiveLogin'
+                array('event' => 'security.interactive_login', 'method' => 'onInteractiveLogin')
             );
 
 .. caution::


### PR DESCRIPTION
- Add missing parenthesis 
- Fix `addArgument` parameter, it should be a `Reference` object instead of a string