### PR TITLE
Install component for dev environment

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -14,7 +14,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/var-dumper
+    $ composer require symfony/var-dumper --dev
 
 Alternatively, you can clone the `<https://github.com/symfony/var-dumper>`_ repository.
 


### PR DESCRIPTION
I think VarDumper is meant to be installed for development environment. So it is better to install it under `require-dev` most of the time
