### PR TITLE
Replace jQuery example with plain JavaScript

### DIFF
--- a/frontend/encore/server-data.rst
+++ b/frontend/encore/server-data.rst
@@ -16,12 +16,17 @@ Fetch this in JavaScript:
 
 .. code-block:: javascript
 
-    // jquery isn't required, but makes things simple
-    var $ = require('jquery');
-
-    $(document).ready(function() {
-        var isAuthenticated = $('.js-user-rating').data('is-authenticated');
+    document.addEventListener('DOMContentLoaded', function() {
+        var userRating = document.querySelector('.js-user-rating');
+        var isAuthenticated = userRating.dataset.isAuthenticated;
     });
+
+.. note::
+
+    When `accessing data attributes from JavaScript`_, the attribute names are
+    converted from dash-style to camelCase. For example, ``data-is-authenticated``
+    becomes ``isAuthenticated`` and ``data-number-of-reviews`` becomes
+    ``numberOfReviews``.
 
 There is no size limit for the value of the ``data-`` attributes, so you can
 store any content. In Twig, use the ``html_attr`` escaping strategy to avoid messing
@@ -33,3 +38,5 @@ method that returns an array, you could do the following:
     <div data-user-profile="{{ app.user ? app.user.profileData|json_encode|e('html_attr') : '' }}">
         <!-- ... -->
     </div>
+
+.. _`accessing data attributes from JavaScript`: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes


### PR DESCRIPTION
The data attributes example relies unnecessarily on jQuery and is potentially more confusing because it masks how attributes actually work in JavaScript and it's another level of abstraction to deal with. It is a better idea to promote web standards here because people tend to copy what they see, so let's steer them in a future-friendly direction.