### PR TITLE
Example of the Doctrine doc with types as the first-class citizen

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -572,10 +572,10 @@ a controller, this is pretty easy. Add the following method to the
     }
 
     // you can use the registry to fetch other em's, if you have mutiple
-    public function editAction(ManagerRegistry $registry)
+    public function editAction(ManagerRegistry $doctrine)
     {
-        $em = $registry->getManager();
-        $em2 = $registry->getManager('other_connection')
+        $em = $doctrine->getManager();
+        $em2 = $doctrine->getManager('other_connection')
     }
 
 .. note::

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -571,7 +571,7 @@ a controller, this is pretty easy. Add the following method to the
         return new Response('Saved new product with id '.$product->getId());
     }
 
-    // you can use the registry to fetch other em's, if you have mutiple
+    // if you have multiple entity managers, use the registry to fetch them
     public function editAction(ManagerRegistry $doctrine)
     {
         $em = $doctrine->getManager();

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -549,16 +549,18 @@ a controller, this is pretty easy. Add the following method to the
     use AppBundle\Entity\Product;
     use Symfony\Component\HttpFoundation\Response;
     use Doctrine\ORM\EntityManagerInterface;
+    use Doctrine\Common\Persistence\ManagerRegistry;
 
     // ...
-    public function createAction()
+    public function createAction(EntityManagerInterface $em)
     {
+        // or fetch the em via the container
+        // $em = $this->get('doctrine')->getManager();
+
         $product = new Product();
         $product->setName('Keyboard');
         $product->setPrice(19.99);
         $product->setDescription('Ergonomic and stylish!');
-
-        $em = $this->getDoctrine()->getManager();
 
         // tells Doctrine you want to (eventually) save the Product (no queries yet)
         $em->persist($product);
@@ -569,25 +571,17 @@ a controller, this is pretty easy. Add the following method to the
         return new Response('Saved new product with id '.$product->getId());
     }
 
-    // you can also receive the $em as an argument
-    public function editAction(EntityManagerInterface $em)
+    // you can use the registry to fetch other em's, if you have mutiple
+    public function editAction(ManagerRegistry $registry)
     {
-        // ...
+        $em = $registry->getManager();
+        $em2 = $registry->getManager('other_connection')
     }
 
 .. note::
 
     If you're following along with this example, you'll need to create a
     route that points to this action to see it work.
-
-.. tip::
-
-    This article shows working with Doctrine from within a controller by using
-    the :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::getDoctrine`
-    method of the controller. This method is a shortcut to get the
-    ``doctrine`` service. You can work with Doctrine anywhere else
-    by injecting that service in the service. See
-    :doc:`/service_container` for more on creating your own services.
 
 Take a look at the previous example in more detail:
 
@@ -638,10 +632,11 @@ Fetching an object back out of the database is even easier. For example,
 suppose you've configured a route to display a specific ``Product`` based
 on its ``id`` value::
 
-    public function showAction($productId)
+    use Doctrine\ORM\EnityManagerInterface;
+
+    public function showAction($productId, EnityManagerInterface $em)
     {
-        $product = $this->getDoctrine()
-            ->getRepository('AppBundle:Product')
+        $product = $em->getRepository('AppBundle:Product')
             ->find($productId);
 
         if (!$product) {
@@ -664,8 +659,7 @@ as its "repository". You can think of a repository as a PHP class whose only
 job is to help you fetch entities of a certain class. You can access the
 repository object for an entity class via::
 
-    $repository = $this->getDoctrine()
-        ->getRepository('AppBundle:Product');
+    $repository = $em->getRepository('AppBundle:Product');
 
 .. note::
 
@@ -676,7 +670,7 @@ repository object for an entity class via::
 
 Once you have a repository object, you can access all sorts of helpful methods::
 
-    $repository = $this->getDoctrine()->getRepository('AppBundle:Product');
+    $repository = $em->getRepository('AppBundle:Product');
 
     // query for a single product by its primary key (usually "id")
     $product = $repository->find($productId);
@@ -699,7 +693,7 @@ Once you have a repository object, you can access all sorts of helpful methods::
 You can also take advantage of the useful ``findBy()`` and ``findOneBy()`` methods
 to easily fetch objects based on multiple conditions::
 
-    $repository = $this->getDoctrine()->getRepository('AppBundle:Product');
+    $repository = $em->getRepository('AppBundle:Product');
 
     // query for a single product matching the given name and price
     $product = $repository->findOneBy(
@@ -732,9 +726,10 @@ Updating an Object
 Once you've fetched an object from Doctrine, updating it is easy. Suppose
 you have a route that maps a product id to an update action in a controller::
 
-    public function updateAction($productId)
+    use Doctrine\ORM\EnityManagerInterface;
+
+    public function updateAction($productId, EntityManagerInterface $em)
     {
-        $em = $this->getDoctrine()->getManager();
         $product = $em->getRepository('AppBundle:Product')->find($productId);
 
         if (!$product) {
@@ -781,7 +776,7 @@ Querying for Objects
 You've already seen how the repository object allows you to run basic queries
 without any work::
 
-    $repository = $this->getDoctrine()->getRepository('AppBundle:Product');
+    $repository = $em->getRepository('AppBundle:Product');
 
     $product = $repository->find($productId);
     $product = $repository->findOneByName('Keyboard');
@@ -801,7 +796,6 @@ Imagine that you want to query for products that cost more than ``19.99``,
 ordered from least to most expensive. You can use DQL, Doctrine's native
 SQL-like language, to construct a query for this scenario::
 
-    $em = $this->getDoctrine()->getManager();
     $query = $em->createQuery(
         'SELECT p
         FROM AppBundle:Product p
@@ -841,8 +835,7 @@ Instead of writing a DQL string, you can use a helpful object called the
 depends on dynamic conditions, as your code soon becomes hard to read with
 DQL as you start to concatenate strings::
 
-    $repository = $this->getDoctrine()
-        ->getRepository('AppBundle:Product');
+    $repository = $em->getRepository('AppBundle:Product');
 
     // createQueryBuilder() automatically selects FROM AppBundle:Product
     // and aliases it to "p"


### PR DESCRIPTION
This updates the doctrine chapter in the new "types-first" philosophy - i.e. using type-hinting and autowiring to fetch services (rather than service ids). Of course, we must still show both (the type hint and the service id), but probably only the first time in a chapter. Afterwards, we should show the type.

This is the first "normal" chapter to get this update. Thoughts?

Thanks!