### PR TITLE
Added the file paths in the config reference

### DIFF
--- a/reference/configuration/assetic.rst
+++ b/reference/configuration/assetic.rst
@@ -11,6 +11,7 @@ Full Default Configuration
 
     .. code-block:: yaml
 
+        # app/config/config.yml
         assetic:
             debug:                '%kernel.debug%'
             use_controller:
@@ -61,6 +62,7 @@ Full Default Configuration
 
     .. code-block:: xml
 
+        <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:assetic="http://symfony.com/schema/dic/assetic"

--- a/reference/configuration/debug.rst
+++ b/reference/configuration/debug.rst
@@ -56,11 +56,13 @@ destination for dumps. Typically, you would set this to ``php://stderr``:
 
     .. code-block:: yaml
 
+        # app/config/config.yml
         debug:
            dump_destination: php://stderr
 
     .. code-block:: xml
 
+        <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/debug"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -73,6 +75,7 @@ destination for dumps. Typically, you would set this to ``php://stderr``:
 
     .. code-block:: php
 
+        // app/config/config.php
         $container->loadFromExtension('debug', array(
            'dump_destination' => 'php://stderr',
         ));

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -12,6 +12,7 @@ Full Default Configuration
 
     .. code-block:: yaml
 
+        # app/config/config.yml
         doctrine:
             dbal:
                 default_connection:   default
@@ -183,6 +184,7 @@ Full Default Configuration
 
     .. code-block:: xml
 
+        <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -14,6 +14,7 @@ Full Default Configuration
 
     .. code-block:: yaml
 
+        # app/config/config.yml
         monolog:
             handlers:
 
@@ -76,6 +77,7 @@ Full Default Configuration
 
     .. code-block:: xml
 
+        <!-- app/config/config.xml -->
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:monolog="http://symfony.com/schema/dic/monolog"

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -8,6 +8,7 @@ TwigBundle Configuration ("twig")
 
     .. code-block:: yaml
 
+        # app/config/config.yml
         twig:
             exception_controller:  twig.controller.exception:showAction
 
@@ -54,6 +55,7 @@ TwigBundle Configuration ("twig")
 
     .. code-block:: xml
 
+        <!-- app/config/config.xml -->
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:twig="http://symfony.com/schema/dic/twig"
@@ -83,6 +85,7 @@ TwigBundle Configuration ("twig")
 
     .. code-block:: php
 
+        // app/config/config.php
         $container->loadFromExtension('twig', array(
             'form_themes' => array(
                 'form_div_layout.html.twig', // Default

--- a/reference/configuration/web_profiler.rst
+++ b/reference/configuration/web_profiler.rst
@@ -11,6 +11,7 @@ Full Default Configuration
 
     .. code-block:: yaml
 
+        # app/config/config.yml
         web_profiler:
 
             # DEPRECATED, it is not useful anymore and can be removed
@@ -31,6 +32,7 @@ Full Default Configuration
 
     .. code-block:: xml
 
+        <!-- app/config/config.xml -->
         <web-profiler:config
             toolbar="false"
             verbose="true"


### PR DESCRIPTION
This morning, a developer asked me on the Symfony Slack in which file he should copy some config displayed in this page: http://symfony.com/doc/2.8/reference/configuration/doctrine.html

I propose to always display the file paths to avoid these confusions.