### PR TITLE
Show controller tag for PHP configuration

### DIFF
--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -373,7 +373,8 @@ The third big change is that, in a new Symfony 3.3 project, your controllers are
         // app/config/services.php
 
         // ...
-
+        
+        $definition->addTag('controller.service_arguments');
         $this->registerClasses($definition, 'AppBundle\\Controller\\', '../../src/AppBundle/Controller/*');
 
 But, you might not even notice this. First, your controllers *can* still extend


### PR DESCRIPTION
Putting the tag in the PHP documentation is necessary so that controllers are marked as public to avoid a deprecation notice and also to wire them up the same way as controllers configured via xml or yml would be.