### PR TITLE
Fix typo

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -237,7 +237,7 @@ console::
                 // pass arguments to the helper
                 'username' => 'Wouter',
 
-                // prefix the key with a double slash when passing options,
+                // prefix the key with a double dash when passing options,
                 // e.g: '--some-option' => 'option_value',
             ));
 

--- a/console.rst
+++ b/console.rst
@@ -237,7 +237,7 @@ console::
                 // pass arguments to the helper
                 'username' => 'Wouter',
 
-                // prefix the key with a double dash when passing options,
+                // prefix the key with two dashes when passing options,
                 // e.g: '--some-option' => 'option_value',
             ));
 


### PR DESCRIPTION
The docs says the option must be prefixed with a "double slash" (`//`) when it should be "double dash" `--`.