### PR TITLE
[PropertyInfo] Complete the list of built-in types supported

### DIFF
--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -285,7 +285,7 @@ Type::getBuiltInType()
 The :method:`Type::getBuiltinType() <Symfony\\Component\\PropertyInfo\\Type::getBuiltinType>`
 method will return the built-in PHP data type, which can be one of 9 possible
 string values: ``array``, ``bool``, ``callable``, ``float``, ``int``, ``null``,
-``object``, ``resource`` or ``string``.
+``object``, ``resource``, ``string`` or ``iterable``.
 
 Constants inside the :class:`Symfony\\Component\\PropertyInfo\\Type`
 class, in the form ``Type::BUILTIN_TYPE_*``, are provided for convenience.


### PR DESCRIPTION
symfony/symfony#24571 introduced `iterable` type but the doc has not been updated.