### PR TITLE
Property class is required

### DIFF
--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -153,7 +153,7 @@ Configuration of the service container then looks like this:
         # app/config/services.yml
 
         app.newsletter_manager:
-            class: AppBundle\Email\NewsletterManagerFactory 
+            class: AppBundle\Email\NewsletterManager 
             # new syntax
             factory: 'AppBundle\Email\NewsletterManagerFactory:createNewsletterManager'
             # old syntax

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -153,6 +153,7 @@ Configuration of the service container then looks like this:
         # app/config/services.yml
 
         app.newsletter_manager:
+            class: AppBundle\Email\NewsletterManagerFactory 
             # new syntax
             factory: 'AppBundle\Email\NewsletterManagerFactory:createNewsletterManager'
             # old syntax


### PR DESCRIPTION
Without property `class` throw exception:
`Uncaught Symfony\Component\DependencyInjection\Exception\RuntimeException: Please add the class to service "$name" even if it is constructed by a factory since we might need to add method calls based on compile-time checks.`