### PR TITLE
[DX] ADR usage

### DIFF
--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -131,7 +131,7 @@ the request from simple method injection like this ::
         }
     }
 
-Like you can easily imagine, the :class:`Symfony\\Component\Httpfoundation\RequestStack` is the best option to gain access to the request, using this approach, a simple update is recommended and the access to request parameters is way easier::
+Like you can easily imagine, the :class:`Symfony\\Component\\Httpfoundation\\RequestStack` is the best option to gain access to the request, using this approach, a simple update is recommended and the access to request parameters is way easier::
 
     <?php
 

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -127,40 +127,12 @@ the request from simple method injection like this ::
 
         public function __invoke(Request $request): Response
         {
-            return new Response($this->twig->render('default/index.html.twig'));
+            $id = $this->requestStack->getCurrentRequest()->get('id');
+            
+            return new Response($this->twig->render('default/index.html.twig', array('id' => $id));
         }
     }
-
-Like you can easily imagine, the :class:`Symfony\\Component\\Httpfoundation\\RequestStack` is the best option to gain access to the request, using this approach, a simple update is recommended and the access to request parameters is way easier::
-
-    <?php
-
-    namespace AppBundle\Action;
-
-    use Twig\Environment;
-    use Symfony\Component\HttpFoundation\Response;
-    use Symfony\Component\HttpFoundation\RequestStack;
-
-    final class HelloAction
-    {
-        private $requestStack;
-
-        private $twig;
-
-        public function __construct(RequestStack $requestStack, Environment $twig)
-        {
-            $this->requestStack = $requestStack
-            $this->twig = $twig;
-        }
-
-        public function __invoke(): Response
-        {
-            $data = $this->requestStack->getCurrentRequest()->get('id');
-
-            return new Response($this->twig->render('default/index.html.twig', array('data' => $data));
-        }
-    }
-
+    
 Final thought
 -------------
 

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -26,7 +26,6 @@ use the latest features of the DependencyInjection component, this way, here's t
         AppBundle\Action\:
             resource: '../../src/AppBundle/Action/'
             tags: ['controller.service_arguments']
-            public: true
 
 Once the file is updated, delete your Controller folder and create an Action class using the ADR principles, i.e::
 

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -127,9 +127,9 @@ the request from simple method injection like this ::
 
         public function __invoke(Request $request): Response
         {
-            $id = $this->requestStack->getCurrentRequest()->get('id');
+            $id = $request->get('id');
             
-            return new Response($this->twig->render('default/index.html.twig', array('id' => $id));
+            return $this->twig->render('default/index.html.twig', array('id' => $id));
         }
     }
     

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -34,7 +34,7 @@ Once the file is updated, delete your Controller folder and create an Action cla
     namespace AppBundle\Action;
 
     use Twig\Environment;
-    use Symfony\Component\HTTPFoundation\Response;
+    use Symfony\Component\HttpFoundation\Response;
 
     final class HelloAction
     {
@@ -45,7 +45,7 @@ Once the file is updated, delete your Controller folder and create an Action cla
             $this->twig = $twig;
         }
 
-        public function __invoke() : Response
+        public function __invoke(): Response
         {
             return new Response($this->twig->render('default/index.html.twig'));
         }
@@ -122,10 +122,10 @@ the request from simple method injection like this ::
 
     <?php
 
-        use Symfony\Component\HTTPFoundation\Request;
+        use Symfony\Component\HttpFoundation\Request;
         // ...
 
-        public function __invoke(Request $request) : Response
+        public function __invoke(Request $request): Response
         {
             return new Response($this->twig->render('default/index.html.twig'));
         }
@@ -138,7 +138,7 @@ Like you can easily imagine, the :class:`Symfony\\Component\\Httpfoundation\\Req
     namespace AppBundle\Action;
 
     use Twig\Environment;
-    use Symfony\Component\HTTPFoundation\Response;
+    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpFoundation\RequestStack;
 
     final class HelloAction
@@ -153,7 +153,7 @@ Like you can easily imagine, the :class:`Symfony\\Component\\Httpfoundation\\Req
             $this->twig = $twig;
         }
 
-        public function __invoke() : Response
+        public function __invoke(): Response
         {
             $data = $this->requestStack->getCurrentRequest()->get('id');
 

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -1,0 +1,187 @@
+.. index::
+single: Action Domain Responder approach
+
+How to implement the ADR pattern
+================================
+
+In Symfony, you're used to implement the MVC pattern and extending the default 'Controller'
+class, since the 3.3 update, Symfony is capable of using natively the ADR approach.
+
+Updating your internal logic
+----------------------------
+
+As you saw from earlier example, you must update the services.yml file in order to
+use the latest features of the DependencyInjection component, this way, here's the updates ::
+
+    # ...
+
+    services:
+        _defaults:
+            autowire: true
+            autoconfigure: true
+            public: false
+
+        # Allow to load every actions
+        AppBundle\Action\:
+            resource: '../../src/AppBundle/Action/'
+            public: true
+
+Once the file is updated, delete your Controller folder and create an Action class using the ADR principles, i.e ::
+
+    <?php
+
+    namespace AppBundle\Action;
+
+    use Twig\Environment;
+    use Symfony\Component\Templating\EngineInterface;
+
+    final class HelloAction
+    {
+        private $renderer;
+
+        public function __construct(Environment $render)
+        {
+            $this->render = $render;
+        }
+
+        public function __invoke()
+        {
+            return new Response($this->render->render('default/index.html.twig'));
+        }
+    }
+
+.. tip::
+
+    As described in the DependencyInjection doc, you must use the __construct() injection
+    approach, this way, your class is easier to update and keep in sync with the framework internal
+    services.
+
+By default, we define the class with the final keyword because this class shouldn't been extended,
+the logic is pretty simple to understand as you understand the ADR pattern, in fact, the 'Action'
+is linked to a single request and his dependencies are linked to this precise Action.
+
+.. tip::
+
+    By using the final approach and the private visibility (inside the container), our class
+    is faster to return and easier to keep out of the framework logic.
+
+
+Once this is done, you can define the routes like before using multiples approach :
+
+.. configuration-block::
+
+    .. code-block:: php-annotations
+
+        # src/AppBundle/Action/HelloAction.php
+        // ...
+
+        /**
+         * @Route("/hello", name="hello")
+         */
+        final class HelloAction
+        {
+            // ...
+        }
+
+    .. code-block:: yaml
+
+        # app/config/routing.yml
+        hello:
+            path:     /hello
+            defaults: { _controller: AppBundle\Action\HelloAction }
+
+    .. code-block:: xml
+
+        <!-- app/config/routing.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <routes xmlns="http://symfony.com/schema/routing"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
+
+            <route id="hello" path="/hello">
+                <default key="_controller">AppBundle\Action\HelloAction</default>
+            </route>
+
+        </routes>
+
+    .. code-block:: php
+
+        // app/config/routing.php
+        $collection->add('hello', new Route('/hello', array(
+            '_controller' => 'HelloAction::class',
+        )));
+
+Accessing the request
+---------------------
+
+As you can imagine, as the logic evolve, your class isn't capable of accessing
+the request from simple method injection like this ::
+
+    <?php
+
+        // ...
+
+        public function __invoke(Request $request)
+        {
+            return new Response($this->render->render('default/index.html.twig'));
+        }
+    }
+
+Like you can easily imagine, the container is the best option to gain access to ths request,
+using this approach, a simple update is recommended ::
+
+    <?php
+
+    namespace AppBundle\Action;
+
+    use Twig\Environment;
+    use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HttpFoundation\RequestStack;
+    use Symfony\Component\Templating\EngineInterface;
+
+    final class HelloAction
+    {
+        private $requestStack;
+
+        private $renderer;
+
+        public function __construct(RequestStack $requestStack, Environment $render)
+        {
+            $this->requestStack = $requestStack
+            $this->render = $render;
+        }
+
+        public function __invoke(Request $request)
+        {
+            return new Response($this->render->render('default/index.html.twig'));
+        }
+    }
+
+This way, you can easily access to parameters ::
+
+    <?php
+
+        // ...
+
+        public function __construct(RequestStack $requestStack, Environment $render)
+        {
+            $this->requestStack = $requestStack
+            $this->render = $render;
+        }
+
+        public function __invoke(Request $request)
+        {
+            $data = $this->requestStack->getCurrentRequest()->get('id');
+
+            return new Response($this->render->render('default/index.html.twig'));
+        }
+    }
+
+Final though
+------------
+
+Keep in mind that this approach can be completely different from what you're used to use, in order to
+keep your code clean and easy to maintain, we recommend to use this approach only if your code is
+decoupled from the internal framework logic (like with Clean Architecture approach) or if you start a new
+project and need to keep the logic linked to your business rules.

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -25,6 +25,7 @@ use the latest features of the DependencyInjection component, this way, here's t
         # Allow to load every actions
         AppBundle\Action\:
             resource: '../../src/AppBundle/Action/'
+            tags: ['controller.service_arguments']
             public: true
 
 Once the file is updated, delete your Controller folder and create an Action class using the ADR principles, i.e::
@@ -38,24 +39,16 @@ Once the file is updated, delete your Controller folder and create an Action cla
 
     final class HelloAction
     {
-        private $twig;
-
-        public function __construct(Environment $twig)
+        public function __invoke(Environment $twig): Response
         {
-            $this->twig = $twig;
-        }
-
-        public function __invoke(): Response
-        {
-            return new Response($this->twig->render('default/index.html.twig'));
+            return new Response($twig->render('default/index.html.twig'));
         }
     }
 
 .. tip::
 
-    As described in the DependencyInjection doc, you must use the __construct() injection
-    approach, this way, your class is easier to update and keep in sync with any framework internal
-    services.
+    As described in the DependencyInjection doc, you can still use the __construct() injection
+    approach.
 
 By default, we define the class with the final keyword because this class shouldn't be extended,
 the logic is pretty simple to understand as you understand the ADR pattern, in fact, the 'Action'
@@ -125,11 +118,11 @@ the request from simple method injection like this ::
         use Symfony\Component\HttpFoundation\Request;
         // ...
 
-        public function __invoke(Request $request): Response
+        public function __invoke(Environment $twig, Request $request): Response
         {
             $id = $request->get('id');
             
-            return $this->twig->render('default/index.html.twig', array('id' => $id));
+            return $twig->render('default/index.html.twig', array('id' => $id));
         }
     }
     

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -108,14 +108,16 @@ Once this is done, you can define the routes like before using multiples approac
     .. code-block:: php
 
         // app/config/routing.php
+        use AppBundle\Action\HelloAction
+        
         $collection->add('hello', new Route('/hello', array(
-            '_controller' => 'HelloAction::class',
+            '_controller' => HelloAction::class,
         )));
 
 Accessing the request
 ---------------------
 
-As you can imagine, as the logic evolve, your class isn't capable of accessing
+As you can imagine, as the logic evolve, your class is capable of accessing
 the request from simple method injection like this ::
 
     <?php

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -4,14 +4,15 @@ single: Action Domain Responder approach
 How to implement the ADR pattern
 ================================
 
-In Symfony, you're used to implement the MVC pattern and extending the default 'Controller'
-class, since the 3.3 update, Symfony is capable of using natively the ADR approach.
+In Symfony, you're used to implement the MVC pattern and extending the default :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller`
+class. 
+Since the 3.3 update, Symfony is capable of using natively the ADR approach.
 
-Updating your internal logic
-----------------------------
+Updating your configuration
+---------------------------
 
-As you saw from earlier example, you must update the services.yml file in order to
-use the latest features of the DependencyInjection component, this way, here's the updates ::
+As the framework evolve, you must update the services.yml file in order to
+use the latest features of the DependencyInjection component, this way, here's the updates::
 
     # ...
 
@@ -26,14 +27,13 @@ use the latest features of the DependencyInjection component, this way, here's t
             resource: '../../src/AppBundle/Action/'
             public: true
 
-Once the file is updated, delete your Controller folder and create an Action class using the ADR principles, i.e ::
+Once the file is updated, delete your Controller folder and create an Action class using the ADR principles, i.e::
 
     <?php
 
     namespace AppBundle\Action;
 
     use Twig\Environment;
-    use Symfony\Component\Templating\EngineInterface;
 
     final class HelloAction
     {
@@ -53,10 +53,10 @@ Once the file is updated, delete your Controller folder and create an Action cla
 .. tip::
 
     As described in the DependencyInjection doc, you must use the __construct() injection
-    approach, this way, your class is easier to update and keep in sync with the framework internal
+    approach, this way, your class is easier to update and keep in sync with any framework internal
     services.
 
-By default, we define the class with the final keyword because this class shouldn't been extended,
+By default, we define the class with the final keyword because this class shouldn't be extended,
 the logic is pretty simple to understand as you understand the ADR pattern, in fact, the 'Action'
 is linked to a single request and his dependencies are linked to this precise Action.
 
@@ -66,7 +66,7 @@ is linked to a single request and his dependencies are linked to this precise Ac
     is faster to return and easier to keep out of the framework logic.
 
 
-Once this is done, you can define the routes like before using multiples approach :
+Once this is done, you can define the routes like before using multiples approach:
 
 .. configuration-block::
 
@@ -158,7 +158,7 @@ using this approach, a simple update is recommended ::
         }
     }
 
-This way, you can easily access to parameters ::
+This way, you can easily access to parameters::
 
     <?php
 
@@ -174,7 +174,7 @@ This way, you can easily access to parameters ::
         {
             $data = $this->requestStack->getCurrentRequest()->get('id');
 
-            return new Response($this->twig->render('default/index.html.twig'));
+            return new Response($this->twig->render('default/index.html.twig', ['data' => $data]));
         }
     }
 

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -8,26 +8,10 @@ In Symfony, you're used to implement the MVC pattern and extending the default :
 class.
 Since the 3.3 update, Symfony is capable of using natively the ADR approach.
 
-Updating your configuration
----------------------------
+Updating your classes
+---------------------
 
-As the framework evolve, you must update the services.yml file in order to
-use the latest features of the DependencyInjection component, this way, here's the updates::
-
-    # ...
-
-    services:
-        _defaults:
-            autowire: true
-            autoconfigure: true
-            public: false
-
-        # Allow to load every actions
-        AppBundle\Action\:
-            resource: '../../src/AppBundle/Action/'
-            tags: ['controller.service_arguments']
-
-Once the file is updated, delete your Controller folder and create an Action class using the ADR principles, i.e::
+As the framework evolve, you must update your classes, first, delete your Controller folder and create an Action one then a new class using the ADR principles, i.e::
 
     <?php
 

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -1,11 +1,11 @@
 .. index::
-single: Action Domain Responder approach
+    single: Action Domain Responder approach
 
 How to implement the ADR pattern
 ================================
 
 In Symfony, you're used to implement the MVC pattern and extending the default :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller`
-class. 
+class.
 Since the 3.3 update, Symfony is capable of using natively the ADR approach.
 
 Updating your configuration
@@ -109,7 +109,7 @@ Once this is done, you can define the routes like before using multiples approac
 
         // app/config/routing.php
         use AppBundle\Action\HelloAction
-        
+
         $collection->add('hello', new Route('/hello', array(
             '_controller' => HelloAction::class,
         )));
@@ -156,7 +156,7 @@ Like you can easily imagine, the :class:`Symfony\\Component\Httpfoundation\Reque
         public function __invoke() : Response
         {
             $data = $this->requestStack->getCurrentRequest()->get('id');
-            
+
             return new Response($this->twig->render('default/index.html.twig', array('data' => $data));
         }
     }

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -34,6 +34,7 @@ Once the file is updated, delete your Controller folder and create an Action cla
     namespace AppBundle\Action;
 
     use Twig\Environment;
+    use Symfony\Component\HTTPFoundation\Response;
 
     final class HelloAction
     {
@@ -44,7 +45,7 @@ Once the file is updated, delete your Controller folder and create an Action cla
             $this->twig = $twig;
         }
 
-        public function __invoke()
+        public function __invoke() : Response
         {
             return new Response($this->twig->render('default/index.html.twig'));
         }
@@ -65,8 +66,7 @@ is linked to a single request and his dependencies are linked to this precise Ac
     By using the final approach and the private visibility (inside the container), our class
     is faster to return and easier to keep out of the framework logic.
 
-
-Once this is done, you can define the routes like before using multiples approach:
+Once this is done, you can define the routes like before using multiples approaches:
 
 .. configuration-block::
 
@@ -122,25 +122,24 @@ the request from simple method injection like this ::
 
     <?php
 
+        use Symfony\Component\HTTPFoundation\Request;
         // ...
 
-        public function __invoke(Request $request)
+        public function __invoke(Request $request) : Response
         {
             return new Response($this->twig->render('default/index.html.twig'));
         }
     }
 
-Like you can easily imagine, the container is the best option to gain access to ths request,
-using this approach, a simple update is recommended ::
+Like you can easily imagine, the :class:`Symfony\\Component\Httpfoundation\RequestStack` is the best option to gain access to the request, using this approach, a simple update is recommended and the access to request parameters is way easier::
 
     <?php
 
     namespace AppBundle\Action;
 
     use Twig\Environment;
-    use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HTTPFoundation\Response;
     use Symfony\Component\HttpFoundation\RequestStack;
-    use Symfony\Component\Templating\EngineInterface;
 
     final class HelloAction
     {
@@ -154,34 +153,16 @@ using this approach, a simple update is recommended ::
             $this->twig = $twig;
         }
 
-        public function __invoke(Request $request)
-        {
-            return new Response($this->twig->render('default/index.html.twig'));
-        }
-    }
-
-This way, you can easily access to parameters::
-
-    <?php
-
-        // ...
-
-        public function __construct(RequestStack $requestStack, Environment $twig)
-        {
-            $this->requestStack = $requestStack
-            $this->twig = $twig;
-        }
-
-        public function __invoke(Request $request)
+        public function __invoke() : Response
         {
             $data = $this->requestStack->getCurrentRequest()->get('id');
-
-            return new Response($this->twig->render('default/index.html.twig', ['data' => $data]));
+            
+            return new Response($this->twig->render('default/index.html.twig', array('data' => $data));
         }
     }
 
 Final thought
-------------
+-------------
 
 Keep in mind that this approach can be completely different from what you're used to use, in order to
 keep your code clean and easy to maintain, we recommend to use this approach only if your code is

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -37,16 +37,16 @@ Once the file is updated, delete your Controller folder and create an Action cla
 
     final class HelloAction
     {
-        private $renderer;
+        private $twig;
 
-        public function __construct(Environment $render)
+        public function __construct(Environment $twig)
         {
-            $this->render = $render;
+            $this->twig = $twig;
         }
 
         public function __invoke()
         {
-            return new Response($this->render->render('default/index.html.twig'));
+            return new Response($this->twig->render('default/index.html.twig'));
         }
     }
 
@@ -124,7 +124,7 @@ the request from simple method injection like this ::
 
         public function __invoke(Request $request)
         {
-            return new Response($this->render->render('default/index.html.twig'));
+            return new Response($this->twig->render('default/index.html.twig'));
         }
     }
 
@@ -144,17 +144,17 @@ using this approach, a simple update is recommended ::
     {
         private $requestStack;
 
-        private $renderer;
+        private $twig;
 
-        public function __construct(RequestStack $requestStack, Environment $render)
+        public function __construct(RequestStack $requestStack, Environment $twig)
         {
             $this->requestStack = $requestStack
-            $this->render = $render;
+            $this->twig = $twig;
         }
 
         public function __invoke(Request $request)
         {
-            return new Response($this->render->render('default/index.html.twig'));
+            return new Response($this->twig->render('default/index.html.twig'));
         }
     }
 
@@ -164,21 +164,21 @@ This way, you can easily access to parameters ::
 
         // ...
 
-        public function __construct(RequestStack $requestStack, Environment $render)
+        public function __construct(RequestStack $requestStack, Environment $twig)
         {
             $this->requestStack = $requestStack
-            $this->render = $render;
+            $this->twig = $twig;
         }
 
         public function __invoke(Request $request)
         {
             $data = $this->requestStack->getCurrentRequest()->get('id');
 
-            return new Response($this->render->render('default/index.html.twig'));
+            return new Response($this->twig->render('default/index.html.twig'));
         }
     }
 
-Final though
+Final thought
 ------------
 
 Keep in mind that this approach can be completely different from what you're used to use, in order to

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -6,7 +6,7 @@ How to implement the ADR pattern
 
 In Symfony, you're used to implement the MVC pattern and extending the default :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller`
 class.
-Since the 3.3 update, Symfony is capable of using natively the ADR approach.
+Since the 3.3 update, Symfony is capable of using natively the `ADR`_ approach.
 
 Update the configuration
 ------------------------
@@ -202,3 +202,5 @@ Keep in mind that this approach can be completely different from what you're use
 keep your code clean and easy to maintain, we recommend to use this approach only if your code is
 decoupled from the internal framework logic (like with Clean Architecture approach) or if you start a new
 project and need to keep the logic linked to your business rules.
+
+.. _`ADR`: https://github.com/pmjones/adr

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -13,7 +13,7 @@ Update the configuration
 
 The first step is to update the default services.yaml file, here's the new content: 
 
-.. code-block:: yml
+.. code-block:: yaml
 
     parameters:
         locale: 'en'
@@ -122,7 +122,7 @@ Creating a Responder
 
 As you can see in the __invoke call, this action require a ``HelloResponder`` class in order to build the response which is returned to the browser, first, update the services.yaml according to this need: 
 
-.. code-block:: yml
+.. code-block:: yaml
 
     parameters:
         locale: 'en'
@@ -137,7 +137,6 @@ As you can see in the __invoke call, this action require a ``HelloResponder`` cl
             resource: '../src/Actions'
             tags: 
                 - 'controller.service_arguments'
-                
                 
         App\Responders\:
             resource: '../src/Responders'
@@ -179,7 +178,9 @@ Accessing the request
 
 In many case, your classes can ask for any data passed via a form or via an API call, 
 as you can imagine, as the logic evolve, your class is capable of accessing the request 
-from a simple method injection like this ::
+from a simple method injection like this:
+
+.. code-block:: php
 
     <?php
 

--- a/controller/adr.rst
+++ b/controller/adr.rst
@@ -29,12 +29,12 @@ The first step is to update the default services.yaml file, here's the new conte
             tags: 
                 - 'controller.service_arguments'
 
-Now that the container knows about our actions, time to build a simple Action !
+Now that the container knows about our actions, time to build a simple Action!
 
 Updating your classes
 ---------------------
 
-As the framework evolve, you must update your classes, first, delete your Controller folder and create an Actions one then a new class using the ADR principles, for this example, call it ``HelloAction.php``: 
+As the framework evolves, you must update your classes, first, delete your Controller folder and create an Actions one then a new class using the ADR principles, for this example, call it ``HelloAction.php``: 
 
 .. code-block:: php
 

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -80,96 +80,10 @@ If your controller implements the ``__invoke()`` method - popular with the
 Action-Domain-Response (ADR) pattern, you can simply refer to the service id
 (``AppBundle\Controller\HelloController`` or ``app.hello_controller`` for example).
 
-If you want to use the ADR pattern rather than the default controller approach, you can use
-the new features provided by the container like public/private injections and autowiring, 
-in order to work, you must update the services.yml file ::
+As this approach is evolving faster and can be easily transposed into Symfony, we recommend
+you to read the following part :
 
-    # ...
-
-    services:
-        _defaults:
-            autowire: true
-            autoconfigure: true
-            public: false
-            
-        # Allow to load every actions
-        AppBundle\Action\:
-            resource: '../../src/AppBundle/Action/'
-            public: true
-
-Once the file is updated, delete your Controller folder and create an Action class using the ADR principles, i.e ::
-
-    <?php
-
-    namespace AppBundle\Action;
-
-    use Twig\Environment;
-    use Symfony\Component\Templating\EngineInterface;
-
-    final class HelloAction
-    {
-        private $renderer;
-        
-        public function __construct(Environment $render) 
-        {
-            $this->render = $render;
-        }
-
-        public function __invoke()
-        {
-            return new Response($this->render->render('default/index.html.twig'));
-        }
-    }
-
-By default, we define the class with the final keyword because this class shouldn't been extended,
-the logic is pretty simple to understand as you understand the ADR pattern, in fact, the 'Action' 
-is linked to a single request and his dependencies are linked to this precise Action.
-
-Once this is done, you can define the routes like before using multiples approach :
-
-.. configuration-block::
-
-    .. code-block:: php-annotations
-    
-        # src/AppBundle/Action/HelloAction.php
-        // ...
-
-        /**
-         * @Route("/hello", name="hello")
-         */
-        final class HelloAction
-        {
-            // ...
-        }
-
-    .. code-block:: yaml
-    
-        # app/config/routing.yml
-        hello:
-            path:     /hello
-            defaults: { _controller: AppBundle\Action\HelloAction }
-
-    .. code-block:: xml
-
-        <!-- app/config/routing.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <routes xmlns="http://symfony.com/schema/routing"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing
-                http://symfony.com/schema/routing/routing-1.0.xsd">
-
-            <route id="hello" path="/hello">
-                <default key="_controller">AppBundle\Action\HelloAction</default>
-            </route>
-
-        </routes>
-
-    .. code-block:: php
-
-        // app/config/routing.php
-        $collection->add('hello', new Route('/hello', array(
-            '_controller' => 'HelloAction::class',
-        )));
+* :doc:`/controller/adr`
 
 Alternatives to base Controller Methods
 ---------------------------------------

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -131,14 +131,6 @@ Once this is done, you can define the routes like before using multiples approac
 
 .. configuration-block::
 
-    .. code-block:: yaml
-    
-        # app/config/routing.yml
-        hello:
-            path:     /hello
-            methods: ['GET']
-            defaults: { _controller: AppBundle\Action\HelloAction }
-
     .. code-block:: php-annotations
     
         # src/AppBundle/Action/HelloAction.php
@@ -151,6 +143,13 @@ Once this is done, you can define the routes like before using multiples approac
         {
             // ...
         }
+
+    .. code-block:: yaml
+    
+        # app/config/routing.yml
+        hello:
+            path:     /hello
+            defaults: { _controller: AppBundle\Action\HelloAction }
 
     .. code-block:: xml
 

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -84,8 +84,7 @@ If you want to use the ADR pattern rather than the default controller approach, 
 the new features provided by the container like public/private injections and autowiring, 
 in order to work, you must update the services.yml file ::
 
-    parameters:
-        #parameter_name: value
+# ...
 
     services:
         _defaults:

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -80,6 +80,126 @@ If your controller implements the ``__invoke()`` method - popular with the
 Action-Domain-Response (ADR) pattern, you can simply refer to the service id
 (``AppBundle\Controller\HelloController`` or ``app.hello_controller`` for example).
 
+If you want to use the ADR pattern rather than the default controller approach, you can use
+the new features provided by the container like public/private injections and autowiring, 
+in order to work, you must update the services.yml file ::
+
+    parameters:
+        #parameter_name: value
+
+    services:
+        _defaults:
+            autowire: true
+            autoconfigure: true
+            public: false
+            
+        # Allow to load every actions
+        AppBundle\Action\:
+            resource: '../../src/AppBundle/Action/'
+            public: true
+
+Once the file is updated, delete your Controller folder and create an Action one then 
+build a HelloAction class that use the ADR principes ::
+
+    <?php
+
+    namespace AppBundle\Action;
+
+    use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\Templating\EngineInterface;
+
+    /**
+     * Class HelloAction
+     */
+    final class HelloAction
+    {
+        /** @var EngineInterface */
+        private $renderEngine;
+
+        /**
+         * HelloAction constructor.
+         *
+         * @param EngineInterface $renderEngine
+         */
+        public function __construct(
+            EngineInterface $renderEngine
+        ) {
+            $this->renderEngine = $renderEngine;
+        }
+
+        /**
+         * @throws \InvalidArgumentException
+         * @throws \RuntimeException
+         *
+         * @return Response
+         */
+        public function __invoke() : Response
+        {
+            return new Response(
+                $this->renderEngine->render('default/index.html.twig')
+            );
+        }
+    }
+
+.. note::
+
+    Please note that the PHP 7.1 syntax isn't mandatory.
+    
+.. _controller-service-invoke:
+
+By default, we define the class with the final keyword because this class shouldn't been extended,
+the logic is pretty simple to understand as you understand the ADR pattern, in fact, the 'Action' 
+is linked to a single request and his dependencies are linked to this precise Action.
+
+Once this is done, you can define the routes like before using multiples approach :
+
+.. configuration-block::
+
+    .. code-block:: yaml
+    
+        # app/config/routing.yml
+        hello:
+            path:     /hello
+            methods: ['GET']
+            defaults: { _controller: AppBundle\Action\HelloAction }
+
+    .. code-block:: php-annotations
+    
+        # src/AppBundle/Action/HelloAction.php
+        // ...
+
+        /**
+         * @Route("/hello", name="hello")
+         */
+        final class HelloAction
+        {
+            // ...
+        }
+
+    .. code-block:: xml
+
+        <!-- app/config/routing.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <routes xmlns="http://symfony.com/schema/routing"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                http://symfony.com/schema/routing/routing-1.0.xsd">
+
+            <route id="hello" path="/hello">
+                <default key="_controller">AppBundle\Action\HelloAction</default>
+            </route>
+
+        </routes>
+
+    .. code-block:: php
+
+        // app/config/routing.php
+        $collection->add('hello', new Route('/hello', array(
+            '_controller' => 'AppBundle\Action\HelloAction',
+        )));
+
+.. note::
+
 Alternatives to base Controller Methods
 ---------------------------------------
 

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -84,7 +84,7 @@ If you want to use the ADR pattern rather than the default controller approach, 
 the new features provided by the container like public/private injections and autowiring, 
 in order to work, you must update the services.yml file ::
 
-# ...
+    # ...
 
     services:
         _defaults:

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -112,10 +112,9 @@ build a HelloAction class that use the ADR principes ::
     {
         private $render;
         
-        public function __construct(
-            EngineInterface $engine
-        ) {
-            $this->renderEngine = $render;
+        public function __construct(EngineInterface $render) 
+        {
+            $this->render = $render;
         }
 
         public function __invoke()

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -119,9 +119,7 @@ build a HelloAction class that use the ADR principes ::
 
         public function __invoke()
         {
-            return new Response(
-                $this->render->render('default/index.html.twig')
-            );
+            return new Response($this->render->render('default/index.html.twig'));
         }
     }
 

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -192,8 +192,6 @@ Once this is done, you can define the routes like before using multiples approac
             '_controller' => 'AppBundle\Action\HelloAction',
         )));
 
-.. note::
-
 Alternatives to base Controller Methods
 ---------------------------------------
 

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -120,7 +120,7 @@ build a HelloAction class that use the ADR principes ::
         public function __invoke()
         {
             return new Response(
-                $this->renderEngine->render('default/index.html.twig')
+                $this->render->render('default/index.html.twig')
             );
         }
     }

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -133,19 +133,13 @@ build a HelloAction class that use the ADR principes ::
          *
          * @return Response
          */
-        public function __invoke() : Response
+        public function __invoke()
         {
             return new Response(
                 $this->renderEngine->render('default/index.html.twig')
             );
         }
     }
-
-.. note::
-
-    Please note that the PHP 7.1 syntax isn't mandatory.
-    
-.. _controller-service-invoke:
 
 By default, we define the class with the final keyword because this class shouldn't been extended,
 the logic is pretty simple to understand as you understand the ADR pattern, in fact, the 'Action' 

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -97,21 +97,20 @@ in order to work, you must update the services.yml file ::
             resource: '../../src/AppBundle/Action/'
             public: true
 
-Once the file is updated, delete your Controller folder and create an Action one then 
-build a HelloAction class that use the ADR principes ::
+Once the file is updated, delete your Controller folder and create an Action class using the ADR principles, i.e ::
 
     <?php
 
     namespace AppBundle\Action;
 
-    use Symfony\Component\HttpFoundation\Response;
+    use Twig\Environment;
     use Symfony\Component\Templating\EngineInterface;
 
     final class HelloAction
     {
-        private $render;
+        private $renderer;
         
-        public function __construct(EngineInterface $render) 
+        public function __construct(Environment $render) 
         {
             $this->render = $render;
         }
@@ -169,7 +168,7 @@ Once this is done, you can define the routes like before using multiples approac
 
         // app/config/routing.php
         $collection->add('hello', new Route('/hello', array(
-            '_controller' => 'AppBundle\Action\HelloAction',
+            '_controller' => 'HelloAction::class',
         )));
 
 Alternatives to base Controller Methods

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -108,31 +108,16 @@ build a HelloAction class that use the ADR principes ::
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Templating\EngineInterface;
 
-    /**
-     * Class HelloAction
-     */
     final class HelloAction
     {
-        /** @var EngineInterface */
-        private $renderEngine;
-
-        /**
-         * HelloAction constructor.
-         *
-         * @param EngineInterface $renderEngine
-         */
+        private $render;
+        
         public function __construct(
-            EngineInterface $renderEngine
+            EngineInterface $engine
         ) {
-            $this->renderEngine = $renderEngine;
+            $this->renderEngine = $render;
         }
 
-        /**
-         * @throws \InvalidArgumentException
-         * @throws \RuntimeException
-         *
-         * @return Response
-         */
         public function __invoke()
         {
             return new Response(

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -81,7 +81,7 @@ Action-Domain-Response (ADR) pattern, you can simply refer to the service id
 (``AppBundle\Controller\HelloController`` or ``app.hello_controller`` for example).
 
 As this approach is evolving faster and can be easily transposed into Symfony, we recommend
-you to read the following part :
+you to read the following part:
 
 * :doc:`/controller/adr`
 


### PR DESCRIPTION
With the new approach used by the container, the old controller can be easily replaced by the ADR pattern, as Symfony grow, I think it should be the role of the documentation to show how to use the pattern and how to adapt the framework structure.

PS : I'm not pretty sure of the 'note' syntax.