### PR TITLE
Reworded the explanation about the --router option

### DIFF
--- a/setup/built_in_web_server.rst
+++ b/setup/built_in_web_server.rst
@@ -83,13 +83,12 @@ Command Options
 
 The built-in web server expects a "router" script (read about the "router"
 script on `php.net`_) as an argument. Symfony already passes such a router
-script when the command is executed in the ``prod`` or in the ``dev`` environment.
-Use the ``--router`` option in any other environment or to use another router
-script:
+script when the command is executed in the ``prod`` or ``dev`` environments.
+Use the ``--router`` option to use your own router script:
 
 .. code-block:: terminal
 
-    $ php app/console server:start --env=test --router=app/config/router_test.php
+    $ php app/console server:start --router=app/config/my_router.php
 
 If your application's document root differs from the standard directory layout,
 you have to pass the correct location using the ``--docroot`` option:


### PR DESCRIPTION
This fixes #7919.

In addition to fixing the reported issue, I propose to reword this phrase because it's a bit difficult to understand: `Use the --router option in any other environment or to use another router script:`