### PR TITLE
Add createdAt property + setter and getter

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -72,6 +72,7 @@ exists in your project::
         private $age;
         private $name;
         private $sportsman;
+        private $createdAt;
 
         // Getters
         public function getName()
@@ -82,6 +83,11 @@ exists in your project::
         public function getAge()
         {
             return $this->age;
+        }
+
+        public function getCreatedAt()
+        {
+            return $this->createdAt;
         }
 
         // Issers
@@ -104,6 +110,11 @@ exists in your project::
         public function setSportsman($sportsman)
         {
             $this->sportsman = $sportsman;
+        }
+
+        public function setCreatedAt($createdAt)
+        {
+            $this->createdAt = $createdAt;
         }
     }
 


### PR DESCRIPTION
"createdAt" property and "setCreatedAt" is not defined on section "Using Callbacks to Serialize Properties with Object Instances" so the PHP Fatal error is triggered: Call to undefined method Person::setCreatedAt()