### PR TITLE
Path package in context aware

### DIFF
--- a/components/asset.rst
+++ b/components/asset.rst
@@ -204,9 +204,13 @@ class can take into account the context of the current request::
         new StaticVersionStrategy('v1'),
         new RequestStackContext($requestStack)
     );
-
-    echo $package->getUrl('/logo.png');
+    
+    echo $package->getUrl('logo.png');
     // result: /somewhere/static/images/logo.png?v1
+    
+    // Both "base path" and "base url" are ignored when using absolute path for asset
+    echo $package->getUrl('/logo.png');
+    // result: /logo.png?v1
 
 Now that the request context is set, the ``PathPackage`` will prepend the
 current request base URL. So, for example, if your entire site is hosted under


### PR DESCRIPTION
How to reproduce :
  - Application has a base url (/some-base-url)
  - Using "PathPackage"
  - Using RequestStackContext (3rd parameter),
  - getUrl of asset with absolute path.

Result :
  Both "base url" of application and "base path" of PathPackage are ignored.

Example :
  Application base url : /some-prefix
  $package = new PathPackage('/static/', new StaticVersionStrategy('v1.2'), new RequestStackContext($requestStack));
  echo $package->getUrl("/img.png"); // /img.png?v1.2

Check merged PR #8574.

NB : Maybe there a conception problem in Asset component. I my opinion only "base path" should be ignored but "base url" should always be used to prefix the generated asset path.