### PR TITLE
Added missing colon

### DIFF
--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -18,7 +18,7 @@ the original service is lost:
             # this replaces the old app.mailer definition with the new one, the
             # old definition is lost
             app.mailer:
-                class AppBundle\DecoratingMailer
+                class: AppBundle\DecoratingMailer
 
     .. code-block:: xml
 


### PR DESCRIPTION
There is a missing colon in yaml example for replacing services