### PR TITLE
Improved the example to generate URLs in the console

### DIFF
--- a/console/request_context.rst
+++ b/console/request_context.rst
@@ -72,11 +72,13 @@ from the ``router`` service and override its settings::
     {
         protected function execute(InputInterface $input, OutputInterface $output)
         {
-            $context = $this->getContainer()->get('router')->getContext();
+            $router = $this->getContainer()->get('router');
+            $context = $router->getContext();
             $context->setHost('example.com');
             $context->setScheme('https');
             $context->setBaseUrl('my/path');
 
-            // ... your code here
+            $url = $router->generate('route-name', array('param-name' => 'param-value'));
+            // ...
         }
     }


### PR DESCRIPTION
This fixes #8827 and a minor issue (code was tabulated with 3 white spaces). 

When merging in 4.0, the code must be tweaked to use `$this->router` variable instead of `$router`.