### PR TITLE
Fixed the default value for toolbar configuration

### DIFF
--- a/reference/configuration/web_profiler.rst
+++ b/reference/configuration/web_profiler.rst
@@ -21,7 +21,7 @@ Configuration
 toolbar
 ~~~~~~~
 
-**type**: ``boolean`` **default**: ``true``
+**type**: ``boolean`` **default**: ``false``
 
 It enables and disables the toolbar entirely. Usually you set this to ``true``
 in the ``dev`` and ``test`` environments and to ``false`` in the ``prod``


### PR DESCRIPTION
Because the below full default configuration shows that `toolbar` is set to `false`, we need to add consistence here.