### PR TITLE
Add rule to import classes except for built-in PHP classes.

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -194,6 +194,9 @@ Structure
 
 * Do not use spaces around ``[`` offset accessor and before ``]`` offset accessor.
 
+* Import classes from other namespaces with the ``use`` statement, except for
+  built-in PHP classes.
+
 Naming Conventions
 ~~~~~~~~~~~~~~~~~~
 

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -192,10 +192,9 @@ Structure
 * Do not use ``else``, ``elseif``, ``break`` after ``if`` and ``case`` conditions
   which return or throw something;
 
-* Do not use spaces around ``[`` offset accessor and before ``]`` offset accessor.
+* Do not use spaces around ``[`` offset accessor and before ``]`` offset accessor;
 
-* Import classes from other namespaces with the ``use`` statement, except for
-  built-in PHP classes.
+* Add a ``use`` statement for every class that is not part of the global namespace.
 
 Naming Conventions
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #9426 (class imports were shown in the example but there was no rule in the text).