### PR TITLE
Fix correct extension in comment of example

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -98,7 +98,7 @@ to :doc:`customize form rendering </form/form_customization>`):
 
     .. code-block:: html+php
 
-        <!-- templates/product/new.html.twig -->
+        <!-- templates/product/new.html.php -->
         <h1>Adding a new product</h1>
 
         <?php echo $view['form']->start($form) ?>


### PR DESCRIPTION
Because this is a PHP template (`html+php`), then the extension should be PHP.