### PR TITLE
Improve service container parameters section

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -572,6 +572,20 @@ Actually, once you define a parameter, it can be referenced via the ``%parameter
 syntax in *any* other service configuration file - like ``config.yml``. Many parameters
 are defined in a :ref:`parameters.yml file <config-parameters-yml>`.
 
+You can then fetch the parameter in the service::
+
+    class SiteUpdateManager
+    {
+        // ...
+
+        private $adminEmail;
+
+        public function __construct($adminEmail)
+        {
+            $this->adminEmail = $adminEmail;
+        }
+    }
+
 You can also fetch parameters directly from the container::
 
     public function newAction()


### PR DESCRIPTION
I've noticed that many young programmers inject the whole container to the service only for fetching parameters, and I think it's because of missing example for using an injected parameter in the service but existing example for doing so in the controller.