### PR TITLE
Remove invalid comma from php code example

### DIFF
--- a/form/data_based_validation.rst
+++ b/form/data_based_validation.rst
@@ -43,7 +43,7 @@ You can also define whole logic inline by using a ``Closure``::
                 }
 
                 return array('company');
-            },
+            }
         ));
     }
 


### PR DESCRIPTION
Remove invalid comma from php code example because it causes a php syntax error