### PR TITLE
Add link to configuration documentation

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -329,6 +329,7 @@ Ok, time to finish mastering the fundamentals by reading these articles:
 * :doc:`/routing`
 * :doc:`/controller`
 * :doc:`/templating`
+* :doc:`/configuration`
 
 Then, learn about other important topics like the
 :doc:`service container </service_container>`,


### PR DESCRIPTION
The link is missing from the fundamentals listing.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
