### PR TITLE
Fix French translation

### DIFF
--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -12,7 +12,7 @@ Imagine you want to translate the string *"Symfony is great"* into French::
     $translator = new Translator('fr_FR');
     $translator->addLoader('array', new ArrayLoader());
     $translator->addResource('array', array(
-        'Symfony is great!' => 'J\'aime Symfony!',
+        'Symfony is great!' => 'Symfony est super !',
     ), 'fr_FR');
 
     var_dump($translator->trans('Symfony is great!'));


### PR DESCRIPTION
In French, the `!` must have one space before and after, the english punctuation here use in French sentence is wrong. And "J'aime Symfony" is "I like Symfony", it has a different sense from "Symfony is great".