### PR TITLE
Adding warning about non-service arguments for controllers

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -338,6 +338,13 @@ controller's service config:
 You can of course also use normal :ref:`constructor injection <services-constructor-injection>`
 in your controllers.
 
+.. caution::
+
+    You can *only* pass *services* to your controller arguments in this way. It's
+    not possible, for example, to pass a service parameter as a controller argument.
+    If you need a parameter, use the ``$this->getParameter('kernel.debug')`` shortcut
+    or pass the value through your controller's ``__construct()`` method.
+
 For more information about services, see the :doc:`/service_container` article.
 
 .. _controller-service-arguments-tag:


### PR DESCRIPTION
Hi guys!

See: https://github.com/symfony/symfony/issues/24555#issuecomment-336734106

This is for 3.3. In 3.4 we can improve this further: by updating the example of this to use `bind` (which is much nicer than the ugly tag) and probably show an example of using `bind` along with a scalar argument to the constructor. In other words, 3.4 is a todo once this is merged.

Thanks!