### PR TITLE
Improved the front controller of the HttpCache

### DIFF
--- a/http_cache.rst
+++ b/http_cache.rst
@@ -99,10 +99,13 @@ caching kernel:
     use App\Kernel;
 
     // ...
-    $kernel = new Kernel($_SERVER['APP_ENV'] ?? 'dev', $_SERVER['APP_DEBUG'] ?? ('prod' !== ($_SERVER['APP_ENV'] ?? 'dev')));
+    $env = $_SERVER['APP_ENV'] ?? 'dev';
+    $debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env));
+    // ...
+    $kernel = new Kernel($env, $debug);
 
     + // Wrap the default Kernel with the CacheKernel one in 'prod' environment
-    + if ('prod' === ($_SERVER['APP_ENV'] ?? 'dev')) {
+    + if ('prod' === $env) {
     +     $kernel = new CacheKernel($kernel);
     + }
 

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -95,14 +95,16 @@ caching kernel:
 
     // public/index.php
 
-    use App\Kernel;
     + use App\CacheKernel;
+    use App\Kernel;
 
     // ...
     $kernel = new Kernel($_SERVER['APP_ENV'] ?? 'dev', $_SERVER['APP_DEBUG'] ?? ('prod' !== ($_SERVER['APP_ENV'] ?? 'dev')));
 
-    + // Wrap the default Kernel with the CacheKernel one
-    + $kernel = new CacheKernel($kernel);
+    + // Wrap the default Kernel with the CacheKernel one in 'prod' environment
+    + if ('prod' === ($_SERVER['APP_ENV'] ?? 'dev')) {
+    +     $kernel = new CacheKernel($kernel);
+    + }
 
     $request = Request::createFromGlobals();
     // ...


### PR DESCRIPTION
I don't think it makes sense to enable HttpCache in `dev` (in the past we only added this to `web/app.php` and not `web/app_dev.php`).

The change in the `+ use App\CacheKernel;` (lines 98 and 99) is to sort the `use ...` alphabetically.