### PR TITLE
Reworded the built-in web server articles for Symfony 3.3

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -158,16 +158,20 @@ the ``create-project`` command:
 Running the Symfony Application
 -------------------------------
 
-Symfony leverages the internal PHP web server (available since PHP 5.4) to run
-applications while developing them. Therefore, running a Symfony application is
-a matter of browsing to the project directory and executing this command:
+In production servers, Symfony applications use web servers such as Apache or
+Nginx (see :doc:`configuring a web server to run Symfony </setup/web_server_configuration>`).
+However, in your local development machine you can also use the web server
+provided by Symfony, which in turn uses the built-in web server provided by PHP.
+
+First, :doc:`install the Symfony Web Server </setup/built_in_web_server>` and
+then, execute this command:
 
 .. code-block:: terminal
 
     $ cd my_project_name/
     $ php bin/console server:run
 
-Then, open your browser and access the ``http://localhost:8000/`` URL to see the
+Open your browser and access the ``http://localhost:8000/`` URL to see the
 Welcome Page of Symfony:
 
 .. image:: /_images/quick_tour/welcome.png
@@ -184,7 +188,7 @@ pressing ``Ctrl+C`` from the terminal or command console.
 
 .. tip::
 
-    PHP's internal web server is great for developing, but should **not** be
+    Symfony's web server is great for developing, but should **not** be
     used on production. Instead, use Apache or Nginx.
     See :doc:`/setup/web_server_configuration`.
 

--- a/setup/built_in_web_server.rst
+++ b/setup/built_in_web_server.rst
@@ -39,7 +39,7 @@ Then, enable the bundle in the kernel of the application::
             $bundles = array(
                 // ...
 
-                if (in_array($this->getEnvironment(), array('dev', 'test'))) {
+                if ('dev' === $this->getEnvironment()) {
                     // ...
                     $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
                 }

--- a/setup/built_in_web_server.rst
+++ b/setup/built_in_web_server.rst
@@ -15,6 +15,42 @@ a full-featured web server such as
     The built-in web server is meant to be run in a controlled environment.
     It is not designed to be used on public networks.
 
+Symfony provides a web server built on top of this PHP server to simplify your
+local setup. This server is distributed as a bundle, so you must first install
+and enable the server bundle.
+
+Installing the Web Server Bundle
+--------------------------------
+
+First, execute this command:
+
+.. terminal::
+
+    $ cd your-project/
+    $ composer require symfony/web-server-bundle
+
+Then, enable the bundle in the kernel of the application::
+
+    // app/AppKernel.php
+    class AppKernel extends Kernel
+    {
+        public function registerBundles()
+        {
+            $bundles = array(
+                // ...
+
+                if (in_array($this->getEnvironment(), array('dev', 'test'))) {
+                    // ...
+                    $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
+                }
+            );
+
+            // ...
+        }
+
+        // ...
+    }
+
 Starting the Web Server
 -----------------------
 

--- a/setup/built_in_web_server.rst
+++ b/setup/built_in_web_server.rst
@@ -24,7 +24,7 @@ Installing the Web Server Bundle
 
 First, execute this command:
 
-.. terminal::
+.. code-block:: terminal
 
     $ cd your-project/
     $ composer require symfony/web-server-bundle


### PR DESCRIPTION
This fixes #8270.

The current scenario for Symfony 3.3 is the worst possible: we don't have the web server by default (like in 3.2) ... and it's not easy to install it (like in 3.3+Flex or 4.0). That's why I propose to add a link in the main `setup.rst` article to the full explanation about installing and enabling the bundle.

In 4.0, we can remove that link and simply say: run `symfony require web-server` and then, execute `./bin/console server:run`.