### PR TITLE
Update shared-entry.rst to use Bootstrap 4's SCSS

### DIFF
--- a/frontend/encore/shared-entry.rst
+++ b/frontend/encore/shared-entry.rst
@@ -21,7 +21,7 @@ that's included on every page:
 
             // you can also extract CSS - this will create a 'vendor.css' file
             // this CSS will *not* be included in page1.css or page2.css anymore
-            'bootstrap-sass/assets/stylesheets/_bootstrap.scss'
+            'bootstrap/scss/bootstrap.scss'
         ])
 
 As soon as you make this change, you need to include two extra JavaScript files


### PR DESCRIPTION
Updated the first example in shared-entry.rst to use Bootstrap 4's SCSS.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
