### PR TITLE
Incompatible ts-loader version

### DIFF
--- a/frontend/encore/typescript.rst
+++ b/frontend/encore/typescript.rst
@@ -5,7 +5,7 @@ Want to use `TypeScript`_? No problem! First, install the dependencies:
 
 .. code-block:: terminal
 
-    $ yarn add --dev typescript ts-loader
+    $ yarn add --dev typescript ts-loader@^3.0
 
 Then, activate the ``ts-loader`` in ``webpack.config.js``:
 


### PR DESCRIPTION
The ts-loader major version must map to the webpack major version:
https://github.com/TypeStrong/ts-loader/issues/748

Since symfony/encore depends on webpack 3, installing latest will produce the error above.