### PR TITLE
Missing link or explanation why no link is provided

### DIFF
--- a/bundles.rst
+++ b/bundles.rst
@@ -45,7 +45,7 @@ Creating a Bundle
 -----------------
 
 The Symfony Standard Edition comes with a handy task that creates a fully-functional
-bundle for you. Of course, creating a bundle by hand is pretty easy as well.
+bundle for you. LINK? Of course, creating a bundle by hand is pretty easy as well. 
 
 To show you how simple the bundle system is, create a new bundle called
 AcmeTestBundle and enable it.


### PR DESCRIPTION
The document says 

> The Symfony Standard Edition comes with a handy task that creates a fully-functional
> bundle for you. Of course, creating a bundle by hand is pretty easy as well.

What is that handy task? In the following documentation the manual way is described.

Maybe something like this? 
http://symfony.com/doc/current/bundles/SensioGeneratorBundle/commands/generate_bundle.html
This document is not tagged with v4, however it has "current" in its url path. 
