### PR TITLE
Fix some odd English in the PDOSessionHandler docs

### DIFF
--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -245,6 +245,6 @@ Microsoft SQL Server
     If the application stores large amounts of session data, this problem can
     be solved by increasing the column size (use ``BLOB`` or even ``MEDIUMBLOB``).
     When using MySQL as the database engine, you can also enable the `strict SQL mode`_
-    to get noticed when such an error happens.
+    to be notified when such an error happens.
 
 .. _`strict SQL mode`: https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html


### PR DESCRIPTION
Spotted this whilst looking at the PDOSessionHandler docs today, thought I would throw a patch your way.

Not sure if the existing wording is meant to imply that this throws an actual PHP Notice, if so "trigger a PHP Notice" might be better, but went for the basic fix here.

I think I'm meant to submit this against the oldest maintained branch, but following the guidelines for a "simple patch"  (https://symfony.com/doc/current/contributing/documentation/overview.html#fast-online-contributions) brought me here. Let me know how I can go about re-targeting this and fixing the conflicts if I need to.