### PR TITLE
Fix routing order formats

### DIFF
--- a/controller/service.rst
+++ b/controller/service.rst
@@ -24,17 +24,11 @@ syntax:
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # app/config/routing.yml
-        hello:
-            path:     /hello
-            defaults: { _controller: app.hello_controller:indexAction }
-
     .. code-block:: php-annotations
 
         # src/AppBundle/Controller/HelloController.php
-        // ...
+        
+        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 
         /**
          * @Route(service="app.hello_controller")
@@ -43,6 +37,13 @@ syntax:
         {
             // ...
         }
+
+    .. code-block:: yaml
+
+        # app/config/routing.yml
+        hello:
+            path:     /hello
+            defaults: { _controller: app.hello_controller:indexAction }
 
     .. code-block:: xml
 

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -26,7 +26,8 @@ syntax:
 
     .. code-block:: php-annotations
 
-        # src/AppBundle/Controller/HelloController.php
+        // src/AppBundle/Controller/HelloController.php
+        // ...
         
         use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 


### PR DESCRIPTION
http://symfony.com/doc/current/contributing/documentation/standards.html#formats:
> * Routing: Annotations, YAML, XML, PHP

Also, I've added `use` statement as `service` option belong to the `Route` annotation class of `FrameworkExtraBundle`.