### PR TITLE
fix broken hash value of link

### DIFF
--- a/service_container/compiler_passes.rst
+++ b/service_container/compiler_passes.rst
@@ -8,7 +8,7 @@ How to Work with Compiler Passes in Bundles
 Compiler passes give you an opportunity to manipulate other service
 definitions that have been registered with the service container. You
 can read about how to create them in the components section
-":ref:`components-di-compiler-pass`".
+":ref:`creating-separate-compiler-passes`".
 
 When using :ref:`separate compiler passes <components-di-separate-compiler-passes>`,
 you need to register them in the ``build()`` method of the bundle class (this

--- a/service_container/compiler_passes.rst
+++ b/service_container/compiler_passes.rst
@@ -8,7 +8,7 @@ How to Work with Compiler Passes in Bundles
 Compiler passes give you an opportunity to manipulate other service
 definitions that have been registered with the service container. You
 can read about how to create them in the components section
-":ref:`creating-separate-compiler-passes`".
+":ref:`components-di-separate-compiler-passes`".
 
 When using :ref:`separate compiler passes <components-di-separate-compiler-passes>`,
 you need to register them in the ``build()`` method of the bundle class (this


### PR DESCRIPTION
E.g. change http://symfony.com/doc/2.8/components/dependency_injection/compilation.html#components-di-separate-compiler-passes to 
http://symfony.com/doc/2.8/components/dependency_injection/compilation.html#creating-separate-compiler-passes

Affects all upstream versions up to 3.3/3.4