### PR TITLE
[FIX] Realpath improvement in PHP 7.2

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -92,7 +92,7 @@ By default, cached paths are only stored for ``120`` seconds by default, conside
    
 .. tip::
 
-    Since PHP 7.2, the default value for ``realpath_cache_size``has been set to 4096K, feel free to delete this trick in your     ``php.ini`` file.
+    Since PHP 7.2, the default value for ``realpath_cache_size`` has been set to 4096K, feel free to delete this trick in your     ``php.ini`` file.
 
 Use Composer's Class Map Functionality
 --------------------------------------

--- a/performance.rst
+++ b/performance.rst
@@ -79,15 +79,11 @@ real and absolute file system paths. This increases the performance for
 applications like Symfony that open many PHP files, especially on Windows
 systems.
 
-By default, PHP sets a ``realpath_cache_size`` of ``16K`` which is too low for
-Symfony. Consider updating this value at least to ``4096K``. In addition, cached
-paths are only stored for ``120`` seconds by default. Consider updating this
-value too using the ``realpath_cache_ttl`` option:
+By default, cached paths are only stored for ``120`` seconds by default, consider updating this value using the ``realpath_cache_ttl`` option:
 
 .. code-block:: ini
 
     ; php.ini
-    realpath_cache_size=4096K
     realpath_cache_ttl=600
 
 .. index::

--- a/performance.rst
+++ b/performance.rst
@@ -84,10 +84,15 @@ By default, cached paths are only stored for ``120`` seconds by default, conside
 .. code-block:: ini
 
     ; php.ini
+    realpath_cache_size=4096K
     realpath_cache_ttl=600
 
 .. index::
    single: Performance; Autoloader
+   
+.. tip::
+
+    Since PHP 7.2, the default value for ``realpath_cache_size``has been set to 4096K, feel free to delete this trick in your     ``php.ini`` file.
 
 Use Composer's Class Map Functionality
 --------------------------------------

--- a/performance.rst
+++ b/performance.rst
@@ -79,20 +79,17 @@ real and absolute file system paths. This increases the performance for
 applications like Symfony that open many PHP files, especially on Windows
 systems.
 
-By default, cached paths are only stored for ``120`` seconds by default, consider updating this value using the ``realpath_cache_ttl`` option:
+Consider increasing the ``realpath_cache_size`` and ``realpath_cache_ttl``:
 
 .. code-block:: ini
 
     ; php.ini
+    ; 4096k is the default value in PHP 7.2
     realpath_cache_size=4096K
     realpath_cache_ttl=600
 
 .. index::
    single: Performance; Autoloader
-   
-.. tip::
-
-    Since PHP 7.2, the default value for ``realpath_cache_size`` has been set to 4096K, feel free to delete this trick in your     ``php.ini`` file.
 
 Use Composer's Class Map Functionality
 --------------------------------------


### PR DESCRIPTION
As PHP 7.2 provide a default value of 4096k (as seen https://github.com/php/php-src/blob/php-7.2.0RC6/UPGRADING#L357), the line about this improvement can be deleted.