### PR TITLE
Updated expression language class example

### DIFF
--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -28,7 +28,7 @@ to another service: ``AppBundle\Mailer``. One way to do this is with an expressi
             AppBundle\Mail\MailerConfiguration: ~
 
             AppBundle\Mailer:
-                arguments: ["@=service('AppBundle\\Mail\\MailerConfiguration').getMailerMethod()"]
+                arguments: ["@=service('AppBundle\\\\Mail\\\\MailerConfiguration').getMailerMethod()"]
 
     .. code-block:: xml
 


### PR DESCRIPTION
The class example has been updated to reflect the backslash escaping as described here:
https://symfony.com/doc/current/components/expression_language/syntax.html