### PR TITLE
Updated code example for LDAP integration

### DIFF
--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -62,14 +62,14 @@ extension with the following service definition:
                 class: Symfony\Component\Ldap\Ldap
                 arguments: ['@ext_ldap_adapter']
             ext_ldap_adapter:
-		class: Symfony\Component\Ldap\Adapter\ExtLdap\Adapter
-		arguments:
-		    -   host: my-server
-			port: 389
-			encryption: tls
-			options:
-			    protocol_version: 3
-			    referrals: false
+                class: Symfony\Component\Ldap\Adapter\ExtLdap\Adapter
+                arguments:
+                    -   host: my-server
+                        port: 389
+                        encryption: tls
+                        options:
+                            protocol_version: 3
+                            referrals: false
 
     .. code-block:: xml
 
@@ -84,15 +84,15 @@ extension with the following service definition:
                     <argument type="service" id="ext_ldap_adapter" />
                 </service>
                 <service id="ext_ldap_adapter" class="Symfony\Component\Ldap\Adapter\ExtLdap\Adapter">
-		    <argument type="collection">
-			<argument key="host">my-server</argument>
-			<argument key="port">389</argument>
-			<argument key="encryption">tls</argument>
-			<argument key="options" type="collection">
-			    <argument key="protocol_version">3</argument>
-			    <argument key="referrals">false</argument>
-			</argument>
-		    </argument>
+                    <argument type="collection">
+                        <argument key="host">my-server</argument>
+                        <argument key="port">389</argument>
+                        <argument key="encryption">tls</argument>
+                        <argument key="options" type="collection">
+                            <argument key="protocol_version">3</argument>
+                            <argument key="referrals">false</argument>
+                        </argument>
+                    </argument>
                 </service>
             </services>
         </container>

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -49,8 +49,8 @@ The providers are configured to use a default service named ``ldap``,
 but you can override this setting in the security component's
 configuration.
 
-An LDAP client can be simply configured, using the following service
-definition:
+An LDAP client can be simply configured using the built-in :phpext:`ldap` PHP
+extension with the following service definition:
 
 .. configuration-block::
 
@@ -59,13 +59,17 @@ definition:
         # app/config/services.yml
         services:
             ldap:
-                class: Symfony\Component\Ldap\LdapClient
-                arguments:
-                    - my-server   # host
-                    - 389         # port
-                    - 3           # version
-                    - false       # SSL
-                    - true        # TLS
+                class: Symfony\Component\Ldap\Ldap
+                arguments: ['@ext_ldap_adapter']
+            ext_ldap_adapter:
+		class: Symfony\Component\Ldap\Adapter\ExtLdap\Adapter
+		arguments:
+		    -   host: my-server
+			port: 389
+			encryption: tls
+			options:
+			    protocol_version: 3
+			    referrals: false
 
     .. code-block:: xml
 
@@ -76,12 +80,19 @@ definition:
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="ldap" class="Symfony\Component\Ldap\LdapClient">
-                    <argument>my-server</argument>
-                    <argument>389</argument>
-                    <argument>3</argument>
-                    <argument>false</argument>
-                    <argument>true</argument>
+                <service id="ldap" class="Symfony\Component\Ldap\Ldap">
+                    <argument type="service" id="ext_ldap_adapter" />
+                </service>
+                <service id="ext_ldap_adapter" class="Symfony\Component\Ldap\Adapter\ExtLdap\Adapter">
+		    <argument type="collection">
+			<argument key="host">my-server</argument>
+			<argument key="port">389</argument>
+			<argument key="encryption">tls</argument>
+			<argument key="options" type="collection">
+			    <argument key="protocol_version">3</argument>
+			    <argument key="referrals">false</argument>
+			</argument>
+		    </argument>
                 </service>
             </services>
         </container>
@@ -89,18 +100,23 @@ definition:
     .. code-block:: php
 
         // app/config/services.php
-        use Symfony\Component\Ldap\LdapClient;
+        use Symfony\Component\Ldap\Ldap;
+        use Symfony\Component\Ldap\Adapter\ExtLdap\Adapter;
         use Symfony\Component\DependencyInjection\Definition;
 
-        $container
-            ->setDefinition('ldap', new Definition(LdapClient::class, array(
-                'my-server',
-                389,
-                3,
-                false,
-                true,
+        $container->register('ldap', Ldap::class)
+            ->addArgument(new Reference('ext_ldap_adapter'));
 
-            ));
+        $container
+            ->setDefinition('ext_ldap_adapter, new Definition(Ldap::class, array(
+                'host' => 'my-server',
+                'port' => 389,
+                'encryption' => 'tls',
+                'options' => array(
+                    'protocol_version' => 3,
+                    'referrals' => false
+                )
+            )));
 
 Fetching Users Using the LDAP User Provider
 -------------------------------------------

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -108,7 +108,7 @@ extension with the following service definition:
             ->addArgument(new Reference('ext_ldap_adapter'));
 
         $container
-            ->setDefinition('ext_ldap_adapter, new Definition(Ldap::class, array(
+            ->setDefinition('ext_ldap_adapter', new Definition(Ldap::class, array(
                 'host' => 'my-server',
                 'port' => 389,
                 'encryption' => 'tls',

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -49,7 +49,7 @@ The providers are configured to use a default service named ``ldap``,
 but you can override this setting in the security component's
 configuration.
 
-An LDAP client can be simply configured using the built-in :phpext:`ldap` PHP
+An LDAP client can be simply configured using the built-in ``ldap`` PHP
 extension with the following service definition:
 
 .. configuration-block::

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -108,7 +108,7 @@ extension with the following service definition:
             ->addArgument(new Reference('ext_ldap_adapter'));
 
         $container
-            ->setDefinition('ext_ldap_adapter', new Definition(Ldap::class, array(
+            ->setDefinition('ext_ldap_adapter', new Definition(Adapter::class, array(
                 'host' => 'my-server',
                 'port' => 389,
                 'encryption' => 'tls',


### PR DESCRIPTION
The LdapClient class mentioned in the code example has been deprecated.
The update example, uses the Ldap class directly, as is recommended in
the deprecation notice.