### PR TITLE
Improved a comment in code example for service definitions doc

### DIFF
--- a/service_container/definitions.rst
+++ b/service_container/definitions.rst
@@ -28,7 +28,7 @@ There are some helpful methods for working with the service definitions::
 
     // get the "app.user_config_manager" definition
     $definition = $container->getDefinition('app.user_config_manager');
-    // get the definition with the "app.user_config_manager" ID or alias
+    // get the definition with the "app.user_config_manager" by ID or alias
     $definition = $container->findDefinition('app.user_config_manager');
 
     // add a new "app.number_generator" definition


### PR DESCRIPTION
The improved sentence in the code comment misses a word, making the comment less reasonable.