### PR TITLE
Make code comments consistent

### DIFF
--- a/components/asset.rst
+++ b/components/asset.rst
@@ -114,13 +114,13 @@ suffix to any asset path::
 In case you want to modify the version format, pass a sprintf-compatible format
 string as the second argument of the ``StaticVersionStrategy`` constructor::
 
-    // put the 'version' word before the version value
+    // puts the 'version' word before the version value
     $package = new Package(new StaticVersionStrategy('v1', '%s?version=%s'));
 
     echo $package->getUrl('/image.png');
     // result: /image.png?version=v1
 
-    // put the asset version before its path
+    // puts the asset version before its path
     $package = new Package(new StaticVersionStrategy('v1', '%2$s/%1$s'));
 
     echo $package->getUrl('/image.png');

--- a/components/class_loader/cache_class_loader.rst
+++ b/components/class_loader/cache_class_loader.rst
@@ -34,10 +34,10 @@ ApcClassLoader
     // sha1(__FILE__) generates an APC namespace prefix
     $cachedLoader = new ApcClassLoader(sha1(__FILE__), $loader);
 
-    // register the cached class loader
+    // registers the cached class loader
     $cachedLoader->register();
 
-    // deactivate the original, non-cached loader if it was registered previously
+    // deactivates the original, non-cached loader if it was registered previously
     $loader->unregister();
 
 XcacheClassLoader
@@ -54,10 +54,10 @@ it is straightforward::
     // sha1(__FILE__) generates an XCache namespace prefix
     $cachedLoader = new XcacheClassLoader(sha1(__FILE__), $loader);
 
-    // register the cached class loader
+    // registers the cached class loader
     $cachedLoader->register();
 
-    // deactivate the original, non-cached loader if it was registered previously
+    // deactivates the original, non-cached loader if it was registered previously
     $loader->unregister();
 
 .. _APC:        http://php.net/manual/en/book.apc.php

--- a/components/class_loader/class_loader.rst
+++ b/components/class_loader/class_loader.rst
@@ -40,13 +40,13 @@ your classes::
     // register a single namespaces
     $loader->addPrefix('Symfony', __DIR__.'/vendor/symfony/symfony/src');
 
-    // register several namespaces at once
+    // registers several namespaces at once
     $loader->addPrefixes(array(
         'Symfony' => __DIR__.'/../vendor/symfony/symfony/src',
         'Monolog' => __DIR__.'/../vendor/monolog/monolog/src',
     ));
 
-    // register a prefix for a class following the PEAR naming conventions
+    // registers a prefix for a class following the PEAR naming conventions
     $loader->addPrefix('Twig_', __DIR__.'/vendor/twig/twig/lib');
 
     $loader->addPrefixes(array(

--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -40,19 +40,19 @@ dispatched. Listeners receive a
     use Symfony\Component\Console\ConsoleEvents;
 
     $dispatcher->addListener(ConsoleEvents::COMMAND, function (ConsoleCommandEvent $event) {
-        // get the input instance
+        // gets the input instance
         $input = $event->getInput();
 
-        // get the output instance
+        // gets the output instance
         $output = $event->getOutput();
 
-        // get the command to be executed
+        // gets the command to be executed
         $command = $event->getCommand();
 
-        // write something about the command
+        // writes something about the command
         $output->writeln(sprintf('Before running command <info>%s</info>', $command->getName()));
 
-        // get the application
+        // gets the application
         $application = $command->getApplication();
     });
 
@@ -74,12 +74,12 @@ C/C++ standard.::
     use Symfony\Component\Console\ConsoleEvents;
 
     $dispatcher->addListener(ConsoleEvents::COMMAND, function (ConsoleCommandEvent $event) {
-        // get the command to be executed
+        // gets the command to be executed
         $command = $event->getCommand();
 
         // ... check if the command can be executed
 
-        // disable the command, this will result in the command being skipped
+        // disables the command, this will result in the command being skipped
         // and code 113 being returned from the Application
         $event->disableCommand();
 
@@ -112,10 +112,10 @@ Listeners receive a
 
         $output->writeln(sprintf('Oops, exception thrown while running command <info>%s</info>', $command->getName()));
 
-        // get the current exit code (the exception code or the exit code set by a ConsoleEvents::TERMINATE event)
+        // gets the current exit code (the exception code or the exit code set by a ConsoleEvents::TERMINATE event)
         $exitCode = $event->getExitCode();
 
-        // change the exception to another one
+        // changes the exception to another one
         $event->setException(new \LogicException('Caught exception', $exitCode, $event->getException()));
     });
 
@@ -138,16 +138,16 @@ Listeners receive a
     use Symfony\Component\Console\ConsoleEvents;
 
     $dispatcher->addListener(ConsoleEvents::TERMINATE, function (ConsoleTerminateEvent $event) {
-        // get the output
+        // gets the output
         $output = $event->getOutput();
 
-        // get the command that has been executed
+        // gets the command that has been executed
         $command = $event->getCommand();
 
-        // display something
+        // displays the given content
         $output->writeln(sprintf('After running command <info>%s</info>', $command->getName()));
 
-        // change the exit code
+        // changes the exit code
         $event->setExitCode(128);
     });
 

--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -15,24 +15,24 @@ number of units, and advance the progress as the command executes::
 
     use Symfony\Component\Console\Helper\ProgressBar;
 
-    // create a new progress bar (50 units)
+    // creates a new progress bar (50 units)
     $progress = new ProgressBar($output, 50);
 
-    // start and displays the progress bar
+    // starts and displays the progress bar
     $progress->start();
 
     $i = 0;
     while ($i++ < 50) {
         // ... do some work
 
-        // advance the progress bar 1 unit
+        // advances the progress bar 1 unit
         $progress->advance();
 
         // you can also advance the progress bar by more than 1 unit
         // $progress->advance(3);
     }
 
-    // ensure that the progress bar is at 100%
+    // ensures that the progress bar is at 100%
     $progress->finish();
 
 Instead of advancing the bar by a number of steps (with the

--- a/components/console/helpers/table.rst
+++ b/components/console/helpers/table.rst
@@ -111,14 +111,14 @@ If the built-in styles do not fit your need, define your own::
     // by default, this is based on the default style
     $style = new TableStyle();
 
-    // customize the style
+    // customizes the style
     $style
         ->setHorizontalBorderChar('<fg=magenta>|</>')
         ->setVerticalBorderChar('<fg=magenta>-</>')
         ->setCrossingChar(' ')
     ;
 
-    // use the style for this table
+    // uses the custom style for this table
     $table->setStyle($style);
 
 Here is a full list of things you can customize:
@@ -136,10 +136,10 @@ Here is a full list of things you can customize:
 
     You can also register a style globally::
 
-        // register the style under the colorful name
+        // registers the style under the colorful name
         Table::setStyleDefinition('colorful', $style);
 
-        // use it for a table
+        // applies the custom style for the given table
         $table->setStyle('colorful');
 
     This method can also be used to override a built-in style.

--- a/components/console/single_command_tool.rst
+++ b/components/console/single_command_tool.rst
@@ -35,7 +35,7 @@ it is possible to remove this need by extending the application::
          */
         protected function getDefaultCommands()
         {
-            // Keep the core default commands to have the HelpCommand
+            // Keeps the core default commands to have the HelpCommand
             // which is used when using the --help option
             $defaultCommands = parent::getDefaultCommands();
 
@@ -51,7 +51,7 @@ it is possible to remove this need by extending the application::
         public function getDefinition()
         {
             $inputDefinition = parent::getDefinition();
-            // clear out the normal first argument, which is the command name
+            // clears out the normal first argument, which is the command name
             $inputDefinition->setArguments();
 
             return $inputDefinition;

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -87,7 +87,7 @@ An anonymous function can be used to filter with more complex criteria::
     $crawler = $crawler
         ->filter('body > p')
         ->reduce(function (Crawler $node, $i) {
-            // filter every other node
+            // filters every other node
             return ($i % 2) == 0;
         });
 
@@ -196,7 +196,7 @@ Accessing Node Values
 
 Access the node name (HTML tag name) of the first node of the current selection (eg. "p" or "div")::
 
-    // will return the node name (HTML tag name) of the first child element under <body>
+    // returns the node name (HTML tag name) of the first child element under <body>
     $tag = $crawler->filterXPath('//body/*')->nodeName();
 
 Access the value of the first node of the current selection::
@@ -317,7 +317,7 @@ instance with just the selected link(s). Calling ``link()`` gives you a special
 The :class:`Symfony\\Component\\DomCrawler\\Link` object has several useful
 methods to get more information about the selected link itself::
 
-    // return the proper URI that can be used to make another request
+    // returns the proper URI that can be used to make another request
     $uri = $link->getUri();
 
 .. note::
@@ -368,13 +368,13 @@ attribute followed by a query string of all of the form's values.
 
 You can virtually set and get values on the form::
 
-    // set values on the form internally
+    // sets values on the form internally
     $form->setValues(array(
         'registration[username]' => 'symfonyfan',
         'registration[terms]'    => 1,
     ));
 
-    // get back an array of values - in the "flat" array like above
+    // gets back an array of values - in the "flat" array like above
     $values = $form->getValues();
 
     // returns the values like PHP would see them,
@@ -391,10 +391,10 @@ To work with multi-dimensional fields::
 
 Pass an array of values::
 
-    // Set a single field
+    // sets a single field
     $form->setValues(array('multi' => array('value')));
 
-    // Set multiple fields at once
+    // sets multiple fields at once
     $form->setValues(array('multi' => array(
         1             => 'value',
         'dimensional' => 'an other value'
@@ -406,17 +406,17 @@ and uploading files::
 
     $form['registration[username]']->setValue('symfonyfan');
 
-    // check or uncheck a checkbox
+    // checks or unchecks a checkbox
     $form['registration[terms]']->tick();
     $form['registration[terms]']->untick();
 
-    // select an option
+    // selects an option
     $form['registration[birthday][year]']->select(1984);
 
-    // select many options from a "multiple" select
+    // selects many options from a "multiple" select
     $form['registration[interests]']->select(array('symfony', 'cookies'));
 
-    // even fake a file upload
+    // fakes a file upload
     $form['registration[photo]']->upload('/path/to/lucas.jpg');
 
 Using the Form Data
@@ -445,7 +445,7 @@ directly::
 
     use Goutte\Client;
 
-    // make a real request to an external site
+    // makes a real request to an external site
     $client = new Client();
     $crawler = $client->request('GET', 'https://github.com/login');
 
@@ -454,7 +454,7 @@ directly::
     $form['login'] = 'symfonyfan';
     $form['password'] = 'anypass';
 
-    // submit that form
+    // submits the given form
     $crawler = $client->submit($form);
 
 .. _components-dom-crawler-invalid:
@@ -467,10 +467,10 @@ to prevent you from setting invalid values. If you want to be able to set
 invalid values, you can use the  ``disableValidation()`` method on either
 the whole form or specific field(s)::
 
-    // Disable validation for a specific field
+    // disables validation for a specific field
     $form['country']->disableValidation()->select('Invalid value');
 
-    // Disable validation for the whole form
+    // disables validation for the whole form
     $form->disableValidation();
     $form['country']->select('Invalid value');
 

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -206,18 +206,18 @@ determine which instance is passed.
         $containerBuilder = new ContainerBuilder(new ParameterBag());
         $containerBuilder->addCompilerPass(new RegisterListenersPass());
 
-        // register the event dispatcher service
+        // registers the event dispatcher service
         $containerBuilder->register('event_dispatcher', ContainerAwareEventDispatcher::class)
             ->addArgument(new Reference('service_container'));
 
-        // register your event listener service
+        // registers your event listener service
         $containerBuilder->register('listener_service_id', \AcmeListener::class)
             ->addTag('kernel.event_listener', array(
                 'event' => 'acme.foo.action',
                 'method' => 'onFooAction',
             ));
 
-        // register an event subscriber
+        // registers an event subscriber
         $containerBuilder->register('subscriber_service_id', \AcmeSubscriber::class)
             ->addTag('kernel.event_subscriber');
 
@@ -302,7 +302,7 @@ each listener of that event::
     $order = new Order();
     // ...
 
-    // create the OrderPlacedEvent and dispatch it
+    // creates the OrderPlacedEvent and dispatches it
     $event = new OrderPlacedEvent($order);
     $dispatcher->dispatch(OrderPlacedEvent::NAME, $event);
 

--- a/components/event_dispatcher/traceable_dispatcher.rst
+++ b/components/event_dispatcher/traceable_dispatcher.rst
@@ -27,7 +27,7 @@ to register event listeners and dispatch events::
 
     // ...
 
-    // register an event listener
+    // registers an event listener
     $eventListener = ...;
     $priority = ...;
     $traceableEventDispatcher->addListener(
@@ -36,7 +36,7 @@ to register event listeners and dispatch events::
         $priority
     );
 
-    // dispatch an event
+    // dispatches an event
     $event = ...;
     $traceableEventDispatcher->dispatch('event.the_name', $event);
 

--- a/components/expression_language/extending.rst
+++ b/components/expression_language/extending.rst
@@ -120,7 +120,7 @@ or by using the second argument of the constructor::
         {
             public function __construct(ParserCacheInterface $parser = null, array $providers = array())
             {
-                // prepend the default provider to let users override it easily
+                // prepends the default provider to let users override it easily
                 array_unshift($providers, new StringExpressionLanguageProvider());
 
                 parent::__construct($parser, $providers);

--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -115,11 +115,11 @@ touch
 modification time for a file. The current time is used by default. You can set
 your own with the second argument. The third argument is the access time::
 
-    // set modification time to the current timestamp
+    // sets modification time to the current timestamp
     $fs->touch('file.txt');
-    // set modification time 10 seconds in the future
+    // sets modification time 10 seconds in the future
     $fs->touch('file.txt', time() + 10);
-    // set access time 10 seconds in the past
+    // sets access time 10 seconds in the past
     $fs->touch('file.txt', time(), time() - 10);
 
 .. note::
@@ -133,9 +133,9 @@ chown
 :method:`Symfony\\Component\\Filesystem\\Filesystem::chown` changes the owner of
 a file. The third argument is a boolean recursive option::
 
-    // set the owner of the lolcat video to www-data
+    // sets the owner of the lolcat video to www-data
     $fs->chown('lolcat.mp4', 'www-data');
-    // change the owner of the video directory recursively
+    // changes the owner of the video directory recursively
     $fs->chown('/video', 'www-data', true);
 
 .. note::
@@ -149,9 +149,9 @@ chgrp
 :method:`Symfony\\Component\\Filesystem\\Filesystem::chgrp` changes the group of
 a file. The third argument is a boolean recursive option::
 
-    // set the group of the lolcat video to nginx
+    // sets the group of the lolcat video to nginx
     $fs->chgrp('lolcat.mp4', 'nginx');
-    // change the group of the video directory recursively
+    // changes the group of the video directory recursively
     $fs->chgrp('/video', 'nginx', true);
 
 .. note::
@@ -165,9 +165,9 @@ chmod
 :method:`Symfony\\Component\\Filesystem\\Filesystem::chmod` changes the mode or
 permissions of a file. The fourth argument is a boolean recursive option::
 
-    // set the mode of the video to 0600
+    // sets the mode of the video to 0600
     $fs->chmod('video.ogg', 0600);
-    // change the mod of the src directory recursively
+    // changes the mod of the src directory recursively
     $fs->chmod('src', 0700, 0000, true);
 
 .. note::
@@ -194,9 +194,9 @@ rename
 :method:`Symfony\\Component\\Filesystem\\Filesystem::rename` changes the name
 of a single file or directory::
 
-    // rename a file
+    // renames a file
     $fs->rename('/tmp/processed_video.ogg', '/path/to/store/video_647.ogg');
-    // rename a directory
+    // renames a directory
     $fs->rename('/tmp/files', '/path/to/store/files');
 
 symlink
@@ -206,9 +206,9 @@ symlink
 symbolic link from the target to the destination. If the filesystem does not
 support symbolic links, a third boolean argument is available::
 
-    // create a symbolic link
+    // creates a symbolic link
     $fs->symlink('/path/to/source', '/path/to/destination');
-    // duplicate the source directory if the filesystem
+    // duplicates the source directory if the filesystem
     // does not support symbolic links
     $fs->symlink('/path/to/source', '/path/to/destination', true);
 
@@ -242,13 +242,13 @@ isAbsolutePath
 :method:`Symfony\\Component\\Filesystem\\Filesystem::isAbsolutePath` returns
 ``true`` if the given path is absolute, ``false`` otherwise::
 
-    // return true
+    // returns true
     $fs->isAbsolutePath('/tmp');
-    // return true
+    // returns true
     $fs->isAbsolutePath('c:\\Windows');
-    // return false
+    // returns false
     $fs->isAbsolutePath('tmp');
-    // return false
+    // returns false
     $fs->isAbsolutePath('../dir');
 
 dumpFile

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -30,13 +30,13 @@ directories::
     $finder->files()->in(__DIR__);
 
     foreach ($finder as $file) {
-        // Dump the absolute path
+        // dumps the absolute path
         var_dump($file->getRealPath());
 
-        // Dump the relative path to the file, omitting the filename
+        // dumps the relative path to the file, omitting the filename
         var_dump($file->getRelativePath());
 
-        // Dump the relative path to the file
+        // dumps the relative path to the file
         var_dump($file->getRelativePathname());
     }
 

--- a/components/form.rst
+++ b/components/form.rst
@@ -128,7 +128,7 @@ The following snippet adds CSRF protection to the form factory::
     use Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator;
     use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
-    // create a Session object from the HttpFoundation component
+    // creates a Session object from the HttpFoundation component
     $session = new Session();
 
     $csrfGenerator = new UriSafeTokenGenerator();
@@ -201,12 +201,12 @@ to bootstrap or access Twig and add the :class:`Symfony\\Bridge\\Twig\\Extension
 
     // ... (see the previous CSRF Protection section for more information)
 
-    // add the FormExtension to Twig
+    // adds the FormExtension to Twig
     $twig->addExtension(
         new FormExtension(new TwigRenderer($formEngine, $csrfManager))
     );
 
-    // create your form factory as normal
+    // creates a form factory
     $formFactory = Forms::createFormFactoryBuilder()
         // ...
         ->getFormFactory();
@@ -256,7 +256,7 @@ to your ``Twig_Environment`` instance::
     use Symfony\Component\Translation\Loader\XliffFileLoader;
     use Symfony\Bridge\Twig\Extension\TranslationExtension;
 
-    // create the Translator
+    // creates the Translator
     $translator = new Translator('en');
     // somehow load some translations into it
     $translator->addLoader('xlf', new XliffFileLoader());
@@ -266,7 +266,7 @@ to your ``Twig_Environment`` instance::
         'en'
     );
 
-    // add the TranslationExtension (gives us trans and transChoice filters)
+    // adds the TranslationExtension (gives us trans and transChoice filters)
     $twig->addExtension(new TranslationExtension($translator));
 
     $formFactory = Forms::createFormFactoryBuilder()
@@ -309,7 +309,7 @@ Your integration with the Validation component will look something like this::
     $vendorFormDir = $vendorDir.'/symfony/form';
     $vendorValidatorDir = $vendorDir.'/symfony/validator';
 
-    // create the validator - details will vary
+    // creates the validator - details will vary
     $validator = Validation::createValidator();
 
     // there are built-in translations for the core error messages

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -110,7 +110,7 @@ to the events discussed below::
     // send the headers and echo the content
     $response->send();
 
-    // triggers the kernel.terminate event
+    // trigger the kernel.terminate event
     $kernel->terminate($request, $response);
 
 See ":ref:`http-kernel-working-example`" for a more concrete implementation.
@@ -468,7 +468,7 @@ because it occurs *after* the ``HttpKernel::handle()`` method, and after the
 response is sent to the user. Recall from above, then the code that uses
 the kernel, ends like this::
 
-    // send the headers and echo the content
+    // sends the headers and echoes the content
     $response->send();
 
     // triggers the kernel.terminate event

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -192,10 +192,10 @@ returned::
 
     $data = $reader->read('/path/to/bundle', 'en');
 
-    // Produces an error if the key "Data" does not exist
+    // produces an error if the key "Data" does not exist
     var_dump($data['Data']['entry1']);
 
-    // Returns null if the key "Data" does not exist
+    // returns null if the key "Data" does not exist
     var_dump($reader->readEntry('/path/to/bundle', 'en', array('Data', 'entry1')));
 
 Additionally, the

--- a/components/property_access.rst
+++ b/components/property_access.rst
@@ -208,7 +208,7 @@ enable this feature by using :class:`Symfony\\Component\\PropertyAccess\\Propert
 
     $person = new Person();
 
-    // Enable magic __call
+    // enables PHP __call() magic method
     $accessor = PropertyAccess::createPropertyAccessorBuilder()
         ->enableMagicCall()
         ->getPropertyAccessor();
@@ -435,13 +435,13 @@ configured to enable extra features. To do that you could use the
     // ...
     $accessorBuilder = PropertyAccess::createPropertyAccessorBuilder();
 
-    // Enable magic __call
+    // enables magic __call
     $accessorBuilder->enableMagicCall();
 
-    // Disable magic __call
+    // disables magic __call
     $accessorBuilder->disableMagicCall();
 
-    // Check if magic __call handling is enabled
+    // checks if magic __call handling is enabled
     $accessorBuilder->isMagicCallEnabled(); // true or false
 
     // At the end get the configured property accessor

--- a/components/routing.rst
+++ b/components/routing.rst
@@ -261,7 +261,7 @@ To load this file, you can use the following code. This assumes that your
     use Symfony\Component\Config\FileLocator;
     use Symfony\Component\Routing\Loader\YamlFileLoader;
 
-    // look inside *this* directory
+    // looks inside *this* directory
     $locator = new FileLocator(array(__DIR__));
     $loader = new YamlFileLoader($locator);
     $collection = $loader->load('routes.yml');

--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -254,7 +254,7 @@ which should be used to encode this user's password::
 
     $encoder = $encoderFactory->getEncoder($user);
 
-    // will return $weakEncoder (see above)
+    // returns $weakEncoder (see above)
     $encodedPassword = $encoder->encodePassword($plainPassword, $user->getSalt());
 
     $user->setPassword($encodedPassword);

--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -193,7 +193,7 @@ first constructor argument::
 
     $role = new Role('ROLE_ADMIN');
 
-    // will show 'ROLE_ADMIN'
+    // shows 'ROLE_ADMIN'
     var_dump($role->getRole());
 
 .. note::

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -383,7 +383,7 @@ A custom name converter can handle such cases::
 
         public function denormalize($propertyName)
         {
-            // remove org_ prefix
+            // removes 'org_' prefix
             return 'org_' === substr($propertyName, 0, 4) ? substr($propertyName, 4) : $propertyName;
         }
     }

--- a/components/stopwatch.rst
+++ b/components/stopwatch.rst
@@ -28,7 +28,7 @@ microtime by yourself. Instead, use the simple
     use Symfony\Component\Stopwatch\Stopwatch;
 
     $stopwatch = new Stopwatch();
-    // Start event named 'eventName'
+    // starts event named 'eventName'
     $stopwatch->start('eventName');
     // ... some code goes here
     $event = $stopwatch->stop('eventName');
@@ -57,7 +57,7 @@ This is exactly what the :method:`Symfony\\Component\\Stopwatch\\Stopwatch::lap`
 method does::
 
     $stopwatch = new Stopwatch();
-    // Start event named 'foo'
+    // starts event named 'foo'
     $stopwatch->start('foo');
     // ... some code goes here
     $stopwatch->lap('foo');
@@ -74,13 +74,13 @@ call::
 In addition to periods, you can get other useful information from the event object.
 For example::
 
-    $event->getCategory();   // Returns the category the event was started in
-    $event->getOrigin();     // Returns the event start time in milliseconds
-    $event->ensureStopped(); // Stops all periods not already stopped
-    $event->getStartTime();  // Returns the start time of the very first period
-    $event->getEndTime();    // Returns the end time of the very last period
-    $event->getDuration();   // Returns the event duration, including all periods
-    $event->getMemory();     // Returns the max memory usage of all periods
+    $event->getCategory();   // returns the category the event was started in
+    $event->getOrigin();     // returns the event start time in milliseconds
+    $event->ensureStopped(); // stops all periods not already stopped
+    $event->getStartTime();  // returns the start time of the very first period
+    $event->getEndTime();    // returns the end time of the very last period
+    $event->getDuration();   // returns the event duration, including all periods
+    $event->getMemory();     // returns the max memory usage of all periods
 
 Sections
 --------

--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -207,7 +207,7 @@ Indentation
 By default the YAML component will use 4 spaces for indentation. This can be
 changed using the third argument as follows::
 
-    // use 8 spaces for indentation
+    // uses 8 spaces for indentation
     echo Yaml::dump($array, 2, 8);
 
 .. code-block:: yaml
@@ -226,10 +226,10 @@ resources and objects) as ``null``.
 Instead of encoding as ``null`` you can choose to throw an exception if an invalid
 type is encountered in either the dumper or parser as follows::
 
-    // throw an exception if a resource or object is encountered
+    // throws an exception if a resource or object is encountered
     Yaml::dump($data, 2, 4, true);
 
-    // throw an exception if an encoded object is found in the YAML string
+    // throws an exception if an encoded object is found in the YAML string
     Yaml::parse($yaml, true);
 
 However, you can activate object support using the next argument::

--- a/controller.rst
+++ b/controller.rst
@@ -167,16 +167,16 @@ and ``redirect()`` methods::
 
     public function indexAction()
     {
-        // redirect to the "homepage" route
+        // redirects to the "homepage" route
         return $this->redirectToRoute('homepage');
 
-        // do a permanent - 301 redirect
+        // does a permanent - 301 redirect
         return $this->redirectToRoute('homepage', array(), 301);
 
-        // redirect to a route with parameters
+        // redirects to a route with parameters
         return $this->redirectToRoute('blog_show', array('slug' => 'my-page'));
 
-        // redirect externally
+        // redirects externally
         return $this->redirect('http://symfony.com/doc');
     }
 
@@ -366,13 +366,13 @@ methods for storing and fetching things from the session::
     {
         $session = $request->getSession();
 
-        // store an attribute for reuse during a later user request
+        // stores an attribute for reuse during a later user request
         $session->set('foo', 'bar');
 
-        // get the attribute set by another controller in another request
+        // gets the attribute set by another controller in another request
         $foobar = $session->get('foobar');
 
-        // use a default value if the attribute doesn't exist
+        // uses a default value if the attribute doesn't exist
         $filters = $session->get('filters', array());
     }
 
@@ -493,20 +493,20 @@ the ``Request`` class::
 
         $request->getPreferredLanguage(array('en', 'fr'));
 
-        // retrieve GET and POST variables respectively
+        // retrieves GET and POST variables respectively
         $request->query->get('page');
         $request->request->get('page');
 
-        // retrieve SERVER variables
+        // retrieves SERVER variables
         $request->server->get('HTTP_HOST');
 
         // retrieves an instance of UploadedFile identified by foo
         $request->files->get('foo');
 
-        // retrieve a COOKIE value
+        // retrieves a COOKIE value
         $request->cookies->get('PHPSESSID');
 
-        // retrieve an HTTP request header, with normalized, lowercase keys
+        // retrieves an HTTP request header, with normalized, lowercase keys
         $request->headers->get('host');
         $request->headers->get('content_type');
     }
@@ -527,12 +527,12 @@ headers and content that's sent back to the client::
 
     use Symfony\Component\HttpFoundation\Response;
 
-    // create a simple Response with a 200 status code (the default)
+    // creates a simple Response with a 200 status code (the default)
     $response = new Response('Hello '.$name, Response::HTTP_OK);
 
     // JsonResponse is a sub-class of Response
     $response = new JsonResponse(array('name' => $name));
-    // set a header!
+    // sets a header!
     $response->headers->set('X-Rate-Limit', 10);
 
 There are special classes that make certain kinds of responses easier:

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -138,13 +138,13 @@ Finally, you need to update the code of the controller that handles the form::
 
                 $fileName = $this->generateUniqueFileName().'.'.$file->guessExtension();
 
-                // Move the file to the directory where brochures are stored
+                // moves the file to the directory where brochures are stored
                 $file->move(
                     $this->getParameter('brochures_directory'),
                     $fileName
                 );
 
-                // Update the 'brochure' property to store the PDF file name
+                // updates the 'brochure' property to store the PDF file name
                 // instead of its contents
                 $product->setBrochure($fileName);
 
@@ -157,7 +157,7 @@ Finally, you need to update the code of the controller that handles the form::
                 'form' => $form->createView(),
             ));
         }
-        
+
         /**
          * @return string
          */

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -577,7 +577,7 @@ Once you have a repository object, you can access all sorts of helpful methods::
 
     $repository = $this->getDoctrine()->getRepository(Product::class);
 
-    // query for a single product by its primary key (usually "id")
+    // looks for a single product by its primary key (usually "id")
     $product = $repository->find($productId);
 
     // dynamic method names to find a single product based on a column value
@@ -587,7 +587,7 @@ Once you have a repository object, you can access all sorts of helpful methods::
     // dynamic method names to find a group of products based on a column value
     $products = $repository->findByPrice(19.99);
 
-    // find *all* products
+    // finds *all* products
     $products = $repository->findAll();
 
 .. note::
@@ -600,12 +600,12 @@ to easily fetch objects based on multiple conditions::
 
     $repository = $this->getDoctrine()->getRepository(Product::class);
 
-    // query for a single product matching the given name and price
+    // looks for a single product matching the given name and price
     $product = $repository->findOneBy(
         array('name' => 'Keyboard', 'price' => 19.99)
     );
 
-    // query for multiple products matching the given name, ordered by price
+    // looks for multiple products matching the given name, ordered by price
     $products = $repository->findBy(
         array('name' => 'Keyboard'),
         array('price' => 'ASC')

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -246,7 +246,7 @@ Now you can see this new code in action! Imagine you're inside a controller::
             $product->setPrice(19.99);
             $product->setDescription('Ergonomic and stylish!');
 
-            // relate this product to the category
+            // relates this product to the category
             $product->setCategory($category);
 
             $em = $this->getDoctrine()->getManager();

--- a/email/testing.rst
+++ b/email/testing.rst
@@ -37,14 +37,14 @@ to get information about the messages sent on the previous request::
         {
             $client = static::createClient();
 
-            // Enable the profiler for the next request (it does nothing if the profiler is not available)
+            // enables the profiler for the next request (it does nothing if the profiler is not available)
             $client->enableProfiler();
 
             $crawler = $client->request('POST', '/path/to/above/action');
 
             $mailCollector = $client->getProfile()->getCollector('swiftmailer');
 
-            // Check that an email was sent
+            // checks that an email was sent
             $this->assertSame(1, $mailCollector->getMessageCount());
 
             $collectedMessages = $mailCollector->getMessages();

--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -55,7 +55,7 @@ The most common way to listen to an event is to register an **event listener**::
                 $response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
             }
 
-            // Send the modified response object to the event
+            // sends the modified response object to the event
             $event->setResponse($response);
         }
     }

--- a/event_dispatcher/class_extension.rst
+++ b/event_dispatcher/class_extension.rst
@@ -15,7 +15,7 @@ magic ``__call()`` method in the class you want to be extended like this:
 
         public function __call($method, $arguments)
         {
-            // create an event named 'foo.method_is_not_found'
+            // creates an event named 'foo.method_is_not_found'
             $event = new HandleUndefinedMethodEvent($this, $method, $arguments);
             $this->dispatcher->dispatch('foo.method_is_not_found', $event);
 
@@ -24,7 +24,7 @@ magic ``__call()`` method in the class you want to be extended like this:
                 throw new \Exception(sprintf('Call to undefined method %s::%s.', get_class($this), $method));
             }
 
-            // return the listener returned value
+            // returns the listener returned value
             return $event->getReturnValue();
         }
     }

--- a/form/create_form_type_extension.rst
+++ b/form/create_form_type_extension.rst
@@ -237,7 +237,7 @@ it in the view::
                     $imageUrl = $accessor->getValue($parentData, $options['image_path']);
                 }
 
-                // set an "image_url" variable that will be available when rendering this field
+                // sets an "image_url" variable that will be available when rendering this field
                 $view->vars['image_url'] = $imageUrl;
             }
         }

--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -121,7 +121,7 @@ the event listener might look like the following::
             $product = $event->getData();
             $form = $event->getForm();
 
-            // check if the Product object is "new"
+            // checks if the Product object is "new"
             // If no data is passed to the form, the data is "null".
             // This should be considered a new "Product"
             if (!$product || null === $product->getId()) {

--- a/form/events.rst
+++ b/form/events.rst
@@ -292,7 +292,7 @@ Creating and binding an event listener to the form is very easy::
                 return;
             }
 
-            // Check whether the user has chosen to display their email or not.
+            // checks whether the user has chosen to display their email or not.
             // If the data was submitted previously, the additional value that is
             // included in the request variables needs to be removed.
             if (true === $user['show_email']) {
@@ -371,7 +371,7 @@ Event subscribers have different uses:
             $user = $event->getData();
             $form = $event->getForm();
 
-            // Check whether the user from the initial data has chosen to
+            // checks whether the user from the initial data has chosen to
             // display their email or not.
             if (true === $user->isShowEmail()) {
                 $form->add('email', 'email');
@@ -387,7 +387,7 @@ Event subscribers have different uses:
                 return;
             }
 
-            // Check whether the user has chosen to display their email or not.
+            // checks whether the user has chosen to display their email or not.
             // If the data was submitted previously, the additional value that
             // is included in the request variables needs to be removed.
             if (true === $user['show_email']) {

--- a/forms.rst
+++ b/forms.rst
@@ -84,7 +84,7 @@ from inside a controller::
     {
         public function newAction(Request $request)
         {
-            // create a task and give it some dummy data for this example
+            // creates a task and gives it some dummy data for this example
             $task = new Task();
             $task->setTask('Write a blog post');
             $task->setDueDate(new \DateTime('tomorrow'));

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -307,16 +307,16 @@ More Response Methods
 The Response class provides many more methods related to the cache. Here are
 the most useful ones::
 
-    // Marks the Response stale
+    // marks the Response stale
     $response->expire();
 
-    // Force the response to return a proper 304 response with no content
+    // forces the response to return a proper 304 response with no content
     $response->setNotModified();
 
 Additionally, most cache-related HTTP headers can be set via the single
 :method:`Symfony\\Component\\HttpFoundation\\Response::setCache` method::
 
-    // Set cache settings in one call
+    // sets cache settings in one call
     $response->setCache(array(
         'etag'          => $etag,
         'last_modified' => $date,

--- a/http_cache/cache_vary.rst
+++ b/http_cache/cache_vary.rst
@@ -35,10 +35,10 @@ trigger a different representation of the requested resource:
 The ``Response`` object offers a clean interface for managing the ``Vary``
 header::
 
-    // set one vary header
+    // sets one vary header
     $response->setVary('Accept-Encoding');
 
-    // set multiple vary headers
+    // sets multiple vary headers
     $response->setVary(array('Accept-Encoding', 'User-Agent'));
 
 The ``setVary()`` method takes a header name or an array of header names for

--- a/http_cache/esi.rst
+++ b/http_cache/esi.rst
@@ -107,7 +107,7 @@ independent of the rest of the page.
         public function aboutAction()
         {
             $response = $this->render('static/about.html.twig');
-            // set the shared max age - which also marks the response as public
+            // sets the shared max age - which also marks the response as public
             $response->setSharedMaxAge(600);
 
             return $response;

--- a/http_cache/expiration.rst
+++ b/http_cache/expiration.rst
@@ -35,7 +35,7 @@ Expiration with the ``Cache-Control`` Header
 Most of the time, you will use the ``Cache-Control`` header. Recall that the
 ``Cache-Control`` header is used to specify many different cache directives::
 
-    // Sets the number of seconds after which the response
+    // sets the number of seconds after which the response
     // should no longer be considered fresh by shared caches
     $response->setSharedMaxAge(600);
 

--- a/introduction/http_fundamentals.rst
+++ b/introduction/http_fundamentals.rst
@@ -216,20 +216,20 @@ have all the request information at your fingertips::
     // the URI being requested (e.g. /about) minus any query parameters
     $request->getPathInfo();
 
-    // retrieve $_GET and $_POST variables respectively
+    // retrieves $_GET and $_POST variables respectively
     $request->query->get('id');
     $request->request->get('category', 'default category');
 
-    // retrieve $_SERVER variables
+    // retrieves $_SERVER variables
     $request->server->get('HTTP_HOST');
 
     // retrieves an instance of UploadedFile identified by "attachment"
     $request->files->get('attachment');
 
-    // retrieve a $_COOKIE value
+    // retrieves a $_COOKIE value
     $request->cookies->get('PHPSESSID');
 
-    // retrieve an HTTP request header, with normalized, lowercase keys
+    // retrieves an HTTP request header, with normalized, lowercase keys
     $request->headers->get('host');
     $request->headers->get('content_type');
 
@@ -256,10 +256,10 @@ needs to be returned to the client::
     $response->setContent('<html><body><h1>Hello world!</h1></body></html>');
     $response->setStatusCode(Response::HTTP_OK);
 
-    // set a HTTP response header
+    // sets a HTTP response header
     $response->headers->set('Content-Type', 'text/html');
 
-    // print the HTTP headers followed by the content
+    // prints the HTTP headers followed by the content
     $response->send();
 
 There are also several response *sub-classes* to help you return

--- a/profiler/profiling_data.rst
+++ b/profiler/profiling_data.rst
@@ -33,16 +33,16 @@ The ``profiler`` service also provides the
 :method:`Symfony\\Component\\HttpKernel\\Profiler\\Profiler::find` method to
 look for tokens based on some criteria::
 
-    // get the latest 10 tokens
+    // gets the latest 10 tokens
     $tokens = $container->get('profiler')->find('', '', 10, '', '', '');
 
-    // get the latest 10 tokens for all URL containing /admin/
+    // gets the latest 10 tokens for all URL containing /admin/
     $tokens = $container->get('profiler')->find('', '/admin/', 10, '', '', '');
 
-    // get the latest 10 tokens for local POST requests
+    // gets the latest 10 tokens for local POST requests
     $tokens = $container->get('profiler')->find('127.0.0.1', '', 10, 'POST', '', '');
 
-    // get the latest 10 tokens for requests that happened between 2 and 4 days ago
+    // gets the latest 10 tokens for requests that happened between 2 and 4 days ago
     $tokens = $container->get('profiler')
         ->find('', '', 10, '', '4 days ago', '2 days ago');
 

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -305,13 +305,13 @@ from any controller::
     {
         $session = $request->getSession();
 
-        // store an attribute for reuse during a later user request
+        // stores an attribute for reuse during a later user request
         $session->set('foo', 'bar');
 
-        // get the value of a session attribute
+        // gets the value of a session attribute
         $foo = $session->get('foo');
 
-        // use a default value if the attribute doesn't exist
+        // uses a default value if the attribute doesn't exist
         $foo = $session->get('foo', 'default_value');
     }
 

--- a/reference/events.rst
+++ b/reference/events.rst
@@ -153,7 +153,7 @@ the parent request)::
             return;
         }
 
-        // Reset the locale of the subrequest to the locale of the parent request
+        // reset the locale of the subrequest to the locale of the parent request
         $this->setLocale($parentRequest);
     }
 

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -70,7 +70,7 @@ some kind of "date picker" to help your user fill in the right format. To do tha
 use the ``single_text`` widget::
 
     $builder->add('publishedAt', 'date', array(
-        // render as a single text box
+        // renders it as a single text box
         'widget' => 'single_text',
     ));
 
@@ -85,10 +85,10 @@ make the following changes::
     $builder->add('publishedAt', 'date', array(
         'widget' => 'single_text',
 
-        // do not render as type="date", to avoid HTML5 date pickers
+        // prevents rendering it as type="date", to avoid HTML5 date pickers
         'html5' => false,
 
-        // add a class that can be selected in JavaScript
+        // adds a class that can be selected in JavaScript
         'attr' => ['class' => 'js-datepicker'],
     ));
 

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -59,10 +59,10 @@ The ``entity`` type has just one required option: the entity which should
 be listed inside the choice field::
 
     $builder->add('users', 'entity', array(
-        // query choices from this entity
+        // looks for choices from this entity
         'class' => 'AppBundle:User',
 
-        // use the User.username property as the visible option string
+        // uses the User.username property as the visible option string
         'choice_label' => 'username',
 
         // used to render a select box, check boxes or radios

--- a/service_container/definitions.rst
+++ b/service_container/definitions.rst
@@ -21,17 +21,17 @@ Getting and Setting Service Definitions
 
 There are some helpful methods for working with the service definitions::
 
-    // find out if there is an "app.mailer" definition
+    // finds out if there is an "app.mailer" definition
     $container->hasDefinition('app.mailer');
-    // find out if there is an "app.mailer" definition or alias
+    // finds out if there is an "app.mailer" definition or alias
     $container->has('app.mailer');
 
-    // get the "app.user_config_manager" definition
+    // gets the "app.user_config_manager" definition
     $definition = $container->getDefinition('app.user_config_manager');
-    // get the definition with the "app.user_config_manager" ID or alias
+    // gets the definition with the "app.user_config_manager" ID or alias
     $definition = $container->findDefinition('app.user_config_manager');
 
-    // add a new "app.number_generator" definition
+    // adds a new "app.number_generator" definition
     $definition = new Definition(\AppBundle\NumberGenerator::class);
     $container->setDefinition('app.number_generator', $definition);
 
@@ -82,16 +82,16 @@ fetched from the container::
         '%app.config_table_name%'  // will be resolved to the value of a container parameter
     ));
 
-    // get all arguments configured for this definition
+    // gets all arguments configured for this definition
     $constructorArguments = $definition->getArguments();
 
-    // get a specific argument
+    // gets a specific argument
     $firstArgument = $definition->getArgument(0);
 
-    // add a new argument
+    // adds a new argument
     $definition->addArgument($argument);
 
-    // replace argument on a specific index (0 = first argument)
+    // replaces argument on a specific index (0 = first argument)
     $definition->replaceArgument($index, $argument);
 
     // replace all previously configured arguments with the passed array
@@ -109,13 +109,13 @@ Method Calls
 If the service you are working with uses setter injection then you can manipulate
 any method calls in the definitions as well::
 
-    // get all configured method calls
+    // gets all configured method calls
     $methodCalls = $definition->getMethodCalls();
 
-    // configure a new method call
+    // configures a new method call
     $definition->addMethodCall('setLogger', array(new Reference('logger')));
 
-    // replace all previously configured method calls with the passed array
+    // replaces all previously configured method calls with the passed array
     $definition->setMethodCalls($methodCalls);
 
 .. tip::

--- a/service_container/parameters.rst
+++ b/service_container/parameters.rst
@@ -133,13 +133,13 @@ Getting and Setting Container Parameters in PHP
 Working with container parameters is straightforward using the container's
 accessor methods for parameters::
 
-    // check if a parameter is defined
+    // checks if a parameter is defined
     $container->hasParameter('mailer.transport');
 
-    // get value of a parameter
+    // gets value of a parameter
     $container->getParameter('mailer.transport');
 
-    // add a new parameter
+    // adds a new parameter
     $container->setParameter('mailer.transport', 'sendmail');
 
 .. caution::

--- a/testing.rst
+++ b/testing.rst
@@ -225,7 +225,7 @@ Now that you can easily navigate through an application, use assertions to test
 that it actually does what you expect it to. Use the Crawler to make assertions
 on the DOM::
 
-    // Assert that the response matches a given CSS selector.
+    // asserts that the response matches a given CSS selector.
     $this->assertGreaterThan(0, $crawler->filter('h1')->count());
 
 Or test against the response content directly if you just want to assert that
@@ -249,17 +249,17 @@ document::
 
         // ...
 
-        // Assert that there is at least one h2 tag
+        // asserts that there is at least one h2 tag
         // with the class "subtitle"
         $this->assertGreaterThan(
             0,
             $crawler->filter('h2.subtitle')->count()
         );
 
-        // Assert that there are exactly 4 h2 tags on the page
+        // asserts that there are exactly 4 h2 tags on the page
         $this->assertCount(4, $crawler->filter('h2'));
 
-        // Assert that the "Content-Type" header is "application/json"
+        // asserts that the "Content-Type" header is "application/json"
         $this->assertTrue(
             $client->getResponse()->headers->contains(
                 'Content-Type',
@@ -268,22 +268,22 @@ document::
             'the "Content-Type" header is "application/json"' // optional message shown on failure
         );
 
-        // Assert that the response content contains a string
+        // asserts that the response content contains a string
         $this->assertContains('foo', $client->getResponse()->getContent());
         // ...or matches a regex
         $this->assertRegExp('/foo(bar)?/', $client->getResponse()->getContent());
 
-        // Assert that the response status code is 2xx
+        // asserts that the response status code is 2xx
         $this->assertTrue($client->getResponse()->isSuccessful(), 'response status is 2xx');
-        // Assert that the response status code is 404
+        // asserts that the response status code is 404
         $this->assertTrue($client->getResponse()->isNotFound());
-        // Assert a specific 200 status code
+        // asserts a specific 200 status code
         $this->assertEquals(
             200, // or Symfony\Component\HttpFoundation\Response::HTTP_OK
             $client->getResponse()->getStatusCode()
         );
 
-        // Assert that the response is a redirect to /demo/contact
+        // asserts that the response is a redirect to /demo/contact
         $this->assertTrue(
             $client->getResponse()->isRedirect('/demo/contact')
             // if the redirection URL was generated as an absolute URL
@@ -367,10 +367,10 @@ giving you a nice API for uploading files.
 The ``request()`` method can also be used to simulate form submissions directly
 or perform more complex requests. Some useful examples::
 
-    // Directly submit a form (but using the Crawler is easier!)
+    // submits a form directly (but using the Crawler is easier!)
     $client->request('POST', '/submit', array('name' => 'Fabien'));
 
-    // Submit a raw JSON string in the request body
+    // submits a raw JSON string in the request body
     $client->request(
         'POST',
         '/submit',
@@ -420,7 +420,7 @@ The Client supports many operations that can be done in a real browser::
     $client->forward();
     $client->reload();
 
-    // Clears all cookies and the history
+    // clears all cookies and the history
     $client->restart();
 
 Accessing Internal Objects
@@ -486,12 +486,12 @@ queries when loading.
 
 To get the Profiler for the last request, do the following::
 
-    // enable the profiler for the very next request
+    // enables the profiler for the very next request
     $client->enableProfiler();
 
     $crawler = $client->request('GET', '/profiler');
 
-    // get the profile
+    // gets the profile
     $profile = $client->getProfile();
 
 For specific details on using the profiler inside a test, see the
@@ -588,19 +588,19 @@ Extracting Information
 
 The Crawler can extract information from the nodes::
 
-    // Returns the attribute value for the first node
+    // returns the attribute value for the first node
     $crawler->attr('class');
 
-    // Returns the node value for the first node
+    // returns the node value for the first node
     $crawler->text();
 
-    // Extracts an array of attributes for all nodes
+    // extracts an array of attributes for all nodes
     // (_text returns the node value)
     // returns an array for each element in crawler,
     // each with the value and href
     $info = $crawler->extract(array('_text', 'href'));
 
-    // Executes a lambda for each node and return an array of results
+    // executes a lambda for each node and return an array of results
     $data = $crawler->each(function ($node, $i) {
         return $node->attr('href');
     });
@@ -680,20 +680,20 @@ method::
 For more complex situations, use the ``Form`` instance as an array to set the
 value of each field individually::
 
-    // Change the value of a field
+    // changes the value of a field
     $form['name'] = 'Fabien';
     $form['my_form[subject]'] = 'Symfony rocks!';
 
 There is also a nice API to manipulate the values of the fields according to
 their type::
 
-    // Select an option or a radio
+    // selects an option or a radio
     $form['country']->select('France');
 
-    // Tick a checkbox
+    // ticks a checkbox
     $form['like_symfony']->tick();
 
-    // Upload a file
+    // uploads a file
     $form['photo']->upload('/path/to/lucas.jpg');
 
 .. tip::
@@ -720,21 +720,21 @@ you can't add fields to an existing form with
 set values of existing fields. In order to add new fields, you have to
 add the values to the raw data array::
 
-    // Get the form.
+    // gets the form
     $form = $crawler->filter('button')->form();
 
-    // Get the raw values.
+    // gets the raw values
     $values = $form->getPhpValues();
 
-    // Add fields to the raw values.
+    // adds fields to the raw values
     $values['task']['tags'][0]['name'] = 'foo';
     $values['task']['tags'][1]['name'] = 'bar';
 
-    // Submit the form with the existing and new values.
+    // submits the form with the existing and new values
     $crawler = $client->request($form->getMethod(), $form->getUri(), $values,
         $form->getPhpFiles());
 
-    // The 2 tags have been added to the collection.
+    // the 2 tags have been added to the collection
     $this->assertEquals(2, $crawler->filter('ul.tags > li')->count());
 
 Where ``task[tags][0][name]`` is the name of a field created
@@ -742,17 +742,17 @@ with JavaScript.
 
 You can remove an existing field, e.g. a tag::
 
-    // Get the values of the form.
+    // gets the values of the form
     $values = $form->getPhpValues();
 
-    // Remove the first tag.
+    // removes the first tag
     unset($values['task']['tags'][0]);
 
-    // Submit the data.
+    // submits the data
     $crawler = $client->request($form->getMethod(), $form->getUri(),
         $values, $form->getPhpFiles());
 
-    // The tag has been removed.
+    // the tag has been removed
     $this->assertEquals(0, $crawler->filter('ul.tags > li')->count());
 
 .. index::

--- a/testing/profiling.rst
+++ b/testing/profiling.rst
@@ -21,7 +21,7 @@ the ``test`` environment)::
         {
             $client = static::createClient();
 
-            // Enable the profiler for the next request
+            // enable the profiler for the next request
             // (it does nothing if the profiler is not available)
             $client->enableProfiler();
 
@@ -29,7 +29,7 @@ the ``test`` environment)::
 
             // ... write some assertions about the Response
 
-            // Check that the profiler is enabled
+            // check that the profiler is enabled
             if ($profile = $client->getProfile()) {
                 // check the number of requests
                 $this->assertLessThan(


### PR DESCRIPTION
This finishes #9088 by doing the opposite change: when the comment describes what the code does instead of what the user must do, use the format: `// returns a ...`  instead of `// return a ...`