### PR TITLE
SF 4+ does not rely on Command inheritance anymore

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -72,9 +72,7 @@ method. Then you can optionally define a help message and the
 Executing the Command
 ---------------------
 
-Symfony registers any PHP class extending :class:`Symfony\\Component\\Console\\Command\\Command`
-as a console command automatically. So you can now execute this command in the
-terminal:
+You can now execute this command in the terminal:
 
 .. code-block:: terminal
 
@@ -82,10 +80,12 @@ terminal:
 
 .. note::
 
-    If you're using the :ref:`default services.yaml configuration <service-container-services-load-example>`,
-    your command classes are automatically registered as services.
+    The command class must be registered as a service with the ``console.command`` tag.
 
-    You can also manually register your command as a service by configuring the service
+    If you're using the :ref:`default services.yaml configuration <service-container-services-load-example>`,
+    this is already done for you, thanks to :ref:`autoconfiguration <services-autoconfigure>`.
+
+    Otherwise, you can manually register your command as a service by configuring the service
     and :doc:`tagging it </service_container/tags>` with ``console.command``.
 
 As you might expect, this command will do nothing as you didn't write any logic


### PR DESCRIPTION
As stated in [UPGRADE FROM 3.x to 4.0](https://github.com/symfony/symfony/blob/master/UPGRADE-4.0.md#httpkernel), relying on convention-based commands discovery is not supported anymore.

This trick will only work with bundle autoconfiguration, which is not enabled by default on many 3rd-party bundles. This means a 3rd party bundle that wants to upgrade from SF 3.4 to SF 4.0 doesn't just have to edit its `composer.json`,  its commands must either be tagged with `console.command` or autoconfigured. 

When [struggling with this](https://stackoverflow.com/questions/49134340/symfony-4-3rd-party-bundle-commands-are-no-longer-automatically-discovered) my eyes just hit the _Symfony registers any PHP class extending Command as a console command automatically_ sentence and I didn't figure out why it didn't work.