### PR TITLE
Mention the need to use autowire & autoconfigure

### DIFF
--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -130,7 +130,7 @@ previous ``priceFilter()`` method::
 Register the Lazy-Loaded Extension as a Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Finally, register your new class as a service and tag it with ``twig.runtime``
+Assuming you have enabled ``autowire:true`` and ``autoconfigure:true`` in your services.yml file, You need to register your new class as a service and tag it with ``twig.runtime``
 (and optionally inject any service needed by the Twig extension runtime):
 
 .. configuration-block::


### PR DESCRIPTION
The example assumes the use of autowire & autoconfigure in services.yml so it doesn't mention it. This creates issues like making the example code fail in environement where autowiring is not enabled: https://stackoverflow.com/questions/50554667/symfony-not-loading-runtime-twig-extension/50564237#50564237 which

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
