### PR TITLE
Removed an outdated section

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -892,15 +892,6 @@ route::
     // or, in Twig
     // {{ path('blog_show', {'slug': 'slug-value'}) }}
 
-Translating Routes
-------------------
-
-Symfony doesn't support defining routes with different contents depending on the
-user language. In those cases, you can define multiple routes per controller,
-one for each supported language; or use any of the bundles created by the
-community to implement this feature, such as `JMSI18nRoutingBundle`_ and
-`BeSimpleI18nRoutingBundle`_.
-
 Keep Going!
 -----------
 


### PR DESCRIPTION
After merging #9515 we forgot to remove this deprecated section, as pointed by @michaelperrin in this comment: https://github.com/symfony/symfony-docs/pull/9515#issuecomment-383922065