### PR TITLE
Update apache_router.rst

### DIFF
--- a/configuration/apache_router.rst
+++ b/configuration/apache_router.rst
@@ -44,9 +44,7 @@ Symfony to use the ``ApacheUrlMatcher`` instead of the default one:
         <!-- app/config/config_prod.xml -->
         <parameters>
             <parameter key="router.options.matcher.cache_class">null</parameter> <!-- disable router cache -->
-            <parameter key="router.options.matcher_class">
-                Symfony\Component\Routing\Matcher\ApacheUrlMatcher
-            </parameter>
+            <parameter key="router.options.matcher_class">Symfony\Component\Routing\Matcher\ApacheUrlMatcher</parameter>
         </parameters>
 
     .. code-block:: php


### PR DESCRIPTION
The matcher class will contain new lines and spaces at the beginning and at the end and the result is an incorrect class name which raise an exception (Class not found ..)