### PR TITLE
Fixing a typo on the mustRun method

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -106,7 +106,7 @@ with a non-zero code)::
 
         echo $process->getOutput();
     } catch (ProcessFailedException $exception) {
-        echo $e->getMessage();
+        echo $exception->getMessage();
     }
 
 Getting real-time Process Output


### PR DESCRIPTION
On the mustRun method of the Process chapter, a bad argument is used on try {} catch{} section.