### PR TITLE
Changed the title of a Doctrine article to avoid confusion

### DIFF
--- a/doctrine/event_listeners_subscribers.rst
+++ b/doctrine/event_listeners_subscribers.rst
@@ -2,9 +2,10 @@
    single: Doctrine; Event listeners and subscribers
 
 .. _doctrine-event-config:
+.. _how-to-register-event-listeners-and-subscribers:
 
-How to Register Event Listeners and Subscribers
-===============================================
+Doctrine Event Listeners and Subscribers
+========================================
 
 Doctrine packages have a rich event system that fires events when almost anything
 happens inside the system. For you, this means that you can create arbitrary
@@ -217,15 +218,15 @@ For a full reference, see chapter `The Event System`_ in the Doctrine documentat
 Lazy loading for Event Listeners
 --------------------------------
 
-One subtle difference between listeners and subscribers is that Symfony can load 
+One subtle difference between listeners and subscribers is that Symfony can load
 entity listeners lazily. This means that your listener class will only be fetched
 from the service container (and thus be instantiated) once the event it is linked
 to actually fires.
 
-Lazy loading might give you a slight performance improvement when your listener 
-runs for events that rarely fire. Also, it can help you when you run into 
+Lazy loading might give you a slight performance improvement when your listener
+runs for events that rarely fire. Also, it can help you when you run into
 *circular dependency issues* that may occur when your listener service in turn
-depends on the DBAL connection. 
+depends on the DBAL connection.
 
 To mark a listener service as lazily loaded, just add the ``lazy`` attribute
 to the tag like so:


### PR DESCRIPTION
Whenever I look for listeners and subscribers in Google, I see this:

![event-listener-subscriber](https://user-images.githubusercontent.com/73419/32549310-3d68ca8a-c489-11e7-89bf-6d712622f925.png)

I click on the first result and ... bam!! 💣💥  it's about DOCTRINE listeners/subscribers, not SYMFONY listeners/subscribers. Let's rename it to avoid confusions. Thanks!