### PR TITLE
Router service is now private

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -576,7 +576,7 @@ Generating URLs with Query Strings
 The ``generate()`` method takes an array of wildcard values to generate the URI.
 But if you pass extra ones, they will be added to the URI as a query string::
 
-    $this->get('router')->generate('blog', array(
+    $this->router->generate('blog', array(
         'page' => 2,
         'category' => 'Symfony'
     ));


### PR DESCRIPTION
The router service is private and not accessible in Symfony 4+, therefor $this->router should be used instead of $this->get('router'). Just above the example in question is explained how to get the router in your construct, so this should be clear.