### PR TITLE
Fix factory-service new syntax in the last example

### DIFF
--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -188,7 +188,7 @@ example takes the ``templating`` service as an argument:
             # ...
 
             AppBundle\Email\NewsletterManager:
-                factory:   'AppBundle\Email\NewsletterManagerFactory:createNewsletterManager'
+                factory:   'AppBundle\Email\NewsletterManagerFactory::createNewsletterManager'
                 arguments: ['@templating']
 
     .. code-block:: xml


### PR DESCRIPTION
It is in fact the continuation of #9701, I'm sorry, I overlooked, and did not fix the new syntax in the last example :(

And an important note! Changes in this PR and #9701 should concern the versions of Symfony, starting with `3.4`, **not** 2.x (eg `2.7`). So I created a separate PR #9729, which returns the "old" syntax to version 2.x, because **only one** colon is needed because the identifier (`app.newsletter_manager_factory`) is used, not the full class name (`App\Email\NewsletterManagerStaticFactory`, then in this case exactly two colons are required!

