### PR TITLE
Update flex.rst - Add step in migration-process

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -176,6 +176,15 @@ manual steps:
    .. code-block:: terminal
 
        $ composer remove symfony/symfony
+       
+   Now add the ``symfony/symfony``-package to the ``conflict``-section of the project's
+   ``composer.json`` file as `shown in this example of the skeleton-project`_ so that it will not be installed again.
+
+   .. code-block:: json
+
+        "conflict": {
+            "symfony/symfony": "*"
+        },
 
    Now you must add in ``composer.json`` all the Symfony dependencies required
    by your project. A quick way to do that is to add all the components that
@@ -254,5 +263,6 @@ manual steps:
 .. _`Symfony Recipes documentation`: https://github.com/symfony/recipes/blob/master/README.rst
 .. _`default services.yaml file`: https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/config/services.yaml
 .. _`shown in this example`: https://github.com/symfony/skeleton/blob/8e33fe617629f283a12bbe0a6578bd6e6af417af/composer.json#L24-L33
+.. _`shown in this example of the skeleton-project`: https://github.com/symfony/skeleton/blob/8e33fe617629f283a12bbe0a6578bd6e6af417af/composer.json#L44-L46
 .. _`copying Symfony's index.php source`: https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/public/index.php
 .. _`copying Symfony's bin/console source`: https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console

--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -177,8 +177,9 @@ manual steps:
 
        $ composer remove symfony/symfony
        
-   Now add the ``symfony/symfony``-package to the ``conflict``-section of the project's
-   ``composer.json`` file as `shown in this example of the skeleton-project`_ so that it will not be installed again.
+   Now add the ``symfony/symfony`` package to the ``conflict`` section of the project's
+   ``composer.json`` file as `shown in this example of the skeleton-project`_ so that
+   it will not be installed again:
 
    .. code-block:: json
 


### PR DESCRIPTION
I added the step to add 'symfony/symfony' to the `conflict`-section of your composer.json-file.

I did not do this until after the step to change your `index.php`-section.  This resulted in a lot of recipe's not being executed since the libraries for that were still being installed by `symfony/symfony`.

Language improvements are welcomed since English is not my mother tongue.