### PR TITLE
pass only strings to loadUserByUsername()

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -186,6 +186,10 @@ This requires you to implement six methods::
         {
             $apiKey = $credentials['token'];
 
+            if (null === $apiKey) {
+                return;
+            }
+
             // if null, authentication will fail
             // if a User object, checkCredentials() is called
             return $userProvider->loadUserByUsername($apiKey);


### PR DESCRIPTION
This completes #7065 as since the change made there the `token` key can refer to `null`.