### PR TITLE
"Array operators" -> "Collection operators"

### DIFF
--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -253,7 +253,7 @@ For example::
 This would print out ``Arthur Dent``.
 
 Collection Operators
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 * ``in`` (contain)
 * ``not in`` (does not contain)

--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -252,7 +252,7 @@ For example::
 
 This would print out ``Arthur Dent``.
 
-Array Operators
+Collection Operators
 ~~~~~~~~~~~~~~~
 
 * ``in`` (contain)


### PR DESCRIPTION
Since ExpressionLanguage 4.1, `in` and `not in` operators will alongside arrays handle traversable objects too