### PR TITLE
Symfony 4 Security:  Added note, how to install profiler bundle

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -127,6 +127,13 @@ be fooled by the "Yes" next to Authenticated, you're just an anonymous user:
 .. image:: /_images/security/anonymous_wdt.png
    :align: center
 
+.. tip::
+    If you do not see toolbar, it can be installed with :doc:`Profiler </profiler>` bundle
+
+    .. code-block:: terminal
+
+        $ composer require profiler --dev
+
 You'll learn later how to deny access to certain URLs or controllers.
 
 .. tip::


### PR DESCRIPTION
There is example picture (`_images/security/anonymous_wdt.png`) with `profiler` bundle,
but when creating Symfony 4 project with `flex` – `profiler` bundle is not included by default.

Therefore for new Symfony 4 users it is hard to follow documentation.
