### PR TITLE
Renamed code block 'terminal' to 'shell'

### DIFF
--- a/configuration/external_parameters.rst
+++ b/configuration/external_parameters.rst
@@ -107,7 +107,7 @@ of the following:
         fastcgi_param DATABASE_USER user;
         fastcgi_param DATABASE_PASSWORD secret;
 
-    .. code-block:: terminal
+    .. code-block:: shell
 
         $ export DATABASE_USER=user
         $ export DATABASE_PASSWORD=secret


### PR DESCRIPTION
The name terminal is okay, but the generated class for the child div will be "highlight-terminal" which has a different styling than you would expect. The highlight-terminal class is used to display a shell with bullets. 

By renaming the 'terminal' to 'shell' the bullets do not show up when this code block is selected.