### PR TITLE
Removed a deprecated feature in a testing article

### DIFF
--- a/testing/profiling.rst
+++ b/testing/profiling.rst
@@ -59,12 +59,6 @@ finish. It's easy to achieve if you embed the token in the error message::
         )
     );
 
-.. caution::
-
-     The profiler store can be different depending on the environment
-     (especially if you use the SQLite store, which is the default configured
-     one).
-
 .. note::
 
     The profiler information is available even if you insulate the client or


### PR DESCRIPTION
Spotted while working on #8705.

This is no longer needed because all profiler storage engines were removed: https://symfony.com/doc/current/profiler/storage.html