### PR TITLE
Removed an internal detail about route placeholders

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -466,10 +466,6 @@ a slash. URLs matching this route might look like:
     Symfony provides you with a way to do this by leveraging service container
     parameters. Read more about this in ":doc:`/routing/service_container_parameters`".
 
-.. caution::
-
-    A route placeholder name cannot start with a digit and cannot be longer than 32 characters.
-
 Special Routing Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I propose to remove this because it's an internal detail and it only adds "cognitive noise" to the reader. Symfony will show you fantastic error messages (see https://github.com/symfony/symfony/blob/ecb629a24599e9c1ec34f34dae5cfd1a0f7986b4/src/Symfony/Component/Routing/RouteCompiler.php#L131-L142) if you make any of these mistakes.