### PR TITLE
doc(http_foundation)

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -297,7 +297,7 @@ PHP callable that is able to create an instance of your ``Request`` class::
         array $server = array(),
         $content = null
     ) {
-        return SpecialRequest::create(
+        return new SpecialRequest(
             $query,
             $request,
             $attributes,


### PR DESCRIPTION
- [x] Fixed code error which used `create()` instead of constructor method.

Fix #8768.