### PR TITLE
[Workflow] Use subject to fetch state_machine

### DIFF
--- a/workflow/state-machines.rst
+++ b/workflow/state-machines.rst
@@ -205,9 +205,9 @@ you can get this state machine by injecting the Workflow registry service::
             $this->workflows = $workflows;
         }
 
-        public function someMethod()
+        public function someMethod($subject)
         {
-            $stateMachine = $this->workflows->get('pull_request');
+            $stateMachine = $this->workflows->get($subject, 'pull_request');
             // ...
         }
 


### PR DESCRIPTION
Not using the subject to fetch the stateMachine will throw an ErrorException  because the first argument passed to the get-method is a string and not an object.
