### PR TITLE
Added a missin namespace in CacheKernel example

### DIFF
--- a/http_cache/cache_invalidation.rst
+++ b/http_cache/cache_invalidation.rst
@@ -51,6 +51,7 @@ Here is how you can configure the Symfony reverse proxy (See :doc:`/http_cache`)
 to support the ``PURGE`` HTTP method::
 
     // src/CacheKernel.php
+    namespace App;
 
     use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
     use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
This finishes #9222 adding a missing `namespace App` in a `CacheKernel` example.