### PR TITLE
Mention that public services must add an alias to their classes

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -224,7 +224,7 @@ Service Naming Conventions
 * A group name uses the underscore notation;
 
 * Add class aliases for public services (e.g. alias ``Symfony\Component\Something\ClassName``
-to ``something.service_name``).
+  to ``something.service_name``).
 
 Documentation
 -------------

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -221,7 +221,10 @@ Service Naming Conventions
 * Use lowercase letters for service and parameter names (except when referring
   to environment variables with the ``%env(VARIABLE_NAME)%`` syntax);
 
-* A group name uses the underscore notation.
+* A group name uses the underscore notation;
+
+* Add class aliases for public services (e.g. alias ``Symfony\Component\Something\ClassName``
+to ``something.service_name``).
 
 Documentation
 -------------


### PR DESCRIPTION
This fixes #7968.