### PR TITLE
Removed deprecations for argument/controller resolvers

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -220,8 +220,8 @@ and is one of the constructor arguments to ``HttpKernel``.
    :align: center
 
 Your job is to create a class that implements the interface and fill in its
-two methods: ``getController()`` and ``getArguments()``. In fact, one default
-implementation already exists, which you can use directly or learn from:
+method: ``getController()``. In fact, one default implementation already
+exists, which you can use directly or learn from:
 :class:`Symfony\\Component\\HttpKernel\\Controller\\ControllerResolver`.
 This implementation is explained more in the sidebar below::
 
@@ -232,29 +232,14 @@ This implementation is explained more in the sidebar below::
     interface ControllerResolverInterface
     {
         public function getController(Request $request);
-
-        public function getArguments(Request $request, $controller);
     }
 
-.. caution::
-
-    The ``getArguments()`` method in the
-    :class:`Symfony\\Component\\Httpkernel\\Controller\\ControllerResolver` and
-    respective interface
-    :class:`Symfony\\Component\\Httpkernel\\Controller\\ControllerResolverInterface`
-    are deprecated as of 3.1 and will be removed in 4.0. You can use the
-    :class:`Symfony\\Component\\Httpkernel\\Controller\\ArgumentResolver` which
-    uses the :class:`Symfony\\Component\\Httpkernel\\Controller\\ArgumentResolverInterface`
-    instead.
 
 Internally, the ``HttpKernel::handle()`` method first calls
 :method:`Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface::getController`
 on the controller resolver. This method is passed the ``Request`` and is responsible
 for somehow determining and returning a PHP callable (the controller) based
 on the request's information.
-
-The second method, :method:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverInterface::getArguments`,
-will be called after another event - ``kernel.controller`` - is dispatched.
 
 .. sidebar:: Resolving the Controller in the Symfony Framework
 

--- a/create_framework/http_kernel_controller_resolver.rst
+++ b/create_framework/http_kernel_controller_resolver.rst
@@ -53,18 +53,9 @@ based on a Request object. All controller resolvers implement the following inte
     // ...
     interface ControllerResolverInterface
     {
-        function getController(Request $request);
-
-        function getArguments(Request $request, $controller);
+        public function getController(Request $request);
     }
 
-.. caution::
-
-    The ``getArguments()`` method is deprecated as of Symfony 3.1. and will be
-    removed in 4.0. You can use the
-    :class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolver` which
-    uses the :class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverInterface`
-    instead.
 
 The ``getController()`` method relies on the same convention as the one we
 have defined earlier: the ``_controller`` request attribute must contain the
@@ -98,7 +89,17 @@ resolver from HttpKernel::
 
 Now, let's see how the controller arguments are guessed. ``getArguments()``
 introspects the controller signature to determine which arguments to pass to
-it by using the native PHP `reflection`_.
+it by using the native PHP `reflection`_. This method is defined in the
+following interface::
+
+    namespace Symfony\Component\HttpKernel\Controller;
+
+    // ...
+    interface ArgumentResolverInterface
+    {
+        public function getArguments(Request $request, $controller);
+    }
+
 
 The ``indexAction()`` method needs the Request object as an argument.
 ``getArguments()`` knows when to inject it properly if it is type-hinted


### PR DESCRIPTION
I've removed the deprecation mentions and updated some text/examples to be correct for 4.0.

Closes #8626.

