### PR TITLE
Fix typo in method setETag. Correct method name is setEtag

### DIFF
--- a/http_cache/validation.rst
+++ b/http_cache/validation.rst
@@ -200,7 +200,7 @@ exposing a simple and efficient pattern::
 
             // create a Response with an ETag and/or a Last-Modified header
             $response = new Response();
-            $response->setETag($article->computeETag());
+            $response->setEtag($article->computeETag());
             $response->setLastModified($article->getPublishedAt());
 
             // Set response as public. Otherwise it will be private by default.


### PR DESCRIPTION
Just small typo fixed. I have copy pasted code from docs and then my code sniffer notified about mismatched method name.
Here is a link to API https://api.symfony.com/4.0/Symfony/Component/HttpFoundation/Response.html#method_setEtag