### PR TITLE
Improve description about "framework.ide" config option

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -279,7 +279,7 @@ need to escape the percent signs (``%``) by doubling them.
 .. note::
 
     If both ``framework.ide`` and ``xdebug.file_link_format`` are defined,
-    Symfony uses the value of the ``framework.ide`` option.
+    Symfony uses the value of the ``xdebug.file_link_format`` option.
 
 .. tip::
 


### PR DESCRIPTION
According to code in https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L179 when both `xdebug.file_link_format` (in `php.ini`) and `framework.ide` (in `app/config/config.yml`) are defined, then `xdebug.file_link_format` wins, but documentetion says the opposite.

P.S.

* PR is targeting the oldest supported documentation branch, where fixed text fragment is present.
* It should be merged to `3.3` and `3.4` branches as well.
* The documentation is changed and not mentioned code, because changing code would introduce a BC break.