### PR TITLE
Updating doctrine class use

### DIFF
--- a/doctrine/event_listeners_subscribers.rst
+++ b/doctrine/event_listeners_subscribers.rst
@@ -131,14 +131,14 @@ a ``postPersist()`` method, which will be called when the event is dispatched::
     {
         public function postPersist(LifecycleEventArgs $args)
         {
-            $entity = $args->getEntity();
+            $object = $args->getObject();
 
             // only act on some "Product" entity
-            if (!$entity instanceof Product) {
+            if (!$object instanceof Product) {
                 return;
             }
 
-            $entityManager = $args->getEntityManager();
+            $objectManager = $args->getObjectManager();
             // ... do something with the Product
         }
     }

--- a/doctrine/event_listeners_subscribers.rst
+++ b/doctrine/event_listeners_subscribers.rst
@@ -169,8 +169,8 @@ interface and have an event method for each event it subscribes to::
     namespace AppBundle\EventListener;
 
     use Doctrine\Common\EventSubscriber;
-    use Doctrine\ORM\Event\LifecycleEventArgs;
-    // for Doctrine 2.4: Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+    // for Doctrine < 2.4: use Doctrine\ORM\Event\LifecycleEventArgs;
+    use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
     use AppBundle\Entity\Product;
 
     class SearchIndexerSubscriber implements EventSubscriber


### PR DESCRIPTION
Because now composer.json of symfony 3.2 use doctrine ^2.5 shouldn't we use use Doctrine\Common\Persistence\Event\LifecycleEventArgs; by default in exemple ?