### PR TITLE
 WebToolbar not rendered without body html tag

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -264,7 +264,14 @@ when you installed Twig. Create a new ``templates/lucky`` directory with a new
 
     {# templates/lucky/number.html.twig #}
 
-    <h1>Your lucky number is {{ number }}</h1>
+    <html>
+      <head>
+          <title>Lucky Number</title>
+      </head>
+      <body>
+          <h1>Your lucky number is: {{ number }}</h1>
+      </body>
+    </html>
 
 The ``{{ number }}`` syntax is used to *print* variables in Twig. Refresh your browser
 to get your *new* lucky number!


### PR DESCRIPTION
Twig tempate edited since WebToolbar disappear with no Body html tag.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
