### PR TITLE
Reworded the introduction of event listeners article

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -9,10 +9,10 @@ During the execution of a Symfony application, lots of event notifications are
 triggered. Your application can listen to these notifications and respond to
 them by executing any piece of code.
 
-Internal events provided by Symfony itself are defined in the
-:class:`Symfony\\Component\\HttpKernel\\KernelEvents` class. Third-party bundles
-and libraries also trigger lots of events and your own application can trigger
-:doc:`custom events </components/event_dispatcher>`.
+Symfony triggers several :doc:`events related to the kernel </reference/events>`
+while processing an HTTP Request, third-party bundles and libraries also trigger
+lots of events and your own application can trigger :doc:`custom events
+</components/event_dispatcher>`.
 
 All the examples shown in this article use the same ``KernelEvents::EXCEPTION``
 event for consistency purposes. In your own application, you can use any event


### PR DESCRIPTION
We have an article explaining the kernel events, so there's no need to link to the KernelEvents class source code.