### PR TITLE
Add example code how to read an option

### DIFF
--- a/components/console/console_arguments.rst
+++ b/components/console/console_arguments.rst
@@ -37,7 +37,7 @@ Have a look at the following command that has three options::
 
         protected function execute(InputInterface $input, OutputInterface $output)
         {
-           // ...
+           $output->writeln('👋 ' . $input->getOption('bar'));
         }
     }
 


### PR DESCRIPTION
There is no example on https://symfony.com/doc/current/components/console/console_arguments.html how to read the given options. At some later point the documentation refers to the `getArgument` method, which of course fails for an »option«. This hinders a fast introduction into console arguments. A simple code snippet like this one may improve this.