### PR TITLE
[Twig] AppRuntime autoconfigurable in runtime example

### DIFF
--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -117,8 +117,10 @@ previous ``priceFilter()`` method::
 
     // src/Twig/AppRuntime.php
     namespace App\Twig;
+    
+    use Twig\Extension\RuntimeExtensionInterface;
 
-    class AppRuntime
+    class AppRuntime implements RuntimeExtensionInterface
     {
         public function __construct()
         {


### PR DESCRIPTION
In the twig runtime's [doc](https://symfony.com/doc/current/templating/twig_extension.html#creating-lazy-loaded-twig-extensions) there is a sentence below the last example:

> If you're using the default services.yaml configuration, this will already work!

This is not true without `RuntimeExtensionInterface` interface, otherwise autoconfigure won't work. The interface is only available since twig `1.35.0` and `2.4.4` though.

This autoconfigure works since 3.4 I think, but docs before 4.1 contain manually adding the tag to the service, so I didn't change those.