### PR TITLE
remove part about adding extension

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -504,14 +504,6 @@ of the form fields::
         ;
     }
 
-The ``constraints`` option is only available if the ``ValidatorExtension``
-was enabled through the form factory builder::
-
-    Forms::createFormFactoryBuilder()
-        ->addExtension(new ValidatorExtension(Validation::createValidator()))
-        ->getFormFactory()
-    ;
-
 .. index::
    single: Validation; Constraint targets
 


### PR DESCRIPTION
I do not really understand this paragraph and did not follow it, but the `constraints` option still works. So I believe it is something historical.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
