### PR TITLE
[Messenger] Give credits to where the messenger component were inspired from

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -8,6 +8,9 @@ The Messenger Component
     The Messenger component helps applications send and receive messages to/from
     other applications or via message queues.
 
+    The component is greatly inspired by Matthias Noback's series of `blog posts
+    about command buses`_ and the `SimpleBus project`_.
+
 Installation
 ------------
 
@@ -191,3 +194,7 @@ loop, the message bus is equipped with the ``WrapIntoReceivedMessage`` middlewar
 It will wrap the received messages into ``ReceivedMessage`` objects and the
 ``SendMessageMiddleware`` middleware will know it should not route these
 messages again to a transport.
+
+
+.. _blog posts about command buses: https://matthiasnoback.nl/tags/command%20bus/
+.. _SimpleBus project: http://simplebus.io


### PR DESCRIPTION
Our initial implementation of the Messenger component is **greatly** inspired by the work of Matthias Noback. It is obvious for anyone that used SimpleBus and see the messenger component. I think it is a good idea to give some credit and to make sure that we all users know that we are inspired by SimpleBus. 

Currently we only reference Matthias [here](https://github.com/symfony/symfony/blob/4.1/src/Symfony/Component/Messenger/MessageBus.php#L19). 

I do understand that the component has diverged from SimpleBus and we (Symfony community) have added many great features the past few months. But I hope we could include some version of this PR. 


