### PR TITLE
Update email field length in annotation (User class in security section)

### DIFF
--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -67,7 +67,7 @@ with the following fields: ``id``, ``username``, ``password``,
         private $password;
 
         /**
-         * @ORM\Column(type="string", length=60, unique=true)
+         * @ORM\Column(type="string", length=254, unique=true)
          */
         private $email;
 


### PR DESCRIPTION
I believe 60 characters for email is not enough, because maximum length of email is 254 chars. See https://stackoverflow.com/a/574698/3000493