### PR TITLE
added initial_place entry

### DIFF
--- a/workflow/state-machines.rst
+++ b/workflow/state-machines.rst
@@ -35,6 +35,7 @@ Below is the configuration for the pull request state machine.
                     type: 'state_machine'
                     supports:
                         - AppBundle\Entity\PullRequest
+                    initial_place: start
                     places:
                         - start
                         - coding


### PR DESCRIPTION
I added the value for the config entry initial_place.

This clarifies the config of the workflow and eliminates ambiguities about which is the initial place of the workflow - doing some tests, it seems that the first place defined in the list will be the initial place when the marking is null.
