### PR TITLE
[DI] Service subscribers

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -6,7 +6,7 @@ Lazy Services
 
 .. seealso::
 
-    Another way to inject services lazily is via a :doc:`service locator </service_container/service_locators>`.
+    Another way to inject services lazily is via a :doc:`service subscriber </service_container/service_subscribers>`.
 
 Why Lazy Services?
 ------------------

--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -6,7 +6,7 @@ Lazy Services
 
 .. seealso::
 
-    Another way to inject services lazily is via a :doc:`service subscriber </service_container/service_subscribers>`.
+    Another way to inject services lazily is via a :doc:`service subscriber </service_container/service_subscribers_locators>`.
 
 Why Lazy Services?
 ------------------

--- a/service_container/service_subscribers.rst
+++ b/service_container/service_subscribers.rst
@@ -79,14 +79,15 @@ services.
 
 **Service Subscribers** are intended to solve this problem by giving access to a
 set of predefined services while instantiating them only when actually needed
-through a service locator.
+through a **Service Locator**, a separate lazy-loaded container.
 
 Defining a Service Subscriber
 -----------------------------
 
 First, turn ``CommandBus`` into an implementation of :class:`Symfony\\Component\\DependencyInjection\\ServiceSubscriberInterface`.
 Use its ``getSubscribedServices`` method to include as many services as needed
-in the service locater and change the container to a PSR-11 ``ContainerInterface``::
+in the service subscriber and change the type hint of the container to
+a PSR-11 ``ContainerInterface``::
 
     // src/AppBundle/CommandBus.php
     namespace AppBundle;
@@ -128,7 +129,7 @@ in the service locater and change the container to a PSR-11 ``ContainerInterface
 .. tip::
 
     If the container does *not* contain the subscribed services, double-check
-    that you  have :ref:`autoconfigure <services-autoconfigure>` enabled. You
+    that you have :ref:`autoconfigure <services-autoconfigure>` enabled. You
     can also manually add the ``container.service_subscriber`` tag.
 
 The injected service is an instance of :class:`Symfony\\Component\\DependencyInjection\\ServiceLocator`
@@ -173,7 +174,7 @@ Optional services
 ~~~~~~~~~~~~~~~~~
 
 For optional dependencies, prepend the service type with a ``?`` to prevent
-errors if there's no matching service in the service container::
+errors if there's no matching service found in the service container::
 
     use Psr\Log\LoggerInterface;
 
@@ -306,7 +307,7 @@ include as many services as needed in it.
     The services defined in the service locator argument must include keys,
     which later become their unique identifiers inside the locator.
 
-Now you can use the service locator injecting it in any other service:
+Now you can use the service locator by injecting it in any other service:
 
 .. configuration-block::
 

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -1,8 +1,8 @@
 .. index::
     single: DependencyInjection; Service Subscribers
 
-Service Subscribers
-===================
+Service Subscribers & Locators
+==============================
 
 Sometimes, a service needs access to several other services without being sure
 that all of them will actually be used. In those cases, you may want the
@@ -85,7 +85,7 @@ Defining a Service Subscriber
 -----------------------------
 
 First, turn ``CommandBus`` into an implementation of :class:`Symfony\\Component\\DependencyInjection\\ServiceSubscriberInterface`.
-Use its ``getSubscribedServices`` method to include as many services as needed
+Use its ``getSubscribedServices()`` method to include as many services as needed
 in the service subscriber and change the type hint of the container to
 a PSR-11 ``ContainerInterface``::
 
@@ -141,7 +141,7 @@ which implements the PSR-11 ``ContainerInterface``, but it is also a callable::
 
     return $handler->handle($command);
 
-Including services
+Including Services
 ------------------
 
 In order to add a new dependency to the service subscriber, use the
@@ -158,7 +158,7 @@ service locator::
         ];
     }
 
-Service types can also be keyed by a service name for use internally::
+Service types can also be keyed by a service name for internal use::
 
     use Psr\Log\LoggerInterface;
 
@@ -170,7 +170,7 @@ Service types can also be keyed by a service name for use internally::
         ];
     }
 
-Optional services
+Optional Services
 ~~~~~~~~~~~~~~~~~
 
 For optional dependencies, prepend the service type with a ``?`` to prevent
@@ -191,7 +191,7 @@ errors if there's no matching service found in the service container::
     Make sure an optional service exists by calling ``has()`` on the service
     locator before calling the service itself.
 
-Aliased services
+Aliased Services
 ~~~~~~~~~~~~~~~~
 
 By default, autowiring is used to match a service type to a service from the


### PR DESCRIPTION
Fixes #7740.

Couple of notes:
* The page name was changed from `Service Locators` to `Service Subscribers`. Maybe `Service Subscribers & Locators` is more appropiate??
* Later on in the page it starts talking about service types as inspired by the API documentation of the `ServiceSubscriberInterface`, but this term isn't used anywhere else in the documentation.

This is my first contribution to the docs so any input is appreciated.