### PR TITLE
[console testing] commands are automatically registered in symfony full stack

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -299,7 +299,6 @@ you can extend your test from
             $kernel->boot();
 
             $application = new Application($kernel);
-            $application->add(new CreateUserCommand());
 
             $command = $application->find('app:create-user');
             $commandTester = new CommandTester($command);


### PR DESCRIPTION
the FrameworkBundle console application should have the commands automatically registered. adding it manually will hide setup problems with commands.