### PR TITLE
Missing use reference

### DIFF
--- a/security/api_key_authentication.rst
+++ b/security/api_key_authentication.rst
@@ -27,6 +27,7 @@ value and then a User object is created::
     // src/AppBundle/Security/ApiKeyAuthenticator.php
     namespace AppBundle\Security;
 
+    use AppBundle\Security\ApiKeyUserProvider;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
     use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;


### PR DESCRIPTION
This example is missing the use statement for a class that is created later on in the code examples.