### PR TITLE
mention phpunit bridge in bundle best practices

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -166,11 +166,6 @@ the ``Tests/`` directory. Tests should follow the following principles:
     A test suite must not contain ``AllTests.php`` scripts, but must rely on the
     existence of a ``phpunit.xml.dist`` file.
 
-.. tip::
-
-    The :doc:`PHPUnit bridge component <../components/phpunit_bridge>` helps with
-    testing legacy code and deprecations.
-
 Continuous Integration
 ----------------------
 
@@ -240,10 +235,9 @@ of Symfony and the latest beta release:
 
     script:
         - composer validate --strict --no-check-lock
+        # simple-phpunit is the PHPUnit wrapper provided by the PHPUnit Bridge component and
+        # it helps with testing legacy code and deprecations (composer require symfony/phpunit-bridge)
         - ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS
-
-Note that simple-phpunit is the phpunit script when using the
-:doc:`PHPUnit bridge component <../components/phpunit_bridge>`.
 
 Consider using `Travis cron`_ too to make sure your project is built even if
 there are no new pull requests or commits.

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -166,6 +166,11 @@ the ``Tests/`` directory. Tests should follow the following principles:
     A test suite must not contain ``AllTests.php`` scripts, but must rely on the
     existence of a ``phpunit.xml.dist`` file.
 
+.. tip::
+
+    The :doc:`PHPUnit bridge component <../components/phpunit_bridge>` helps with
+    testing legacy code and deprecations.
+
 Continuous Integration
 ----------------------
 
@@ -236,6 +241,9 @@ of Symfony and the latest beta release:
     script:
         - composer validate --strict --no-check-lock
         - ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS
+
+Note that simple-phpunit is the phpunit script when using the
+:doc:`PHPUnit bridge component <../components/phpunit_bridge>`.
 
 Consider using `Travis cron`_ too to make sure your project is built even if
 there are no new pull requests or commits.


### PR DESCRIPTION
i noticed that the bundle best practices don't mention the phpunit bridge. should we go even further and add it to the list of things a bundle should be using?