### PR TITLE
Fix ConsoleLogger URL

### DIFF
--- a/components/console/logger.rst
+++ b/components/console/logger.rst
@@ -77,7 +77,7 @@ instance.
 By default, the console logger behaves like the
 :doc:`Monolog's Console Handler </logging/monolog_console>`.
 The association between the log level and the verbosity can be configured
-through the second parameter of the :class:`Symfony\\Component\\Console\\ConsoleLogger`
+through the second parameter of the :class:`Symfony\\Component\\Console\\Logger\\ConsoleLogger`
 constructor::
 
     use Psr\Log\LogLevel;


### PR DESCRIPTION
Change https://api.symfony.com/2.7/Symfony/Component/Console/ConsoleLogger.html to https://api.symfony.com/2.7/Symfony/Component/Console/Logger/ConsoleLogger.html

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
