### PR TITLE
Fix controllers-as-services code example

### DIFF
--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -307,6 +307,7 @@ The third big change is that, in a new Symfony 3.3 project, your controllers are
             AppBundle\Controller\:
                 resource: '../../src/AppBundle/Controller'
                 tags: ['controller.service_arguments']
+                public: true
 
     .. code-block:: xml
 


### PR DESCRIPTION
The code example that I edited already contains a comment:

```
# controllers are imported separately to make sure they're public
```
... but it doesn't act accordingly, leading to working code under 3.4 but triggering a deprecation.
