### PR TITLE
Added the name attribute to XLIFF 2 documents

### DIFF
--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -438,7 +438,7 @@ loaded/dumped when using this component inside a Symfony application:
     <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0"
            srcLang="fr-FR" trgLang="en-US">
       <file id="messages.en_US">
-        <unit id="LCa0a2j">
+        <unit id="LCa0a2j" name="original-content">
           <notes>
             <note category="state">new</note>
             <note category="approved">true</note>


### PR DESCRIPTION
This fixes #9287. It's a simple fix because we only display one XLIFF 2 document in the docs.

-----

@Nyholm I'm sure you did the right thing ... but just asking: making the `name` value the same as `source` is the best possible solution here? In Symfony's code the `source` attribute is short (https://github.com/symfony/symfony/pull/26149/files) but in real world it can be super long and super ugly (containing `CDATA`, etc.) So, don't you think this will be very verbose? Could we make the `name` value the same as the `id` attribute instead? If the XLIFF standard forces us to do this, then forget my comment and accept my apologies 😄  