### PR TITLE
Mentioned the new case-sensitivity of container parameters

### DIFF
--- a/service_container/parameters.rst
+++ b/service_container/parameters.rst
@@ -170,6 +170,11 @@ accessor methods for parameters::
     To learn more about compiling the container see
     :doc:`/components/dependency_injection/compilation`.
 
+.. versionadded:: 3.4
+    Container parameters are case sensitive starting from Symfony 3.4. In
+    previous Symfony versions, parameters were case insensitive, meaning that
+    ``mailer.transport`` and ``Mailer.Transport`` were considered the same parameter.
+
 .. _component-di-parameters-array:
 
 Array Parameters


### PR DESCRIPTION
I prefer to mention this feature only in this article and not in the main `service_container.rst` article to not complicate too much that introductory article.