### PR TITLE
Fix Rendering template chapter

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -201,7 +201,7 @@ If you're returning HTML from your controller, you'll probably want to render
 a template. Fortunately, Symfony comes with `Twig`_: a templating language that's
 easy, powerful and actually quite fun.
 
-First, install Twig::
+First, install Twig:
 
 .. code-block:: terminal
 


### PR DESCRIPTION
Deleting the ":" character in excess to display correctly the terminal block code on "Rendering template chapter