### PR TITLE
Update email.rst

### DIFF
--- a/email.rst
+++ b/email.rst
@@ -51,6 +51,7 @@ The Swift Mailer library works by creating, configuring and then sending
 of the message and is accessible via the ``Swift_Mailer`` service. Overall,
 sending an email is pretty straightforward::
 
+// Put PHP Doc here
     public function index($name, \Swift_Mailer $mailer)
     {
         $message = (new \Swift_Message('Hello Email'))
@@ -80,6 +81,8 @@ sending an email is pretty straightforward::
 
         return $this->render(...);
     }
+
+// Write an example of execution
 
 To keep things decoupled, the email body has been stored in a template and
 rendered with the ``renderView()`` method. The ``registration.html.twig``


### PR DESCRIPTION
1) Above the method (line#54):
public function index($name, \Swift_Mailer $mailer)
a PHP Doc should be written although the IDE provides a functionality to automatically write it.

2) Below this same method, an example should be written to run it (line #85):
I run this method this way: http://localhost:8000/email/username but it doesn't work, it gives this error:
No route found for "GET /email/username"
I think it is a bit unclear.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
