### PR TITLE
setfacl commands in the right order

### DIFF
--- a/setup/file_permissions.rst
+++ b/setup/file_permissions.rst
@@ -50,8 +50,8 @@ following script to determine your web server user and grant the needed permissi
 
     $ HTTPDUSER=$(ps axo user,comm | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1)
     # if this doesn't work, try adding `-n` option
-    $ sudo setfacl -R -m u:"$HTTPDUSER":rwX -m u:$(whoami):rwX var
     $ sudo setfacl -dR -m u:"$HTTPDUSER":rwX -m u:$(whoami):rwX var
+    $ sudo setfacl -R -m u:"$HTTPDUSER":rwX -m u:$(whoami):rwX var
 
 .. note::
 


### PR DESCRIPTION
Order matters. Very unlikely case (but still likely): new files can be created between setfacl commands and those files will be out for default ACL application. So, the right order to apply setfacl is the default first and change current ones after.