### PR TITLE
Fix show code without new line

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -74,12 +74,12 @@ SwiftmailerBundle:
     }
 
 The ``aliases`` option allows Flex to install packages using short and easy to
-remember names (``composer require mailer`` vs ``composer require
-symfony/swiftmailer-bundle``). The ``bundles`` option tells Flex in which
-environments this bundle should be enabled automatically (``all`` in this
-case). The ``env`` option makes Flex to add new environment variables to the
-application. Finally, the ``copy-from-recipe`` option allows the recipe to copy
-files and directories into your application.
+remember names (``composer require mailer`` vs
+``composer require symfony/swiftmailer-bundle``). The ``bundles`` option tells
+Flex in which environments this bundle should be enabled automatically (``all``
+in this case). The ``env`` option makes Flex to add new environment variables to
+the application. Finally, the ``copy-from-recipe`` option allows the recipe to
+copy files and directories into your application.
 
 The instructions defined in this ``manifest.json`` file are also used by
 Symfony Flex when uninstalling dependencies (e.g. ``composer remove mailer``)


### PR DESCRIPTION
Show "composer require symfony/swiftmailer-bundle" without new line

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
