### PR TITLE
Add "Next" links to Best Practices

### DIFF
--- a/best_practices/business-logic.rst
+++ b/best_practices/business-logic.rst
@@ -333,6 +333,10 @@ were defined by the PHP community. You can learn more about
 use the `PHP-CS-Fixer`_, which is a command-line utility that can fix the
 coding standards of an entire codebase in a matter of seconds.
 
+----
+
+Next: :doc:`/best_practices/controllers`
+
 .. _`full definition`: https://en.wikipedia.org/wiki/Business_logic
 .. _`Doctrine project`: http://www.doctrine-project.org/
 .. _`fixture class`: https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html#writing-simple-fixtures

--- a/best_practices/configuration.rst
+++ b/best_practices/configuration.rst
@@ -203,5 +203,9 @@ that you store them outside the Symfony project and make them available
 through environment variables. Learn how to do it in the following article:
 :doc:`/configuration/external_parameters`.
 
+----
+
+Next: :doc:`/best_practices/business-logic`
+
 .. _`feature toggles`: https://en.wikipedia.org/wiki/Feature_toggle
 .. _`constant() function`: http://twig.sensiolabs.org/doc/functions/constant.html

--- a/best_practices/controllers.rst
+++ b/best_practices/controllers.rst
@@ -211,4 +211,8 @@ If you need to execute some code before or after the execution of your controlle
 you can use the EventDispatcher component to
 :doc:`set up before and after filters </event_dispatcher/before_after_filters>`.
 
+----
+
+Next: :doc:`/best_practices/templates`
+
 .. _`ParamConverter`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html

--- a/best_practices/creating-the-project.rst
+++ b/best_practices/creating-the-project.rst
@@ -177,6 +177,10 @@ In addition, Symfony3 uses a slightly different directory structure:
 The changes are pretty superficial, but for now, we recommend that you use
 the Symfony directory structure.
 
+----
+
+Next: :doc:`/best_practices/configuration`
+
 .. _`Composer`: https://getcomposer.org/
 .. _`Phar extension`: http://php.net/manual/en/intro.phar.php
 .. _`public checksums repository`: https://github.com/sensiolabs/checksums

--- a/best_practices/forms.rst
+++ b/best_practices/forms.rst
@@ -231,3 +231,7 @@ any of the types defined by the third-party bundles installed in your applicatio
 
 Add the ``app_`` prefix to your custom form field types to avoid name collisions
 that can lead to hard to debug errors.
+
+----
+
+Next: :doc:`/best_practices/i18n`

--- a/best_practices/i18n.rst
+++ b/best_practices/i18n.rst
@@ -93,4 +93,8 @@ English in the application would be:
         </file>
     </xliff>
 
+----
+
+Next: :doc:`/best_practices/security`
+
 .. _`JMSTranslationBundle`: https://github.com/schmittjoh/JMSTranslationBundle

--- a/best_practices/introduction.rst
+++ b/best_practices/introduction.rst
@@ -102,5 +102,9 @@ practices**. The reasons for not doing it are various:
 * The amount of work spent on this could be better dedicated to improving
   your tests or adding features that provide real value to the end users.
 
+----
+
+Next: :doc:`/best_practices/creating-the-project`
+
 .. _`Fabien Potencier`: https://connect.sensiolabs.com/profile/fabpot
 .. _`download and install`: https://symfony.com/download

--- a/best_practices/security.rst
+++ b/best_practices/security.rst
@@ -368,6 +368,10 @@ If your company uses a user login method not supported by Symfony, you can
 develop :doc:`your own user provider </security/custom_provider>` and
 :doc:`your own authentication provider </security/custom_authentication_provider>`.
 
+----
+
+Next: :doc:`/best_practices/web-assets`
+
 .. _`ParamConverter`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
 .. _`@Security annotation`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/security.html
 .. _`FOSUserBundle`: https://github.com/FriendsOfSymfony/FOSUserBundle

--- a/best_practices/templates.rst
+++ b/best_practices/templates.rst
@@ -168,5 +168,9 @@ name is irrelevant because you never use it in your own code):
             tags:
                 - { name: twig.extension }
 
+----
+
+Next: :doc:`/best_practices/forms`
+
 .. _`Twig`: http://twig.sensiolabs.org/
 .. _`Parsedown`: http://parsedown.org/

--- a/best_practices/web-assets.rst
+++ b/best_practices/web-assets.rst
@@ -93,4 +93,8 @@ with Assetic to reduce their size before serving them to the user. Check out
 the `official Assetic documentation`_ to learn more about all the available
 features.
 
+----
+
+Next: :doc:`/best_practices/tests`
+
 .. _`official Assetic documentation`: https://github.com/kriswallsmith/assetic


### PR DESCRIPTION
To avoid needing to go back and forth to the Best Practices index, this PR adds a link to the next page at the bottom of each Best Practice page. I just ordered them based on the way they are laid out in the index.