### PR TITLE
Use OpenSSL instead of Mcrypt in the examples

### DIFF
--- a/session/proxy_examples.rst
+++ b/session/proxy_examples.rst
@@ -87,19 +87,22 @@ guest sessions.
 Encryption of Session Data
 --------------------------
 
-If you wanted to encrypt the session data, you could use the proxy to encrypt
-and decrypt the session as required::
+If you want to encrypt the session data, you can use the proxy to encrypt and
+decrypt the session as required. The following example uses the `php-encryption`_
+library, but you can adapt it to any other library that you may be using::
 
     // src/AppBundle/Session/EncryptedSessionProxy.php
     namespace AppBundle\Session;
 
+    use Defuse\Crypto\Crypto;
+    use Defuse\Crypto\Key;
     use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
 
     class EncryptedSessionProxy extends SessionHandlerProxy
     {
         private $key;
 
-        public function __construct(\SessionHandlerInterface $handler, $key)
+        public function __construct(\SessionHandlerInterface $handler, Key $key)
         {
             $this->key = $key;
 
@@ -110,12 +113,12 @@ and decrypt the session as required::
         {
             $data = parent::read($id);
 
-            return openssl_decrypt($data, \OPENSSL_ALGO_SHA1, $this->key);
+            return Crypto::decrypt($data, $this->key);
         }
 
         public function write($id, $data)
         {
-            $data = openssl_encrypt($data, \OPENSSL_ALGO_SHA1, $this->key);
+            $data = Crypto::encrypt($data, $this->key);
 
             return parent::write($id, $data);
         }
@@ -154,3 +157,5 @@ can intercept the session before it is written::
             return parent::write($id, $data);
         }
     }
+
+.. _`php-encryption`: https://github.com/defuse/php-encryption

--- a/session/proxy_examples.rst
+++ b/session/proxy_examples.rst
@@ -110,12 +110,12 @@ and decrypt the session as required::
         {
             $data = parent::read($id);
 
-            return mcrypt_decrypt(\MCRYPT_3DES, $this->key, $data);
+            return openssl_decrypt($data, \OPENSSL_ALGO_SHA1, $this->key);
         }
 
         public function write($id, $data)
         {
-            $data = mcrypt_encrypt(\MCRYPT_3DES, $this->key, $data);
+            $data = openssl_encrypt($data, \OPENSSL_ALGO_SHA1, $this->key);
 
             return parent::write($id, $data);
         }


### PR DESCRIPTION
This fixes #7925. Some comments:

* openssl_*() functions are not documented on php.net (see http://php.net/manual/en/function.openssl-decrypt.php) so I used this article as a reference: http://thefsb.tumblr.com/post/110749271235/using-opensslendecrypt-in-php-instead-of
* I think we don't need to use the `OPENSSL_RAW_DATA` or `OPENSSL_ZERO_PADDING` options ... but I'd like someone to verify this.
* I can't find an equivalent of `\MCRYPT_3DES` so I used `\OPENSSL_ALGO_SHA1`. I'm not sure if that's correct.