### PR TITLE
Update Custom UsernamePasswordToken Authenticator

### DIFF
--- a/security/custom_password_authenticator.rst
+++ b/security/custom_password_authenticator.rst
@@ -61,6 +61,7 @@ the user::
                     // (so don't put any un-trusted messages / error strings here)
                     throw new CustomUserMessageAuthenticationException(
                         'You can only log in between 2 and 4!',
+                        array(), // Message Data
                         412 // HTTP 412 Precondition Failed
                     );
                 }


### PR DESCRIPTION
Hello,
the "CustomUserMessageAuthenticationException" require a third parameter called $messageData ($messageData Data to be passed into the translator) that must be an array.
Thanks for reviewing this modification.