### PR TITLE
[Encore] Encore.configureUrlLoader() documentation

### DIFF
--- a/frontend.rst
+++ b/frontend.rst
@@ -53,7 +53,7 @@ Optimizing
 * :doc:`Versioning (and the manifest.json file) </frontend/encore/versioning>`
 * :doc:`Using A CDN </frontend/encore/cdn>`
 * :doc:`Creating a "Shared" entry for re-used modules </frontend/encore/shared-entry>`
-* :doc:`Using the URL Loader </frontend/encore/url-loader>`
+* :doc:`/frontend/encore/url-loader`
 
 Guides
 ......

--- a/frontend.rst
+++ b/frontend.rst
@@ -53,6 +53,7 @@ Optimizing
 * :doc:`Versioning (and the manifest.json file) </frontend/encore/versioning>`
 * :doc:`Using A CDN </frontend/encore/cdn>`
 * :doc:`Creating a "Shared" entry for re-used modules </frontend/encore/shared-entry>`
+* :doc:`Using the URL Loader </frontend/encore/url-loader>`
 
 Guides
 ......

--- a/frontend/encore/url-loader.rst
+++ b/frontend/encore/url-loader.rst
@@ -1,15 +1,12 @@
-Using the URL Loader
-===============================
+Inlining files in CSS with Webpack URL Loader
+=============================================
 
-The `URL Loader`_ allows you to convert files into Data URLs and embed them
-directly into the compiled version of your code. This can be useful if you
-want to avoid extra network requests for some of the ``url()`` calls present
-in your CSS files.
+A simple technique to improve the performance of web applications is to reduce
+the number of HTTP requests inlining small files as base64 encoded URLs in the
+generated CSS files.
 
-In Encore that loader is disabled by default, but you can easily enable it for
-images and fonts.
-
-First, add the loader to your project:
+Webpack Encore provides this feature via Webpack's `URL Loader`_ plugin, but
+it's disabled by default. First, add the URL loader to your project:
 
 .. code-block:: terminal
 
@@ -30,15 +27,25 @@ Then enable it in your ``webpack.config.js``:
         })
     ;
 
-Every fonts and images files having a size below or equal to 4 KB will now be
-inlined directly where they are required. If their size is over 4 KB the default
-behavior will be used instead. You can change that threshold by modifying the
-``limit`` option.
+The ``limit`` option defines the maximum size in bytes of the inlined files. In
+the previous example, font and image files having a size below or equal to 4 KB
+will be inlined and the rest of files will be processed as usual.
 
-You can also use all of the other options supported by the `URL Loader`_.
+You can also use all the other options supported by the `URL Loader`_. If you
+want to disable this loader for either images or fonts, remove the corresponding
+key from the object that is passed to the ``configureUrlLoader()`` method:
 
-If you wish to disable that loader for either images or fonts simply remove the
-corresponding key from the object that is passed to the ``configureUrlLoader()``
-method.
+.. code-block:: javascript
+
+    // webpack.config.js
+    // ...
+
+    Encore
+        // ...
+        .configureUrlLoader({
+            // 'fonts' is not defined, so only images will be inlined
+            images: { limit: 4096 }
+        })
+    ;
 
 .. _`URL loader`: https://github.com/webpack-contrib/url-loader

--- a/frontend/encore/url-loader.rst
+++ b/frontend/encore/url-loader.rst
@@ -1,0 +1,44 @@
+Using the URL Loader
+===============================
+
+The `URL Loader`_ allows you to convert files into Data URLs and embed them
+directly into the compiled version of your code. This can be useful if you
+want to avoid extra network requests for some of the ``url()`` calls present
+in your CSS files.
+
+In Encore that loader is disabled by default, but you can easily enable it for
+images and fonts.
+
+First, add the loader to your project:
+
+.. code-block:: terminal
+
+    $ yarn add --dev url-loader
+
+Then enable it in your ``webpack.config.js``:
+
+.. code-block:: javascript
+
+    // webpack.config.js
+    // ...
+
+    Encore
+        // ...
+        .configureUrlLoader({
+            fonts: { limit: 4096 },
+            images: { limit: 4096 }
+        })
+    ;
+
+Every fonts and images files having a size below or equal to 4 KB will now be
+inlined directly where they are required. If their size is over 4 KB the default
+behavior will be used instead. You can change that threshold by modifying the
+``limit`` option.
+
+You can also use all of the other options supported by the `URL Loader`_.
+
+If you wish to disable that loader for either images or fonts simply remove the
+corresponding key from the object that is passed to the ``configureUrlLoader()``
+method.
+
+.. _`URL loader`: https://github.com/webpack-contrib/url-loader


### PR DESCRIPTION
This PR adds the documentation for the `Encore.configureUrlLoader()` method (https://github.com/symfony/webpack-encore/pull/296).

Not sure if it should be more detailed since the other options of the URL loader are typically not needed...