### PR TITLE
Fix upgrading to Flex

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -163,7 +163,7 @@ manual steps:
    new project (don't copy the ``symfony/symfony`` dependency, but add the
    relevant components you are effectively using in your project).
 
-#. Install the dependencies in the new project executing ``composer install``.
+#. Install the dependencies in the new project executing ``composer update``.
    This will make Symfony Flex generate all the configuration files in
    ``config/packages/``
 


### PR DESCRIPTION
When upgrading to Flex `composer install` won't install any new (merged) dependencies. `composer update` should be used instead.