### PR TITLE
Backport #7510 for the Symfony 2.7 docs

### DIFF
--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -239,10 +239,9 @@ the information will be available in the profiler.
 
 .. tip::
 
-    The following configuration options are compatible with ``%env()%`` parameters:
-    ``url``, ``transport``, ``username``, ``password``, ``host``,
-    ``port``, ``timeout``, ``source_ip``, ``local_domain``,
-    ``encryption``, ``auth_mode``.
+    The following options can be set via environment variables using the
+    ``%env()%`` syntax: ``url``, ``transport``, ``username``, ``password``,
+    ``host``, ``port``, ``timeout``, ``source_ip``, ``local_domain``.
     For details, see the :doc:`/configuration/external_parameters` article.
 
 Full Default Configuration

--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -101,7 +101,7 @@ timeout
 **type**: ``integer``
 
 .. versionadded:: 2.4.2
-    The ``url`` option was added in SwiftMailerBundle 2.4.2.
+    The ``timeout`` option was added in SwiftMailerBundle 2.4.2.
 
 The timeout in seconds when using ``smtp`` as the transport.
 
@@ -111,7 +111,7 @@ source_ip
 **type**: ``string``
 
 .. versionadded:: 2.4.2
-    The ``url`` option was added in SwiftMailerBundle 2.4.2.
+    The ``source_ip`` option was added in SwiftMailerBundle 2.4.2.
 
 The source IP address when using ``smtp`` as the transport.
 
@@ -121,7 +121,7 @@ local_domain
 **type**: ``string``
 
 .. versionadded:: 2.4.2
-    The ``url`` option was added in SwiftMailerBundle 2.4.2.
+    The ``local_domain`` option was added in SwiftMailerBundle 2.4.2.
 
 The domain name to use in ``HELO`` command.
 

--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -59,7 +59,7 @@ The exact transport method to use to deliver emails. Valid values are:
 
 * smtp
 * gmail (see :doc:`/email/gmail`)
-* mail
+* mail (deprecated in SwiftMailer since version 5.4.5)
 * sendmail
 * null (same as setting `disable_delivery`_ to ``true``)
 

--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -18,11 +18,15 @@ a mailer. It is also possible to configure several mailers (see
 Configuration
 -------------
 
+* `url`_
 * `transport`_
 * `username`_
 * `password`_
 * `host`_
 * `port`_
+* `timeout`_
+* `source_ip`_
+* `local_domain`_
 * `encryption`_
 * `auth_mode`_
 * `spool`_
@@ -36,6 +40,15 @@ Configuration
 * `delivery_whitelist`_
 * `disable_delivery`_
 * `logging`_
+
+url
+~~~
+
+**type**: ``string``
+
+The URL to configure swift mailer.
+
+Example: ``smtp://user:pass@host:port/?timeout=60&encryption=ssl&auth_mode=login&...``
 
 transport
 ~~~~~~~~~
@@ -78,6 +91,27 @@ port
 
 The port when using ``smtp`` as the transport. This defaults to 465 if encryption
 is ``ssl`` and 25 otherwise.
+
+timeout
+~~~~~~~
+
+**type**: ``integer``
+
+The timeout when using ``smtp`` as the transport
+
+source_ip
+~~~~~~~~~
+
+**type**: ``string``
+
+The source IP when using ``smtp`` as the transport
+
+local_domain
+~~~~~~~~~~~~
+
+**type**: ``string``
+
+The domain name to use in HELO command.
 
 encryption
 ~~~~~~~~~~
@@ -190,6 +224,14 @@ logging
 
 If true, Symfony's data collector will be activated for Swift Mailer and
 the information will be available in the profiler.
+
+.. tip::
+
+    The following configuration options are compatible with ``%env()%`` parameters:
+    ``url``, ``transport``, ``username``, ``password``, ``host``,
+    ``port``, ``timeout``, ``source_ip``, ``local_domain``,
+    ``encryption``, ``auth_mode``.
+    For details, see the :doc:`/configuration/external_parameters` article.
 
 Full Default Configuration
 --------------------------

--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -46,7 +46,7 @@ url
 
 **type**: ``string``
 
-The URL to configure swift mailer.
+The entire SwiftMailer configuration using a DSN-like URL format.
 
 Example: ``smtp://user:pass@host:port/?timeout=60&encryption=ssl&auth_mode=login&...``
 
@@ -97,21 +97,21 @@ timeout
 
 **type**: ``integer``
 
-The timeout when using ``smtp`` as the transport
+The timeout in seconds when using ``smtp`` as the transport.
 
 source_ip
 ~~~~~~~~~
 
 **type**: ``string``
 
-The source IP when using ``smtp`` as the transport
+The source IP address when using ``smtp`` as the transport.
 
 local_domain
 ~~~~~~~~~~~~
 
 **type**: ``string``
 
-The domain name to use in HELO command.
+The domain name to use in ``HELO`` command.
 
 encryption
 ~~~~~~~~~~

--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -46,9 +46,6 @@ url
 
 **type**: ``string``
 
-.. versionadded:: 2.4.2
-    The ``url`` option was added in SwiftMailerBundle 2.4.2.
-
 The entire SwiftMailer configuration using a DSN-like URL format.
 
 Example: ``smtp://user:pass@host:port/?timeout=60&encryption=ssl&auth_mode=login&...``
@@ -100,18 +97,12 @@ timeout
 
 **type**: ``integer``
 
-.. versionadded:: 2.4.2
-    The ``timeout`` option was added in SwiftMailerBundle 2.4.2.
-
 The timeout in seconds when using ``smtp`` as the transport.
 
 source_ip
 ~~~~~~~~~
 
 **type**: ``string``
-
-.. versionadded:: 2.4.2
-    The ``source_ip`` option was added in SwiftMailerBundle 2.4.2.
 
 The source IP address when using ``smtp`` as the transport.
 
@@ -120,8 +111,8 @@ local_domain
 
 **type**: ``string``
 
-.. versionadded:: 2.4.2
-    The ``local_domain`` option was added in SwiftMailerBundle 2.4.2.
+.. versionadded:: 2.4.0
+    The ``local_domain`` option was introduced in SwiftMailerBundle 2.4.0.
 
 The domain name to use in ``HELO`` command.
 

--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -46,6 +46,9 @@ url
 
 **type**: ``string``
 
+.. versionadded:: 2.4.2
+    The ``url`` option was added in SwiftMailerBundle 2.4.2.
+
 The entire SwiftMailer configuration using a DSN-like URL format.
 
 Example: ``smtp://user:pass@host:port/?timeout=60&encryption=ssl&auth_mode=login&...``
@@ -97,6 +100,9 @@ timeout
 
 **type**: ``integer``
 
+.. versionadded:: 2.4.2
+    The ``url`` option was added in SwiftMailerBundle 2.4.2.
+
 The timeout in seconds when using ``smtp`` as the transport.
 
 source_ip
@@ -104,12 +110,18 @@ source_ip
 
 **type**: ``string``
 
+.. versionadded:: 2.4.2
+    The ``url`` option was added in SwiftMailerBundle 2.4.2.
+
 The source IP address when using ``smtp`` as the transport.
 
 local_domain
 ~~~~~~~~~~~~
 
 **type**: ``string``
+
+.. versionadded:: 2.4.2
+    The ``url`` option was added in SwiftMailerBundle 2.4.2.
 
 The domain name to use in ``HELO`` command.
 


### PR DESCRIPTION
All the documented options are part of SwiftmailerBundle releases that are compatible with Symfony 2.7.