### PR TITLE
Fixed a minor syntax issue in a VarDumper article

### DIFF
--- a/components/var_dumper/advanced.rst
+++ b/components/var_dumper/advanced.rst
@@ -375,23 +375,23 @@ thus to dumpers. To help you do this (see the source code for how it works),
 the component comes with a set of wrappers for common additional semantics. You
 can use:
 
- * :class:`Symfony\\Component\\VarDumper\\Caster\\ConstStub` to wrap a value that is
-   best represented by a PHP constant;
- * :class:`Symfony\\Component\\VarDumper\\Caster\\ClassStub` to wrap a PHP identifier
-   (*i.e.* a class name, a method name, an interface, *etc.*);
- * :class:`Symfony\\Component\\VarDumper\\Caster\\CutStub` to replace big noisy
-   objects/strings/*etc.* by ellipses;
- * :class:`Symfony\\Component\\VarDumper\\Caster\\CutArrayStub` to keep only some
-   useful keys of an array;
- * :class:`Symfony\\Component\\VarDumper\\Caster\\EnumStub` to wrap a set of virtual
-   values (*i.e.* values that do not exist as properties in the original PHP data
-   structure, but are worth listing alongside with real ones);
- * :class:`Symfony\\Component\\VarDumper\\Caster\\LinkStub` to wrap strings that can
-   be turned into links by dumpers;
- * :class:`Symfony\\Component\\VarDumper\\Caster\\TraceStub` and their
- * :class:`Symfony\\Component\\VarDumper\\Caster\\FrameStub` and
- * :class:`Symfony\\Component\\VarDumper\\Caster\\ArgsStub` relatives to wrap PHP
-   traces (used by :class:`Symfony\\Component\\VarDumper\\Caster\\ExceptionCaster`).
+* :class:`Symfony\\Component\\VarDumper\\Caster\\ConstStub` to wrap a value that is
+  best represented by a PHP constant;
+* :class:`Symfony\\Component\\VarDumper\\Caster\\ClassStub` to wrap a PHP identifier
+  (*i.e.* a class name, a method name, an interface, *etc.*);
+* :class:`Symfony\\Component\\VarDumper\\Caster\\CutStub` to replace big noisy
+  objects/strings/*etc.* by ellipses;
+* :class:`Symfony\\Component\\VarDumper\\Caster\\CutArrayStub` to keep only some
+  useful keys of an array;
+* :class:`Symfony\\Component\\VarDumper\\Caster\\EnumStub` to wrap a set of virtual
+  values (*i.e.* values that do not exist as properties in the original PHP data
+  structure, but are worth listing alongside with real ones);
+* :class:`Symfony\\Component\\VarDumper\\Caster\\LinkStub` to wrap strings that can
+  be turned into links by dumpers;
+* :class:`Symfony\\Component\\VarDumper\\Caster\\TraceStub` and their
+* :class:`Symfony\\Component\\VarDumper\\Caster\\FrameStub` and
+* :class:`Symfony\\Component\\VarDumper\\Caster\\ArgsStub` relatives to wrap PHP
+  traces (used by :class:`Symfony\\Component\\VarDumper\\Caster\\ExceptionCaster`).
 
 For example, if you know that your ``Product`` objects have a ``brochure`` property
 that holds a file name or a URL, you can wrap them in a ``LinkStub`` to tell


### PR DESCRIPTION
An extra white space makes this list look like a blockquote:

![wrong-list](https://user-images.githubusercontent.com/73419/35519594-f8b2b136-0514-11e8-9499-dced8267f2c0.png)

3.3 version is the first one which contains this error.