### PR TITLE
changed jquery plugin link

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -743,4 +743,4 @@ the relationship between the removed ``Tag`` and ``Task`` object.
 
 .. _`Owning Side and Inverse Side`: http://docs.doctrine-project.org/en/latest/reference/unitofwork-associations.html
 .. _`JSFiddle`: http://jsfiddle.net/847Kf/4/
-.. _`symfony-collection`: https://github.com/ninsuo/symfony-collection
+.. _`symfony-collection`: https://github.com/mktcode/symfony-collection


### PR DESCRIPTION
Just to start a discussion on this plugin....
I tried to use it but due to the fact, that it does not support entity relations (they get mixed up when reordering entries in the collection), it wasn't really useful for me. I think that ordering entities should take place in the database by some "sort" property of the entity. So I added an option to specify a field name for that ordering and therefore I recoded many lines of this plugin in my fork. Unfortunately the author doesn't seem to have that much time to review my changes and merge them but I am confident that my changes really do make sense. So I try to draw some attention.... :)

This is the PR https://github.com/ninsuo/symfony-collection/pull/48