### PR TITLE
Added tip to require browser-kit in WebTestCase.

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -129,6 +129,12 @@ tests as far as PHPUnit is concerned, but they have a very specific workflow:
 Your First Functional Test
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+First, install the BrowserKit component in your project:
+
+.. code-block:: terminal
+
+    $ composer require --dev browser-kit
+
 Functional tests are simple PHP files that typically live in the ``tests/Controller``
 directory for your bundle. If you want to test the pages handled by your
 ``PostController`` class, start by creating a new ``PostControllerTest.php``
@@ -155,11 +161,7 @@ As an example, a test could look like this::
             );
         }
     }
-    
-.. tip::
-    
-    Do not forget to require the ``browser-kit`` component via ``composer require browser-kit``, if you want to use the ``WebTestCase`` class.
-    
+
 .. tip::
 
     To run your functional tests, the ``WebTestCase`` class needs to know which

--- a/testing.rst
+++ b/testing.rst
@@ -158,7 +158,7 @@ As an example, a test could look like this::
     
 .. tip::
     
-    Do not forget to require the ``Browser-Kit`` via ``composer require browser-kit`` if you want to use the ``WebTestCase`` class.
+    Do not forget to require the ``browser-kit`` component via ``composer require browser-kit``, if you want to use the ``WebTestCase`` class.
     
 .. tip::
 

--- a/testing.rst
+++ b/testing.rst
@@ -155,7 +155,11 @@ As an example, a test could look like this::
             );
         }
     }
-
+    
+.. tip::
+    
+    Do not forget to require the ``Browser-Kit`` via ``composer require browser-kit`` if you want to use the ``WebTestCase`` class.
+    
 .. tip::
 
     To run your functional tests, the ``WebTestCase`` class needs to know which


### PR DESCRIPTION
Hello,

I played around with the WebTestCase in Symfony 4+ and I came across that fact, that you have to require the browser-kit component to use the WebTestCase class.
For people who don't know the internals of symfony, it can be hard to figure out what to do now, because all they got is this error message:

```
php bin/phpunit tests
#!/usr/bin/env php
PHPUnit 6.5.3 by Sebastian Bergmann and contributors.

Testing tests
PHP Fatal error:  Class 'Symfony\Component\BrowserKit\Client' not found in /media/tim/996cb512-7026-4e7a-8f4b-f2f38c02939f/tim/PhpstormProjects/symfony4TestRoutes/vendor/symfony/http-kernel/Client.php on line 31
``` 

With the new flex system, this could be confusing for some developers, that they have to require additional packages. 
It think it is good to mention that in the docs.

If I missed something here or if you think that the browser-kit should be required by the packages which provides `ẀebTestCase` and it is a WIP thing, then let me know that.