### PR TITLE
Update simple-example.rst to use const for jQuery

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -163,7 +163,7 @@ Great! Use ``require()`` to import ``jquery`` and ``greet.js``:
     // assets/js/app.js
 
     // loads the jquery package from node_modules
-    var $ = require('jquery');
+    const $ = require('jquery');
 
     // import the function from greet.js (the .js extension is optional)
     // ./ (or ../) means to look for a local file


### PR DESCRIPTION
Updated simple-example.rst to use `const` instead of `var` for requiring jQuery, so it's in line with other examples in the front-end section.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
