### PR TITLE
Fix a typo in the HTML5 date form property

### DIFF
--- a/reference/forms/types/options/html5.rst.inc
+++ b/reference/forms/types/options/html5.rst.inc
@@ -9,5 +9,5 @@ html5
 If this is set to ``true`` (the default), it'll use the HTML5 type (date, time
 or datetime) to render the field. When set to ``false``, it'll use the text type.
 
-This is useful when you want to use a custom JavaScript datapicker, which
+This is useful when you want to use a custom JavaScript datepicker, which
 often requires a text type instead of an HTML5 type.


### PR DESCRIPTION
This changes "datapicker" to "datepicker".