### PR TITLE
fix hash value of link

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -362,7 +362,7 @@ giving you a nice API for uploading files.
 .. tip::
 
     You will learn more about the ``Link`` and ``Form`` objects in the
-    :ref:`Crawler <testing-crawler>` section below.
+    :ref:`Crawler <the-crawler>` section below.
 
 The ``request()`` method can also be used to simulate form submissions directly
 or perform more complex requests. Some useful examples::
@@ -518,8 +518,6 @@ will no longer be followed::
 
 .. index::
    single: Tests; Crawler
-
-.. _testing-crawler:
 
 The Crawler
 -----------


### PR DESCRIPTION
http://symfony.com/doc/2.7/testing.html#testing-crawler replaced by http://symfony.com/doc/2.7/testing.html#the-crawler in http://symfony.com/doc/2.7/testing.html

Affects all versions from 2.7 up to 3.4