### PR TITLE
Update event_dispatcher.rst

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -497,8 +497,7 @@ with some other dispatchers:
 
 * :doc:`/components/event_dispatcher/container_aware_dispatcher`
 * :doc:`/components/event_dispatcher/immutable_dispatcher`
-* :doc:`/components/event_dispatcher/traceable_dispatcher` (provided by the
-  :doc:`HttpKernel component </components/http_kernel>`)
+* :doc:`/components/event_dispatcher/traceable_dispatcher`
 
 Learn More
 ----------


### PR DESCRIPTION
The TraceableDispatcher is not part of the HttpKernel component anymore