### PR TITLE
[Autowiring] - Rephrase aliasing when multiple classes with same interface

### DIFF
--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -358,11 +358,10 @@ Suppose you create a second class - ``UppercaseTransformer`` that implements
     }
 
 If you register this as a service, you now have *two* services that implement the
-``App\Util\TransformerInterface`` type. Autowiring subsystem can not decide which
-one to use. Remember, Autowiring isn't magic: it simply
-looks for a service whose id matches the type-hint. So you need to choose one by
-creating an alias from the type to the correct service id
-(see :ref:`autowiring-interface-alias`).
+``App\Util\TransformerInterface`` type. Autowiring subsystem can not decide
+which one to use. Remember, autowiring isn't magic; it simply looks for a service
+whose id matches the type-hint. So you need to choose one by creating an alias
+from the type to the correct service id (see :ref:`autowiring-interface-alias`).
 
 If you want ``Rot13Transformer`` to be the service that's used for autowiring, create
 that alias:

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -358,9 +358,11 @@ Suppose you create a second class - ``UppercaseTransformer`` that implements
     }
 
 If you register this as a service, you now have *two* services that implement the
-``App\Util\TransformerInterface`` type. Symfony doesn't know which one should
-be used for autowiring, so you need to choose one by creating an alias from the type
-to the correct service id (see :ref:`autowiring-interface-alias`).
+``App\Util\TransformerInterface`` type. Autowiring subsystem can not decide which
+one to use. Remember, Autowiring isn't magic: it simply
+looks for a service whose id matches the type-hint. So you need to choose one by
+creating an alias from the type to the correct service id
+(see :ref:`autowiring-interface-alias`).
 
 If you want ``Rot13Transformer`` to be the service that's used for autowiring, create
 that alias:


### PR DESCRIPTION
This PR aims to enforce the "non-magic" aspect of the Autowiring.

Especially that sentence:
```If you register this as a service, you now have two services that implement the App\Util\TransformerInterface type. Symfony doesn't know which one should be used for autowiring, so you need to choose one by creating an alias from the type to the correct service id (see Working with Interfaces).```

This:
`Symfony doesn't know which one should be used for autowiring`
The more I read the more I think it is clear, but somehow It feels like, after one or two readings, you could understand that Symfony is somehow "choosing" by some sort of magic the service (i.e: Reflection for instance). Where it is definitely not and the "developer" *must decide* and tells the autowiring which one to use.

I think the current sentence is also clearer when you read all the documentation page where often (I guess) developers go straight to what they need and in this case "how to configure when you have an interface and multiple classes"

So I propose this change (which should not hurt) and open the discussion. Feel free to close if you think it is useless, I won't mind it did not take that long to do the PR ;)

