### PR TITLE
Fixed the path of an image

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -434,7 +434,7 @@ The picture below shows how Symfony calls Guard Authenticator methods:
 
 .. raw:: html
 
-    <object data="./_images/security/authentication-guard-methods.svg" type="image/svg+xml"></object>
+    <object data="../_images/security/authentication-guard-methods.svg" type="image/svg+xml"></object>
 
 .. _guard-customize-error:
 


### PR DESCRIPTION
Sorry for all these pull requests about this SVG image. Hopefully this will be the last one. We've made some changes on the symfony.com server too to prepare for images like this that are embedded using `<object>` instead of `<img>`. We'll see if it works.