### PR TITLE
Recommend using the FQCN as a service ID

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -381,13 +381,17 @@ Bundles must be versioned following the `Semantic Versioning Standard`_.
 Services
 --------
 
-If the bundle defines services, they must be prefixed with the bundle alias.
-For example, AcmeBlogBundle services must be prefixed with ``acme_blog``.
+If the bundle defines services, they should use the FQCN of the
+underlying class as an ID. If they cannot, or if the class is defined in
+another vendor, they must be prefixed with the bundle alias.
+
+For example, AcmeBlogBundle services created from classes defined in the
+``AnotherVendor`` namespace must be prefixed with ``acme_blog``.
 
 In addition, services not meant to be used by the application directly, should
 be :ref:`defined as private <container-private-services>`. For public services,
 :ref:`aliases should be created <service-autowiring-alias>` from the interface/class
-to the service id. For example, in MonologBundle, an alias is created from
+to the service id when applicable. For example, in MonologBundle, an alias is created from
 ``Psr\Log\LoggerInterface`` to ``logger`` so that the ``LoggerInterface`` type-hint
 can be used for autowiring.
 


### PR DESCRIPTION
In most cases, service definitions live in the same root namespace as
the class they use.
I think this rules dates from before autowiring, and made some sense at
that time because you wanted people to name their services
`guzzle.http_client` rather than `http_client`, which would have caused
collisions. Now, the possible collisions come from far less likely
scenarios where a bundle defines a service from another bundle, and can
be solved by requiring the prefix only for those. Likewise, if a bundle
needs to define several services from one class, they should use the
prefix (since they cannot use the FQCN anyway). Finally the paragraph
below recommends to create an alias from the interface/alias to the
service id. That's a risk of collision, and if it is acceptable, then
this change is acceptable too IMO.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
