### PR TITLE
WSSE implementation without SALT not working

### DIFF
--- a/security/custom_authentication_provider.rst
+++ b/security/custom_authentication_provider.rst
@@ -270,6 +270,7 @@ the ``PasswordDigest`` header value matches with the user's password::
             $expected = base64_encode(sha1(base64_decode($nonce).$created.$secret, true));
 
             return hash_equals($expected, $digest);
+            # this won't return TRUE ever
         }
 
         public function supports(TokenInterface $token)


### PR DESCRIPTION
I implemented the WSSE token in Symfony 2 using *SHA512* algorithm *WITH* salt. Because bcrypt, without specifying the salt, generates one every time encodes a password, the hash_equals at the end of the AuthenticationProvider won't return TRUE ever.

That's because a client encodes the password without a salt, generating a different hash stored in the database. When comparing ONLY these hashes, the password validates. But when concatenating with nonce, created and encode/decoding base64, the hashed won't match:

$expected = base64_encode(sha1(base64_decode($nonce).$created.$secret, true));

So the salt it should be mentioned in the article.