### PR TITLE
Fix typo in the Twig article

### DIFF
--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -128,7 +128,7 @@ format
 The format used by the ``date`` filter to display values when no specific format
 is passed as argument.
 
-internal_format
+interval_format
 ...............
 
 **type**: ``string`` **default**: ``%d days``


### PR DESCRIPTION
Minor typo found in the Twig article about the `internal_format` option.