### PR TITLE
Delete use_virtuals_forms.rst

### DIFF
--- a/form/use_virtuals_forms.rst
+++ b/form/use_virtuals_forms.rst
@@ -1,8 +1,0 @@
-How to Use the virtual Form Field Option
-========================================
-
-.. caution::
-
-    As of Symfony 2.3, the ``virtual`` option is renamed to ``inherit_data``.
-    You can read everything about the new option in
-    ":doc:`/form/inherit_data_option`".

--- a/forms.rst
+++ b/forms.rst
@@ -695,12 +695,6 @@ There's a lot more to learn and a lot of *powerful* tricks in the form system.
 
 Learn more
 ----------
-
-.. toctree::
-    :hidden:
-
-    form/use_virtuals_forms
-
 .. toctree::
     :maxdepth: 1
     :glob:


### PR DESCRIPTION
As this is about an option from Symfony 2 and removed years ago in Symfony 2.3, this can be removed from the docs for Symfony 3