### PR TITLE
To help locking a command easily

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -70,6 +70,29 @@ method can be safely called repeatedly, even if the lock is already acquired.
     across several requests. To disable the automatic release behavior, set the
     third argument of the ``createLock()`` method to ``false``.
 
+Simplified Commands
+-------------------
+
+Use the LockableTrait to easily implement locking mechanism in Commands.
+
+    // ...
+    use Symfony\Component\Console\Command\LockableTrait;
+    use Symfony\Component\Console\Command\Command
+
+    class FooCommand  extends Command
+    {
+        use LockableTrait;
+        .....
+        protected function execute(InputInterface $input, OutputInterface $output)
+        {
+            if (!$this->lock()) {
+                //Manage locked command
+            }
+            .....
+            $this->release();
+        }
+    }
+
 Blocking Locks
 --------------
 


### PR DESCRIPTION
There is no explained simple way of adding a lock to a command. After following this page's tutorial, the lock->acquire would always acquire and never lock even consecutive locks would not lock anything. After research, I stumbled on a suggestion on StackOverflow. It worked like a charm and it's 3 lines of code (including the "use" statement) so I think it should be in this documentation.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
