### PR TITLE
Simplified the requirements article

### DIFF
--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -6,57 +6,27 @@
 Requirements for Running Symfony
 ================================
 
-To run Symfony, your system needs to adhere to a list of requirements. You
-can easily see if your system passes all requirements by running the
-``web/config.php`` in your Symfony distribution. Since the CLI often uses
-a different ``php.ini`` configuration file, it's also a good idea to check
-your requirements from the command line via:
+Symfony 2.7 requires **PHP 5.3.9** or higher to run, in addition to other minor
+requirements. To make things simple, Symfony provides a tool to quickly check if
+your system meets all those requirements.
+
+Beware that PHP can define a different configuration for the command console and
+the web server, so you need to check requirements in both.
+
+Checking Requirements for the Web Server
+----------------------------------------
+
+Browse the ``web/config.php`` file in your browser and fix the reported issues.
+When using the PHP built-in web server, this file is available at
+``http://127.0.0.1:8000/config.php``
+
+Checking Requirements for the Command Console
+---------------------------------------------
+
+Open your console or terminal, enter in your project directory, execute this
+command and fix the reported issues:
 
 .. code-block:: terminal
 
+    $ cd my-project/
     $ php app/check.php
-
-Below is the list of required and optional requirements.
-
-Required
---------
-
-* PHP needs to be a minimum version of PHP 5.3.9
-* `JSON extension`_ needs to be enabled
-* `ctype extension`_ needs to be enabled
-* Your ``php.ini`` needs to have the ``date.timezone`` setting
-
-.. caution::
-
-    Be aware that PHP 5.3.16 is not suitable to run Symfony,
-    because of a `major bug in the Reflection subsystem`_.
-
-Optional
---------
-
-* You need to have the PHP-XML module installed
-* You need to have at least version 2.6.21 of libxml
-* PHP tokenizer needs to be enabled
-* mbstring functions need to be enabled
-* iconv needs to be enabled
-* POSIX needs to be enabled (only on \*nix)
-* Intl needs to be installed with ICU 4+
-* APC 3.0.17+ (or another opcode cache needs to be installed)
-* ``php.ini`` recommended settings
-
-  * ``short_open_tag = Off``
-  * ``magic_quotes_gpc = Off``
-  * ``register_globals = Off``
-  * ``session.auto_start = Off``
-
-Doctrine
---------
-
-If you want to use Doctrine, you will need to have PDO installed. Additionally,
-you need to have the PDO driver installed for the database server you want
-to use.
-
-.. _`Requirements section of the README`: https://github.com/symfony/symfony/blob/2.7/README.md#requirements
-.. _`JSON extension`: https://php.net/manual/book.json.php
-.. _`ctype extension`: https://php.net/manual/book.ctype.php
-.. _`major bug in the Reflection subsystem`: https://bugs.php.net/bug.php?id=62715

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -11,7 +11,7 @@ requirements. To make things simple, Symfony provides a tool to quickly check if
 your system meets all those requirements.
 
 Beware that PHP can define a different configuration for the command console and
-the web server, so you need to check requirements in both.
+the web server, so you need to check requirements in both environments.
 
 Checking Requirements for the Web Server
 ----------------------------------------
@@ -20,7 +20,7 @@ Browse the ``web/config.php`` file in your browser and fix the reported issues.
 When using the PHP built-in web server, this file is available at
 ``http://127.0.0.1:8000/config.php``
 
-Once you've fixed all the reported issues, delete this ``web/config.php`` file
+Once you've fixed all the reported issues, delete the ``web/config.php`` file
 to avoid leaking internal information about your application to visitors.
 
 Checking Requirements for the Command Console

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -16,9 +16,8 @@ the web server, so you need to check requirements in both environments.
 Checking Requirements for the Web Server
 ----------------------------------------
 
-Browse the ``web/config.php`` file in your browser and fix the reported issues.
-When using the PHP built-in web server, this file is available at
-``http://127.0.0.1:8000/config.php``
+Symfony includes a ``config.php`` file in the ``web/`` directory of your project.
+Open that file with your browser to check the requirements.
 
 Once you've fixed all the reported issues, delete the ``web/config.php`` file
 to avoid leaking internal information about your application to visitors.

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -20,6 +20,9 @@ Browse the ``web/config.php`` file in your browser and fix the reported issues.
 When using the PHP built-in web server, this file is available at
 ``http://127.0.0.1:8000/config.php``
 
+Once you've fixed all the reported issues, delete this ``web/config.php`` file
+to avoid leaking internal information about your application to visitors.
+
 Checking Requirements for the Command Console
 ---------------------------------------------
 


### PR DESCRIPTION
Explaining the full list of requirements is not very smart, because we have a Requirement Checker that does that and it's hard to keep the doc in sync with that tool.

I propose to simplify this article to only mention the specific PHP version required by Symfony and then explain how to check the other requirements.

If you agree with this, I'll make the PRs for the other maintained Symfony versions. If this is merged, we can then simplify the installation article even more (removing this section: "Checking Symfony Requirements" -> https://github.com/symfony/symfony-docs/pull/8135/files#diff-1ef3833b924d9500d8baaa4bfa9fdb68R84)