### PR TITLE
Update typescript.rst

### DIFF
--- a/frontend/encore/typescript.rst
+++ b/frontend/encore/typescript.rst
@@ -28,7 +28,7 @@ also configure the `ts-loader options`_ via a callback:
 
     .enableTypeScriptLoader(function (typeScriptConfigOptions) {
         typeScriptConfigOptions.transpileOnly = true;
-        typeScriptConfigOptions.configFileName = '/path/to/tsconfig.json';
+        typeScriptConfigOptions.configFile = '/path/to/tsconfig.json';
     });
 
 If React assets are enabled (``.enableReactPreset()``), any ``.tsx`` file will be


### PR DESCRIPTION
`configFileName` was renamed in `configFile` for Typescript configuration

```
Module build failed: Error: ts-loader was supplied with an unexpected loader option: configFileName

Please take a look at the options you are supplying; the following are valid options:
silent / logLevel / logInfoToStdOut / instance / compiler / context / configFile / transpileOnly / ignoreDiagnostics / errorFormatter / colors / compilerOptions / appendTsSuffixTo / appendTsxSuffixTo / onlyCompileBundledFiles / happyPackMode / getCustomTransformers / reportFiles / experimentalWatchApi / allowTsInNodeModules
```