### PR TITLE
Fix "RequestExceptionInterface" link

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -596,7 +596,7 @@ below for more details).
        :class:`Symfony\\Component\\HttpKernel\\Exception\\HttpException` class.
 
     3) If the original exception implements
-       :class:`Symfony\\Component\\HttpKernel\\Exception\\RequestExceptionInterface`,
+       :class:`Symfony\\Component\\HttpFoundation\\Exception\\RequestExceptionInterface`,
        then the status code of the ``FlattenException`` object is populated with
        ``400`` and no other headers are modified.
 


### PR DESCRIPTION
Change http://api.symfony.com/3.3/Symfony/Component/HttpKernel/Exception/RequestExceptionInterface.html to http://api.symfony.com/3.3/Symfony/Component/HttpFoundation/Exception/RequestExceptionInterface.html