### PR TITLE
Fix autoescape_service example

### DIFF
--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -43,7 +43,7 @@ TwigBundle Configuration ("twig")
             autoescape:                ~
 
             # See http://twig.sensiolabs.org/doc/recipes.html#using-the-template-name-to-set-the-default-escaping-strategy
-            autoescape_service:        ~ # Example: '@my_service'
+            autoescape_service:        ~ # Example: 'my_service'
             autoescape_service_method: ~ # use in combination with autoescape_service option
             base_template_class:       ~ # Example: Twig_Template
             cache:                     '%kernel.cache_dir%/twig'


### PR DESCRIPTION
As @fabpot said in https://github.com/symfony/symfony/issues/8833, the `autoescape_service` value must not start with an `@`.