### PR TITLE
[Filesystem] Improved the code of an example

### DIFF
--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -34,7 +34,7 @@ endpoint for filesystem operations::
     $fileSystem = new Filesystem();
 
     try {
-        $fileSystem->mkdir('/tmp/random/dir/'.mt_rand());
+        $fileSystem->mkdir(sys_get_temp_dir().'/'.random_int(0, 1000));
     } catch (IOExceptionInterface $exception) {
         echo "An error occurred while creating your directory at ".$exception->getPath();
     }


### PR DESCRIPTION
This continues #9903 and removes the last `mt_rand()` example in the docs.