### PR TITLE
Revert a wrong change from #7877

### DIFF
--- a/form/type_guesser.rst
+++ b/form/type_guesser.rst
@@ -188,7 +188,8 @@ and tag it with ``form.type_guesser``:
         services:
             # ...
 
-            AppBundle\Form\TypeGuesser\PHPDocTypeGuesser: [form.type_guesser]
+            AppBundle\Form\TypeGuesser\PHPDocTypeGuesser:
+                tags: [form.type_guesser]
 
     .. code-block:: xml
 


### PR DESCRIPTION
As spotted by https://github.com/symfony/symfony-docs/pull/7978, the short service syntax is about arguments and not tags, so this change was wrong.