### PR TITLE
Use Twig's namespaced paths

### DIFF
--- a/profiler/data_collector.rst
+++ b/profiler/data_collector.rst
@@ -153,7 +153,7 @@ block and set the value of two variables called ``icon`` and ``text``:
 
 .. code-block:: html+twig
 
-    {% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+    {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
     {% block toolbar %}
         {% set icon %}


### PR DESCRIPTION
This only solves an inconsistency in this article. Both paths are valid and functional by default in Symfony. But http://symfony.com/doc/2.7/templating/namespaced_paths.html:

> As an added bonus, the namespaced syntax is faster.

What do you think about using it everywhere?