### PR TITLE
Fixed example in docs throwing exception.

### DIFF
--- a/frontend/encore/babel.rst
+++ b/frontend/encore/babel.rst
@@ -22,8 +22,8 @@ Need to extend the Babel configuration further? The easiest way is via
             // add additional presets
             babelConfig.presets.push('es2017');
 
-            // no plugins are added by default, but you can add some
-            // babelConfig.plugins.push('styled-jsx/babel');
+            // no plugins are added by default, so you can set them
+            // babelConfig.plugins = ['styled-jsx/babel'];
         })
     ;
 


### PR DESCRIPTION
`push` here ends in exception because there is no plugins array, we have to create it.