### PR TITLE
Link to Composer's article about class loading optimizations

### DIFF
--- a/components/class_loader/cache_class_loader.rst
+++ b/components/class_loader/cache_class_loader.rst
@@ -9,6 +9,7 @@ Cache a Class Loader
 ====================
 
 The ``ApcClassLoader``, the ``WinCacheClassLoader`` and the ``XcacheClassLoader``
-are deprecated since Symfony 3.3. Use the ``--optimize`` and ``--apcu-autoloader``
-options instead when dumping the autoloader using the ``composer dump-autoload``
-command.
+are deprecated since Symfony 3.3. As an alternative, use any of the
+`class loading optimizations`_ provided by Composer.
+
+.. _`class loading optimizations`: https://getcomposer.org/doc/articles/autoloader-optimization.md


### PR DESCRIPTION
This makes this article --> https://symfony.com/doc/master/components/class_loader/cache_class_loader.html  similar to this one --> https://symfony.com/doc/master/components/class_loader.html  and reduces the doc to maintain for us because we just link to the reference article published by Composer.