### PR TITLE
[Workflow] Fixed example usage of DefinitionBuilder

### DIFF
--- a/components/workflow.rst
+++ b/components/workflow.rst
@@ -44,8 +44,8 @@ these statuses are called **places**. You can define the workflow like this::
     use Symfony\Component\Workflow\Workflow;
     use Symfony\Component\Workflow\MarkingStore\SingleStateMarkingStore;
 
-    $definition = new DefinitionBuilder();
-    $definition->addPlaces(['draft', 'review', 'rejected', 'published'])
+    $definitionBuilder = new DefinitionBuilder();
+    $definition = $definitionBuilder->addPlaces(['draft', 'review', 'rejected', 'published'])
         // Transitions are defined with a unique name, an origin place and a destination place
         ->addTransition(new Transition('to_review', 'draft', 'review'))
         ->addTransition(new Transition('publish', 'review', 'published'))


### PR DESCRIPTION
Hi,

the first code example uses the `DefinitionBuilder` with the fluent interface and a finale `build()` call. `$definition` still is the builder and not the built defintion.

Cheers
Matthias