### PR TITLE
Updating Doctrine syntax for getRepository method

### DIFF
--- a/best_practices/controllers.rst
+++ b/best_practices/controllers.rst
@@ -106,7 +106,7 @@ for the homepage of our app:
         public function indexAction()
         {
             $posts = $this->getDoctrine()
-                ->getRepository('AppBundle:Post')
+                ->getRepository(Post::class)
                 ->findLatest();
 
             return $this->render('default/index.html.twig', array(
@@ -170,7 +170,7 @@ manually. In our application, we have this situation in ``CommentController``:
     public function newAction(Request $request, $postSlug)
     {
         $post = $this->getDoctrine()
-            ->getRepository('AppBundle:Post')
+            ->getRepository(Post::class)
             ->findOneBy(array('slug' => $postSlug));
 
         if (!$post) {

--- a/best_practices/security.rst
+++ b/best_practices/security.rst
@@ -226,7 +226,7 @@ more advanced use-case, you can always do the same security check in PHP:
      */
     public function editAction($id)
     {
-        $post = $this->getDoctrine()->getRepository('AppBundle:Post')
+        $post = $this->getDoctrine()->getRepository(Post::class)
             ->find($id);
 
         if (!$post) {

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -279,7 +279,7 @@ did before. First, fetch a ``$product`` object and then access its related
     public function showAction($productId)
     {
         $product = $this->getDoctrine()
-            ->getRepository('AppBundle:Product')
+            ->getRepository(Product::class)
             ->find($productId);
 
         $categoryName = $product->getCategory()->getName();
@@ -306,7 +306,7 @@ You can also query in the other direction::
     public function showProductsAction($categoryId)
     {
         $category = $this->getDoctrine()
-            ->getRepository('AppBundle:Category')
+            ->getRepository(Category::class)
             ->find($categoryId);
 
         $products = $category->getProducts();
@@ -327,7 +327,7 @@ to the given ``Category`` object via their ``category_id`` value.
     example::
 
         $product = $this->getDoctrine()
-            ->getRepository('AppBundle:Product')
+            ->getRepository(Product::class)
             ->find($productId);
 
         $category = $product->getCategory();
@@ -388,7 +388,7 @@ object and its related ``Category`` with just one query::
     public function showAction($productId)
     {
         $product = $this->getDoctrine()
-            ->getRepository('AppBundle:Product')
+            ->getRepository(Product::class)
             ->findOneByIdJoinedToCategory($productId);
 
         $category = $product->getCategory();

--- a/doctrine/mapping_model_classes.rst
+++ b/doctrine/mapping_model_classes.rst
@@ -113,7 +113,7 @@ Annotations, XML, Yaml, PHP and StaticPHP. The arguments are:
   bundle is only used with one type of Doctrine;
 * A map/hash of aliases to namespace. This should be the same convention used
   by Doctrine auto-mapping. In the example above, this allows the user to call
-  ``$om->getRepository('CmfRoutingBundle:Route')``.
+  ``$om->getRepository(Route::class)``.
 
 .. note::
 

--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -210,19 +210,19 @@ The same applies to repository calls::
         {
             // Retrieves a repository managed by the "default" em
             $products = $this->get('doctrine')
-                ->getRepository('AcmeStoreBundle:Product')
+                ->getRepository(Product::class)
                 ->findAll()
             ;
 
             // Explicit way to deal with the "default" em
             $products = $this->get('doctrine')
-                ->getRepository('AcmeStoreBundle:Product', 'default')
+                ->getRepository(Product::class, 'default')
                 ->findAll()
             ;
 
             // Retrieves a repository managed by the "customer" em
             $customers = $this->get('doctrine')
-                ->getRepository('AcmeCustomerBundle:Customer', 'customer')
+                ->getRepository(Customer::class, 'customer')
                 ->findAll()
             ;
         }

--- a/doctrine/repository.rst
+++ b/doctrine/repository.rst
@@ -97,7 +97,7 @@ entities, ordered alphabetically by name.
 You can use this new method just like the default finder methods of the repository::
 
     $em = $this->getDoctrine()->getManager();
-    $products = $em->getRepository('AppBundle:Product')
+    $products = $em->getRepository(Product::class)
         ->findAllOrderedByName();
 
 .. note::

--- a/form/data_transformers.rst
+++ b/form/data_transformers.rst
@@ -202,7 +202,7 @@ to and from the issue number and the ``Issue`` object::
             }
 
             $issue = $this->manager
-                ->getRepository('AppBundle:Issue')
+                ->getRepository(Issue::class)
                 // query for the issue with this id
                 ->find($issueNumber)
             ;

--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -690,7 +690,7 @@ the relationship between the removed ``Tag`` and ``Task`` object.
         public function editAction($id, Request $request)
         {
             $em = $this->getDoctrine()->getManager();
-            $task = $em->getRepository('AppBundle:Task')->find($id);
+            $task = $em->getRepository(Task::class)->find($id);
 
             if (!$task) {
                 throw $this->createNotFoundException('No task found for id '.$id);

--- a/introduction/from_flat_php_to_symfony2.rst
+++ b/introduction/from_flat_php_to_symfony2.rst
@@ -562,7 +562,7 @@ them for you. Here's the same sample application, now built in Symfony::
         {
             $post = $this->get('doctrine')
                 ->getManager()
-                ->getRepository('AppBundle:Post')
+                ->getRepository(Post::class)
                 ->find($id);
 
             if (!$post) {

--- a/testing/database.rst
+++ b/testing/database.rst
@@ -49,7 +49,7 @@ Suppose the class you want to test looks like this::
         public function calculateTotalSalary($id)
         {
             $employeeRepository = $this->entityManager
-                ->getRepository('AppBundle:Employee');
+                ->getRepository(Employee:class);
             $employee = $employeeRepository->find($id);
 
             return $employee->getSalary() + $employee->getBonus();

--- a/testing/doctrine.rst
+++ b/testing/doctrine.rst
@@ -45,7 +45,7 @@ which makes all of this quite easy::
         public function testSearchByCategoryName()
         {
             $products = $this->em
-                ->getRepository('AppBundle:Product')
+                ->getRepository(Product::class)
                 ->searchByCategoryName('foo')
             ;
 


### PR DESCRIPTION
Changed Doctrine methods to use the `class` constant syntax which is the prefer syntax now. 