### PR TITLE
[VarDumper] DebugBundle is not enabled

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -80,8 +80,7 @@ DebugBundle and Twig Integration
 --------------------------------
 
 The DebugBundle allows greater integration of the component into the Symfony
-full-stack framework. It is enabled by default in the *dev* and *test*
-environment of the Symfony Standard Edition.
+full-stack framework. 
 
 Since generating (even debug) output in the controller or in the model
 of your application may just break it by e.g. sending HTTP headers or

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -79,8 +79,8 @@ current PHP SAPI:
 DebugBundle and Twig Integration
 --------------------------------
 
-The DebugBundle allows greater integration of the component into the Symfony
-full-stack framework. 
+The DebugBundle allows greater integration of this component into Symfony
+applications. 
 
 Since generating (even debug) output in the controller or in the model
 of your application may just break it by e.g. sending HTTP headers or


### PR DESCRIPTION
DebugBungle is not enabled by default
https://github.com/symfony/symfony/issues/25283