### PR TITLE
Fix error on @MaxDepth property

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -793,7 +793,7 @@ Here, we set it to 2 for the ``$child`` property:
             /**
              * @MaxDepth(2)
              */
-            public $foo;
+            public $child;
 
             // ...
         }
@@ -802,7 +802,7 @@ Here, we set it to 2 for the ``$child`` property:
 
         Acme\MyObj:
             attributes:
-                foo:
+                child:
                     max_depth: 2
 
     .. code-block:: xml
@@ -814,7 +814,7 @@ Here, we set it to 2 for the ``$child`` property:
                 http://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
         >
             <class name="Acme\MyObj">
-                <attribute name="foo" max-depth="2" />
+                <attribute name="child" max-depth="2" />
             </class>
         </serializer>
 


### PR DESCRIPTION
Change property annotation according to documentation

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
