### PR TITLE
Update json_login_setup.rst

### DIFF
--- a/security/json_login_setup.rst
+++ b/security/json_login_setup.rst
@@ -79,6 +79,9 @@ path:
              */
             public function loginAction(Request $request)
             {
+              // Remember to create a route to a 'secure_location' where a user will be 
+              // redirected to after a successful login
+              return $this->redirectToRoute('secure_location');
             }
         }
 
@@ -116,11 +119,12 @@ path:
 
         return $collection;
 
-Don't let this empty controller confuse you. When you submit a ``POST`` request
-to the ``/login`` URL with the following JSON document as the body, the security
-system intercepts the requests. It takes care of authenticating the user with
-the submitted username and password or triggers an error in case the authentication
-process fails:
+When you submit a ``POST`` request to the ``/login`` URL with the 
+following JSON document as the body, the security system intercepts the requests. 
+It takes care of authenticating the user with the submitted username and password or 
+triggers an error in case the authentication process fails. It will redirect the
+user to secure location when the authentication is successful. Hence remember to create 
+this 'secure_location' destination somewhere in your system:
 
 .. code-block:: json
 

--- a/security/json_login_setup.rst
+++ b/security/json_login_setup.rst
@@ -83,6 +83,23 @@ path:
               // redirected to after a successful login
               return $this->redirectToRoute('secure_location');
             }
+            
+            
+            /**
+             * @Route("/secure", name="secure_location")
+             */
+            public function SecureAction(Request $request)
+            {
+              if (!$this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY')) {              
+                return new JsonResponse(array(
+                  error' => "Login first",
+                ));
+              }
+              
+              return new JsonResponse(array(
+                'message' => "This is a secure area",
+              ));
+            }
         }
 
     .. code-block:: yaml
@@ -91,6 +108,11 @@ path:
         login:
             path:     /login
             defaults: { _controller: AppBundle:Security:login }
+            
+        secure_location: 
+            path:     /secure
+            defaults: { _controller: AppBundle:Security:secure }
+        
 
     .. code-block:: xml
 
@@ -104,6 +126,10 @@ path:
             <route id="login" path="/login">
                 <default key="_controller">AppBundle:Security:login</default>
             </route>
+            
+            <route id="secure_location" path="/secure">
+                <default key="_controller">AppBundle:Security:secure</default>
+            </route>
         </routes>
 
     .. code-block:: php
@@ -116,15 +142,15 @@ path:
         $collection->add('login', new Route('/login', array(
             '_controller' => 'AppBundle:Security:login',
         )));
+        
+        $collection->add('secure_location', new Route('/secure', array(
+            '_controller' => 'AppBundle:Security:secure',
+        )));
 
         return $collection;
 
 When you submit a ``POST`` request to the ``/login`` URL with the 
-following JSON document as the body, the security system intercepts the requests. 
-It takes care of authenticating the user with the submitted username and password or 
-triggers an error in case the authentication process fails. It will redirect the
-user to secure location when the authentication is successful. Hence remember to create 
-this 'secure_location' destination somewhere in your system:
+following JSON document as the body, the security system intercepts the request and perform the authentication:
 
 .. code-block:: json
 
@@ -132,11 +158,12 @@ this 'secure_location' destination somewhere in your system:
         "username": "dunglas",
         "password": "MyPassword"
     }
+    
+The security system takes care of authenticating the user with the submitted username and password and return a json response of whether authentication was successfully or not. 
+If the authentication was successfully, the security system will redirect the response to ``secure_location`` route.
+This ``secure_location`` can be defined anywhere in your controller. Just remember to guard it against accessing it without authentication.
 
-If the JSON document has a different structure, you can specify the path to
-access the ``username`` and ``password`` properties using the ``username_path``
-and ``password_path`` keys (they default respectively to ``username`` and
-``password``). For example, if the JSON document has the following structure:
+If the JSON document has a different structure, you can specify the path to access the ``username`` and ``password`` properties using the ``username_path`` and ``password_path`` keys (they default respectively to ``username`` and ``password``). For example, if the JSON document has the following structure:
 
 .. code-block:: json
 
@@ -147,7 +174,7 @@ and ``password_path`` keys (they default respectively to ``username`` and
                 "password": "MyPassword"
             }
         }
-    }
+    }    
 
 The security configuration should be:
 


### PR DESCRIPTION
After a successfully login, the json_login system failed with an error:  "The controller must return a response (null given). Did you forget to add a return statement somewhere in your controller? (500 Internal Server Error)",  because it had nowhere to go after a successfully authentication.
A quick fix was to redirect the user to a secure location in the login controller. This works when the login is successful and respective json responses are sent when the login fails.
Am not core symfony developer hence i don't know if this is a perfect method or there is another better way. But this worked on my end.