### PR TITLE
SF4 - Command "security:check" is not defined

### DIFF
--- a/security/security_checker.rst
+++ b/security/security_checker.rst
@@ -19,7 +19,7 @@ Then run this command:
 
 .. code-block:: terminal
 
-    $ php bin/console security:check
+    $ php bin/security-checker security:check
 
 A good security practice is to execute this command regularly to be able to
 update or replace compromised dependencies as soon as possible. Internally,


### PR DESCRIPTION
In a project using SF4, security:check command is undefined, we have to use bin/security-checker to execute this command.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
