### PR TITLE
Adjust .platform.app.yaml from 'symfony' to 'composer'

### DIFF
--- a/deployment/platformsh.rst
+++ b/deployment/platformsh.rst
@@ -41,7 +41,7 @@ Platform.sh how to deploy your application (read more about
     # The type of the application to build.
     type: php:5.6
     build:
-      flavor: symfony
+      flavor: composer
 
     # The relationships of the application with services or other applications.
     # The left-hand side is the name of the relationship as it will be exposed


### PR DESCRIPTION
Based on this commit (https://github.com/platformsh/platformsh-example-symfony/commit/3de359c88fb5316ff653f0142428e658880f1b65#diff-fe14053ff51cb358f8b709415b2a2d17) & documentation (https://docs.platform.sh/frameworks/symfony.html) the flavor 'symfony' is an alias of 'composer' and it seems advised to use 'composer' now. 