### PR TITLE
Add cautionary advice about SQL reserved words

### DIFF
--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -140,6 +140,13 @@ For this entry, suppose that you already have a ``User`` entity inside an
 To make things shorter, some of the getter and setter methods aren't shown.
 But you can generate these manually or with your own IDE.
 
+.. caution::
+
+    In the example above, the User entity's table name is "app_users" because
+    "USER" is a SQL reserved word. If you wish to call your table name "user",
+    `it must be quoted with backticks`_ to avoid errors. The annotation should
+    look like ``@ORM\Table(name="`user`")``.
+
 Next, make sure to :ref:`create the database table <doctrine-creating-the-database-tables-schema>`:
 
 .. code-block:: terminal
@@ -572,3 +579,4 @@ or worry about it.
 
 .. _fixtures: https://symfony.com/doc/master/bundles/DoctrineFixturesBundle/index.html
 .. _FOSUserBundle: https://github.com/FriendsOfSymfony/FOSUserBundle
+.. _`it must be quoted with backticks`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html#quoting-reserved-words


### PR DESCRIPTION
I ran into this issue while following the security docs to set up authentication from the database and thought that it would be a helpful tip for future readers.