### PR TITLE
Clarifying usage of delivery_whitelist

### DIFF
--- a/email/dev_environment.rst
+++ b/email/dev_environment.rst
@@ -190,6 +190,10 @@ In the above example all email messages will be redirected to ``dev@example.com`
 and messages sent to the ``admin@mydomain.com`` address or to any email address
 belonging to the domain ``specialdomain.com`` will also be delivered as normal.
 
+.. caution::
+
+    The ``delivery_whitelist`` option can only be used in conjuction with the ``delivery_addresses`` option.
+
 Viewing from the Web Debug Toolbar
 ----------------------------------
 

--- a/email/dev_environment.rst
+++ b/email/dev_environment.rst
@@ -192,7 +192,7 @@ belonging to the domain ``specialdomain.com`` will also be delivered as normal.
 
 .. caution::
 
-    The ``delivery_whitelist`` option can only be used in conjuction with the ``delivery_addresses`` option.
+    The delivery_whitelist option is ignored unless the delivery_addresses option is defined.
 
 Viewing from the Web Debug Toolbar
 ----------------------------------

--- a/email/dev_environment.rst
+++ b/email/dev_environment.rst
@@ -192,7 +192,7 @@ belonging to the domain ``specialdomain.com`` will also be delivered as normal.
 
 .. caution::
 
-    The delivery_whitelist option is ignored unless the delivery_addresses option is defined.
+    The ``delivery_whitelist`` option is ignored unless the ``delivery_addresses`` option is defined.
 
 Viewing from the Web Debug Toolbar
 ----------------------------------


### PR DESCRIPTION
There was nothing to suggest that `delivery_whitelist` could not be used on its own. We had to find this out by trial an error.

Hopefully, this change (or better equivalent) will help other people.

Cheers.