### PR TITLE
Clarification on search user

### DIFF
--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -173,6 +173,16 @@ use the ``ldap`` user provider.
     provider is used. However, the LDAP component itself does not provide
     any escaping yet. Thus, it's your responsibility to prevent LDAP injection
     attacks when using the component directly.
+    
+.. caution::
+
+    It's important to note that the user you configure for the user provider
+    is only going to be retrieving data. It is a statically defined user and
+    password. If you wish to keep your password out of version control, you
+    may want to configure the password as a parameter.
+    
+    If your ldap server allows you to retrieve information anonymously, you
+    can leave the ``search_dn`` and ``search_password`` as ``null``.
 
 The ``ldap`` user provider supports many different configuration options:
 

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -176,13 +176,12 @@ use the ``ldap`` user provider.
     
 .. caution::
 
-    It's important to note that the user you configure for the user provider
-    is only going to be retrieving data. It is a statically defined user and
-    password. If you wish to keep your password out of version control, you
-    may want to configure the password as a parameter.
+    The user configured above in the the user provider is only used to retrieve
+    data. It's a static user defined by its username and password (for improved
+    security, define the password as an environment variable).
     
-    If your ldap server allows you to retrieve information anonymously, you
-    can leave the ``search_dn`` and ``search_password`` as ``null``.
+    If your LDAP server allows to retrieve information anonymously, you can
+    set the ``search_dn`` and ``search_password`` options to ``null``.
 
 The ``ldap`` user provider supports many different configuration options:
 


### PR DESCRIPTION
I had issues with configuration because I misunderstood the configuration for the user provider. I didn't realize that the configured user was actually a static one only used for retrieving information. 

I also added a clarification for the case that you are getting information anonymously, which was what my situation required.

These changes are relevant for Symfony 2.8+ (2.8 being the oldest maintained version I checked)

Also, I added a note on keeping the password out of VC by using a parameter, but in Symfony 4 this should be an environment variable instead. I'm not sure how I'm supposed to propose the change for this slight difference once hitting that version.