### PR TITLE
mention old way to create PHPUnit mock objects

### DIFF
--- a/create_framework/unit_testing.rst
+++ b/create_framework/unit_testing.rst
@@ -93,6 +93,9 @@ We are now ready to write our first test::
         private function getFrameworkForException($exception)
         {
             $matcher = $this->createMock(Routing\Matcher\UrlMatcherInterface::class);
+            // use getMock() on PHPUnit 5.3 or below
+            // $matcher = $this->getMock(Routing\Matcher\UrlMatcherInterface::class);
+
             $matcher
                 ->expects($this->once())
                 ->method('match')
@@ -149,6 +152,9 @@ Response::
     public function testControllerResponse()
     {
         $matcher = $this->createMock(Routing\Matcher\UrlMatcherInterface::class);
+        // use getMock() on PHPUnit 5.3 or below
+        // $matcher = $this->getMock(Routing\Matcher\UrlMatcherInterface::class);
+
         $matcher
             ->expects($this->once())
             ->method('match')

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -185,6 +185,8 @@ allows you to return a list of extensions to register::
         protected function getExtensions()
         {
             $validator = $this->createMock(ValidatorInterface::class);
+            // use getMock() on PHPUnit 5.3 or below
+            // $validator = $this->getMock(ValidatorInterface::class);
             $validator
                 ->method('validate')
                 ->will($this->returnValue(new ConstraintViolationList()));

--- a/testing/database.rst
+++ b/testing/database.rst
@@ -71,6 +71,8 @@ it's easy to pass a mock object within a test::
         {
             // First, mock the object to be used in the test
             $employee = $this->createMock(Employee::class);
+            // use getMock() on PHPUnit 5.3 or below
+            // $employee = $this->getMock(Employee::class);
             $employee->expects($this->once())
                 ->method('getSalary')
                 ->will($this->returnValue(1000));


### PR DESCRIPTION
This addresses an issue raised in symfony/symfony#20948.