### PR TITLE
Clearer wording of allow_delete template behavior

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -625,9 +625,11 @@ Now, you need to put some code into the ``removeTag()`` method of ``Task``::
 Template Modifications
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The ``allow_delete`` option has one consequence: if an item of a collection
+The ``allow_delete`` option means that if an item of a collection
 isn't sent on submission, the related data is removed from the collection
-on the server. The solution is to remove the form element from the DOM.
+on the server. In order for this to work in an HTML form, you must remove 
+the DOM element for the collection item to be removed, before submitting
+the form.
 
 First, add a "delete this tag" link to each tag form:
 


### PR DESCRIPTION
```
The allow_delete option has one consequence: if an item of a collection isn't sent on submission, the related data is removed from the collection on the server. The solution is to remove the form element from the DOM.
```

*The solution is to remove the form element from the DOM* is a confusing sentence. Saying "the solution" implies that there is some sort of problem with enabling `allow_delete` that needs to be solved. I found it very confusing what the problem was, and reread the section multiple times to figure out what it was supposed to be. 

I finally understood that what it's _trying_ to say is that if you want the *intended* behavior to work, (not problematic, because you are enabling the behavior intentionally), you have to remove the collection item from the submitted data. In terms of submitting the form through a webpage, that means removing the DOM element.

Also removed `has one consequence` from the first sentence of the paragraph, because calling it a consequence, again, implies that it's a behavior you don't really want, despite the fact you're enabling it intentionally.

Overall, I think these small changes would prevent some unnecessary confusion like what I experienced.