### PR TITLE
bugfixes should be placed for the 2.8 branch

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,8 +7,8 @@ Contributing
 ------------
 
 >**Note**
->Unless you're documenting a feature that was introduced *after* Symfony 2.7
->(e.g. in Symfony 2.8), all pull requests must be based off of the **2.7** branch,
+>Unless you're documenting a feature that was introduced *after* Symfony 2.8
+>(e.g. in Symfony 3.4), all pull requests must be based off of the **2.8** branch,
 >**not** the master or older branches.
 
 We love contributors! For more information on how you can contribute to the

--- a/contributing/code/patches.rst
+++ b/contributing/code/patches.rst
@@ -16,12 +16,6 @@ software:
 * Git;
 * PHP version 5.3.9 or above.
 
-.. caution::
-
-    Before Symfony 2.7, the minimal PHP version was 5.3.3. Please keep
-    this in mind, if you are working on a bug fix for earlier versions
-    of Symfony.
-
 Configure Git
 ~~~~~~~~~~~~~
 
@@ -112,7 +106,7 @@ Choose the right Branch
 Before working on a patch, you must determine on which branch you need to
 work:
 
-* ``2.7``, if you are fixing a bug for an existing feature or want to make a
+* ``2.8``, if you are fixing a bug for an existing feature or want to make a
   change that falls into the :doc:`list of acceptable changes in patch versions
   </contributing/code/maintenance>` (you may have to choose a higher branch if
   the feature you are fixing was introduced in a later version);
@@ -123,7 +117,7 @@ work:
 
     All bug fixes merged into maintenance branches are also merged into more
     recent branches on a regular basis. For instance, if you submit a patch
-    for the ``2.7`` branch, the patch will also be applied by the core team on
+    for the ``2.8`` branch, the patch will also be applied by the core team on
     the ``master`` branch.
 
 Create a Topic Branch
@@ -136,18 +130,18 @@ topic branch:
 
     $ git checkout -b BRANCH_NAME master
 
-Or, if you want to provide a bugfix for the ``2.7`` branch, first track the remote
-``2.7`` branch locally:
+Or, if you want to provide a bugfix for the ``2.8`` branch, first track the remote
+``2.8`` branch locally:
 
 .. code-block:: terminal
 
-    $ git checkout -t origin/2.7
+    $ git checkout -t origin/2.8
 
-Then create a new branch off the ``2.7`` branch to work on the bugfix:
+Then create a new branch off the ``2.8`` branch to work on the bugfix:
 
 .. code-block:: terminal
 
-    $ git checkout -b BRANCH_NAME 2.7
+    $ git checkout -b BRANCH_NAME 2.8
 
 .. tip::
 
@@ -251,7 +245,7 @@ while to finish your changes):
 
 .. tip::
 
-    Replace ``master`` with the branch you selected previously (e.g. ``2.7``)
+    Replace ``master`` with the branch you selected previously (e.g. ``2.8``)
     if you are working on a bugfix
 
 When doing the ``rebase`` command, you might have to fix merge conflicts.
@@ -278,8 +272,8 @@ You can now make a pull request on the ``symfony/symfony`` GitHub repository.
 
 .. tip::
 
-    Take care to point your pull request towards ``symfony:2.7`` if you want
-    the core team to pull a bugfix based on the ``2.7`` branch.
+    Take care to point your pull request towards ``symfony:2.8`` if you want
+    the core team to pull a bugfix based on the ``2.8`` branch.
 
 To ease the core team work, always include the modified components in your
 pull request message, like in:
@@ -350,7 +344,7 @@ Rework your Patch
 
 Based on the feedback on the pull request, you might need to rework your
 patch. Before re-submitting the patch, rebase with ``upstream/master`` or
-``upstream/2.7``, don't merge; and force the push to the origin:
+``upstream/2.8``, don't merge; and force the push to the origin:
 
 .. code-block:: terminal
 

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -240,8 +240,7 @@ choice_loader
 ~~~~~~~~~~~~~
 
 .. versionadded:: 2.7
-
-    The ``choice_loader`` option was added in Symfony 2.7.
+    The ``choice_loader`` option was introduced in Symfony 2.7.
 
 **type**: :class:`Symfony\\Component\\Form\\ChoiceList\\Loader\\ChoiceLoaderInterface`
 
@@ -261,7 +260,6 @@ choices_as_values
 **type**: ``boolean`` **default**: false
 
 .. versionadded:: 2.7
-
     The ``choices_as_values`` option was introduced in Symfony 2.7.
 
 The ``choices_as_values`` option was added to keep backward compatibility with the


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
