### PR TITLE
Added a note about using ":" in Redis passwords

### DIFF
--- a/components/cache/cache_pools.rst
+++ b/components/cache/cache_pools.rst
@@ -129,6 +129,15 @@ helper allows creating a connection to a Redis server using a DSN configuration:
 
 See the method's docblock for more options.
 
+.. caution::
+
+    Redis connections don't support login + password credentials, but just a
+    password. This can produce undesired effects when the password contains a
+    ``:`` character (e.g. ``foo:bar`` password would be wrongly parsed as ``foo``
+    login + ``bar`` password). The solution is to add a fake login to the
+    connection DSN. Instead of ``'redis://foo:bar@localhost'``, use
+    ``'redis://__ignore_this__:foo:bar@localhost'``
+
 PDO & Doctrine DBAL Cache Adapter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This fixes #7531.