### PR TITLE
Explain why yarn is more preferred than npm

### DIFF
--- a/frontend/encore/installation.rst
+++ b/frontend/encore/installation.rst
@@ -12,7 +12,12 @@ Then, install Encore into your project with Yarn:
 .. note::
 
     If you want to use `npm`_ instead of `yarn`_, replace ``yarn add xxx --dev`` by
-    ``npm install xxx --save-dev``.
+    ``npm install xxx --save-dev``. 
+
+    Encore includes a file that locks dependency versions when `yarn` is used (the `yarn.lock` file).
+    It's highly encouraged to use `yarn` to avoid any issues and to maintain consistency across machines.
+    
+    If you already in trouble remove `node_modules` and use `yarn` to install dependencies.
 
 .. tip::
 


### PR DESCRIPTION
Currently it's not possible to run encore after installing dependencies with `NPM`. Error in console:

```
$ npx encore
/node_modules/@symfony/webpack-encore/bin/encore.js:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
```

Only after using yarn the problem was solved.

The lock file is a must, we will know everyone's dependencies are in the same situation.
Unfortunately the `package-lock.json` file from `NPM@5` is not supported by `yarn`
https://github.com/yarnpkg/yarn/issues/3614

Related:
https://github.com/symfony/webpack-encore/issues/39