### PR TITLE
Remove/update lines causing build failures

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -164,12 +164,12 @@ and adding a priority.
         <!-- app/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="'http://www.w3.org/2001/XMLSchema-Instance"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-Instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
                 <!-- ... be sure autowiring is enabled -->
-                <defaults autowire="true" ... />
+                <defaults autowire="true" />
                 <!-- ... -->
 
                 <service id="AppBundle\ArgumentResolver\UserValueResolver">

--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -291,7 +291,7 @@ In that case, you might want to override one or both of the ``showAction()`` and
 
                 <services>
                     <!-- ... be sure autowiring is enabled -->
-                    <defaults autowire="true" ... />
+                    <defaults autowire="true" />
                     <!-- ... -->
 
                     <service id="AppBundle\Controller\CustomExceptionController" public="true">

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -396,7 +396,7 @@ Now, register this class as a Doctrine listener:
                 http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <!-- ... be sure autowiring is enabled -->
-            <defaults autowire="true" ... />
+            <defaults autowire="true" />
             <!-- ... -->
 
             <service id="AppBundle\EventListener\BrochureUploaderListener">

--- a/profiler/data_collector.rst
+++ b/profiler/data_collector.rst
@@ -251,10 +251,10 @@ to specify a tag that contains the template:
 
             <services>
                 <service id="AppBundle\DataCollector\RequestCollector" public="false">
+                    <!-- priority="300" -->
                     <tag name="data_collector"
                         template="data_collector/template.html.twig"
                         id="app.request_collector"
-                        <!-- priority="300" -->
                     />
                 </service>
             </services>

--- a/security/api_key_authentication.rst
+++ b/security/api_key_authentication.rst
@@ -444,7 +444,6 @@ configuration or set it to ``false``:
                 <firewall name="secured_area"
                     pattern="^/api"
                     stateless="false"
-                    ...
                 >
                 </firewall>
             </config>

--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -151,7 +151,7 @@ all the classes are already loaded as services. All you need to do is specify th
                 http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <prototype namespace="AppBundle\" resource="../../src/AppBundle/*" ... />
+                <prototype namespace="AppBundle\" resource="../../src/AppBundle/*" />
 
                 <service id="AppBundle\Mail\NewsletterManager">
                     <configurator service="AppBundle\Mail\EmailConfigurator" method="configure" />

--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -24,11 +24,11 @@ to another service: ``AppBundle\Mailer``. One way to do this is with an expressi
         # app/config/config.yml
         services:
             # ...
-            
+
             AppBundle\Mail\MailerConfiguration: ~
-            
+
             AppBundle\Mailer:
-                arguments: ["@=service('AppBundle\Mail\MailerConfiguration').getMailerMethod()"]
+                arguments: ["@=service('AppBundle\\Mail\\MailerConfiguration').getMailerMethod()"]
 
     .. code-block:: xml
 
@@ -56,7 +56,7 @@ to another service: ``AppBundle\Mailer``. One way to do this is with an expressi
         use AppBundle\Mail\MailerConfiguration;
         use AppBundle\Mailer;
         use Symfony\Component\ExpressionLanguage\Expression;
-        
+
         $container->autowire(AppBundle\Mail\MailerConfiguration::class);
 
         $container->autowire(Mailer::class)


### PR DESCRIPTION
This pull request amends the invalid code blocks within the documentation to fix the build errors (both locally and on `platform.sh`). ~~Additionally, this normalizes the dependency installation and build calls executed by both `travis` and `platform.sh` so they both use the same environment to build the documentation. _This is important as currently, often one will fail while the other will succeed; this should not ever happen and they should both either fail or succeed._~~

See https://github.com/symfony/symfony-docs/pull/8004#issuecomment-306661624 and https://github.com/symfony/symfony-docs/pull/8004#issuecomment-306857202 for the origin story.

~~*Note: This should likely be applied to the `3.3` branch which is where the errors originate, will update the target branch once this is confirmed.*~~