### PR TITLE
Reworded the introduction of the contributing docs

### DIFF
--- a/contributing/documentation/format.rst
+++ b/contributing/documentation/format.rst
@@ -1,8 +1,8 @@
 Documentation Format
 ====================
 
-The Symfony documentation uses reStructuredText_ as its markup language and
-Sphinx_ for generating the documentation in the formats read by the end users,
+The Symfony documentation uses `reStructuredText`_ as its markup language and
+`Sphinx`_ for generating the documentation in the formats read by the end users,
 such as HTML and PDF.
 
 reStructuredText

--- a/contributing/documentation/index.rst
+++ b/contributing/documentation/index.rst
@@ -1,29 +1,27 @@
 Contributing Documentation
 ==========================
 
-Documentation is as important as code for Open Source projects. That's why
-Symfony dedicates a great amount of resources to document new features and to
-keep the rest of the documentation up-to-date.
+Documentation is as important as code. That's why Symfony dedicates a great
+amount of resources to document new features and to keep the rest of the
+documentation up-to-date.
 
-More than 1,000 developers have contributed to Symfony documentation and we are
-glad that you are considering joining this big family. This guide will explain
-everything you need to contribute to the documentation:
+These short guides explain everything you need to contribute to the documentation:
 
 :doc:`The Contribution Process </contributing/documentation/overview>`
-  Explains the steps to follow to contribute fixes and new contents. It follows
-  the standard GitHub contribution process of most Open Source projects, so you
-  may already know everything that is needed.
+  Explains the steps to follow to contribute fixes and new contents. It's the
+  same contribution process followed by most open source projects, so you may
+  already know everything that is needed.
 
 :doc:`Documentation Formats </contributing/documentation/format>`
-  Explains the technical details of the reStructuredText format used to write
-  the docs. Skip it if you already are familiar with this format.
+  Explains the technical details of the reStructuredText format that is used to
+  write the docs. Skip it if you are already familiar with this format.
 
 :doc:`Documentation Standards </contributing/documentation/standards>`
   Explains how to write docs and code examples to match the style and tone of
-  the rest of the documentation.
+  the rest of the existing documentation.
 
 :doc:`License </contributing/documentation/license>`
-  Explains the details of the Creative Commons BB-SA 3.0 license used by the
+  Explains the details of the Creative Commons BY-SA 3.0 license used for the
   Symfony Documentation.
 
 .. toctree::

--- a/contributing/documentation/index.rst
+++ b/contributing/documentation/index.rst
@@ -9,21 +9,22 @@ More than 1,000 developers all around the world have contributed to Symfony
 documentation and we are glad that you are considering joining this big family.
 This guide will explain everything you need to contribute to the documentation:
 
-* :doc:`The Contribution Process </contributing/documentation/overview>`,
+:doc:`The Contribution Process </contributing/documentation/overview>`
   explains in detail the steps to follow to contribute fixes and new contents.
   It follows the standard GitHub contribution process of most Open Source
   projects, so you may already know everything that is needed.
 
-* :doc:`Formats </contributing/documentation/format>`, explains the technical
-  details of the reStructuredText format used to write the docs. Skip it if
-  you already are familiar with this format.
+:doc:`Documentation Formats </contributing/documentation/format>`
+  explains the technical details of the reStructuredText format used to write
+  the docs. Skip it if you already are familiar with this format.
 
-* :doc:`Standards </contributing/documentation/standards>`, explains how to
-  write docs and code examples to match the style and tone of the rest of the
-  documentation.
+:doc:`Documentation Standards </contributing/documentation/standards>`
+  explains how to write docs and code examples to match the style and tone of
+  the rest of the documentation.
 
-* :doc:`License </contributing/documentation/license>`, explains the details of
-  the Creative Commons BB-SA 3.0 license used by Symfony Documentation.
+:doc:`License </contributing/documentation/license>`
+  explains the details of the Creative Commons BB-SA 3.0 license used by the
+  Symfony Documentation.
 
 .. toctree::
     :hidden:

--- a/contributing/documentation/index.rst
+++ b/contributing/documentation/index.rst
@@ -1,13 +1,29 @@
 Contributing Documentation
 ==========================
 
-.. toctree::
-    :maxdepth: 2
+Documentation is as important as code for Open Source projects. That's why
+Symfony dedicates a great amount of resources to document new features and to
+keep the rest of the documentation up-to-date.
 
-    overview
-    format
-    standards
-    license
+More than 1,000 developers all around the world have contributed to Symfony
+documentation and we are glad that you are considering joining this big family.
+This guide will explain everything you need to contribute to the documentation:
+
+* :doc:`The Contribution Process </contributing/documentation/overview>`,
+  explains in detail the steps to follow to contribute fixes and new contents.
+  It follows the standard GitHub contribution process of most Open Source
+  projects, so you may already know everything that is needed.
+
+* :doc:`Formats </contributing/documentation/format>`, explains the technical
+  details of the reStructuredText format used to write the docs. Skip it if
+  you already are familiar with this format.
+
+* :doc:`Standards </contributing/documentation/standards>`, explains how to
+  write docs and code examples to match the style and tone of the rest of the
+  documentation.
+
+* :doc:`License </contributing/documentation/license>`, explains the details of
+  the Creative Commons BB-SA 3.0 license used by Symfony Documentation.
 
 .. toctree::
     :hidden:

--- a/contributing/documentation/index.rst
+++ b/contributing/documentation/index.rst
@@ -1,11 +1,8 @@
 Contributing Documentation
 ==========================
 
-Documentation is as important as code. That's why Symfony dedicates a great
-amount of resources to document new features and to keep the rest of the
-documentation up-to-date.
-
-These short guides explain everything you need to contribute to the documentation:
+These short articles explain everything you need to contribute to the Symfony
+documentation:
 
 :doc:`The Contribution Process </contributing/documentation/overview>`
   Explains the steps to follow to contribute fixes and new contents. It's the

--- a/contributing/documentation/index.rst
+++ b/contributing/documentation/index.rst
@@ -5,25 +5,25 @@ Documentation is as important as code for Open Source projects. That's why
 Symfony dedicates a great amount of resources to document new features and to
 keep the rest of the documentation up-to-date.
 
-More than 1,000 developers all around the world have contributed to Symfony
-documentation and we are glad that you are considering joining this big family.
-This guide will explain everything you need to contribute to the documentation:
+More than 1,000 developers have contributed to Symfony documentation and we are
+glad that you are considering joining this big family. This guide will explain
+everything you need to contribute to the documentation:
 
 :doc:`The Contribution Process </contributing/documentation/overview>`
-  explains in detail the steps to follow to contribute fixes and new contents.
-  It follows the standard GitHub contribution process of most Open Source
-  projects, so you may already know everything that is needed.
+  Explains the steps to follow to contribute fixes and new contents. It follows
+  the standard GitHub contribution process of most Open Source projects, so you
+  may already know everything that is needed.
 
 :doc:`Documentation Formats </contributing/documentation/format>`
-  explains the technical details of the reStructuredText format used to write
+  Explains the technical details of the reStructuredText format used to write
   the docs. Skip it if you already are familiar with this format.
 
 :doc:`Documentation Standards </contributing/documentation/standards>`
-  explains how to write docs and code examples to match the style and tone of
+  Explains how to write docs and code examples to match the style and tone of
   the rest of the documentation.
 
 :doc:`License </contributing/documentation/license>`
-  explains the details of the Creative Commons BB-SA 3.0 license used by the
+  Explains the details of the Creative Commons BB-SA 3.0 license used by the
   Symfony Documentation.
 
 .. toctree::

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -1,30 +1,16 @@
 Contributing to the Documentation
 =================================
 
-One of the essential principles of the Symfony project is that **documentation
-is as important as code**. That's why a great amount of resources are dedicated
-to documenting new features and to keeping the rest of the documentation
-up-to-date.
-
-More than 1,000 developers all around the world have contributed to Symfony's
-documentation and we are glad that you are considering joining this big family.
-This guide will explain everything you need to contribute to the Symfony
-documentation.
-
 Before Your First Contribution
 ------------------------------
 
-**Before contributing**, you should consider the following:
+**Before contributing**, you need to:
 
-* Symfony documentation is written using `reStructuredText`_ markup language.
-  If you are not familiar with this format, read
-  :doc:`this article </contributing/documentation/format>` for a quick overview
-  of its basic features.
-* Symfony documentation is hosted on `GitHub`_. You'll need a free GitHub user
-  account to contribute to the documentation.
-* Symfony documentation is published under a
-  :doc:`Creative Commons BY-SA 3.0 License </contributing/documentation/license>`
-  and all your contributions will implicitly adhere to that license.
+* Sign up for a free `GitHub`_ account, which is the service where the Symfony
+  documentation is hosted.
+* Be familiar with the `reStructuredText`_ markup language, which is used to
+  write Symfony docs. Read :doc:`this article </contributing/documentation/format>`
+  for a quick overview.
 
 .. _minor-changes-e-g-typos:
 

--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -2,7 +2,7 @@ Documentation Standards
 =======================
 
 Contributions must follow these standards to match the style and tone of the
-rest of the Symfony Documentation.
+rest of the Symfony documentation.
 
 Sphinx
 ------

--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -1,8 +1,8 @@
 Documentation Standards
 =======================
 
-In order to help the reader as much as possible and to create code examples that
-look and feel familiar, you should follow these standards.
+Contributions must follow these standards to match the style and tone of the
+rest of the Symfony Documentation.
 
 Sphinx
 ------

--- a/contributing/documentation/translations.rst
+++ b/contributing/documentation/translations.rst
@@ -1,7 +1,7 @@
 Translations
 ============
 
-The Symfony documentation is not officially translated, though some community
-groups still maintain some translations. For more information, see `this blog post`_.
+The official Symfony documentation is published only in English, but some
+community groups maintain `unofficial translations`_.
 
-.. _`this blog post`: https://symfony.com/blog/discontinuing-the-symfony-community-translations
+.. _`unofficial translations`: https://symfony.com/blog/discontinuing-the-symfony-community-translations


### PR DESCRIPTION
I propose a more gentle and actionable introduction to the "contributing docs" guide. The current introduction is confusing and intimidating to newcomers:

![contributing-index](https://cloud.githubusercontent.com/assets/73419/25700725/3afaea3e-30c9-11e7-8237-2734986ab93a.png)
