### PR TITLE
Fixed the paths of the Monolog config files

### DIFF
--- a/logging.rst
+++ b/logging.rst
@@ -74,7 +74,7 @@ to write logs using the :phpfunction:`syslog` function:
 
     .. code-block:: yaml
 
-        # config/packages/monolog.yaml
+        # config/packages/prod/monolog.yaml
         monolog:
             handlers:
                 # this "file_log" key could be anything
@@ -150,7 +150,7 @@ one of the messages reaches an ``action_level``. Take this example:
 
     .. code-block:: yaml
 
-        # config/packages/monolog.yaml
+        # config/packages/prod/monolog.yaml
         monolog:
             handlers:
                 filter_for_errors:
@@ -264,7 +264,7 @@ option of your handler to ``rotating_file``:
 
     .. code-block:: yaml
 
-        # config/packages/dev/monolog.yaml
+        # config/packages/prod/monolog.yaml
         monolog:
             handlers:
                 main:

--- a/logging.rst
+++ b/logging.rst
@@ -92,7 +92,7 @@ to write logs using the :phpfunction:`syslog` function:
 
     .. code-block:: xml
 
-        <!-- config/packages/monolog.xml -->
+        <!-- config/packages/prod/monolog.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -119,7 +119,7 @@ to write logs using the :phpfunction:`syslog` function:
 
     .. code-block:: php
 
-        // config/packages/monolog.php
+        // config/packages/prod/monolog.php
         $container->loadFromExtension('monolog', array(
             'handlers' => array(
                 'file_log' => array(
@@ -171,7 +171,7 @@ one of the messages reaches an ``action_level``. Take this example:
 
     .. code-block:: xml
 
-        <!-- config/packages/monolog.xml -->
+        <!-- config/packages/prod/monolog.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -204,7 +204,7 @@ one of the messages reaches an ``action_level``. Take this example:
 
     .. code-block:: php
 
-        // config/packages/monolog.php
+        // config/packages/prod/monolog.php
         $container->loadFromExtension('monolog', array(
             'handlers' => array(
                 'filter_for_errors' => array(
@@ -277,7 +277,7 @@ option of your handler to ``rotating_file``:
 
     .. code-block:: xml
 
-        <!-- config/packages/dev/monolog.xml -->
+        <!-- config/packages/prod/monolog.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -301,7 +301,7 @@ option of your handler to ``rotating_file``:
 
     .. code-block:: php
 
-        // config/packages/dev/monolog.php
+        // config/packages/prod/monolog.php
         $container->loadFromExtension('monolog', array(
             'handlers' => array(
                 'main' => array(

--- a/logging/channels_handlers.rst
+++ b/logging/channels_handlers.rst
@@ -31,7 +31,7 @@ from the ``security`` channel:
 
     .. code-block:: yaml
 
-        # config/packages/monolog.yaml
+        # config/packages/prod/monolog.yaml
         monolog:
             handlers:
                 security:
@@ -137,7 +137,7 @@ You can also configure additional channels without the need to tag your services
 
     .. code-block:: yaml
 
-        # config/packages/monolog.yaml
+        # config/packages/prod/monolog.yaml
         monolog:
             channels: ['foo', 'bar']
 

--- a/logging/channels_handlers.rst
+++ b/logging/channels_handlers.rst
@@ -48,7 +48,7 @@ from the ``security`` channel:
 
     .. code-block:: xml
 
-        <!-- config/packages/monolog.xml-->
+        <!-- config/packages/prod/monolog.xml-->
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:monolog="http://symfony.com/schema/dic/monolog"
@@ -75,7 +75,7 @@ from the ``security`` channel:
 
     .. code-block:: php
 
-        // config/packages/monolog.php
+        // config/packages/prod/monolog.php
         $container->loadFromExtension('monolog', array(
             'handlers' => array(
                 'security' => array(
@@ -143,7 +143,7 @@ You can also configure additional channels without the need to tag your services
 
     .. code-block:: xml
 
-        <!-- config/packages/monolog.xml -->
+        <!-- config/packages/prod/monolog.xml -->
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:monolog="http://symfony.com/schema/dic/monolog"
@@ -160,7 +160,7 @@ You can also configure additional channels without the need to tag your services
 
     .. code-block:: php
 
-        // config/packages/monolog.php
+        // config/packages/prod/monolog.php
         $container->loadFromExtension('monolog', array(
             'channels' => array(
                 'foo',

--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -109,7 +109,7 @@ Finally, set the formatter to be used on whatever handler you want:
 
     .. code-block:: yaml
 
-        # config/packages/monolog.yaml
+        # config/packages/prod/monolog.yaml
         monolog:
             handlers:
                 main:

--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -120,7 +120,7 @@ Finally, set the formatter to be used on whatever handler you want:
 
     .. code-block:: xml
 
-        <!-- config/packages/monolog.xml -->
+        <!-- config/packages/prod/monolog.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -143,7 +143,7 @@ Finally, set the formatter to be used on whatever handler you want:
 
     .. code-block:: php
 
-        // config/packages/monolog.php
+        // config/packages/prod/monolog.php
         $container->loadFromExtension('monolog', array(
             'handlers' => array(
                 'main' => array(

--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -80,7 +80,7 @@ Full Default Configuration
 
     .. code-block:: xml
 
-        <!-- config/packages/monolog.xml -->
+        <!-- config/packages/prod/monolog.xml -->
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:monolog="http://symfony.com/schema/dic/monolog"

--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -14,7 +14,7 @@ Full Default Configuration
 
     .. code-block:: yaml
 
-        # config/packages/monolog.yaml
+        # config/packages/prod/monolog.yaml
         monolog:
             handlers:
 


### PR DESCRIPTION
After reading this comment: https://github.com/symfony/symfony-docs/pull/8235#discussion_r182166453  I realized that some config paths are wrong for Monolog because the recipe (https://github.com/symfony/recipes/tree/master/symfony/monolog-bundle/3.1/config/packages) doesn't create any config file in `config/packages/monolog.yaml` (all files are defined per environment).

Most of the examples used `config/packages/prod/monolog.yaml`, so I used that too. It makes sense tome because you usually only carefully configure logs in `prod`. The only article where we maintain `config/packages/dev/monolog.yaml` would be `logging/monolog_console.rst` where I think it makes sense.