### PR TITLE
Forward slash regex alternative

### DIFF
--- a/routing/slash_in_parameter.rst
+++ b/routing/slash_in_parameter.rst
@@ -76,3 +76,9 @@ a more permissive regex path.
         return $collection;
 
 That's it! Now, the ``{username}`` parameter can contain the ``/`` character.
+
+Routes with ``_format`` parameter
+-------------------
+
+Using the expression ``.+`` with the ``_format`` parameter will match the ``.{_format}`` from your route. For example it will output a username of ``test/test`` as ``test/test.html``. 
+When using the ``_format`` parameter you can use  ``[^.]+`` (providing your parameter value doesn't contain dots).


### PR DESCRIPTION
When using the _format parameter in a route with the existing regex to allow slashes, it will append the _format onto your parameter value. Providing an alternative regex for this scenario.