### PR TITLE
Requirements: Rewrite note about PHP 5.3.16

### DIFF
--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -28,8 +28,8 @@ Required
 
 .. caution::
 
-    Be aware that Symfony has some known limitations when using PHP 5.3.16.
-    For more information see the `Requirements section of the README`_.
+    Be aware that PHP 5.3.16 is not suitable to run Symfony,
+    because of a `major bug in the Reflection subsystem`_.
 
 Optional
 --------
@@ -59,3 +59,4 @@ to use.
 .. _`Requirements section of the README`: https://github.com/symfony/symfony/blob/2.7/README.md#requirements
 .. _`JSON extension`: https://php.net/manual/book.json.php
 .. _`ctype extension`: https://php.net/manual/book.ctype.php
+.. _`major bug in the Reflection subsystem`: https://bugs.php.net/bug.php?id=62715


### PR DESCRIPTION
The `README.md` file was rewritten in this commit:
https://github.com/symfony/symfony/commit/c7d30ca486db73808beb286c830e2f8f40c02514#diff-04c6e90faac2675aa89e2176d2eec7d8L19

So the link in _For more information see the Requirements section of the README_ was outdated because the _Requirements_ section was removed.

I removed the link and added an explanation that was present in the `README.md` file (see commit above).