### PR TITLE
Add reference built in listener for kernel.response event in >= 3.1

### DIFF
--- a/reference/events.rst
+++ b/reference/events.rst
@@ -152,6 +152,7 @@ Listener Class Name                                                             
 :class:`Symfony\\Component\\HttpKernel\\EventListener\\EsiListener`                  0
 :class:`Symfony\\Component\\HttpKernel\\EventListener\\ResponseListener`             0
 :class:`Symfony\\Component\\Security\\Http\\RememberMe\\ResponseListener`            0
+:class:`Symfony\\Bundle\\FrameworkBundle\\DataCollector\\RequestDataCollector`       0
 :class:`Symfony\\Component\\HttpKernel\\EventListener\\ProfilerListener`             -100
 :class:`Symfony\\Bundle\\FrameworkBundle\\EventListener\\TestSessionListener`        -128
 :class:`Symfony\\Bundle\\WebProfilerBundle\\EventListener\\WebDebugToolbarListener`  -128


### PR DESCRIPTION
The class `RequestDataCollector` listen event `kernel.response` in >= 3.1 version of symfony.

See : https://github.com/symfony/http-kernel/blob/3.1/DataCollector/RequestDataCollector.php#L313