### PR TITLE
Add fallback configuration

### DIFF
--- a/components/translation.rst
+++ b/components/translation.rst
@@ -153,6 +153,17 @@ and returns it (if it exists).
 
 Fallback Locales
 ~~~~~~~~~~~~~~~~
+Turn on the translation system
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config.yaml
+        framework:
+            #uncomment this line
+            translator: { fallbacks: ['%locale%'] }
+
 
 If the message is not located in the catalog of the specific locale, the
 translator will look into the catalog of one or more fallback locales. For


### PR DESCRIPTION
I was trying to translate validators message and I lost many time before find this [answer](https://stackoverflow.com/questions/27885176/symfony2-translation-of-validation-messages-issue) 
I didn't uncomment this line ` translator: { fallbacks: ['%locale%'] }` in app/config.yml the documentation doesn't speak about that or I missed something ?