### PR TITLE
Mentioned Debian explicitly

### DIFF
--- a/components/http_foundation/session_configuration.rst
+++ b/components/http_foundation/session_configuration.rst
@@ -139,8 +139,8 @@ the ``php.ini`` directive ``session.gc_maxlifetime``. The meaning in this contex
 that any stored session that was saved more than ``gc_maxlifetime`` ago should be
 deleted. This allows one to expire records based on idle time.
 
-However, some operating systems do their own session handling and set the
-``session.gc_probability`` variable to ``0`` to stop PHP doing garbage
+However, some operating systems (e.g. Debian) do their own session handling and set
+the ``session.gc_probability`` variable to ``0`` to stop PHP doing garbage
 collection. That's why Symfony now overwrites this value to ``1``.
 
 If you wish to use the original value set in your ``php.ini``, add the following


### PR DESCRIPTION
Question: The next sentence ("That's why...") doesn't make sense to me! If Debian thinks it's better to do it with its own cronjob, **why** is Symfony overwriting it?? => Suggestion: Symfony overwrites this value to ``1``, because ...