### PR TITLE
Update page_creation.rst to correct hidden colon

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -84,7 +84,7 @@ to creating a page?
    in its own section, including how to make *variable* URLs;
 
 #. *Create a controller*: The method below the route - ``numberAction()`` - is called
-   the *controller*: this is a function where *you* build the page and ultimately
+   the *controller*. This is a function where *you* build the page and ultimately
    return a ``Response`` object. You'll learn more about :doc:`controllers </controller>`
    in their own section, including how to return JSON responses.
 


### PR DESCRIPTION
86-87:  Italicized word covers top of colon

Old:  The method below the route - ``numberAction()`` - is called
   the *controller*: this is a function where *you*
New:  The method below the route - ``numberAction()`` - is called
   the *controller*. This is a function where *you*

Instead of having the top of the colon bleed into the italicized word "controller" it makes visual sense to have the sentence end with a period and the next "This is a function..." begin with a capital letter since it can stand on its own as a sentence.