### PR TITLE
Update guard_authentication.rst

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -155,7 +155,6 @@ This requires you to implement seven methods::
 
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\JsonResponse;
-    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Security\Core\User\UserInterface;
     use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
     use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -218,7 +217,7 @@ This requires you to implement seven methods::
                 // $this->translator->trans($exception->getMessageKey(), $exception->getMessageData())
             );
 
-            return new JsonResponse($data, Response::HTTP_FORBIDDEN);
+            return new JsonResponse($data, JsonResponse::HTTP_FORBIDDEN);
         }
 
         /**
@@ -231,7 +230,7 @@ This requires you to implement seven methods::
                 'message' => 'Authentication Required'
             );
 
-            return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
+            return new JsonResponse($data, JsonResponse::HTTP_UNAUTHORIZED);
         }
 
         public function supportsRememberMe()


### PR DESCRIPTION
As the guard component shows the usage of the JsonResponse class, the usage of the const heritage should be added in order to ease the syntax and show the proper way for returning HTTP headers code as using Response subclasses. 