### PR TITLE
Fixed Flex doc (typo breaks ordered list)

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -234,8 +234,8 @@ manual steps:
 #. Move the public assets, such as images or compiled CSS/JS files, from
    ``src/AppBundle/Resources/public/`` to ``public/`` (e.g. ``public/images/``).
 
-  Move the source of the assets (e.g. the SCSS files) to ``assets/`` and use
-  :doc:`Webpack Encore </frontend>` to manage and compile them.
+#. Move the source of the assets (e.g. the SCSS files) to ``assets/`` and use
+   :doc:`Webpack Encore </frontend>` to manage and compile them.
 
 #. Create the new ``public/index.php`` front controller
    `copying Symfony's index.php source`_ and, if you made any customization in


### PR DESCRIPTION
A typo was breaking the ordered list in the *Upgrading Existing Applications to Flex* part.

(I'm new to PR workflow, OSS, and even to whatever Markdown flavor this doc is using, but it's likely just a typo, I hope I'm doing things right !)
  