### PR TITLE
Update routing.rst: fixing table

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -506,12 +506,12 @@ redirect between them.
 Symfony follows this logic to redirect between URLs with and without trailing
 slashes (but only for ``GET`` and ``HEAD`` requests):
 
-----------  ----------------------------------------  ------------------------------------------
+==========  ========================================  ==========================================
 Route path  If the requested URL is ``/foo``          If the requested URL is ``/foo/``
-----------  ----------------------------------------  ------------------------------------------
+==========  ========================================  ==========================================
 ``/foo``    It matches (``200`` status response)      It doesn't match (``404`` status response)
 ``/foo/``   It makes a ``301`` redirect to ``/foo/``  It matches (``200`` status response)
-----------  ----------------------------------------  ------------------------------------------
+==========  ========================================  ==========================================
 
 In summary, adding a trailing slash in the route path is the best way to ensure
 that both URLs work. Read the :doc:`/routing/redirect_trailing_slash` article to


### PR DESCRIPTION
See: http://symfony.com/doc/current/routing.html#redirecting-urls-with-trailing-slashes

The table is broken, I'm not sure when this happened - it works in 2.7, and in 3.3, this information is gone completely. So, this is the first branch where it's not correct.