### PR TITLE
remove "choices_as_values" mention

### DIFF
--- a/form/create_custom_field_type.rst
+++ b/form/create_custom_field_type.rst
@@ -35,8 +35,7 @@ for form fields, which is ``<BundleName>\Form\Type``. Make sure the field extend
                     'Standard Shipping' => 'standard',
                     'Expedited Shipping' => 'expedited',
                     'Priority Shipping' => 'priority',
-                ),
-                'choices_as_values' => true,
+                )
             ));
         }
 

--- a/form/create_custom_field_type.rst
+++ b/form/create_custom_field_type.rst
@@ -35,7 +35,7 @@ for form fields, which is ``<BundleName>\Form\Type``. Make sure the field extend
                     'Standard Shipping' => 'standard',
                     'Expedited Shipping' => 'expedited',
                     'Priority Shipping' => 'priority',
-                )
+                ),
             ));
         }
 


### PR DESCRIPTION
"choices_as_values" is still mentioned in the "Create a custom form field type" doc but has been removed in 4.0.