### PR TITLE
phpunit supports only 7.0+

### DIFF
--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -21,7 +21,7 @@ Below is the list of required and optional requirements.
 Required
 --------
 
-* PHP needs to be a minimum version of PHP 5.5.9
+* PHP needs to be a minimum version of PHP 5.5.9 (7.0 if you are using testing)
 * `JSON extension`_ needs to be enabled
 * `ctype extension`_ needs to be enabled
 * Your ``php.ini`` needs to have the ``date.timezone`` setting


### PR DESCRIPTION
Symfony\Bundle\FrameworkBundle\Tests\TestCase uses namespaced PHPUnit, which is v6 and supports only PHP 7+ , https://phpunit.de/

regards