### PR TITLE
Fix factory-service new syntax in the last example

### DIFF
--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -184,7 +184,7 @@ method in the previous example takes the ``templating`` service as an argument:
 
             app.newsletter_manager:
                 class:     AppBundle\Email\NewsletterManager
-                factory:   'newsletter_manager_factory:createNewsletterManager'
+                factory:   'newsletter_manager_factory::createNewsletterManager'
                 arguments: ['@templating']
 
     .. code-block:: xml


### PR DESCRIPTION
It is in fact the continuation of #9701, I'm sorry, I overlooked, and did not fix the new syntax in the last example :(

Immediately I am doing in the branch `2.7`.