### PR TITLE
QuestionHelper - `disableStty` is static method

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -212,6 +212,7 @@ convenient for passwords::
     On Windows systems, this ``stty`` command may generate gibberish output and
     mangle the input text. If that's your case, disable it with this command::
 
+        use Symfony\Component\Console\Helper\QuestionHelper;
         use Symfony\Component\Console\Question\ChoiceQuestion;
 
         // ...
@@ -219,7 +220,7 @@ convenient for passwords::
         {
             // ...
             $helper = $this->getHelper('question');
-            $helper->disableStty();
+            QuestionHelper::disableStty();
 
             // ...
         }


### PR DESCRIPTION
The docs suggest disabling stty must be done on each instance of `QuestionHelper`, however it is a static method setting a static property, i.e. it effects _all_ instances.
Besides, its always a good idea to call `static` methods using the `static` call syntax.