### PR TITLE
Validation group should be precised

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -148,6 +148,28 @@ Using custom validators is very easy, just as the ones provided by Symfony itsel
             }
         }
 
+If you are using validation groups, you need to either reference the Default group when using the constraint, or set the correct group.
+
+
+    .. code-block:: php-annotations
+
+        // src/Entity/AcmeEntity.php
+        use Symfony\Component\Validator\Constraints as Assert;
+        use App\Validator\Constraints as AcmeAssert;
+
+        class AcmeEntity
+        {
+            // ...
+
+            /**
+             * @Assert\NotBlank
+             * @AcmeAssert\ContainsAlphanumeric(groups={"default"})
+             */
+            protected $name;
+
+            // ...
+        }
+
 If your constraint contains options, then they should be public properties
 on the custom Constraint class you created earlier. These options can be
 configured like options on core Symfony constraints.


### PR DESCRIPTION
My custom constraint was not working and I didn't know why. I'm using validation group on my forms, and I had to add a group to make my constraint works. There was no error or nothing  in the doc referencing validation group  when creating custom constraint.

 like here https://symfony.com/doc/current/form/without_class.html : 

`If you are using validation groups, you need to either reference the Default group when creating the form, or set the correct group on the constraint you are adding.
new NotBlank(array('groups' => array('create', 'update'))); `

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
