### PR TITLE
Fixed the default value of Choice strict option

### DIFF
--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -365,7 +365,7 @@ too many options per the `max`_ option.
 strict
 ~~~~~~
 
-**type**: ``boolean`` **default**: ``false``
+**type**: ``boolean`` **default**: ``true``
 
 The validator will also check the type of the input value. Specifically,
 this value is passed to as the third argument to the PHP :phpfunction:`in_array`


### PR DESCRIPTION
This default value changed:

In 3.4 and before, is `false`: https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Validator/Constraints/Choice.php#L37

In 4.0 and later, is `true`: https://github.com/symfony/symfony/blob/bd6df791f74c67766c714010ad1141fd815b6cba/src/Symfony/Component/Validator/Constraints/Choice.php#L37