### PR TITLE
Replaced class per id in service definition in XML

### DIFF
--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -116,7 +116,7 @@ services.
                 http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service class="App\Mail\PhpMailer" public="false" />
+                <service id="App\Mail\PhpMailer" public="false" />
 
                 <service id="app.mailer" alias="App\Mail\PhpMailer" />
             </services>


### PR DESCRIPTION
Using only `class` results in `Top-level services must have "id" attribute, none found`. Whereas using `id` instead of `class` is understood, and it is coherent with the YAML and PHP versions of the same definition.