### PR TITLE
Fix factory-service new syntax

### DIFF
--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -105,7 +105,7 @@ Configuration of the service container then looks like this:
 
             App\Email\NewsletterManager:
                 # call a method on the specified factory service
-                factory: 'App\Email\NewsletterManagerFactory:createNewsletterManager'
+                factory: 'App\Email\NewsletterManagerFactory::createNewsletterManager'
 
     .. code-block:: xml
 
@@ -154,7 +154,7 @@ Configuration of the service container then looks like this:
         # config/services.yaml
         App\Email\NewsletterManager:
             # new syntax
-            factory: 'App\Email\NewsletterManagerFactory:createNewsletterManager'
+            factory: 'App\Email\NewsletterManagerFactory::createNewsletterManager'
             # old syntax
             factory: ['@App\Email\NewsletterManagerFactory', createNewsletterManager]
 


### PR DESCRIPTION
As I understand, this applies to all versions, not just 4.0. At least, the factory does not work for me, if I use only one `:`

https://github.com/symfony/dependency-injection/blob/e237279af4735c1566a62853c65de12b3266f0ef/Definition.php#L106-L108
