### PR TITLE
Reworded the setup article about using other versions

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -25,7 +25,9 @@ In other words, your new app is ready!
 
 .. tip::
 
-    You can also download a specific version of Symfony:
+    New projects are based by default on the latest Symfony stable version, but
+    you can select other version if needed (read about the
+    :doc:`Symfony version release process </contributing/community/releases>`):
 
     .. code-block:: terminal
 
@@ -34,9 +36,6 @@ In other words, your new app is ready!
 
         # use a beta or RC version (useful for testing new Symfony versions)
         $ composer create-project symfony/skeleton my-project 4.0.0-BETA1
-
-    Some version are long-term support (LTS) versions. Read the :doc:`Symfony Release process </contributing/community/releases>`
-    to learn more.
 
 Running your Symfony Application
 --------------------------------

--- a/setup.rst
+++ b/setup.rst
@@ -23,20 +23,6 @@ This will create a new ``my-project`` directory, download some dependencies into
 it and even generate the basic directories and files you'll need to get started.
 In other words, your new app is ready!
 
-.. tip::
-
-    New projects are based by default on the latest Symfony stable version, but
-    you can select other version if needed (read about the
-    :doc:`Symfony version release process </contributing/community/releases>`):
-
-    .. code-block:: terminal
-
-        # use the most recent version in any Symfony branch
-        $ composer create-project symfony/skeleton my-project "4.0.*"
-
-        # use a beta or RC version (useful for testing new Symfony versions)
-        $ composer create-project symfony/skeleton my-project 4.0.0-BETA1
-
 Running your Symfony Application
 --------------------------------
 


### PR DESCRIPTION
  As explained in #8886:

> You can't install specific branch versions with a single command when using Flex, so let's not mention it. The installation of beta and RC versions is covered in other articles, so we're not missing anything by removing this. Thanks!