### PR TITLE
Mention the new behavior of dump() which returns the passed value

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -50,6 +50,9 @@ For example::
 
     dump($someVar);
 
+    // dump() returns the passed value, so you can dump an object and keep using it
+    dump($someObject)->someMethod();
+
 By default, the output format and destination are selected based on your
 current PHP SAPI:
 


### PR DESCRIPTION
This fixes #8459.