### PR TITLE
FIX : accessing global variable tokenStorage

### DIFF
--- a/session/proxy_examples.rst
+++ b/session/proxy_examples.rst
@@ -134,7 +134,7 @@ can intercept the session before it is written::
 
         private function getUser()
         {
-            if (!$token = $tokenStorage->getToken()) {
+            if (!$token = $this->tokenStorage->getToken()) {
                 return;
             }
 


### PR DESCRIPTION
Global variable tokenStorage needs '$this->' to get accessed correctly
