### PR TITLE
Update js-datepicker usage for new jQuery UI

### DIFF
--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -108,7 +108,7 @@ Assuming you're using jQuery, you can initialize the date picker via:
     <script>
         $(document).ready(function() {
             $('.js-datepicker').datepicker({
-                format: 'yyyy-mm-dd'
+                dateFormat: 'yy-mm-dd'
             });
         });
     </script>

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -101,14 +101,16 @@ make the following changes::
         'attr' => ['class' => 'js-datepicker'],
     ));
 
-Assuming you're using jQuery, you can initialize the date picker via:
+Then, add the following JavaScript code in your template to initialize the date
+picker:
 
 .. code-block:: html
 
     <script>
         $(document).ready(function() {
+            // you may need to change this code if you are not using Bootstrap Datepicker
             $('.js-datepicker').datepicker({
-                dateFormat: 'yy-mm-dd'
+                format: 'yyyy-mm-dd'
             });
         });
     </script>


### PR DESCRIPTION
Old variable used - "format" - doesn't work anymore in jQuery UI.