### PR TITLE
Note about trailing-slash when using Finder with FTP

### DIFF
--- a/components/finder.rst
+++ b/components/finder.rst
@@ -114,6 +114,7 @@ It's also possible to ignore directories that you don't have permission to read:
 
 As the Finder uses PHP iterators, you can pass any URL with a supported
 `protocol`_::
+(Note: Even if you don`t specify a path, your URL should end with a `/`)
 
     $finder->in('ftp://example.com/pub/');
 

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -114,7 +114,11 @@ It's also possible to ignore directories that you don't have permission to read:
 
 As the Finder uses PHP iterators, you can pass any URL with a supported
 `protocol`_::
-(Note: Even if you don`t specify a path, your URL should end with a `/`)
+(Note: Even if you dont want to enter a specitic path in your ftp-server and instead just go to the root of your server, your URL should end with a `/`)
+
+    $finder->in('ftp://example.com/');
+
+Use this to go directly to subfolder "pub":
 
     $finder->in('ftp://example.com/pub/');
 

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -114,12 +114,11 @@ It's also possible to ignore directories that you don't have permission to read:
 
 As the Finder uses PHP iterators, you can pass any URL with a supported
 `protocol`_::
-(Note: Even if you dont want to enter a specitic path in your ftp-server and instead just go to the root of your server, your URL should end with a `/`)
 
+    // always add a trailing slash when looking for in the FTP root dir
     $finder->in('ftp://example.com/');
 
-Use this to go directly to subfolder "pub":
-
+    // you can also look for in a FTP directory
     $finder->in('ftp://example.com/pub/');
 
 And it also works with user-defined streams::


### PR DESCRIPTION
Added a short note on how to use the finder with FTP. There was nothing written about the need of the trailing slash.