### PR TITLE
Fixed security expression testing user

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -964,7 +964,7 @@ You can also use expressions inside your templates:
     .. code-block:: html+jinja
 
         {% if is_granted(expression(
-            '"ROLE_ADMIN" in roles or (user and user.isSuperAdmin())'
+            '"ROLE_ADMIN" in roles or (not is_anonymous() and user.isSuperAdmin())'
         )) %}
             <a href="...">Delete</a>
         {% endif %}
@@ -972,7 +972,7 @@ You can also use expressions inside your templates:
     .. code-block:: html+php
 
         <?php if ($view['security']->isGranted(new Expression(
-            '"ROLE_ADMIN" in roles or (user and user.isSuperAdmin())'
+            '"ROLE_ADMIN" in roles or (not is_anonymous() and user.isSuperAdmin())'
         ))): ?>
             <a href="...">Delete</a>
         <?php endif; ?>

--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -18,7 +18,7 @@ accepts an :class:`Symfony\\Component\\ExpressionLanguage\\Expression` object::
     public function indexAction()
     {
         $this->denyAccessUnlessGranted(new Expression(
-            '"ROLE_ADMIN" in roles or (user and user.isSuperAdmin())'
+            '"ROLE_ADMIN" in roles or (not is_anonymous() and user.isSuperAdmin())'
         ));
 
         // ...


### PR DESCRIPTION
The example "user and ..." is broken when the user is a string.
