### PR TITLE
Add constructor call to the "Getting Services from the Service Container" section

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -186,6 +186,8 @@ as a service, you can use normal dependency injection. Imagine you have a
         public function __construct(UserManager $userManager)
         {
             $this->userManager = $userManager;
+            
+            parent::__construct();
         }
 
         // ...


### PR DESCRIPTION
Parent constructor call is required when using auto-wired services in a command constructor, without it you will receive the error:

```
There are no commands defined in the "app" namespace.
```

Some discussion of what I ran into: https://github.com/symfony/symfony-docs/issues/8843