### PR TITLE
improve validation groups references

### DIFF
--- a/validation/groups.rst
+++ b/validation/groups.rst
@@ -137,7 +137,7 @@ With this configuration, there are three validation groups:
 ``User``
     Equivalent to all constraints of the ``User`` object in the ``Default``
     group. This is always the name of the class. The difference between this
-    and ``Default`` is explained below.
+    and ``Default`` is explained in :doc:`/validation/sequence_provider`.
 
 ``registration``
     Contains the constraints on the ``email`` and ``password`` fields only.

--- a/validation/sequence_provider.rst
+++ b/validation/sequence_provider.rst
@@ -128,7 +128,7 @@ that group are valid, the second group, ``Strict``, will be validated.
 
 .. caution::
 
-    As you have already seen in the previous section, the ``Default`` group
+    As you have already seen in :doc:`/validation/groups`, the ``Default`` group
     and the group containing the class name (e.g. ``User``) were identical.
     However, when using Group Sequences, they are no longer identical. The
     ``Default`` group will now reference the group sequence, instead of all


### PR DESCRIPTION
Validation groups and group sequence providers are not part of the same
document. Thus, referring to "next" or "previous" sections is not really
useful.