### PR TITLE
Add information for enable property_info service

### DIFF
--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -348,14 +348,17 @@ Using PHP reflection, the :class:`Symfony\\Component\\PropertyInfo\\Extractor\\R
 provides list, type and access information from setter and accessor methods.
 It can also provide return and scalar types for PHP 7+.
 
-This service is automatically registered with the ``property_info`` service in
-the Symfony Framework, you just have to enable it in config.yml.
+.. note::
 
-.. code-block:: yaml
+    When using the Symfony framework, this service is automatically registered
+    when the ``property_info`` feature is enabled:
 
-    framework:
-        property_info:
-            enabled: true
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        framework:
+            property_info:
+                enabled: true
 
 .. code-block:: php
 

--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -357,7 +357,6 @@ the Symfony Framework, you just have to enable it in config.yml.
         property_info:
             enabled: true
 
-
 .. code-block:: php
 
     use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;

--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -349,7 +349,14 @@ provides list, type and access information from setter and accessor methods.
 It can also provide return and scalar types for PHP 7+.
 
 This service is automatically registered with the ``property_info`` service in
-the Symfony Framework.
+the Symfony Framework, you just have to enable it in config.yml.
+
+.. code-block:: yaml
+
+    framework:
+        property_info:
+            enabled: true
+
 
 .. code-block:: php
 


### PR DESCRIPTION
add code for enable property_info service because service is not available by default in symfony full stack.
Also, I don't really understand why the property_info is mentionned in ReflectionExtractor section because property_info service lead to Symfony\Component\PropertyInfo\PropertyInfoExtractor and not the ReflectionExtractor class.