### PR TITLE
Create an index page for the new Code of Conduct section

### DIFF
--- a/contributing/code_of_conduct/code_of_conduct.rst
+++ b/contributing/code_of_conduct/code_of_conduct.rst
@@ -1,0 +1,92 @@
+Code of Conduct
+===============
+
+Our Pledge
+----------
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnic origin, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance,
+religion, or sexual identity and orientation.
+
+Our Standards
+-------------
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Our Responsibilities
+--------------------
+
+:doc:`Enforcement team members </contributing/code_of_conduct/enforcement_team>`
+are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Enforcement team members have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Scope
+-----
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by enforcement team members.
+
+Enforcement
+-----------
+
+Instances of abusive, harassing, or otherwise unacceptable behavior
+:doc:`may be reported </contributing/code_of_conduct/reporting_guidelines>`
+by contacting the :doc:`enforcement team members </contributing/code_of_conduct/enforcement_team>`.
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The enforcement team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Enforcement team members who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by the
+:doc:`core team </contributing/code/core_team>`.
+
+Attribution
+-----------
+
+This Code of Conduct is adapted from the `Contributor Covenant`_, version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+Related Documents
+-----------------
+
+.. toctree::
+    :maxdepth: 1
+
+    reporting_guidelines
+    enforcement_team
+    concrete_example_document
+
+.. _Contributor Covenant: https://www.contributor-covenant.org

--- a/contributing/code_of_conduct/index.rst
+++ b/contributing/code_of_conduct/index.rst
@@ -1,92 +1,10 @@
 Code of Conduct
 ===============
 
-Our Pledge
-----------
-
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnic origin, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance,
-religion, or sexual identity and orientation.
-
-Our Standards
--------------
-
-Examples of behavior that contributes to creating a positive environment
-include:
-
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-Our Responsibilities
---------------------
-
-:doc:`Enforcement team members </contributing/code_of_conduct/enforcement_team>`
-are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
-
-Enforcement team members have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
-
-Scope
------
-
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by enforcement team members.
-
-Enforcement
------------
-
-Instances of abusive, harassing, or otherwise unacceptable behavior
-:doc:`may be reported </contributing/code_of_conduct/reporting_guidelines>`
-by contacting the :doc:`enforcement team members </contributing/code_of_conduct/enforcement_team>`.
-All complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The enforcement team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
-
-Enforcement team members who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by the
-:doc:`core team </contributing/code/core_team>`.
-
-Attribution
------------
-
-This Code of Conduct is adapted from the `Contributor Covenant`_, version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
-
-Related Documents
------------------
-
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
 
+    code_of_conduct
     reporting_guidelines
     enforcement_team
     concrete_example_document
-
-.. _Contributor Covenant: https://www.contributor-covenant.org

--- a/contributing/map.rst.inc
+++ b/contributing/map.rst.inc
@@ -1,6 +1,6 @@
 * **Code of Conduct**
 
-  * :doc:`/code_of_conduct/conde_of_conduct`
+  * :doc:`/code_of_conduct/code_of_conduct`
   * :doc:`/code_of_conduct/reporting_guidelines`
   * :doc:`/code_of_conduct/enforcement_team`
   * :doc:`/code_of_conduct/concrete_example_document`

--- a/contributing/map.rst.inc
+++ b/contributing/map.rst.inc
@@ -1,3 +1,10 @@
+* **Code of Conduct**
+
+  * :doc:`/code_of_conduct/conde_of_conduct`
+  * :doc:`/code_of_conduct/reporting_guidelines`
+  * :doc:`/code_of_conduct/enforcement_team`
+  * :doc:`/code_of_conduct/concrete_example_document`
+
 * **Code**
 
   * :doc:`Bugs </contributing/code/bugs>`

--- a/contributing/map.rst.inc
+++ b/contributing/map.rst.inc
@@ -1,9 +1,9 @@
 * **Code of Conduct**
 
-  * :doc:`/code_of_conduct/code_of_conduct`
-  * :doc:`/code_of_conduct/reporting_guidelines`
-  * :doc:`/code_of_conduct/enforcement_team`
-  * :doc:`/code_of_conduct/concrete_example_document`
+  * :doc:`/contributing/code_of_conduct/code_of_conduct`
+  * :doc:`/contributing/code_of_conduct/reporting_guidelines`
+  * :doc:`/contributing/code_of_conduct/enforcement_team`
+  * :doc:`/contributing/code_of_conduct/concrete_example_document`
 
 * **Code**
 


### PR DESCRIPTION
Currently we put the CoC contents in the index page ... but that doesn't look OK on the website: https://symfony.com/doc/current/contributing/code_of_conduct/index.html

It's better to create an `index.rst` page and move the actual CoC contents to a dedicated page.