### PR TITLE
Adding a tip for validation in forms without class

### DIFF
--- a/form/without_class.rst
+++ b/form/without_class.rst
@@ -109,8 +109,8 @@ but here's a short example:
 
 .. tip::
 
-    Remember that when your form is not mapped to an object, every object in your array of submitted data
-    will be validated with the ``Symfony\Component\Validator\Constraints\Valid`` constraint,
-    unless you disable validation like described in :doc:`this article </form/disabling_validation>`.
+    If the form is not mapped to an object, every object in your array of
+    submitted data is validated using the ``Symfony\Component\Validator\Constraints\Valid``
+    constraint, unless you :doc:`disable validation </form/disabling_validation>`.
 
  

--- a/form/without_class.rst
+++ b/form/without_class.rst
@@ -106,3 +106,11 @@ but here's a short example:
     .. code-block:: php
 
         new NotBlank(array('groups' => array('create', 'update')))
+
+.. tip::
+
+    Remember that when your form is not mapped to an object, every object in your array of submitted data
+    will be validated with the ``Symfony\Component\Validator\Constraints\Valid`` constraint,
+    unless you disable validation like described in :doc:`this article </form/disabling_validation>`.
+
+ 


### PR DESCRIPTION
When a form is mapped to an array instead of an object (i.e. a search form), every object in the array is validated with Symfony\Component\Validator\Constraints\Valid constraint.

For example a search form mapped to an array including a field of type Symfony\Bridge\Doctrine\Form\Type\EntityType will validate the choosen entity itself, resulting in an invalid form if the (already persisted) entity is, for some reasons, invalid.

References: https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php#L171:L186

I'm wondering if this behavior is a bug, while the validation of objects has this approach 
"If an object is passed without explicit constraints, validate that object against the constraints defined for the object's class [eventually none]"
https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php#L154:L169