### PR TITLE
Update LessThan.rst "Basic Usage" part

### DIFF
--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -23,8 +23,8 @@ Basic Usage
 
 The following constraints ensure that:
 
-* the number of ``siblings`` of a ``Person`` is less than or equal to ``5``
-* ``age`` is less than``80``
+* the number of ``siblings`` of a ``Person`` is less than ``5``
+* ``age`` is less than ``80``
 
 .. configuration-block::
 


### PR DESCRIPTION
* Fix first bullet point containing information about the LessThanOrEqual constraint
* Fix second bullet point not displaying the number `80 ` in code highlighted format.