### PR TITLE
fix creating a CacheKernel in HTTP cache documentation

### DIFF
--- a/http_cache.rst
+++ b/http_cache.rst
@@ -80,6 +80,8 @@ but is a great way to start.
 To enable the proxy, first create a caching kernel::
 
     // src/CacheKernel.php
+    namespace App;
+
     use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 
     class CacheKernel extends HttpCache
@@ -92,6 +94,9 @@ caching kernel:
 .. code-block:: diff
 
     // public/index.php
+
+    use App\Kernel;
+    + use App\CacheKernel;
 
     // ...
     $kernel = new Kernel($_SERVER['APP_ENV'] ?? 'dev', $_SERVER['APP_DEBUG'] ?? ('prod' !== ($_SERVER['APP_ENV'] ?? 'dev')));


### PR DESCRIPTION
Hey, I was trying out to use the HTTP Cache for a talk and lecture I am giving, and with the instructions in the HTTP Cache documentation I only got an error that the class was not found. The changes I introduced here were also necessary. However, I am not completely sure if I missed something else, since I just skimmed the documentation, but I thought I send a PR anyway so that you see what I am talking about :smiley: 