### PR TITLE
[Routing] `@Route` is usable without SensioFrameworkBundle since 3.4

### DIFF
--- a/best_practices/controllers.rst
+++ b/best_practices/controllers.rst
@@ -96,7 +96,7 @@ for the homepage of our app:
     namespace AppBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Symfony\Component\Routing\Annotation\Route;
     use Doctrine\ORM\EntityManagerInterface;
 
     class DefaultController extends Controller
@@ -149,7 +149,7 @@ For example:
 .. code-block:: php
 
     use AppBundle\Entity\Post;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Symfony\Component\Routing\Annotation\Route;
 
     /**
      * @Route("/{id}", name="admin_post_show")
@@ -202,9 +202,9 @@ flexible:
 .. code-block:: php
 
     use AppBundle\Entity\Post;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\Routing\Annotation\Route;
 
     /**
      * @Route("/comment/{postSlug}/new", name = "comment_new")

--- a/best_practices/security.rst
+++ b/best_practices/security.rst
@@ -109,8 +109,8 @@ Using ``@Security``, this looks like:
 
 .. code-block:: php
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+    use Symfony\Component\Routing\Annotation\Route;
     // ...
 
     /**
@@ -135,8 +135,8 @@ method on the ``Post`` object:
 .. code-block:: php
 
     use AppBundle\Entity\Post;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+    use Symfony\Component\Routing\Annotation\Route;
 
     /**
      * @Route("/{id}/edit", name="admin_post_edit")
@@ -191,6 +191,7 @@ Now you can reuse this method both in the template and in the security expressio
 
     use AppBundle\Entity\Post;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+    use Symfony\Component\Routing\Annotation\Route;
 
     /**
      * @Route("/{id}/edit", name="admin_post_edit")

--- a/components/routing.rst
+++ b/components/routing.rst
@@ -368,7 +368,7 @@ routes with UTF-8 characters:
         namespace AppBundle\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class DefaultController extends Controller
         {
@@ -442,7 +442,7 @@ You can also include UTF-8 strings as routing requirements:
         namespace AppBundle\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class DefaultController extends Controller
         {
@@ -508,7 +508,7 @@ You can also include UTF-8 strings as routing requirements:
         // ...
 
         return $collection;
-    
+
 .. tip::
 
     In addition to UTF-8 characters, the Routing component also supports all

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -127,16 +127,9 @@ your ``composer.json`` file to load from there:
         }
     }
 
-Now, suppose you want to use Twig and load routes via annotations. For annotation
-routing, you need SensioFrameworkExtraBundle. This comes with a normal Symfony project.
-But in this case, you need to download it:
-
-.. code-block:: bash
-
-    $ composer require sensio/framework-extra-bundle
-
-Instead of putting *everything* in ``index.php``, create a new ``app/AppKernel.php``
-to hold the kernel. Now it looks like this::
+Now, suppose you want to use Twig and load routes via annotations. Instead of
+putting *everything* in ``index.php``, create a new ``app/AppKernel.php`` to
+hold the kernel. Now it looks like this::
 
     // app/AppKernel.php
 
@@ -161,7 +154,6 @@ to hold the kernel. Now it looks like this::
             $bundles = array(
                 new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
                 new Symfony\Bundle\TwigBundle\TwigBundle(),
-                new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle()
             );
 
             if ($this->getEnvironment() == 'dev') {
@@ -208,6 +200,12 @@ to hold the kernel. Now it looks like this::
             return __DIR__.'/../var/logs';
         }
     }
+
+
+.. versionadded:: 3.4
+    Support for annotation routing without an external bundle was added in
+    Symfony 3.4. Prior to version 3.4, you needed to install the
+    SensioFrameworkExtraBundle.
 
 Unlike the previous kernel, this loads an external ``app/config/config.yml`` file,
 because the configuration started to get bigger:
@@ -261,7 +259,7 @@ has one file in it::
     namespace App\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class MicroController extends Controller
     {

--- a/controller.rst
+++ b/controller.rst
@@ -16,8 +16,8 @@ This renders a page that prints a lucky (random) number::
     // src/AppBundle/Controller/LuckyController.php
     namespace AppBundle\Controller;
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class LuckyController
     {
@@ -59,7 +59,7 @@ class::
     namespace AppBundle\Controller;
 
     use Symfony\Component\HttpFoundation\Response;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class LuckyController
     {
@@ -325,7 +325,7 @@ controller's service config:
 
         // app/config/services.php
         use AppBundle\Controller\LuckyController;
-        
+
         $container->register(LuckyController::class)
             ->setPublic(true)
             ->addTag('controller.service_arguments', [

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -34,6 +34,9 @@ syntax:
     .. code-block:: php-annotations
 
         # src/AppBundle/Controller/HelloController.php
+
+        // You need to use Sensio's annotation to specify a service id
+        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
         // ...
 
         /**

--- a/controller/soap_web_service.rst
+++ b/controller/soap_web_service.rst
@@ -61,7 +61,7 @@ can be retrieved via ``/soap?wsdl``::
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Response;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Symfony\Component\Routing\Annotation\Route;
     use AppBundle\Service\HelloService;
 
     class HelloServiceController extends Controller

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -110,9 +110,9 @@ Finally, you need to update the code of the controller that handles the form::
     // src/AppBundle/Controller/ProductController.php
     namespace AppBundle\ProductController;
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\Routing\Annotation\Route;
     use AppBundle\Entity\Product;
     use AppBundle\Form\ProductType;
 

--- a/doctrine/registration_form.rst
+++ b/doctrine/registration_form.rst
@@ -222,9 +222,9 @@ into the database::
 
     use AppBundle\Form\UserType;
     use AppBundle\Entity\User;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\Routing\Annotation\Route;
     use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
     use Doctrine\ORM\EntityManagerInterface;
 

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -47,8 +47,8 @@ random) number and prints it. To do that, create a "Controller class" and a
     // src/AppBundle/Controller/LuckyController.php
     namespace AppBundle\Controller;
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class LuckyController
     {

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -51,8 +51,8 @@ because that will be explained in the next section)::
 
     namespace AppBundle\Controller;
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class DefaultController extends Controller
     {
@@ -95,8 +95,8 @@ at the three lines of code above the ``indexAction()`` method::
     // src/AppBundle/Controller/DefaultController.php
     namespace AppBundle\Controller;
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class DefaultController extends Controller
     {

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -22,9 +22,9 @@ text content::
     // src/AppBundle/Controller/DefaultController.php
     namespace AppBundle\Controller;
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class DefaultController extends Controller
     {
@@ -57,8 +57,8 @@ a new method called ``helloAction()`` with the following content::
     // src/AppBundle/Controller/DefaultController.php
     namespace AppBundle\Controller;
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class DefaultController extends Controller
     {
@@ -114,7 +114,7 @@ Tweak the ``hello`` route by adding a new ``_format`` variable with ``html``
 as its default value::
 
     // src/AppBundle/Controller/DefaultController.php
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Symfony\Component\Routing\Annotation\Route;
 
     // ...
 
@@ -152,8 +152,8 @@ To restrict the formats supported by a given action, use the ``requirements``
 option of the ``@Route()`` annotation::
 
     // src/AppBundle/Controller/DefaultController.php
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+    use Symfony\Component\Routing\Annotation\Route;
 
     // ...
 
@@ -253,9 +253,9 @@ forget to add the new ``use`` statement that imports this ``Request`` class)::
     // src/AppBundle/Controller/DefaultController.php
     namespace AppBundle\Controller;
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class DefaultController extends Controller
     {
@@ -335,7 +335,7 @@ And you can display the flash message in the template like this:
     {% endfor %}
 
 .. versionadded:: 3.3
-    The ``app.flashes()`` Twig function was introduced in Symfony 3.3. Prior, 
+    The ``app.flashes()`` Twig function was introduced in Symfony 3.3. Prior,
     you had to use ``app.session.flashBag()``.
 
 Final Thoughts

--- a/routing.rst
+++ b/routing.rst
@@ -40,7 +40,7 @@ The route is simple:
         namespace AppBundle\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends Controller
         {
@@ -174,7 +174,7 @@ To fix this, add a *requirement* that the ``{page}`` wildcard can *only* match n
         namespace AppBundle\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends Controller
         {
@@ -272,7 +272,7 @@ So how can you make ``blog_list`` once again match when the user visits
         namespace AppBundle\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends Controller
         {

--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -29,8 +29,8 @@ Loading Routes
 The routes in a Symfony application are loaded by the
 :class:`Symfony\\Bundle\\FrameworkBundle\\Routing\\DelegatingLoader`.
 This loader uses several other loaders (delegates) to load resources of
-different types, for instance YAML files or ``@Route`` and ``@Method`` annotations
-in controller files. The specialized loaders implement
+different types, for instance YAML files or ``@Route`` annotations in controller
+files. The specialized loaders implement
 :class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`
 and therefore have two important methods:
 :method:`Symfony\\Component\\Config\\Loader\\LoaderInterface::supports`

--- a/routing/hostname_pattern.rst
+++ b/routing/hostname_pattern.rst
@@ -14,7 +14,7 @@ You can also match on the HTTP *host* of the incoming request.
         namespace AppBundle\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class MainController extends Controller
         {
@@ -96,7 +96,7 @@ you can use placeholders in your hostname:
         namespace AppBundle\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class MainController extends Controller
         {
@@ -173,7 +173,7 @@ instance, if you want to match both ``m.example.com`` and
         namespace AppBundle\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class MainController extends Controller
         {
@@ -266,7 +266,7 @@ instance, if you want to match both ``m.example.com`` and
             namespace AppBundle\Controller;
 
             use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-            use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+            use Symfony\Component\Routing\Annotation\Route;
 
             class MainController extends Controller
             {
@@ -367,7 +367,7 @@ You can also set the host option on imported routes:
         namespace AppBundle\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         /**
          * @Route(host="hello.example.com")

--- a/routing/redirect_trailing_slash.rst
+++ b/routing/redirect_trailing_slash.rst
@@ -42,9 +42,9 @@ system, as explained below:
         // src/AppBundle/Controller/RedirectingController.php
         namespace AppBundle\Controller;
 
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
         use Symfony\Component\HttpFoundation\Request;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class RedirectingController extends Controller
         {

--- a/routing/requirements.rst
+++ b/routing/requirements.rst
@@ -198,14 +198,12 @@ accomplished with the following route configuration:
         // src/AppBundle/Controller/BlogApiController.php
         namespace AppBundle\Controller;
 
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
         // ...
 
         class BlogApiController extends Controller
         {
             /**
-             * @Route("/api/posts/{id}")
-             * @Method({"GET","HEAD"})
+             * @Route("/api/posts/{id}", methods={"GET","HEAD"})
              */
             public function showAction($id)
             {
@@ -213,8 +211,7 @@ accomplished with the following route configuration:
             }
 
             /**
-             * @Route("/api/posts/{id}")
-             * @Method("PUT")
+             * @Route("/api/posts/{id}", methods="PUT")
              */
             public function editAction($id)
             {

--- a/routing/requirements.rst
+++ b/routing/requirements.rst
@@ -16,7 +16,7 @@ a routing ``{wildcard}`` to only match some regular expression:
         namespace AppBundle\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends Controller
         {

--- a/routing/slash_in_parameter.rst
+++ b/routing/slash_in_parameter.rst
@@ -26,7 +26,7 @@ a more permissive regex path.
 
     .. code-block:: php-annotations
 
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class DemoController
         {

--- a/security.rst
+++ b/security.rst
@@ -189,9 +189,9 @@ example, if you use annotations, create something like this::
     // src/AppBundle/Controller/DefaultController.php
     // ...
 
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class DefaultController extends Controller
     {

--- a/security/form_login_setup.rst
+++ b/security/form_login_setup.rst
@@ -92,7 +92,7 @@ configuration (``login``):
 
         // ...
         use Symfony\Component\HttpFoundation\Request;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class SecurityController extends Controller
         {

--- a/security/json_login_setup.rst
+++ b/security/json_login_setup.rst
@@ -70,7 +70,7 @@ path:
 
         // ...
         use Symfony\Component\HttpFoundation\Request;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class SecurityController extends Controller
         {

--- a/service_container.rst
+++ b/service_container.rst
@@ -81,6 +81,7 @@ You can also use the unique "Service ID" to access a service directly::
     namespace AppBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class ProductController extends Controller
     {
@@ -238,7 +239,7 @@ You can also fetch a service directly from the container via its "id", which wil
 be its class name in this case::
 
     use AppBundle\Service\MessageGenerator;
-    
+
     // accessing services like this only works if you extend Controller
     class ProductController extends Controller
     {
@@ -475,7 +476,7 @@ pass here. No problem! In your configuration, you can explicitly set this argume
 
         // app/config/services.php
         use AppBundle\Updates\SiteUpdateManager;
-        
+
         // _defaults and importing directories does not work in PHP
         // but registering a service explicitly does
         $container->autowire(SiteUpdateManager::class)
@@ -773,7 +774,7 @@ from the container::
     public function newAction(MessageGenerator $messageGenerator)
     {
         // type-hinting it as an argument DOES work
-    
+
         // but accessing it directly from the container does NOT Work
         $this->container->get(MessageGenerator::class);
     }

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -122,8 +122,8 @@ Now, you can use the ``TwitterClient`` service immediately in a controller::
     namespace AppBundle\Controller;
 
     use AppBundle\Service\TwitterClient;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class DefaultController extends Controller
     {

--- a/templating.rst
+++ b/templating.rst
@@ -579,7 +579,7 @@ configuration:
         // src/AppBundle/Controller/WelcomeController.php
 
         // ...
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class WelcomeController extends Controller
         {
@@ -648,7 +648,7 @@ route:
         // src/AppBundle/Controller/ArticleController.php
 
         // ...
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class ArticleController extends Controller
         {

--- a/templating/formats.rst
+++ b/templating/formats.rst
@@ -23,7 +23,7 @@ different formats based on the "request format". For that reason, a common
 pattern is to do the following::
 
     // ...
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class ArticleController extends Controller
     {


### PR DESCRIPTION
Since https://github.com/symfony/symfony/pull/23044, annotation routes are supported by the framework bundle. So I think we should push using the annotation of the Routing component instead of the one of SensioFrameworkExtraBundle.