### PR TITLE
Show a simple use of $this->roles in getRoles()

### DIFF
--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -107,7 +107,9 @@ For this entry, suppose that you already have a ``User`` entity inside an
 
         public function getRoles()
         {
-            return array('ROLE_USER');
+            // the $this->roles variable is used to test roles by the Symfony's security system
+            $this->roles = array('ROLE_USER');
+            return $this->roles;
         }
 
         public function eraseCredentials()


### PR DESCRIPTION
I tried to keep it very simple but I think this is important because I spent many times to find this detail.
Before to find this, I customized the getRoles function without understand why my roles wasn't the array returned by the function.