### PR TITLE
Fix typo for variable name

### DIFF
--- a/reference/forms/types/options/choice_label.rst.inc
+++ b/reference/forms/types/options/choice_label.rst.inc
@@ -17,7 +17,7 @@ more control::
             'maybe' => null,
         ),
         'choice_label' => function ($choiceValue, $key, $value) {
-            if ($value == choiceValue) {
+            if ($value == $choiceValue) {
                 return 'Definitely!';
             }
 


### PR DESCRIPTION
The variable name `choice_value` did not contain the `$`.