### PR TITLE
Different way for updating flex projects

### DIFF
--- a/setup/_update_dep_errors.rst.inc
+++ b/setup/_update_dep_errors.rst.inc
@@ -6,7 +6,7 @@ other Symfony dependencies too. In that case, try the following command:
 
 .. code-block:: terminal
 
-    $ composer update "symfony/*" --with-dependencies
+    $ composer update "symfony/*" --with-all-dependencies
 
 This updates ``symfony/symfony`` and *all* packages that it depends on, which will
 include several other packages. By using tight version constraints in

--- a/setup/_update_dep_errors.rst.inc
+++ b/setup/_update_dep_errors.rst.inc
@@ -6,7 +6,7 @@ other Symfony dependencies too. In that case, try the following command:
 
 .. code-block:: terminal
 
-    $ composer update symfony/symfony --with-dependencies
+    $ composer update "symfony/*" --with-dependencies
 
 This updates ``symfony/symfony`` and *all* packages that it depends on, which will
 include several other packages. By using tight version constraints in

--- a/setup/upgrade_minor.rst
+++ b/setup/upgrade_minor.rst
@@ -1,7 +1,7 @@
 .. index::
     single: Upgrading; Minor Version
 
-Upgrading a Minor Version (e.g. 3.3.3 to 3.4.0)
+Upgrading a Minor Version (e.g. 4.0.0 to 4.1.0)
 ===============================================
 
 If you're upgrading a minor version (where the middle number changes), then
@@ -21,8 +21,8 @@ There are two steps to upgrading a minor version:
 1) Update the Symfony Library via Composer
 ------------------------------------------
 
-First, you need to update Symfony by modifying your ``composer.json`` file
-to use the new version:
+First, you need to update all Symfony packages by modifying your ``composer.json`` file
+to use the new version (the list of packages may vary depending on what you've installed):
 
 .. code-block:: json
 
@@ -30,7 +30,17 @@ to use the new version:
         "...": "...",
 
         "require": {
-            "symfony/symfony": "3.4.*",
+            "symfony/asset": "^4.1",
+            "symfony/console": "^4.1",
+            "symfony/expression-language": "^4.1",
+            "symfony/form": "^4.1",
+            "symfony/framework-bundle": "^4.1",
+            "symfony/process": "^4.1",
+            "symfony/security-bundle": "^4.1",
+            "symfony/twig-bundle": "^4.1",
+            "symfony/validator": "^4.1",
+            "symfony/web-link": "^4.1",
+            "symfony/yaml": "^4.1"
         },
         "...": "...",
     }
@@ -39,7 +49,7 @@ Next, use Composer to download new versions of the libraries:
 
 .. code-block:: terminal
 
-    $ composer update symfony/symfony
+    $ composer update "symfony/*"
 
 .. include:: /setup/_update_dep_errors.rst.inc
 
@@ -55,7 +65,7 @@ to your code to get everything working. Additionally, some features you're
 using might still work, but might now be deprecated. While that's just fine,
 if you know about these deprecations, you can start to fix them over time.
 
-Every version of Symfony comes with an UPGRADE file (e.g. `UPGRADE-3.4.md`_)
+Every version of Symfony comes with an UPGRADE file (e.g. `UPGRADE-4.1.md`_)
 included in the Symfony directory that describes these changes. If you follow
 the instructions in the document and update your code accordingly, it should be
 safe to update in the future.
@@ -63,4 +73,4 @@ safe to update in the future.
 These documents can also be found in the `Symfony Repository`_.
 
 .. _`Symfony Repository`: https://github.com/symfony/symfony
-.. _`UPGRADE-3.4.md`: https://github.com/symfony/symfony/blob/3.4/UPGRADE-3.4.md
+.. _`UPGRADE-4.1.md`: https://github.com/symfony/symfony/blob/4.1/UPGRADE-4.1.md

--- a/setup/upgrade_minor.rst
+++ b/setup/upgrade_minor.rst
@@ -21,8 +21,7 @@ There are two steps to upgrading a minor version:
 1) Update the Symfony Library via Composer
 ------------------------------------------
 
-First, you need to update all Symfony packages by modifying your ``composer.json`` file
-to use the new version (the list of packages may vary depending on what you've installed):
+Your composer.json file should already be configured to allow your Symfony packages to be upgraded minor versions. But, if a package was not upgraded that should have been, check your ``composer.json`` file.
 
 .. code-block:: json
 
@@ -30,17 +29,17 @@ to use the new version (the list of packages may vary depending on what you've i
         "...": "...",
 
         "require": {
-            "symfony/asset": "^4.1",
-            "symfony/console": "^4.1",
-            "symfony/expression-language": "^4.1",
-            "symfony/form": "^4.1",
-            "symfony/framework-bundle": "^4.1",
-            "symfony/process": "^4.1",
-            "symfony/security-bundle": "^4.1",
-            "symfony/twig-bundle": "^4.1",
-            "symfony/validator": "^4.1",
-            "symfony/web-link": "^4.1",
-            "symfony/yaml": "^4.1"
+            "symfony/asset": "^4.0",
+            "symfony/console": "^4.0",
+            "symfony/expression-language": "^4.0",
+            "symfony/form": "^4.0",
+            "symfony/framework-bundle": "^4.0",
+            "symfony/process": "^4.0",
+            "symfony/security-bundle": "^4.0",
+            "symfony/twig-bundle": "^4.0",
+            "symfony/validator": "^4.0",
+            "symfony/web-link": "^4.0",
+            "symfony/yaml": "^4.0"
         },
         "...": "...",
     }
@@ -49,7 +48,7 @@ Next, use Composer to download new versions of the libraries:
 
 .. code-block:: terminal
 
-    $ composer update "symfony/*"
+    $ composer update "symfony/*" --with-all-dependencies
 
 .. include:: /setup/_update_dep_errors.rst.inc
 

--- a/setup/upgrade_patch.rst
+++ b/setup/upgrade_patch.rst
@@ -1,7 +1,7 @@
 .. index::
     single: Upgrading; Patch Version
 
-Upgrading a Patch Version (e.g. 3.3.2 to 3.3.3)
+Upgrading a Patch Version (e.g. 4.1.0 to 4.1.1)
 ===============================================
 
 When a new patch version is released (only the last number changed), it is a
@@ -10,12 +10,12 @@ version is *really* easy:
 
 .. code-block:: terminal
 
-    $ composer update symfony/symfony
+    $ composer update "symfony/*"
 
 That's it! You should not encounter any backwards-compatibility breaks or
 need to change anything else in your code. That's because when you started
 your project, your ``composer.json`` included Symfony using a constraint
-like ``3.3.*``, where only the *last* version number will change when you
+like ``^4.1``, where only the *last* version number will change when you
 update.
 
 .. tip::

--- a/setup/upgrade_patch.rst
+++ b/setup/upgrade_patch.rst
@@ -8,15 +8,7 @@ When a new patch version is released (only the last number changed), it is a
 release that only contains bug fixes. This means that upgrading to a new patch
 version is *really* easy:
 
-.. code-block:: terminal
-
-    $ composer update "symfony/*"
-
-That's it! You should not encounter any backwards-compatibility breaks or
-need to change anything else in your code. That's because when you started
-your project, your ``composer.json`` included Symfony using a constraint
-like ``^4.1``, where only the *last* version number will change when you
-update.
+To upgrade to a new "patch" release, see the :doc:Upgrading a Minor Version </setup/upgrade_minor> documentation. Thanks to Symfony's backwards compatibility promise, it's always safe to upgrade to the latest "minor" version.
 
 .. tip::
 


### PR DESCRIPTION
Since flex doesn't use symfony/symfony, I changed update symfony/symfony into "symfony/*" to update all Symfony packages.
