### PR TITLE
preUpdate Event Listener On Uploaded Imagery

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -363,7 +363,7 @@ automatically upload the file when persisting the entity::
             if ($file instanceof UploadedFile) {
                 $fileName = $this->uploader->upload($file);
                 $entity->setBrochure($fileName);
-            } elseif($file instanceof File) {
+            } elseif ($file instanceof File) {
                 // prevents the full file path being saved on updates
                 // as the path is set on the postLoad listener
                 $entity->setBrocure($file->getFilename());

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -321,6 +321,7 @@ automatically upload the file when persisting the entity::
     namespace App\EventListener;
 
     use Symfony\Component\HttpFoundation\File\UploadedFile;
+    use Symfony\Component\HttpFoundation\File\File;
     use Doctrine\ORM\Event\LifecycleEventArgs;
     use Doctrine\ORM\Event\PreUpdateEventArgs;
     use App\Entity\Product;
@@ -362,6 +363,10 @@ automatically upload the file when persisting the entity::
             if ($file instanceof UploadedFile) {
                 $fileName = $this->uploader->upload($file);
                 $entity->setBrochure($fileName);
+            } elseif($file instanceof File) {
+                // prevents the full file path being saved on updates
+                // as the path is set on the postLoad listener
+                $entity->setBrocure($file->getFilename());
             }
         }
     }

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -366,7 +366,7 @@ automatically upload the file when persisting the entity::
             } elseif ($file instanceof File) {
                 // prevents the full file path being saved on updates
                 // as the path is set on the postLoad listener
-                $entity->setBrocure($file->getFilename());
+                $entity->setBrochure($file->getFilename());
             }
         }
     }


### PR DESCRIPTION
I've noticed a scenario (a bit of an edge case when uploading imagery).

If you have an entity (say a brochure) but you can give it a title and an image and the image title can be updated without the image being updated (the file type is not an UploadedFile but a File on save it'll persist the full file path instead of the desired filename. The above is a safety measure to ensure the above.