### PR TITLE
Fix wrong place of parent constructor call

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -246,9 +246,9 @@ as a service, you can use normal dependency injection. Imagine you have a
 
         public function __construct(UserManager $userManager)
         {
-            $this->userManager = $userManager;
-
             parent::__construct();
+
+            $this->userManager = $userManager;
         }
 
         // ...


### PR DESCRIPTION
Calling parent constructor after doing stuff in the overrided constructor is a bad habit. The documentation should encourage good practices.