### PR TITLE
Add pipe to dump command

### DIFF
--- a/workflow/dumping-workflows.rst
+++ b/workflow/dumping-workflows.rst
@@ -14,8 +14,7 @@ PNG image of the workflow defined above::
 
 .. code-block:: terminal
 
-    $ php dump-graph.php > out.dot
-    $ dot -Tpng out.dot -o graph.png
+    $ php dump-graph.php | dot -Tpng -o graph.png
 
 The result will look like this:
 
@@ -26,8 +25,7 @@ with the ``WorkflowDumpCommand``:
 
 .. code-block:: terminal
 
-    $ php bin/console workflow:dump name > out.dot
-    $ dot -Tpng out.dot -o graph.png
+    $ php bin/console workflow:dump name | dot -Tpng -o graph.png
 
 .. note::
 


### PR DESCRIPTION
Save creating an interim file (and cluttering up the directory) by using pipe to create the image file immediately.