### PR TITLE
Add form_theme in error customization

### DIFF
--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -873,6 +873,8 @@ and customize the ``form_errors`` fragment.
 
     .. code-block:: html+twig
 
+        {% form_theme form _self %}
+
         {# form_errors.html.twig #}
         {% block form_errors %}
             {% spaceless %}
@@ -932,6 +934,8 @@ fields (e.g. a whole form), and not just an individual field.
 .. configuration-block::
 
     .. code-block:: html+twig
+
+        {% form_theme form _self %}
 
         {# form_errors.html.twig #}
         {% block form_errors %}


### PR DESCRIPTION
User form_theme __self in error examples as in other examples of the page.