### PR TITLE
[Console] Fix SymfonyStyle::ask usage

### DIFF
--- a/console/style.rst
+++ b/console/style.rst
@@ -238,11 +238,11 @@ User Input Methods
     the third argument::
 
         $io->ask('Number of workers to start', 1, function ($number) {
-            if (!ctype_digit($number)) {
-                throw new \RuntimeException('You must type an integer.');
+            if (!is_numeric($number)) {
+                throw new \RuntimeException('You must type a number.');
             }
 
-            return $number;
+            return (int) $number;
         });
 
 :method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::askHidden`

--- a/console/style.rst
+++ b/console/style.rst
@@ -238,7 +238,7 @@ User Input Methods
     the third argument::
 
         $io->ask('Number of workers to start', 1, function ($number) {
-            if (!is_integer($number)) {
+            if (!ctype_digit($number)) {
                 throw new \RuntimeException('You must type an integer.');
             }
 


### PR DESCRIPTION
Use function "ctype_digit" instead of "is_integer" because "$number" is not an integer value, but a string

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
