### PR TITLE
Fix : the "secret" config parameter is not used anymore for CSRF tokens

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -131,10 +131,11 @@ used to add more entropy to security related operations. Its value should
 be a series of characters, numbers and symbols chosen randomly and the
 recommended length is around 32 characters.
 
-In practice, Symfony uses this value for generating the
-:doc:`CSRF tokens </form/csrf_protection>`, for encrypting the cookies used
+In practice, Symfony uses this value for encrypting the cookies used
 in the :doc:`remember me functionality </security/remember_me>` and for
 creating signed URIs when using :ref:`ESI (Edge Side Includes) <edge-side-includes>`.
+Up to version 2.4, Symfony used this value for generating the
+:doc:`CSRF tokens </form/csrf_protection>`.
 
 This option becomes the service container parameter named ``kernel.secret``,
 which you can use whenever the application needs an immutable random string


### PR DESCRIPTION
I previously commented on this in an old closed issue (that I suppose will remain ignored): https://github.com/symfony/symfony/issues/14026#issuecomment-298575820

The _secret_ config parameter is not used anymore for CSRF tokens but this statement is still written in the current documentation https://symfony.com/doc/current/reference/configuration/framework.html#secret
This is confusing and I would recommend to clarify this by removing the statement or describing that it was valid until a certain version.
My understanding is that the CSRF token provider that used this parameter has been deprecated since v2.4 and removed in v3.0 according to https://github.com/symfony/symfony/blob/2.4/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/DefaultCsrfProvider.php#L22 or http://api.symfony.com/2.3/Symfony/Component/Form/Extension/Csrf/CsrfProvider/SessionCsrfProvider.html#method___construct