### PR TITLE
Update http_cache.rst

### DIFF
--- a/http_cache.rst
+++ b/http_cache.rst
@@ -289,7 +289,7 @@ two things:
 * Don't try to cache PUT, POST or DELETE requests. It won't work and with good
   reason. These methods are meant to be used when mutating the state of your application
   (e.g. deleting a blog post). Caching them would prevent certain requests from hitting
-  and mutating your application.
+  and mutating your application. (Technically caching POST requests is possible however this is very narrow case `Caching POST`_
 
 * You should *never* change the state of your application (e.g. update a blog post)
   when responding to a GET or HEAD request. If those requests are cached, future
@@ -366,3 +366,4 @@ Learn more
 .. _`RFC 7234 - Caching`: https://tools.ietf.org/html/rfc7234
 .. _`RFC 7232 - Conditional Requests`: https://tools.ietf.org/html/rfc7232
 .. _`FOSHttpCacheBundle`: http://foshttpcachebundle.readthedocs.org/
+.. _`Caching POST`: https://www.mnot.net/blog/2012/09/24/caching_POST

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -33,7 +33,6 @@ Nottingham's `Cache Tutorial`_.
 .. index::
    single: Cache; Proxy
    single: Cache; Reverse proxy
-   single: Cache; Gateway
 
 .. _gateway-caches:
 
@@ -286,10 +285,14 @@ Safe Methods: Only caching GET or HEAD requests
 HTTP caching only works for "safe" HTTP methods (like GET and HEAD). This means
 two things:
 
-* Don't try to cache PUT, POST or DELETE requests. It won't work and with good
-  reason. These methods are meant to be used when mutating the state of your application
+* Don't try to cache PUT or DELETE requests. It won't work and with good reason.
+  These methods are meant to be used when mutating the state of your application
   (e.g. deleting a blog post). Caching them would prevent certain requests from hitting
-  and mutating your application. (Technically caching POST requests is possible however this is very narrow case `Caching POST`_
+  and mutating your application.
+
+* POST requests are generally considered uncachable, but `they can be cached`_
+  when they include explicit freshness information. However POST caching is not
+  widely implemented, so you should avoid it if possible.
 
 * You should *never* change the state of your application (e.g. update a blog post)
   when responding to a GET or HEAD request. If those requests are cached, future
@@ -366,4 +369,4 @@ Learn more
 .. _`RFC 7234 - Caching`: https://tools.ietf.org/html/rfc7234
 .. _`RFC 7232 - Conditional Requests`: https://tools.ietf.org/html/rfc7232
 .. _`FOSHttpCacheBundle`: http://foshttpcachebundle.readthedocs.org/
-.. _`Caching POST`: https://www.mnot.net/blog/2012/09/24/caching_POST
+.. _`they can be cached`: https://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-20#section-2.3.4


### PR DESCRIPTION
I want to point out that POST method is cacheable however this is very very narrow case but it is possible. Reading documentation you can learn that POST is not cacheable but this is not true and technically you can cache it.