### PR TITLE
Improved the Symfony License pages

### DIFF
--- a/contributing/code/license.rst
+++ b/contributing/code/license.rst
@@ -31,5 +31,5 @@ Other Symfony Licenses
 Check out the :doc:`license of the Symfony documentation </contributing/documentation/license>`
 and other `Symfony licenses and trademarks`_.
 
-.. `the MIT license`: https://en.wikipedia.org/wiki/MIT_License
+.. _`the MIT license`: https://en.wikipedia.org/wiki/MIT_License
 .. _`Symfony licenses and trademarks`: https://symfony.com/license

--- a/contributing/code/license.rst
+++ b/contributing/code/license.rst
@@ -1,20 +1,9 @@
 .. _symfony2-license:
 
-Symfony License
-===============
+Symfony Code License
+====================
 
-Symfony is released under the MIT license.
-
-According to `Wikipedia`_:
-
-    "It is a permissive license, meaning that it permits reuse within
-    proprietary software on the condition that the license is distributed with
-    that software. The license is also GPL-compatible, meaning that the GPL
-    permits combination and redistribution with software that uses the MIT
-    License."
-
-The License
------------
+Symfony code is released under `the MIT license`_:
 
 Copyright (c) 2004-2018 Fabien Potencier
 
@@ -36,4 +25,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-.. _Wikipedia: https://en.wikipedia.org/wiki/MIT_License
+Other Symfony Licenses
+----------------------
+
+Check out the `license of the Symfony documentation`_ and other
+`Symfony licenses and trademarks`_.
+
+.. `the MIT license`: https://en.wikipedia.org/wiki/MIT_License
+.. _`license of the Symfony documentation`: https://symfony.com/doc/current/contributing/documentation/license.html
+.. _`Symfony licenses and trademarks`: https://symfony.com/license

--- a/contributing/code/license.rst
+++ b/contributing/code/license.rst
@@ -28,9 +28,8 @@ THE SOFTWARE.
 Other Symfony Licenses
 ----------------------
 
-Check out the `license of the Symfony documentation`_ and other
-`Symfony licenses and trademarks`_.
+Check out the :doc:`license of the Symfony documentation </contributing/documentation/license>`
+and other `Symfony licenses and trademarks`_.
 
 .. `the MIT license`: https://en.wikipedia.org/wiki/MIT_License
-.. _`license of the Symfony documentation`: https://symfony.com/doc/current/contributing/documentation/license.html
 .. _`Symfony licenses and trademarks`: https://symfony.com/license

--- a/contributing/documentation/license.rst
+++ b/contributing/documentation/license.rst
@@ -48,5 +48,13 @@ Attribution-Share Alike 3.0 Unported License (`CC BY-SA 3.0`_).
 
 This is a human-readable summary of the `Legal Code (the full license)`_.
 
+Other Symfony Licenses
+----------------------
+
+Check out the `license of the Symfony code`_ and other
+`Symfony licenses and trademarks`_.
+
 .. _`CC BY-SA 3.0`: http://creativecommons.org/licenses/by-sa/3.0/
 .. _Legal Code (the full license): http://creativecommons.org/licenses/by-sa/3.0/legalcode
+.. _`license of the Symfony code`: https://symfony.com/doc/current/contributing/code/license.html
+.. _`Symfony licenses and trademarks`: https://symfony.com/license

--- a/contributing/documentation/license.rst
+++ b/contributing/documentation/license.rst
@@ -51,10 +51,9 @@ This is a human-readable summary of the `Legal Code (the full license)`_.
 Other Symfony Licenses
 ----------------------
 
-Check out the `license of the Symfony code`_ and other
-`Symfony licenses and trademarks`_.
+Check out the :doc:`license of the Symfony code </contributing/code/license>`
+and other `Symfony licenses and trademarks`_.
 
 .. _`CC BY-SA 3.0`: http://creativecommons.org/licenses/by-sa/3.0/
 .. _Legal Code (the full license): http://creativecommons.org/licenses/by-sa/3.0/legalcode
-.. _`license of the Symfony code`: https://symfony.com/doc/current/contributing/code/license.html
 .. _`Symfony licenses and trademarks`: https://symfony.com/license


### PR DESCRIPTION
We need to be more precise because "Symfony License" !== "Symfony Code License". When you Google for Symfony License, the first result should be the actual second result:

![symfony-license-google](https://user-images.githubusercontent.com/73419/39986945-88dbb5aa-5763-11e8-9791-3289cf6ef040.png)
