### PR TITLE
[Dependency Injection ] Fix _instanceof configuration section.

### DIFF
--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -489,9 +489,9 @@ inherited from an abstract definition:
             # ...
 
             _instanceof:
-                class: AppBundle\Domain\LoaderInterface
-                public: true
-                tags: ['app.domain_loader']
+                AppBundle\Domain\LoaderInterface:
+                    public: true
+                    tags: ['app.domain_loader']
 
     .. code-block:: xml
 


### PR DESCRIPTION
It seems that previous configuration 
```yml
    _instanceof:
        class: AppBundle\Domain\LoaderInterface
        public: true
        tags: ['app.domain_loader']
```
throws an error: `Type definition "class" must be a non-empty array within "_instanceof" in `. Moreover, it will not be possible to configure multiple 'elements'

After this changes it works as expected.