### PR TITLE
[TwigBundle] Fix default value of strict_variables

### DIFF
--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -439,7 +439,7 @@ by Symfony. Besides, it simplifies how you refer to those templates:
 strict_variables
 ~~~~~~~~~~~~~~~~
 
-**type**: ``boolean`` **default**: ``'%kernel.debug%'``
+**type**: ``boolean`` **default**: ``false``
 
 If set to ``true``, Symfony shows an exception whenever a Twig variable,
 attribute or method doesn't exist. If set to ``false`` these errors are ignored


### PR DESCRIPTION
See https://github.com/symfony/symfony/blob/d78a98d793c2846d6decbff652d63f981e4f32f4/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php#L177

However, I'm proposing revert it since 4.1 and fix it inside the configuration section, see https://github.com/symfony/symfony-docs/pull/9049