### PR TITLE
Update AbstractGuardAuthenticator implementation code to pass curl test according to documentation

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -264,7 +264,7 @@ Finally, configure your ``firewalls`` key in ``security.yml`` to use this authen
                 # ...
 
                 main:
-                    anonymous: ~
+                    # remove anonymous authentication to force digest authentication
                     logout: ~
 
                     guard:

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -172,8 +172,8 @@ This requires you to implement seven methods::
         public function getCredentials(Request $request)
         {
             if (!$token = $request->headers->get('X-AUTH-TOKEN')) {
-                // No token?
-                $token = null;
+                // No token? Return null and show "Authentication Required"
+                return null;
             }
 
             // What you return here will be passed to getUser() as $credentials


### PR DESCRIPTION
Make the test curl http://localhost:8000/ return this value:
{"message":"Authentication Required"}
instead of
{"message":"Username could not be found."}