### PR TITLE
Added a short section about registering commands

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -64,7 +64,7 @@ method. Then you can optionally define a help message and the
 Registering the Command
 -----------------------
 
-Symfony commands must be registered as services and :ref:`tagged </service_container/tags>`
+Symfony commands must be registered as services and :doc:`tagged </service_container/tags>`
 with the ``console.command`` tag. If the PHP class of your command extends from
 :class:`Symfony\\Component\\Console\\Command\\Command`, Symfony does this for
 you automatically.

--- a/console.rst
+++ b/console.rst
@@ -61,10 +61,18 @@ method. Then you can optionally define a help message and the
         ;
     }
 
+Registering the Command
+-----------------------
+
+Symfony commands must be registered as services and :ref:`tagged </service_container/tags>`
+with the ``console.command`` tag. If the PHP class of your command extends from
+:class:`Symfony\\Component\\Console\\Command\\Command`, Symfony does this for
+you automatically.
+
 Executing the Command
 ---------------------
 
-After configuring the command, you can execute it in the terminal:
+After configuring and registering the command, you can execute it in the terminal:
 
 .. code-block:: terminal
 


### PR DESCRIPTION
After merging #9403, I realized that we could add a short section explaining that commands must be registered (although Symfony does this for you most of the times). If we merge this, in 3.4 I'll change the description to mention the autoconfiguration instead of this, which is what #9403 fixed.