### PR TITLE
Transition from mt_rand to random_int

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -38,7 +38,7 @@ class::
          */
         public function number($max)
         {
-            $number = mt_rand(0, $max);
+            $number = random_int(0, $max);
 
             return new Response(
                 '<html><body>Lucky number: '.$number.'</body></html>'

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -53,7 +53,7 @@ random) number and prints it. To do that, create a "Controller class" and a
     {
         public function number()
         {
-            $number = mt_rand(0, 100);
+            $number = random_int(0, 100);
 
             return new Response(
                 '<html><body>Lucky number: '.$number.'</body></html>'
@@ -248,7 +248,7 @@ variable so you can use it in Twig::
          */
         public function number()
         {
-            $number = mt_rand(0, 100);
+            $number = random_int(0, 100);
 
             return $this->render('lucky/number.html.twig', array(
                 'number' => $number,


### PR DESCRIPTION
Considering that mt_rand has a warning notice surrounding it, having the examples use random_int nudges people in the direction of the more secure way of generating random ints, building better habits.