### PR TITLE
Add command to require Symfony security

### DIFF
--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -35,7 +35,12 @@ and :ref:`user serialization to the session <security-serialize-equatable>`
 
 1) Create your User Entity
 --------------------------
+Firstable you need to require a Symfony security
 
+.. code-block:: terminal
+
+    $ composer req security
+    
 For this entry, suppose that you already have a ``User`` entity inside an
 ``AppBundle`` with the following fields: ``id``, ``username``, ``password``,
 ``email`` and ``isActive``::

--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -35,11 +35,12 @@ and :ref:`user serialization to the session <security-serialize-equatable>`
 
 1) Create your User Entity
 --------------------------
-Firstable you need to require a Symfony security
+
+Before you begin, first make sure you install the Security component:
 
 .. code-block:: terminal
 
-    $ composer req security
+    $ composer require security
     
 For this entry, suppose that you already have a ``User`` entity inside an
 ``AppBundle`` with the following fields: ``id``, ``username``, ``password``,


### PR DESCRIPTION
The command should be there, because if someone unfamiliar with new Symfony structure use it, it will not work.