### PR TITLE
ChoiceValidator : remove 'strict' option

### DIFF
--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -17,7 +17,6 @@ an array of items is one of those valid choices.
 |                | - `multipleMessage`_                                                 |
 |                | - `minMessage`_                                                      |
 |                | - `maxMessage`_                                                      |
-|                | - `strict`_                                                          |
 |                | - `payload`_                                                         |
 +----------------+----------------------------------------------------------------------+
 | Class          | :class:`Symfony\\Component\\Validator\\Constraints\\Choice`          |
@@ -359,14 +358,5 @@ maxMessage
 
 This is the validation error message that's displayed when the user chooses
 too many options per the `max`_ option.
-
-strict
-~~~~~~
-
-**type**: ``boolean`` **default**: ``true``
-
-The validator will also check the type of the input value. Specifically,
-this value is passed to as the third argument to the PHP :phpfunction:`in_array`
-method when checking to see if a value is in the valid choices array.
 
 .. include:: /reference/constraints/_payload-option.rst.inc


### PR DESCRIPTION
Since https://github.com/symfony/validator/commit/52feb05c34551058cb2ae8be515c3632bd7fb5b4#diff-343abfd5be03d0bef6587c21d10d0dd9.
'strict' option did not exist anymore.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
