### PR TITLE
Explained the locateResource() method of HttpKernel

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -463,6 +463,17 @@ API is being used. The following code, would work for *all* users::
         }
     }
 
+Resources
+---------
+
+If the bundle references any resources (config files, templates, translation
+files, etc.), don't use physical paths (e.g. ``__DIR__/config/services.xml``)
+but logical paths (e.g. ``@AppBundle/Resources/config/services.xml``).
+
+The logical paths are required beucase of the bundle overriding mechanism that
+lets you override any resource/file of any bundle. See :ref:`http-kernel-resource-locator`
+for more details about transforming physical paths into logical paths.
+
 Learn more
 ----------
 

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -466,13 +466,17 @@ API is being used. The following code, would work for *all* users::
 Resources
 ---------
 
-If the bundle references any resources (config files, templates, translation
-files, etc.), don't use physical paths (e.g. ``__DIR__/config/services.xml``)
-but logical paths (e.g. ``@AppBundle/Resources/config/services.xml``).
+If the bundle references any resources (config files, translation files, etc.),
+don't use physical paths (e.g. ``__DIR__/config/services.xml``) but logical
+paths (e.g. ``@AppBundle/Resources/config/services.xml``).
 
 The logical paths are required because of the bundle overriding mechanism that
 lets you override any resource/file of any bundle. See :ref:`http-kernel-resource-locator`
 for more details about transforming physical paths into logical paths.
+
+Beware that templates use a simplified version of the logical path showed above.
+For example, a ``index.html.twig`` template located in the ``Resources/views/Default/``
+directory of the AppBundle, is referenced as ``@App/Default/index.html.twig``
 
 Learn more
 ----------

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -470,7 +470,7 @@ If the bundle references any resources (config files, templates, translation
 files, etc.), don't use physical paths (e.g. ``__DIR__/config/services.xml``)
 but logical paths (e.g. ``@AppBundle/Resources/config/services.xml``).
 
-The logical paths are required beucase of the bundle overriding mechanism that
+The logical paths are required because of the bundle overriding mechanism that
 lets you override any resource/file of any bundle. See :ref:`http-kernel-resource-locator`
 for more details about transforming physical paths into logical paths.
 

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -476,7 +476,7 @@ for more details about transforming physical paths into logical paths.
 
 Beware that templates use a simplified version of the logical path showed above.
 For example, a ``index.html.twig`` template located in the ``Resources/views/Default/``
-directory of the AppBundle, is referenced as ``@App/Default/index.html.twig``
+directory of the AppBundle, is referenced as ``@App/Default/index.html.twig``.
 
 Learn more
 ----------

--- a/bundles/override.rst
+++ b/bundles/override.rst
@@ -7,6 +7,14 @@ How to Override any Part of a Bundle
 This document is a quick reference for how to override different parts of
 third-party bundles.
 
+.. tip::
+
+    The bundle overriding mechanism means that you cannot use physical paths to
+    refer to bundle's resources (e.g. ``__DIR__/config/services.xml``). Always
+    use logical paths in your bundles (e.g. ``@AppBundle/Resources/config/services.xml``)
+    and call the :ref:`locateResource() method <http-kernel-resource-locator>`
+    to turn them into physical paths when needed.
+
 Templates
 ---------
 

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -592,7 +592,7 @@ each event has their own event object:
 =====================  ================================  ===================================================================================
 Name                   ``KernelEvents`` Constant         Argument passed to the listener
 =====================  ================================  ===================================================================================
-kernel.request         ``KernelEvents::REQUEST``         :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent`                    
+kernel.request         ``KernelEvents::REQUEST``         :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent`
 kernel.controller      ``KernelEvents::CONTROLLER``      :class:`Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent`
 kernel.view            ``KernelEvents::VIEW``            :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForControllerResultEvent`
 kernel.response        ``KernelEvents::RESPONSE``        :class:`Symfony\\Component\\HttpKernel\\Event\\FilterResponseEvent`
@@ -700,6 +700,32 @@ look like this::
 
         // ...
     }
+
+.. _http-kernel-resource-locator:
+
+Locating Resources
+------------------
+
+The HttpKernel component is responsible of the bundle mechanism used in Symfony
+applications. The key feature of the bundles is that they allow to override any
+resource used by the application (config files, templates, controllers,
+translation files, etc.)
+
+This overriding mechanism works because resources are referenced not by their
+physical path but by their logical path. For example, the ``services.xml`` file
+stored in the ``Resources/config/`` directory of a bundle called AppBundle is
+referenced as ``@AppBundle/Resources/config/services.xml``. This logical path
+will work when the application overrides that file and even if you change the
+directory of AppBundle.
+
+The HttpKernel component provides a method called :method:`Symfony\\Component\\HttpKernel\\Kernel::locateResource`
+which can be used to transform logical paths into physical paths::
+
+    use Symfony\Component\HttpKernel\HttpKernel;
+
+    // ...
+    $kernel = new HttpKernel($dispatcher, $resolver);
+    $path = $kernel->locateResource('@AppBundle/Resources/config/services.xml');
 
 Learn more
 ----------


### PR DESCRIPTION
This fixes #4065 and replaces #7479, which didn't explain the method inside the HttpKernel component docs.