### PR TITLE
Remove docs about service_name:method

### DIFF
--- a/controller/service.rst
+++ b/controller/service.rst
@@ -19,9 +19,6 @@ If the service id is the fully-qualified class name (FQCN) of your controller,
 you're done! You can use the normal ``App\Controller\HelloController::index``
 syntax in your routing and it will find your service.
 
-But, if your service has a different id, you can use a special
-``service_id:method_name`` syntax:
-
 .. configuration-block::
 
     .. code-block:: php-annotations

--- a/routing.rst
+++ b/routing.rst
@@ -534,8 +534,6 @@ Controller Naming Pattern
 -------------------------
 
 The ``controller`` value in your routes has a very simple format ``CONTROLLER_CLASS::METHOD``.
-If your controller is registered as a service, you can also use just one colon separator
-(e.g. ``service_name:index``).
 
 .. tip::
 


### PR DESCRIPTION
The 'service_name:method' syntax is deprecated as of 4.1

This fixes https://github.com/symfony/symfony-docs/issues/9306.