### PR TITLE
Revert fix factory-service new syntax

### DIFF
--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -106,7 +106,7 @@ Configuration of the service container then looks like this:
             app.newsletter_manager:
                 class:   AppBundle\Email\NewsletterManager
                 # call a method on the specified factory service
-                factory: 'app.newsletter_manager_factory::createNewsletterManager'
+                factory: 'app.newsletter_manager_factory:createNewsletterManager'
 
     .. code-block:: xml
 
@@ -160,7 +160,7 @@ Configuration of the service container then looks like this:
 
         app.newsletter_manager:
             # new syntax
-            factory: 'app.newsletter_manager_factory::createNewsletterManager'
+            factory: 'app.newsletter_manager_factory:createNewsletterManager'
             # old syntax
             factory: ['@app.newsletter_manager_factory', createNewsletterManager]
 


### PR DESCRIPTION
This should apply **only** to branches 2.x (`2.7` and `2.8`), new versions (> 3.x) use the full class name, and therefore two colons should be used, not one
