### PR TITLE
Updated from `new MyFormType()` to `MyFormType::class`

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -371,8 +371,8 @@ type
 This is the field type for each item in this collection (e.g. ``text``,
 ``choice``, etc). For example, if you have an array of email addresses,
 you'd use the :doc:`email </reference/forms/types/email>` type. If you want
-to embed a collection of some other form, create a new instance of your
-form type and pass it as this option.
+to embed a collection of some other form, pass the form type class as this
+option (e.g. ``MyFormType::class``)
 
 Inherited Options
 -----------------


### PR DESCRIPTION
Passing a new instance of the form type gave me this error:

> Type error: Argument 1 passed to Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener::__construct() must be of the type string, object given

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
