### PR TITLE
Update compiler_passes.rst

### DIFF
--- a/service_container/compiler_passes.rst
+++ b/service_container/compiler_passes.rst
@@ -56,7 +56,7 @@ and process the services inside the ``process()`` method::
         {
             // in this method you can manipulate the service container:
             // for example, changing some container service:
-            $container->getDefinition('app.some_private_service')->setPublic(true);
+            $container->findDefinition('app.some_private_service')->setPublic(true);
 
             // or processing tagged services:
             foreach ($container->findTaggedServiceIds('some_tag') as $id => $tags) {


### PR DESCRIPTION
I think that `findDefinition` is better than `getDefinition` as it will also look at aliases.
I found this by myself while migrating from sf < 3.4 to sf >= 3.4.
In particular I was following [this](https://symfony.com/doc/current/service_container/3.3-di-changes.html) and at point 2 services managed directly by `CompilerPass` were never founded.

Moreover - not related directly to this PR - I'm not sure that this "split" `getDefinition`/`findDefinition`/`getAlias` is really useful, but maybe I don't have the bigger picture.

WDYT?

PS.: Maybe this edit could be applied not only for sf 4 but also for previous versions?