### PR TITLE
Added the Code of Conduct to Symfony Docs repo

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,12 @@
+Code of Conduct
+===============
+
+This project follows a [Code of Conduct][code_of_conduct] in order to ensure an
+open and welcoming environment. Please read the full text for understanding the
+accepted and unaccepted behavior.
+
+Please read also the [reporting guidelines][guidelines], in case you encountered
+or witnessed any misbehavior.
+
+[code_of_conduct]: https://symfony.com/doc/current/contributing/code_of_conduct/code_of_conduct.html
+[guidelines]: https://symfony.com/doc/current/contributing/code_of_conduct/reporting_guidelines.html


### PR DESCRIPTION
We need to add this file if we want GitHub to display a link to it as in the main Symfony repo:

![coc-resource](https://user-images.githubusercontent.com/73419/39698793-95f4dff4-51f6-11e8-85d6-c6804e258cca.png)
