### PR TITLE
Fix wrong namespace

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -105,7 +105,7 @@ First, create your sender::
     namespace App\MessageSender;
 
     use App\Message\ImportantAction;
-    use Symfony\Component\Message\SenderInterface;
+    use Symfony\Component\Messenger\Transport\SenderInterface;
 
     class ImportantActionToEmailSender implements SenderInterface
     {
@@ -154,7 +154,7 @@ First, create your receiver::
     namespace App\MessageReceiver;
 
     use App\Message\NewOrder;
-    use Symfony\Component\Message\ReceiverInterface;
+    use Symfony\Component\Messenger\Transport\ReceiverInterface;
     use Symfony\Component\Serializer\SerializerInterface;
 
     class NewOrdersFromCsvFile implements ReceiverInterface


### PR DESCRIPTION
From namespace of SenderInterface and ReceiverInterface, : from 'Message' to 'Messenger\Transport'

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
