### PR TITLE
[SwiftMailerBundle] add missing options allowed with an env variable

### DIFF
--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -232,7 +232,8 @@ the information will be available in the profiler.
 
     The following options can be set via environment variables using the
     ``%env()%`` syntax: ``url``, ``transport``, ``username``, ``password``,
-    ``host``, ``port``, ``timeout``, ``source_ip``, ``local_domain``.
+    ``host``, ``port``, ``timeout``, ``source_ip``, ``local_domain``,
+    ``encryption``, ``auth_mode``.
     For details, see the :doc:`/configuration/external_parameters` article.
 
 Full Default Configuration


### PR DESCRIPTION
CF https://github.com/symfony/swiftmailer-bundle/blob/master/DependencyInjection/SwiftmailerExtension.php#L81