### PR TITLE
Return null when csrfToken is not valid

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -505,7 +505,7 @@ and add the following logic::
             $csrfToken = $request->request->get('_csrf_token');
             
             if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken('authenticate', $csrfToken))) {
-                throw new InvalidCsrfTokenException('Invalid CSRF token.');
+                return null;
             }
             
             // ... all your normal logic


### PR DESCRIPTION
I am not 100% sure of this change, but throwing an `InvalidCsrfTokenException` when the csrfToken is not valid makes the framework redirect to the url returned by `getLoginUrl` method, and from there, it keeps redirecting in a loop until the browser kills the redirections.

According to the documentation for `getCredentials` method, it should return `null` when there is some parameter missing, so I guess `null` is the correct value to return when the csrfToken validation fails.