### PR TITLE
New section about JSON file manifest strategy

### DIFF
--- a/components/asset.rst
+++ b/components/asset.rst
@@ -142,9 +142,11 @@ string as the second argument of the ``StaticVersionStrategy`` constructor::
 JSON File Manifest
 ..................
 
-Use the :class:`Symfony\\Component\\Asset\\VersionStrategy\\JsonManifestVersionStrategy`
-to take advantage of the strategy used by popular tools such as `Webpack 
-<https://webpack.js.org/>`_, which generates a JSON file mapping all source file names to their corresponding output file. For example::
+A popular strategy to manage asset versioning, which is used by tools such as
+`Webpack`_, is to generate a JSON file mapping all source file names to their
+corresponding output file:
+
+.. code-block:: json
 
     // rev-manifest.json
     {
@@ -153,6 +155,8 @@ to take advantage of the strategy used by popular tools such as `Webpack
         "...": "..."
     }
 
+In those cases, use the 
+:class:`Symfony\\Component\\Asset\\VersionStrategy\\JsonManifestVersionStrategy`::
 
     use Symfony\Component\Asset\Package;
     use Symfony\Component\Asset\VersionStrategy\JsonManifestVersionStrategy;
@@ -372,3 +376,4 @@ Learn more
 ----------
 
 .. _Packagist: https://packagist.org/packages/symfony/asset
+.. _`Webpack`: https://webpack.js.org/

--- a/components/asset.rst
+++ b/components/asset.rst
@@ -139,6 +139,29 @@ string as the second argument of the ``StaticVersionStrategy`` constructor::
     echo $package->getUrl('image.png');
     // result: v1/image.png
 
+JSON File Manifest
+..................
+
+Use the :class:`Symfony\\Component\\Asset\\VersionStrategy\\JsonManifestVersionStrategy`
+to take advantage of the strategy used by popular tools such as `Webpack 
+<https://webpack.js.org/>`_, which generate a JSON file mapping all source file names to their corresponding output file. For example::
+
+    // rev-manifest.json
+    {
+        "css/app.css": "build/css/app.b916426ea1d10021f3f17ce8031f93c2.css",
+        "js/app.js": "build/js/app.13630905267b809161e71d0f8a0c017b.js"
+        "...": "..."
+    }
+
+
+    use Symfony\Component\Asset\Package;
+    use Symfony\Component\Asset\VersionStrategy\JsonManifestVersionStrategy;
+
+    $package = new Package(new JsonManifestVersionStrategy(__DIR__'./rev-manifest.json'));
+
+    echo $package->getUrl('css/app.css');
+    // result: build/css/app.b916426ea1d10021f3f17ce8031f93c2.css
+
 Custom Version Strategies
 .........................
 

--- a/components/asset.rst
+++ b/components/asset.rst
@@ -144,7 +144,7 @@ JSON File Manifest
 
 Use the :class:`Symfony\\Component\\Asset\\VersionStrategy\\JsonManifestVersionStrategy`
 to take advantage of the strategy used by popular tools such as `Webpack 
-<https://webpack.js.org/>`_, which generate a JSON file mapping all source file names to their corresponding output file. For example::
+<https://webpack.js.org/>`_, which generates a JSON file mapping all source file names to their corresponding output file. For example::
 
     // rev-manifest.json
     {

--- a/components/asset.rst
+++ b/components/asset.rst
@@ -151,7 +151,7 @@ corresponding output file:
     // rev-manifest.json
     {
         "css/app.css": "build/css/app.b916426ea1d10021f3f17ce8031f93c2.css",
-        "js/app.js": "build/js/app.13630905267b809161e71d0f8a0c017b.js"
+        "js/app.js": "build/js/app.13630905267b809161e71d0f8a0c017b.js",
         "...": "..."
     }
 

--- a/frontend/encore/versioning.rst
+++ b/frontend/encore/versioning.rst
@@ -59,3 +59,8 @@ like normal:
     <script src="{{ asset('build/app.js') }}"></script>
 
     <link href="{{ asset('build/dashboard.css') }}" rel="stylesheet" />
+
+Learn more
+----------
+
+* :doc:`/components/asset`


### PR DESCRIPTION
@see https://symfony.com/blog/new-in-symfony-3-3-manifest-based-asset-versioning

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
