### PR TITLE
Update events.rst

### DIFF
--- a/form/events.rst
+++ b/form/events.rst
@@ -84,8 +84,8 @@ View data        ``null``
 
 .. sidebar:: ``FormEvents::PRE_SET_DATA`` in the Form component
 
-    The ``collection`` form type relies on the
-    ``Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener``
+    The ``Symfony\Component\Form\Extension\Core\Type\CollectionType`` form type relies
+    on the ``Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener``
     subscriber, listening to the ``FormEvents::PRE_SET_DATA`` event in order
     to reorder the form's fields depending on the data from the pre-populated
     object, by removing and adding all form rows.


### PR DESCRIPTION
There is no more a `collection` form type, but a `Symfony\Component\Form\Extension\Core\Type\CollectionType` one.