### PR TITLE
Typo fix

### DIFF
--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -326,7 +326,7 @@ correctly. To validate the types of the options, call
 
             // check all items in an array recursively for a type
             $resolver->setAllowedTypes('dates', 'DateTime[]');
-            $resolver->setAllowedtypes('ports', 'int[]');
+            $resolver->setAllowedTypes('ports', 'int[]');
         }
     }
 


### PR DESCRIPTION
`Symfony\Component\OptionsResolver\OptionsResolver::setAllowedtypes` method doesn't exist
it's `setAllowedTypes`.