### PR TITLE
[POC][DO NOT MERGE] Added improved diff lexer

### DIFF
--- a/_build/_theme/_exts/symfonycom/sphinx/lexer.py
+++ b/_build/_theme/_exts/symfonycom/sphinx/lexer.py
@@ -21,3 +21,20 @@ class TerminalLexer(RegexLexer):
             ('(.+)$', bygroups(using(BatchLexer)), '#pop')
         ],
     }
+
+
+class NonCopyDiffLexer(RegexLexer):
+    name = 'NonCopyDiff'
+    aliases = ['non-copy-diff']
+    filenames = []
+
+    tokens = {
+        'root': [
+            ('^\+ ', Generic.DiffIndicator, 'inserted'),
+            ('^- ', Generic.DiffIndicator, 'deleted'),
+            ('^  ', Generic.DiffIndicator, 'text')
+        ],
+        'inserted': [('.+$', Generic.Inserted)],
+        'deleted': [('.+$', Generic.Deleted)],
+        'text': [('.+$', Text)]
+    }

--- a/_build/conf.py
+++ b/_build/conf.py
@@ -24,7 +24,7 @@ from pygments.lexers.compiled import CLexer
 from pygments.lexers.special import TextLexer
 from pygments.lexers.text import RstLexer
 from pygments.lexers.web import PhpLexer
-from symfonycom.sphinx.lexer import TerminalLexer
+from symfonycom.sphinx.lexer import TerminalLexer, NonCopyDiffLexer
 
 # -- General configuration -----------------------------------------------------
 
@@ -110,6 +110,7 @@ lexers['rst'] = RstLexer()
 lexers['varnish3'] = CLexer()
 lexers['varnish4'] = CLexer()
 lexers['terminal'] = TerminalLexer()
+lexers['diff'] = NonCopyDiffLexer()
 
 config_block = {
     'markdown': 'Markdown',

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -114,25 +114,27 @@ First, make sure that ``LuckyController`` extends Symfony's base
     }
 
 Now, use the handy ``render()`` function to render a template. Pass it our ``number``
-variable so we can render that::
+variable so we can render that:
 
-    // src/AppBundle/Controller/LuckyController.php
-    // ...
+.. code-block:: diff
 
-    class LuckyController extends Controller
-    {
-        /**
-         * @Route("/lucky/number")
-         */
-        public function numberAction()
-        {
-            $number = mt_rand(0, 100);
+      // src/AppBundle/Controller/LuckyController.php
+      // ...
 
-            return $this->render('lucky/number.html.twig', array(
-                'number' => $number,
-            ));
-        }
-    }
+      class LuckyController extends Controller
+      {
+          /**
+           * @Route("/lucky/number")
+           */
+          public function numberAction()
+          {
+    +         $number = mt_rand(0, 100);
+
+    +         return $this->render('lucky/number.html.twig', array(
+    +             'number' => $number,
+    +         ));
+          }
+      }
 
 Finally, template files should live in the ``app/Resources/views`` directory. Create
 a new ``app/Resources/views/lucky`` directory with a new ``number.html.twig`` file


### PR DESCRIPTION
Just to play with something discussed this afternoon: Allowing to show diff, but making `+`/`-` not copyable.

View the page on platform.sh: 

And make sure you inject the following CSS when viewing:
```css
.gi:before { content:'+ '; }
.gd:before { content:'- '; }
.gi, .gd   { background:none !important; }
.g-DiffIndicator { display:none; }
```

/cc @weaverryan 