### PR TITLE
Add mandatory method and attribute

### DIFF
--- a/doctrine/registration_form.rst
+++ b/doctrine/registration_form.rst
@@ -154,8 +154,6 @@ With some validation added, your class may look something like this::
         public function eraseCredentials()
         {
         }
-
-        // other methods, including security methods like getRoles()
     }
 
 The :class:`Symfony\\Component\\Security\\Core\\User\\UserInterface` requires

--- a/doctrine/registration_form.rst
+++ b/doctrine/registration_form.rst
@@ -87,6 +87,15 @@ With some validation added, your class may look something like this::
          * @ORM\Column(type="string", length=64)
          */
         private $password;
+        
+        /**
+         * @ORM\Column(type="array")
+         */
+        private $roles;
+
+        public function __construct() {
+            $this->roles = array('ROLE_USER');
+        }
 
         // other properties and methods
 
@@ -135,6 +144,15 @@ With some validation added, your class may look something like this::
             // The bcrypt algorithm doesn't require a separate salt.
             // You *may* need a real salt if you choose a different encoder.
             return null;
+        }
+        
+        public function getRoles()
+        {
+            return $this->roles;
+        }
+
+        public function eraseCredentials()
+        {
         }
 
         // other methods, including security methods like getRoles()


### PR DESCRIPTION
For the page "Implement a Simple Registration Form"
Without $roles, construct(), getRoles() and eraseCredentials(), this entity doesn't work because of his interface
It may be nice to add these methods so that you do not have any errors when you copy paste