### PR TITLE
Fix YAML indentation

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -53,8 +53,8 @@ You can mark the service as ``lazy`` by manipulating its definition:
 
         # config/services.yaml
         services:
-           App\Twig\AppExtension:
-             lazy:  true
+            App\Twig\AppExtension:
+                lazy:  true
 
     .. code-block:: xml
 


### PR DESCRIPTION
As above.

I've targeted master as the service class definition changed since 2.7.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
