### PR TITLE
Add note about LocaleListener

### DIFF
--- a/translation/locale.rst
+++ b/translation/locale.rst
@@ -29,9 +29,8 @@ it::
 .. note::
 
     Using a listener like this requires that it is called **before** 
-    LocaleListener attempts to access it. In Symfony Framework it is called
-    with priority 8 by default. You will need to set your event listener
-    with a higher one if you want this to work.
+    LocaleListener attempts to access it. You will need to set your event listener
+    with a higher priority if you want this to work.
 
 Read :doc:`/session/locale_sticky_session` for more information on making
 the user's locale "sticky" to their session.

--- a/translation/locale.rst
+++ b/translation/locale.rst
@@ -25,6 +25,7 @@ it::
             // some logic to determine the $locale
             $request->setLocale($locale);
         }
+
 .. note::
 
     Using a listener like this requires that it is called **before** 

--- a/translation/locale.rst
+++ b/translation/locale.rst
@@ -25,6 +25,12 @@ it::
             // some logic to determine the $locale
             $request->setLocale($locale);
         }
+.. note::
+
+    Using a listener like this requires that it is called **before** 
+    LocaleListener attempts to access it. In Symfony Framework it is called
+    with priority 8 by default. You will need to set your event listener
+    with a higher one if you want this to work.
 
 Read :doc:`/session/locale_sticky_session` for more information on making
 the user's locale "sticky" to their session.

--- a/translation/locale.rst
+++ b/translation/locale.rst
@@ -28,9 +28,10 @@ it::
 
 .. note::
 
-    Using a listener like this requires that it is called **before** 
-    LocaleListener attempts to access it. You will need to set your event listener
-    with a higher priority if you want this to work.
+    The custom listener must be called **before** ``LocaleListener``, which
+    initializes the locale based on the current request. To do so, set your
+    listener priority to a higher value than ``LocaleListener`` priority (which
+    you can obtain running the ``debug:event kernel.request`` command).
 
 Read :doc:`/session/locale_sticky_session` for more information on making
 the user's locale "sticky" to their session.


### PR DESCRIPTION
LocaleListener uses information provided by Request object. 
Setting your own Listener, which is supposed to change request object locale, without priority results in LocaleListener already having it's locale set up and not reacting at all. This change adds this warning to documentation.