### PR TITLE
Minor reword to explain that path() generates absolute URLs

### DIFF
--- a/routing/scheme.rst
+++ b/routing/scheme.rst
@@ -48,17 +48,18 @@ the URI scheme via schemes:
 The above configuration forces the ``secure`` route to always use HTTPS.
 
 When generating the ``secure`` URL, and if the current scheme is HTTP, Symfony
-will automatically generate an absolute URL with HTTPS as the scheme:
+will automatically generate an absolute URL with HTTPS as the scheme, even when
+using the ``path()`` function:
 
 .. code-block:: twig
 
     {# If the current scheme is HTTPS #}
     {{ path('secure') }}
-    {# generates /secure #}
+    {# generates a relative URL: /secure #}
 
     {# If the current scheme is HTTP #}
     {{ path('secure') }}
-    {# generates https://example.com/secure #}
+    {# generates an absolute URL: https://example.com/secure #}
 
 The requirement is also enforced for incoming requests. If you try to access
 the ``/secure`` path with HTTP, you will automatically be redirected to the


### PR DESCRIPTION
I propose this change as a way to avoid confusion like #8189.