### PR TITLE
Update simple-example.rst

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -72,7 +72,7 @@ To build the assets, use the ``encore`` executable:
 
     # shorter version of the above 3 commands
     $ yarn run encore dev
-    $ yarn run encore dev -- --watch
+    $ yarn run encore dev --watch
     $ yarn run encore production
 
 .. note::


### PR DESCRIPTION
As stated by yarn command line: 

> warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.