### PR TITLE
Removed all remaining Action() method suffixes

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -55,10 +55,10 @@ Next, create an ``index.php`` file that defines the kernel class and executes it
         {
             // kernel is a service that points to this class
             // optional 3rd argument is the route name
-            $routes->add('/random/{limit}', 'kernel:randomAction');
+            $routes->add('/random/{limit}', 'kernel:randomNumber');
         }
 
-        public function randomAction($limit)
+        public function randomNumber($limit)
         {
             return new JsonResponse(array(
                 'number' => rand(0, $limit)
@@ -257,7 +257,7 @@ has one file in it::
         /**
          * @Route("/random/{limit}")
          */
-        public function randomAction($limit)
+        public function randomNumber($limit)
         {
             $number = rand(0, $limit);
 

--- a/console/command_in_controller.rst
+++ b/console/command_in_controller.rst
@@ -36,7 +36,7 @@ Run this command from inside your controller via::
 
     class SpoolController extends Controller
     {
-        public function sendSpoolAction($messages = 10, KernelInterface $kernel)
+        public function sendSpool($messages = 10, KernelInterface $kernel)
         {
             $application = new Application($kernel);
             $application->setAutoExit(false);
@@ -87,7 +87,7 @@ Now, use it in your controller::
 
     class SpoolController extends Controller
     {
-        public function sendSpoolAction($messages = 10)
+        public function sendSpool($messages = 10)
         {
             // ...
             $output = new BufferedOutput(

--- a/controller.rst
+++ b/controller.rst
@@ -616,7 +616,7 @@ Streaming File Responses
 You can use the :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::file`
 helper to serve a file from inside a controller::
 
-    public function fileAction()
+    public function download()
     {
         // send the file contents and force the browser to download it
         return $this->file('/path/to/some_file.pdf');
@@ -627,7 +627,7 @@ The ``file()`` helper provides some arguments to configure its behavior::
     use Symfony\Component\HttpFoundation\File\File;
     use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
-    public function fileAction()
+    public function download()
     {
         // load the file from the filesystem
         $file = new File('/path/to/some_file.pdf');

--- a/create_framework/http_kernel_controller_resolver.rst
+++ b/create_framework/http_kernel_controller_resolver.rst
@@ -10,7 +10,7 @@ class::
 
     class LeapYearController
     {
-        public function indexAction($request)
+        public function index($request)
         {
             if (is_leap_year($request->attributes->get('year'))) {
                 return new Response('Yep, this is a leap year!');
@@ -99,39 +99,39 @@ following interface::
         public function getArguments(Request $request, $controller);
     }
 
-The ``indexAction()`` method needs the Request object as an argument.
+The ``index()`` method needs the Request object as an argument.
 ``getArguments()`` knows when to inject it properly if it is type-hinted
 correctly::
 
-    public function indexAction(Request $request)
+    public function index(Request $request)
 
     // won't work
-    public function indexAction($request)
+    public function index($request)
 
 More interesting, ``getArguments()`` is also able to inject any Request
 attribute; the argument just needs to have the same name as the corresponding
 attribute::
 
-    public function indexAction($year)
+    public function index($year)
 
 You can also inject the Request and some attributes at the same time (as the
 matching is done on the argument name or a type hint, the arguments order does
 not matter)::
 
-    public function indexAction(Request $request, $year)
+    public function index(Request $request, $year)
 
-    public function indexAction($year, Request $request)
+    public function index($year, Request $request)
 
 Finally, you can also define default values for any argument that matches an
 optional attribute of the Request::
 
-    public function indexAction($year = 2012)
+    public function index($year = 2012)
 
 Let's just inject the ``$year`` request attribute for our controller::
 
     class LeapYearController
     {
-        public function indexAction($year)
+        public function index($year)
         {
             if (is_leap_year($year)) {
                 return new Response('Yep, this is a leap year!');

--- a/create_framework/http_kernel_httpkernel_class.rst
+++ b/create_framework/http_kernel_httpkernel_class.rst
@@ -96,7 +96,7 @@ The error controller reads as follows::
 
     class ErrorController
     {
-        public function exceptionAction(FlattenException $exception)
+        public function exception(FlattenException $exception)
         {
             $msg = 'Something went wrong! ('.$exception->getMessage().')';
 
@@ -134,7 +134,7 @@ instead of a full Response object::
 
     class LeapYearController
     {
-        public function indexAction(Request $request, $year)
+        public function index(Request $request, $year)
         {
             $leapYear = new LeapYear();
             if ($leapYear->isLeapYear($year)) {

--- a/create_framework/http_kernel_httpkernelinterface.rst
+++ b/create_framework/http_kernel_httpkernelinterface.rst
@@ -54,7 +54,7 @@ PHP; it implements ``HttpKernelInterface`` and wraps another
 ``HttpKernelInterface`` instance::
 
     // example.com/web/front.php
-    
+
     // ..
 
     $framework = new Simplex\Framework($dispatcher, $matcher, $controllerResolver, $argumentResolver);
@@ -74,7 +74,7 @@ to cache a response for 10 seconds, use the ``Response::setTtl()`` method::
     // example.com/src/Calendar/Controller/LeapYearController.php
 
     // ...
-    public function indexAction(Request $request, $year)
+    public function index(Request $request, $year)
     {
         $leapYear = new LeapYear();
         if ($leapYear->isLeapYear($year)) {

--- a/create_framework/separation_of_concerns.rst
+++ b/create_framework/separation_of_concerns.rst
@@ -106,7 +106,7 @@ Move the controller to ``Calendar\Controller\LeapYearController``::
 
     class LeapYearController
     {
-        public function indexAction(Request $request, $year)
+        public function index(Request $request, $year)
         {
             $leapYear = new LeapYear();
             if ($leapYear->isLeapYear($year)) {

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -402,7 +402,7 @@ be able to go to ``/product/1`` to see your new product::
     /**
      * @Route("/product/{id}", name="product_show")
      */
-    public function showAction($id)
+    public function show($id)
     {
         $product = $this->getDoctrine()
             ->getRepository(Product::class)
@@ -491,7 +491,7 @@ Now, simplify your controller::
     /**
      * @Route("/product/{id}", name="product_show")
      */
-    public function showAction(Product $product)
+    public function show(Product $product)
     {
         // use the Product!
         // ...
@@ -510,7 +510,7 @@ Once you've fetched an object from Doctrine, updating it is easy::
     /**
      * @Route("/product/edit/{id}")
      */
-    public function updateAction($id)
+    public function update($id)
     {
         $entityManager = $this->getDoctrine()->getManager();
         $product = $entityManager->getRepository(Product::class)->find($id);

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -370,7 +370,7 @@ did before. First, fetch a ``$product`` object and then access its related
     use App\Entity\Product;
     // ...
 
-    public function showAction($id)
+    public function show($id)
     {
         $product = $this->getDoctrine()
             ->getRepository(Product::class)
@@ -400,7 +400,7 @@ the category (i.e. it's "lazily loaded").
 Because we mapped the optional ``OneToMany`` side, you can also query in the other
 direction::
 
-    public function showProductsAction($id)
+    public function showProducts($id)
     {
         $category = $this->getDoctrine()
             ->getRepository(Category::class)
@@ -481,7 +481,7 @@ This will *still* return an array of ``Product`` objects. But now, when you call
 Now, you can use this method in your controller to query for a ``Product``
 object and its related ``Category`` with just one query::
 
-    public function showAction($id)
+    public function show($id)
     {
         $product = $this->getDoctrine()
             ->getRepository(Product::class)

--- a/doctrine/dbal.rst
+++ b/doctrine/dbal.rst
@@ -47,7 +47,7 @@ object::
 
     class UserController extends Controller
     {
-        public function indexAction(Connection $connection)
+        public function index(Connection $connection)
         {
             $users = $connection->fetchAll('SELECT * FROM users');
 

--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -235,7 +235,7 @@ the default entity manager (i.e. ``default``) is returned::
 
     class UserController extends Controller
     {
-        public function indexAction(EntityManagerInterface $entityManager)
+        public function index(EntityManagerInterface $entityManager)
         {
             // These methods also return the default entity manager, but it's preferred
             // to get it by injecting EntityManagerInterface in the action method
@@ -261,7 +261,7 @@ The same applies to repository calls::
 
     class UserController extends Controller
     {
-        public function indexAction()
+        public function index()
         {
             // Retrieves a repository managed by the "default" em
             $products = $this->getDoctrine()

--- a/doctrine/registration_form.rst
+++ b/doctrine/registration_form.rst
@@ -238,7 +238,7 @@ into the database::
         /**
          * @Route("/register", name="user_registration")
          */
-        public function registerAction(Request $request, UserPasswordEncoderInterface $passwordEncoder)
+        public function register(Request $request, UserPasswordEncoderInterface $passwordEncoder)
         {
             // 1) build the form
             $user = new User();

--- a/email.rst
+++ b/email.rst
@@ -51,7 +51,7 @@ The Swift Mailer library works by creating, configuring and then sending
 of the message and is accessible via the ``Swift_Mailer`` service. Overall,
 sending an email is pretty straightforward::
 
-    public function indexAction($name, \Swift_Mailer $mailer)
+    public function index($name, \Swift_Mailer $mailer)
     {
         $message = (new \Swift_Message('Hello Email'))
             ->setFrom('send@example.com')

--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -45,7 +45,7 @@ be used to move the ``attachment`` file to a permanent location::
 
     use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-    public function uploadAction()
+    public function upload()
     {
         // ...
 

--- a/routing/external_resources.rst
+++ b/routing/external_resources.rst
@@ -163,7 +163,7 @@ class with the ``name`` attribute of the ``@Route`` annotation::
         /**
          * @Route("/blog", name="index")
          */
-        public function indexAction()
+        public function index()
         {
             // ...
         }
@@ -171,7 +171,7 @@ class with the ``name`` attribute of the ``@Route`` annotation::
         /**
          * @Route("/blog/posts/{slug}", name="post")
          */
-        public function showAction(Post $post)
+        public function show(Post $post)
         {
             // ...
         }

--- a/security.rst
+++ b/security.rst
@@ -1065,7 +1065,7 @@ the User object, and use the ``isGranted()`` method (or
 
         use Symfony\Component\Security\Core\User\UserInterface\UserInterface;
 
-        public function indexAction(UserInterface $user = null)
+        public function index(UserInterface $user = null)
         {
             // $user is null when not logged-in or anon.
         }

--- a/serializer.rst
+++ b/serializer.rst
@@ -35,7 +35,7 @@ you need it or it can be used in a controller::
 
     class DefaultController extends Controller
     {
-        public function indexAction(SerializerInterface $serializer)
+        public function index(SerializerInterface $serializer)
         {
             // keep reading for usage examples
         }

--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -345,7 +345,7 @@ action methods, just like you can with the constructor of services. For example:
 
     class InvoiceController extends Controller
     {
-        public function listAction(LoggerInterface $logger)
+        public function listInvoices(LoggerInterface $logger)
         {
             $logger->info('A new way to access services!');
         }
@@ -707,8 +707,8 @@ code to not fetch this service directly from the container. For example:
 
 .. code-block:: diff
 
-    -     public function indexAction()
-    +     public function indexAction(GitHubNotifier $gitHubNotifier, MarkdownTransformer $markdownTransformer)
+    -     public function index()
+    +     public function index(GitHubNotifier $gitHubNotifier, MarkdownTransformer $markdownTransformer)
         {
     -         // the old way of fetching services
     -         $githubNotifier = $this->container->get('app.github_notifier');

--- a/testing/profiling.rst
+++ b/testing/profiling.rst
@@ -71,7 +71,7 @@ provided by the collectors obtained through the ``$client->getProfile()`` call::
 
     class LuckyControllerTest extends WebTestCase
     {
-        public function testNumberAction()
+        public function testRandomNumber()
         {
             $client = static::createClient();
 


### PR DESCRIPTION
This is a continuation of #9703 and removes all the remaining `Action()` suffixes in controller actions.