### PR TITLE
[Form] Added a small explanation about named forms

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -705,8 +705,9 @@ the choice is ultimately up to you.
 
 
 .. note::
-    A form name is generated from the type class name, if you want to set it
-    explicitly, use :method:`FormFactoryInterface::createNamed() <Symfony\\Component\\Form\\FormFactoryInterface>`.
+
+    The form name is automatically generated from the type class name. If you want
+    to modify it, use the :method:`Symfony\\Component\\Form\\FormFactoryInterface::createNamed` method.
     You can even suppress the name completely by setting it to an empty string.
 
 Final Thoughts

--- a/forms.rst
+++ b/forms.rst
@@ -703,6 +703,12 @@ the choice is ultimately up to you.
 
         $form->get('agreeTerms')->setData(true);
 
+
+.. note::
+    A form name is generated from the type class name, if you want to set it
+    explicitly, use :method:`FormFactoryInterface::createNamed() <Symfony\\Component\\Form\\FormFactoryInterface>`.
+    You can even suppress the name completely by setting it to an empty string.
+
 Final Thoughts
 --------------
 


### PR DESCRIPTION
I've added a small explanation on how to add the same form multiple times to the same page, by using named forms. Should fix #4090.

Note that this feature was already added in at least one of the patches in 2.1.