### PR TITLE
Fix "radio-custom" and "checkbox-custom" usage

### DIFF
--- a/form/bootstrap4.rst
+++ b/form/bootstrap4.rst
@@ -97,8 +97,8 @@ and ``checkbox-custom`` respectively.
 
 .. code-block:: html+twig
 
-    {{ form_row(form.myRadio, {attr: {class: 'radio-custom'} }) }}
-    {{ form_row(form.myCheckbox, {attr: {class: 'checkbox-custom'} }) }}
+    {{ form_row(form.myRadio, {label_attr: {class: 'radio-custom'} }) }}
+    {{ form_row(form.myCheckbox, {label_attr: {class: 'checkbox-custom'} }) }}
 
 Labels and Errors
 -----------------


### PR DESCRIPTION
See "radio_widget" block from https://github.com/symfony/twig-bridge/blob/3.4/Resources/views/Form/bootstrap_4_layout.html.twig

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
