### PR TITLE
[Form] Event form modification improvements

### DIFF
--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -591,6 +591,11 @@ callbacks only because in two different scenarios, the data that you can use is
 available in different events. Other than that, the listeners always perform
 exactly the same things on a given form.
 
+.. tip::
+
+    The ``FormEvents::POST_SUBMIT`` event does not allow to modify the form
+    the listener is bound to, but it allows to modify its parent.
+
 One piece that is still missing is the client-side updating of your form after
 the sport is selected. This should be handled by making an AJAX call back to
 your application. Assume that you have a sport meetup creation controller::

--- a/form/events.rst
+++ b/form/events.rst
@@ -219,7 +219,8 @@ View data        Normalized data transformed using a view transformer
 
 .. caution::
 
-    At this point, you cannot add or remove fields to the form.
+    At this point, you cannot add or remove fields to the current form and its
+    children.
 
 .. sidebar:: ``FormEvents::POST_SUBMIT`` in the Form component
 


### PR DESCRIPTION
* `FormEvents::SUBMIT` *does* allow to modify the form (tested on Symfony 3.3 but looking at the code, this seems to be true for 2.7 as well);
* `FormEvents::POST_SUBMIT` allows to modify the parent form, this was not explicit in the documentation so I thought it would be a nice addition.