### PR TITLE
Trigger DnsMock::register

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -356,6 +356,8 @@ In order to avoid making a real network connection, add the ``@dns-sensitive``
 annotation to the class and use the ``DnsMock::withMockedHosts()`` to configure
 the data you expect to get for the given hosts::
 
+    namespace Symfony\Component\Validator\Tests\Constraints;
+
     use PHPUnit\Framework\TestCase;
     use Symfony\Component\Validator\Constraints\Email;
 


### PR DESCRIPTION
DnsMock::register mocks PHP functions on the namespace level.

See:
https://github.com/symfony/phpunit-bridge/blob/3.4/DnsMock.php#L180
https://github.com/symfony/validator/blob/master/Tests/Constraints/EmailValidatorTest.php#L363