### PR TITLE
Change order of arguments/option to chmod

### DIFF
--- a/setup/file_permissions.rst
+++ b/setup/file_permissions.rst
@@ -15,5 +15,5 @@ was writable. But that is no longer true! In Symfony 4, everything works automat
 
     If you decide to store log files on disk, you *will* need to make sure your
     logs directory (e.g. ``var/log/``) is writable by your web server user and
-    terminal user. One way this can be done is by using ``chmod 777 -R var/log/``.
+    terminal user. One way this can be done is by using ``chmod -R 777 var/log/``.
     Just be aware that your logs are readable by any user on your production system.


### PR DESCRIPTION
“chmod 777 -R” does not work on macOS (probably also not on BSD), while “chmod -R 777” does.