### PR TITLE
Added about command in debug page

### DIFF
--- a/debug/debugging.rst
+++ b/debug/debugging.rst
@@ -68,6 +68,10 @@ When developing a large application, it can be hard to keep track of all the
 different services, routes and translations. Luckily, Symfony has some commands
 that can help you visualize and find the information.
 
+``about``
+    Shows information about the current project, such as the Symfony version,
+    the Kernel and PHP.
+
 ``debug:container``
     Displays information about the contents of the Symfony container for all public
     services. To find only those matching a name, append the name as an argument.


### PR DESCRIPTION
Issue #7700.

I've added a piece of text only in the debug page. Are there any other pages where this command can be added/explained?

It has been added as the first item in the enumeration, because I would assume users want to know general project info first, and then debug some specific things.