### PR TITLE
Token was deauthenticated Error Symfony 4

### DIFF
--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -136,7 +136,7 @@ with the following fields: ``id``, ``username``, ``password``,
         }
 
         /**
-         * if you want to keep the control on what attributes are are compared at each request to know if user have changed,
+         * if you want to keep the control on what attributes are compared at each request to know if user have changed,
          * you can implement Equatable interface and the method isEqualTo and add all attributes you want compare.
          * The equality comparison should neither be done by referential equality
          * nor by comparing identities (i.e. getId() === getId()).

--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -42,14 +42,13 @@ with the following fields: ``id``, ``username``, ``password``,
 
     use Doctrine\ORM\Mapping as ORM;
     use Symfony\Component\Security\Core\User\UserInterface;
-    use Serializable;
     use Symfony\Component\Security\Core\User\EquatableInterface;
 
     /**
      * @ORM\Table(name="app_users")
      * @ORM\Entity(repositoryClass="App\Repository\UserRepository")
      */
-    class User implements UserInterface, Serializable, EquatableInterface
+    class User implements UserInterface, \Serializable, EquatableInterface
     {
         /**
          * @ORM\Column(type="integer")
@@ -116,7 +115,7 @@ with the following fields: ``id``, ``username``, ``password``,
         {
             return serialize(array(
                 $this->id,
-                $this->username, // you should use $this->email if you don't use username but email to log user
+                $this->username,
                 $this->password,
                 // see section on salt below
                 // $this->salt,
@@ -128,7 +127,7 @@ with the following fields: ``id``, ``username``, ``password``,
         {
             list (
                 $this->id,
-                $this->username, // you should use $this->email if you don't use username but email to log user
+                $this->username,
                 $this->password,
                 // see section on salt below
                 // $this->salt
@@ -149,10 +148,6 @@ with the following fields: ``id``, ``username``, ``password``,
         public function isEqualTo(UserInterface $user)
         {
             if ($this->password !== $user->getPassword()) {
-                return false;
-            }
-
-            if ($this->username !== $user->getUsername()) {
                 return false;
             }
 

--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -42,13 +42,14 @@ with the following fields: ``id``, ``username``, ``password``,
 
     use Doctrine\ORM\Mapping as ORM;
     use Symfony\Component\Security\Core\User\UserInterface;
+    use Serializable;
     use Symfony\Component\Security\Core\User\EquatableInterface;
 
     /**
      * @ORM\Table(name="app_users")
      * @ORM\Entity(repositoryClass="App\Repository\UserRepository")
      */
-    class User implements UserInterface, EquatableInterface
+    class User implements UserInterface, Serializable, EquatableInterface
     {
         /**
          * @ORM\Column(type="integer")
@@ -109,8 +110,34 @@ with the following fields: ``id``, ``username``, ``password``,
         public function eraseCredentials()
         {
         }
+        
+        /** @see \Serializable::serialize() */
+        public function serialize()
+        {
+            return serialize(array(
+                $this->id,
+                $this->username, // you should use $this->email if you don't use username but email to log user
+                $this->password,
+                // see section on salt below
+                // $this->salt,
+            ));
+        }
+
+        /** @see \Serializable::unserialize() */
+        public function unserialize($serialized)
+        {
+            list (
+                $this->id,
+                $this->username, // you should use $this->email if you don't use username but email to log user
+                $this->password,
+                // see section on salt below
+                // $this->salt
+                ) = unserialize($serialized, ['allowed_classes' => false]);
+        }
 
         /**
+         * if you want to keep the control on what attributes are are compared at each request to know if user have changed,
+         * you can implement Equatable interface and the method isEqualTo and add all attributes you want compare.
          * The equality comparison should neither be done by referential equality
          * nor by comparing identities (i.e. getId() === getId()).
          *
@@ -125,7 +152,7 @@ with the following fields: ``id``, ``username``, ``password``,
                 return false;
             }
 
-            if ($this->email !== $user->getUsername()) {
+            if ($this->username !== $user->getUsername()) {
                 return false;
             }
 

--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -42,12 +42,13 @@ with the following fields: ``id``, ``username``, ``password``,
 
     use Doctrine\ORM\Mapping as ORM;
     use Symfony\Component\Security\Core\User\UserInterface;
+    use Symfony\Component\Security\Core\User\EquatableInterface;
 
     /**
      * @ORM\Table(name="app_users")
      * @ORM\Entity(repositoryClass="App\Repository\UserRepository")
      */
-    class User implements UserInterface, \Serializable
+    class User implements UserInterface, EquatableInterface
     {
         /**
          * @ORM\Column(type="integer")
@@ -109,28 +110,26 @@ with the following fields: ``id``, ``username``, ``password``,
         {
         }
 
-        /** @see \Serializable::serialize() */
-        public function serialize()
+        /**
+         * The equality comparison should neither be done by referential equality
+         * nor by comparing identities (i.e. getId() === getId()).
+         *
+         * However, you do not need to compare every attribute, but only those that
+         * are relevant for assessing whether re-authentication is required.
+         *
+         * @return bool
+         */
+        public function isEqualTo(UserInterface $user)
         {
-            return serialize(array(
-                $this->id,
-                $this->username,
-                $this->password,
-                // see section on salt below
-                // $this->salt,
-            ));
-        }
+            if ($this->password !== $user->getPassword()) {
+                return false;
+            }
 
-        /** @see \Serializable::unserialize() */
-        public function unserialize($serialized)
-        {
-            list (
-                $this->id,
-                $this->username,
-                $this->password,
-                // see section on salt below
-                // $this->salt
-            ) = unserialize($serialized, ['allowed_classes' => false]);
+            if ($this->email !== $user->getUsername()) {
+                return false;
+            }
+
+            return true;
         }
     }
 


### PR DESCRIPTION
We should no long used Serializable interface without username/email, password, id attributes it's caused error when you log with a user 'Token was deauthenticated after trying to refresh it'
Here I propose to add EquatableInterface and isEqualTo method to choose what attributes do you want compare for each request.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
