### PR TITLE
add missing twig dump construct

### DIFF
--- a/templating/debug.rst
+++ b/templating/debug.rst
@@ -33,10 +33,31 @@ for example, inside your controller::
     The output of the ``dump()`` function is then rendered in the web developer
     toolbar.
 
-The same mechanism can be used in Twig templates thanks to ``dump()`` function:
+In a Twig template, two constructs are available for dumping a variable.
+Choosing between both is mostly a matter of personal taste, still:
+
+* ``{% dump foo.bar %}`` is the way to go when the original template output
+  shall not be modified: variables are not dumped inline, but in the web
+  debug toolbar;
+* on the contrary, ``{{ dump(foo.bar) }}`` dumps inline and thus may or not
+  be suited to your use case (e.g. you shouldn't use it in an HTML
+  attribute or a ``<script>`` tag).
 
 .. code-block:: html+twig
 
+    {# app/Resources/views/article/recent_list.html.twig #}
+    {% dump articles %}
+
+    {% for article in articles %}
+        <a href="/article/{{ article.slug }}">
+            {{ article.title }}
+        </a>
+    {% endfor %}
+    
+or
+
+.. code-block:: html+twig
+    
     {# app/Resources/views/article/recent_list.html.twig #}
     {{ dump(articles) }}
 

--- a/templating/debug.rst
+++ b/templating/debug.rst
@@ -33,8 +33,7 @@ for example, inside your controller::
     The output of the ``dump()`` function is then rendered in the web developer
     toolbar.
 
-In a Twig template, two constructs are available for dumping a variable.
-Choosing between both is mostly a matter of personal taste, still:
+In a Twig template, you can use the ``dump`` utility as a function or a tag:
 
 * ``{% dump foo.bar %}`` is the way to go when the original template output
   shall not be modified: variables are not dumped inline, but in the web
@@ -46,22 +45,13 @@ Choosing between both is mostly a matter of personal taste, still:
 .. code-block:: html+twig
 
     {# app/Resources/views/article/recent_list.html.twig #}
+    {# the contents of this variable are sent to the Web Debug Toolbar #}
     {% dump articles %}
 
     {% for article in articles %}
-        <a href="/article/{{ article.slug }}">
-            {{ article.title }}
-        </a>
-    {% endfor %}
-    
-or
+        {# the contents of this variable are display on the web page #}
+        {{ dump(article) }}
 
-.. code-block:: html+twig
-    
-    {# app/Resources/views/article/recent_list.html.twig #}
-    {{ dump(articles) }}
-
-    {% for article in articles %}
         <a href="/article/{{ article.slug }}">
             {{ article.title }}
         </a>


### PR DESCRIPTION
added missing {% dump foo %} construct, in addition to {{ dump(foo) }}.
The first one if the only one dumping to the debug toolbar.
NB: copy pasted from the var_dumper component doc : https://symfony.com/doc/2.8/components/var_dumper.html