### PR TITLE
Update guard_authentication.rst

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -148,7 +148,7 @@ user (if any).
 To create a custom authentication system, just create a class and make it implement
 :class:`Symfony\\Component\\Security\\Guard\\GuardAuthenticatorInterface`. Or, extend
 the simpler :class:`Symfony\\Component\\Security\\Guard\\AbstractGuardAuthenticator`.
-This requires you to implement six methods::
+This requires you to implement seven methods::
 
     // src/AppBundle/Security/TokenAuthenticator.php
     namespace AppBundle\Security;


### PR DESCRIPTION
"Or, extend the simpler :class:`Symfony\\Component\\Security\\Guard\\AbstractGuardAuthenticator`. This requires you to implement seven methods::" not six.

GuardAuthenticatorInterface defines 8 methods, and AbstractGuardAuthenticator implements only the createAuthenticatedToken method:

http://api.symfony.com/3.2/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.html
http://api.symfony.com/3.2/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.html

Thanks!