### PR TITLE
Update requirements.rst

### DIFF
--- a/routing/requirements.rst
+++ b/routing/requirements.rst
@@ -75,7 +75,7 @@ a routing ``{wildcard}`` to only match some regular expression:
 Thanks to the ``\d+`` requirement (i.e. a "digit" of any length), ``/blog/2`` will
 match this route but ``/blog/some-string`` will *not* match.
 
-.. sidebar:: Earlier Routes always Win
+.. sidebar:: Earlier Routes Always Win
 
     Why would you ever care about requirements? If a request matches *two* routes,
     then the first route always wins. By adding requirements to the first route,


### PR DESCRIPTION
The word "always" in a title should be capitalized.