### PR TITLE
add warning that monolog.logger tag needs you to inject the service even when autowiring

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -685,6 +685,11 @@ channel when injecting the logger in a service.
             ->addArgument(new Reference('logger'))
             ->addTag('monolog.logger', array('channel' => 'app'));
 
+.. warning::
+
+    If you use autowiring, you need to explicitly declare the logger in the
+    ``arguments``. If you don't, the channel is ignored.
+
 .. tip::
 
     You can also configure custom channels in the configuration and retrieve


### PR DESCRIPTION
With autowiring, i was expecting this to work:

```
services:
    App\Log\CustomLogger:
        tags:
            - { name: monolog.logger, channel: my_channel }
```

But it seems that the channel is silently ignored like this. It only works if i also specify the arguments explicitly. I found [this bug report](https://github.com/symfony/monolog-bundle/issues/218) but as its almost a year old, we better document what has to be done until its fixed (if a fix is possible at all).