### PR TITLE
Configuration for webpack dev-server in vm/docker for rebound host interfaces

### DIFF
--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -32,10 +32,19 @@ to bind to all IP addresses and allow any host to access the server:
 
 .. code-block:: terminal
 
-    $ ./node_modules/.bin/encore dev-server --host 0.0.0.0 --disable-host-check
+    $ ./node_modules/.bin/encore dev-server --public http://docker-host:9000 --port 9000 --host 0.0.0.0 --disable-host-check
 
 You can now access the dev-server using the IP address to your virtual machine on
-port 8080 - e.g. http://192.168.1.1:8080.
+port 9000 - e.g. http://192.168.1.1:9000.
+If you've activated the :ref:`manifest.json versioning <load-manifest-files>` you need additional configuration to alter the url used in your templates to the ``dev-server``:
+
+.. code-block:: javascript
+    
+    Encore
+        .setManifestKeyPrefix('build/')
+
+When you're using the ``dev-server`` in a docker container, configure accordingly and bind the port from the ``dev-server`` (default 8080) onto a port on the host and provide this port --public parameter above.
+
 
 Hot Module Replacement HMR
 --------------------------


### PR DESCRIPTION
This is the discussion, for setting an absolute url as publicPath, when you're binding the dev server not to localhost but to any external interface (0.0.0.0) and disable host checking:

https://github.com/symfony/webpack-encore/pull/96

The problem is, that when you bind the dev-server to all interfaces with `--host 0.0.0.0` this url will be written to the manifest.json, when versioning is used:
`"build/main.js": "http://0.0.0.0:8080/build/main.js",

Instead the external-interface should be used:
`"build/main.js": "http://192.168.1.1:8080/build/main.js"

When in docker, you need a port mapping, to make the dev-server accessible, when browsing the site with a browser running on the host.
(please note, that it isn't possible to access docker containers with their internal ip from the host, when running docker on windows. That's why we should always recommend a host-port-mapping for the docker-container)

best regards
philipp