### PR TITLE
Rename enforcement team to CARE team

### DIFF
--- a/contributing/code_of_conduct/care_team.rst
+++ b/contributing/code_of_conduct/care_team.rst
@@ -1,10 +1,10 @@
-Enforcement Team
-================
+CARE Team
+=========
 
 Our Pledge
 ----------
 
-In the interest of fostering an open and welcoming environment, the enforcement team
+In the interest of fostering an open and welcoming environment, the CoC Active Response Ensurers, or CARE,
 pledge to ensure that the spirit of the :doc:`Code of Conduct </contributing/code_of_conduct/index>`
 is respected. Our main priority is to ensure the safety of our community members.
 The second goal is to help educate the community as a whole to be aware of the CoC
@@ -12,19 +12,19 @@ and how to help implement its spirit throughout the community. In case these goa
 conflict, we will prioritize safety of community members over all other goals.
 
 If you think there is or has been a violation to the code of conduct please contact
-enforcement team or if you prefer contact only individual members of the enforcement team.
+the CARE team or if you prefer contact only individual members of the CARE team.
 
 Members
 -------
 
-Here are all the members of the Code of Conduct enforcement team. You can contact
+Here are all the members of the Code of Conduct CARE team. You can contact
 any of them directly using the contact details below or you can also contact all of
 them at once by emailing **coc@symfony.com**.
 
-About the Enforcement Team
---------------------------
+About the CARE Team
+-------------------
 
-The :doc:`Symfony project leader </contributing/code/core_team>` appoints enforcement
-team with candidates they see fit. The enforcement team will consist of at least
+The :doc:`Symfony project leader </contributing/code/core_team>` appoints the CARE
+team with candidates they see fit. The CARE team will consist of at least
 3 people. The team should be representing as many demographics as possible,
 ideally from different employers.

--- a/contributing/code_of_conduct/code_of_conduct.rst
+++ b/contributing/code_of_conduct/code_of_conduct.rst
@@ -37,12 +37,12 @@ Examples of unacceptable behavior by participants include:
 Our Responsibilities
 --------------------
 
-:doc:`Enforcement team members </contributing/code_of_conduct/enforcement_team>`
+:doc:`CoC Active Response Ensurers, or CARE</contributing/code_of_conduct/care_team>`,
 are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
-Enforcement team members have the right and responsibility to remove, edit, or
+CARE team members have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviors that they deem inappropriate,
@@ -56,20 +56,20 @@ when an individual is representing the project or its community. Examples of
 representing a project or community include using an official project e-mail
 address, posting via an official social media account, or acting as an appointed
 representative at an online or offline event. Representation of a project may be
-further defined and clarified by enforcement team members.
+further defined and clarified by CARE team members.
 
 Enforcement
 -----------
 
 Instances of abusive, harassing, or otherwise unacceptable behavior
 :doc:`may be reported </contributing/code_of_conduct/reporting_guidelines>`
-by contacting the :doc:`enforcement team members </contributing/code_of_conduct/enforcement_team>`.
+by contacting the :doc:`CARE team members </contributing/code_of_conduct/care_team>`.
 All complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The enforcement team is
+is deemed necessary and appropriate to the circumstances. The CARE team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 
-Enforcement team members who do not follow or enforce the Code of Conduct in good
+CARE team members who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by the
 :doc:`core team </contributing/code/core_team>`.
 
@@ -86,7 +86,7 @@ Related Documents
     :maxdepth: 1
 
     reporting_guidelines
-    enforcement_team
+    care_team
     concrete_example_document
 
 .. _Contributor Covenant: https://www.contributor-covenant.org

--- a/contributing/code_of_conduct/index.rst
+++ b/contributing/code_of_conduct/index.rst
@@ -6,5 +6,5 @@ Code of Conduct
 
     code_of_conduct
     reporting_guidelines
-    enforcement_team
+    care_team
     concrete_example_document

--- a/contributing/code_of_conduct/reporting_guidelines.rst
+++ b/contributing/code_of_conduct/reporting_guidelines.rst
@@ -2,7 +2,7 @@ Reporting Guidelines
 ====================
 
 If you believe someone is violating the Code of Conduct we ask that you report
-it to the :doc:`enforcement team </contributing/code_of_conduct/enforcement_team>`
+it to the :doc:`CARE team </contributing/code_of_conduct/care_team>`
 by emailing, Twitter, in person or any way you see fit.
 
 **All reports will be kept confidential.** The privacy of everyone included in
@@ -32,11 +32,11 @@ In your report please include:
 What happens after you file a report?
 -------------------------------------
 
-You will receive a reply from the :doc:`enforcement team </contributing/code_of_conduct/enforcement_team>`
+You will receive a reply from the :doc:`CARE team </contributing/code_of_conduct/care_team>`
 acknowledging receipt as soon as possible, but within 24 hours.
 
 The team member receiving the report will immediately contact all or some other
-enforcement team members to review the incident and determine:
+CARE team members to review the incident and determine:
 
 * What happened.
 * Whether this event constitutes a Code of Conduct violation.
@@ -69,20 +69,20 @@ let them know what action (if any) we'll be taking. We'll take into account feed
 from the reporter on the appropriateness of our response, but our response will be
 determined by what will be best for community safety.
 
-The enforcement team keeps a private record of all incidents. By default all reports
-are shared with the entire enforcement team unless the reporter specifically asks
-to exclude specific enforcement team members, in which case these enforcement team
+The CARE team keeps a private record of all incidents. By default all reports
+are shared with the entire CARE team unless the reporter specifically asks
+to exclude specific CARE team members, in which case these CARE team
 members will not be included in any communication on the incidents as well as records
 created related to the incidents.
 
-Enforcement team members are expected to inform the enforcement team and the reporters
+CARE team members are expected to inform the CARE team and the reporters
 in case of conflicts on interest and recuse themselves if this is deemed a problem.
 
 Appealing the response
 ----------------------
 
 Only permanent resolutions (such as bans) may be appealed. To appeal a decision
-of the working group, contact the :doc:`enforcement team </contributing/code_of_conduct/enforcement_team>`
+of the working group, contact the :doc:`CARE team </contributing/code_of_conduct/care_team>`
 with your appeal and they will review the case.
 
 Document origin

--- a/contributing/map.rst.inc
+++ b/contributing/map.rst.inc
@@ -2,7 +2,7 @@
 
   * :doc:`/contributing/code_of_conduct/code_of_conduct`
   * :doc:`/contributing/code_of_conduct/reporting_guidelines`
-  * :doc:`/contributing/code_of_conduct/enforcement_team`
+  * :doc:`/contributing/code_of_conduct/care_team`
   * :doc:`/contributing/code_of_conduct/concrete_example_document`
 
 * **Code**


### PR DESCRIPTION
There were some negative comments about calling it the "enforcement team". This is what it is, but it made some people feel like it was too harsh, too close to policing and easy to give knee-jerk reactions to. Reading the "less obvious checklist" posted by @lsmith77 in https://github.com/symfony/diversity/issues/6#issuecomment-387390245, I noticed DjangoCon had a positive name for this team/group.

> _Your CoC is useless if you can not respond to issues. Set up a CoC team. In DjangoCon Europe, they’re sometimes called CoC Active Response Ensurers or CARE. An ideal size for this is four people. These people are the primary responsible persons for dealing with any reports, and should be able to have their hands free at any time. They can involve other team members if needed, but having a small CARE team makes it easier to respond consistently, professionally and timely, without distracting the rest of the team._
>
> Source: https://github.com/mxsasha/lessobviouschecklist/blob/master/README.md#code-of-conduct

I would like to propose an adoption of this name as it sounds more positive and caring (:smile:)

Note that I made this towards the master, if I need to change this to 2.7 or 2.8 let me know.