### PR TITLE
Fix typo on Method for getSubject Docs

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -349,7 +349,7 @@ This means that each event has access to the following information:
 :method:`Symfony\\Component\\Workflow\\Event\\Event::getMarking`
     Returns the :class:`Symfony\\Component\\Workflow\\Marking` of the workflow.
 
-:method:`Symfony\\Component\\Worflow\\Event\\Event::getSubject`
+:method:`Symfony\\Component\\Workflow\\Event\\Event::getSubject`
     Returns the object that dispatches the event.
 
 :method:`Symfony\\Component\\Workflow\\Event\\Event::getTransition`


### PR DESCRIPTION
Typo causes a 404 not found when referencing the getSubject method of the workflow documentation. 

Earliest maintained version this occurs is 4.0
