### PR TITLE
Update debugging.rst

### DIFF
--- a/debug/debugging.rst
+++ b/debug/debugging.rst
@@ -83,6 +83,9 @@ that can help you visualize and find the information.
     fallback translation for all known messages, if translations exist for
     the given locale.
 
+``debug:event-dispatcher``
+    Displays information about all the registered listeners in the event dispatcher.
+
 .. tip::
 
     When in doubt how to use a console command, open the help section by


### PR DESCRIPTION
I noticed that the command `debug:event-dispatcher`is not present in the documentation page http://symfony.com/doc/current/debug/debugging.html#useful-debugging-commands