### PR TITLE
Removed any reference to X-Status-Code

### DIFF
--- a/reference/events.rst
+++ b/reference/events.rst
@@ -241,19 +241,8 @@ and set a new ``Exception`` object, or do nothing::
 
 .. note::
 
-    If you want to overwrite the status code (which you should do not without a good
-    reason), set the ``X-Status-Code`` header::
-
-        $response = new Response(
-            'Error',
-            404, // this status code will be ignored
-            array(
-                'X-Status-Code' => 200 // this status code will actually be sent to the client
-            )
-        );
-
-    If you do **not** set the ``X-Status-Code`` header, then Symfony uses the following
-    logic to determine the status code:
+    Symfony uses the following logic to determine the HTTP status code of the
+    response:
 
     * If :method:`Symfony\\Component\\HttpFoundation\\Response::isClientError`,
       :method:`Symfony\\Component\\HttpFoundation\\Response::isServerError` or


### PR DESCRIPTION
Fabien says that end users should NEVER use X-Status-Code (see https://github.com/symfony/symfony/issues/22019), so let's remove any reference to it in the docs ... and let's not document the new way to do it (see http://symfony.com/blog/new-in-symfony-3-3-deprecated-x-status-code).