### PR TITLE
Update external_resources.rst (deprecated SensioFrameworkExtraBundle's routing annotations)

### DIFF
--- a/routing/external_resources.rst
+++ b/routing/external_resources.rst
@@ -98,7 +98,7 @@ suppose you want to prefix all routes in the AppBundle with ``/site`` (e.g.
 
     .. code-block:: php-annotations
 
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         /**
          * @Route("/site")


### PR DESCRIPTION
Updated because SensioFrameworkExtraBundle's routing annotations have been deprecated.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
