### PR TITLE
added initial_place entry

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -33,6 +33,7 @@ like this:
                             - 'currentPlace'
                     supports:
                         - AppBundle\Entity\BlogPost
+                    initial_place: draft
                     places:
                         - draft
                         - review


### PR DESCRIPTION
I added the value for the config entry initial_place.

This clarifies the config of the workflow and eliminates ambiguities about which is the initial place of the workflow - doing some tests, it seems that the first place defined in the list will be the initial place when the marking is null.