### PR TITLE
remove CompilerPassInterface from kernel

### DIFF
--- a/service_container/compiler_passes.rst
+++ b/service_container/compiler_passes.rst
@@ -17,11 +17,10 @@ Compiler passes are registered in the ``build()`` method of the application kern
 
     use App\DependencyInjection\Compiler\CustomPass;
     use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-    use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
-    class Kernel extends BaseKernel implements CompilerPassInterface
+    class Kernel extends BaseKernel
     {
         use MicroKernelTrait;
 


### PR DESCRIPTION
It is not needed here - `build` methods is a part of `Kernel`, but `CompilerPassInterface` defines `process`.