### PR TITLE
Use "children" property instead of "child"

### DIFF
--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -337,7 +337,7 @@ You can also apply a form theme to a specific child of your form:
 
 .. code-block:: html+twig
 
-    {% form_theme form.child 'form/fields.html.twig' %}
+    {% form_theme form.children 'form/fields.html.twig' %}
 
 This is useful when you want to have a custom theme for a nested form that's
 different than the one of your main form. Just specify both your themes:
@@ -346,7 +346,7 @@ different than the one of your main form. Just specify both your themes:
 
     {% form_theme form 'form/fields.html.twig' %}
 
-    {% form_theme form.child 'form/fields_child.html.twig' %}
+    {% form_theme form.children 'form/fields_child.html.twig' %}
 
 Form Theming in PHP
 -------------------


### PR DESCRIPTION
Fix error: Neither the property "child" nor one of the methods "child()", "getchild()"/"ischild()"/"haschild()" or "__call()" exist and have public access in class "Symfony\Component\Form\FormView".

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
