### PR TITLE
[HttpFoundation] Add info for getAcceptableFormats() method

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -293,6 +293,18 @@ by using the following methods:
 :method:`Symfony\\Component\\HttpFoundation\\Request::getAcceptableFormats`
     Returns the list of accepted client formats associated with the request.
 
+Note that
+:method:`Symfony\\Component\\HttpFoundation\\Request::getAcceptableFormats`
+will use the data from
+:method:`Symfony\\Component\\HttpFoundation\\Request::getAcceptableContentTypes`
+and return the client acceptable formats::
+
+    $request->getAcceptableContentTypes();
+    // returns ['text/html', 'application/xhtml+xml', 'application/xml', '*/*']
+
+    $request->getAcceptableFormats();
+    // returns ['html', 'xml']
+
 :method:`Symfony\\Component\\HttpFoundation\\Request::getLanguages`
     Returns the list of accepted languages ordered by descending quality.
 

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -290,6 +290,9 @@ by using the following methods:
 :method:`Symfony\\Component\\HttpFoundation\\Request::getAcceptableContentTypes`
     Returns the list of accepted content types ordered by descending quality.
 
+:method:`Symfony\\Component\\HttpFoundation\\Request::getAcceptableFormats`
+    Returns the list of accepted client formats associated with the request.
+
 :method:`Symfony\\Component\\HttpFoundation\\Request::getLanguages`
     Returns the list of accepted languages ordered by descending quality.
 


### PR DESCRIPTION
Adds info for `Request::getAcceptableFormats()`

Should it add more info on docs page? Ex: `Request::getAcceptableContentTypes` returns the accepted content types which can be `text/html`, `application/json`, etc. 
`Request::getAcceptableFormats` processes that and returns the formats based on those content types `html`, `json`

ref https://github.com/symfony/symfony/pull/26486