### PR TITLE
Correct default firewall name on Security docs

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -48,7 +48,7 @@ configuration looks like this:
                     pattern: ^/(_(profiler|wdt)|css|images|js)/
                     security: false
 
-                default:
+                main:
                     anonymous: ~
 
     .. code-block:: xml
@@ -70,7 +70,7 @@ configuration looks like this:
                     pattern="^/(_(profiler|wdt)|css|images|js)/"
                     security="false" />
 
-                <firewall name="default">
+                <firewall name="main">
                     <anonymous />
                 </firewall>
             </config>
@@ -90,7 +90,7 @@ configuration looks like this:
                     'pattern'   => '^/(_(profiler|wdt)|css|images|js)/',
                     'security'  => false,
                 ),
-                'default' => array(
+                'main' => array(
                     'anonymous' => null,
                 ),
             ),
@@ -106,7 +106,7 @@ by your security.
     You can also match a request against other details of the request (e.g. host). For more
     information and examples read :doc:`/security/firewall_restriction`.
 
-All other URLs will be handled by the ``default`` firewall (no ``pattern``
+All other URLs will be handled by the ``main`` firewall (no ``pattern``
 key means it matches *all* URLs). You can think of the firewall like your
 security system, and so it usually makes sense to have just one main firewall.
 But this does *not* mean that every URL requires authentication - the ``anonymous``
@@ -144,7 +144,7 @@ To activate this, add the ``http_basic`` key under your firewall:
 
             firewalls:
                 # ...
-                default:
+                main:
                     anonymous: ~
                     http_basic: ~
 
@@ -161,7 +161,7 @@ To activate this, add the ``http_basic`` key under your firewall:
             <config>
                 <!-- ... -->
 
-                <firewall name="default">
+                <firewall name="main">
                     <anonymous />
                     <http-basic />
                 </firewall>
@@ -175,7 +175,7 @@ To activate this, add the ``http_basic`` key under your firewall:
             // ...
             'firewalls' => array(
                 // ...
-                'default' => array(
+                'main' => array(
                     'anonymous'  => null,
                     'http_basic' => null,
                 ),
@@ -216,7 +216,7 @@ user to be logged in to access this URL:
             # ...
             firewalls:
                 # ...
-                default:
+                main:
                     # ...
 
             access_control:
@@ -236,7 +236,7 @@ user to be logged in to access this URL:
             <config>
                 <!-- ... -->
 
-                <firewall name="default">
+                <firewall name="main">
                     <!-- ... -->
                 </firewall>
 
@@ -252,7 +252,7 @@ user to be logged in to access this URL:
             // ...
             'firewalls' => array(
                 // ...
-                'default' => array(
+                'main' => array(
                     // ...
                 ),
             ),
@@ -707,7 +707,7 @@ URL pattern. You saw this earlier, where anything matching the regular expressio
 
             firewalls:
                 # ...
-                default:
+                main:
                     # ...
 
             access_control:
@@ -727,7 +727,7 @@ URL pattern. You saw this earlier, where anything matching the regular expressio
             <config>
                 <!-- ... -->
 
-                <firewall name="default">
+                <firewall name="main">
                     <!-- ... -->
                 </firewall>
 
@@ -744,7 +744,7 @@ URL pattern. You saw this earlier, where anything matching the regular expressio
 
             'firewalls' => array(
                 // ...
-                'default' => array(
+                'main' => array(
                     // ...
                 ),
             ),

--- a/security.rst
+++ b/security.rst
@@ -14,9 +14,9 @@ is both flexible and (hopefully) fun to work with.
 Since there's a lot to talk about, this article is organized into a few big
 sections:
 
-#. Initial ``security.yml`` setup (*authentication*).
+#. Initial ``security.yml`` setup (*authentication*);
 
-#. Denying access to your app (*authorization*).
+#. Denying access to your app (*authorization*);
 
 #. Fetching the current User object.
 
@@ -611,10 +611,10 @@ basic auth and loads users right from the ``security.yml`` file.
 Your next steps depend on your setup:
 
 * Configure a different way for your users to login, like a :ref:`login form <security-form-login>`
-  or :doc:`something completely custom </security/custom_authentication_provider>`.
+  or :doc:`something completely custom </security/custom_authentication_provider>`;
 
 * Load users from a different source, like the :doc:`database </security/entity_provider>`
-  or :doc:`some other source </security/custom_provider>`.
+  or :doc:`some other source </security/custom_provider>`;
 
 * Learn how to deny access, load the User object and deal with roles in the
   :ref:`Authorization <security-authorization>` section.
@@ -684,7 +684,7 @@ There are **two** ways to deny access to something:
 
 #. :ref:`access_control in security.yml <security-authorization-access-control>`
    allows you to protect URL patterns (e.g. ``/admin/*``). This is easy,
-   but less flexible.
+   but less flexible;
 
 #. :ref:`in your code via the security.authorization_checker service <security-securing-controller>`.
 

--- a/security.rst
+++ b/security.rst
@@ -14,9 +14,9 @@ is both flexible and (hopefully) fun to work with.
 Since there's a lot to talk about, this article is organized into a few big
 sections:
 
-#. Initial ``security.yml`` setup (*authentication*);
+#. Initial ``security.yml`` setup (*authentication*).
 
-#. Denying access to your app (*authorization*);
+#. Denying access to your app (*authorization*).
 
 #. Fetching the current User object.
 
@@ -611,10 +611,10 @@ basic auth and loads users right from the ``security.yml`` file.
 Your next steps depend on your setup:
 
 * Configure a different way for your users to login, like a :ref:`login form <security-form-login>`
-  or :doc:`something completely custom </security/custom_authentication_provider>`;
+  or :doc:`something completely custom </security/custom_authentication_provider>`.
 
 * Load users from a different source, like the :doc:`database </security/entity_provider>`
-  or :doc:`some other source </security/custom_provider>`;
+  or :doc:`some other source </security/custom_provider>`.
 
 * Learn how to deny access, load the User object and deal with roles in the
   :ref:`Authorization <security-authorization>` section.
@@ -684,7 +684,7 @@ There are **two** ways to deny access to something:
 
 #. :ref:`access_control in security.yml <security-authorization-access-control>`
    allows you to protect URL patterns (e.g. ``/admin/*``). This is easy,
-   but less flexible;
+   but less flexible.
 
 #. :ref:`in your code via the security.authorization_checker service <security-securing-controller>`.
 


### PR DESCRIPTION
- Change firewall name from "default" to "main"