### PR TITLE
Fix incoherent utf8mb4 collation in Doctrine setup

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -138,7 +138,7 @@ can automatically generate an empty ``test_project`` database for you:
 
         [mysqld]
         # Version 5.5.3 introduced "utf8mb4", which is recommended
-        collation-server     = utf8mb4_general_ci # Replaces utf8_general_ci
+        collation-server     = utf8mb4_unicode_ci # Replaces utf8_unicode_ci
         character-set-server = utf8mb4            # Replaces utf8
 
     You can also change the defaults for Doctrine so that the generated SQL


### PR DESCRIPTION
The "Setting up the Database to be UTF8" section of the "Databases and the Doctrine ORM" page recommends the following default collation setup:

- in MySQL's my.cnf: `collation-server = utf8mb4_general_ci`
- and/or in Symfony's config.yml: `collate: utf8mb4_unicode_ci`

As a reader I am confused by this difference. If there's a reason for it, I think it should be explained in the text. On the other hand, if there is none, both lines should probably reference `utf8mb4_unicode_ci` (reason: http://stackoverflow.com/a/766996/2516943). This PR intends to fix the latter case.