### PR TITLE
[TwigBundle] Set the parameter kernel.debug as default value of strict_variables option

### DIFF
--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -51,7 +51,7 @@ TwigBundle Configuration ("twig")
             cache:                     '%kernel.cache_dir%/twig'
             charset:                   '%kernel.charset%'
             debug:                     '%kernel.debug%'
-            strict_variables:          ~
+            strict_variables:          '%kernel.debug%'
             auto_reload:               ~
             optimizations:             ~
             default_path: '%kernel.project_dir%/templates'


### PR DESCRIPTION
Depends of https://github.com/symfony/symfony/pull/25780