### PR TITLE
[Twig] Fix Twig namespaces

### DIFF
--- a/components/form.rst
+++ b/components/form.rst
@@ -178,6 +178,9 @@ to bootstrap or access Twig and add the :class:`Symfony\\Bridge\\Twig\\Extension
     use Symfony\Bridge\Twig\Extension\FormExtension;
     use Symfony\Component\Form\FormRenderer;
     use Symfony\Bridge\Twig\Form\TwigRendererEngine;
+    use Twig\Environment;
+    use Twig\Loader\FilesystemLoader;
+    use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
     // the Twig file that holds all the default markup for rendering forms
     // this file comes with TwigBridge
@@ -191,12 +194,12 @@ to bootstrap or access Twig and add the :class:`Symfony\\Bridge\\Twig\\Extension
     // the path to your other templates
     $viewsDirectory = realpath(__DIR__.'/../views');
 
-    $twig = new Twig_Environment(new Twig_Loader_Filesystem(array(
+    $twig = new Environment(new FilesystemLoader(array(
         $viewsDirectory,
         $vendorTwigBridgeDirectory.'/Resources/views/Form',
     )));
     $formEngine = new TwigRendererEngine(array($defaultFormTheme), $twig);
-    $twig->addRuntimeLoader(new \Twig_FactoryRuntimeLoader(array(
+    $twig->addRuntimeLoader(new FactoryRuntimeLoader(array(
         FormRenderer::class => function () use ($formEngine, $csrfManager) {
             return new FormRenderer($formEngine, $csrfManager);
         },
@@ -213,7 +216,7 @@ to bootstrap or access Twig and add the :class:`Symfony\\Bridge\\Twig\\Extension
         ->getFormFactory();
 
 .. versionadded:: 1.30
-    The ``Twig_FactoryRuntimeLoader`` was introduced in Twig 1.30.
+    The ``Twig\\RuntimeLoader\\FactoryRuntimeLoader`` was introduced in Twig 1.30.
 
 The exact details of your `Twig Configuration`_ will vary, but the goal is
 always to add the :class:`Symfony\\Bridge\\Twig\\Extension\\FormExtension`
@@ -253,7 +256,7 @@ installed:
     $ composer require symfony/translation symfony/config
 
 Next, add the :class:`Symfony\\Bridge\\Twig\\Extension\\TranslationExtension`
-to your ``Twig_Environment`` instance::
+to your ``Twig\\Environment`` instance::
 
     use Symfony\Component\Form\Forms;
     use Symfony\Component\Translation\Translator;

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -97,12 +97,13 @@ service and use it directly::
     namespace App\Controller;
 
     use Symfony\Component\HttpFoundation\Response;
+    use Twig\Environment;
 
     class HelloController
     {
         private $twig;
 
-        public function __construct(\Twig_Environment $twig)
+        public function __construct(Environment $twig)
         {
             $this->twig = $twig;
         }

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -84,7 +84,7 @@ called to determine the default escaping applied to the template.
 base_template_class
 ~~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``'Twig_Template'``
+**type**: ``string`` **default**: ``'Twig\\Template'``
 
 Twig templates are compiled into PHP classes before using them to render
 contents. This option defines the base class from which all the template classes

--- a/service_container.rst
+++ b/service_container.rst
@@ -766,7 +766,7 @@ But, with ``autoconfigure: true``, you don't need the tag. In fact, if you're us
 the :ref:`default services.yaml config <service-container-services-load-example>`,
 you don't need to do *anything*: the service will be automatically loaded. Then,
 ``autoconfigure`` will add the ``twig.extension`` tag *for* you, because your class
-implements ``Twig_ExtensionInterface``. And thanks to ``autowire``, you can even add
+implements ``Twig\\Extension\\ExtensionInterface``. And thanks to ``autowire``, you can even add
 constructor arguments without any configuration.
 
 .. _container-public:

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -60,8 +60,8 @@ Autoconfiguring Tags
 
 If you enable :ref:`autoconfigure <services-autoconfigure>`, then some tags are
 automatically applied for you. That's true for the ``twig.extension`` tag: the
-container sees that your class extends ``Twig_Extension`` (or more accurately,
-that it implements ``Twig_ExtensionInterface``) and adds the tag for you.
+container sees that your class extends ``AbstractExtension`` (or more accurately,
+that it implements ``ExtensionInterface``) and adds the tag for you.
 
 .. tip::
 

--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -98,14 +98,16 @@ callable defined in ``getFilters()``::
     namespace App\Twig;
 
     use App\Twig\AppRuntime;
+    use Twig\Extension\AbstractExtension;
+    use Twig\TwigFilter;
 
-    class AppExtension extends \Twig_Extension
+    class AppExtension extends AbstractExtension
     {
         public function getFilters()
         {
             return array(
                 // the logic of this filter is now implemented in a different class
-                new \Twig_SimpleFilter('price', array(AppRuntime::class, 'priceFilter')),
+                new TwigFilter('price', array(AppRuntime::class, 'priceFilter')),
             );
         }
     }


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
Fix Twig namespaces used in documentation