### PR TITLE
add missing option in yaml configuration

### DIFF
--- a/testing/profiling.rst
+++ b/testing/profiling.rst
@@ -25,7 +25,7 @@ tests significantly. That's why Symfony disables it by default:
 
         # ...
         framework:
-            profiler: { collect: false }
+            profiler: { enabled: true, collect: false }
 
     .. code-block:: xml
 


### PR DESCRIPTION
Add enabled: true in framework.profiler configuration in yaml example. 
xml and php examples are ok.
