### PR TITLE
More fixes about Twig classes namespaces

### DIFF
--- a/best_practices/templates.rst
+++ b/best_practices/templates.rst
@@ -112,14 +112,16 @@ Markdown content into HTML::
     }
 
 Next, create a new Twig extension and define a new filter called ``md2html``
-using the ``Twig_SimpleFilter`` class. Inject the newly defined ``markdown``
+using the ``Twig\TwigFilter`` class. Inject the newly defined ``markdown``
 service in the constructor of the Twig extension::
 
     namespace AppBundle\Twig;
 
     use AppBundle\Utils\Markdown;
+    use Twig\Extension\AbstractExtension;
+    use Twig\TwigFilter;
 
-    class AppExtension extends \Twig_Extension
+    class AppExtension extends AbstractExtension
     {
         private $parser;
 
@@ -131,7 +133,7 @@ service in the constructor of the Twig extension::
         public function getFilters()
         {
             return array(
-                new \Twig_SimpleFilter(
+                new TwigFilter(
                     'md2html',
                     array($this, 'markdownToHtml'),
                     array('is_safe' => array('html'), 'pre_escape' => 'html')

--- a/components/form.rst
+++ b/components/form.rst
@@ -183,7 +183,6 @@ to bootstrap or access Twig and add the :class:`Symfony\\Bridge\\Twig\\Extension
     use Symfony\Bridge\Twig\Form\TwigRendererEngine;
     use Twig\Environment;
     use Twig\Loader\FilesystemLoader;
-    use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
     // the Twig file that holds all the default markup for rendering forms
     // this file comes with TwigBridge

--- a/service_container.rst
+++ b/service_container.rst
@@ -77,7 +77,7 @@ security.authorization_checker  ``Symfony\Component\Security\Core\Authorization\
 security.password_encoder       ``Symfony\Component\Security\Core\Encoder\UserPasswordEncoder``
 session                         ``Symfony\Component\HttpFoundation\Session\Session``
 translator                      ``Symfony\Component\Translation\DataCollectorTranslator``
-twig                            ``Twig_Environment``
+twig                            ``Twig\Environment``
 validator                       ``Symfony\Component\Validator\Validator\ValidatorInterface``
 =============================== =======================================================================
 


### PR DESCRIPTION
This continues the work done on #9994.