### PR TITLE
[SecurityBundle] Document switch_user.stateless firewall option

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -302,6 +302,7 @@ Each part will be explained in the next section.
                         provider:             ~
                         parameter:            _switch_user
                         role:                 ROLE_ALLOWED_TO_SWITCH
+                        stateless:            false
 
             access_control:
                 requires_channel:     ~

--- a/security/impersonating_user.rst
+++ b/security/impersonating_user.rst
@@ -66,6 +66,11 @@ firewall listener:
             ),
         ));
 
+.. tip::
+
+    For using the ``switch_user`` listener in a ``stateless`` firewall, set the
+    ``switch_user.stateless`` option to ``true``.
+
 To switch to another user, just add a query string with the ``_switch_user``
 parameter and the username as the value to the current URL:
 


### PR DESCRIPTION
Fixes #8447.
Note for mergers: this should be removed in 4.0, the `switch_user.stateless` is set according to the firewall `stateless` option value there so it just works naturally and the config option is useless.