### PR TITLE
Clarify unanimous access strategy description

### DIFF
--- a/security/voters.rst
+++ b/security/voters.rst
@@ -278,7 +278,9 @@ strategies available:
     This grants access if there are more voters granting access than denying;
 
 ``unanimous``
-    This only grants access once *all* voters grant access.
+    This only grants access if there is no voter denying access. 
+    ``allow_if_all_abstain`` configuration option can be used if voter granting 
+    access is also required.
 
 In the above scenario, both voters should grant access in order to grant access
 to the user to read the post. In this case, the default strategy is no longer

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -278,9 +278,9 @@ strategies available:
     This grants access if there are more voters granting access than denying;
 
 ``unanimous``
-    This only grants access if there is no voter denying access. 
-    ``allow_if_all_abstain`` configuration option can be used if voter granting 
-    access is also required.
+    This only grants access if there is no voter denying access. If all voters
+    abstained from voting, the decision is based on the ``allow_if_all_abstain``
+    config option (which defaults to ``false``).
 
 In the above scenario, both voters should grant access in order to grant access
 to the user to read the post. In this case, the default strategy is no longer


### PR DESCRIPTION
In my opinion saying that unanimous strategy "requires all voters to grant access" is misleading. In actuality, this strategy requires that no voter denies access, and this PR intends to clarify that.