### PR TITLE
fix list item indentation

### DIFF
--- a/request/load_balancer_reverse_proxy.rst
+++ b/request/load_balancer_reverse_proxy.rst
@@ -84,15 +84,15 @@ In this case, you'll need to - *very carefully* - trust *all* proxies.
    proxies, configure Symfony to *always* trust incoming request. This is
    done inside of your front controller:
 
-.. code-block:: diff
+   .. code-block:: diff
 
-       // web/app.php
+	  // web/app.php
 
-       // ...
-       $request = Request::createFromGlobals();
-       + Request::setTrustedProxies(array('127.0.0.1', $request->server->get('REMOTE_ADDR')));
+	  // ...
+	  $request = Request::createFromGlobals();
+	  + Request::setTrustedProxies(array('127.0.0.1', $request->server->get('REMOTE_ADDR')));
 
-       // ...
+	  // ...
 
 #. Ensure that the trusted_proxies setting in your ``app/config/config.yml``
    is not set or it will overwrite the ``setTrustedProxies()`` call above.


### PR DESCRIPTION
The current indentation of the code block leads to the code example not being treated as part of the list item. Thus, the following item also is treated as the beginning of a new ordered list.

This is how the list does currently look like on [symfony.com]():

<img width="702" alt="bildschirmfoto 2017-03-17 um 16 20 50" src="https://cloud.githubusercontent.com/assets/1957048/24049968/cc9c97c4-0b2d-11e7-92b1-c91d977419ce.png">

And this is the same document with the patch applied:

<img width="698" alt="bildschirmfoto 2017-03-17 um 16 27 07" src="https://cloud.githubusercontent.com/assets/1957048/24050280/a5f80bca-0b2e-11e7-84bb-89d96c6351ad.png">