### PR TITLE
Update deployment.rst

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -217,7 +217,7 @@ Deployments not Using the ``composer.json`` File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Symfony applications provide a ``kernel.project_dir`` parameter and a related
-:method:`Symfony\\Component\\HttpKernel\\Kernel\\Kernel::getProjectDir>` method.
+:method:`Symfony\\Component\\HttpKernel\\Kernel::getProjectDir` method.
 You can use this method to perform operations with file paths relative to your
 project's root directory. The logic to find that project root directory is based
 on the location of the main ``composer.json`` file.


### PR DESCRIPTION
Fix 404 not found
the link was:
- http://api.symfony.com/3.4/Symfony/Component/HttpKernel/Kernel/Kernel.html#method_getProjectDir> (404)
And I tried to make it like this:
-http://api.symfony.com/3.4/Symfony/Component/HttpKernel/Kernel.html#method_getProjectDir (working)

But since I don't know how links are generated from the doc I guess that removing the useless "Kernel" and ">" can do the job.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
