### PR TITLE
Update command_in_controller.rst

### DIFF
--- a/console/command_in_controller.rst
+++ b/console/command_in_controller.rst
@@ -36,8 +36,9 @@ Run this command from inside your controller via::
 
     class SpoolController extends Controller
     {
-        public function sendSpoolAction($messages = 10, KernelInterface $kernel)
+        public function sendSpoolAction($messages = 10)
         {
+            $kernel = $this->get('kernel');
             $application = new Application($kernel);
             $application->setAutoExit(false);
 


### PR DESCRIPTION
The "KernelInterface $kernel" param, doesnt work (yet) on Symfony 3.3 (Could'nt be resolved automatically).