### PR TITLE
Fix linebreak in Code line

### DIFF
--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -328,8 +328,8 @@ effect after removing the explicit rules:
     '{0} There are no apples|[20,Inf[ There are many apples|There is one apple|a_few: There are %count% apples'
 
 For example, for ``1`` apple, the standard rule ``There is one apple`` will
-be used. For ``2-19`` apples, the second standard rule ``There are %count%
-apples`` will be selected.
+be used. For ``2-19`` apples, the second standard rule 
+``There are %count% apples`` will be selected.
 
 An :class:`Symfony\\Component\\Translation\\Interval` can represent a finite set
 of numbers:


### PR DESCRIPTION
Small fix that prevents a line break inside an inline code example.

This affects all maintained branches (2.7, 2.8, 3.4, 4.0 and master).
