### PR TITLE
Update dotenv usage

### DIFF
--- a/components/dotenv.rst
+++ b/components/dotenv.rst
@@ -66,6 +66,13 @@ You should never store a ``.env`` file in your code repository as it might
 contain sensitive information; create a ``.env.dist`` file with sensible
 defaults instead.
 
+.. note::
+
+    Symfony Dotenv can be used in any environment of your application:
+    development, testing, staging and even production. However, in production
+    it's recommended to configure real environment variables to avoid the
+    performance overhead of parsing the ``.env`` file for every request.
+
 As a ``.env`` file is a regular shell script, you can ``source`` it in your own
 shell scripts:
 

--- a/components/dotenv.rst
+++ b/components/dotenv.rst
@@ -66,9 +66,6 @@ You should never store a ``.env`` file in your code repository as it might
 contain sensitive information; create a ``.env.dist`` file with sensible
 defaults instead.
 
-Symfony Dotenv should only be used in development/testing/staging environments.
-For production environments, use "real" environment variables.
-
 As a ``.env`` file is a regular shell script, you can ``source`` it in your own
 shell scripts:
 


### PR DESCRIPTION
Based on the discussion in https://github.com/symfony/symfony/issues/25643, I propose to remove this note. There is no downside of using dotenv in production, and it actually brings extra value when using a "simple" Linux installation, as the environments on console and web are automatically 'identical'.