### PR TITLE
Documented the logout_on_user_change option

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -463,6 +463,12 @@ If ``true`` this option makes Symfony to trigger a logout when the user has
 changed. Not doing that is deprecated, so this option should be set to ``true``
 to avoid getting deprecation messages.
 
+The user is considered to have changed when the user class implements
+:class:`Symfony\\Component\\Security\\Core\\User\\EquatableInterface` and the
+``isEqualTo()`` method returns ``false``. Also, when any of the properties
+required by the :class:`Symfony\\Component\\Security\\Core\\User\\UserInterface`
+(like the username, password or salt) changes.
+
 .. _reference-security-ldap:
 
 LDAP functionality

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -141,6 +141,7 @@ Each part will be explained in the next section.
                     # See "Firewall Context" below for more details
                     context: context_key
                     stateless: false
+                    logout_on_user_change: false
                     x509:
                         provider: some_key_from_above
                     remote_user:
@@ -449,6 +450,18 @@ all the other firewalls.
 The ``invalidate_session`` option allows to redefine this behavior. Set this
 option to ``false`` in every firewall and the user will only be logged out from
 the current firewall and not the other ones.
+
+logout_on_user_change
+~~~~~~~~~~~~~~~~~~~~~
+
+**type**: ``boolean`` **default**: ``false``
+
+.. versionadded:: 3.4
+    The ``logout_on_user_change`` option was introduced in Symfony 3.4.
+
+If ``true`` this option makes Symfony to trigger a logout when the user has
+changed. Not doing that is deprecated, so this option should be set to ``true``
+to avoid getting deprecation messages.
 
 .. _reference-security-ldap:
 


### PR DESCRIPTION
This fixes #8428.

@iltar I need your help here. In your PR (https://github.com/symfony/symfony/pull/23882/files) you said:

```
This config item will trigger a logout when the user has changed.
```

I need more precision about what this means: *"the user has changed"*. What exactly has changed? The token, the object that represents the user, some property of the user, etc. Thanks!