### PR TITLE
Add a note about correct cfg value server_version for MariaDB

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -363,7 +363,10 @@ The following block shows all possible configuration keys:
     to find your PostgreSQL version and ``mysql -V`` to get your MySQL
     version).
     
-    Always wrap the server version number with quotes to parse it as a string
+    If you are running a MariaDB database, you should prefix the ``server_version`` 
+    with ``mariadb-`` (e.g. ``server_version: mariadb-10.2.12``).
+    
+    Always wrap the server version number with quotes to parse it as a string
     instead of a float number. Otherwise, the floating-point representation
     issues can make your version be considered a different number (e.g. ``5.6``
     will be rounded as ``5.5999999999999996447286321199499070644378662109375``).


### PR DESCRIPTION
Because when using a MariaDB database, you should prefix the `server_version` with `mariadb-`otherwise doctrine/dbal is not able to recognize it and use `MySQL57Platform` which results in:
- possible bugs
- endless schema diff generation

Because this feature/bug is not documented, it is time to do it properly 📦 👍

* Discussion on https://github.com/doctrine/dbal/issues/2985#issuecomment-378595588
* Also, why it should be prefixed when using `MariaDB`: https://github.com/doctrine/dbal/blob/f76bf5ef631cec551a86c2291fc749534febebf1/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php#L135