### PR TITLE
Controller naming habits

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -58,8 +58,8 @@ This controller is pretty straightforward:
   the ``use`` keyword imports the ``Response`` class, which the controller
   must return.
 
-* *line 7*: The class can technically be called anything - but should end in the
-  word ``Controller``
+* *line 7*: The class can technically be called anything, 
+  it is common to use `Controller` at the end. 
 
 * *line 12*: The action method is allowed to have a ``$max`` argument thanks to the
   ``{max}`` :doc:`wildcard in the route </routing>`.

--- a/controller.rst
+++ b/controller.rst
@@ -58,8 +58,8 @@ This controller is pretty straightforward:
   the ``use`` keyword imports the ``Response`` class, which the controller
   must return.
 
-* *line 7*: The class can technically be called anything, 
-  it is common to use `Controller` at the end. 
+* *line 7*: The class can technically be called anything, but it's suffixed
+  with ``Controller`` by convention.
 
 * *line 12*: The action method is allowed to have a ``$max`` argument thanks to the
   ``{max}`` :doc:`wildcard in the route </routing>`.


### PR DESCRIPTION
As Symfony isn't an `MVC` framework but a `Request/Response` one (see https://github.com/symfony/symfony-docs/pull/8153#discussion_r163571638), the name of the class which handles the Request isn't forced to contain `Controller`, it's probably more a common usage than a need to make Symfony works.