### PR TITLE
class attribute still needed in some cases

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -1263,7 +1263,7 @@ also have to be added as regular services:
     .. code-block:: yaml
 
         services:
-            Twig_Extensions_Extension_Intl:
+            Twig\Extensions\IntlExtension:
                 tags: [twig.extension]
 
     .. code-block:: xml
@@ -1275,7 +1275,7 @@ also have to be added as regular services:
                 http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="Twig_Extensions_Extension_Intl">
+                <service id="Twig\Extensions\IntlExtension">
                     <tag name="twig.extension" />
                 </service>
             </services>
@@ -1284,7 +1284,7 @@ also have to be added as regular services:
     .. code-block:: php
 
         $container
-            ->register('Twig_Extensions_Extension_Intl')
+            ->register('Twig\Extensions\IntlExtension')
             ->addTag('twig.extension')
         ;
 


### PR DESCRIPTION
The class attribute is still needed for non namespaced classes like Twig_Extensions_Extension_Intl

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
