### PR TITLE
Fixed the parse() method in the ExpressionLanguage AST examples

### DIFF
--- a/components/expression_language/ast.rst
+++ b/components/expression_language/ast.rst
@@ -21,7 +21,7 @@ method after parsing any expression to get its AST::
     use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
     $ast = (new ExpressionLanguage())
-        ->parse('1 + 2')
+        ->parse('1 + 2', array())
         ->getNodes()
     ;
 
@@ -41,7 +41,7 @@ method to turn the AST into an array::
     // ...
 
     $astAsArray = (new ExpressionLanguage())
-        ->parse('1 + 2')
+        ->parse('1 + 2', array())
         ->getNodes()
         ->toArray()
     ;


### PR DESCRIPTION
This fixes #7943.