### PR TITLE
Doctrine event listener could persist a null value

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -362,9 +362,8 @@ automatically upload the file when persisting the entity::
             // only upload new files
             if ($file instanceof UploadedFile) {
                 $fileName = $this->uploader->upload($file);
+                $entity->setBrochure($fileName);
             }
-
-            $entity->setBrochure($fileName);
         }
     }
 


### PR DESCRIPTION
In the current docs, say the entity name is updated and we have not uploaded a new file, it looks like the fileName would be null meaning if the entity already has a brochure it would be removed?