### PR TITLE
Handler formatter example was using wrong defined service

### DIFF
--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -71,7 +71,7 @@ using a processor.
                     type: stream
                     path: '%kernel.logs_dir%/%kernel.environment%.log'
                     level: debug
-                    formatter: app.logger.session_request_processor
+                    formatter: monolog.formatter.session_request
 
     .. code-block:: xml
 
@@ -106,7 +106,7 @@ using a processor.
                     type="stream"
                     path="%kernel.logs_dir%/%kernel.environment%.log"
                     level="debug"
-                    formatter="app.logger.session_request_processor"
+                    formatter="monolog.formatter.session_request"
                 />
             </monolog:config>
         </container>
@@ -132,7 +132,7 @@ using a processor.
                     'type'      => 'stream',
                     'path'      => '%kernel.logs_dir%/%kernel.environment%.log',
                     'level'     => 'debug',
-                    'formatter' => 'app.logger.session_request_processor',
+                    'formatter' => 'monolog.formatter.session_request',
                 ),
             ),
         ));


### PR DESCRIPTION
The service class passed to the formatter in the example handler was using the processor service instead of the formatter service. It should instead use `monolog.formatter.session_request`, otherwise monolog complains that the class does not implement interface `Monolog\Formatter\FormatterInterface`.