### PR TITLE
Update standards.rst

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -147,9 +147,7 @@ Structure
 
 * Always use `identical comparison`_ unless you need type juggling;
 
-* Use `Yoda conditions`_ when checking a variable against an expression to avoid
-  an accidental assignment inside the condition statement (this applies to ``==``,
-  ``!=``, ``===``, and ``!==``);
+* Use your IDE to check for Assignment In Conditions and make sure it hilights it as an error.
 
 * Add a comma after each array item in a multi-line array, even after the
   last one;

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -147,7 +147,7 @@ Structure
 
 * Always use `identical comparison`_ unless you need type juggling;
 
-* Use your IDE to check for Assignment In Conditions and make sure it highlights it as an error.
+* Use your IDE to check for Assignment In Conditions and make sure it highlights it as an error.;
 
 * Add a comma after each array item in a multi-line array, even after the
   last one;
@@ -267,4 +267,3 @@ License
 .. _`PSR-2`: http://www.php-fig.org/psr/psr-2/
 .. _`PSR-4`: http://www.php-fig.org/psr/psr-4/
 .. _`identical comparison`: http://php.net/manual/en/language.operators.comparison.php
-.. _`Yoda conditions`: https://en.wikipedia.org/wiki/Yoda_conditions

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -147,7 +147,7 @@ Structure
 
 * Always use `identical comparison`_ unless you need type juggling;
 
-* Use your IDE to check for Assignment In Conditions and make sure it hilights it as an error.
+* Use your IDE to check for Assignment In Conditions and make sure it highlights it as an error.
 
 * Add a comma after each array item in a multi-line array, even after the
   last one;

--- a/doctrine/reverse_engineering.rst
+++ b/doctrine/reverse_engineering.rst
@@ -4,6 +4,14 @@
 How to Generate Entities from an Existing Database
 ==================================================
 
+.. caution::
+
+    The feature explained in this article doesn't work in modern Symfony
+    applications that have no bundles. The workaround is to temporarily create
+    a bundle. See `doctrine/doctrine#729`_ for details. Moreover, this feature
+    to generate entities from existing databases will be completely removed in
+    the next Doctrine version.
+
 When starting work on a brand new project that uses a database, two different
 situations comes naturally. In most cases, the database model is designed
 and built from scratch. Sometimes, however, you'll start with an existing and
@@ -53,12 +61,6 @@ The first step towards building entity classes from an existing database
 is to ask Doctrine to introspect the database and generate the corresponding
 metadata files. Metadata files describe the entity class to generate based on
 table fields.
-
-.. caution::
-
-    If your application has *no* bundles, then this command will currently fail!
-    The workaround, is to temporarily create a bundle. See `doctrine/doctrine#729`_
-    for details.
 
 .. code-block:: terminal
 


### PR DESCRIPTION
Yoda Conditions decrease readability and most IDEs have inspections to prevent Assignment in Conditions, use this instead.