### PR TITLE
Add @a2lix/symfony-collection solution

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -619,7 +619,7 @@ Template Modifications
 
 The ``allow_delete`` option means that if an item of a collection
 isn't sent on submission, the related data is removed from the collection
-on the server. In order for this to work in an HTML form, you must remove 
+on the server. In order for this to work in an HTML form, you must remove
 the DOM element for the collection item to be removed, before submitting
 the form.
 
@@ -747,13 +747,17 @@ the relationship between the removed ``Tag`` and ``Task`` object.
     updated (whether you're adding new tags or removing existing tags) on
     each Tag object itself.
 
-.. sidebar:: Form collection jQuery plugin
+.. sidebar:: Form collection external solutions
 
-    The jQuery plugin  `symfony-collection`_ helps with ``collection`` form elements,
-    by providing the JavaScript functionality needed to add, edit and delete
-    elements of the collection. More advanced functionality like moving or duplicating
-    an element in the collection and customizing the buttons is also possible.
+    The package `@a2lix/symfony-collection`_ helps with ``collection`` form elements,
+    by providing to modern browsers the Javascript functionality needed to add, edit and delete
+    elements of the collection.
+
+    If you want to use jQuery, there is a jQuery extension, `symfony-collection`_ with
+    more advanced functionality like moving or duplicating an element in the collection
+    and customizing the buttons is also possible.
 
 .. _`Owning Side and Inverse Side`: http://docs.doctrine-project.org/en/latest/reference/unitofwork-associations.html
 .. _`JSFiddle`: http://jsfiddle.net/847Kf/4/
+.. _`@a2lix/symfony-collection`: https://github.com/a2lix/symfony-collection
 .. _`symfony-collection`: https://github.com/ninsuo/symfony-collection


### PR DESCRIPTION
Hello,

I wrote a blog post earlier this month about this package: https://a2lix.fr/2018/04/05/manage-symfony-form-collection-with-vanilla-javascript.html.
IMO, as there are Symfony best practices, we should do a bit of Javascript good practices and start discouraging the use of jQuery in the documentation right now.

I thought about updating the different parts of jQuery code of this form_collections.rst to a modern JS code, but it doesn't satisfy me because to do good things, it will increase number of lines of JS.
And, IMO, it's better to push people to use an external JS solution (or create symfony JS based solution) instead of explain quickly how redo a poor JS solution.

Any thoughts?