### PR TITLE
Export workflow chart to SVG

### DIFF
--- a/workflow/dumping-workflows.rst
+++ b/workflow/dumping-workflows.rst
@@ -6,7 +6,7 @@ How to Dump Workflows
 
 To help you debug your workflows, you can dump a representation of your workflow
 with the use of a ``DumperInterface``. Use the ``GraphvizDumper`` to create a
-PNG image of the workflow defined above::
+SVG image of the workflow defined above::
 
     // dump-graph.php
     $dumper = new GraphvizDumper();
@@ -14,7 +14,7 @@ PNG image of the workflow defined above::
 
 .. code-block:: terminal
 
-    $ php dump-graph.php | dot -Tpng -o graph.png
+    $ php dump-graph.php | dot -Tsvg -o graph.svg
 
 The result will look like this:
 
@@ -25,7 +25,7 @@ Inside a Symfony application, you can dump the dot file with the
 
 .. code-block:: terminal
 
-    $ php bin/console workflow:dump name | dot -Tpng -o graph.png
+    $ php bin/console workflow:dump name | dot -Tsvg -o graph.svg
 
 .. note::
 

--- a/workflow/dumping-workflows.rst
+++ b/workflow/dumping-workflows.rst
@@ -6,7 +6,7 @@ How to Dump Workflows
 
 To help you debug your workflows, you can dump a representation of your workflow
 with the use of a ``DumperInterface``. Use the ``GraphvizDumper`` to create a
-SVG image of the workflow defined above::
+PNG or SVG image of the workflow defined above::
 
     // dump-graph.php
     $dumper = new GraphvizDumper();
@@ -15,6 +15,9 @@ SVG image of the workflow defined above::
 .. code-block:: terminal
 
     $ php dump-graph.php | dot -Tsvg -o graph.svg
+
+    # run this command if you prefer PNG images:
+    # $ php dump-graph.php | dot -Tpng -o graph.png
 
 The result will look like this:
 


### PR DESCRIPTION
It should be encouraged to use SVG since SVG is better format suited for vector graphics and widely supported now.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
