### PR TITLE
Add hint that recipe to be installed is contrib

### DIFF
--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -41,7 +41,8 @@ The easiest way is to install the Apache recipe by executing the following comma
     $ composer require symfony/apache-pack
 
 This recipe installs a ``.htaccess`` file in the ``public/`` directory that contains
-the rewrite rules.
+the rewrite rules. Since this is a *contrib* recipe, make sure to enable the `allow-contrib`
+setting in your `composer.json` before installing it!
 
 .. tip::
 


### PR DESCRIPTION
Since I just stumbled over this and lost a few unnecessary minutes over it, I think it might be useful to explicitly mention that `symfony/apache-pack` is a contrib recipe.