### PR TITLE
Specified import order of config files

### DIFF
--- a/deployment/platformsh.rst
+++ b/deployment/platformsh.rst
@@ -126,12 +126,13 @@ following file (it's your role to add this file to your code base)::
     # Store session into /tmp.
     ini_set('session.save_path', '/tmp/sessions');
 
-Make sure this file is listed in your *imports*:
+Make sure this file is listed in your *imports* (after the default `parameters.yml` file):
 
 .. code-block:: yaml
 
     # app/config/config.yml
     imports:
+        - { resource: parameters.yml }
         - { resource: parameters_platform.php }
 
 Deploy your Application


### PR DESCRIPTION
If the `parameters_platform.php` is included before `platform.yml` the latter overrides the former and results in an inability to connect to the database which (in my case) was very time consuming to debug.