### PR TITLE
Remove out-of-context rewrite rule tip

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -322,8 +322,6 @@ You are now able to serialize only attributes in the groups you want::
     );
     // $obj2 = MyObj(foo: 'foo', bar: 'bar')
 
-.. include:: /_includes/_rewrite_rule_tip.rst.inc
-
 .. _ignoring-attributes-when-serializing:
 
 Selecting Specific Attributes


### PR DESCRIPTION
The `.. include:: /_includes/_rewrite_rule_tip.rst.inc` has absolutely nothing to do with the surrounding context. Having it here is confusing.