### PR TITLE
Recommend to never inline PHPDoc blocks

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -251,7 +251,8 @@ Documentation
 
 * The ``@package`` and ``@subpackage`` annotations are not used;
 
-* Inline the ``@inheritdoc`` tag.
+* Don't inline PHPDoc blocks, even when they contain just one tag (e.g. don't
+  put ``/** {@inheritdoc} */`` in a single line).
 
 License
 ~~~~~~~


### PR DESCRIPTION
I guess the existing recommendation is wrong because we never do that in the Symfony code. See https://github.com/symfony/symfony/search?utf8=%E2%9C%93&q=%7B%40inheritdoc%7D&type=