### PR TITLE
Update the documentation for Symfony Flex

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -95,8 +95,8 @@ two public repositories:
 
 * `Contrib recipe repository`_, contains all the recipes created by the
   community. All of them are guaranteed to work, but their associated packages
-  could be unmaintained. Symfony Flex will ask users to confirm the installation
-  of those community-contributed recipies.
+  could be unmaintained. Symfony Flex will ask your permission before installing
+  any of these recipes.
 
 Read the `Symfony Recipes documentation`_ to learn everything about how to
 create recipes for your own packages.

--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -95,13 +95,8 @@ two public repositories:
 
 * `Contrib recipe repository`_, contains all the recipes created by the
   community. All of them are guaranteed to work, but their associated packages
-  could be unmaintained. Symfony Flex ignores these recipes by default, but you
-  can execute this command to start using them in your project:
-
-  .. code-block:: terminal
-
-        $ cd your-project/
-        $ composer config extra.symfony.allow-contrib true
+  could be unmaintained. Symfony Flex will ask users to confirm the installation
+  of those community-contributed recipies.
 
 Read the `Symfony Recipes documentation`_ to learn everything about how to
 create recipes for your own packages.


### PR DESCRIPTION
Per https://twitter.com/symfony_en/status/999539927003123712

> Contrib recipes are no longer ignored. They were ignored in the first versions of Flex … but now the user is asked: do you want to install this recipe from contrib?

**Please confirm this is actually the case because I'm only basing this on a tweet.** Thanks :)
