### PR TITLE
Update locale_sticky_session.rst

### DIFF
--- a/session/locale_sticky_session.rst
+++ b/session/locale_sticky_session.rst
@@ -164,13 +164,6 @@ event::
                 $this->session->set('_locale', $user->getLocale());
             }
         }
-
-        public static function getSubscribedEvents()
-        {
-            return array(
-                SecurityEvents::INTERACTIVE_LOGIN => array(array('onInteractiveLogin', 15)),
-            );
-        }
     }
 
 Then register the listener:
@@ -185,7 +178,7 @@ Then register the listener:
                 class: AppBundle\EventListener\UserLocaleListener
                 arguments: ['@session']
                 tags:
-                    - { name: kernel.event_listener, event: security.interactive_login, method: onInteractiveLogin }
+                    - { name: kernel.event_listener, event: security.interactive_login, method: onInteractiveLogin, priority: 15 }
 
     .. code-block:: xml
 

--- a/session/locale_sticky_session.rst
+++ b/session/locale_sticky_session.rst
@@ -132,7 +132,6 @@ event::
     // src/AppBundle/EventListener/UserLocaleListener.php
     namespace AppBundle\EventListener;
 
-    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
     use Symfony\Component\HttpFoundation\Session\Session;
     use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
     use Symfony\Component\Security\Http\SecurityEvents;
@@ -197,7 +196,7 @@ Then register the listener:
 
                     <tag name="kernel.event_listener"
                         event="security.interactive_login"
-                        method="onInteractiveLogin" />
+                        method="onInteractiveLogin" priority=15 />
                 </service>
             </services>
         </container>
@@ -213,7 +212,7 @@ Then register the listener:
             ->addArgument(new Reference('session'))
             ->addTag(
                 'kernel.event_listener',
-                array('event' => 'security.interactive_login', 'method' => 'onInteractiveLogin')
+                array('event' => 'security.interactive_login', 'method' => 'onInteractiveLogin', 'priority' => 15)
             );
 
 .. caution::


### PR DESCRIPTION
Hi, I removed the 'public static function getSubscribedEvents' on the UserLocaleListener because it's useless, it's not an EventSubscriber. What do you think?

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
