### PR TITLE
duplicate adjective "later"

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -231,7 +231,7 @@ each time you ask for it.
 
     Thanks to this configuration, you can automatically use any classes from the
     ``src/AppBundle`` directory as a service, without needing to manually configure
-    it. Later, you'll learn more about this later in :ref:`service-psr4-loader`.
+    it. Later, you'll learn more about this in :ref:`service-psr4-loader`.
 
     If you'd prefer to manually wire your service, that's totally possible: see
     :ref:`services-explicitly-configure-wire-services`.


### PR DESCRIPTION
Redundant word in "**Later**, you'll learn more about this **later** in Importing Many Services at once with resource.". I think it should be removed.