### PR TITLE
Fixed typo in workflow.announce event description

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -241,7 +241,7 @@ order:
     * ``workflow.[workflow name].entered.[place name]``
 
 ``workflow.announce``
-    Triggered for each place that now is available for the object.
+    Triggered for each transition that now is accessible for the object.
 
     The three events being dispatched are:
 


### PR DESCRIPTION
Maybe I'm wrong but I think that the term `place` is confusing here.
I assume that **transitions** are announced.