### PR TITLE
Wrong attribute serializer xml

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -814,9 +814,7 @@ Here, we set it to 2 for the ``$child`` property:
                 http://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
         >
             <class name="Acme\MyObj">
-                <attribute name="foo">
-                    <max-depth>2</max-depth>
-                </attribute>
+                <attribute name="foo" max-depth="2" />
         </serializer>
 
 The metadata loader corresponding to the chosen format must be configured in


### PR DESCRIPTION
The given example in docs is wrong.

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd#L67

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml#L19

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
