### PR TITLE
Added translations directory to file tree

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -137,6 +137,9 @@ following directory structure, which is the same used by default in Symfony 4:
 .. code-block:: text
 
     your-project/
+    ├── assets/
+    ├── bin/
+    │   └── console
     ├── config/
     │   ├── bundles.php
     │   ├── packages/
@@ -148,7 +151,9 @@ following directory structure, which is the same used by default in Symfony 4:
     │   ├── ...
     │   └── Kernel.php
     ├── templates/
+    ├── tests/
     ├── translations/
+    ├── var/
     └── vendor/
 
 This means that installing the ``symfony/flex`` dependency in your application

--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -148,6 +148,7 @@ following directory structure, which is the same used by default in Symfony 4:
     │   ├── ...
     │   └── Kernel.php
     ├── templates/
+    ├── translations/
     └── vendor/
 
 This means that installing the ``symfony/flex`` dependency in your application


### PR DESCRIPTION
The description below the directory tree references the translation directory, which is missing in the tree.