### PR TITLE
Use version number in installer command

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -59,7 +59,7 @@ with the ``new`` command:
 
 .. code-block:: terminal
 
-    $ symfony new my_project_name
+    $ symfony new my_project_name 3.4
 
 This command creates a new directory called ``my_project_name/`` that contains
 an empty project based on the most recent stable Symfony version available. In


### PR DESCRIPTION
Force the installer to use 3.4 - otherwise the command doesn't work.