### PR TITLE
Explained the explicit typing in YAML documents

### DIFF
--- a/components/yaml/yaml_format.rst
+++ b/components/yaml/yaml_format.rst
@@ -300,8 +300,8 @@ Comments can be added in YAML by prefixing them with a hash mark (``#``):
     Comments are simply ignored by the YAML parser and do not need to be
     indented according to the current level of nesting in a collection.
 
-Explicity Typing
-----------------
+Explicit Typing
+---------------
 
 The YAML specification defines some tags to set the type of any data explicitly:
 

--- a/components/yaml/yaml_format.rst
+++ b/components/yaml/yaml_format.rst
@@ -300,4 +300,25 @@ Comments can be added in YAML by prefixing them with a hash mark (``#``):
     Comments are simply ignored by the YAML parser and do not need to be
     indented according to the current level of nesting in a collection.
 
+Explicity Typing
+----------------
+
+The YAML specification defines some tags to set the type of any data explicitly:
+
+.. code-block:: yaml
+
+    data:
+        # this value is parsed as a string (it's not transformed into a DateTime)
+        start_date: !str 2002-12-14
+
+        # this value is parsed as a float number (it will be 3.0 instead of 3)
+        price: !!float 3
+
+        # this value is parsed as binary data encoded in base64
+        picture: !!binary |
+            R0lGODlhDAAMAIQAAP//9/X
+            17unp5WZmZgAAAOfn515eXv
+            Pz7Y6OjuDg4J+fn5OTk6enp
+            56enmleECcgggoBADs=
+
 .. _YAML: http://yaml.org/

--- a/components/yaml/yaml_format.rst
+++ b/components/yaml/yaml_format.rst
@@ -308,9 +308,6 @@ The YAML specification defines some tags to set the type of any data explicitly:
 .. code-block:: yaml
 
     data:
-        # this value is parsed as a string (it's not transformed into a DateTime)
-        start_date: !str 2002-12-14
-
         # this value is parsed as a float number (it will be 3.0 instead of 3)
         price: !!float 3
 


### PR DESCRIPTION
I was going to fix #8173 but I couldn't find the explicit typing explanation anywhere, so I include it here.

-----

When merging this into 3.4, the `!str` tag must be changed by `!!tag` and we must add this:

```
.. versionadded:: 3.4
    The support of ``!!str`` tag was introduced in Symfony 3.4. In previous
    versions you needed to use the ``!str`` tag.
```