### PR TITLE
[Translation] Add the true default location where translations are stored

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -360,6 +360,8 @@ Translation Resource/File Names and Locations
 
 Symfony looks for message files (i.e. translations) in the following default locations:
 
+* the ``translations`` directory (at the root of the project);
+
 * the ``app/Resources/translations`` directory;
 
 * the ``app/Resources/<bundle name>/translations`` directory;


### PR DESCRIPTION
https://github.com/symfony/framework-bundle/blob/7c221a91384d7ba889c1f7e05e02111f6bfe8831/DependencyInjection/Configuration.php#L692
https://github.com/symfony/framework-bundle/blob/7c221a91384d7ba889c1f7e05e02111f6bfe8831/DependencyInjection/FrameworkExtension.php#L997
According to these lines, there is a default path which is handled before the others. It doesn't appear in the 3.4 docs.