### PR TITLE
Removed not needed use statements

### DIFF
--- a/components/console/single_command_tool.rst
+++ b/components/console/single_command_tool.rst
@@ -40,10 +40,6 @@ Of course, you can still register a command as usual::
   require __DIR__.'/vendor/autoload.php';
 
   use Symfony\Component\Console\Application;
-  use Symfony\Component\Console\Input\InputArgument;
-  use Symfony\Component\Console\Input\InputInterface;
-  use Symfony\Component\Console\Input\InputOption;
-  use Symfony\Component\Console\Output\OutputInterface;
 
   use Acme\Command\DefaultCommand;
 

--- a/components/console/single_command_tool.rst
+++ b/components/console/single_command_tool.rst
@@ -39,9 +39,8 @@ Of course, you can still register a command as usual::
   <?php
   require __DIR__.'/vendor/autoload.php';
 
-  use Symfony\Component\Console\Application;
-
   use Acme\Command\DefaultCommand;
+  use Symfony\Component\Console\Application;
 
   $application = new Application('echo', '1.0.0');
   $command = new DefaultCommand();


### PR DESCRIPTION
The use statements were needed in the previous example but not in this one.