### PR TITLE
Update licence hint for JMS serializer

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1245,7 +1245,7 @@ Learn more
 .. seealso::
 
     A popular alternative to the Symfony Serializer Component is the third-party
-    library, `JMS serializer`_ (released under the Apache license, so incompatible with GPLv2 projects).
+    library, `JMS serializer`_ (versions before `v1.12.0` were released under the Apache license, so incompatible with GPLv2 projects).
 
 .. _`PSR-1 standard`: https://www.php-fig.org/psr/psr-1/
 .. _`JMS serializer`: https://github.com/schmittjoh/serializer


### PR DESCRIPTION
JMS serializer changed its license to MIT in `v1.12.0`

See:
- https://github.com/schmittjoh/serializer/releases
- https://github.com/schmittjoh/serializer/pull/956
- https://github.com/schmittjoh/serializer/issues/950

I'm not sure which branch this should PR should target.
Also, I'm unsure about the best wording, maybe you can guide me a bit?