### PR TITLE
mention google translate

### DIFF
--- a/contributing/documentation/translations.rst
+++ b/contributing/documentation/translations.rst
@@ -1,7 +1,14 @@
 Translations
 ============
 
-The official Symfony documentation is published only in English, but some
-community groups maintain `unofficial translations`_.
+The official Symfony documentation is published only in English. You can
+read about the reasons in `this blog post`_.
 
-.. _`unofficial translations`: https://symfony.com/blog/discontinuing-the-symfony-community-translations
+We have taken steps to improve the experience when using
+`Google Translate`_ to prevent code blocks from being translated.
+
+To translate any page in our documentation please copy any URL from the
+documentation and paste it into the form on the Google Translate site.
+
+.. _`this blog post`: https://symfony.com/blog/discontinuing-the-symfony-community-translations
+.. _`Google Translate`: https://translate.google.com


### PR DESCRIPTION
also remove mention of unofficial translations since these are no longer accessible

to further simplify the use of google translate, we might want to consider to add a drop down with the lets say top 5 languages spoken in the countries that most frequently visit symfony.com .. or we might even provide a dynamic "translate" button by looking at the browser language settings.