### PR TITLE
[Messenger] Update the messenger documentation

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -86,11 +86,11 @@ that will do the required processing for your message::
        }
     }
 
-Adapters
---------
+Transports
+----------
 
-In order to send and receive messages, you will have to configure an adapter. An
-adapter will be responsible of communicating with your message broker or 3rd parties.
+In order to send and receive messages, you will have to configure a transport. An
+transport will be responsible of communicating with your message broker or 3rd parties.
 
 Your own sender
 ~~~~~~~~~~~~~~~
@@ -190,4 +190,4 @@ To allow us to receive and send messages on the same bus and prevent an infinite
 loop, the message bus is equipped with the ``WrapIntoReceivedMessage`` middleware.
 It will wrap the received messages into ``ReceivedMessage`` objects and the
 ``SendMessageMiddleware`` middleware will know it should not route these
-messages again to an adapter.
+messages again to a transport.

--- a/messenger.rst
+++ b/messenger.rst
@@ -253,13 +253,11 @@ within the buses to add some extra capabilities like this:
             buses:
                 messenger.bus.default:
                     middleware:
-                        # Works with the FQCN if the class discovery is enabled
-                        - App\\Middleware\\MyMiddleware
+                        - "App\\Middleware\\MyMiddleware"
+                        - "App\\Middleware\\AnotherMiddleware"
 
-                        # Or with some service name
-                        - app.middleware.yours
-
-Note that if the service is abstract, then a child service will be created per bus.
+Note that if the service is abstract, then a different instance of service will be
+created per bus.
 
 Disabling default middleware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/messenger.rst
+++ b/messenger.rst
@@ -109,7 +109,7 @@ configure the following services for you:
 
 .. note::
 
-    In order to use Symfony's built-in AMQP adapter, you will need the Serializer
+    In order to use Symfony's built-in AMQP transport, you will need the Serializer
     Component. Ensure that it is installed with:
 
     .. code-block:: terminal
@@ -253,8 +253,8 @@ within the buses to add some extra capabilities like this:
             buses:
                 messenger.bus.default:
                     middleware:
-                        - "App\\Middleware\\MyMiddleware"
-                        - "App\\Middleware\\AnotherMiddleware"
+                        - 'App\Middleware\MyMiddleware'
+                        - 'App\Middleware\AnotherMiddleware'
 
 Note that if the service is abstract, then a different instance of service will be
 created per bus.

--- a/messenger.rst
+++ b/messenger.rst
@@ -228,17 +228,17 @@ your ``CommandBus`` in your services:
     services:
         App\CommandBus: ['@messenger.bus.commands']
 
-Middlewares
------------
+Middleware
+----------
 
 What happens when you dispatch a message to a message bus(es) depends on its
-middlewares (and their order). By default, the middlewares configured for each
-bus looks like this.
+collection of middleware (and their order). By default, the middleware configured
+for each bus looks like this:
 
 1. ``logging`` middleware. Responsible of logging the beginning and the end of the
    message within the bus.
 
-2. _Your own middlewares__
+2. _Your own collection of middleware__
 
 3. ``route_messages`` middleware. Will route the messages your configured to their
    corresponding sender and stop the middleware chain.
@@ -246,10 +246,10 @@ bus looks like this.
 4. ``call_message_handler`` middleware. Will call the message handler(s) for the
    given message.
 
-Adding your own middlewares
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Adding your own middleware
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As described in the component documentation, you can add your own middlewares
+As described in the component documentation, you can add your own middleware
 within the buses to add some extra capabilities like this:
 
 .. code-block:: yaml
@@ -258,7 +258,7 @@ within the buses to add some extra capabilities like this:
         messenger:
             buses:
                 default:
-                    middlewares:
+                    middleware:
                         # Works with the FQCN if the class discovery is enabled
                         - App\\Middleware\\MyMiddleware
 
@@ -267,11 +267,11 @@ within the buses to add some extra capabilities like this:
 
 Note that if the service is abstract, then a child service will be created per bus.
 
-Disabling default middlewares
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Disabling default middleware
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you don't want the default middlewares to be present on your bus, you can disable
-them like this:
+If you don't want the default collection of middleware to be present on your bus,
+you can disable them like this:
 
 .. code-block:: yaml
 
@@ -279,7 +279,7 @@ them like this:
         messenger:
             buses:
                 default:
-                    default_middlewares: false
+                    default_middleware: false
 
 Your own Transport
 ------------------

--- a/messenger.rst
+++ b/messenger.rst
@@ -208,25 +208,19 @@ Auto-wiring is a great feature that allows you to reduce the amount of configura
 required for your service container to be created. When using multiple buses, by default,
 the auto-wiring will not work as it won't know why bus to inject in your own services.
 
-In order to clarify this, you will have to create your own decorators for your message
-buses. Let's create one for your ``CommandBus``::
-
-    namespace App;
-
-    use Symfony\Component\Messenger\AbstractMessageBusDecorator;
-
-    final class CommandBus extends AbstractMessageBusDecorator
-    {
-    }
-
-Last step is to register your service (and explicit its argument) to be able to typehint
-your ``CommandBus`` in your services:
+In order to clarify this, you can use the DependencyInjection's binding capabilities
+to clarify which bus will be injected based on the argument's name:
 
 .. code-block:: yaml
 
     # config/services.yaml
     services:
-        App\CommandBus: ['@messenger.bus.commands']
+        _defaults:
+            # ...
+
+            bind:
+                $commandBus: '@messenger.bus.commands'
+                $eventBus: '@messenger.bus.events'
 
 Middleware
 ----------

--- a/messenger.rst
+++ b/messenger.rst
@@ -279,30 +279,48 @@ Once you have written your transport's sender and receiver, you can register you
 transport factory to be able to use it via a DSN in the Symfony application.
 
 Create your Transport Factory
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You need to give FrameworkBundle the opportunity to create your transport from a
 DSN. You will need an transport factory::
 
-    use Symfony\Component\Messenger\Transport\Factory\AdapterFactoryInterface;
+    use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
+    use Symfony\Component\Messenger\Transport\TransportInterface;
     use Symfony\Component\Messenger\Transport\ReceiverInterface;
     use Symfony\Component\Messenger\Transport\SenderInterface;
 
     class YourTransportFactory implements TransportFactoryInterface
     {
-        public function createReceiver(string $dsn, array $options): ReceiverInterface
+        public function createTransport(string $dsn, array $options): TransportInterface
         {
-            return new YourReceiver(/* ... */);
-        }
-
-        public function createSender(string $dsn, array $options): SenderInterface
-        {
-            return new YourSender(/* ... */);
+            return new YourTransport(/* ... */);
         }
 
         public function supports(string $dsn, array $options): bool
         {
             return 0 === strpos($dsn, 'my-transport://');
+        }
+    }
+
+The transport object is needs to implements the ``TransportInterface`` (which simply combine
+the ``SenderInterface`` and ``ReceiverInterface``). It will look
+like this::
+
+    class YourTransport implements TransportInterface
+    {
+        public function send($message) : void
+        {
+            // ...
+        }
+
+        public function receive(callable $handler) : void
+        {
+            // ...
+        }
+
+        public function stop() : void
+        {
+            // ...
         }
     }
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -44,7 +44,7 @@ Registering Handlers
 --------------------
 
 In order to do something when your message is dispatched, you need to create a
-message handler. It's a class with an `__invoke` method::
+message handler. It's a class with an ``__invoke`` method::
 
     // src/MessageHandler/MyMessageHandler.php
     namespace App\MessageHandler;
@@ -232,7 +232,7 @@ for each bus looks like this:
 1. ``logging`` middleware. Responsible of logging the beginning and the end of the
    message within the bus.
 
-2. _Your own collection of middleware__
+2. _Your own collection of middleware_
 
 3. ``route_messages`` middleware. Will route the messages your configured to their
    corresponding sender and stop the middleware chain.
@@ -355,4 +355,4 @@ will give you access to the following services:
 #. ``messenger.sender.yours``: the sender.
 #. ``messenger.receiver.yours``: the receiver.
 
-.. _`enqueue's transport`: https://github.com/sroze/enqueue-bridge
+.. _`enqueue's transport`: https://github.com/enqueue/messenger-adapter

--- a/messenger.rst
+++ b/messenger.rst
@@ -219,6 +219,59 @@ your ``CommandBus`` in your services:
     services:
         App\CommandBus: ['@messenger.bus.commands']
 
+Middlewares
+-----------
+
+What happens when you dispatch a message to a message bus(es) depends on its
+middlewares (and their order). By default, the middlewares configured for each
+bus looks like this.
+
+1. ``logging`` middleware. Responsible of logging the beginning and the end of the
+   message within the bus.
+
+2. _Your own middlewares__
+
+3. ``route_messages`` middleware. Will route the messages your configured to their
+   corresponding sender and stop the middleware chain.
+
+4. ``call_message_handler`` middleware. Will call the message handler(s) for the
+   given message.
+
+Adding your own middlewares
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As described in the component documentation, you can add your own middlewares
+within the buses to add some extra capabilities like this:
+
+.. code-block:: yaml
+
+    framework:
+        messenger:
+            buses:
+                default:
+                    middlewares:
+                        # Works with the FQCN if the class discovery is enabled
+                        - App\\Middleware\\MyMiddleware
+
+                        # Or with some service name
+                        - app.middleware.yours
+
+Note that if the service is abstract, then a child service will be created per bus.
+
+Disabling default middlewares
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you don't want the default middlewares to be present on your bus, you can disable
+them like this:
+
+.. code-block:: yaml
+
+    framework:
+        messenger:
+            buses:
+                default:
+                    default_middlewares: false
+
 Your own Transport
 ------------------
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -168,6 +168,57 @@ like this:
 The first argument is the receiver's service name. It might have been created by
 your ``transports`` configuration or it can be your own receiver.
 
+Multiple buses
+--------------
+
+If you are interested into architectures like CQRS, you might want to have multiple
+buses within your application.
+
+You can create multiple buses (in this example, a command and an event bus) like
+this:
+
+.. code-block:: yaml
+
+    framework:
+        messenger:
+            # The bus that is going to be injected when injecting MessageBusInterface:
+            default_bus: commands
+
+            # Create buses
+            buses:
+                commands: ~
+                events: ~
+
+This will generate the ``messenger.bus.commands`` and ``messenger.bus.events`` services
+that you can inject in your services.
+
+Type-hints and auto-wiring
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Auto-wiring is a great feature that allows you to reduce the amount of configuration
+required for your service container to be created. When using multiple buses, by default,
+the auto-wiring will not work as it won't know why bus to inject in your own services.
+
+In order to clarify this, you will have to create your own decorators for your message
+buses. Let's create one for your ``CommandBus``::
+
+    namespace App;
+
+    use Symfony\Component\Messenger\AbstractMessageBusDecorator;
+
+    final class CommandBus extends AbstractMessageBusDecorator
+    {
+    }
+
+Last step is to register your service (and explicit its argument) to be able to typehint
+your ``CommandBus`` in your services:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+    services:
+        App\CommandBus: ['@messenger.bus.commands']
+
 Your own Transport
 ------------------
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -195,8 +195,8 @@ this:
 
             # Create buses
             buses:
-                commands: ~
-                events: ~
+                messenger.bus.commands: ~
+                messenger.bus.events: ~
 
 This will generate the ``messenger.bus.commands`` and ``messenger.bus.events`` services
 that you can inject in your services.
@@ -257,7 +257,7 @@ within the buses to add some extra capabilities like this:
     framework:
         messenger:
             buses:
-                default:
+                messenger.bus.default:
                     middleware:
                         # Works with the FQCN if the class discovery is enabled
                         - App\\Middleware\\MyMiddleware
@@ -278,7 +278,7 @@ you can disable them like this:
     framework:
         messenger:
             buses:
-                default:
+                messenger.bus.default:
                     default_middleware: false
 
 Your own Transport

--- a/messenger.rst
+++ b/messenger.rst
@@ -107,6 +107,15 @@ configure the following services for you:
 1. A ``messenger.sender.amqp`` sender to be used when routing messages.
 2. A ``messenger.receiver.amqp`` receiver to be used when consuming messages.
 
+.. note::
+
+    In order to use Symfony's built-in AMQP adapter, you will need the Serializer
+    Component. Ensure that it is installed with:
+
+    .. code-block:: terminal
+
+        $ composer require symfony/serializer-pack
+
 Routing
 -------
 


### PR DESCRIPTION
- [x] Fixes #9641 with the middleware configuration.
- [x] Fixes #9617 with the multiple bus configuration.
- [x] Change adapters to transports (waiting merge: https://github.com/symfony/symfony/pull/27129)
- [x] middlewares config entry is renamed middleware (symfony/symfony#27177)
- [x] in the config, message buses names are the full service id you'll use (symfony/symfony#27162)
- [x] Add TransportInterface as first class citizen sender+receiver (symfony/symfony#27164)