### PR TITLE
Adding quotes to a server_version on an example just after explanation why are necessary

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -398,13 +398,13 @@ If you want to configure multiple connections in YAML, put them under the
                     user:             root
                     password:         null
                     host:             localhost
-                    server_version:   5.6
+                    server_version:   '5.6'
                 customer:
                     dbname:           customer
                     user:             root
                     password:         null
                     host:             localhost
-                    server_version:   5.7
+                    server_version:   '5.7'
 
 The ``database_connection`` service always refers to the *default* connection,
 which is the first one defined or the one configured via the


### PR DESCRIPTION
just adding some quotes to server_version, couple of lines before is explained this: 

"Always wrap the server version number with quotes to parse it as a string instead of a float number"


