### PR TITLE
[Workflow] Incorrect placeholders for leave/enter transitions

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -184,7 +184,7 @@ events are dispatched:
 
 * ``workflow.leave``
 * ``workflow.[workflow name].leave``
-* ``workflow.[workflow name].leave.[transition name]``
+* ``workflow.[workflow name].leave.[place name]``
 
 * ``workflow.transition``
 * ``workflow.[workflow name].transition``
@@ -192,7 +192,7 @@ events are dispatched:
 
 * ``workflow.enter``
 * ``workflow.[workflow name].enter``
-* ``workflow.[workflow name].enter.[transition name]``
+* ``workflow.[workflow name].enter.[place name]``
 
 * ``workflow.announce``
 * ``workflow.[workflow name].announce``


### PR DESCRIPTION
Both leave and enter transitions are related to particular places. The names of most verbose ones incorrectly stated the ``[transition name]`` placeholder. The name of the place being leaved/entered is used to generate the event name instead