### PR TITLE
add note about same-state transitions

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -238,6 +238,10 @@ order:
     * ``workflow.[workflow name].announce``
     * ``workflow.[workflow name].announce.[transition name]``
 
+.. note::
+
+    The leaving and entering events are triggered even for transitions that stay in same place.
+
 Here is an example how to enable logging for every time a the "blog_publishing" workflow leaves a place::
 
     use Psr\Log\LoggerInterface;


### PR DESCRIPTION
maybe this could be made more understandable, but "leave" and "enter" made me think a transition that "stays" in the same place would maybe not trigger those events. i checked the code and tested my application and in fact it works. i think it makes sense to mention this explicitly.

if transitions are explained in more detail somewhere, it could be a good idea to also mention the possibility of same-place transitions there.