### PR TITLE
Adding Code of Conduct

### DIFF
--- a/contributing/code_of_conduct/index.rst
+++ b/contributing/code_of_conduct/index.rst
@@ -7,8 +7,8 @@ Our Pledge
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance, ethnic origin,
+size, disability, ethnic origin, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance,
 religion, or sexual identity and orientation.
 
 Our Standards

--- a/contributing/code_of_conduct/index.rst
+++ b/contributing/code_of_conduct/index.rst
@@ -1,0 +1,91 @@
+Code of Conduct
+===============
+
+Our Pledge
+----------
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+Our Standards
+-------------
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Our Responsibilities
+--------------------
+
+:doc:`Enforcement team members </contributing/code_of_conduct/enforcement_team>`
+are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Enforcement team members have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Scope
+-----
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by enforcement team members.
+
+Enforcement
+-----------
+
+Instances of abusive, harassing, or otherwise unacceptable behavior 
+:doc:`may be reported </contributing/code_of_conduct/reporting_guidelines>`
+by contacting the :doc:`enforcement team members </contributing/code_of_conduct/enforcement_team>`.
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Enforcement team members who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+Attribution
+-----------
+
+This Code of Conduct is adapted from the `Contributor Covenant`_, version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+Related documents
+-----------------
+
+.. toctree::
+    :maxdepth: 1
+
+    reporting_guidelines
+    enforcement_team
+
+.. _Contributor Covenant: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/contributing/code_of_conduct/index.rst
+++ b/contributing/code_of_conduct/index.rst
@@ -65,7 +65,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior
 :doc:`may be reported </contributing/code_of_conduct/reporting_guidelines>`
 by contacting the :doc:`enforcement team members </contributing/code_of_conduct/enforcement_team>`.
 All complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
+is deemed necessary and appropriate to the circumstances. The enforcement team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 

--- a/contributing/code_of_conduct/index.rst
+++ b/contributing/code_of_conduct/index.rst
@@ -70,7 +70,8 @@ obligated to maintain confidentiality with regard to the reporter of an incident
 Further details of specific enforcement policies may be posted separately.
 
 Enforcement team members who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by the core team.
+faith may face temporary or permanent repercussions as determined by the
+:doc:`core team </contributing/code/core_team>`.
 
 Attribution
 -----------

--- a/contributing/code_of_conduct/index.rst
+++ b/contributing/code_of_conduct/index.rst
@@ -87,5 +87,6 @@ Related documents
 
     reporting_guidelines
     enforcement_team
+    concrete_example_document
 
 .. _Contributor Covenant: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/contributing/code_of_conduct/index.rst
+++ b/contributing/code_of_conduct/index.rst
@@ -79,7 +79,7 @@ Attribution
 This Code of Conduct is adapted from the `Contributor Covenant`_, version 1.4,
 available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
-Related documents
+Related Documents
 -----------------
 
 .. toctree::
@@ -89,4 +89,4 @@ Related documents
     enforcement_team
     concrete_example_document
 
-.. _Contributor Covenant: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+.. _Contributor Covenant: https://www.contributor-covenant.org

--- a/contributing/code_of_conduct/index.rst
+++ b/contributing/code_of_conduct/index.rst
@@ -8,7 +8,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance, race,
+education, socio-economic status, nationality, personal appearance, ethnic origin,
 religion, or sexual identity and orientation.
 
 Our Standards

--- a/contributing/code_of_conduct/index.rst
+++ b/contributing/code_of_conduct/index.rst
@@ -70,8 +70,7 @@ obligated to maintain confidentiality with regard to the reporter of an incident
 Further details of specific enforcement policies may be posted separately.
 
 Enforcement team members who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+faith may face temporary or permanent repercussions as determined by the core team.
 
 Attribution
 -----------


### PR DESCRIPTION
Adding the Contributor Covenant Code of Conduct version 1.4. 
Relates to https://github.com/symfony/diversity/issues/1

**TODO**
- [x] Add the link to the enforcement team page
- [x] Add the link to the enforcement process
- [x] Add the link to concrete real-world examples of unwanted behavior
- [x] Change "Project maintainers" to "Enforcement team members"

Part of https://github.com/symfony/symfony-docs/pull/9340 and https://github.com/symfony/symfony-docs/pull/9393

Replaces https://github.com/symfony/symfony/pull/24896