### PR TITLE
 flex loading files in routes and the route definition without prefix…

### DIFF
--- a/routing/external_resources.rst
+++ b/routing/external_resources.rst
@@ -146,6 +146,7 @@ suppose you want to prefix all application routes with ``/site`` (e.g.
 
 The path of each route being loaded from the new routing resource will now
 be prefixed with the string ``/site``.
+When using YAML or XML routing files, you need to group them by prefix in folders.
 
 Prefixing the Names of Imported Routes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
… wins over the route definition with a prefix. #9608

see issue #9608  
https://github.com/symfony/symfony-docs/issues/9608

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
