### PR TITLE
Fix composer usage for security-csrf

### DIFF
--- a/security/csrf.rst
+++ b/security/csrf.rst
@@ -17,7 +17,7 @@ requires installing the Symfony Form component):
 
 .. code-block:: terminal
 
-    $ composer require security-csrf form
+    $ composer require symfony/security-csrf symfony/form
 
 Then, enable/disable the CSRF protection with the ``csrf_protection`` option
 (see the :ref:`CSRF configuration reference <reference-framework-csrf-protection>`


### PR DESCRIPTION
See: https://packagist.org/packages/symfony/security-csrf

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
