### PR TITLE
[Routing] do not install SensioFrameworkExtraBundle

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -20,12 +20,6 @@ the change is simple.
 Creating Routes
 ---------------
 
-First, add support for annotations via the SensioFrameworkExtraBundle:
-
-.. code-block:: terminal
-
-    $ composer require sensio/framework-extra-bundle
-
 A *route* is a map from a URL path to a controller. Suppose you want one route that
 matches ``/blog`` exactly and another more dynamic route that can match *any* URL
 like ``/blog/my-post`` or ``/blog/all-about-symfony``:

--- a/routing.rst
+++ b/routing.rst
@@ -22,7 +22,17 @@ Creating Routes
 
 A *route* is a map from a URL path to a controller. Suppose you want one route that
 matches ``/blog`` exactly and another more dynamic route that can match *any* URL
-like ``/blog/my-post`` or ``/blog/all-about-symfony``:
+like ``/blog/my-post`` or ``/blog/all-about-symfony``.
+
+Routes can be configured in YAML, XML and PHP. All formats provide the same
+features and performance, so choose the one you prefer. If you choose PHP
+annotations, run this command once in your app to add support for them:
+
+.. code-block:: terminal
+
+    $ composer require annotations
+
+Now you can configure the routes:
 
 .. configuration-block::
 


### PR DESCRIPTION
The routing annotations of SensioFrameworkExtraBundle are deprecate since https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/562
Also the example code in this documentation does not use SensioFrameworkExtraBundle at all but the core annotation as it should be. So installing the SensioFrameworkExtraBundle is pointless.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
