### PR TITLE
Explain why the Web Debug Toolbar is gone

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -262,6 +262,20 @@ to get your *new* lucky number!
 
     http://localhost:8000/lucky/number
 
+Now you may wonder where the Web Debug Toolbar has gone: that's because we don't write
+a ``body`` element using the current template. If we incorporate the default
+``base.html.twig``, which contains all default elements, including ``body``, you'll see
+that the Toolbar re-appears:
+
+.. code-block:: diff
+
+    {# templates/lucky/number.html.twig #}
+    + {% extends 'base.html.twig' %}
+
+    + {% block body %}
+    <h1>Your lucky number is {{ number }}</h1>
+    + {% endblock %}
+
 In the :doc:`/templating` article, you'll learn all about Twig: how to loop, render
 other templates and leverage its powerful layout inheritance system.
 

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -262,7 +262,9 @@ to get your *new* lucky number!
 
     http://localhost:8000/lucky/number
 
-Now you may wonder where the Web Debug Toolbar has gone: that's because there is no ``</body>`` tag in the current template. You can add the body element yourself, or extend ``base.html.twig``, which contains all default HTML elements.
+Now you may wonder where the Web Debug Toolbar has gone: that's because there is
+no ``</body>`` tag in the current template. You can add the body element yourself,
+or extend ``base.html.twig``, which contains all default HTML elements.
 
 In the :doc:`/templating` article, you'll learn all about Twig: how to loop, render
 other templates and leverage its powerful layout inheritance system.

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -262,19 +262,7 @@ to get your *new* lucky number!
 
     http://localhost:8000/lucky/number
 
-Now you may wonder where the Web Debug Toolbar has gone: that's because we don't write
-a ``body`` element using the current template. If we incorporate the default
-``base.html.twig``, which contains all default elements, including ``body``, you'll see
-that the Toolbar re-appears:
-
-.. code-block:: diff
-
-    {# templates/lucky/number.html.twig #}
-    + {% extends 'base.html.twig' %}
-
-    + {% block body %}
-    <h1>Your lucky number is {{ number }}</h1>
-    + {% endblock %}
+Now you may wonder where the Web Debug Toolbar has gone: that's because there is no ``</body>`` tag in the current template. You can add the body element yourself, or extend ``base.html.twig``, which contains all default HTML elements.
 
 In the :doc:`/templating` article, you'll learn all about Twig: how to loop, render
 other templates and leverage its powerful layout inheritance system.


### PR DESCRIPTION
When rendering a response using a template, the Web Debug Toolbar is gone, which was confusing to me. Only after searching I found the reason: there is no body element when using this rendering method. It seems logical to me to also explain extending a template to incorporate base.html.twig, so the Toolbar re-appears.