### PR TITLE
[ExpressionLanguage] Use CacheItemPoolInterface in code example

### DIFF
--- a/components/expression_language/extending.rst
+++ b/components/expression_language/extending.rst
@@ -120,12 +120,12 @@ or by using the second argument of the constructor::
     It is recommended to create your own ``ExpressionLanguage`` class in your
     library. Now you can add the extension by overriding the constructor::
 
+        use Psr\Cache\CacheItemPoolInterface;
         use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
-        use Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface;
 
         class ExpressionLanguage extends BaseExpressionLanguage
         {
-            public function __construct(ParserCacheInterface $parser = null, array $providers = array())
+            public function __construct(CacheItemPoolInterface $parser = null, array $providers = array())
             {
                 // prepends the default provider to let users override it easily
                 array_unshift($providers, new StringExpressionLanguageProvider());


### PR DESCRIPTION
`ParserCacheInterface` was removed in symfony 4.0 in favour of `CacheItemPoolInterface`.
This PR updates code example to use currently available interface