### PR TITLE
Don't use Flex shortcuts when installing packages

### DIFF
--- a/_includes/_annotation_loader_tip.rst.inc
+++ b/_includes/_annotation_loader_tip.rst.inc
@@ -1,7 +1,7 @@
 .. note::
 
     In order to use the annotation loader, you should have installed the
-    ``doctrine/annotations`` and ``doctrine/cache`` packages with Composer.
+    ``sensio/framework-extra-bundle`` and ``doctrine/cache`` packages with Composer.
 
 .. tip::
 

--- a/_includes/_annotation_loader_tip.rst.inc
+++ b/_includes/_annotation_loader_tip.rst.inc
@@ -1,7 +1,7 @@
 .. note::
 
     In order to use the annotation loader, you should have installed the
-    ``sensio/framework-extra-bundle`` and ``doctrine/cache`` packages with Composer.
+    ``doctrine/annotations`` and ``doctrine/cache`` packages with Composer.
 
 .. tip::
 

--- a/best_practices/i18n.rst
+++ b/best_practices/i18n.rst
@@ -3,7 +3,7 @@ Internationalization
 
 Internationalization and localization adapt the applications and their contents
 to the specific region or language of the users. In Symfony this is an opt-in
-feature that needs to be installed before using it (``composer require translation``).
+feature that needs to be installed before using it (``composer require symfony/translation``).
 
 Translation Source File Location
 --------------------------------

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -23,7 +23,7 @@ Alternatively, you can clone the `<https://github.com/symfony/var-dumper>`_ repo
 .. note::
 
     If using it inside a Symfony application, make sure that the DebugBundle has
-    been installed (or run ``composer require debug`` to install it).
+    been installed (or run ``composer require symfony/debug-bundle`` to install it).
 
 .. _components-var-dumper-dump:
 

--- a/contributing/code/reproducer.rst
+++ b/contributing/code/reproducer.rst
@@ -65,8 +65,8 @@ to a route definition. Then, after creating your project:
    of controllers, actions, etc. as in your original application.
 #. Create a simple controller and add your routing definition that shows the bug.
 #. Don't create or modify any other file.
-#. Execute ``composer require server`` and use the ``server:run`` command to browse
-   to the new route and see if the bug appears or not.
+#. Execute ``composer require symfony/web-server-bundle`` and use the ``server:run``
+   command to browse to the new route and see if the bug appears or not.
 #. If you can see the bug, you're done and you can already share the code with us.
 #. If you can't see the bug, you must keep making small changes. For example, if
    your original route was defined using XML, forget about the previous route

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -468,7 +468,7 @@ the :ref:`doctrine-queries` section.
     If the number of database queries is too high, the icon will turn yellow to
     indicate that something may not be correct. Click on the icon to open the
     Symfony Profiler and see the exact queries that were executed. If you don't
-    see the web debug toolbar, try running ``composer require symfony/web-profiler-bundle``
+    see the web debug toolbar, try running ``composer require --dev symfony/profiler-pack``
     to install it.
 
 Automatically Fetching Objects (ParamConverter)

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -18,12 +18,12 @@ tight integration with a third-party library called `Doctrine`_.
 Installing Doctrine
 -------------------
 
-First, install Doctrine, as well as the MakerBundle, which will help generate some
-code:
+First, install Doctrine support via the ORM pack, as well as the MakerBundle,
+which will help generate some code:
 
 .. code-block:: terminal
 
-    $ composer require doctrine/doctrine-bundle
+    $ composer require symfony/orm-pack
     $ composer require symfony/maker-bundle --dev
 
 Configuring the Database

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -23,8 +23,8 @@ code:
 
 .. code-block:: terminal
 
-    composer require doctrine
-    composer require maker --dev
+    $ composer require doctrine/doctrine-bundle
+    $ composer require symfony/maker-bundle --dev
 
 Configuring the Database
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -468,8 +468,8 @@ the :ref:`doctrine-queries` section.
     If the number of database queries is too high, the icon will turn yellow to
     indicate that something may not be correct. Click on the icon to open the
     Symfony Profiler and see the exact queries that were executed. If you don't
-    see the web debug toolbar, try running ``composer require profiler`` to install
-    it.
+    see the web debug toolbar, try running ``composer require symfony/web-profiler-bundle``
+    to install it.
 
 Automatically Fetching Objects (ParamConverter)
 -----------------------------------------------
@@ -479,7 +479,7 @@ for you automatically! First, install the bundle in case you don't have it:
 
 .. code-block:: terminal
 
-    $ composer require annotations
+    $ composer require doctrine/annotations
 
 Now, simplify your controller::
 

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -479,7 +479,7 @@ for you automatically! First, install the bundle in case you don't have it:
 
 .. code-block:: terminal
 
-    $ composer require doctrine/annotations
+    $ composer require sensio/framework-extra-bundle
 
 Now, simplify your controller::
 

--- a/doctrine/dbal.rst
+++ b/doctrine/dbal.rst
@@ -25,7 +25,7 @@ First, install the Doctrine bundle:
 
 .. code-block:: terminal
 
-    composer require doctrine/doctrine-bundle
+    $ composer require doctrine/doctrine-bundle
 
 Then configure the ``DATABASE_URL`` environment variable in ``.env``:
 

--- a/doctrine/registration_form.rst
+++ b/doctrine/registration_form.rst
@@ -14,7 +14,7 @@ First, make sure you have all the dependencies you need installed:
 
 .. code-block:: terminal
 
-    $ composer require doctrine/doctrine-bundle symfony/form symfony/security-bundle symfony/validator
+    $ composer require symfony/orm-pack symfony/form symfony/security-bundle symfony/validator
 
 .. tip::
 

--- a/doctrine/registration_form.rst
+++ b/doctrine/registration_form.rst
@@ -14,7 +14,7 @@ First, make sure you have all the dependencies you need installed:
 
 .. code-block:: terminal
 
-    $ composer require doctrine form security validator
+    $ composer require doctrine/doctrine-bundle symfony/form symfony/security-bundle symfony/validator
 
 .. tip::
 

--- a/email.rst
+++ b/email.rst
@@ -17,7 +17,7 @@ install the Swift Mailer based mailer before using it:
 
 .. code-block:: terminal
 
-    $ composer require mailer
+    $ composer require symfony/swiftmailer-bundle
 
 If your application doesn't use Symfony Flex, follow the installation
 instructions on `SwiftMailerBundle`_.

--- a/forms.rst
+++ b/forms.rst
@@ -17,7 +17,7 @@ install the form feature before using it:
 
 .. code-block:: terminal
 
-    $ composer require form
+    $ composer require symfony/form
 
 .. note::
 
@@ -321,7 +321,7 @@ Before using validation, add support for it in your application:
 
 .. code-block:: terminal
 
-    $ composer require validator
+    $ composer require symfony/validator
 
 Validation is done by adding a set of rules (called constraints) to a class. To
 see this in action, add validation constraints so that the ``task`` field cannot

--- a/logging.rst
+++ b/logging.rst
@@ -12,7 +12,7 @@ install the Monolog based logger before using it:
 
 .. code-block:: terminal
 
-    $ composer require logger
+    $ composer require symfony/monolog-bundle
 
 Logging a Message
 -----------------

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -191,11 +191,11 @@ The Web Debug Toolbar: Debugging Dream
 One of Symfony's *killer* features is the Web Debug Toolbar: a bar that displays
 a *huge* amount of debugging information along the bottom of your page while developing.
 
-To use the web debug toolbar, just install it:
+To use the web debug toolbar, install the Profiler pack first:
 
 .. code-block:: terminal
 
-    $ composer require --dev symfony/web-profiler-bundle
+    $ composer require --dev symfony/profiler-pack
 
 As soon as this finishes, refresh your page. You should see a black bar along the
 bottom of the page. You'll learn more about all the information it holds along the

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -195,15 +195,15 @@ To use the web debug toolbar, just install it:
 
 .. code-block:: terminal
 
-    $ composer require --dev profiler
+    $ composer require --dev symfony/web-profiler-bundle
 
 As soon as this finishes, refresh your page. You should see a black bar along the
 bottom of the page. You'll learn more about all the information it holds along the
 way, but feel free to experiment: hover over and click the different icons to get
 information about routing, performance, logging and more.
 
-The ``profiler`` package is also a great example of Flex! After downloading the
-package, the recipe created several configuration files so that the web debug toolbar
+This is also a great example of Flex! After downloading the profiler package,
+the recipe created several configuration files so that the web debug toolbar
 worked instantly.
 
 Rendering a Template
@@ -217,7 +217,7 @@ First, install Twig:
 
 .. code-block:: terminal
 
-    $ composer require twig
+    $ composer require symfony/twig-bundle
 
 Second, make sure that ``LuckyController`` extends Symfony's base
 :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller` class:

--- a/profiler.rst
+++ b/profiler.rst
@@ -12,7 +12,7 @@ install the profiler before using it:
 
 .. code-block:: terminal
 
-    $ composer require profiler --dev
+    $ composer require symfony/web-profiler-bundle --dev
 
 .. toctree::
     :maxdepth: 1

--- a/profiler.rst
+++ b/profiler.rst
@@ -12,7 +12,7 @@ install the profiler before using it:
 
 .. code-block:: terminal
 
-    $ composer require symfony/web-profiler-bundle --dev
+    $ composer require --dev symfony/profiler-pack
 
 .. toctree::
     :maxdepth: 1

--- a/routing.rst
+++ b/routing.rst
@@ -24,7 +24,7 @@ First, install the annotations package:
 
 .. code-block:: terminal
 
-    $ composer require annotations
+    $ composer require doctrine/annotations
 
 A *route* is a map from a URL path to a controller. Suppose you want one route that
 matches ``/blog`` exactly and another more dynamic route that can match *any* URL

--- a/routing.rst
+++ b/routing.rst
@@ -20,11 +20,11 @@ the change is simple.
 Creating Routes
 ---------------
 
-First, install the annotations package:
+First, add support for annotations via the SensioFrameworkExtraBundle:
 
 .. code-block:: terminal
 
-    $ composer require doctrine/annotations
+    $ composer require sensio/framework-extra-bundle
 
 A *route* is a map from a URL path to a controller. Suppose you want one route that
 matches ``/blog`` exactly and another more dynamic route that can match *any* URL

--- a/security.rst
+++ b/security.rst
@@ -34,7 +34,7 @@ install the security feature before using it:
 
 .. code-block:: terminal
 
-    $ composer require security
+    $ composer require symfony/security-bundle
 
 .. _security-firewalls:
 .. _firewalls-authentication:
@@ -136,7 +136,7 @@ You'll learn later how to deny access to certain URLs or controllers.
 
     .. code-block:: terminal
 
-        $ composer require profiler --dev
+        $ composer require symfony/web-profiler-bundle --dev
 
 .. tip::
 

--- a/security.rst
+++ b/security.rst
@@ -136,7 +136,7 @@ You'll learn later how to deny access to certain URLs or controllers.
 
     .. code-block:: terminal
 
-        $ composer require symfony/web-profiler-bundle --dev
+        $ composer require --dev symfony/profiler-pack
 
 .. tip::
 

--- a/security/csrf.rst
+++ b/security/csrf.rst
@@ -17,7 +17,7 @@ requires installing the Symfony Form component):
 
 .. code-block:: terminal
 
-    $ composer require security-csrf form
+    $ composer require symfony/security-csrf symfony/form
 
 Then, enable/disable the CSRF protection with the ``csrf_protection`` option
 (see the :ref:`CSRF configuration reference <reference-framework-csrf-protection>`

--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -27,11 +27,11 @@ and :ref:`user serialization to the session <security-serialize-equatable>`
 1) Create your User Entity
 --------------------------
 
-Before you begin, first make sure you install the Security component:
+Before you begin, run this command to add support for the Symfony security:
 
 .. code-block:: terminal
 
-    $ composer require security
+    $ composer require symfony/security-bundle
 
 For this entry, suppose that you already have a ``User`` entity
 with the following fields: ``id``, ``username``, ``password``,

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -42,7 +42,7 @@ install the Ldap component before using it:
 
 .. code-block:: terminal
 
-    $ composer require ldap
+    $ composer require symfony/ldap
 
 Ldap Configuration Reference
 ----------------------------

--- a/security/security_checker.rst
+++ b/security/security_checker.rst
@@ -13,7 +13,7 @@ First, install the security checker in your project:
 
 .. code-block:: terminal
 
-    $ composer require security-checker
+    $ composer require sensiolabs/security-checker
 
 Then run this command:
 

--- a/serializer.rst
+++ b/serializer.rst
@@ -119,11 +119,11 @@ properties and setters (``setXxx()``) to change properties:
 Using Serialization Groups Annotations
 --------------------------------------
 
-To use annotations, first install the annotations package:
+To use annotations, first add support for them via the SensioFrameworkExtraBundle:
 
 .. code-block:: terminal
 
-    $ composer require doctrine/annotations
+    $ composer require sensio/framework-extra-bundle
 
 Next, add the :ref:`@Groups annotations <component-serializer-attributes-groups-annotations>`
 to your class and choose which groups to use when serializing::

--- a/serializer.rst
+++ b/serializer.rst
@@ -19,7 +19,7 @@ install the serializer before using it:
 
 .. code-block:: terminal
 
-    $ composer require serializer
+    $ composer require symfony/serializer
 
 Using the Serializer Service
 ----------------------------
@@ -123,7 +123,7 @@ To use annotations, first install the annotations package:
 
 .. code-block:: terminal
 
-    $ composer require annotations
+    $ composer require doctrine/annotations
 
 Next, add the :ref:`@Groups annotations <component-serializer-attributes-groups-annotations>`
 to your class and choose which groups to use when serializing::

--- a/setup.rst
+++ b/setup.rst
@@ -45,7 +45,7 @@ First, move into your new project and install the server:
 .. code-block:: terminal
 
     $ cd my-project
-    $ composer require server --dev
+    $ composer require symfony/web-server-bundle --dev
 
 To start the server, run:
 
@@ -115,14 +115,14 @@ few other project-specific tasks (e.g. creating database schema).
 Checking for Security Vulnerabilities
 -------------------------------------
 
-Symfony provides a utility called the "Security Checker" (or ``sec-checker``) to
-check whether your project's dependencies contain any known security
-vulnerability. Run this command to install it in your application:
+Symfony provides a utility called the "Security Checker" to check whether your
+project's dependencies contain any known security vulnerability. Run this
+command to install it in your application:
 
 .. code-block:: terminal
 
     $ cd my-project/
-    $ composer require sec-checker --dev
+    $ composer require sensiolabs/security-checker --dev
 
 From now on, this utility will be run automatically whenever you install or
 update any dependency in the application. If a dependency contains a vulnerability,

--- a/setup/built_in_web_server.rst
+++ b/setup/built_in_web_server.rst
@@ -27,7 +27,7 @@ Move into your project directory and run this command:
 .. code-block:: terminal
 
     $ cd your-project/
-    $ composer require server --dev
+    $ composer require symfony/web-server-bundle --dev
 
 Starting the Web Server
 -----------------------

--- a/templating.rst
+++ b/templating.rst
@@ -744,7 +744,7 @@ To use this function, install the *asset* package:
 
 .. code-block:: terminal
 
-    $ composer require asset
+    $ composer require symfony/asset
 
 You can now use the ``asset()`` function:
 

--- a/templating/PHP.rst
+++ b/templating/PHP.rst
@@ -21,7 +21,7 @@ If you want to use the PHP templating engine, first install the templating compo
 
 .. code-block:: terminal
 
-    $ composer require templating
+    $ composer require symfony/templating
 
 Next, enable the php engine:
 

--- a/templating/debug.rst
+++ b/templating/debug.rst
@@ -14,7 +14,7 @@ is installed:
 
 .. code-block:: terminal
 
-    $ composer require var-dumper
+    $ composer require symfony/var-dumper
 
 This is useful, for example, inside your controller::
 

--- a/testing.rst
+++ b/testing.rst
@@ -139,7 +139,7 @@ First, install the BrowserKit component in your project:
 
 .. code-block:: terminal
 
-    $ composer require --dev browser-kit
+    $ composer require --dev symfony/browser-kit
 
 Functional tests are simple PHP files that typically live in the ``tests/Controller``
 directory for your bundle. If you want to test the pages handled by your
@@ -210,7 +210,7 @@ component, run:
 
 .. code-block:: terminal
 
-    $ composer require --dev css-selector
+    $ composer require --dev symfony/css-selector
 
 Now you can use CSS selectors with the crawler. To assert that the phrase
 "Hello World" is on the page at least once, you can use this assertion::

--- a/translation.rst
+++ b/translation.rst
@@ -55,7 +55,7 @@ First, run this command to install the translator before using it:
 
 .. code-block:: terminal
 
-    $ composer require translator
+    $ composer require symfony/translation
 
 Configuration
 -------------

--- a/validation.rst
+++ b/validation.rst
@@ -19,7 +19,7 @@ install the validator before using it:
 
 .. code-block:: terminal
 
-    $ composer require validator
+    $ composer require symfony/validator
 
 .. index::
    single: Validation; The basics

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -12,7 +12,7 @@ install the workflow feature before using it:
 
 .. code-block:: terminal
 
-    $ composer require workflow
+    $ composer require symfony/workflow
 
 Creating a Workflow
 -------------------


### PR DESCRIPTION
This fixes #9693. I've left some shortcuts on purpose:

* in `frontend/encore/installation.rst`: `composer require encore` because Webpack Encore is a bit special and the shortcut is the best way to install it.
* in `quick_tour/*.rst` because it shows the features provided by Symfony and shortcuts is one of those features. Readers will learn about them and later they'll decide if they want to use them or not.
* in `setup/flex.rst` because they are used on purpose to talk about Flex shortcuts.