### PR TITLE
Add a warning for Doctrine users

### DIFF
--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -63,6 +63,11 @@ To use it, first register a new handler service:
                 array('db_username' => 'myuser', 'db_password' => 'mypassword')
             ))
         ;
+.. caution::
+
+    If you are using the same database connection for your sessions and for Doctrine,
+    it is important to verify which ``lock mode`` you are using, because the default
+    value is going to cause an PDOException when you try to flush data.
 
 Next, tell Symfony to use your service as the session handler:
 


### PR DESCRIPTION
Warning: When the same database connection is used for Doctrine and for pdosessionhandler

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
