### PR TITLE
Remember Me Missing Role Information

### DIFF
--- a/security/remember_me.rst
+++ b/security/remember_me.rst
@@ -122,7 +122,8 @@ The ``remember_me`` firewall defines the following configuration options:
 ``always_remember_me`` (default value: ``false``)
     If ``true``, the value of the ``remember_me_parameter`` is ignored and the
     "Remember Me" feature is always enabled, regardless of the desire of the
-    end user.
+    end user. If you are utilising access_control you may need to
+    add IS_AUTHENTICATED_REMEMBERED to the roles key, dependent on your setup.
 
 ``token_provider`` (default value: ``null``)
     Defines the service id of a token provider to use. By default, tokens are


### PR DESCRIPTION
If your session is removed or deleted from /var/lib/php/sessions but you have a valid remember me cookie, the user no longer has the role `IS_AUTHENTICATED_FULLY` but does have the role `IS_AUTHENTICATED_REMEMBERED`, couldn't see this in the documentation currently. So believe this should be in their somewhere. May also be related to this ticket I found.

https://github.com/symfony/symfony/issues/9203