### PR TITLE
[Security] add tip about using custom functions

### DIFF
--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -301,6 +301,10 @@ and functions including ``request``, which is the Symfony
 For a list of the other functions and variables, see
 :ref:`functions and variables <security-expression-variables>`.
 
+.. tip::
+
+    Since Symfony 4.1 you can also use custom functions (that are registered via providers using the tag ``security.expression_language_provider``; also see :ref:`custom providers <components-expression-language-provider>`) inside your ``allow_if`` expressions.
+
 Forcing a Channel (http, https)
 -------------------------------
 

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -303,7 +303,12 @@ For a list of the other functions and variables, see
 
 .. tip::
 
-    Since Symfony 4.1 you can also use custom functions (that are registered via providers using the tag ``security.expression_language_provider``; also see :ref:`custom providers <components-expression-language-provider>`) inside your ``allow_if`` expressions.
+    The ``allow_if`` expressions can also contain custom functions registered
+    with :ref:`expression providers <components-expression-language-provider>`.
+
+    .. versionadded:: 4.1
+        The feature to use custom functions inside ``allow_if`` expressions was
+        introduced in Symfony 4.1.
 
 Forcing a Channel (http, https)
 -------------------------------


### PR DESCRIPTION
Since 4.1 its possible to use custom functions inside security `allow_if` expressions.

See https://github.com/symfony/symfony/pull/26660