### PR TITLE
Fixed the import in the PHP Array Cache adapter article

### DIFF
--- a/components/cache/adapters/php_array_cache_adapter.rst
+++ b/components/cache/adapters/php_array_cache_adapter.rst
@@ -9,7 +9,7 @@ This adapter is a highly performant way to cache static data (e.g. application c
 that is optimized and preloaded into OPcache memory storage::
 
     use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
-    use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
+    use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
     // somehow, decide it's time to warm up the cache!
     if ($needsWarmup) {


### PR DESCRIPTION
This fixes #8672.

In 3.3 and 3.4 is wrong: http://symfony.com/doc/3.3/components/cache/adapters/php_array_cache_adapter.html

In current/master is correct: http://symfony.com/doc/current/components/cache/adapters/php_array_cache_adapter.html