### PR TITLE
Update controller syntax for bundle-less applications

### DIFF
--- a/templating/embedding_controllers.rst
+++ b/templating/embedding_controllers.rst
@@ -68,7 +68,7 @@ The ``recent_list`` template is perfectly straightforward:
     you'll learn how to do this correctly.
 
 To include the controller, you'll need to refer to it using the standard
-string syntax for controllers (i.e. **bundle**:**controller**:**action**):
+string syntax for controllers (i.e. **controllerPath**::**action**):
 
 .. configuration-block::
 
@@ -79,7 +79,7 @@ string syntax for controllers (i.e. **bundle**:**controller**:**action**):
         {# ... #}
         <div id="sidebar">
             {{ render(controller(
-                'AppBundle:Article:recentArticles',
+                'App\\Controller\\ArticleController::recentArticles',
                 { 'max': 3 }
             )) }}
         </div>
@@ -92,7 +92,7 @@ string syntax for controllers (i.e. **bundle**:**controller**:**action**):
         <div id="sidebar">
             <?php echo $view['actions']->render(
                 new \Symfony\Component\HttpKernel\Controller\ControllerReference(
-                    'AppBundle:Article:recentArticles',
+                    'App\\Controller\\ArticleController::recentArticles',
                     array('max' => 3)
                 )
             ) ?>


### PR DESCRIPTION
Update information how to render controller action in bundle-less applications.
Symfony 4 encourages to do not use bundles, thus why embedding controller action in twig is slightly different.
`App\\Controller\\ArticleController:recentArticles`  instead of 'bundle syntax' `AppBundle:Article:recentArticles`