### PR TITLE
There is nothing to edit. This is a suggestion.

### DIFF
--- a/logging/monolog_console.rst
+++ b/logging/monolog_console.rst
@@ -31,7 +31,7 @@ Instead of using these semantic methods to test for each of the verbosity
 levels, the `MonologBridge`_ provides a `ConsoleHandler`_ that listens to
 console events and writes log messages to the console output depending on the
 current log level and the console verbosity.
-
+ 
 The example above could then be rewritten as::
 
     use Psr\Log\LoggerInterface;


### PR DESCRIPTION
If I use Monolog to send information to the console, this creates a problem during PHPUnit testing as I can't find any way to validate my command. I tried following the documentation here : https://symfony.com/doc/current/console.html 

But I did not manage to get anything from the logger. And the hardest part is the fact that we're missing information to access logger from Symfony4. 3.4 returns an error saying that $kernel->getContainer()->get('logger') is private and will not work in 4.0. How do I inject monolog with a ConsoleHandler to my PHPUnit Tests. Thank you!

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
