### PR TITLE
Fix YAML and XML syntax errors in configuration blocks

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -164,12 +164,12 @@ and adding a priority.
         <!-- app/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="'http://www.w3.org/2001/XMLSchema-Instance"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-Instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
                 <!-- ... be sure autowiring is enabled -->
-                <defaults autowire="true" ... />
+                <defaults autowire="true" />
                 <!-- ... -->
 
                 <service id="AppBundle\ArgumentResolver\UserValueResolver">

--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -291,7 +291,7 @@ In that case, you might want to override one or both of the ``showAction()`` and
 
                 <services>
                     <!-- ... be sure autowiring is enabled -->
-                    <defaults autowire="true" ... />
+                    <defaults autowire="true" />
                     <!-- ... -->
 
                     <service id="AppBundle\Controller\CustomExceptionController" public="true">

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -396,7 +396,7 @@ Now, register this class as a Doctrine listener:
                 http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <!-- ... be sure autowiring is enabled -->
-            <defaults autowire="true" ... />
+            <defaults autowire="true" />
             <!-- ... -->
 
             <service id="AppBundle\EventListener\BrochureUploaderListener">

--- a/profiler/data_collector.rst
+++ b/profiler/data_collector.rst
@@ -254,7 +254,6 @@ to specify a tag that contains the template:
                     <tag name="data_collector"
                         template="data_collector/template.html.twig"
                         id="app.request_collector"
-                        <!-- priority="300" -->
                     />
                 </service>
             </services>

--- a/security/api_key_authentication.rst
+++ b/security/api_key_authentication.rst
@@ -444,7 +444,6 @@ configuration or set it to ``false``:
                 <firewall name="secured_area"
                     pattern="^/api"
                     stateless="false"
-                    ...
                 >
                 </firewall>
             </config>

--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -151,7 +151,7 @@ all the classes are already loaded as services. All you need to do is specify th
                 http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <prototype namespace="AppBundle\" resource="../../src/AppBundle/*" ... />
+                <prototype namespace="AppBundle\" resource="../../src/AppBundle/*" />
 
                 <service id="AppBundle\Mail\NewsletterManager">
                     <configurator service="AppBundle\Mail\EmailConfigurator" method="configure" />

--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -24,11 +24,11 @@ to another service: ``AppBundle\Mailer``. One way to do this is with an expressi
         # app/config/config.yml
         services:
             # ...
-            
+
             AppBundle\Mail\MailerConfiguration: ~
-            
+
             AppBundle\Mailer:
-                arguments: ["@=service('AppBundle\Mail\MailerConfiguration').getMailerMethod()"]
+                arguments: ["@=service('AppBundle\\Mail\\MailerConfiguration').getMailerMethod()"]
 
     .. code-block:: xml
 
@@ -56,7 +56,7 @@ to another service: ``AppBundle\Mailer``. One way to do this is with an expressi
         use AppBundle\Mail\MailerConfiguration;
         use AppBundle\Mailer;
         use Symfony\Component\ExpressionLanguage\Expression;
-        
+
         $container->autowire(AppBundle\Mail\MailerConfiguration::class);
 
         $container->autowire(Mailer::class)


### PR DESCRIPTION
I changed the configuration blocks, especially for the XML version of configuration to conform to the XML file format.

Despite the fact that the syntax errors are "voluntary" to give hints to the reader for possible extra attributes, I fixed the doc for several reasons:

* The code doesn't get highlighted on the Symfony docs pages because of these errors. Example: on the [profiler data collector page](http://symfony.com/doc/current/profiler/data_collector.html), at the bottom, click on the XML tab and you will see it is not highlighted.
* The documentation can't be compiled with newer versions of Sphinx (1.5.x) as it results in errors because of these syntax errors.
* This is a regression since the Symfony 3.3 docs as there was no syntax error before.
* The YAML error is indeed an error (backslashes need to be escaped in double-quote strings).

Screenshot of a non-highlighted code (due to the commented attribute, which is not allowed in XML):
<img width="734" alt="how_to_create_a_custom_data_collector__current_" src="https://user-images.githubusercontent.com/344445/26977532-8605c1e0-4d28-11e7-92e9-f7df7dcc4e09.png">
