### PR TITLE
Changed symfony/web-server-bundle to dev package

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -50,7 +50,7 @@ First, move into your new project and install the server:
 .. code-block:: terminal
 
     cd my-project
-    composer require server
+    composer require server --dev
 
 To start the server, run:
 


### PR DESCRIPTION
The symfony/web-server-bundle package should be installed as dev requirement. This bundle is not needable for production.