### PR TITLE
Add missing "bundles" sub-dir for third party-bundle templates

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -217,7 +217,7 @@ manual steps:
 
    * ``app/Resources/views/`` -> ``templates/``
    * ``app/Resources/translations/`` -> ``translations/``
-   * ``app/Resources/<BundleName>/views/`` -> ``templates/<BundleName>/``
+   * ``app/Resources/<BundleName>/views/`` -> ``templates/bundles/<BundleName>/``
    * rest of ``app/Resources/`` files -> ``src/Resources/``
 
 #. Move the original PHP source code from ``src/AppBundle/*`` to ``src/``. In


### PR DESCRIPTION
Migration Guide is inconsistent at this point. The docs in [How to overwrite bundle templates](https://symfony.com/doc/current/templating/overriding.html#overriding-core-templates) containing the correct template structure.