### PR TITLE
Fix "class_exists" PHP function URL

### DIFF
--- a/doctrine/mapping_model_classes.rst
+++ b/doctrine/mapping_model_classes.rst
@@ -93,7 +93,7 @@ be adapted for your case::
         }
     }
 
-Note the :phpfunction:`class_exists()` check. This is crucial, as you do not want your
+Note the :phpfunction:`class_exists` check. This is crucial, as you do not want your
 bundle to have a hard dependency on all Doctrine bundles but let the user
 decide which to use.
 


### PR DESCRIPTION
Change http://php.net/manual/en/function.class-exists().php to http://php.net/manual/en/function.class-exists.php

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
