### PR TITLE
Update scheme.rst (deprecated SensioFrameworkExtraBundle's routing annotations)

### DIFF
--- a/routing/scheme.rst
+++ b/routing/scheme.rst
@@ -16,7 +16,7 @@ the URI scheme via schemes:
         namespace AppBundle\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class MainController extends Controller
         {


### PR DESCRIPTION
Updated because SensioFrameworkExtraBundle's routing annotations have been deprecated.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
