### PR TITLE
[HttpFoundation] Fix clearstatcache first arg

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -533,7 +533,7 @@ Please note that this will not work when the ``X-Sendfile`` header is set.
 
     If you *just* created the file during this same request, the file *may* be sent
     without any content. This may be due to cached file stats that return zero for
-    the size of the file. To fix this issue, call ``clearstatcache(false, $file)``
+    the size of the file. To fix this issue, call ``clearstatcache(true, $file)``
     with the path to the binary file.
 
 .. _component-http-foundation-json-response:


### PR DESCRIPTION
According to http://php.net/manual/en/function.clearstatcache.php:

> **filename**  
    Clear the realpath and the stat cache for a specific filename only; _only used if **clear_realpath_cache** is **TRUE**_.

So it seems either we provide the second argument and set the first one to `true`, either the second arg is not used at all.

