### PR TITLE
Added a missing <script> tag in an example

### DIFF
--- a/routing/generate_url_javascript.rst
+++ b/routing/generate_url_javascript.rst
@@ -26,7 +26,7 @@ variables. The ``escape()`` function helps escape any non-JavaScript-safe values
 But if you *actually* need to generate routes in pure JavaScript, consider using
 the `FOSJsRoutingBundle`_. It makes the following possible:
 
-.. code-block:: javascript
+.. code-block:: html+javascript
 
     <script>
     var url = Routing.generate('blog_show', {

--- a/routing/generate_url_javascript.rst
+++ b/routing/generate_url_javascript.rst
@@ -28,8 +28,10 @@ the `FOSJsRoutingBundle`_. It makes the following possible:
 
 .. code-block:: javascript
 
+    <script>
     var url = Routing.generate('blog_show', {
         'slug': 'my-blog-post'
     });
+    </script>
 
 .. _`FOSJsRoutingBundle`: https://github.com/FriendsOfSymfony/FOSJsRoutingBundle

--- a/routing/generate_url_javascript.rst
+++ b/routing/generate_url_javascript.rst
@@ -26,7 +26,7 @@ variables. The ``escape()`` function helps escape any non-JavaScript-safe values
 But if you *actually* need to generate routes in pure JavaScript, consider using
 the `FOSJsRoutingBundle`_. It makes the following possible:
 
-.. code-block:: html+javascript
+.. code-block:: html+twig
 
     <script>
     var url = Routing.generate('blog_show', {


### PR DESCRIPTION
It's obvious that this code is JavaScript ... but to make it consistent with the other example of the article, I propose to add the `<script>` tags to the second example. Close it if you disagree. Thanks!