### PR TITLE
Deprecated loadClassCache() method

### DIFF
--- a/debug/debugging.rst
+++ b/debug/debugging.rst
@@ -61,6 +61,11 @@ cache files, or you can change the extension used by Symfony for these files::
 
     $kernel->loadClassCache('classes', '.php.cache');
 
+.. versionadded:: 3.3
+    The ``loadClassCache()`` was deprecated in Symfony 3.3 and removed in
+    Symfony 4.0. No alternative is provided because this feature is useless
+    when using PHP 7 or higher.
+
 Useful Debugging Commands
 -------------------------
 


### PR DESCRIPTION
This fixes #7337. I didn't found any other occurrence of the deprecated classes/methods mentioned in the related issue. In #7819 we're taking care of the deprecation of `addClassesToCompile()`.