### PR TITLE
Observer instead of Mediator pattern

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -25,7 +25,7 @@ before or after a method is executed, without interfering with other plugins.
 This is not an easy problem to solve with single inheritance, and even if
 multiple inheritance was possible with PHP, it comes with its own drawbacks.
 
-The Symfony EventDispatcher component implements the `Observer`_ pattern
+The Symfony EventDispatcher component implements the `Observer` pattern
 in a simple and effective way to make all these things possible and to make
 your projects truly extensible.
 
@@ -516,7 +516,7 @@ Learn More
 * :ref:`The kernel.event_listener tag <dic-tags-kernel-event-listener>`
 * :ref:`The kernel.event_subscriber tag <dic-tags-kernel-event-subscriber>`
 
-.. _Mediator: https://en.wikipedia.org/wiki/Mediator_pattern
+.. _Observer: https://en.wikipedia.org/wiki/Observer_pattern
 .. _Closures: https://php.net/manual/en/functions.anonymous.php
 .. _PHP callable: https://php.net/manual/en/language.pseudo-types.php#language.types.callback
 .. _Packagist: https://packagist.org/packages/symfony/event-dispatcher

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -25,7 +25,7 @@ before or after a method is executed, without interfering with other plugins.
 This is not an easy problem to solve with single inheritance, and even if
 multiple inheritance was possible with PHP, it comes with its own drawbacks.
 
-The Symfony EventDispatcher component implements the `Mediator`_ pattern
+The Symfony EventDispatcher component implements the `Observer`_ pattern
 in a simple and effective way to make all these things possible and to make
 your projects truly extensible.
 

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -25,9 +25,9 @@ before or after a method is executed, without interfering with other plugins.
 This is not an easy problem to solve with single inheritance, and even if
 multiple inheritance was possible with PHP, it comes with its own drawbacks.
 
-The Symfony EventDispatcher component implements the `Observer`_ pattern
-in a simple and effective way to make all these things possible and to make
-your projects truly extensible.
+The Symfony EventDispatcher component implements the `Mediator`_ and `Observer`_
+design patterns to make all these things possible and to make your projects
+truly extensible.
 
 Take a simple example from :doc:`the HttpKernel component </components/http_kernel>`.
 Once a ``Response`` object has been created, it may be useful to allow other
@@ -516,6 +516,7 @@ Learn More
 * :ref:`The kernel.event_listener tag <dic-tags-kernel-event-listener>`
 * :ref:`The kernel.event_subscriber tag <dic-tags-kernel-event-subscriber>`
 
+.. _Mediator: https://en.wikipedia.org/wiki/Mediator_pattern
 .. _Observer: https://en.wikipedia.org/wiki/Observer_pattern
 .. _Closures: https://php.net/manual/en/functions.anonymous.php
 .. _PHP callable: https://php.net/manual/en/language.pseudo-types.php#language.types.callback

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -25,7 +25,7 @@ before or after a method is executed, without interfering with other plugins.
 This is not an easy problem to solve with single inheritance, and even if
 multiple inheritance was possible with PHP, it comes with its own drawbacks.
 
-The Symfony EventDispatcher component implements the `Observer` pattern
+The Symfony EventDispatcher component implements the `Observer`_ pattern
 in a simple and effective way to make all these things possible and to make
 your projects truly extensible.
 


### PR DESCRIPTION
Actually Event Dispatcher component implements Observer pattern (GoF) but not a Mediator.
I think we should change this description so as not to confuse users in the future.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
