### PR TITLE
Update doctrine.rst

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -368,7 +368,7 @@ you can query the database directly:
 
 .. code-block:: terminal
 
-    $ php bin/console doctrine:query:sql 'SELECT * FROM product'
+    $ php bin/console doctrine:query:sql "SELECT * FROM product"
 
 Take a look at the previous example in more detail:
 


### PR DESCRIPTION
I run this command in windows cmd, then return:
`Error thrown while running command "doctrine:query:sql "'SELECT" "*" FROM "product'"". Message: "Too many arguments, expected arguments "command" "sql"."`


  `Too many arguments, expected arguments "command" "sql".`

Use double quotes fix it.