### PR TITLE
Update missingFieldsMessage default value

### DIFF
--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -314,7 +314,7 @@ error will be returned. If set to ``true``, extra fields are ok.
 extraFieldsMessage
 ~~~~~~~~~~~~~~~~~~
 
-**type**: ``boolean`` **default**: ``The fields {{ fields }} were not expected.``
+**type**: ``boolean`` **default**: ``This field was not expected.``
 
 The message shown if `allowExtraFields`_ is false and an extra field is
 detected.
@@ -332,7 +332,7 @@ option are not present in the underlying collection.
 missingFieldsMessage
 ~~~~~~~~~~~~~~~~~~~~
 
-**type**: ``boolean`` **default**: ``The fields {{ fields }} are missing.``
+**type**: ``boolean`` **default**: ``This field is missing.``
 
 The message shown if `allowMissingFields`_ is false and one or more fields
 are missing from the underlying collection.


### PR DESCRIPTION
In Symfony 2.1.0 changed default value for extraFieldsMessage and missingFieldsMessage in Collection constraint

Change log:
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Validator/CHANGELOG.md#210
Current code: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Validator/Constraints/Collection.php#L36

so this is a pull request to update the doc.