### PR TITLE
Update translation.rst

### DIFF
--- a/components/translation.rst
+++ b/components/translation.rst
@@ -34,9 +34,8 @@ The constructor of the ``Translator`` class needs one argument: The locale.
 .. code-block:: php
 
     use Symfony\Component\Translation\Translator;
-    use Symfony\Component\Translation\MessageSelector;
 
-    $translator = new Translator('fr_FR', new MessageSelector());
+    $translator = new Translator('fr_FR');
 
 .. note::
 


### PR DESCRIPTION
`MessageSelector` doesn't implement `Symfony\Component\Translation\Formatter\MessageFormatterInterface` - the expected second parameter for `Translator::__construct`, which is generated if not provided anyway. removing the second parameter in the example seems like the best option imho.