### PR TITLE
Fix typo in Memcached adapter documentation

### DIFF
--- a/components/cache/adapters/memcached_adapter.rst
+++ b/components/cache/adapters/memcached_adapter.rst
@@ -271,7 +271,7 @@ Available Options
     small outgoing messages and sending them all at once.
 
 ``use_udp`` (type: ``bool``, default: ``false``)
-    Enables or disabled the use of `User Datagram Protocol (UDP)`_ mode (instead
+    Enables or disables the use of `User Datagram Protocol (UDP)`_ mode (instead
     of `Transmission Control Protocol (TCP)`_ mode), where all operations are
     executed in a "fire-and-forget" manner; no attempt to ensure the operation
     has been received or acted on will be made once the client has executed it.


### PR DESCRIPTION
PS: I sent this pull request against the `3.4` branch; is that OK? This issue first appeared in the `3.3` branch but that branch now only receives security fixes according to the maintenance roadmap.