### PR TITLE
Update email.rst

### DIFF
--- a/email.rst
+++ b/email.rst
@@ -131,6 +131,15 @@ an email is pretty straightforward::
         return $this->render(...);
     }
 
+.. caution::
+
+    Starting from SwiftMailer 6.0, creation of ``Swift_Message`` instance 
+    is done by creating a new class instead of calling a static method.
+    
+    .. code-block:: php
+
+            $message = new \Swift_Message;
+
 To keep things decoupled, the email body has been stored in a template and
 rendered with the ``renderView()`` method. The ``registration.html.twig``
 template might look something like this:


### PR DESCRIPTION
Add note about creating Swift_Message for Swift Mailler 6.

Update http://symfony.com/doc/current/email.html#sending-emails according to  http://swiftmailer.org/docs/introduction.html as `$message = \Swift_Message::newInstance()` will produce `Error: Class 'AppBundle\Service\Swift_Message' not found` or similar for Swift Mailer 6.0.

Proposal: http://pr-7929-pgc3jri-6qmocelev2lwe.eu.platform.sh/email.html#sending-emails