### PR TITLE
Error execution Introduce missing InputArgument

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -24,6 +24,7 @@ For example, a command called ``CreateUser`` must follow this structure::
     use Symfony\Component\Console\Command\Command;
     use Symfony\Component\Console\Input\InputInterface;
     use Symfony\Component\Console\Output\OutputInterface;
+    use Symfony\Component\Console\Input\InputArgument;
 
     class CreateUserCommand extends Command
     {


### PR DESCRIPTION
Fatal error: Class 'AppBundle\Command\InputArgument' not found in D:\work\share\test\php\console\AppBundle\
Command\GenerateAdminCommand.php on line 14                                                                
                                                                                                           
Call Stack:                                                                                                
    0.0003     125424   1. {main}() D:\work\share\test\php\console\rayphp:0                                
    0.0178     709576   2. Symfony\Component\Console\Command\Command->__construct(???) D:\work\share\test\p
hp\console\rayphp:9                                                                                        
    0.0178     710080   3. AppBundle\Command\GenerateAdminCommand->configure() D:\work\share\test\php\conso
le\vendor\symfony\console\Command\Command.php:63