### PR TITLE
Removed tabs in 2.7 docs

### DIFF
--- a/request/load_balancer_reverse_proxy.rst
+++ b/request/load_balancer_reverse_proxy.rst
@@ -87,13 +87,13 @@ In this case, you'll need to - *very carefully* - trust *all* proxies.
 
    .. code-block:: diff
 
-	  // web/app.php
+        // web/app.php
 
-	  // ...
-	  $request = Request::createFromGlobals();
-	  + Request::setTrustedProxies(array('127.0.0.1', $request->server->get('REMOTE_ADDR')));
+        // ...
+        $request = Request::createFromGlobals();
+        + Request::setTrustedProxies(array('127.0.0.1', $request->server->get('REMOTE_ADDR')));
 
-	  // ...
+        // ...
 
 #. Ensure that the trusted_proxies setting in your ``app/config/config.yml``
    is not set or it will overwrite the ``setTrustedProxies()`` call above.


### PR DESCRIPTION
While reviewing docs, I found some `\t` in some articles. This first PR contains the `\t` present in every Symfony Docs version. And I'm going to open another PR against 2.8 branch for the other `\t` that are present in 2.8 and higher Symfony Docs versions.