### PR TITLE
Fix FQCN in PHP example for expression language

### DIFF
--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -60,7 +60,7 @@ to another service: ``App\Mailer``. One way to do this is with an expression:
         $container->autowire(MailerConfiguration::class);
 
         $container->autowire(Mailer::class)
-            ->addArgument(new Expression('service("App\Mail\MailerConfiguration").getMailerMethod()'));
+            ->addArgument(new Expression('service("App\\\\Mail\\\\MailerConfiguration").getMailerMethod()'));
 
 To learn more about the expression language syntax, see :doc:`/components/expression_language/syntax`.
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->

I was following the example and got an error `You have requested a non-existent service \"AppMailMailerConfiguration\"`. I debugged it and I think it’s not an code issue but just the documentation. The YAML version also uses 4 `\`. Maybe we need to fix the XML version as well but I wasn’t sure and didn’t have time to test it.
