### PR TITLE
[BrowserKit] Updated Project URI of Goutte

### DIFF
--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -232,4 +232,4 @@ Learn more
 * :doc:`/components/dom_crawler`
 
 .. _`Packagist`: https://packagist.org/packages/symfony/browser-kit
-.. _`Goutte`: https://github.com/fabpot/Goutte
+.. _`Goutte`: https://github.com/FriendsOfPHP/Goutte


### PR DESCRIPTION
Tiny fix that is updating the Github URI to [Goutte](https://github.com/FriendsOfPHP/Goutte)