### PR TITLE
Add GroupSequence validation_groups capability doc

### DIFF
--- a/validation/sequence_provider.rst
+++ b/validation/sequence_provider.rst
@@ -140,9 +140,7 @@ that group are valid, the second group, ``Strict``, will be validated.
     sequence, which will contain the ``Default`` group which references the
     same group sequence, ...).
 
-You can also define a group sequence in the `validation_groups` form option:
-
-.. code-block:: php
+You can also define a group sequence in the ``validation_groups`` form option::
 
     use Symfony\Component\Validator\Constraints\GroupSequence;
     use Symfony\Component\Form\AbstractType;

--- a/validation/sequence_provider.rst
+++ b/validation/sequence_provider.rst
@@ -143,6 +143,7 @@ that group are valid, the second group, ``Strict``, will be validated.
 You can also define a group sequence in the `validation_groups` form option:
 
 .. code-block:: php
+
     use Symfony\Component\Validator\Constraints\GroupSequence;
     use Symfony\Component\Form\AbstractType;
     // ...

--- a/validation/sequence_provider.rst
+++ b/validation/sequence_provider.rst
@@ -140,6 +140,24 @@ that group are valid, the second group, ``Strict``, will be validated.
     sequence, which will contain the ``Default`` group which references the
     same group sequence, ...).
 
+You can also define a group sequence in the `validation_groups` form option:
+
+.. code-block:: php
+    use Symfony\Component\Validator\Constraints\GroupSequence;
+    use Symfony\Component\Form\AbstractType;
+    // ...
+    
+    class MyType extends AbstractType
+    {
+        // ...
+        public function configureOptions(OptionsResolver $resolver)
+        {
+            $resolver->setDefaults([
+                'validation_groups' => new GroupSequence(['First', 'Second']),
+            ]);
+        }
+    }
+
 Group Sequence Providers
 ------------------------
 


### PR DESCRIPTION
When using form types without object, we often define constraints in the form itself.

I missed a way to use the sequential groups without object, but already implemented, so here is the documentation for it :yum: 

Cheers.