### PR TITLE
action_method.rst

### DIFF
--- a/form/action_method.rst
+++ b/form/action_method.rst
@@ -49,7 +49,7 @@ form, you can use ``setAction()`` and ``setMethod()``:
         $formFactory = $formFactoryBuilder->getFormFactory();
 
         $form = $formFactory->createBuilder('form', $task)
-            ->setAction($router->generate('target_route'))
+            ->setAction('...')
             ->setMethod('GET')
             ->add('task', 'text')
             ->add('dueDate', 'date')
@@ -102,7 +102,7 @@ options:
         $formFactory = $formFactoryBuilder->getFormFactory();
 
         $form = $formFactory->create(new TaskType(), $task, array(
-            'action' => $router->generate('target_route'),
+            'action' => '...',
             'method' => 'GET',
         ));
 

--- a/form/action_method.rst
+++ b/form/action_method.rst
@@ -49,7 +49,7 @@ form, you can use ``setAction()`` and ``setMethod()``:
         $formFactory = $formFactoryBuilder->getFormFactory();
 
         $form = $formFactory->createBuilder('form', $task)
-            ->setAction($this->generateUrl('target_route'))
+            ->setAction($router->generate('target_route'))
             ->setMethod('GET')
             ->add('task', 'text')
             ->add('dueDate', 'date')
@@ -102,7 +102,7 @@ options:
         $formFactory = $formFactoryBuilder->getFormFactory();
 
         $form = $formFactory->create(new TaskType(), $task, array(
-            'action' => $this->generateUrl('target_route'),
+            'action' => $router->generate('target_route'),
             'method' => 'GET',
         ));
 


### PR DESCRIPTION
On the form documentation [How to Change the Action and Method of a Form](https://symfony.com/doc/current/form/action_method.html), the examples "Standalone use" contain `$this->generateUrl`which does not make sense, since we are not inside a controller

I though also about replacing by `...` since the important here is just to know how to change the action and not how to generate the route ..
