### PR TITLE
Mention the website-skeleton in the getting started guide

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -17,7 +17,7 @@ Create your new project by running:
 
 .. code-block:: terminal
 
-    $ composer create-project symfony/skeleton my-project
+    $ composer create-project symfony/website-skeleton my-project
 
 This will create a new ``my-project`` directory, download some dependencies into
 it and even generate the basic directories and files you'll need to get started.

--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -184,8 +184,9 @@ manual steps:
 
    .. code-block:: terminal
 
-       $ composer require annotations asset doctrine twig profiler \
-         logger mailer form orm-fixtures security translation validator
+       $ composer require annotations asset orm-pack twig \
+         logger mailer form security translation validator
+       $ composer require --dev dotend maker-bundle orm-fixtures profiler
 
 #. If the project's ``composer.json`` file doesn't contain ``symfony/symfony``
    dependency, it already defines its dependencies explicitly, as required by

--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -186,7 +186,7 @@ manual steps:
 
        $ composer require annotations asset orm-pack twig \
          logger mailer form security translation validator
-       $ composer require --dev dotend maker-bundle orm-fixtures profiler
+       $ composer require --dev dotenv maker-bundle orm-fixtures profiler
 
 #. If the project's ``composer.json`` file doesn't contain ``symfony/symfony``
    dependency, it already defines its dependencies explicitly, as required by


### PR DESCRIPTION
This fixes #8989.

@weaverryan you said that even if we show `website-skeleton`, you still want to show how to install each individual dependency. So, we shouldn't change anything from the original contents, right?