### PR TITLE
Add URL-encoding notice

### DIFF
--- a/email.rst
+++ b/email.rst
@@ -37,9 +37,10 @@ environment variable in the ``.env`` file:
     # use this to disable email delivery
     MAILER_URL=null://localhost
 
-    # use this to configure a traditional SMTP server
+    # use this to configure a traditional SMTP server (make sure to URL-encode the
+    # values of the username and password if they contain non-alphanumeric characters
+    # such as '+', '@', ':' and '*', which are reserved in URLs)
     MAILER_URL=smtp://localhost:25?encryption=ssl&auth_mode=login&username=&password=
-    # keep in mind that, since this is an URL, any special characters in username/password should be URL-encoded
 
 Refer to the :doc:`SwiftMailer configuration reference </reference/configuration/swiftmailer>`
 for the detailed explanation of all the available config options.

--- a/email.rst
+++ b/email.rst
@@ -39,6 +39,7 @@ environment variable in the ``.env`` file:
 
     # use this to configure a traditional SMTP server
     MAILER_URL=smtp://localhost:25?encryption=ssl&auth_mode=login&username=&password=
+    # keep in mind that, since this is an URL, any special characters in username/password should be URL-encoded
 
 Refer to the :doc:`SwiftMailer configuration reference </reference/configuration/swiftmailer>`
 for the detailed explanation of all the available config options.


### PR DESCRIPTION
I've had trouble connecting to Amazon SES via recommended method.
I kept getting: 
> Exception occurred while flushing email queue: Failed to authenticate on SMTP server with username "***"
I've traced it to "+" sign in the password that Amazon SES automatically assigned to my SMTP credentials.
I had a hunch that special characters might be a problem and was thinking along the lines of wrapping the whole MAILER_URL value in single quotes.
Then I ran into https://stackoverflow.com/a/50498999/1419874 that solved the issue for me too.
Since the OP lost 3hrs and myself almost an hour, I think URL encoding might not be so obvious.
Hence I propose this change. I've intentionally put it at the top, since I think it applies to any method that has special characters in username/password, not just Amazon SES.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
