### PR TITLE
Fix typo er(r)or

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -372,7 +372,7 @@ method. Here are several common services you might need::
     // you can also fetch parameters
     $someParameter = $this->getParameter('some_parameter');
 
-If you receive an eror like:
+If you receive an error like:
 
 .. code-block:: text
 


### PR DESCRIPTION
Fix typo in word "error" at the Accessing the Container Directly block