### PR TITLE
fix YAML code block indentation

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -50,13 +50,15 @@ You can mark the service as ``lazy`` by manipulating its definition:
 
     .. code-block:: yaml
 
+        # app/config/services.yml
         services:
-           app.twig_extension:
-             class: AppBundle\Twig\AppExtension
-             lazy:  true
+            app.twig_extension:
+                class: AppBundle\Twig\AppExtension
+                lazy:  true
 
     .. code-block:: xml
 
+        <!-- app/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -70,6 +72,7 @@ You can mark the service as ``lazy`` by manipulating its definition:
 
     .. code-block:: php
 
+        // app/config/services.php
         use AppBundle\Twig\AppExtension;
 
         $container->register('app.twig_extension', AppExtension::class)


### PR DESCRIPTION
same as #9574 but on the `2.7` branch