### PR TITLE
cross-reference console command testing from testing guide

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -918,6 +918,7 @@ Learn more
 
     testing/*
 
+* :ref:`Testing a console command <console-testing-commands>`
 * :doc:`The chapter about tests in the Symfony Framework Best Practices </best_practices/tests>`
 * :doc:`/components/dom_crawler`
 * :doc:`/components/css_selector`


### PR DESCRIPTION
this feature is "hidden" in the console documentation. it belongs there, but we should find it from the testing guide as well.