### PR TITLE
Use symfony/skeleton to show the welcome page again

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -17,7 +17,7 @@ Create your new project by running:
 
 .. code-block:: terminal
 
-    $ composer create-project symfony/website-skeleton my-project
+    $ composer create-project symfony/skeleton my-project
 
 This will create a new ``my-project`` directory, download some dependencies into
 it and even generate the basic directories and files you'll need to get started.


### PR DESCRIPTION
If you create the symfony/website-skeleton as suggested in the docs you won't see the welcome page as stated later on this page ("If everything is working, you'll see a welcome page") but a 404 error, because of the routes the profiler generates.
(see also https://stackoverflow.com/questions/48643561/symfony-4-setup-issues-router-exception/48647114#48647114)
Also on the 'next' page "Create your First Page in Symfony" the installation of the profiler is suggested which is already installed with the symfony/website-skeleton.