### PR TITLE
Remove deprecation message on install

### DIFF
--- a/frontend/encore/installation.rst
+++ b/frontend/encore/installation.rst
@@ -7,7 +7,7 @@ Then, install Encore into your project with Yarn:
 
 .. code-block:: terminal
 
-    $ yarn add @symfony/webpack-encore --dev
+    $ yarn add @symfony/webpack-encore --only=dev
 
 .. note::
 


### PR DESCRIPTION
Updates the installation command to ensure no deprecation message is provided during the process as "Usage of the `--dev` option is deprecated. Use `--only=dev` instead."