### PR TITLE
Separate dev dependencies from application dependencies

### DIFF
--- a/frontend/encore/reactjs.rst
+++ b/frontend/encore/reactjs.rst
@@ -5,7 +5,8 @@ Using React? Make sure you have React installed, along with the `babel-preset-re
 
 .. code-block:: terminal
 
-    $ yarn add --dev react react-dom prop-types babel-preset-react
+    $ yarn add --dev babel-preset-react
+    $ yarn add react react-dom prop-types
 
 Enable react in your ``webpack.config.js``:
 


### PR DESCRIPTION
react react-dom and prop-types shouldn't be dev dependencies