### PR TITLE
Removed the term "simple" from creating a new page

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -8,7 +8,7 @@ Create your First Page in Symfony
 =================================
 
 Creating a new page - whether it's an HTML page or a JSON endpoint - is a
-simple two-step process:
+two-step process:
 
 #. **Create a route**: A route is the URL (e.g. ``/about``) to your page and
    points to a controller;


### PR DESCRIPTION
Something that's simple for me, might not be simple for a developer who is new to Symfony. I think this is a friendlier approach to the process of creating a new page.

I haven't checked the other docs as I quickly pressed edit when I noticed this.