### PR TITLE
Replacing EntityManagerInterface -> $this->getDoctrine()->getManager();

### DIFF
--- a/best_practices/controllers.rst
+++ b/best_practices/controllers.rst
@@ -97,16 +97,16 @@ for the homepage of our app:
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-    use Doctrine\ORM\EntityManagerInterface;
 
     class DefaultController extends Controller
     {
         /**
          * @Route("/", name="homepage")
          */
-        public function indexAction(EntityManagerInterface $em)
+        public function indexAction()
         {
-            $posts = $em->getRepository('AppBundle:Post')
+            $posts = $this->getDoctrine()
+                ->getRepository('AppBundle:Post')
                 ->findLatest();
 
             return $this->render('default/index.html.twig', array(

--- a/best_practices/security.rst
+++ b/best_practices/security.rst
@@ -224,9 +224,10 @@ more advanced use-case, you can always do the same security check in PHP:
     /**
      * @Route("/{id}/edit", name="admin_post_edit")
      */
-    public function editAction($id, EntityManagerInterface $em)
+    public function editAction($id)
     {
-        $post = $em->getRepository('AppBundle:Post')
+        $post = $this->getDoctrine()
+            ->getRepository('AppBundle:Post')
             ->find($id);
 
         if (!$post) {

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -551,10 +551,11 @@ a controller, this is pretty easy. Add the following method to the
     use Doctrine\ORM\EntityManagerInterface;
     use Doctrine\Common\Persistence\ManagerRegistry;
 
-    public function createAction(EntityManagerInterface $em)
+    public function createAction()
     {
-        // or fetch the em via the container
-        // $em = $this->get('doctrine')->getManager();
+        // you can fetch the EntityManager via $this->getDoctrine()
+        // or you can add an argument to your action: createAction(EntityManagerInterface $em)
+        $em = $this->get('doctrine')->getManager();
 
         $product = new Product();
         $product->setName('Keyboard');
@@ -571,8 +572,9 @@ a controller, this is pretty easy. Add the following method to the
     }
 
     // if you have multiple entity managers, use the registry to fetch them
-    public function editAction(ManagerRegistry $doctrine)
+    public function editAction()
     {
+        $doctrine = $this->getDoctrine();
         $em = $doctrine->getManager();
         $em2 = $doctrine->getManager('other_connection')
     }
@@ -586,11 +588,11 @@ Take a look at the previous example in more detail:
 
 .. _doctrine-entity-manager:
 
-* **line 10** The ``EntityManagerInterface`` type-hint tells Symfony to pass you Doctrine's
+* **line 14** The ``$this->getDoctrine()->getManager()`` method gets Doctrine's
   *entity manager* object, which is the most important object in Doctrine. It's
   responsible for saving objects to, and fetching objects from, the database.
 
-* **lines 15-18** In this section, you instantiate and work with the ``$product``
+* **lines 16-18** In this section, you instantiate and work with the ``$product``
   object like any other normal PHP object.
 
 * **line 21** The ``persist($product)`` call tells Doctrine to "manage" the
@@ -633,11 +635,10 @@ Fetching an object back out of the database is even easier. For example,
 suppose you've configured a route to display a specific ``Product`` based
 on its ``id`` value::
 
-    use Doctrine\ORM\EntityManagerInterface;
-
-    public function showAction($productId, EntityManagerInterface $em)
+    public function showAction($productId)
     {
-        $product = $em->getRepository('AppBundle:Product')
+        $product = $this->getDoctrine()
+            ->getRepository('AppBundle:Product')
             ->find($productId);
 
         if (!$product) {
@@ -727,11 +728,11 @@ Updating an Object
 Once you've fetched an object from Doctrine, updating it is easy. Suppose
 you have a route that maps a product id to an update action in a controller::
 
-    use Doctrine\ORM\EntityManagerInterface;
-
-    public function updateAction($productId, EntityManagerInterface $em)
+    public function updateAction($productId)
     {
-        $product = $em->getRepository('AppBundle:Product')->find($productId);
+        $product = $this->getDoctrine()
+            ->getRepository('AppBundle:Product')
+            ->find($productId);
 
         if (!$product) {
             throw $this->createNotFoundException(

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -588,11 +588,11 @@ Take a look at the previous example in more detail:
 
 .. _doctrine-entity-manager:
 
-* **line 14** The ``$this->getDoctrine()->getManager()`` method gets Doctrine's
+* **line 13** The ``$this->getDoctrine()->getManager()`` method gets Doctrine's
   *entity manager* object, which is the most important object in Doctrine. It's
   responsible for saving objects to, and fetching objects from, the database.
 
-* **lines 16-18** In this section, you instantiate and work with the ``$product``
+* **lines 15-18** In this section, you instantiate and work with the ``$product``
   object like any other normal PHP object.
 
 * **line 21** The ``persist($product)`` call tells Doctrine to "manage" the

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -549,7 +549,6 @@ a controller, this is pretty easy. Add the following method to the
     use AppBundle\Entity\Product;
     use Symfony\Component\HttpFoundation\Response;
     use Doctrine\ORM\EntityManagerInterface;
-    use Doctrine\Common\Persistence\ManagerRegistry;
 
     public function createAction()
     {

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -388,7 +388,6 @@ object and its related ``Category`` with just one query::
     public function showAction($productId)
     {
         $product = $this->getDoctrine()
-            ->getManager()
             ->getRepository('AppBundle:Product')
             ->findOneByIdJoinedToCategory($productId);
 

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -236,11 +236,10 @@ Now you can see this new code in action! Imagine you're inside a controller::
     use AppBundle\Entity\Category;
     use AppBundle\Entity\Product;
     use Symfony\Component\HttpFoundation\Response;
-    use Doctrine\ORM\EntityManagerInterface;
 
     class DefaultController extends Controller
     {
-        public function createProductAction(EntityManagerInterface $em)
+        public function createProductAction()
         {
             $category = new Category();
             $category->setName('Computer Peripherals');
@@ -253,6 +252,7 @@ Now you can see this new code in action! Imagine you're inside a controller::
             // relate this product to the category
             $product->setCategory($category);
 
+            $em = $this->getDoctrine()->getManager();
             $em->persist($category);
             $em->persist($product);
             $em->flush();
@@ -276,11 +276,10 @@ When you need to fetch associated objects, your workflow looks just like it
 did before. First, fetch a ``$product`` object and then access its related
 ``Category`` object::
 
-    use Doctrine\ORM\EntityManagerInterface;
-
-    public function showAction($productId, EntityManagerInterface $em)
+    public function showAction($productId)
     {
-        $product = $em->getRepository('AppBundle:Product')
+        $product = $this->getDoctrine()
+            ->getRepository('AppBundle:Product')
             ->find($productId);
 
         $categoryName = $product->getCategory()->getName();
@@ -304,11 +303,10 @@ the category (i.e. it's "lazily loaded").
 
 You can also query in the other direction::
 
-    use Doctrine\ORM\EntityManagerInterface;
-
-    public function showProductsAction($categoryId, EntityManagerInterface $em)
+    public function showProductsAction($categoryId)
     {
-        $category = $em->getRepository('AppBundle:Category')
+        $category = $this->getDoctrine()
+            ->getRepository('AppBundle:Category')
             ->find($categoryId);
 
         $products = $category->getProducts();
@@ -367,11 +365,11 @@ can avoid the second query by issuing a join in the original query. Add the
 following method to the ``ProductRepository`` class::
 
     // src/AppBundle/Repository/ProductRepository.php
-    use Doctrine\ORM\EntityManagerInterface;
-
     public function findOneByIdJoinedToCategory($productId)
     {
-        $query = $em->createQuery(
+        $query = $this->getDoctrine()
+            ->getManager()
+            ->createQuery(
             'SELECT p, c FROM AppBundle:Product p
             JOIN p.category c
             WHERE p.id = :id'
@@ -387,11 +385,11 @@ following method to the ``ProductRepository`` class::
 Now, you can use this method in your controller to query for a ``Product``
 object and its related ``Category`` with just one query::
 
-    use Doctrine\ORM\EntityManagerInterface;
-
-    public function showAction($productId, EntityManagerInterface $em)
+    public function showAction($productId)
     {
-        $product = $em->getRepository('AppBundle:Product')
+        $product = $this->getDoctrine()
+            ->getManager()
+            ->getRepository('AppBundle:Product')
             ->findOneByIdJoinedToCategory($productId);
 
         $category = $product->getCategory();

--- a/doctrine/registration_form.rst
+++ b/doctrine/registration_form.rst
@@ -226,14 +226,13 @@ into the database::
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
-    use Doctrine\ORM\EntityManagerInterface;
 
     class RegistrationController extends Controller
     {
         /**
          * @Route("/register", name="user_registration")
          */
-        public function registerAction(Request $request, UserPasswordEncoderInterface $passwordEncoder, EntityManagerInterface $em)
+        public function registerAction(Request $request, UserPasswordEncoderInterface $passwordEncoder)
         {
             // 1) build the form
             $user = new User();
@@ -248,6 +247,7 @@ into the database::
                 $user->setPassword($password);
 
                 // 4) save the User!
+                $em = $this->getDoctrine()->getManager();
                 $em->persist($user);
                 $em->flush();
 

--- a/doctrine/repository.rst
+++ b/doctrine/repository.rst
@@ -96,12 +96,12 @@ entities, ordered alphabetically by name.
 
 You can use this new method just like the default finder methods of the repository::
 
-    use Doctrine\ORM\EntityManagerInterface;
     // ...
 
-    public function listAction(EntityManagerInterface $em)
+    public function listAction()
     {
-        $products = $em->getRepository('AppBundle:Product')
+        $products = $this->getDoctrine()
+            ->getRepository('AppBundle:Product')
             ->findAllOrderedByName();
     }
 

--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -679,11 +679,11 @@ the relationship between the removed ``Tag`` and ``Task`` object.
         // src/AppBundle/Controller/TaskController.php
 
         use Doctrine\Common\Collections\ArrayCollection;
-        use Doctrine\ORM\EntityManagerInterface;
 
         // ...
-        public function editAction($id, Request $request, EntityManagerInterface $e,)
+        public function editAction($id, Request $request)
         {
+            $em = $this->getDoctrine()->getManager();
             $task = $em->getRepository('AppBundle:Task')->find($id);
 
             if (!$task) {

--- a/form/form_dependencies.rst
+++ b/form/form_dependencies.rst
@@ -32,13 +32,11 @@ create your form::
 
     // src/AppBundle/Controller/DefaultController.php
     use AppBundle\Form\TaskType;
-    use Doctrine\ORM\EntityManagerInterface;
 
     // ...
-    public function newAction(EntityManagerInterface $em)
+    public function newAction()
     {
-        // or fetch the em via the container
-        // $em = $this->get('doctrine')->getManager();
+        $em = $this->get('doctrine')->getManager();
 
         $task = ...;
         $form = $this->createForm(TaskType::class, $task, array(

--- a/form/form_dependencies.rst
+++ b/form/form_dependencies.rst
@@ -36,7 +36,7 @@ create your form::
     // ...
     public function newAction()
     {
-        $em = $this->get('doctrine')->getManager();
+        $em = $this->getDoctrine()->getManager();
 
         $task = ...;
         $form = $this->createForm(TaskType::class, $task, array(

--- a/forms.rst
+++ b/forms.rst
@@ -221,7 +221,7 @@ your controller::
     // ...
     use Symfony\Component\HttpFoundation\Request;
 
-    public function newAction(Request $request, EntityManagerInterface $em)
+    public function newAction(Request $request)
     {
         // just setup a fresh $task object (remove the dummy data)
         $task = new Task();
@@ -241,6 +241,7 @@ your controller::
 
             // ... perform some action, such as saving the task to the database
             // for example, if Task is a Doctrine entity, save it!
+            // $em = $this->getDoctrine()->getManager();
             // $em->persist($task);
             // $em->flush();
 

--- a/introduction/from_flat_php_to_symfony2.rst
+++ b/introduction/from_flat_php_to_symfony2.rst
@@ -545,22 +545,22 @@ them for you. Here's the same sample application, now built in Symfony::
     namespace AppBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-    use Doctrine\ORM\EntityManagerInterface;
 
     class BlogController extends Controller
     {
-        public function listAction(EntityManagerInterface $em)
+        public function listAction()
         {
-            $posts = $em
+            $posts = $this->getDoctrine()
+                ->getManager()
                 ->createQuery('SELECT p FROM AppBundle:Post p')
                 ->execute();
 
             return $this->render('Blog/list.html.php', array('posts' => $posts));
         }
 
-        public function showAction(EntityManagerInterface $em)
+        public function showAction()
         {
-            $post = $em
+            $post = $this->getDoctrine()
                 ->getRepository('AppBundle:Post')
                 ->find($id);
 


### PR DESCRIPTION
When I was updating everything to use type-hints for 3.3, we had discussed that we should probably recommend using the helper method `$this->getDoctrine()` in the controller instead of type-hinting `EntityManagerInterface`. This reverts my changes to reflect that.