### PR TITLE
Updating Doctrine syntax for getRepository method

### DIFF
--- a/best_practices/controllers.rst
+++ b/best_practices/controllers.rst
@@ -95,6 +95,7 @@ for the homepage of our app:
 
     namespace AppBundle\Controller;
 
+    use AppBundle\Entity\Post;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 
@@ -106,7 +107,7 @@ for the homepage of our app:
         public function indexAction()
         {
             $posts = $this->getDoctrine()
-                ->getRepository('AppBundle:Post')
+                ->getRepository(Post::class)
                 ->findLatest();
 
             return $this->render('default/index.html.twig', array(
@@ -170,7 +171,7 @@ manually. In our application, we have this situation in ``CommentController``:
     public function newAction(Request $request, $postSlug)
     {
         $post = $this->getDoctrine()
-            ->getRepository('AppBundle:Post')
+            ->getRepository(Post::class)
             ->findOneBy(array('slug' => $postSlug));
 
         if (!$post) {

--- a/best_practices/security.rst
+++ b/best_practices/security.rst
@@ -226,7 +226,7 @@ more advanced use-case, you can always do the same security check in PHP:
      */
     public function editAction($id)
     {
-        $post = $this->getDoctrine()->getRepository('AppBundle:Post')
+        $post = $this->getDoctrine()->getRepository(Post::class)
             ->find($id);
 
         if (!$post) {

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -634,7 +634,7 @@ on its ``id`` value::
     public function showAction($productId)
     {
         $product = $this->getDoctrine()
-            ->getRepository('AppBundle:Product')
+            ->getRepository(Product::class)
             ->find($productId);
 
         if (!$product) {
@@ -658,18 +658,18 @@ job is to help you fetch entities of a certain class. You can access the
 repository object for an entity class via::
 
     $repository = $this->getDoctrine()
-        ->getRepository('AppBundle:Product');
+        ->getRepository(Product::class);
 
 .. note::
 
-    The ``AppBundle:Product`` string is a shortcut you can use anywhere
+    You can also use ``AppBundle:Product`` syntax. This string is a shortcut you can use anywhere
     in Doctrine instead of the full class name of the entity (i.e. ``AppBundle\Entity\Product``).
     As long as your entity lives under the ``Entity`` namespace of your bundle,
     this will work.
 
 Once you have a repository object, you can access all sorts of helpful methods::
 
-    $repository = $this->getDoctrine()->getRepository('AppBundle:Product');
+    $repository = $this->getDoctrine()->getRepository(Product::class);
 
     // query for a single product by its primary key (usually "id")
     $product = $repository->find($productId);
@@ -692,7 +692,7 @@ Once you have a repository object, you can access all sorts of helpful methods::
 You can also take advantage of the useful ``findBy()`` and ``findOneBy()`` methods
 to easily fetch objects based on multiple conditions::
 
-    $repository = $this->getDoctrine()->getRepository('AppBundle:Product');
+    $repository = $this->getDoctrine()->getRepository(Product::class);
 
     // query for a single product matching the given name and price
     $product = $repository->findOneBy(
@@ -730,7 +730,7 @@ you have a route that maps a product id to an update action in a controller::
     public function updateAction($productId)
     {
         $em = $this->getDoctrine()->getManager();
-        $product = $em->getRepository('AppBundle:Product')->find($productId);
+        $product = $em->getRepository(Product::class)->find($productId);
 
         if (!$product) {
             throw $this->createNotFoundException(
@@ -776,7 +776,7 @@ Querying for Objects
 You've already seen how the repository object allows you to run basic queries
 without any work::
 
-    $repository = $this->getDoctrine()->getRepository('AppBundle:Product');
+    $repository = $this->getDoctrine()->getRepository(Product::class);
 
     $product = $repository->find($productId);
     $product = $repository->findOneByName('Keyboard');
@@ -837,7 +837,7 @@ depends on dynamic conditions, as your code soon becomes hard to read with
 DQL as you start to concatenate strings::
 
     $repository = $this->getDoctrine()
-        ->getRepository('AppBundle:Product');
+        ->getRepository(Product::class);
 
     // createQueryBuilder() automatically selects FROM AppBundle:Product
     // and aliases it to "p"

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -279,7 +279,7 @@ did before. First, fetch a ``$product`` object and then access its related
     public function showAction($productId)
     {
         $product = $this->getDoctrine()
-            ->getRepository('AppBundle:Product')
+            ->getRepository(Product::class)
             ->find($productId);
 
         $categoryName = $product->getCategory()->getName();
@@ -306,7 +306,7 @@ You can also query in the other direction::
     public function showProductsAction($categoryId)
     {
         $category = $this->getDoctrine()
-            ->getRepository('AppBundle:Category')
+            ->getRepository(Category::class)
             ->find($categoryId);
 
         $products = $category->getProducts();
@@ -327,7 +327,7 @@ to the given ``Category`` object via their ``category_id`` value.
     example::
 
         $product = $this->getDoctrine()
-            ->getRepository('AppBundle:Product')
+            ->getRepository(Product::class)
             ->find($productId);
 
         $category = $product->getCategory();
@@ -388,7 +388,7 @@ object and its related ``Category`` with just one query::
     public function showAction($productId)
     {
         $product = $this->getDoctrine()
-            ->getRepository('AppBundle:Product')
+            ->getRepository(Product::class)
             ->findOneByIdJoinedToCategory($productId);
 
         $category = $product->getCategory();

--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -204,25 +204,28 @@ entity manager to persist and fetch its entities.
 
 The same applies to repository calls::
 
+    use AcmeStoreBundle\Entity\Customer;
+    use AcmeStoreBundle\Entity\Product;
+
     class UserController extends Controller
     {
         public function indexAction()
         {
             // Retrieves a repository managed by the "default" em
             $products = $this->get('doctrine')
-                ->getRepository('AcmeStoreBundle:Product')
+                ->getRepository(Product::class)
                 ->findAll()
             ;
 
             // Explicit way to deal with the "default" em
             $products = $this->get('doctrine')
-                ->getRepository('AcmeStoreBundle:Product', 'default')
+                ->getRepository(Product::class, 'default')
                 ->findAll()
             ;
 
             // Retrieves a repository managed by the "customer" em
             $customers = $this->get('doctrine')
-                ->getRepository('AcmeCustomerBundle:Customer', 'customer')
+                ->getRepository(Customer::class, 'customer')
                 ->findAll()
             ;
         }

--- a/doctrine/repository.rst
+++ b/doctrine/repository.rst
@@ -97,7 +97,7 @@ entities, ordered alphabetically by name.
 You can use this new method just like the default finder methods of the repository::
 
     $em = $this->getDoctrine()->getManager();
-    $products = $em->getRepository('AppBundle:Product')
+    $products = $em->getRepository(Product::class)
         ->findAllOrderedByName();
 
 .. note::

--- a/form/data_transformers.rst
+++ b/form/data_transformers.rst
@@ -208,7 +208,7 @@ to and from the issue number and the ``Issue`` object::
             }
 
             $issue = $this->manager
-                ->getRepository('AppBundle:Issue')
+                ->getRepository(Issue::class)
                 // query for the issue with this id
                 ->find($issueNumber)
             ;

--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -677,13 +677,14 @@ the relationship between the removed ``Tag`` and ``Task`` object.
 
         // src/AppBundle/Controller/TaskController.php
 
+        use AppBundle\Entity\Task;
         use Doctrine\Common\Collections\ArrayCollection;
 
         // ...
         public function editAction($id, Request $request)
         {
             $em = $this->getDoctrine()->getManager();
-            $task = $em->getRepository('AppBundle:Task')->find($id);
+            $task = $em->getRepository(Task::class)->find($id);
 
             if (!$task) {
                 throw $this->createNotFoundException('No task found for id '.$id);

--- a/introduction/from_flat_php_to_symfony2.rst
+++ b/introduction/from_flat_php_to_symfony2.rst
@@ -544,6 +544,7 @@ them for you. Here's the same sample application, now built in Symfony::
     // src/AppBundle/Controller/BlogController.php
     namespace AppBundle\Controller;
 
+    use AppBundle\Entity\Post;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
     class BlogController extends Controller
@@ -562,7 +563,7 @@ them for you. Here's the same sample application, now built in Symfony::
         {
             $post = $this->get('doctrine')
                 ->getManager()
-                ->getRepository('AppBundle:Post')
+                ->getRepository(Post::class)
                 ->find($id);
 
             if (!$post) {

--- a/testing/database.rst
+++ b/testing/database.rst
@@ -36,6 +36,7 @@ Suppose the class you want to test looks like this::
     // src/AppBundle/Salary/SalaryCalculator.php
     namespace AppBundle\Salary;
 
+    use AppBundle\Entity\Employee;
     use Doctrine\Common\Persistence\ObjectManager;
 
     class SalaryCalculator
@@ -50,7 +51,7 @@ Suppose the class you want to test looks like this::
         public function calculateTotalSalary($id)
         {
             $employeeRepository = $this->entityManager
-                ->getRepository('AppBundle:Employee');
+                ->getRepository(Employee::class);
             $employee = $employeeRepository->find($id);
 
             return $employee->getSalary() + $employee->getBonus();

--- a/testing/doctrine.rst
+++ b/testing/doctrine.rst
@@ -21,6 +21,7 @@ which makes all of this quite easy::
     // tests/AppBundle/Repository/ProductRepositoryTest.php
     namespace Tests\AppBundle\Repository;
 
+    use AppBundle\Entity\Product;
     use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
     class ProductRepositoryTest extends KernelTestCase
@@ -45,7 +46,7 @@ which makes all of this quite easy::
         public function testSearchByCategoryName()
         {
             $products = $this->em
-                ->getRepository('AppBundle:Product')
+                ->getRepository(Product::class)
                 ->searchByCategoryName('foo')
             ;
 


### PR DESCRIPTION
Changed Doctrine methods to use the `class` constant syntax which is the prefer syntax now.