### PR TITLE
Mention security voters as the recommended alternative to ACL

### DIFF
--- a/security/acl.rst
+++ b/security/acl.rst
@@ -9,7 +9,7 @@ How to Use Access Control Lists (ACLs)
     ACL support was removed in Symfony 4.0. Install the `Symfony ACL bundle`_
     and refer to its documentation if you want to keep using ACL.
 
-    Alternatively, consider using :doc:`security voters </security/voters>`,
+    Consider using :doc:`security voters </security/voters>`,
     the alternative to ACLs recommended by Symfony.
 
 .. _`Symfony ACL bundle`: https://github.com/symfony/acl-bundle

--- a/security/acl.rst
+++ b/security/acl.rst
@@ -9,4 +9,7 @@ How to Use Access Control Lists (ACLs)
     ACL support was removed in Symfony 4.0. Install the `Symfony ACL bundle`_
     and refer to its documentation if you want to keep using ACL.
 
+    Alternatively, consider using :doc:`security voters </security/voters>`,
+    the alternative to ACLs recommended by Symfony.
+
 .. _`Symfony ACL bundle`: https://github.com/symfony/acl-bundle

--- a/security/acl_advanced.rst
+++ b/security/acl_advanced.rst
@@ -9,7 +9,7 @@ How to Use advanced ACL Concepts
     ACL support was removed in Symfony 4.0. Install the `Symfony ACL bundle`_
     and refer to its documentation if you want to keep using ACL.
 
-    Alternatively, consider using :doc:`security voters </security/voters>`,
+    Consider using :doc:`security voters </security/voters>`,
     the alternative to ACLs recommended by Symfony.
 
 .. _`Symfony ACL bundle`: https://github.com/symfony/acl-bundle

--- a/security/acl_advanced.rst
+++ b/security/acl_advanced.rst
@@ -9,4 +9,7 @@ How to Use advanced ACL Concepts
     ACL support was removed in Symfony 4.0. Install the `Symfony ACL bundle`_
     and refer to its documentation if you want to keep using ACL.
 
+    Alternatively, consider using :doc:`security voters </security/voters>`,
+    the alternative to ACLs recommended by Symfony.
+
 .. _`Symfony ACL bundle`: https://github.com/symfony/acl-bundle


### PR DESCRIPTION
This morning we had this conversation with a person who thinks that Symfony Docs are bad: https://twitter.com/PhillippOh/status/932905608998805504  At the end, it was all about thinking that the rest of Symfony Docs are the same as the poor ACL docs. So, let's recommend using voters everywhere.

Reowrds are welcome because I don't like the repetition of the word *"alternative"*. Thanks!