### PR TITLE
Documented the use of PHP streams as the process input

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -230,6 +230,29 @@ stream resources or Traversable objects as argument. As shown in the above examp
 you need to explicitly call the :method:`Symfony\\Component\\Process\\InputStream::close`
 method when you are done writing to the standard input of the subprocess.
 
+Using PHP Streams as the Standard Input of a Process
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The input of a process can also be defined using `PHP streams`_::
+
+    $stream = fopen('php://temporary', 'w+');
+
+    $process = new Process('cat');
+    $process->setInput($stream);
+    $process->start();
+
+    fwrite($stream, 'foo');
+
+    // ... read process output or do other things
+
+    fwrite($stream, 'bar');
+    fclose($stream);
+
+    $process->wait();
+
+    // will echo: 'foobar'
+    echo $process->getOutput();
+
 Stopping a Process
 ------------------
 
@@ -420,3 +443,4 @@ Use :method:`Symfony\\Component\\Process\\Process::disableOutput` and
 .. _`pid`: https://en.wikipedia.org/wiki/Process_identifier
 .. _`PHP Documentation`: http://php.net/manual/en/pcntl.constants.php
 .. _Packagist: https://packagist.org/packages/symfony/process
+.. _`PHP streams`: http://www.php.net/manual/en/book.stream.php


### PR DESCRIPTION
This fixes #3955 ... and goes to 3.3 branch instead of 2.7 because 3.3 is the first one that contains the needed parent section `Streaming to the Standard Input of a Process`.