### PR TITLE
use is_granted() instead of deprecated has_role()

### DIFF
--- a/best_practices/security.rst
+++ b/best_practices/security.rst
@@ -121,7 +121,7 @@ Using ``@Security``, this looks like:
      * Displays a form to create a new Post entity.
      *
      * @Route("/new", name="admin_post_new")
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("is_granted('ROLE_ADMIN')")
      */
     public function new()
     {

--- a/security.rst
+++ b/security.rst
@@ -892,7 +892,7 @@ using annotations::
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
     /**
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("is_granted('ROLE_ADMIN')")
      */
     public function hello($name)
     {

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -265,7 +265,7 @@ key:
             access_control:
                 -
                     path: ^/_internal/secure
-                    allow_if: "'127.0.0.1' == request.getClientIp() or has_role('ROLE_ADMIN')"
+                    allow_if: "'127.0.0.1' == request.getClientIp() or is_granted('ROLE_ADMIN')"
 
     .. code-block:: xml
 
@@ -279,7 +279,7 @@ key:
 
             <config>
                 <rule path="^/_internal/secure"
-                    allow-if="'127.0.0.1' == request.getClientIp() or has_role('ROLE_ADMIN')" />
+                    allow-if="'127.0.0.1' == request.getClientIp() or is_granted('ROLE_ADMIN')" />
             </config>
         </srv:container>
 
@@ -288,7 +288,7 @@ key:
             'access_control' => array(
                 array(
                     'path' => '^/_internal/secure',
-                    'allow_if' => '"127.0.0.1" == request.getClientIp() or has_role("ROLE_ADMIN")',
+                    'allow_if' => '"127.0.0.1" == request.getClientIp() or is_granted("ROLE_ADMIN")',
                 ),
             ),
 

--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -61,9 +61,11 @@ Additionally, you have access to a number of functions inside the expression:
     Similar, but not equal to ``IS_AUTHENTICATED_REMEMBERED``, see below.
 ``is_fully_authenticated``
     Similar, but not equal to ``IS_AUTHENTICATED_FULLY``, see below.
-``has_role``
-    Checks to see if the user has the given role - equivalent to an expression like
-    ``'ROLE_ADMIN' in roles``.
+``is_granted``
+    Checks if the user has the given permission. Optionally accepts a second argument
+    with the object where permission is checked on. It's equivalent to using
+    the :doc:`isGranted() method </security/securing_services>` from the authorization
+    checker service.
 
 .. sidebar:: ``is_remember_me`` is different than checking ``IS_AUTHENTICATED_REMEMBERED``
 


### PR DESCRIPTION
using `has_role()` was deprecated in https://github.com/symfony/symfony/pull/27305 since `4.2` by @nicolas-grekas 
