### PR TITLE
Add default indication in input arguments/options description

### DIFF
--- a/console/input.rst
+++ b/console/input.rst
@@ -91,7 +91,7 @@ There are three argument variants you can use:
     provided;
 
 ``InputArgument::OPTIONAL``
-    The argument is optional and therefore can be omitted;
+    The argument is optional and therefore can be omitted. This is the default mode when you omit or pass null to the ``$mode`` parameter of the ``addArgument`` method;
 
 ``InputArgument::IS_ARRAY``
     The argument can contain any number of values. For that reason, it must be
@@ -178,7 +178,7 @@ There are four option variants you can use:
 ``InputOption::VALUE_IS_ARRAY``
     This option accepts multiple values (e.g. ``--dir=/foo --dir=/bar``);
 ``InputOption::VALUE_NONE``
-    Do not accept input for this option (e.g. ``--yell``);
+    Do not accept input for this option (e.g. ``--yell``). This is the default mode when you omit or pass null to the ``$mode`` parameter of the ``addOption`` method;
 ``InputOption::VALUE_REQUIRED``
     This value is required (e.g. ``--iterations=5``), the option itself is
     still optional;

--- a/console/input.rst
+++ b/console/input.rst
@@ -91,11 +91,12 @@ There are three argument variants you can use:
     provided;
 
 ``InputArgument::OPTIONAL``
-    The argument is optional and therefore can be omitted. This is the default mode when you omit or pass null to the ``$mode`` parameter of the ``addArgument`` method;
+    The argument is optional and therefore can be omitted. This is the default
+    behavior of arguments;
 
 ``InputArgument::IS_ARRAY``
     The argument can contain any number of values. For that reason, it must be
-    used at the end of the argument list
+    used at the end of the argument list.
 
 You can combine ``IS_ARRAY`` with ``REQUIRED`` and ``OPTIONAL`` like this::
 
@@ -177,11 +178,15 @@ There are four option variants you can use:
 
 ``InputOption::VALUE_IS_ARRAY``
     This option accepts multiple values (e.g. ``--dir=/foo --dir=/bar``);
+
 ``InputOption::VALUE_NONE``
-    Do not accept input for this option (e.g. ``--yell``). This is the default mode when you omit or pass null to the ``$mode`` parameter of the ``addOption`` method;
+    Do not accept input for this option (e.g. ``--yell``). This is the default
+    behavior of options;
+
 ``InputOption::VALUE_REQUIRED``
     This value is required (e.g. ``--iterations=5``), the option itself is
     still optional;
+
 ``InputOption::VALUE_OPTIONAL``
     This option may or may not have a value (e.g. ``--yell`` or
     ``--yell=loud``).


### PR DESCRIPTION
As i had to check in the code to find the information (even if it can seems logical for some people), i think it can be good to precise that here.