### PR TITLE
Document new Monolog HTTP code exclusion feature

### DIFF
--- a/logging/monolog_exclude_http_codes.rst
+++ b/logging/monolog_exclude_http_codes.rst
@@ -14,7 +14,7 @@ logging these HTTP codes based on the MonologBundle configuration:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # config/packages/prod/monolog.yaml
         monolog:
             handlers:
                 main:
@@ -25,7 +25,7 @@ logging these HTTP codes based on the MonologBundle configuration:
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- config/packages/prod/monolog.xml -->
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:monolog="http://symfony.com/schema/dic/monolog"
@@ -48,7 +48,7 @@ logging these HTTP codes based on the MonologBundle configuration:
 
     .. code-block:: php
 
-        // app/config/config.php
+        // config/packages/prod/monolog.php
         $container->loadFromExtension('monolog', array(
             'handlers' => array(
                 'main' => array(

--- a/logging/monolog_exclude_http_codes.rst
+++ b/logging/monolog_exclude_http_codes.rst
@@ -38,8 +38,8 @@ logging these HTTP codes based on the MonologBundle configuration:
                 <monolog:handler type="fingers_crossed" name="main" handler="...">
                     <!-- ... -->
                     <monolog:excluded-http-code code="403">
-                      <monolog:url>^/foo</monolog:url>
-                      <monolog:url>^/bar</monolog:url>
+                        <monolog:url>^/foo</monolog:url>
+                        <monolog:url>^/bar</monolog:url>
                     </monolog:excluded-http-code>
                     <monolog:excluded-http-code code="404" />
                 </monolog:handler>

--- a/logging/monolog_exclude_http_codes.rst
+++ b/logging/monolog_exclude_http_codes.rst
@@ -4,7 +4,7 @@
    single: Monolog; Exclude HTTP Codes
 
 How to Configure Monolog to Exclude Specific HTTP Codes from the Log
-===========================================================
+====================================================================
 
 Sometimes your logs become flooded with unwanted HTTP errors, for example,
 403s and 404s. When using a ``fingers_crossed`` handler, you can exclude

--- a/logging/monolog_exclude_http_codes.rst
+++ b/logging/monolog_exclude_http_codes.rst
@@ -1,0 +1,60 @@
+.. index::
+   single: Logging
+   single: Logging; Exclude HTTP Codes
+   single: Monolog; Exclude HTTP Codes
+
+How to Configure Monolog to Exclude Specific HTTP Codes from the Log
+===========================================================
+
+Sometimes your logs become flooded with unwanted HTTP errors, for example,
+403s and 404s. When using a ``fingers_crossed`` handler, you can exclude
+logging these HTTP codes based on the MonologBundle configuration:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        monolog:
+            handlers:
+                main:
+                    # ...
+                    type: fingers_crossed
+                    handler: ...
+                    excluded_http_codes:
+                        - 403
+                        - 404
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:monolog="http://symfony.com/schema/dic/monolog"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/monolog
+                http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+            <monolog:config>
+                <monolog:handler type="fingers_crossed" name="main" handler="...">
+                    <!-- ... -->
+                    <monolog:excluded-http-code>403</monolog:excluded-http-code>
+                    <monolog:excluded-http-code>404</monolog:excluded-http-code>
+                </monolog:handler>
+            </monolog:config>
+        </container>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container->loadFromExtension('monolog', array(
+            'handlers' => array(
+                'main' => array(
+                    // ...
+                    'type'                => 'fingers_crossed',
+                    'handler'             => ...,
+                    'excluded_http_codes' => array(403, 404),
+                ),
+            ),
+        ));

--- a/logging/monolog_exclude_http_codes.rst
+++ b/logging/monolog_exclude_http_codes.rst
@@ -6,6 +6,10 @@
 How to Configure Monolog to Exclude Specific HTTP Codes from the Log
 ====================================================================
 
+..versionadded:: 4.1
+    The ability to exclude log messages based on their status codes was
+    introduced in Symfony 4.1 and MonologBundle 3.3.
+
 Sometimes your logs become flooded with unwanted HTTP errors, for example,
 403s and 404s. When using a ``fingers_crossed`` handler, you can exclude
 logging these HTTP codes based on the MonologBundle configuration:

--- a/logging/monolog_exclude_http_codes.rst
+++ b/logging/monolog_exclude_http_codes.rst
@@ -21,9 +21,7 @@ logging these HTTP codes based on the MonologBundle configuration:
                     # ...
                     type: fingers_crossed
                     handler: ...
-                    excluded_http_codes:
-                        - 403
-                        - 404
+                    excluded_http_codes: [403, 404, { 400: ['^/foo', '^/bar'] }]
 
     .. code-block:: xml
 
@@ -39,8 +37,11 @@ logging these HTTP codes based on the MonologBundle configuration:
             <monolog:config>
                 <monolog:handler type="fingers_crossed" name="main" handler="...">
                     <!-- ... -->
-                    <monolog:excluded-http-code>403</monolog:excluded-http-code>
-                    <monolog:excluded-http-code>404</monolog:excluded-http-code>
+                    <monolog:excluded-http-code code="403">
+                      <monolog:url>^/foo</monolog:url>
+                      <monolog:url>^/bar</monolog:url>
+                    </monolog:excluded-http-code>
+                    <monolog:excluded-http-code code="404" />
                 </monolog:handler>
             </monolog:config>
         </container>


### PR DESCRIPTION
I'm submitting PRs on symfony/symfony and symfony/monolog-bundle that introduces an easy way of excluding specific HTTP codes from Monolog.

This PR documents that new feature, pending its acceptance.

Pending PRs:
https://github.com/symfony/symfony/pull/23707
https://github.com/symfony/monolog-bundle/pull/221