### PR TITLE
Fix explanation when Creating a Validator

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -45,7 +45,7 @@ includes some simple default logic::
     // in the base Symfony\Component\Validator\Constraint class
     public function validatedBy()
     {
-        return ContainsAlphanumericValidator::class;
+        return get_class($this).'Validator';
     }
 
 In other words, if you create a custom ``Constraint`` (e.g. ``MyConstraint``),


### PR DESCRIPTION
In the base class Symfony\Component\Validator\Constraint, the method validatedBy() contain this code instead.
This makes the explanation understandable.