### PR TITLE
Fix "image_url" usage

### DIFF
--- a/form/create_form_type_extension.rst
+++ b/form/create_form_type_extension.rst
@@ -267,7 +267,7 @@ Specifically, you need to override the ``file_widget`` block:
 
             {{ block('form_widget') }}
             {% if image_url is not null %}
-                <img src="{{ asset(image_url) }}"/>
+                <img src="{{ asset(image_url.pathname) }}"/>
             {% endif %}
 
             {% endspaceless %}


### PR DESCRIPTION
On Symfony 3.4 when using "asset(image_url)" we get the following error: "Illegal offset type in isset or empty" because "$imageUrl" is not a "string" but an instance of "Symfony\Component\HttpFoundation\File\File"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
