### PR TITLE
Update phrasing of `var` write permission requirements

### DIFF
--- a/setup/file_permissions.rst
+++ b/setup/file_permissions.rst
@@ -2,7 +2,7 @@ Setting up or Fixing File Permissions
 =====================================
 
 One important Symfony requirement is that the ``var`` directory must be
-writable both by the web server and the command line user.
+writable both by your user, and the web server's user.
 
 On Linux and macOS systems, if your web server user is different from your
 command line user, you need to configure permissions properly to avoid issues.


### PR DESCRIPTION
The current phrasing can be somewhat confusing.  It suggests, to the uninitated, that either PHP or Symfony is running its own process in the background separate from the web server.