### PR TITLE
Update service_container.rst. Removed "+/-" from example class.

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -406,13 +406,12 @@ example, suppose you want to make the admin email configurable:
     class SiteUpdateManager
     {
         // ...
-    +    private $adminEmail;
+        private $adminEmail;
 
-    -    public function __construct(MessageGenerator $messageGenerator, \Swift_Mailer $mailer)
-    +    public function __construct(MessageGenerator $messageGenerator, \Swift_Mailer $mailer, $adminEmail)
+        public function __construct(MessageGenerator $messageGenerator, \Swift_Mailer $mailer, $adminEmail)
         {
             // ...
-    +        $this->adminEmail = $adminEmail;
+            $this->adminEmail = $adminEmail;
         }
 
         public function notifyOfSiteUpdate()
@@ -421,8 +420,7 @@ example, suppose you want to make the admin email configurable:
 
             $message = \Swift_Message::newInstance()
                 // ...
-    -            ->setTo('manager@example.com')
-    +            ->setTo($this->adminEmail)
+                ->setTo($this->adminEmail)
                 // ...
             ;
             // ...


### PR DESCRIPTION
Diff text removed on example class. 
See screen.

<img width="724" alt="diff_symbols" src="https://user-images.githubusercontent.com/7052418/30204641-cfbc6048-948e-11e7-880a-e9c75e729bfa.png">
