### PR TITLE
Change IntegerType::scale default value to 0

### DIFF
--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -46,7 +46,15 @@ Field Options
 
 .. include:: /reference/forms/types/options/grouping.rst.inc
 
-.. include:: /reference/forms/types/options/scale.rst.inc
+scale
+~~~~~
+
+**type**: ``integer`` **default**: ``0``. Any other value is ignored.
+
+This specifies how many decimals will be allowed until the field rounds
+the submitted value (via ``rounding_mode``). For example, if ``scale`` is set
+to ``2``, a submitted value of ``20.123`` will be rounded to, for example,
+``20.12`` (depending on your `rounding_mode`_).
 
 rounding_mode
 ~~~~~~~~~~~~~

--- a/reference/forms/types/options/scale.rst.inc
+++ b/reference/forms/types/options/scale.rst.inc
@@ -1,7 +1,7 @@
 scale
 ~~~~~
 
-**type**: ``integer`` **default**: Locale-specific (usually around ``3``)
+**type**: ``integer`` **default**: ``0``. Any other value is ignored.
 
 This specifies how many decimals will be allowed until the field rounds
 the submitted value (via ``rounding_mode``). For example, if ``scale`` is set

--- a/reference/forms/types/options/scale.rst.inc
+++ b/reference/forms/types/options/scale.rst.inc
@@ -1,7 +1,7 @@
 scale
 ~~~~~
 
-**type**: ``integer`` **default**: ``0``. Any other value is ignored.
+**type**: ``integer`` **default**: Locale-specific (usually around ``3``)
 
 This specifies how many decimals will be allowed until the field rounds
 the submitted value (via ``rounding_mode``). For example, if ``scale`` is set


### PR DESCRIPTION
which is 0 and can't be changed

see symfony/symfony#26795

see https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php#L35: the PHPDoc says it's unused, but the doc doesn't.