### PR TITLE
[Form] Fix maxlength attribute

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -568,10 +568,10 @@ the correct values of a number of field options.
     field ``nullable``). This is very useful, as your client-side validation will
     automatically match your validation rules.
 
-``max_length``
-    If the field is some sort of text field, then the ``max_length`` option can be
-    guessed from the validation constraints (if ``Length`` or ``Range`` is used) or
-    from the Doctrine metadata (via the field's length).
+``maxlength``
+    If the field is some sort of text field, then the ``maxlength`` option attribute
+    can be guessed from the validation constraints (if ``Length`` or ``Range`` is used)
+    or from the Doctrine metadata (via the field's length).
 
 .. caution::
 


### PR DESCRIPTION
Surprisingly, some reminiscence of the very old Symfony `max_length` form option (deprecated since Symfony 2.5!) is still present on the forms documentation page (including for Symfony 3.3), despite #3461 was merged and was already fixing it.

These was the only reminiscences, all other pages are up-to-date.