### PR TITLE
[Workflow] fix event name for completed event

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -280,7 +280,7 @@ order:
 
     The three events being dispatched are:
 
-    * ``workflow.transition``
+    * ``workflow.completed``
     * ``workflow.[workflow name].completed``
     * ``workflow.[workflow name].completed.[transition name]``
 


### PR DESCRIPTION
Fixes the wrong event for the Workflow completed event.