### PR TITLE
Update service_container.rst

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -60,7 +60,7 @@ Find out by running:
 
 .. code-block:: terminal
 
-     $ php bin/console debug:container
+     $ php app/console debug:container
 
 This is just a *small* sample of the output:
 


### PR DESCRIPTION
Terminal command to find out available services is wrong for 2.8. Here is the good one.