### PR TITLE
Create composer_prevent_upgrade_conflicts.rst

### DIFF
--- a/setup/composer_prevent_upgrade_conflicts.rst
+++ b/setup/composer_prevent_upgrade_conflicts.rst
@@ -1,0 +1,35 @@
+
+.. index::
+    double: Composer; Conflicts
+
+How to prevent PHP conflicts during upgrades when using Composer
+================================================================
+
+Each Symfony release is guaranteed to work with a specific PHP version,
+so for example when you download and install Symfony 2.8 you are
+sure that it can work on PHP 5.4.16.
+
+When you upgrade Symfony (e.g. from 2.8.25 to 2.8.26) you must be sure that
+all the upgraded dependencies are still compatible with your own PHP version
+running in your production server (e.g. the old PHP 5.4.16).
+
+Achieving this is very simple: just remember to add such constraints in your
+``composer.json`` file located in your project root directory (my_project_name),
+so that when you will launch updates that would not be a pain. Just replace these lines::
+
+    // my_project_name/composer.json
+        "config": {
+            "bin-dir": "bin"
+        },
+    
+with these::
+
+    // my_project_name/composer.json
+        "config": {
+            "bin-dir": "bin",
+            "platform": {
+                    "php": "5.4.16"
+            }
+        },
+        
+and enjoy your Symfony upgrades.


### PR DESCRIPTION
As requested in https://github.com/symfony/symfony-docs/pull/7298#issuecomment-294297047 I added a page regarding php version constraints in composer.json. In fact, when installing Symfony you have to meet some production server requirements.

Without that, for first install that's ok (if you read symfony requirements you can choose the right Symfony version that's shipped with the right libraries version), but doing updates (just running composer update) may break things with libraries being updated that don't meet your server requirements (e.g. php version) or may do nothing (e.g. running composer update symfony/symfony if you have 2.8.12 installed won't install 2.8.15, despite of what is said here http://symfony.com/doc/current/setup/upgrade_patch.html because of the need of twig/twig 1.30.0 - so you would run "composer update symfony/symfony twig/twig" and so on for other such dependencies to obtain the patch update - that's not so confortable!).

Best regards.