### PR TITLE
Remove deprecated trusted_proxies config option

### DIFF
--- a/http_cache/varnish.rst
+++ b/http_cache/varnish.rst
@@ -20,9 +20,9 @@ Varnish automatically forwards the IP as ``X-Forwarded-For`` and leaves the
 trusted proxy, Symfony will see all requests as coming through insecure HTTP
 connections from the Varnish host instead of the real client.
 
-Remember to configure :ref:`framework.trusted_proxies <reference-framework-trusted-proxies>`
-in the Symfony configuration so that Varnish is seen as a trusted proxy and the
-:ref:`X-Forwarded <varnish-x-forwarded-headers>` headers are used.
+Remember to call the :method:`Symfony\\Component\\HttpFoundation\\Request::setTrustedProxies`
+method in your front controller so that Varnish is seen as a trusted proxy
+and the :ref:`X-Forwarded <varnish-x-forwarded-headers>` headers are used.
 
 Varnish, in its default configuration, sends the ``X-Forwarded-For`` header but
 does not filter out the ``Forwarded`` header. If you have access to the Varnish

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -22,7 +22,6 @@ Configuration
 
 * `secret`_
 * `http_method_override`_
-* `trusted_proxies`_
 * `ide`_
 * `test`_
 * `default_locale`_
@@ -183,44 +182,6 @@ named ``kernel.http_method_override``.
         Request::enableHttpMethodParameterOverride(); // <-- add this line
         $request = Request::createFromGlobals();
         // ...
-
-.. _reference-framework-trusted-proxies:
-
-trusted_proxies
-~~~~~~~~~~~~~~~
-
-**type**: ``array``
-
-Configures the IP addresses that should be trusted as proxies. For more
-details, see :doc:`/request/load_balancer_reverse_proxy`.
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # app/config/config.yml
-        framework:
-            trusted_proxies:  [192.0.0.1, 10.0.0.0/8]
-
-    .. code-block:: xml
-
-        <!-- app/config/config.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:framework="http://symfony.com/schema/dic/symfony"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
-            <framework:config trusted-proxies="192.0.0.1, 10.0.0.0/8" />
-        </container>
-
-    .. code-block:: php
-
-        // app/config/config.php
-        $container->loadFromExtension('framework', array(
-            'trusted_proxies' => array('192.0.0.1', '10.0.0.0/8'),
-        ));
 
 ide
 ~~~

--- a/request/load_balancer_reverse_proxy.rst
+++ b/request/load_balancer_reverse_proxy.rst
@@ -23,17 +23,18 @@ Solution: trusted_proxies
 This is no problem, but you *do* need to tell Symfony what is happening
 and which reverse proxy IP addresses will be doing this type of thing:
 
-.. configuration-block::
+.. code-block:: php
 
-   .. code-block:: diff
+    // web/app.php
 
-	  // web/app.php
+    // ...
+    $request = Request::createFromGlobals();
 
-	  // ...
-	  $request = Request::createFromGlobals();
-	  + Request::setTrustedProxies(['127.0.0.1', '10.0.0.0/8']);
+    // use the setTrustedProxies() method to tell Symfony
+    // about your reverse proxy IP addresses
+    Request::setTrustedProxies(['127.0.0.1', '10.0.0.0/8']);
 
-	  // ...
+    // ...
 
 In this example, you're saying that your reverse proxy (or proxies) has
 the IP address ``192.0.0.1`` or matches the range of IP addresses that use

--- a/request/load_balancer_reverse_proxy.rst
+++ b/request/load_balancer_reverse_proxy.rst
@@ -25,39 +25,19 @@ and which reverse proxy IP addresses will be doing this type of thing:
 
 .. configuration-block::
 
-    .. code-block:: yaml
+   .. code-block:: diff
 
-        # app/config/config.yml
-        # ...
-        framework:
-            trusted_proxies:  [192.0.0.1, 10.0.0.0/8]
+	  // web/app.php
 
-    .. code-block:: xml
+	  // ...
+	  $request = Request::createFromGlobals();
+	  + Request::setTrustedProxies(['127.0.0.1', '10.0.0.0/8']);
 
-        <!-- app/config/config.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:framework="http://symfony.com/schema/dic/symfony"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
-                                http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
-            <framework:config trusted-proxies="192.0.0.1, 10.0.0.0/8">
-                <!-- ... -->
-            </framework:config>
-        </container>
-
-    .. code-block:: php
-
-        // app/config/config.php
-        $container->loadFromExtension('framework', array(
-            'trusted_proxies' => array('192.0.0.1', '10.0.0.0/8'),
-        ));
+	  // ...
 
 In this example, you're saying that your reverse proxy (or proxies) has
 the IP address ``192.0.0.1`` or matches the range of IP addresses that use
-the CIDR notation ``10.0.0.0/8``. For more details, see the
-:ref:`framework.trusted_proxies <reference-framework-trusted-proxies>` option.
+the CIDR notation ``10.0.0.0/8``.
 
 You are also saying that you trust that the proxy does not send conflicting
 headers, e.g. sending both ``X-Forwarded-For`` and ``Forwarded`` in the same


### PR DESCRIPTION
"[BC BREAK] The "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies" parameter have been removed. Use the Request::setTrustedProxies() method in your front controller instead."

By the way, is 'trusted_hosts' config option still revellant?

Fixes: #7671