### PR TITLE
Documentation: add missing php tags / "use" statements

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -44,6 +44,7 @@ random) number and prints it. To do that, create a "Controller class" and a
 "controller" method inside of it that will be executed when someone goes to
 ``/lucky/number``::
 
+    <?php
     // src/AppBundle/Controller/LuckyController.php
     namespace AppBundle\Controller;
 
@@ -116,7 +117,9 @@ First, make sure that ``LuckyController`` extends Symfony's base
 Now, use the handy ``render()`` function to render a template. Pass it our ``number``
 variable so we can render that::
 
+    <?php
     // src/AppBundle/Controller/LuckyController.php
+    namespace AppBundle\Controller;
 
     // ...
     class LuckyController extends Controller

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -121,7 +121,10 @@ variable so we can render that::
     // src/AppBundle/Controller/LuckyController.php
     namespace AppBundle\Controller;
 
-    // ...
+    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
     class LuckyController extends Controller
     {
         /**


### PR DESCRIPTION
Not sure if these were needed 
<br>However, this <b>was the only way I was able to get the page creation working</b> on my: <br><b>macintosh computer</b> (mac)

Left the ending php tag out which seemed the convention after looking at the default_controller. 

Cheers, Michael Dimmitt 🙂
Happy to have a discussion about this PR. 
And add any additional details. 

elsewise this would be the error,
```[RuntimeException]                                                
  The autoloader expected class "AppBundle\Controller\ LuckyController" 
  to be defined in file "/Users/michaeldimmitt/new_h/bartender  
  /vendor/composer/../../src/AppBundle/Controller/LuckyController.php". 
  The file was found but the class was not in it, the class n  
  ame or namespace probably has a typo.    ```