### PR TITLE
Use stricter syntax when testing

### DIFF
--- a/email/testing.rst
+++ b/email/testing.rst
@@ -47,17 +47,17 @@ to get information about the messages sent on the previous request::
             $mailCollector = $client->getProfile()->getCollector('swiftmailer');
 
             // Check that an email was sent
-            $this->assertEquals(1, $mailCollector->getMessageCount());
+            $this->assertSame(1, $mailCollector->getMessageCount());
 
             $collectedMessages = $mailCollector->getMessages();
             $message = $collectedMessages[0];
 
             // Asserting email data
             $this->assertInstanceOf('Swift_Message', $message);
-            $this->assertEquals('Hello Email', $message->getSubject());
-            $this->assertEquals('send@example.com', key($message->getFrom()));
-            $this->assertEquals('recipient@example.com', key($message->getTo()));
-            $this->assertEquals(
+            $this->assertSame('Hello Email', $message->getSubject());
+            $this->assertSame('send@example.com', key($message->getFrom()));
+            $this->assertSame('recipient@example.com', key($message->getTo()));
+            $this->assertSame(
                 'You should see me from the profiler!',
                 $message->getBody()
             );


### PR DESCRIPTION
e.g. 
```php 
$mailCollector->getMessageCount();
``` 
returns an int so its better to use 

```php 
$this->assertSame($expected, $actual);
```` 

will also meaning faster testing and better testing within the given example.