### PR TITLE
Fixed a minor syntax issue

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -378,8 +378,9 @@ method takes an instance of
 You can clear a cookie via the
 :method:`Symfony\\Component\\HttpFoundation\\ResponseHeaderBag::clearCookie` method.
 
-Note you can create a 
-:class:`Symfony\\Component\\HttpFoundation\\Cookie` object from a raw header value using :method:`Symfony\Component\HttpFoundation\Cookie::fromString`.
+Note you can create a
+:class:`Symfony\\Component\\HttpFoundation\\Cookie` object from a raw header
+value using :method:`Symfony\\Component\\HttpFoundation\\Cookie::fromString`.
 
 .. versionadded:: 3.3
     The ``Cookie::fromString()`` method was introduced in Symfony 3.3.


### PR DESCRIPTION
After merging #7313, Travis reported a minor syntax issue: the backslashes here weren't escaped:

```
:method:`Symfony\Component\HttpFoundation\Cookie::fromString`
```