### PR TITLE
Add precisions on `routes.yaml` changes for annotations enabling

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -101,6 +101,21 @@ routes. To do this, install the annotations package:
 
     $ composer require annotations
 
+Enable parsing of annotations in all controllers:
+
+.. code-block:: diff
+
+    # config/routes.yaml
+
+    -  # the "app_lucky_number" route name is not important yet
+    -  app_lucky_number:
+    -      path: /lucky/number
+    -      controller: App\Controller\LuckyController::number
+    +  # Load all controllers routes
+    +  controllers:
+    +      resource: ../src/Controller
+    +      type: annotation
+
 You can now add your route directly *above* the controller:
 
 .. code-block:: diff


### PR DESCRIPTION
The documentation "[Create your First Page in Symfony](https://symfony.com/doc/current/page_creation.html)" for Symfony Flex miss precisions about changes to do in `routes.yaml` while enabling annotations.

Maybe there is a change to do in default `routes.yaml` (commented configuration), or update `annotations` recipe to add this default configuration ?
If someone point me out how to do, I'm okay to try.