### PR TITLE
Add Tobias Nyholm in the core team

### DIFF
--- a/contributing/code/core_team.rst
+++ b/contributing/code/core_team.rst
@@ -83,6 +83,9 @@ Active Core Members
   * **Maxime Steinhausser** (`ogizanagi`_) can merge into Config_, Console_,
     Form_, Serializer_, DependencyInjection_, and HttpKernel_ components.
 
+  * **Tobias Niholm** (`Nyholm`) manages the official and contrib recipes
+    repositories.
+
 * **Deciders** (``@symfony/deciders`` on GitHub):
 
   * **Jordi Boggiano** (`seldaek`_);
@@ -223,4 +226,4 @@ discretion of the **Project Leader**.
 .. _`lyrixx`: https://github.com/lyrixx/
 .. _`chalasr`: https://github.com/chalasr/
 .. _`ogizanagi`: https://github.com/ogizanagi/
-.. _`csarrazi`: https://github.com/csarrazi/
+.. _`Nyholm`: https://github.com/Nyholm

--- a/contributing/code/core_team.rst
+++ b/contributing/code/core_team.rst
@@ -83,7 +83,7 @@ Active Core Members
   * **Maxime Steinhausser** (`ogizanagi`_) can merge into Config_, Console_,
     Form_, Serializer_, DependencyInjection_, and HttpKernel_ components.
 
-  * **Tobias Niholm** (`Nyholm`) manages the official and contrib recipes
+  * **Tobias Nyholm** (`Nyholm`) manages the official and contrib recipes
     repositories.
 
 * **Deciders** (``@symfony/deciders`` on GitHub):


### PR DESCRIPTION
See http://symfony.com/blog/new-core-team-member-in-charge-of-the-recipes for the announcement.