### PR TITLE
[Lock] Deprecate Filesystem/LockHandler

### DIFF
--- a/components/filesystem/lock_handler.rst
+++ b/components/filesystem/lock_handler.rst
@@ -1,6 +1,13 @@
 LockHandler
 ===========
 
+.. versionadded:: 3.4
+
+    The ``LockHandler`` class has been deprecated in Symfony 3.4
+    and it will be removed in Symfony 4.0. Use ``SemaphoreStore`` or
+    ``FlockStore`` from the ``Lock`` component  instead.
+
+
 What is a Lock?
 ---------------
 

--- a/components/filesystem/lock_handler.rst
+++ b/components/filesystem/lock_handler.rst
@@ -3,10 +3,9 @@ LockHandler
 
 .. versionadded:: 3.4
 
-    The ``LockHandler`` class has been deprecated in Symfony 3.4
-    and it will be removed in Symfony 4.0. Use ``SemaphoreStore`` or
-    ``FlockStore`` from the ``Lock`` component  instead.
-
+    The ``LockHandler`` class was deprecated in Symfony 3.4 and it will be
+    removed in Symfony 4.0. Use ``SemaphoreStore`` or ``FlockStore`` from the
+    ``Lock`` component  instead.
 
 What is a Lock?
 ---------------

--- a/console/lockable_trait.rst
+++ b/console/lockable_trait.rst
@@ -5,9 +5,10 @@ Prevent Multiple Executions of a Console Command
     The ``LockableTrait`` was introduced in Symfony 3.2.
 
 A simple but effective way to prevent multiple executions of the same command in
-a single server is to use **file locks**. The Filesystem component provides a
-:doc:`LockHandler </components/filesystem/lock_handler>` class that eases the
-creation and release of these locks.
+a single server is to use **locks**. The Lock component provides a
+:ref:`SemaphoreStore <_lock-store-semaphore>` class and a
+:ref:`FlockStore <_lock-store-flock>` class that eases the creation and
+release of these locks.
 
 In addition, the Console component provides a PHP trait called ``LockableTrait``
 that adds two convenient methods to lock and release commands::

--- a/console/lockable_trait.rst
+++ b/console/lockable_trait.rst
@@ -5,10 +5,10 @@ Prevent Multiple Executions of a Console Command
     The ``LockableTrait`` was introduced in Symfony 3.2.
 
 A simple but effective way to prevent multiple executions of the same command in
-a single server is to use **locks**. The Lock component provides a
-:ref:`SemaphoreStore <_lock-store-semaphore>` class and a
-:ref:`FlockStore <_lock-store-flock>` class that eases the creation and
-release of these locks.
+a single server is to use `locks`_. The :doc:`Lock component </components/lock>`
+provides multiple classes to create locks based on the filesystem (:ref:`FlockStore <_lock-store-flock>`),
+shared memory (:ref:`SemaphoreStore <_lock-store-semaphore>`) and even databases
+and Redis servers.
 
 In addition, the Console component provides a PHP trait called ``LockableTrait``
 that adds two convenient methods to lock and release commands::
@@ -40,3 +40,5 @@ that adds two convenient methods to lock and release commands::
             $this->release();
         }
     }
+
+.. _`locks`: https://en.wikipedia.org/wiki/Lock_(computer_science)


### PR DESCRIPTION
This PR deprecate the Filesystem\LockHandler in favor of Lock\SemaphoreStore and Lock\FlockStore.

see: https://github.com/symfony/symfony/pull/23724