### PR TITLE
Fix framework instantiation in event-dispatcher

### DIFF
--- a/create_framework/event_dispatcher.rst
+++ b/create_framework/event_dispatcher.rst
@@ -138,6 +138,9 @@ the registration of a listener for the ``response`` event::
 
         $response->setContent($response->getContent().'GA CODE');
     });
+    
+    $controllerResolver = new ControllerResolver();
+    $argumentResolver = new ArgumentResolver();
 
     $framework = new Simplex\Framework($dispatcher, $matcher, $controllerResolver, $argumentResolver);
     $response = $framework->handle($request);

--- a/create_framework/event_dispatcher.rst
+++ b/create_framework/event_dispatcher.rst
@@ -139,7 +139,7 @@ the registration of a listener for the ``response`` event::
         $response->setContent($response->getContent().'GA CODE');
     });
 
-    $framework = new Simplex\Framework($dispatcher, $matcher, $resolver);
+    $framework = new Simplex\Framework($dispatcher, $matcher, $controllerResolver, $argumentResolver);
     $response = $framework->handle($request);
 
     $response->send();


### PR DESCRIPTION
As the `$resolver` parameter was split up into `$controllerResolver` and `$argumentResolver`, the Framework instantiation call in this code example seems to be outdated and not in line with earlier steps taken in the tutorial.