### PR TITLE
Showing the new debug:autowiring command

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -268,12 +268,12 @@ If you need a service in a controller, just type-hint an argument with its class
 
 Awesome!
 
-What other services can you type-hint? To see them, use the ``debug:container`` console
+What other services can you type-hint? To see them, use the ``debug:autowiring`` console
 command:
 
 .. code-block:: terminal
 
-    $ php bin/console debug:container --types
+    $ php bin/console debug:autowiring
 
 If you need control over the *exact* value of an argument, you can override your
 controller's service config:

--- a/service_container.rst
+++ b/service_container.rst
@@ -323,7 +323,7 @@ type-hints by running:
 
 .. code-block:: terminal
 
-    $ php bin/console debug:container --types
+    $ php bin/console debug:autowiring
 
 This is just a small subset of the output:
 

--- a/service_container/debug.rst
+++ b/service_container/debug.rst
@@ -22,10 +22,10 @@ To see a list of all of the available types that can be used for autowiring, run
 
 .. code-block:: terminal
 
-    $ php bin/console debug:container --types
+    $ php bin/console debug:autowiring
 
-.. versionadded:: 3.3
-   The ``--types`` option was introduced in Symfony 3.3.
+.. versionadded:: 3.4
+   The ``debug:autowiring`` command was introduced in Symfony 3.3.
 
 Detailed Info about a Single Service
 ------------------------------------


### PR DESCRIPTION
New to 3.4, this is all the places where we used `debug:container` before, where this command is better.