### PR TITLE
Use the proper path of version 2.x

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -11,10 +11,10 @@ configured under the ``framework`` key in your application configuration.
 .. code-block:: terminal
 
     # displays the default config values defined by Symfony
-    $ php bin/console config:dump framework
+    $ php app/console config:dump framework
 
     # displays the actual config values used by your application
-    $ php bin/console debug:config framework
+    $ php app/console debug:config framework
 
 .. note::
 


### PR DESCRIPTION
This doc used the path added as of version 3.x.
In version 2.x, it has to be app/foo for the commands.