### PR TITLE
Removed invalid examples

### DIFF
--- a/best_practices/security.rst
+++ b/best_practices/security.rst
@@ -238,12 +238,20 @@ more advanced use-case, you can always do the same security check in PHP:
         // equivalent code without using the "denyAccessUnlessGranted()" shortcut:
         //
         // use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+        // use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface
+        //
         // ...
         //
-        // if (!$this->get('security.authorization_checker')->isGranted('edit', $post)) {
+        // public function __construct(AuthorizationCheckerInterface $authorizationChecker) {
+        //      $this->authorizationChecker = $authorizationChecker;
+        // }
+        //
+        // ...
+        //
+        // if (!$this->authorizationChecker->isGranted('edit', $post)) {
         //    throw $this->createAccessDeniedException();
         // }
-
+        //
         // ...
     }
 
@@ -357,14 +365,22 @@ via the even easier shortcut in a controller:
 
         $this->denyAccessUnlessGranted('edit', $post);
 
-        // or without the shortcut:
-        //
         // use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+        // use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface
+        //
         // ...
         //
-        // if (!$this->get('security.authorization_checker')->isGranted('edit', $post)) {
+        // public function __construct(AuthorizationCheckerInterface $authorizationChecker) {
+        //      $this->authorizationChecker = $authorizationChecker;
+        // }
+        //
+        // ...
+        //
+        // if (!$this->authorizationChecker->isGranted('edit', $post)) {
         //    throw $this->createAccessDeniedException();
         // }
+        //
+        // ...
     }
 
 Learn More

--- a/controller.rst
+++ b/controller.rst
@@ -299,9 +299,7 @@ If you extend the base ``Controller`` class, you can access :ref:`public service
 via the :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::get`
 method. Here are several common services you might need::
 
-    $templating = $this->get('templating');
-
-    $router = $this->get('router');
+    $twig = $this->get('twig');
 
     $mailer = $this->get('mailer');
 

--- a/controller.rst
+++ b/controller.rst
@@ -290,31 +290,6 @@ in your controllers.
 
 For more information about services, see the :doc:`/service_container` article.
 
-.. _controller-access-services-directly:
-
-Accessing the Container Directly
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you extend the base ``Controller`` class, you can access :ref:`public services <container-public>`
-via the :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::get`
-method. Here are several common services you might need::
-
-    $twig = $this->get('twig');
-
-    $mailer = $this->get('mailer');
-
-    // you can also fetch parameters
-    $someParameter = $this->getParameter('some_parameter');
-
-If you receive an error like:
-
-.. code-block:: text
-
-    You have requested a non-existent service "my_service_id"
-
-Check to make sure the service exists (use :ref:`debug:container <container-debug-container>`)
-and that it's :ref:`public <container-public>`.
-
 .. index::
    single: Controller; Managing errors
    single: Controller; 404 pages

--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -235,18 +235,10 @@ the default entity manager (i.e. ``default``) is returned::
 
     class UserController extends Controller
     {
-        protected $em;
-
-        public function __construct(EntityManagerInterface $em)
+        public function indexAction(EntityManagerInterface $em)
         {
-            $this->em = $em;
-        }
-
-        public function indexAction()
-        {
-            // All 4 return the "default" entity manager, though using
-            // dependency injection is a best practice
-            $em = $this->em;
+            // These methods also return the default entity manager, but it's preferred
+            // to get it by inyecting EntityManagerInterface in the action method
             $em = $this->getDoctrine()->getManager();
             $em = $this->getDoctrine()->getManager('default');
             $em = $this->get('doctrine.orm.default_entity_manager');

--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -231,11 +231,22 @@ the default entity manager (i.e. ``default``) is returned::
 
     // ...
 
+    use Doctrine\ORM\EntityManagerInterface;
+
     class UserController extends Controller
     {
+        protected $em;
+
+        public function __construct(EntityManagerInterface $em)
+        {
+            $this->em = $em;
+        }
+
         public function indexAction()
         {
-            // All 3 return the "default" entity manager
+            // All 4 return the "default" entity manager, though using
+            // dependency injection is a best practice
+            $em = $this->em;
             $em = $this->getDoctrine()->getManager();
             $em = $this->getDoctrine()->getManager('default');
             $em = $this->get('doctrine.orm.default_entity_manager');

--- a/routing.rst
+++ b/routing.rst
@@ -576,7 +576,7 @@ Generating URLs with Query Strings
 The ``generate()`` method takes an array of wildcard values to generate the URI.
 But if you pass extra ones, they will be added to the URI as a query string::
 
-    $this->get('router')->generate('blog', array(
+    $this->router->generate('blog', array(
         'page' => 2,
         'category' => 'Symfony'
     ));


### PR DESCRIPTION
Templating isn't a service in Symfony 4+ (even after `composer req templating`), so probably we're looking for the twig service.

The Router service isn't public and can therefor not be called from the container:
```
$ php bin/console debug:container router

 // This service is an alias for the service router.default

Information for Service "router.default"
========================================

 ---------------- -----------------------------------------------
  Option           Value
 ---------------- -----------------------------------------------
  Service ID       router.default
  Class            Symfony\Bundle\FrameworkBundle\Routing\Router
  Tags             -
  Calls            setConfigCacheFactory
  Public           no
  Synthetic        no
  Lazy             no
  Shared           yes
  Abstract         no
  Autowired        no
  Autoconfigured   no
 ---------------- -----------------------------------------------
```