### PR TITLE
Improved the description of the global Twig variables

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -743,12 +743,12 @@ needed objects and values. It is an instance of
 
 The available attributes are:
 
-* ``app.user``
-* ``app.request``
-* ``app.session``
-* ``app.environment``
-* ``app.debug``
-* ``app.security`` (deprecated as of 2.6)
+* ``app.user``, a PHP object representing the current user;
+* ``app.request``, a :class:``Symfony\\Component\\HttpFoundation\\Request`` object;
+* ``app.session``, a :class:``Symfony\\Component\\HttpFoundation\\Session\\Session`` object;
+* ``app.environment``, a string with the name of the execution environment;
+* ``app.debug``, a boolean telling whether the debug mode is enabled in the app;
+* ``app.security`` (deprecated as of 2.6).
 
 .. caution::
 


### PR DESCRIPTION
This finished #7191. When merged, don't forget to add this description in 3.2 and master:

```
* ``app.token`` (a :class:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\TokenInterface`
  object representing the security token)
```