### PR TITLE
Adding guidelines for reporting violations of code of conduct

### DIFF
--- a/contributing/code_of_conduct/enforcement_team.rst
+++ b/contributing/code_of_conduct/enforcement_team.rst
@@ -1,5 +1,30 @@
 Enforcement Team
 ================
 
-We're preparing the "Enforcement Team" for the new Symfony Code of Conduct.
-Come back to this article in a few days to see the members of that team.
+Our Pledge
+----------
+
+In the interest of fostering an open and welcoming environment, the enforcement team
+pledge to ensure that the spirit of the :doc:`Code of Conduct </contributing/code_of_conduct/index>`
+is respected. Our main priority is to ensure the safety of our community members.
+The second goal is to help educate the community as a whole to be aware of the CoC
+and how to help implement its spirit throughout the community. In case these goals
+conflict, we will prioritize safety of community members over all other goals.
+
+If you think there is or has been a violation to the code of conduct please contact
+enforcement team or if you prefer contact only individual members of the enforcement team.
+
+Members
+-------
+
+Here are all the members of the Code of Conduct enforcement team. You can contact
+any of them directly using the contact details below or you can also contact all of
+them at once by emailing **coc@symfony.com**.
+
+About the Enforcement Team
+--------------------------
+
+The :doc:`Symfony project leader </contributing/code/core_team>` appoints enforcement
+team with candidates they see fit. The enforcement team will consist of at least
+3 people. The team should be representing as many demographics as possible,
+ideally from different employers.

--- a/contributing/code_of_conduct/reporting_guidelines.rst
+++ b/contributing/code_of_conduct/reporting_guidelines.rst
@@ -1,6 +1,98 @@
 Reporting Guidelines
 ====================
 
-We're preparing the "Reporting Guidelines" to explain how can you report a
-violation of the new Symfony Code of Conduct. Come back to this article in a
-few days to see the process in detail.
+If you believe someone is violating the Code of Conduct we ask that you report
+it to the :doc:`enforcement team </contributing/code_of_conduct/enforcement_team>`
+by emailing, Twitter, in person or any way you see fit.
+
+**All reports will be kept confidential.** The privacy of everyone included in
+the report is of our highest concern. Second to privacy there is transparency.
+After every report we will determine if a public statement should be made. If
+that's the case, the identities of all victims, reporters, and the accused will
+remain confidential unless those individuals instruct us otherwise. The details
+of the incident may also be generalized.
+
+If you believe anyone is in physical danger or doing something that is against
+the law, please notify appropriate emergency services first by calling the relevant
+local authorities. If you are unsure what service or agency is appropriate to
+contact, include this in your report and we will attempt to notify them.
+
+In your report please include:
+
+  * Your contact info for follow-up contact.
+  * Names (legal, nicknames, or pseudonyms) of any individuals involved.
+  * If there were other witnesses besides you, please try to include them as well.
+  * When and where the incident occurred. Please be as specific as possible.
+  * Your description of what occurred.
+  * If there is a publicly available record (e.g. a mailing list archive or a
+    public IRC or Slack log), please include a link and a screenshot.
+  * If you believe this incident is ongoing.
+  * Any other information you believe we should have.
+
+What happens after you file a report?
+-------------------------------------
+
+You will receive a reply from the :doc:`enforcement team </contributing/code_of_conduct/enforcement_team>`
+acknowledging receipt as soon as possible, but within 24 hours.
+
+The team member receiving the report will immediately contact all or some other
+enforcement team members to review the incident and determine:
+
+  * What happened.
+  * Whether this event constitutes a Code of Conduct violation.
+  * What kind of response is appropriate.
+
+If this is determined to be an ongoing incident or a threat to physical safety,
+the team's immediate priority will be to protect everyone involved. This means
+we may delay an "official" response until we believe that the situation has ended
+and that everyone is physically safe.
+
+Once the team has a complete account of the events, they will make a decision as
+to how to respond. Responses may include:
+
+  * Nothing (if we determine no Code of Conduct violation occurred).
+  * A private reprimand from the Code of Conduct response team to the individual(s)
+    involved.
+  * An imposed vacation (i.e. asking someone to "take a week off" from a mailing
+    list or Slack).
+  * A permanent or temporary ban from some or all Symfony conference/community
+    spaces (events, meetings, mailing lists, IRC, Slack, etc.)
+  * A request to engage in mediation and/or an accountability plan.
+  * On a case by case basis, other actions may be possible but will usually be
+    coordinated with the core team and the Symfony company.
+
+We'll respond within one week to the person who filed the report with either a
+resolution or an explanation of why the situation is not yet resolved.
+
+Once we've determined our final actions, we'll contact the original reporter to
+let them know what action (if any) we'll be taking. We'll take into account feedback
+from the reporter on the appropriateness of our response, but our response will be
+determined by what will be best for community safety.
+
+The enforcement team keeps a private record of all incidents. By default all reports
+are shared with the entire enforcement team unless the reporter specifically asks
+to exclude specific enforcement team members, in which case these enforcement team
+members will not be included in any communication on the incidents as well as records
+created related to the incidents.
+
+Enforcement team members are expected to inform the enforcement team and the reporters
+in case of conflicts on interest and recuse themselves if this is deemed a problem.
+
+Appealing the response
+----------------------
+
+Only permanent resolutions (such as bans) may be appealed. To appeal a decision
+of the working group, contact the :doc:`enforcement team </contributing/code_of_conduct/enforcement_team>`
+with your appeal and they will review the case.
+
+Document origin
+---------------
+
+Reporting Guidelines derived from those of the `Stumptown Syndicate`_ and the
+`Django Software Foundation`_.
+
+Adopted by `Symfony`_ organizers on 21 February 2018.
+
+.. _`Stumptown Syndicate`: http://stumptownsyndicate.org/code-of-conduct/reporting-guidelines/
+.. _`Django Software Foundation`: https://www.djangoproject.com/conduct/reporting/
+.. _`Symfony`: https://symfony.com

--- a/contributing/index.rst
+++ b/contributing/index.rst
@@ -8,5 +8,6 @@ Contributing
     code/index
     documentation/index
     community/index
+    code_of_conduct/index
 
 .. include:: /contributing/map.rst.inc


### PR DESCRIPTION
We need some guidelines on how to report a violation of the code of conduct. These are adapted from [Stumptown Syndicate](http://stumptownsyndicate.org/code-of-conduct/reporting-guidelines/) and the [Django Software Foundation](https://www.djangoproject.com/conduct/reporting/).

FYI @lsmith77 

This is related to https://github.com/symfony/diversity/issues/2

## TODO

- [ ] Add the enforcement team instead of the placeholders
- [ ] Add the code of conduct instead of the place holder
