### PR TITLE
fix(Caution): Validator folder for YAML or XML format

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -43,8 +43,9 @@ So far, this is just an ordinary class that serves some purpose inside your
 application. The goal of validation is to tell you if the data
 of an object is valid. For this to work, you'll configure a list of rules
 (called :ref:`constraints <validation-constraints>`) that the object must
-follow in order to be valid. These rules can be specified via a number of
-different formats (YAML, XML, annotations, or PHP).
+follow in order to be valid. These rules are usually defined using PHP code or
+annotations but they can also be defined as a ``validation.yaml`` or
+``validation.xml`` file inside the ``config/validator/`` directory:
 
 For example, to guarantee that the ``$name`` property is not empty, add the
 following:
@@ -112,11 +113,6 @@ following:
 
     Protected and private properties can also be validated, as well as "getter"
     methods (see :ref:`validator-constraint-targets`).
-
-.. caution::
-    
-    If you're using the YAML or XML formats, the ``config/validator`` folder 
-    structure should be respected !  
 
 .. index::
    single: Validation; Using the validator

--- a/validation.rst
+++ b/validation.rst
@@ -113,6 +113,11 @@ following:
     Protected and private properties can also be validated, as well as "getter"
     methods (see :ref:`validator-constraint-targets`).
 
+.. caution::
+    
+    If you're using the YAML or XML formats, the ``config/validator`` folder 
+    structure should be respected !  
+
 .. index::
    single: Validation; Using the validator
 


### PR DESCRIPTION
Hi, 

The validator waits for a `config/validator` folder structure if we use the "file" approach, this structure must be respected, it could be a great idea to informat that the structure is mandatory. 
