### PR TITLE
Use the new Security helper in some code examples

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -99,16 +99,15 @@ retrieved from the token storage::
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
     use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
-    use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-    use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+    use Symfony\Component\Security\Core\Security;
 
     class UserValueResolver implements ArgumentValueResolverInterface
     {
-        private $tokenStorage;
+        private $security;
 
-        public function __construct(TokenStorageInterface $tokenStorage)
+        public function __construct(Security $security)
         {
-            $this->tokenStorage = $tokenStorage;
+            $this->security = $security;
         }
 
         public function supports(Request $request, ArgumentMetadata $argument)
@@ -117,18 +116,12 @@ retrieved from the token storage::
                 return false;
             }
 
-            $token = $this->tokenStorage->getToken();
-
-            if (!$token instanceof TokenInterface) {
-                return false;
-            }
-
-            return $token->getUser() instanceof User;
+            return $this->security->getUser() instanceof User;
         }
 
         public function resolve(Request $request, ArgumentMetadata $argument)
         {
-            yield $this->tokenStorage->getToken()->getUser();
+            yield $this->security->getUser();
         }
     }
 
@@ -136,8 +129,7 @@ In order to get the actual ``User`` object in your argument, the given value
 must fulfill the following requirements:
 
 * An argument must be type-hinted as ``User`` in your action method signature;
-* A security token must be present;
-* The value must be an instance of the ``User``.
+* The value must be an instance of the ``User`` class.
 
 When all those requirements are met and ``true`` is returned, the
 ``ArgumentResolver`` calls ``resolve()`` with the same values as it called

--- a/profiler/matchers.rst
+++ b/profiler/matchers.rst
@@ -91,22 +91,22 @@ matcher::
     // src/AppBundle/Profiler/SuperAdminMatcher.php
     namespace AppBundle\Profiler;
 
-    use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+    use Symfony\Component\Security\Core\Security;
 
     class SuperAdminMatcher implements RequestMatcherInterface
     {
-        protected $authorizationChecker;
+        protected $security;
 
-        public function __construct(AuthorizationCheckerInterface $authorizationChecker)
+        public function __construct(Security $security)
         {
-            $this->authorizationChecker = $authorizationChecker;
+            $this->security = $security;
         }
 
         public function matches(Request $request)
         {
-            return $this->authorizationChecker->isGranted('ROLE_SUPER_ADMIN');
+            return $this->security->isGranted('ROLE_SUPER_ADMIN');
         }
     }
 

--- a/security.rst
+++ b/security.rst
@@ -832,8 +832,8 @@ You can easily deny access from inside a controller::
         // The second parameter is used to specify on what object the role is tested.
         $this->denyAccessUnlessGranted('ROLE_ADMIN', null, 'Unable to access this page!');
 
-        // Old way :
-        // if (false === $this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
+        // Old way:
+        // if (false === $this->get('security.helper')->isGranted('ROLE_ADMIN')) {
         //     throw $this->createAccessDeniedException('Unable to access this page!');
         // }
 
@@ -912,9 +912,7 @@ user is logged in (you don't care about roles), then you can use
 
     public function helloAction($name)
     {
-        if (!$this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY')) {
-            throw $this->createAccessDeniedException();
-        }
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
 
         // ...
     }
@@ -1042,6 +1040,8 @@ the User object, and use the ``isGranted()`` method (or
     if (!$this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY')) {
         throw $this->createAccessDeniedException();
     }
+    // equivalent shortcut:
+    // $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
 
     // boo :(. Never check for the User object to see if they're logged in
     if ($this->getUser()) {
@@ -1052,15 +1052,17 @@ the User object, and use the ``isGranted()`` method (or
 
     An alternative way to get the current user in a controller is to type-hint
     the controller argument with
-    :class:`Symfony\\Component\\Security\\Core\\User\\UserInterface`
-    (and default it to ``null`` if being logged-in is optional)::
+    :class:`Symfony\\Component\\Security\\Core\\Security`::
 
-        use Symfony\Component\Security\Core\User\UserInterface;
+        use Symfony\Component\Security\Core\Security;
 
-        public function indexAction(UserInterface $user = null)
+        public function indexAction(Security $security)
         {
-            // $user is null when not logged-in or anon.
+            $user = $security->getUser();
         }
+
+    .. versionadded:: 3.4
+        The ``Security`` utility class was introduced in Symfony 3.4.
 
     This is only recommended for experienced developers who don't extend from the
     :ref:`Symfony base controller <the-base-controller-class-services>` and

--- a/security.rst
+++ b/security.rst
@@ -833,7 +833,7 @@ You can easily deny access from inside a controller::
         $this->denyAccessUnlessGranted('ROLE_ADMIN', null, 'Unable to access this page!');
 
         // Old way:
-        // if (false === $this->get('security.helper')->isGranted('ROLE_ADMIN')) {
+        // if (false === $this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
         //     throw $this->createAccessDeniedException('Unable to access this page!');
         // }
 

--- a/security/impersonating_user.rst
+++ b/security/impersonating_user.rst
@@ -111,15 +111,29 @@ user rather than the impersonated user. Use the following snippet to iterate
 over the user's roles until you find one that a ``SwitchUserRole`` object::
 
     use Symfony\Component\Security\Core\Role\SwitchUserRole;
+    use Symfony\Component\Security\Core\Security;
+    // ...
 
-    $authorizationChecker = $this->get('security.authorization_checker');
-    $tokenStorage = $this->get('security.token_storage');
+    public class SomeService
+    {
+        private $security;
 
-    if ($authorizationChecker->isGranted('ROLE_PREVIOUS_ADMIN')) {
-        foreach ($tokenStorage->getToken()->getRoles() as $role) {
-            if ($role instanceof SwitchUserRole) {
-                $impersonatorUser = $role->getSource()->getUser();
-                break;
+        public function __construct(Security $security)
+        {
+            $this->security = $security;
+        }
+
+        public function someMethod()
+        {
+            // ...
+
+            if ($this->security->isGranted('ROLE_PREVIOUS_ADMIN')) {
+                foreach ($this->security->getToken()->getRoles() as $role) {
+                    if ($role instanceof SwitchUserRole) {
+                        $impersonatorUser = $role->getSource()->getUser();
+                        break;
+                    }
+                }
             }
         }
     }

--- a/security/securing_services.rst
+++ b/security/securing_services.rst
@@ -41,27 +41,27 @@ Before you add security, the class looks something like this::
     }
 
 Your goal is to check the user's role when the ``sendNewsletter()`` method is
-called. The first step towards this is to inject the ``security.authorization_checker``
-service into the object::
+called. The first step towards this is to inject the ``security.helper`` service
+using the :class:`Symfony\\Component\\Security\\Core\\Security` class::
 
     // src/AppBundle/Newsletter/NewsletterManager.php
 
     // ...
-    use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
     use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+    use Symfony\Component\Security\Core\Security;
 
     class NewsletterManager
     {
-        protected $authorizationChecker;
+        protected $security;
 
-        public function __construct(AuthorizationCheckerInterface $authorizationChecker)
+        public function __construct(Security $security)
         {
-            $this->authorizationChecker = $authorizationChecker;
+            $this->security = $security;
         }
 
         public function sendNewsletter()
         {
-            if (!$this->authorizationChecker->isGranted('ROLE_NEWSLETTER_ADMIN')) {
+            if (!$this->security->isGranted('ROLE_NEWSLETTER_ADMIN')) {
                 throw new AccessDeniedException();
             }
 
@@ -72,8 +72,8 @@ service into the object::
     }
 
 If you're using the :ref:`default services.yml configuration <service-container-services-load-example>`,
-Symfony will automatically pass the ``security.authorization_checker`` to your service
-thanks to autowiring and the ``AuthorizationCheckerInterface`` type-hint.
+Symfony will automatically pass the ``security.helper`` to your service
+thanks to autowiring and the ``Security`` type-hint.
 
 If the current user does not have the ``ROLE_NEWSLETTER_ADMIN``, they will
 be prompted to log in.

--- a/session/proxy_examples.rst
+++ b/session/proxy_examples.rst
@@ -110,15 +110,15 @@ can intercept the session before it is written::
 
     use AppBundle\Entity\User;
     use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
-    use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+    use Symfony\Component\Security\Core\Security;
 
     class ReadOnlySessionProxy extends SessionHandlerProxy
     {
-        private $tokenStorage;
+        private $security;
 
-        public function __construct(\SessionHandlerInterface $handler, TokenStorageInterface $tokenStorage)
+        public function __construct(\SessionHandlerInterface $handler, Security $security)
         {
-            $this->tokenStorage = $tokenStorage;
+            $this->security = $security;
 
             parent::__construct($handler);
         }
@@ -134,11 +134,7 @@ can intercept the session before it is written::
 
         private function getUser()
         {
-            if (!$token = $this->tokenStorage->getToken()) {
-                return;
-            }
-
-            $user = $token->getUser();
+            $user = $this->security->getUser();
             if (is_object($user)) {
                 return $user;
             }


### PR DESCRIPTION
This fixes #8437 replacing `use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;` by `use Symfony\Component\Security\Core\Security;` when possible.

Also, replace `use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;` by `use Symfony\Component\Security\Core\Security;` when possible.