### PR TITLE
Document Memcached cache adapter added in Symfony 3.3

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -117,6 +117,7 @@ Configuration
     * `default_doctrine_provider`_
     * `default_psr6_provider`_
     * `default_redis_provider`_
+    * `default_memcached_provider`_
     * `pools`_
         * :ref:`name <reference-cache-pools-name>`
             * `adapter`_
@@ -1729,7 +1730,7 @@ app
 
 The cache adapter used by the ``cache.app`` service. The FrameworkBundle
 ships with multiple adapters: ``apcu``, ``doctrine``, ``system``, ``filesystem``,
-``psr6`` and ``redis``.
+``psr6``, ``redis`` and ``memcached``.
 
 .. tip::
 
@@ -1774,6 +1775,17 @@ default_redis_provider
 **type**: ``string`` **default**: ``redis://localhost``
 
 The DSN to use by the Redis provider. The provider is available as the ``cache.redis``
+service.
+
+default_memcached_provider
+..........................
+
+.. versionadded:: 3.3
+    The ``default_memcached_provider`` option was introduced in Symfony 3.3.
+
+**type**: ``string`` **default**: ``memcached://localhost``
+
+The DSN to use by the Memcached provider. The provider is available as the ``cache.memcached``
 service.
 
 pools
@@ -2013,6 +2025,7 @@ Full Default Configuration
                 default_doctrine_provider: ~
                 default_psr6_provider: ~
                 default_redis_provider: 'redis://localhost'
+                default_memcached_provider: 'memcached://localhost'
                 pools:
                     # Prototype
                     name:


### PR DESCRIPTION
Adds documentation for Memcached cache adapter.

Related blog post: https://symfony.com/blog/new-in-symfony-3-3-memcached-cache-adapter

Closes #7828