### PR TITLE
Be consistent how we write "core team"

### DIFF
--- a/contributing/code/core_team.rst
+++ b/contributing/code/core_team.rst
@@ -9,7 +9,7 @@ All the Symfony Core members are long-time contributors with solid technical
 expertise and they have demonstrated a strong commitment to drive the project
 forward.
 
-This document states the rules that govern the Symfony Core team. These rules
+This document states the rules that govern the Symfony core team. These rules
 are effective upon publication of this document and all Symfony Core members
 must adhere to said rules and protocol.
 
@@ -121,7 +121,7 @@ Active Core Members
 Former Core Members
 ~~~~~~~~~~~~~~~~~~~
 
-They are no longer part of the Core Team, but we are very grateful for all their
+They are no longer part of the core team, but we are very grateful for all their
 Symfony contributions:
 
 * **Bernhard Schussek** (`webmozart`_);

--- a/contributing/code/security.rst
+++ b/contributing/code/security.rst
@@ -11,13 +11,13 @@ Reporting a Security Issue
 If you think that you have found a security issue in Symfony, don't use the
 bug tracker and don't publish it publicly. Instead, all security issues must
 be sent to **security [at] symfony.com**. Emails sent to this address are
-forwarded to the Symfony core-team private mailing-list.
+forwarded to the Symfony core team private mailing-list.
 
 Resolving Process
 -----------------
 
 For each report, we first try to confirm the vulnerability. When it is
-confirmed, the core-team works on a solution following these steps:
+confirmed, the core team works on a solution following these steps:
 
 #. Send an acknowledgement to the reporter;
 #. Work on a patch;


### PR DESCRIPTION
While writing another PR, I discovered that we are not consistent how we refer to the Symfony core team. 

We are currently using "core team", "Core team", "Core Team" and "core-team". This PR make sure that we are always using "core team". That term was the most popular one. 