### PR TITLE
Minor reword in autowiring introduction

### DIFF
--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -4,11 +4,11 @@
 Defining Services Dependencies Automatically (Autowiring)
 =========================================================
 
-Autowiring allows you to manage services in the container with minimal configuration.
-It reads the type-hints on your constructor (or other methods) and automatically
-passes you the correct services. Symfony's autowiring is designed to be predictable:
-if it is not absolutely clear which dependency should be passed, you'll see an
-actionable exception.
+Autowiring allows you to manage services in the container with minimal
+configuration. It reads the type-hints on your constructor (or other methods)
+and automatically passes the correct services to each method. Symfony's
+autowiring is designed to be predictable: if it is not absolutely clear which
+dependency should be passed, you'll see an actionable exception.
 
 .. tip::
 


### PR DESCRIPTION
I used this in the reword of the Best Practices docs and Fabien [added this comment](https://github.com/symfony/symfony-docs/pull/8599#discussion_r149743314) because he didn't like a phrase of this paragraph. This PR changes that too here.