### PR TITLE
[yaml] Fix `!php/*` tag should not contain `:` at the end for Symfony 4

### DIFF
--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -243,7 +243,7 @@ You can dump objects by using the ``DUMP_OBJECT`` flag::
     $object->foo = 'bar';
 
     $dumped = Yaml::dump($object, 2, 4, Yaml::DUMP_OBJECT);
-    // !php/object O:8:"stdClass":1:{s:5:"foo";s:7:"bar";}
+    // !php/object 'O:8:"stdClass":1:{s:5:"foo";s:7:"bar";}'
 
 And parse them by using the ``PARSE_OBJECT`` flag::
 
@@ -269,7 +269,7 @@ By default the parser will encode invalid types as ``null``. You can make the
 parser throw exceptions by using the ``PARSE_EXCEPTION_ON_INVALID_TYPE``
 flag::
 
-    $yaml = '!php/object O:8:"stdClass":1:{s:5:"foo";s:7:"bar";}';
+    $yaml = '!php/object \'O:8:"stdClass":1:{s:5:"foo";s:7:"bar";}\'';
     Yaml::parse($yaml, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE); // throws an exception
 
 Similarly you can use ``DUMP_EXCEPTION_ON_INVALID_TYPE`` when dumping::

--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -243,7 +243,7 @@ You can dump objects by using the ``DUMP_OBJECT`` flag::
     $object->foo = 'bar';
 
     $dumped = Yaml::dump($object, 2, 4, Yaml::DUMP_OBJECT);
-    // !php/object:O:8:"stdClass":1:{s:5:"foo";s:7:"bar";}
+    // !php/object O:8:"stdClass":1:{s:5:"foo";s:7:"bar";}
 
 And parse them by using the ``PARSE_OBJECT`` flag::
 
@@ -269,7 +269,7 @@ By default the parser will encode invalid types as ``null``. You can make the
 parser throw exceptions by using the ``PARSE_EXCEPTION_ON_INVALID_TYPE``
 flag::
 
-    $yaml = '!php/object:O:8:"stdClass":1:{s:5:"foo";s:7:"bar";}';
+    $yaml = '!php/object O:8:"stdClass":1:{s:5:"foo";s:7:"bar";}';
     Yaml::parse($yaml, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE); // throws an exception
 
 Similarly you can use ``DUMP_EXCEPTION_ON_INVALID_TYPE`` when dumping::
@@ -319,10 +319,10 @@ Parsing PHP Constants
 ~~~~~~~~~~~~~~~~~~~~~
 
 By default, the YAML parser treats the PHP constants included in the contents as
-regular strings. Use the ``PARSE_CONSTANT`` flag and the special ``!php/const:``
+regular strings. Use the ``PARSE_CONSTANT`` flag and the special ``!php/const``
 syntax to parse them as proper PHP constants::
 
-    $yaml = '{ foo: PHP_INT_SIZE, bar: !php/const:PHP_INT_SIZE }';
+    $yaml = '{ foo: PHP_INT_SIZE, bar: !php/const PHP_INT_SIZE }';
     $parameters = Yaml::parse($yaml, Yaml::PARSE_CONSTANT);
     // $parameters = array('foo' => 'PHP_INT_SIZE', 'bar' => 8);
 


### PR DESCRIPTION
As mentioned in the [upgrade guide](https://github.com/symfony/symfony/blob/master/UPGRADE-4.0.md):

> The !php/object: tag was removed in favor of the !php/object tag (without the colon).
> The !php/const: tag was removed in favor of the !php/const tag (without the colon).