### PR TITLE
[Form] Document disabling the usage of globally defined form themes

### DIFF
--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -355,10 +355,11 @@ themes:
 
 .. caution::
 
-    When using the ``only`` keyword, form themes shipped with Symfony
-    (``form_div_layout.html.twig`` and others) will not be used, so to render your
-    forms correcly, you need to either provide the base form theme yourself, or
-    ``use`` one of the built in form themes from your own theme:
+    When using the ``only`` keyword, none of Symfony's built-in form themes
+    (``form_div_layout.html.twig``, etc.) will be applied. In order to render
+    your forms correctly, you need to either provide a full-featured form theme
+    yourself, or extend one of the built-in form themes with Twig's ``use``
+    keyword instead of ``extends`` to reuse the original theme contents.
 
     .. code-block:: html+twig
 

--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -336,6 +336,37 @@ name of all the templates as an array using the ``with`` keyword:
 The templates can also be located in different bundles, use the Twig namespaced
 path to reference these templates, e.g. ``@AcmeFormExtra/form/fields.html.twig``.
 
+Disabling usage of globally defined themes
+..........................................
+
+Sometimes it is useful to disable usage of globally defined form themes in order
+to have more control over rendering of a form. You might want this, for example,
+when creating admin interface for a bundle which can be installed on a wide range
+of Symfony apps and you can't control what themes are defined globally.
+
+You can do this by including the ``only`` keyword after the list of used form
+themes:
+
+.. code-block:: html+twig
+
+    {% form_theme form with ['common.html.twig', 'form/fields.html.twig'] only %}
+
+    {# ... #}
+
+.. caution::
+
+    When using the ``only`` keyword, form themes shipped with Symfony
+    (``form_div_layout.html.twig`` and others) will not be used, so to render your
+    forms correcly, you need to either provide the base form theme yourself, or
+    ``use`` one of the built in form themes from your own theme:
+
+    .. code-block:: html+twig
+
+        {# app/Resources/views/common.html.twig #}
+        {% use "form_div_layout.html.twig" %}
+
+        {# ... #}
+
 Child Forms
 ...........
 


### PR DESCRIPTION
This PR documents the option to disable the usage of globally defined form themes. This is suggested as a feature in https://github.com/symfony/symfony/pull/22610 (reviewed, but not yet merged)