### PR TITLE
Removing more AppBundle

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -454,7 +454,7 @@ Resources
 
 If the bundle references any resources (config files, translation files, etc.),
 don't use physical paths (e.g. ``__DIR__/config/services.xml``) but logical
-paths (e.g. ``@AppBundle/Resources/config/services.xml``).
+paths (e.g. ``@FooBundle/Resources/config/services.xml``).
 
 The logical paths are required because of the bundle overriding mechanism that
 lets you override any resource/file of any bundle. See :ref:`http-kernel-resource-locator`
@@ -462,7 +462,7 @@ for more details about transforming physical paths into logical paths.
 
 Beware that templates use a simplified version of the logical path shown above.
 For example, an ``index.html.twig`` template located in the ``Resources/views/Default/``
-directory of the AppBundle, is referenced as ``@App/Default/index.html.twig``.
+directory of the FooBundle, is referenced as ``@Foo/Default/index.html.twig``.
 
 Learn more
 ----------

--- a/bundles/override.rst
+++ b/bundles/override.rst
@@ -12,7 +12,7 @@ features of a bundle.
 
     The bundle overriding mechanism means that you cannot use physical paths to
     refer to bundle's resources (e.g. ``__DIR__/config/services.xml``). Always
-    use logical paths in your bundles (e.g. ``@AppBundle/Resources/config/services.xml``)
+    use logical paths in your bundles (e.g. ``@FooBundle/Resources/config/services.xml``)
     and call the :ref:`locateResource() method <http-kernel-resource-locator>`
     to turn them into physical paths when needed.
 

--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -247,7 +247,7 @@ method::
         // ...
         $helper = $this->getHelper('question');
 
-        $question = new Question('Please enter the name of the bundle', 'AppBundle');
+        $question = new Question('Please enter the name of the bundle', 'AcmeDemoBundle');
         $question->setNormalizer(function ($value) {
             // $value can be null here
             return $value ? trim($value) : '';

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -258,8 +258,8 @@ on the request's information.
 
     a) If the ``_controller`` key doesn't follow the recommended PHP namespace
        format (e.g. ``App\Controller\DefaultController::index``) its format is
-       transformed into it. For example, the legacy ``AppBundle:Default:index``
-       format would be changed to ``Acme\AppBundle\Controller\DefaultController::indexAction``.
+       transformed into it. For example, the legacy ``FooBundle:Default:index``
+       format would be changed to ``Acme\FooBundle\Controller\DefaultController::indexAction``.
        This transformation is specific to the :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerResolver`
        sub-class used by the Symfony Framework.
 
@@ -742,10 +742,10 @@ translation files, etc.)
 
 This overriding mechanism works because resources are referenced not by their
 physical path but by their logical path. For example, the ``services.xml`` file
-stored in the ``Resources/config/`` directory of a bundle called AppBundle is
-referenced as ``@AppBundle/Resources/config/services.xml``. This logical path
+stored in the ``Resources/config/`` directory of a bundle called FooBundle is
+referenced as ``@FooBundle/Resources/config/services.xml``. This logical path
 will work when the application overrides that file and even if you change the
-directory of AppBundle.
+directory of FooBundle.
 
 The HttpKernel component provides a method called :method:`Symfony\\Component\\HttpKernel\\Kernel::locateResource`
 which can be used to transform logical paths into physical paths::
@@ -754,7 +754,7 @@ which can be used to transform logical paths into physical paths::
 
     // ...
     $kernel = new HttpKernel($dispatcher, $resolver);
-    $path = $kernel->locateResource('@AppBundle/Resources/config/services.xml');
+    $path = $kernel->locateResource('@FooBundle/Resources/config/services.xml');
 
 Learn more
 ----------

--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -54,8 +54,6 @@ Code Examples
 * The code examples should look real for a web application context. Avoid abstract
   or trivial examples (``foo``, ``bar``, ``demo``, etc.);
 * The code should follow the :doc:`Symfony Best Practices </best_practices/introduction>`.
-  Unless the example requires a custom bundle, make sure to always use the
-  ``AppBundle`` bundle to store your code;
 * Use ``Acme`` when the code requires a vendor name;
 * Use ``example.com`` as the domain of sample URLs and ``example.org`` and
   ``example.net`` when additional domains are required. All of these domains are

--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -50,12 +50,21 @@ The following configuration code shows how you can configure two entity managers
                     default:
                         connection: default
                         mappings:
-                            AppBundle:  ~
-                            AcmeStoreBundle: ~
+                            App:
+                                is_bundle: false
+                                type: annotation
+                                dir: '%kernel.project_dir%/src/Entity'
+                                prefix: 'App\Entity'
+                                alias: App
                     customer:
                         connection: customer
                         mappings:
-                            AcmeCustomerBundle: ~
+                            AppCustomer:
+                                is_bundle: false
+                                type: annotation
+                                dir: '%kernel.project_dir%/src/CustomerEntity'
+                                prefix: 'App\Customer\Entity'
+                                alias: AppCustomer
 
     .. code-block:: xml
 
@@ -94,12 +103,25 @@ The following configuration code shows how you can configure two entity managers
 
                 <doctrine:orm default-entity-manager="default">
                     <doctrine:entity-manager name="default" connection="default">
-                        <doctrine:mapping name="AppBundle" />
-                        <doctrine:mapping name="AcmeStoreBundle" />
+                        <doctrine:mapping
+                            name="App"
+                            is_bundle="false"
+                            type="annotation"
+                            dir="%kernel.project_dir%/src/Entity"
+                            prefix="App\Entity"
+                            alias="App"
+                        />
                     </doctrine:entity-manager>
 
                     <doctrine:entity-manager name="customer" connection="customer">
-                        <doctrine:mapping name="AcmeCustomerBundle" />
+                        <doctrine:mapping
+                            name="AppCustomer"
+                            is_bundle="false"
+                            type="annotation"
+                            dir="%kernel.project_dir%/src/CustomerEntity"
+                            prefix="App\CustomerEntity"
+                            alias="AppCustomer"
+                        />
                     </doctrine:entity-manager>
                 </doctrine:orm>
             </doctrine:config>
@@ -139,14 +161,25 @@ The following configuration code shows how you can configure two entity managers
                     'default' => array(
                         'connection' => 'default',
                         'mappings'   => array(
-                            'AppBundle'  => null,
-                            'AcmeStoreBundle' => null,
+                            'App'  => array(
+                                is_bundle => false,
+                                type => 'annotation',
+                                dir => '%kernel.project_dir%/src/Entity',
+                                prefix => 'App\Entity',
+                                alias => 'App',
+                            )
                         ),
                     ),
                     'customer' => array(
                         'connection' => 'customer',
                         'mappings'   => array(
-                            'AcmeCustomerBundle' => null,
+                            'AppCustomer'  => array(
+                                is_bundle => false,
+                                type => 'annotation',
+                                dir => '%kernel.project_dir%/src/CustomerEntity',
+                                prefix => 'App\CustomerEntity',
+                                alias => 'AppCustomer',
+                            )
                         ),
                     ),
                 ),
@@ -155,8 +188,8 @@ The following configuration code shows how you can configure two entity managers
 
 In this case, you've defined two entity managers and called them ``default``
 and ``customer``. The ``default`` entity manager manages entities in the
-AppBundle and AcmeStoreBundle, while the ``customer`` entity manager manages
-entities in the AcmeCustomerBundle. You've also defined two connections, one
+``src/Entity`` directory, while the ``customer`` entity manager manages
+entities in ``src/CustomerEntity``. You've also defined two connections, one
 for each entity manager.
 
 .. note::

--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -50,21 +50,21 @@ The following configuration code shows how you can configure two entity managers
                     default:
                         connection: default
                         mappings:
-                            App:
+                            Main:
                                 is_bundle: false
                                 type: annotation
-                                dir: '%kernel.project_dir%/src/Entity'
-                                prefix: 'App\Entity'
-                                alias: App
+                                dir: '%kernel.project_dir%/src/Entity/Main'
+                                prefix: 'App\Entity\Main'
+                                alias: Main
                     customer:
                         connection: customer
                         mappings:
-                            AppCustomer:
+                            Customer:
                                 is_bundle: false
                                 type: annotation
-                                dir: '%kernel.project_dir%/src/CustomerEntity'
-                                prefix: 'App\Customer\Entity'
-                                alias: AppCustomer
+                                dir: '%kernel.project_dir%/src/Entity/Customer'
+                                prefix: 'App\Entity\Customer'
+                                alias: Customer
 
     .. code-block:: xml
 
@@ -104,23 +104,23 @@ The following configuration code shows how you can configure two entity managers
                 <doctrine:orm default-entity-manager="default">
                     <doctrine:entity-manager name="default" connection="default">
                         <doctrine:mapping
-                            name="App"
+                            name="Main"
                             is_bundle="false"
                             type="annotation"
-                            dir="%kernel.project_dir%/src/Entity"
-                            prefix="App\Entity"
-                            alias="App"
+                            dir="%kernel.project_dir%/src/Entity/Main"
+                            prefix="App\Entity\Main"
+                            alias="Main"
                         />
                     </doctrine:entity-manager>
 
                     <doctrine:entity-manager name="customer" connection="customer">
                         <doctrine:mapping
-                            name="AppCustomer"
+                            name="Customer"
                             is_bundle="false"
                             type="annotation"
-                            dir="%kernel.project_dir%/src/CustomerEntity"
-                            prefix="App\CustomerEntity"
-                            alias="AppCustomer"
+                            dir="%kernel.project_dir%/src/Entity/Customer"
+                            prefix="App\Entity\Customer"
+                            alias="Customer"
                         />
                     </doctrine:entity-manager>
                 </doctrine:orm>
@@ -161,24 +161,24 @@ The following configuration code shows how you can configure two entity managers
                     'default' => array(
                         'connection' => 'default',
                         'mappings'   => array(
-                            'App'  => array(
+                            'Main'  => array(
                                 is_bundle => false,
                                 type => 'annotation',
-                                dir => '%kernel.project_dir%/src/Entity',
-                                prefix => 'App\Entity',
-                                alias => 'App',
+                                dir => '%kernel.project_dir%/src/Entity/Main',
+                                prefix => 'App\Entity\Main',
+                                alias => 'Main',
                             )
                         ),
                     ),
                     'customer' => array(
                         'connection' => 'customer',
                         'mappings'   => array(
-                            'AppCustomer'  => array(
+                            'Customer'  => array(
                                 is_bundle => false,
                                 type => 'annotation',
-                                dir => '%kernel.project_dir%/src/CustomerEntity',
-                                prefix => 'App\CustomerEntity',
-                                alias => 'AppCustomer',
+                                dir => '%kernel.project_dir%/src/Entity/Customer',
+                                prefix => 'App\Entity\Customer',
+                                alias => 'Customer',
                             )
                         ),
                     ),
@@ -188,8 +188,8 @@ The following configuration code shows how you can configure two entity managers
 
 In this case, you've defined two entity managers and called them ``default``
 and ``customer``. The ``default`` entity manager manages entities in the
-``src/Entity`` directory, while the ``customer`` entity manager manages
-entities in ``src/CustomerEntity``. You've also defined two connections, one
+``src/Entity/Main`` directory, while the ``customer`` entity manager manages
+entities in ``src/Entity/Customer``. You've also defined two connections, one
 for each entity manager.
 
 .. note::

--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -36,8 +36,8 @@ and :ref:`user serialization to the session <security-serialize-equatable>`
 1) Create your User Entity
 --------------------------
 
-For this entry, suppose that you already have a ``User`` entity inside an
-``AppBundle`` with the following fields: ``id``, ``username``, ``password``,
+For this entry, suppose that you already have a ``User`` entity
+with the following fields: ``id``, ``username``, ``password``,
 ``email`` and ``isActive``::
 
     // src/Entity/User.php

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -479,7 +479,7 @@ application handlers.
 .. code-block:: php
 
     // src/HandlerCollection.php
-    namespace AppBundle;
+    namespace App;
 
     class HandlerCollection
     {


### PR DESCRIPTION
This is still not all of them (and we have a few pending PR's which remove some additional ones). But this gets us *close* to all AppBundle gone.

I've even renamed some instances that are not technically problematic. That's because I want to be able to do a `git grep AppBundle` on 4.0 and higher and see *nothing*. This will make it easier to spot merge issues later.

This helps #7809. 