### PR TITLE
Popper js is required

### DIFF
--- a/frontend/encore/bootstrap.rst
+++ b/frontend/encore/bootstrap.rst
@@ -37,11 +37,12 @@ file into ``global.scss``. You can even customize the Bootstrap variables first!
 Importing Bootstrap JavaScript
 ------------------------------
 
-Bootstrap JavaScript requires jQuery, so make sure you have this installed:
+Bootstrap JavaScript requires jQuery and popper, so make sure you have this installed:
 
 .. code-block:: terminal
 
     $ yarn add jquery --dev
+    $ yarn add popper --dev
 
 Next, make sure to call ``.autoProvidejQuery()`` in your ``webpack.config.js`` file:
 

--- a/frontend/encore/bootstrap.rst
+++ b/frontend/encore/bootstrap.rst
@@ -37,12 +37,12 @@ file into ``global.scss``. You can even customize the Bootstrap variables first!
 Importing Bootstrap JavaScript
 ------------------------------
 
-Bootstrap JavaScript requires jQuery and popper, so make sure you have this installed:
+Bootstrap JavaScript requires jQuery and Popper.js, so make sure you have this installed:
 
 .. code-block:: terminal
 
     $ yarn add jquery --dev
-    $ yarn add popper --dev
+    $ yarn add popper.js --dev
 
 Next, make sure to call ``.autoProvidejQuery()`` in your ``webpack.config.js`` file:
 


### PR DESCRIPTION
If you don't add popper js you will probably have the following message while compiling with yarn

This dependency was not found:
* popper.js in ./node_modules/bootstrap/dist/js/bootstrap.js

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
