### PR TITLE
Changing type definition of query_builder option: Closure by callable

### DIFF
--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -181,13 +181,13 @@ instead of the ``default`` entity manager.
 query_builder
 ~~~~~~~~~~~~~
 
-**type**: ``Doctrine\ORM\QueryBuilder`` or a Closure **default**: ``null``
+**type**: ``Doctrine\ORM\QueryBuilder`` or a ``callable`` **default**: ``null``
 
 Allows you to create a custom query for your choices. See
 :ref:`ref-form-entity-query-builder` for an example.
 
-The value of this option can either be a ``QueryBuilder`` object, a Closure or
-``null`` (which will load all entities). When using a Closure, you will be
+The value of this option can either be a ``QueryBuilder`` object, a ``callable`` or
+``null`` (which will load all entities). When using a ``callable``, you will be
 passed the ``EntityRepository`` of the entity as the only argument and should
 return a ``QueryBuilder``.
 

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -186,8 +186,8 @@ query_builder
 Allows you to create a custom query for your choices. See
 :ref:`ref-form-entity-query-builder` for an example.
 
-The value of this option can either be a ``QueryBuilder`` object, a ``callable`` or
-``null`` (which will load all entities). When using a ``callable``, you will be
+The value of this option can either be a ``QueryBuilder`` object, a callable or
+``null`` (which will load all entities). When using a callable, you will be
 passed the ``EntityRepository`` of the entity as the only argument and should
 return a ``QueryBuilder``.
 


### PR DESCRIPTION
According to its own definition:
https://github.com/symfony/symfony/blob/2.7/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php#L43