### PR TITLE
Update hostname_pattern.rst

### DIFF
--- a/routing/hostname_pattern.rst
+++ b/routing/hostname_pattern.rst
@@ -260,8 +260,11 @@ You can also set the host option on imported routes:
 
         use Symfony\Component\Routing\RouteCollection;
 
+        $importedCollection = $loader->import("@AcmeHelloBundle/Resources/config/routing.php");
+        $importedCollection->setHost('hello.example.com');
+        
         $collection = new RouteCollection();
-        $collection->addCollection($loader->import("@AcmeHelloBundle/Resources/config/routing.php"), '', array(), array(), array(), 'hello.example.com');
+        $collection->addCollection($importedCollection);
 
         return $collection;
 


### PR DESCRIPTION
`Symfony\Component\Routing\RouteCollection::addCollection` accepts one argument of type `RouteCollection` that is why
`$collection->addCollection($loader->import("@AcmeHelloBundle/Resources/config/routing.php"), '', array(), array(), array(), 'hello.example.com');` is not correct.