### PR TITLE
Fix configuration-block not working

### DIFF
--- a/routing/redirect_in_config.rst
+++ b/routing/redirect_in_config.rst
@@ -185,7 +185,7 @@ The :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController::u
 and :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController::redirectAction`
 methods accept an additional argument called ``keepRequestMethod``. When it's
 set to ``true``, temporary redirects use ``307`` code instead of ``302`` and
-permanent redirects use ``308`` code instead of ``301``::
+permanent redirects use ``308`` code instead of ``301``:
 
 .. configuration-block::
 


### PR DESCRIPTION
The `::` shorthand in the line before the `.. configuration-block::` breaks the entire block.