### PR TITLE
Document host parameter and external parameters in "How to Use PdoSessionHandler..."

### DIFF
--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -23,8 +23,8 @@ To use it, first register a new handler service:
 
             Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
                 arguments:
-                    - 'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%'
-                    - { db_username: '%env(MYDATABASE_USERNAME)%', db_password: '%env(MYDATABASE_PASSWORD)%' }
+                    - 'mysql:dbname=mydatabase, host=myhost'
+                    - { db_username: myuser, db_password: mypassword }
 
                     # If you're using Doctrine & want to re-use that connection, then:
                     # comment-out the above 2 lines and uncomment the line below
@@ -43,10 +43,10 @@ To use it, first register a new handler service:
 
             <services>
                 <service id="Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler" public="false">
-                    <argument>mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%</argument>
+                    <argument>mysql:dbname=mydatabase, host=myhost</argument>
                     <argument type="collection">
-                        <argument key="db_username">%env(MYDATABASE_USERNAME)%</argument>
-                        <argument key="db_password">%env(MYDATABASE_PASSWORD)%</argument>
+                        <argument key="db_username">myuser</argument>
+                        <argument key="db_password">mypassword</argument>
                     </argument>
                 </service>
             </services>
@@ -60,21 +60,16 @@ To use it, first register a new handler service:
         $storageDefinition = $container->autowire(PdoSessionHandler::class)
             ->setArguments(
                 array(
-                    'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%',
-                    array(
-                        'db_username' => '%env(MYDATABASE_USERNAME)%',
-                        'db_password' => '%env(MYDATABASE_PASSWORD)',
-                    ),
+                    'mysql:dbname=mydatabase, host=myhost',
+                    array('db_username' => 'myuser', 'db_password' => 'mypassword'),
                 )
             );
 
-.. note::
+.. tip::
 
-    Ideally you want to reuse your database information from your environment variables.
-    These variables can be referenced in the service configuration using ``%env(PARAMETER_NAME)%``.
-    Do not forget to wrap these with single or double quotes in yaml.
-
-    See :doc:`/configuration/external_parameters`.
+    Configure the database credentials as
+    :doc:`parameters defined with environment variables </configuration/external_parameters>`
+    to make your application more secure.
 
 Next, tell Symfony to use your service as the session handler:
 
@@ -127,8 +122,8 @@ a second array argument to ``PdoSessionHandler``:
 
             Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
                 arguments:
-                    - 'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%'
-                    - { db_table: '%env(SESSIONS_TABLE)%, db_username: '%env(MYDATABASE_USERNAME)%', db_password: '%env(MYDATABASE_PASSWORD)%' }
+                    - 'mysql:dbname=mydatabase, host=myhost'
+                    - { db_table: 'sessions', db_username: 'myuser', db_password: 'mypassword' }
 
     .. code-block:: xml
 
@@ -141,11 +136,11 @@ a second array argument to ``PdoSessionHandler``:
 
             <services>
                 <service id="Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler" public="false">
-                    <argument>mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%</argument>
+                    <argument>mysql:dbname=mydatabase, host=myhost</argument>
                     <argument type="collection">
-                        <argument key="db_username">%env(MYDATABASE_USERNAME)%</argument>
-                        <argument key="db_password">%env(MYDATABASE_PASSWORD)%</argument>
-                        <argument key="db_table">%env(SESSIONS_TABLE)%</argument>
+                        <argument key="db_table">sessions</argument>
+                        <argument key="db_username">myuser</argument>
+                        <argument key="db_password">mypassword</argument>
                     </argument>
                 </service>
             </services>
@@ -159,16 +154,11 @@ a second array argument to ``PdoSessionHandler``:
         // ...
 
         $container->autowire(PdoSessionHandler::class)
-            ->setArguments(
-                array(
-                    'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%',
-                    array(
-                        'db_table' => '%env(SESSIONS_TABLE)%',
-                        'db_username' => '%env(MYDATABASE_USERNAME)%',
-                        'db_password' => '%env(MYDATABASE_PASSWORD)',
-                    ),
-                )
-            );
+            ->setArguments(array(
+                'mysql:dbname=mydatabase, host=myhost',
+                array('db_table' => 'sessions', 'db_username' => 'myuser', 'db_password' => 'mypassword')
+            ))
+        ;
 
 These are parameters that you can configure:
 

--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -58,11 +58,15 @@ To use it, first register a new handler service:
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
         $storageDefinition = $container->autowire(PdoSessionHandler::class)
-            ->setArguments(array(
-                'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%',
-                array('db_username' => '%env(MYDATABASE_USERNAME)%', 'db_password' => '%env(MYDATABASE_PASSWORD)'),
-            ))
-        ;
+            ->setArguments(
+                array(
+                    'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%',
+                    array(
+                        'db_username' => '%env(MYDATABASE_USERNAME)%',
+                        'db_password' => '%env(MYDATABASE_PASSWORD)',
+                    ),
+                )
+            );
 
 .. note::
 
@@ -162,7 +166,7 @@ a second array argument to ``PdoSessionHandler``:
                         'db_table' => '%env(SESSIONS_TABLE)%',
                         'db_username' => '%env(MYDATABASE_USERNAME)%',
                         'db_password' => '%env(MYDATABASE_PASSWORD)',
-                    )
+                    ),
                 )
             );
 

--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -58,12 +58,11 @@ To use it, first register a new handler service:
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
         $storageDefinition = $container->autowire(PdoSessionHandler::class)
-            ->setArguments(
-                array(
-                    'mysql:dbname=mydatabase, host=myhost',
-                    array('db_username' => 'myuser', 'db_password' => 'mypassword'),
-                )
-            );
+            ->setArguments(array(
+                'mysql:dbname=mydatabase, host=myhost',
+                array('db_username' => 'myuser', 'db_password' => 'mypassword')
+            ))
+        ;
 
 .. tip::
 

--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -23,8 +23,8 @@ To use it, first register a new handler service:
 
             Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
                 arguments:
-                    - 'mysql:dbname=mydatabase'
-                    - { db_username: myuser, db_password: mypassword }
+                    - 'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%'
+                    - { db_username: '%env(MYDATABASE_USERNAME)%', db_password: '%env(MYDATABASE_PASSWORD)%' }
 
                     # If you're using Doctrine & want to re-use that connection, then:
                     # comment-out the above 2 lines and uncomment the line below
@@ -43,10 +43,10 @@ To use it, first register a new handler service:
 
             <services>
                 <service id="Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler" public="false">
-                    <argument>mysql:dbname=mydatabase</argument>
+                    <argument>mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%</argument>
                     <argument type="collection">
-                        <argument key="db_username">myuser</argument>
-                        <argument key="db_password">mypassword</argument>
+                        <argument key="db_username">%env(MYDATABASE_USERNAME)%</argument>
+                        <argument key="db_password">%env(MYDATABASE_PASSWORD)%</argument>
                     </argument>
                 </service>
             </services>
@@ -59,10 +59,18 @@ To use it, first register a new handler service:
 
         $storageDefinition = $container->autowire(PdoSessionHandler::class)
             ->setArguments(array(
-                'mysql:dbname=mydatabase',
-                array('db_username' => 'myuser', 'db_password' => 'mypassword')
+                'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%',
+                array('db_username' => '%env(MYDATABASE_USERNAME)%', 'db_password' => '%env(MYDATABASE_PASSWORD)')
             ))
         ;
+
+.. note::
+
+    Ideally you want to reuse your database information from your environment variables.
+    These variables can be referenced in the service configuration using ``%env(PARAMETER_NAME)%``.
+    Do not forget to wrap these with single or double quotes in yaml.
+
+    See :doc:`/configuration/external_parameters`.
 
 Next, tell Symfony to use your service as the session handler:
 
@@ -115,8 +123,8 @@ a second array argument to ``PdoSessionHandler``:
 
             Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
                 arguments:
-                    - 'mysql:dbname=mydatabase'
-                    - { db_table: sessions, db_username: myuser, db_password: mypassword }
+                    - 'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%'
+                    - { db_table: '%env(SESSIONS_TABLE)%, db_username: '%env(MYDATABASE_USERNAME)%', db_password: '%env(MYDATABASE_PASSWORD)%' }
 
     .. code-block:: xml
 
@@ -129,11 +137,11 @@ a second array argument to ``PdoSessionHandler``:
 
             <services>
                 <service id="Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler" public="false">
-                    <argument>mysql:dbname=mydatabase</argument>
+                    <argument>mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%</argument>
                     <argument type="collection">
-                        <argument key="db_table">sessions</argument>
-                        <argument key="db_username">myuser</argument>
-                        <argument key="db_password">mypassword</argument>
+                        <argument key="db_username">%env(MYDATABASE_USERNAME)%</argument>
+                        <argument key="db_password">%env(MYDATABASE_PASSWORD)%</argument>
+                        <argument key="db_table">%env(SESSIONS_TABLE)%</argument>
                     </argument>
                 </service>
             </services>
@@ -148,8 +156,11 @@ a second array argument to ``PdoSessionHandler``:
 
         $container->autowire(PdoSessionHandler::class)
             ->setArguments(array(
-                'mysql:dbname=mydatabase',
-                array('db_table' => 'sessions', 'db_username' => 'myuser', 'db_password' => 'mypassword')
+                'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%',
+                array(
+                    'db_table' => '%env(SESSIONS_TABLE)%',
+                    'db_username' => '%env(MYDATABASE_USERNAME)%',
+                    'db_password' => '%env(MYDATABASE_PASSWORD)')
             ))
         ;
 

--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -60,7 +60,7 @@ To use it, first register a new handler service:
         $storageDefinition = $container->autowire(PdoSessionHandler::class)
             ->setArguments(array(
                 'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%',
-                array('db_username' => '%env(MYDATABASE_USERNAME)%', 'db_password' => '%env(MYDATABASE_PASSWORD)')
+                array('db_username' => '%env(MYDATABASE_USERNAME)%', 'db_password' => '%env(MYDATABASE_PASSWORD)'),
             ))
         ;
 
@@ -161,7 +161,7 @@ a second array argument to ``PdoSessionHandler``:
                     array(
                         'db_table' => '%env(SESSIONS_TABLE)%',
                         'db_username' => '%env(MYDATABASE_USERNAME)%',
-                        'db_password' => '%env(MYDATABASE_PASSWORD)'
+                        'db_password' => '%env(MYDATABASE_PASSWORD)',
                     )
                 )
             );

--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -155,14 +155,16 @@ a second array argument to ``PdoSessionHandler``:
         // ...
 
         $container->autowire(PdoSessionHandler::class)
-            ->setArguments(array(
-                'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%',
+            ->setArguments(
                 array(
-                    'db_table' => '%env(SESSIONS_TABLE)%',
-                    'db_username' => '%env(MYDATABASE_USERNAME)%',
-                    'db_password' => '%env(MYDATABASE_PASSWORD)')
-            ))
-        ;
+                    'mysql:dbname=%env(MYDATABASE_NAME)%, host=%env(MYDATABASE_HOST)%',
+                    array(
+                        'db_table' => '%env(SESSIONS_TABLE)%',
+                        'db_username' => '%env(MYDATABASE_USERNAME)%',
+                        'db_password' => '%env(MYDATABASE_PASSWORD)'
+                    )
+                )
+            );
 
 These are parameters that you can configure:
 


### PR DESCRIPTION
I recently had the use case to store sessions via pdo on a docker grid.
I noticed the `doctrine/pdo_session_storage.rst` documentation is missing the option 
to configure a host on the PdoSessionHandler and that
the service configuration does not use external environment parameters.

  - add host parameter to first argument
    useful when database is on another host e.g. docker grid
  - wrap parameter values in %env()%
  - add note how to use external parameters