### PR TITLE
Update service_container.rst

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -289,10 +289,12 @@ made. To do that, you create a new class::
         {
             $happyMessage = $this->messageGenerator->getHappyMessage();
 
-            $message = (new \Swift_Message('Someone just updated the site. We told them: '.$happyMessage))
-                ->setSubject('Site update just happened!')
+            $message = (new \Swift_Message('Site update just happened!))
                 ->setFrom('admin@example.com')
-                ->setTo('manager@example.com');
+                ->setTo('manager@example.com')
+                ->addPart(
+                    'Someone just updated the site. We told them: '.$happyMessage
+                );
 
             return $this->mailer->send($message) > 0;
         }

--- a/service_container.rst
+++ b/service_container.rst
@@ -289,13 +289,10 @@ made. To do that, you create a new class::
         {
             $happyMessage = $this->messageGenerator->getHappyMessage();
 
-            $message = \Swift_Message::newInstance()
+            $message = (new \Swift_Message('Someone just updated the site. We told them: '.$happyMessage))
                 ->setSubject('Site update just happened!')
                 ->setFrom('admin@example.com')
-                ->setTo('manager@example.com')
-                ->addPart(
-                    'Someone just updated the site. We told them: '.$happyMessage
-                );
+                ->setTo('manager@example.com');
 
             return $this->mailer->send($message) > 0;
         }


### PR DESCRIPTION
Since 6 use `$message = (new \Swift_Message('message'))` instead of `$message = \Swift_Message::newInstance()`

Please check https://github.com/swiftmailer/swiftmailer/blob/master/CHANGES#L24 and https://swiftmailer.symfony.com/docs/introduction.html#basic-usage