### PR TITLE
Turn on syntax highlight

### DIFF
--- a/frontend/encore/typescript.rst
+++ b/frontend/encore/typescript.rst
@@ -9,7 +9,7 @@ Want to use `TypeScript`_? No problem! First, install the dependencies:
 
 Then, activate the ``ts-loader`` in ``webpack.config.js``:
 
-.. code-block:: diff
+.. code-block:: javascript
 
     // webpack.config.js
     // ...
@@ -48,7 +48,7 @@ process, which can speedup compile time. To enable it, install the plugin:
 
 Then enable it by calling:
 
-.. code-block:: diff
+.. code-block:: javascript
 
     // webpack.config.js
 


### PR DESCRIPTION
Because the syntax diff is not used in fact, it's just a code highlight, similar to the example on the [React page](https://symfony.com/doc/3.3/frontend/encore/reactjs.html)