### PR TITLE
Add the `_failure_path` hidden field in template

### DIFF
--- a/security/form_login.rst
+++ b/security/form_login.rst
@@ -343,8 +343,8 @@ The name of the hidden fields in the login form is also configurable using the
                 main:
                     # ...
                     form_login:
-                        target_path_parameter: redirect_url
-                        failure_path_parameter: redirect_url
+                        target_path_parameter: login_success
+                        failure_path_parameter: login_fail
 
     .. code-block:: xml
 
@@ -361,8 +361,8 @@ The name of the hidden fields in the login form is also configurable using the
 
                 <firewall name="main">
                     <!-- ... -->
-                    <form-login target-path-parameter="redirect_url" />
-                    <form-login failure-path-parameter="redirect_url" />
+                    <form-login target-path-parameter="login_success" />
+                    <form-login failure-path-parameter="login_fail" />
                 </firewall>
             </config>
         </srv:container>
@@ -377,8 +377,8 @@ The name of the hidden fields in the login form is also configurable using the
                 'main' => array(
                     // ...
                     'form_login' => array(
-                        'target_path_parameter' => 'redirect_url',
-                        'failure_path_parameter' => 'redirect_url',
+                        'target_path_parameter' => 'login_success',
+                        'failure_path_parameter' => 'login_fail',
                     ),
                 ),
             ),

--- a/security/form_login.rst
+++ b/security/form_login.rst
@@ -218,108 +218,6 @@ this by setting ``use_referer`` to true (it defaults to false):
             ),
         ));
 
-Control the Redirect URL from inside the Form
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can also override where the user is redirected to via the form itself by
-including a hidden field with the name ``_target_path``. For example, to
-redirect to the URL defined by some ``account`` route, use the following:
-
-.. configuration-block::
-
-    .. code-block:: html+twig
-
-        {# src/AppBundle/Resources/views/Security/login.html.twig #}
-        {% if error %}
-            <div>{{ error.message }}</div>
-        {% endif %}
-
-        <form action="{{ path('login') }}" method="post">
-            <label for="username">Username:</label>
-            <input type="text" id="username" name="_username" value="{{ last_username }}" />
-
-            <label for="password">Password:</label>
-            <input type="password" id="password" name="_password" />
-
-            <input type="hidden" name="_target_path" value="account" />
-
-            <input type="submit" name="login" />
-        </form>
-
-    .. code-block:: html+php
-
-        <!-- src/AppBundle/Resources/views/Security/login.html.php -->
-        <?php if ($error): ?>
-            <div><?php echo $error->getMessage() ?></div>
-        <?php endif ?>
-
-        <form action="<?php echo $view['router']->generate('login') ?>" method="post">
-            <label for="username">Username:</label>
-            <input type="text" id="username" name="_username" value="<?php echo $last_username ?>" />
-
-            <label for="password">Password:</label>
-            <input type="password" id="password" name="_password" />
-
-            <input type="hidden" name="_target_path" value="account" />
-
-            <input type="submit" name="login" />
-        </form>
-
-Now, the user will be redirected to the value of the hidden form field. The
-value attribute can be a relative path, absolute URL, or a route name. You
-can even change the name of the hidden form field by changing the ``target_path_parameter``
-option to another value.
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # app/config/security.yml
-        security:
-            # ...
-
-            firewalls:
-                main:
-                    # ...
-                    form_login:
-                        target_path_parameter: redirect_url
-
-    .. code-block:: xml
-
-        <!-- app/config/security.xml -->
-        <?xml version="1.0" encoding="UTF-8"?>
-        <srv:container xmlns="http://symfony.com/schema/dic/security"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:srv="http://symfony.com/schema/dic/services"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services
-                http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-            <config>
-                <!-- ... -->
-
-                <firewall name="main">
-                    <!-- ... -->
-                    <form-login target-path-parameter="redirect_url" />
-                </firewall>
-            </config>
-        </srv:container>
-
-    .. code-block:: php
-
-        // app/config/security.php
-        $container->loadFromExtension('security', array(
-            // ...
-
-            'firewalls' => array(
-                'main' => array(
-                    // ...
-                    'form_login' => array(
-                        'target_path_parameter' => 'redirect_url',
-                    ),
-                ),
-            ),
-        ));
-
 Redirecting on Login Failure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -376,6 +274,115 @@ back to the login form itself. You can set this to a different route (e.g.
                     'form_login' => array(
                         // ...
                         'failure_path' => 'login_failure',
+                    ),
+                ),
+            ),
+        ));
+
+Control the Redirect URL from inside the Form
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can also override where the user is redirected to via the form itself by
+including a hidden field with the name ``_target_path`` for success and
+``_failure_path`` for failure. For example, to redirect to the URL defined 
+by some ``account`` route, use the following:
+
+.. configuration-block::
+
+    .. code-block:: html+twig
+
+        {# src/AppBundle/Resources/views/Security/login.html.twig #}
+        {% if error %}
+            <div>{{ error.message }}</div>
+        {% endif %}
+
+        <form action="{{ path('login') }}" method="post">
+            <label for="username">Username:</label>
+            <input type="text" id="username" name="_username" value="{{ last_username }}" />
+
+            <label for="password">Password:</label>
+            <input type="password" id="password" name="_password" />
+
+            <input type="hidden" name="_target_path" value="account" />
+            <input type="hidden" name="_failure_path" value="login" />
+
+            <input type="submit" name="login" />
+        </form>
+
+    .. code-block:: html+php
+
+        <!-- src/AppBundle/Resources/views/Security/login.html.php -->
+        <?php if ($error): ?>
+            <div><?php echo $error->getMessage() ?></div>
+        <?php endif ?>
+
+        <form action="<?php echo $view['router']->path('login') ?>" method="post">
+            <label for="username">Username:</label>
+            <input type="text" id="username" name="_username" value="<?php echo $last_username ?>" />
+
+            <label for="password">Password:</label>
+            <input type="password" id="password" name="_password" />
+
+            <input type="hidden" name="_target_path" value="account" />
+            <input type="hidden" name="_failure_path" value="login" />
+
+            <input type="submit" name="login" />
+        </form>
+
+Now, the user will be redirected to the value of the hidden form field. The
+value attribute can be a relative path, absolute URL, or a route name. 
+You can even change the name of the hidden form field by changing the 
+``target_path_parameter`` and ``failure_path_parameter`` options to another 
+value.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/security.yml
+        security:
+            # ...
+
+            firewalls:
+                main:
+                    # ...
+                    form_login:
+                        target_path_parameter: redirect_url
+                        failure_path_parameter: redirect_url
+
+    .. code-block:: xml
+
+        <!-- app/config/security.xml -->
+        <?xml version="1.0" encoding="UTF-8"?>
+        <srv:container xmlns="http://symfony.com/schema/dic/security"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:srv="http://symfony.com/schema/dic/services"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <config>
+                <!-- ... -->
+
+                <firewall name="main">
+                    <!-- ... -->
+                    <form-login target-path-parameter="redirect_url" />
+                    <form-login failure-path-parameter="redirect_url" />
+                </firewall>
+            </config>
+        </srv:container>
+
+    .. code-block:: php
+
+        // app/config/security.php
+        $container->loadFromExtension('security', array(
+            // ...
+
+            'firewalls' => array(
+                'main' => array(
+                    // ...
+                    'form_login' => array(
+                        'target_path_parameter' => 'redirect_url',
+                        'failure_path_parameter' => 'redirect_url',
                     ),
                 ),
             ),

--- a/security/form_login.rst
+++ b/security/form_login.rst
@@ -221,11 +221,9 @@ this by setting ``use_referer`` to true (it defaults to false):
 Redirecting on Login Failure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In addition to redirecting the user after a successful login, you can also set
-the URL that the user should be redirected to after a failed login (e.g. an
-invalid username or password was submitted). By default, the user is redirected
-back to the login form itself. You can set this to a different route (e.g.
-``login_failure``) with the following config:
+After a failed login (e.g. an invalid username or password was submitted), the
+user is redirected back to the login form itself. Use the ``failure_path``
+option to define the route or URL the user is redirected to:
 
 .. configuration-block::
 
@@ -283,9 +281,8 @@ Control the Redirect URL from inside the Form
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can also override where the user is redirected to via the form itself by
-including a hidden field with the name ``_target_path`` for success and
-``_failure_path`` for failure. For example, to redirect to the URL defined 
-by some ``account`` route, use the following:
+including a hidden field with the name ``_target_path`` for successful logins
+and ``_failure_path`` for login errors:
 
 .. configuration-block::
 
@@ -331,9 +328,8 @@ by some ``account`` route, use the following:
 
 Now, the user will be redirected to the value of the hidden form field. The
 value attribute can be a relative path, absolute URL, or a route name. 
-You can even change the name of the hidden form field by changing the 
-``target_path_parameter`` and ``failure_path_parameter`` options to another 
-value.
+The name of the hidden fields in the login form is also configurable using the
+``target_path_parameter`` and ``failure_path_parameter`` options of the firewall.
 
 .. configuration-block::
 


### PR DESCRIPTION
Today I learnt about this [feature](https://github.com/symfony/symfony/commit/d0057d0e643da62fd05eed01d319ba2df72bcc84) so I guess it was time to document it.

Basically, what we can do with the `_target_path` form field is also possible for failure via the `_failure_path` field. It's very useful when you want multiple login forms for the same firewall (a general login, and a login during e-commerce checkout for example).

I also moved the sections to me more logic, as the last section was about **Redirecting on Login Failure** via the option - because it was not explained yet in the page. This section is now just before the updated **Control the Redirect URL from inside the Form**.