### PR TITLE
Minor reword for the intro of the Templating article

### DIFF
--- a/templating.rst
+++ b/templating.rst
@@ -4,20 +4,18 @@
 Creating and Using Templates
 ============================
 
-As you know, the :doc:`controller </controller>` is responsible for
-handling each request that comes into a Symfony application. In reality,
-the controller delegates most of the heavy work to other places so that
-code can be tested and reused. When a controller needs to generate HTML,
+As explained in :doc:`the previous article </controller>`, controllers are
+responsible for handling each request that comes into a Symfony application and
+the usually end up rendering a template to generate the response contents.
+
+In reality, the controller delegates most of the heavy work to other places so
+that code can be tested and reused. When a controller needs to generate HTML,
 CSS or any other content, it hands the work off to the templating engine.
+
 In this article, you'll learn how to write powerful templates that can be
 used to return content to the user, populate email bodies, and more. You'll
 learn shortcuts, clever ways to extend templates and how to reuse template
 code.
-
-.. note::
-
-    How to render templates is covered in the
-    :ref:`controller <controller-rendering-templates>` article.
 
 .. index::
    single: Templating; What is a template?


### PR DESCRIPTION
I don't like that the beginning of the article is *"As you know..."* ... because most of the people reading that will probably don't know 😄 

I don't like either other minor things of that intro, so I propose this reword:

### Before

![before_text](https://user-images.githubusercontent.com/73419/27003536-ebdcaac6-4df8-11e7-9d4d-7db73d5223d4.png)

### After

![after_text](https://user-images.githubusercontent.com/73419/27003537-ee9530a8-4df8-11e7-8003-fd88bf15e889.png)
