### PR TITLE
Changed link to Capifony

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -198,7 +198,7 @@ Don't forget that deploying your application also involves updating any dependen
 (typically via Composer), migrating your database, clearing your cache and
 other potential things like pushing assets to a CDN (see `Common Post-Deployment Tasks`_).
 
-.. _`Capifony`: http://capifony.org/
+.. _`Capifony`: https://github.com/everzet/capifony
 .. _`Capistrano`: http://capistranorb.com/
 .. _`sf2debpkg`: https://github.com/liip/sf2debpkg
 .. _`Fabric`: http://www.fabfile.org/


### PR DESCRIPTION
Changed the link to Capifony since capifony.org is not owned by the previous mantainers and now redirecting to a SPAM page