### PR TITLE
Update dbal.rst

### DIFF
--- a/doctrine/dbal.rst
+++ b/doctrine/dbal.rst
@@ -20,6 +20,8 @@ makes it easy to execute queries and perform other database actions.
 
     Read the official Doctrine `DBAL Documentation`_ to learn all the details
     and capabilities of Doctrine's DBAL library.
+    
+    Before you start you will need `DoctrineBundle`_ which supports both Doctrine ORM and Doctrine DBAL (together or just DBAL). This will generate ``config/packages/doctrine.yaml``.
 
 To get started, configure the ``DATABASE_URL`` environment variable in ``.env``:
 
@@ -156,3 +158,4 @@ mapping type:
 .. _`Doctrine`:      http://www.doctrine-project.org
 .. _`DBAL Documentation`: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/index.html
 .. _`Custom Mapping Types`: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#custom-mapping-types
+.. _`DoctrineBundle`:      https://symfony.com/doc/current/bundles/DoctrineBundle/index.html

--- a/doctrine/dbal.rst
+++ b/doctrine/dbal.rst
@@ -20,10 +20,14 @@ makes it easy to execute queries and perform other database actions.
 
     Read the official Doctrine `DBAL Documentation`_ to learn all the details
     and capabilities of Doctrine's DBAL library.
-    
-    Before you start you will need `DoctrineBundle`_ which supports both Doctrine ORM and Doctrine DBAL (together or just DBAL). This will generate ``config/packages/doctrine.yaml``.
 
-To get started, configure the ``DATABASE_URL`` environment variable in ``.env``:
+First, install the Doctrine bundle:
+
+.. code-block:: terminal
+
+    composer require doctrine/doctrine-bundle
+
+Then configure the ``DATABASE_URL`` environment variable in ``.env``:
 
 .. code-block:: text
 
@@ -158,4 +162,3 @@ mapping type:
 .. _`Doctrine`:      http://www.doctrine-project.org
 .. _`DBAL Documentation`: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/index.html
 .. _`Custom Mapping Types`: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#custom-mapping-types
-.. _`DoctrineBundle`:      https://symfony.com/doc/current/bundles/DoctrineBundle/index.html


### PR DESCRIPTION
Current documentation steps do not work for fresh Symfony 4 instance. Doctrine.yml file does not exist and DBAL installation from Composer does not get recognized or autowired. DoctrineBundle is a way to use both Doctrine ORM on the top of Doctrine DBAL or just pure DBAL.