### PR TITLE
Include a reference to the namespace option

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -134,18 +134,21 @@ Full Default Configuration
                             port:                 ~
                             instance_class:       ~
                             class:                ~
+                            namespace:            ~
                         metadata_cache_driver:
                             type:                 array # Required
                             host:                 ~
                             port:                 ~
                             instance_class:       ~
                             class:                ~
+                            namespace:            ~
                         result_cache_driver:
                             type:                 array # Required
                             host:                 ~
                             port:                 ~
                             instance_class:       ~
                             class:                ~
+                            namespace:            ~
                         connection:           ~
                         class_metadata_factory_name:  Doctrine\ORM\Mapping\ClassMetadataFactory
                         default_repository_class:  Doctrine\ORM\EntityRepository


### PR DESCRIPTION
Currently the Symfony doc doesn't appear to mention the `namespace` option for Doctrine's cache drivers that is available [since DoctrineBundle v1.3.0](https://github.com/doctrine/DoctrineBundle/commit/d2110726f116b2f2e8b3e6887ecedcd707542b68)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
