### PR TITLE
Fix references to annotation loader tip

### DIFF
--- a/components/routing.rst
+++ b/components/routing.rst
@@ -312,7 +312,7 @@ Last but not least there are
 route definitions from class annotations. The specific details are left
 out here.
 
-.. include:: /_includes/_rewrite_rule_tip.rst.inc
+.. include:: /_includes/_annotation_loader_tip.rst.inc
 
 The all-in-one Router
 ~~~~~~~~~~~~~~~~~~~~~

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -310,6 +310,8 @@ You are now able to serialize only attributes in the groups you want::
     );
     // $obj2 = MyObj(foo: 'foo', bar: 'bar')
 
+.. include:: /_includes/_annotation_loader_tip.rst.inc
+
 .. _ignoring-attributes-when-serializing:
 
 Ignoring Attributes

--- a/components/validator/resources.rst
+++ b/components/validator/resources.rst
@@ -119,7 +119,7 @@ method. It takes an optional annotation reader instance, which defaults to
 To disable the annotation loader after it was enabled, call
 :method:`Symfony\\Component\\Validator\\ValidatorBuilder::disableAnnotationMapping`.
 
-.. include:: /_includes/_rewrite_rule_tip.rst.inc
+.. include:: /_includes/_annotation_loader_tip.rst.inc
 
 Using Multiple Loaders
 ----------------------


### PR DESCRIPTION
Tips were refactored to an include file in 0ddf3d21b12c05fb5b34f982feb4005dab877185 but referenced the wrong filename. a0b19c3e372d75b48e2f3606d8c4109788e9e39a removed the wrong tip from the serializer page.

This fixes the tip references on routing/validator and restores the tip on the serializer, but with the right reference.