### PR TITLE
(fix): JsonResponse is mandatory for response.

### DIFF
--- a/security/json_login_setup.rst
+++ b/security/json_login_setup.rst
@@ -69,6 +69,7 @@ path:
         // src/AppBundle/Controller/SecurityController.php
 
         // ...
+        use Symfony\Component\HttpFoundation\JsonResponse;
         use Symfony\Component\HttpFoundation\Request;
         use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 
@@ -79,6 +80,7 @@ path:
              */
             public function loginAction(Request $request)
             {
+                return new JsonResponse();
             }
         }
 


### PR DESCRIPTION
Small typo about the return of the action, in the case of Lexik is used, the response is created by Lexik but by default, Symfony will throw an exception telling that a Response is required. 