### PR TITLE
Fixed wrong argument position

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1140,7 +1140,7 @@ parameter of the ``ObjectNormalizer``::
         public $bar;
     }
 
-    $normalizer = new ObjectNormalizer(null, null, null, new ReflectionExtractor());
+    $normalizer = new ObjectNormalizer(null, null, new ReflectionExtractor());
     $serializer = new Serializer(array(new DateTimeNormalizer(), $normalizer));
 
     $obj = $serializer->denormalize(


### PR DESCRIPTION
ReflectionExtractor argument is on position 4 however given the current constructor signature the correct position should be 3.
Tested with version 4.1

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
