### PR TITLE
[Workflow] Add a line about the attribute type when persisted.

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -138,7 +138,7 @@ like this:
 
     class BlogPost
     {
-        // This property is used by the marking store
+        // This property is used by the marking store, by default, Symfony "mark" this attribute as an array.
         public $currentPlace;
         public $title;
         public $content;
@@ -155,7 +155,12 @@ like this:
     The ``type`` (default value ``single_state``) and ``arguments`` (default value ``marking``)
     attributes of the ``marking_store`` option are optional. If omitted, their default values
     will be used.
+    
+.. note::
 
+    Please note that if you decide to store $currentPlace using Doctrine, 
+    the attribute must be mapped to an array.
+    
 With this workflow named ``blog_publishing``, you can get help to decide
 what actions are allowed on a blog post::
 

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -161,7 +161,10 @@ like this:
     If a ``multiple_state`` is used, the persisted state type should be an ``array``, 
     using Doctrine, you can use ``json`` or ``json_array``. 
 
-    If a ``single_state`` is used, the persisted state type could be a string
+    If a ``single_state`` is used, the persisted state type could be a string, 
+    if you need to store an int (due to DB limitations and/or project constraints),
+    be aware that you need to implement :class:`Symfony\\Component\\Workflow\\MarkingStore\\MarkingStoreInterface`
+    in order to transform the int back to something understandable by Workflow.
 
     If something else is used, you're in charge of choosing the best storage format.
     

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -138,7 +138,7 @@ like this:
 
     class BlogPost
     {
-        // This property is used by the marking store, by default, Symfony "mark" this attribute as an array.
+        // This property is used by the marking store, by default, Symfony set the marking store as an array.
         public $currentPlace;
         public $title;
         public $content;

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -158,10 +158,10 @@ like this:
     
 .. note::
 
-    If a ``multiple_state`` is used, the persisted state type should be an ``array``, 
-    using Doctrine, you can use ``json`` or ``json_array``. 
+    If a ``multiple_state`` is used, the attribute should be an ``array``, 
+    using Doctrine, you can use ``json``. 
 
-    If a ``single_state`` is used, the persisted state type could be a string, 
+    If a ``single_state`` is used, the persisted state type should be a string, 
     if you need to store an int (due to DB limitations and/or project constraints),
     be aware that you need to implement :class:`Symfony\\Component\\Workflow\\MarkingStore\\MarkingStoreInterface`
     in order to transform the int back to something understandable by Workflow.

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -158,8 +158,12 @@ like this:
     
 .. note::
 
-    Please note that if you decide to store $currentPlace using Doctrine, 
-    the attribute must be mapped to an array.
+    If a ``multiple_state`` is used, the persisted state type should be an ``array``, 
+    using Doctrine, you can use ``json`` or ``json_array``. 
+
+    If a ``single_state`` is used, the persisted state type could be a string
+
+    If something else is used, you're in charge of choosing the best storage format.
     
 With this workflow named ``blog_publishing``, you can get help to decide
 what actions are allowed on a blog post::

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -138,7 +138,7 @@ like this:
 
     class BlogPost
     {
-        // This property is used by the marking store, by default, Symfony set the marking as an array.
+        // This property is used by the marking store. If the current object is managed by a state machine, this property is a string, else if it's managed by a workflow it's an array.
         public $currentPlace;
         public $title;
         public $content;

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -138,17 +138,10 @@ like this:
 
     class BlogPost
     {
-        // This property is used by the marking store. If the current object is managed by a state machine, this property is a string, else if it's managed by a workflow it's an array.
         public $currentPlace;
         public $title;
         public $content;
     }
-
-.. note::
-
-    The marking store type could be "multiple_state" or "single_state".
-    A single state marking store does not support a model being on multiple places
-    at the same time.
 
 .. tip::
 
@@ -158,6 +151,10 @@ like this:
     
 .. note::
 
+    The marking store type could be "multiple_state" or "single_state".
+    A single state marking store does not support a model being on multiple places
+    at the same time.
+    
     If a ``multiple_state`` is used, the attribute should be an ``array``, 
     using Doctrine, you can use ``json``. 
 

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -138,7 +138,7 @@ like this:
 
     class BlogPost
     {
-        // This property is used by the marking store, by default, Symfony set the marking store as an array.
+        // This property is used by the marking store, by default, Symfony set the marking as an array.
         public $currentPlace;
         public $title;
         public $content;


### PR DESCRIPTION
By default, the attribute must be an array in order to allow PropertyAccess to update the state and content of this last one, if we need to persist it via Doctrine, the mapping must define an array. 