### PR TITLE
Remove leading slash from rm -rf /vendor/*

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -195,7 +195,7 @@ manual steps:
 
    .. code-block:: terminal
 
-       $ rm -fr /vendor/*
+       $ rm -fr vendor/*
        $ composer install
 
 #. No matter which of the previous steps you followed. At this point, you'll have


### PR DESCRIPTION
The leading slash makes the command delete the folder vendor from / of the file system instead the vendor folder from the current folder, which can cause major loss if someone has something there.