### PR TITLE
Quote “user” table in example code with backticks

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -27,7 +27,7 @@ property they use to access their account via the API::
 
     /**
      * @ORM\Entity
-     * @ORM\Table(name="user")
+     * @ORM\Table(name="`user`")
      */
     class User implements UserInterface
     {


### PR DESCRIPTION
Naming the table “user” without backtick quoting will trigger an error for anybody that copy/pastes the code because “USER” is a SQL reserved word. See #9541 for more details.