### PR TITLE
[error_pages] Removing misleading `is_granted` checker in code example

### DIFF
--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -97,11 +97,6 @@ To override the 404 error template for HTML pages, create a new
 
     {% block body %}
         <h1>Page not found</h1>
-
-        {% if is_granted('IS_AUTHENTICATED_FULLY') %}
-            {# ... #}
-        {% endif %}
-
         <p>
             The requested page couldn't be located. Checkout for any URL
             misspelling or <a href="{{ path('homepage') }}">return to the homepage</a>.


### PR DESCRIPTION
Docs contain misleading code section that leaves you wondering for a while ;)

This commit clearly states that it's no longer possible:
https://github.com/symfony/symfony/pull/5325/files