### PR TITLE
Revert asset versioning back to SF 3 directory structure

### DIFF
--- a/frontend/encore/versioning.rst
+++ b/frontend/encore/versioning.rst
@@ -16,7 +16,7 @@ ignoring any existing cache:
     // ...
 
     Encore
-        .setOutputPath('public/build/')
+        .setOutputPath('web/build/')
         // ...
     +     .enableVersioning()
 
@@ -49,7 +49,7 @@ in your ``script`` and ``link`` tags. If you're using Symfony, just activate the
         # ...
         assets:
             # feature is supported in Symfony 3.3 and higher
-            json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'
+            json_manifest_path: '%kernel.project_dir%/web/build/manifest.json'
 
 That's it! Just be sure to wrap each path in the Twig ``asset()`` function
 like normal:


### PR DESCRIPTION
I don't believe SF 3 started using the `public/` directory, right? I think the 3.x docs were updated a bit prematurely since the 3.4 docs are affected too. Should the 3.4 change be another PR or could that be cherry-picked by a maintainer?