### PR TITLE
Update empty_data.rst.inc

### DIFF
--- a/reference/forms/types/options/empty_data.rst.inc
+++ b/reference/forms/types/options/empty_data.rst.inc
@@ -1,7 +1,7 @@
 empty_data
 ~~~~~~~~~~
 
-**type**: ``mixed``
+**type**: ``string`` or ``array`` when the form is compound
 
 .. This file should only be included with start-after or end-before that's
    set to this placeholder value. Its purpose is to let us include only


### PR DESCRIPTION
More clear what type of empty_date is available for set.

When I used IntegerType I do like this:
```
$builder->add('someInt', IntegerType::class, array(
    'required'   => false,
    'empty_data' => 1,
));
```
And when I to pass empty someInt I get _null_.
About available types I found only [here](https://symfony.com/doc/current/form/use_empty_data.html).
I think, information about type will be useful and save time for others