### PR TITLE
change targetDirectory to targetDir

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -237,11 +237,11 @@ logic to a separate service::
 
     class FileUploader
     {
-        private $targetDirectory;
+        private $targetDir;
 
-        public function __construct($targetDirectory)
+        public function __construct($targetDir)
         {
-            $this->targetDirectory = $targetDirectory;
+            $this->targetDir = $targetDir;
         }
 
         public function upload(UploadedFile $file)
@@ -255,7 +255,7 @@ logic to a separate service::
 
         public function getTargetDirectory()
         {
-            return $this->targetDirectory;
+            return $this->targetDir;
         }
     }
 


### PR DESCRIPTION
the argument name passed for the FileUploader service  class is not the same inside the service.yml file

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
