### PR TITLE
Update argument_value_resolver.rst

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -43,7 +43,7 @@ Symfony ships with four value resolvers in the HttpKernel component:
     
 .. note::
     If your argument is a Doctrine Entity you will need to create a 
-    :doc:`param converter </bundles/SensioFrameworkExtraBundle/annotations/converters>`
+    :ref:`param converter <http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html>`
 
 Adding a Custom Value Resolver
 ------------------------------
@@ -90,11 +90,11 @@ retrieved from the token storage::
     // src/AppBundle/ArgumentResolver/UserValueResolver.php
     namespace AppBundle\ArgumentResolver;
 
-    use AppBundle\Entity\User;
     use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
     use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+    use Symfony\Component\Security\Core\User\UserInterface;
 
     class UserValueResolver implements ArgumentValueResolverInterface
     {
@@ -107,7 +107,7 @@ retrieved from the token storage::
 
         public function supports(Request $request, ArgumentMetadata $argument)
         {
-            if (User::class !== $argument->getType()) {
+            if (UserInterface::class !== $argument->getType()) {
                 return false;
             }
 
@@ -117,7 +117,7 @@ retrieved from the token storage::
                 return false;
             }
 
-            return $token->getUser() instanceof User;
+            return $token->getUser() instanceof UserInterface;
         }
 
         public function resolve(Request $request, ArgumentMetadata $argument)

--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -40,6 +40,10 @@ Symfony ships with four value resolvers in the HttpKernel component:
 
     Prior to Symfony 3.1, this logic was resolved within the ``ControllerResolver``.
     The old functionality is rewritten to the aforementioned value resolvers.
+    
+.. note::
+    If your argument is a Doctrine Entity you will need to create a 
+    :doc:`param converter </bundles/SensioFrameworkExtraBundle/annotations/converters>`
 
 Adding a Custom Value Resolver
 ------------------------------
@@ -51,12 +55,12 @@ controller::
 
     namespace AppBundle\Controller;
 
-    use AppBundle\Entity\User;
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\Security\Core\User\UserInterface;
 
     class UserController
     {
-        public function indexAction(User $user)
+        public function indexAction(UserInterface $user)
         {
             return new Response('Hello '.$user->getUsername().'!');
         }
@@ -89,6 +93,8 @@ retrieved from the token storage::
     use AppBundle\Entity\User;
     use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
     use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+    use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
     class UserValueResolver implements ArgumentValueResolverInterface
     {


### PR DESCRIPTION
I'm proposing 3 changes.
1. I added a note with a link to the @ParamConverter page. When the argument is a doctrine entity(as the current version of the page shows) the ArgumentValueResolver will not work. The ParamConverter must be used.
2. I updated the controller example to show the argument as the UserInterface instead of the User entity. This will work.
3. Added two missing use statements in the ArgumentValueResolver example.