### PR TITLE
fix schema_filter example

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -24,7 +24,7 @@ Full Default Configuration
                         commented:            true
                 # If defined, all the tables whose names match this regular expression are ignored
                 # by the schema tool (in this example, any table name starting with `wp_`)
-                #schema_filter:               "/^wp_/"
+                #schema_filter:               ~^(?!wp_)~
 
                 connections:
                     # A collection of different named connections (e.g. default, conn2, etc)


### PR DESCRIPTION
I fixed the schema_filter example, that was wrong.
I set it the same way that is reported in https://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html