### PR TITLE
Update cache_invalidation.rst

### DIFF
--- a/http_cache/cache_invalidation.rst
+++ b/http_cache/cache_invalidation.rst
@@ -74,9 +74,9 @@ Here is how you can configure the Symfony reverse proxy to support the
 
             $response = new Response();
             if ($this->getStore()->purge($request->getUri())) {
-                $response->setStatusCode(200, 'Purged');
+                $response->setStatusCode(Response::HTTP_OK, 'Purged');
             } else {
-                $response->setStatusCode(404, 'Not found');
+                $response->setStatusCode(Response::HTTP_NOT_FOUND, 'Not found');
             }
 
             return $response;


### PR DESCRIPTION
In the same example, an HTTP status code constant is used instead of the equivalent integer code

I updated the other status codes