### PR TITLE
Fix setup documentation - Could not find package "server"

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -35,7 +35,7 @@ First, move into your new project and install the server:
 .. code-block:: terminal
 
     $ cd my-project
-    $ composer require server --dev
+    $ composer require symfony/web-server-bundle --dev
 
 To start the server, run:
 


### PR DESCRIPTION
Before:

```shell
composer require server --dev

                                  
  [InvalidArgumentException]      
  Could not find package server.  
                                  
  Did you mean one of these?      
      aura/sql                    
      react/http                  
      react/socket                
      cboden/ratchet              
      laravel/passport            
                                  
```

After:

```shell
composer require symfony/web-server-bundle --dev


Using version ^4.0 for symfony/web-server-bundle
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 13 installs, 0 updates, 0 removals
  - Installing symfony/process (v4.0.3): Downloading (100%)         
  - Installing symfony/polyfill-mbstring (v1.6.0): Loading from cache
  - Installing symfony/http-foundation (v4.0.3): Loading from cache
  - Installing symfony/event-dispatcher (v4.0.3): Loading from cache
  - Installing psr/log (1.0.2): Loading from cache
  - Installing symfony/debug (v4.0.3): Loading from cache
  - Installing symfony/http-kernel (v4.0.3): Loading from cache
  - Installing psr/container (1.0.0): Loading from cache
  - Installing symfony/dependency-injection (v4.0.3): Loading from cache
  - Installing symfony/console (v4.0.3): Loading from cache
  - Installing symfony/filesystem (v4.0.3): Loading from cache
  - Installing symfony/config (v4.0.3): Loading from cache
  - Installing symfony/web-server-bundle (v4.0.3): Downloading (100%)         
symfony/http-kernel suggests installing symfony/browser-kit ()
symfony/http-kernel suggests installing symfony/var-dumper ()
symfony/dependency-injection suggests installing symfony/yaml ()
symfony/dependency-injection suggests installing symfony/finder (For using double-star glob patterns or when GLOB_BRACE portability is required)
symfony/dependency-injection suggests installing symfony/expression-language (For using expressions in service container configuration)
symfony/dependency-injection suggests installing symfony/proxy-manager-bridge (Generate service proxies to lazy load them)
symfony/console suggests installing symfony/lock ()
symfony/config suggests installing symfony/yaml (To use the yaml reference dumper)
symfony/web-server-bundle suggests installing symfony/monolog-bridge (For using the log server.)
symfony/web-server-bundle suggests installing symfony/expression-language (For using the filter option of the log server.)
Writing lock file
Generating autoload files

```