### PR TITLE
Add special Abstract prefix not usage for PHPUnit test cases

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -190,9 +190,10 @@ Naming Conventions
 
 * Use namespaces for all classes;
 
-* Prefix abstract classes with ``Abstract``. Please note some early Symfony classes
-  do not follow this convention and have not been renamed for backward compatibility
-  reasons. However all new abstract classes must follow this naming convention;
+* Prefix all abstract classes with ``Abstract`` except PHPUnit ``*TestCase``.
+  Please note some early Symfony classes do not follow this convention and
+  have not been renamed for backward compatibility reasons. However all new
+  abstract classes must follow this naming convention;
 
 * Suffix interfaces with ``Interface``;
 


### PR DESCRIPTION
As we can see here: 
![image](https://user-images.githubusercontent.com/1698357/32507068-bddf178a-c3e6-11e7-8d28-05f3b18ea18c.png)

You are not using the `Abstract` prefix at all for the test cases.
I assume this is to follow PHPUnit conventions on this part?

In this case, the coding standard may be more accurate about this.