### PR TITLE
Add an explanation about «constraints» validation

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -449,27 +449,33 @@ If you're ever unsure of how to specify an option, either check the API document
 for the constraint or play it safe by always passing in an array of options
 (the first method shown above).
 
-.. index::
-   single: Validation; Constraint targets
+Constraints in Form Classes
+---------------------------
 
-.. _validator-constraint-targets:
-
-Constraint in Form Classes
-------------------
-
-When creating your own form classes, you may want to add constraint directly in the formBuilder.
-This is done by simply adding them as a parameter in your field options::
+Constraints can be defined while building the form via the ``constraints`` option
+of the form fields::
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('myField', TextType::class, ['required' => true, 'constraints' => [new Length(['min' => 3])]])
+            ->add('myField', TextType::class, array(
+                'required' => true,
+                'constraints' => array(new Length(array('min' => 3)))
+            ))
     }
 
-Please note the *constraints* keyword will only be available if you have
-added the *ValidatorExtention* to the formBuilder::
+The ``constraints`` option is only available when adding the ValidatorExtention
+to the formBuilder::
 
-    Forms::createFormFactoryBuilder()->addExtension(new ValidatorExtension(Validation::createValidator()))->getFormFactory();
+    Forms::createFormFactoryBuilder()
+        ->addExtension(new ValidatorExtension(Validation::createValidator()))
+        ->getFormFactory()
+    ;
+
+.. index::
+   single: Validation; Constraint targets
+
+.. _validator-constraint-targets:
 
 Constraint Targets
 ------------------

--- a/validation.rst
+++ b/validation.rst
@@ -454,6 +454,23 @@ for the constraint or play it safe by always passing in an array of options
 
 .. _validator-constraint-targets:
 
+Constraint in Form Classes
+------------------
+
+When creating your own form classes, you may want to add constraint directly in the formBuilder.
+This is done by simply adding them as a parameter in your field options::
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('myField', TextType::class, ['required' => true, 'constraints' => [new Length(['min' => 3])]])
+    }
+
+Please note the *constraints* keyword will only be available if you have
+added the *ValidatorExtention* to the formBuilder::
+
+    Forms::createFormFactoryBuilder()->addExtension(new ValidatorExtension(Validation::createValidator()))->getFormFactory();
+
 Constraint Targets
 ------------------
 


### PR DESCRIPTION
Added an explanation about the use of «constraints» in Form Classes and the requirement of «ValidatorExtension» if «constraints» keyword is used.

This is currently not explained in doc, nor in Forms, Validation, Custom validation or any other page.