### PR TITLE
Document the built in env var processors

### DIFF
--- a/configuration/external_parameters.rst
+++ b/configuration/external_parameters.rst
@@ -237,6 +237,40 @@ It is also possible to combine the processors:
        auth: '%env(file:resolve:AUTH_FILE)%'
 
 
+Custom Environment Variable Processors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Its possible to add further processors for environment variables. You just need
+to add an implementation of `Symfony\Component\DependencyInjection\EnvVarProcessorInterface`.
+
+.. code-block:: php
+
+    class LowercasingEnvVarProcessor implements EnvVarProcessorInterface
+    {
+        private $container;
+
+        public function __construct(ContainerInterface $container)
+        {
+            $this->container = $container;
+        }
+
+        public function getEnv($prefix, $name, \Closure $getEnv)
+        {
+            $env = $getEnv($name);
+
+            return strtolower($env);
+        }
+
+        public static function getProvidedTypes()
+        {
+            return [
+                'lowercase' => 'string',
+            ];
+        }
+    }
+
+
+
 .. _configuration-env-var-in-prod:
 
 Configuring Environment Variables in Production

--- a/configuration/external_parameters.rst
+++ b/configuration/external_parameters.rst
@@ -143,11 +143,25 @@ you will want to have specific types so that they match the types expected by yo
 
 A number of different types are supported:
 
-``env(string):FOO)``
+``env(string:FOO)``
     Casts ``FOO`` to a string
+
+.. code-block:: php
+
+    parameters:
+        env(SECRET): "some_secret"
+    framework:
+       secret: '%env(string:SECRET)%'
     
 ``env(bool:FOO)``
     Casts ``FOO`` to a bool
+
+.. code-block:: php
+
+    parameters:
+        env(HTTP_METHOD_OVERRIDE): "true"
+    framework:
+       http_method_override: '%env(bool:HTTP_METHOD_OVERRIDE)%'
 
 ``env(int:FOO)``
     Casts ``FOO`` to an int
@@ -158,25 +172,69 @@ A number of different types are supported:
 ``env(const:FOO)``
     Finds the const value named in ``FOO``
 
+.. code-block:: php
+
+    parameters:
+        env(HEALTH_CHECK_METHOD): "Symfony\Component\HttpFoundation\Request:METHOD_HEAD"
+    security:
+       access_control:
+         - { path: '^/health-check$', methods: '%env(const:HEALTH_CHECK_METHOD)%' }
+
 ``env(base64:FOO)``
     Decodes ``FOO`` that is a base64 encoded string
     
 ``env(json:FOO)``
     Decodes ``FOO`` that is a json encoded string into either an array or ``null``
+
+.. code-block:: php
+
+    parameters:
+        env(TRUSTED_HOSTS): "['10.0.0.1', '10.0.0.2']"
+    framework:
+       trusted_hosts: '%env(json:TRUSTED_HOSTS)%'
     
 ``env(resolve:FOO)``
     Resolves references in the string ``FOO`` to other parameters
+
+.. code-block:: php
+
+    parameters:
+        env(HOST): '10.0.0.1'
+        env(SENTRY_DSN): "http://%env(HOST)%/project"
+    sentry:
+        dsn: '%env(resolve:SENTRY_DSN)%'
     
 ``env(csv:FOO)``
     Decodes ``FOO`` that is a single row of comma seperated values
 
+.. code-block:: php
+
+    parameters:
+        env(TRUSTED_HOSTS): "10.0.0.1, 10.0.0.2"
+    framework:
+       trusted_hosts: '%env(csv:TRUSTED_HOSTS)%'
+
 ``env(file:FOO)``
     Reads the contents of a file named in ``FOO``
+
+.. code-block:: php
+
+    parameters:
+        env(AUTH_FILE): "auth.json"
+    google:
+       auth: '%env(file:AUTH_FILE)%'
     
 It is also possible to combine the processors:
 
 ``env(json:file:FOO)``
     Reads the contents of a file named in ``FOO``, and then decode it from json, resulting in an array or ``null``
+
+.. code-block:: php
+
+    parameters:
+        env(AUTH_FILE): "%kernel.root%/auth.json"
+    google:
+       auth: '%env(file:resolve:AUTH_FILE)%'
 
 
 .. _configuration-env-var-in-prod:

--- a/configuration/external_parameters.rst
+++ b/configuration/external_parameters.rst
@@ -99,6 +99,86 @@ will be used whenever the corresponding environment variable is *not* found:
         // config/services.php
         $container->setParameter('env(DATABASE_HOST)', 'localhost');
 
+Environment Variable Processors
+-------------------------------
+
+When using environment variables they are always strings by default, but sometimes
+you will want to have specific types so that they match the types expected by your code.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/framework.yaml
+        framework:
+            router:
+                http_port: env(int:HTTP_PORT)
+
+    .. code-block:: xml
+
+        <!-- config/packages/framework.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony
+                http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+            <framework:config>
+                <framework:router http_port="%env(int:HTTP_PORT)%" />
+            </framework:config>
+        </container>
+
+    .. code-block:: php
+
+        // config/packages/doctrine.php
+        $container->loadFromExtension('framework', array(
+            'router' => array(
+                'http_port' => '%env(int:HTTP_PORT)%',
+            )
+        ));
+
+A number of different types are supported:
+
+``env(string):FOO)``
+    Casts ``FOO`` to a string
+    
+``env(bool:FOO)``
+    Casts ``FOO`` to a bool
+
+``env(int:FOO)``
+    Casts ``FOO`` to an int
+
+``env(float:FOO)``
+    Casts ``FOO`` to an float
+
+``env(const:FOO)``
+    Finds the const value named in ``FOO``
+
+``env(base64:FOO)``
+    Decodes ``FOO`` that is a base64 encoded string
+    
+``env(json:FOO)``
+    Decodes ``FOO`` that is a json encoded string into either an array or ``null``
+    
+``env(resolve:FOO)``
+    Resolves references in the string ``FOO`` to other parameters
+    
+``env(csv:FOO)``
+    Decodes ``FOO`` that is a single row of comma seperated values
+
+``env(file:FOO)``
+    Reads the contents of a file named in ``FOO``
+    
+It is also possible to combine the processors:
+
+``env(json:file:FOO)``
+    Reads the contents of a file named in ``FOO``, and then decode it from json, resulting in an array or ``null``
+
+
 .. _configuration-env-var-in-prod:
 
 Configuring Environment Variables in Production


### PR DESCRIPTION
This is start at adding documentation for env var processors, e.g. `%env(int:FOO)%`

I would welcome some feedback, if this a appropriate way to go about this, I think it needs some more examples to show how its used.

It also would ideally add a description of how custom processors are added, although that might be a later request.

starts to fix https://github.com/symfony/symfony-docs/issues/8382, https://github.com/symfony/symfony-docs/issues/9094