### PR TITLE
Don't recommend base64 encoding of random_bytes result

### DIFF
--- a/components/security/secure_tools.rst
+++ b/components/security/secure_tools.rst
@@ -41,9 +41,8 @@ the number bytes passed as an argument (10 in the above example).
     The ``random_bytes()`` function returns a binary string which may contain
     the ``\0`` character. This can cause trouble in several common scenarios,
     such as storing this value in a database or including it as part of the
-    URL. The solution is to encode or hash the value returned by
-    ``random_bytes()`` (to do that, you can use a simple ``base64_encode()``
-    PHP function).
+    URL. The solution is to hash the value returned by ``random_bytes()`` with
+    a hashing function such as :phpfunction:`md5` or :phpfunction:`sha1`.
 
 Generating a Secure Random Number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This fixes #9348. base64 is not safe for URLs, so let's recommend hashing the values.