### PR TITLE
Change form.xxx_bind to form.xxx_submit

### DIFF
--- a/form/events.rst
+++ b/form/events.rst
@@ -252,9 +252,9 @@ Name                    ``FormEvents`` Constant        Event's Data
 ======================  =============================  ===============
 ``form.pre_set_data``   ``FormEvents::PRE_SET_DATA``   Model data
 ``form.post_set_data``  ``FormEvents::POST_SET_DATA``  Model data
-``form.pre_bind``       ``FormEvents::PRE_SUBMIT``     Request data
-``form.bind``           ``FormEvents::SUBMIT``         Normalized data
-``form.post_bind``      ``FormEvents::POST_SUBMIT``    View data
+``form.pre_submit``     ``FormEvents::PRE_SUBMIT``     Request data
+``form.submit``         ``FormEvents::SUBMIT``         Normalized data
+``form.post_submit``    ``FormEvents::POST_SUBMIT``    View data
 ======================  =============================  ===============
 
 Event Listeners


### PR DESCRIPTION
Form Events names have changed in 4.0 version, using 'submit' instead of 'bind'.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
