### PR TITLE
Update doctrine.rst

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -31,7 +31,12 @@ Full Default Configuration
                         port:                 ~
                         user:                 root
                         password:             ~
+                        # charset of the database
                         charset:              ~
+                        # charset and collation of the tables. Not inherited from database
+                        default_table_options:
+                            charset:          ~
+                            collate:          ~
                         path:                 ~
                         memory:               ~
 


### PR DESCRIPTION
my doctrine.yml had a ```charset: utf8mb4``` but my schema update generated tables with utf8. Seems like there is a separate configuration directive for the tables and this is not inherited from the database