### PR TITLE
Fixed URLs to APIs outside of the Symfony project

### DIFF
--- a/components/psr7.rst
+++ b/components/psr7.rst
@@ -36,8 +36,8 @@ that builds objects implementing PSR-7 interfaces from HttpFoundation objects.
 It also provide a default implementation using Zend Diactoros internally.
 
 The following code snippet explain how to convert a :class:`Symfony\\Component\\HttpFoundation\\Request`
-to a Zend Diactoros :class:`Zend\\Diactoros\\ServerRequest` implementing the
-:class:`Psr\\Http\\Message\\ServerRequestInterface` interface::
+to a ``Zend\\Diactoros\\ServerRequest`` class implementing the
+``Psr\\Http\\Message\\ServerRequestInterface`` interface::
 
     use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
     use Symfony\Component\HttpFoundation\Request;
@@ -48,9 +48,9 @@ to a Zend Diactoros :class:`Zend\\Diactoros\\ServerRequest` implementing the
     $psr7Factory = new DiactorosFactory();
     $psrRequest = $psr7Factory->createRequest($symfonyRequest);
 
-And now from a :class:`Symfony\\Component\\HttpFoundation\\Response` to a Zend
-Diactoros :class:`Zend\\Diactoros\\Response` implementing the :class:`Psr\\Http\\Message\\ResponseInterface`
-interface::
+And now from a :class:`Symfony\\Component\\HttpFoundation\\Response` to a
+``Zend\\Diactoros\\Response`` class implementing the
+``Psr\\Http\\Message\\ResponseInterface`` interface::
 
     use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
     use Symfony\Component\HttpFoundation\Response;
@@ -68,8 +68,8 @@ On the other hand, the bridge provide a factory interface called
 that builds HttpFoundation objects from objects implementing PSR-7 interfaces.
 
 The next snippet explain how to convert an object implementing the
-:class:`Psr\\Http\\Message\\ServerRequestInterface`
-interface to a :class:`Symfony\\Component\\HttpFoundation\\Request` instance::
+``Psr\\Http\\Message\\ServerRequestInterface`` interface to a
+:class:`Symfony\\Component\\HttpFoundation\\Request` instance::
 
     use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 
@@ -78,7 +78,7 @@ interface to a :class:`Symfony\\Component\\HttpFoundation\\Request` instance::
     $httpFoundationFactory = new HttpFoundationFactory();
     $symfonyRequest = $httpFoundationFactory->createRequest($psrRequest);
 
-From an object implementing the :class:`Psr\\Http\\Message\\ResponseInterface`
+From an object implementing the ``Psr\\Http\\Message\\ResponseInterface``
 to a :class:`Symfony\\Component\\HttpFoundation\\Response` instance::
 
     use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;


### PR DESCRIPTION
As explained in #9732, any `:class:` or `:method:` directive that points to classes outside of the `Symfony\` namespace will result in 404 errors. I'll fix the other occurrences of these errors in the upper branches too while merging.