### PR TITLE
Anchor to "Configuring the voter" section fixed

### DIFF
--- a/security/voters.rst
+++ b/security/voters.rst
@@ -186,7 +186,7 @@ would look like this::
         }
     }
 
-That's it! The voter is done! Next, :ref:`configure it <declaring-the-voter-as-a-service>`.
+That's it! The voter is done! Next, :ref:`configure it <configuring-the-voter>`.
 
 To recap, here's what's expected from the two abstract methods:
 


### PR DESCRIPTION
Currently old link from version 2.7 is used and makes page scroll to the top.
This patch fixes it.