### PR TITLE
Documented the trailing_slash_on_root option

### DIFF
--- a/routing/external_resources.rst
+++ b/routing/external_resources.rst
@@ -187,7 +187,7 @@ be prefixed with the string ``/site``.
             use Symfony\Component\Routing\RouteCollection;
 
             $app = $loader->import('../src/Controller/', 'annotation');
-            // the second argument is the $trailing_slash_on_root option
+            // the second argument is the $trailingSlashOnRoot option
             $app->addPrefix('/site', false);
             // ...
 

--- a/routing/external_resources.rst
+++ b/routing/external_resources.rst
@@ -156,18 +156,6 @@ be prefixed with the string ``/site``.
 
     .. configuration-block::
 
-        .. code-block:: php-annotations
-
-            use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-
-            /**
-             * @Route("/site", "trailing_slash_on_root"="false")
-             */
-            class DefaultController
-            {
-                // ...
-            }
-
         .. code-block:: yaml
 
             # config/routes.yaml

--- a/routing/external_resources.rst
+++ b/routing/external_resources.rst
@@ -147,6 +147,65 @@ suppose you want to prefix all application routes with ``/site`` (e.g.
 The path of each route being loaded from the new routing resource will now
 be prefixed with the string ``/site``.
 
+.. note::
+
+    If any of the prefixed routes defines an empty path, Symfony adds a trailing
+    slash to it. In the previous example, an empty path prefixed with ``/site``
+    will result in the ``/site/`` URL. If you want to avoid this behavior, set
+    the ``trailing_slash_on_root`` option to ``false``:
+
+    .. configuration-block::
+
+        .. code-block:: php-annotations
+
+            use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+
+            /**
+             * @Route("/site", "trailing_slash_on_root"="false")
+             */
+            class DefaultController
+            {
+                // ...
+            }
+
+        .. code-block:: yaml
+
+            # config/routes.yaml
+            controllers:
+                resource: '../src/Controller/'
+                type:     annotation
+                prefix:   /site
+                trailing_slash_on_root: false
+
+        .. code-block:: xml
+
+            <!-- config/routes.xml -->
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <routes xmlns="http://symfony.com/schema/routing"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://symfony.com/schema/routing
+                    http://symfony.com/schema/routing/routing-1.0.xsd">
+
+                <import
+                    resource="../src/Controller/"
+                    type="annotation"
+                    prefix="/site"
+                    trailing-slash-on-root="false" />
+            </routes>
+
+        .. code-block:: php
+
+            // config/routes.php
+            use Symfony\Component\Routing\RouteCollection;
+
+            $app = $loader->import('../src/Controller/', 'annotation');
+            // the second argument is the $trailing_slash_on_root option
+            $app->addPrefix('/site', false);
+            // ...
+
+    .. versionadded:: 4.1
+        The ``trailing_slash_on_root`` option was introduced in Symfony 4.1.
+
 Prefixing the Names of Imported Routes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This fixes #9484.

@nicolas-grekas could you please verify if the config of the example is correct? I don't know if `trailing_slash_on_root` is defined for annotations. Thanks!