### PR TITLE
Little typo error

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -488,7 +488,7 @@ and add the following logic::
 
     use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
     use Symfony\Component\Security\Csrf\CsrfToken;
-    use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenExceptionl
+    use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 
     class ExampleFormAuthenticator extends AbstractFormLoginAuthenticator
     {


### PR DESCRIPTION
replace :
`use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenExceptionl` 
by :
`use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;`