### PR TITLE
Remove remember me from interactive login examples

### DIFF
--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -310,7 +310,6 @@ The ``security.interactive_login`` event is triggered after a user has actively
 logged into your website.  It is important to distinguish this action from
 non-interactive authentication methods, such as:
 
-* authentication based on a "remember me" cookie.
 * authentication based on your session.
 * authentication using a HTTP basic or HTTP digest header.
 


### PR DESCRIPTION
Interactive login event was added to the remember me listener as part of commit symfony/symfony@8ccb8eb