### PR TITLE
Updated bootKernel examples to return the $kernel object

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -224,8 +224,8 @@ console::
     {
         public function testExecute()
         {
-            self::bootKernel();
-            $application = new Application(self::$kernel);
+            $kernel = self::bootKernel();
+            $application = new Application($kernel);
 
             $application->add(new CreateUserCommand());
 

--- a/testing/doctrine.rst
+++ b/testing/doctrine.rst
@@ -36,9 +36,9 @@ which makes all of this quite easy::
          */
         protected function setUp()
         {
-            self::bootKernel();
+            $kernel = self::bootKernel();
 
-            $this->em = static::$kernel->getContainer()
+            $this->em = $kernel->getContainer()
                 ->get('doctrine')
                 ->getManager();
         }


### PR DESCRIPTION
This fixes #7783.