### PR TITLE
incorrect session short description

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -453,8 +453,8 @@ Managing the Session
 --------------------
 
 Symfony provides a nice session object that you can use to store information
-about the user between requests. By default, Symfony stores the attributes in a
-cookie by using native PHP sessions.
+about the user between requests. By default, Symfony stores the token in a
+cookie and writes the attributes to a file by using native PHP sessions.
 
 .. versionadded:: 3.3
     The ability to request a ``Session`` instance in controllers was introduced


### PR DESCRIPTION
The session cookie only holds the session token. By default, the data attributes are stored (inside a bag) at a file.
@see NativeFileSessionHandler.