### PR TITLE
Improved the configuration references

### DIFF
--- a/reference/configuration/debug.rst
+++ b/reference/configuration/debug.rst
@@ -25,9 +25,11 @@ key in your application configuration.
 Configuration
 -------------
 
+.. class:: list-config-options
+
+* `dump_destination`_
 * `max_items`_
 * `max_string_length`_
-* `dump_destination`_
 
 max_items
 ~~~~~~~~~

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -25,96 +25,98 @@ configured under the ``framework`` key in your application configuration.
 Configuration
 -------------
 
-* `secret`_
-* `http_method_override`_
-* `trusted_proxies`_
-* `ide`_
-* `test`_
-* `default_locale`_
-* `trusted_hosts`_
-* :ref:`form <reference-framework-form>`
-    * :ref:`enabled <reference-form-enabled>`
-* `csrf_protection`_
-    * :ref:`enabled <reference-csrf_protection-enabled>`
-    * `field_name`_ (deprecated since 2.4)
-* `esi`_
-    * :ref:`enabled <reference-esi-enabled>`
-* `fragments`_
-    * :ref:`enabled <reference-fragments-enabled>`
-    * :ref:`path <reference-fragments-path>`
-* `profiler`_
-    * :ref:`enabled <reference-profiler-enabled>`
-    * `collect`_
-    * `only_exceptions`_
-    * `only_master_requests`_
-    * `dsn`_
-    * `username`_ (deprecated since 2.8)
-    * `password`_ (deprecated since 2.8)
-    * `lifetime`_ (deprecated since 2.8)
-    * `matcher`_
-        * `ip`_
-        * :ref:`path <reference-profiler-matcher-path>`
-        * `service`_
-* `request`_:
-    * `formats`_
-* `router`_
-    * `resource`_
-    * `type`_
-    * `http_port`_
-    * `https_port`_
-    * `strict_requirements`_
-* `session`_
-    * `storage_id`_
-    * `handler_id`_
-    * `name`_
-    * `cookie_lifetime`_
-    * `cookie_path`_
-    * `cookie_domain`_
-    * `cookie_secure`_
-    * `cookie_httponly`_
-    * `gc_divisor`_
-    * `gc_probability`_
-    * `gc_maxlifetime`_
-    * `use_strict_mode`_
-    * `save_path`_
-    * `metadata_update_threshold`_
-* `assets`_
-    * `base_path`_
-    * `base_urls`_
-    * `packages`_
-    * `version`_
-    * `version_format`_
-* `templating`_
-    * `hinclude_default_template`_
-    * :ref:`form <reference-templating-form>`
-        * `resources`_
-    * :ref:`cache <reference-templating-cache>`
-    * `engines`_
-    * `loaders`_
-* `translator`_
-    * :ref:`enabled <reference-translator-enabled>`
-    * `fallbacks`_
-    * `logging`_
-    * :ref:`paths <reference-translator-paths>`
-* `property_access`_
-    * `magic_call`_
-    * `throw_exception_on_invalid_index`_
-* `validation`_
-    * :ref:`enabled <reference-validation-enabled>`
-    * :ref:`cache <reference-validation-cache>`
-    * :ref:`enable_annotations <reference-validation-enable_annotations>`
-    * `translation_domain`_
-    * `strict_email`_
-    * `api`_
+.. class:: list-config-options list-config-options--complex
+
 * `annotations`_
-    * :ref:`cache <reference-annotations-cache>`
-    * `file_cache_dir`_
-    * `debug`_
+  * :ref:`cache <reference-annotations-cache>`
+  * `debug`_
+  * `file_cache_dir`_
+* `assets`_
+  * `base_path`_
+  * `base_urls`_
+  * `packages`_
+  * `version_format`_
+  * `version`_
+* `csrf_protection`_
+  * :ref:`enabled <reference-csrf_protection-enabled>`
+  * `field_name`_ (deprecated since 2.4)
+* `default_locale`_
+* `esi`_
+  * :ref:`enabled <reference-esi-enabled>`
+* :ref:`form <reference-framework-form>`
+  * :ref:`enabled <reference-form-enabled>`
+* `fragments`_
+  * :ref:`enabled <reference-fragments-enabled>`
+  * :ref:`path <reference-fragments-path>`
+* `http_method_override`_
+* `ide`_
+* `profiler`_
+  * `collect`_
+  * `dsn`_
+  * :ref:`enabled <reference-profiler-enabled>`
+  * `lifetime`_ (deprecated since 2.8)
+  * `matcher`_
+    * `ip`_
+    * `service`_
+    * :ref:`path <reference-profiler-matcher-path>`
+  * `only_exceptions`_
+  * `only_master_requests`_
+  * `password`_ (deprecated since 2.8)
+  * `username`_ (deprecated since 2.8)
+* `property_access`_
+  * `magic_call`_
+  * `throw_exception_on_invalid_index`_
+* `request`_:
+  * `formats`_
+* `router`_
+  * `http_port`_
+  * `https_port`_
+  * `resource`_
+  * `strict_requirements`_
+  * `type`_
+* `secret`_
 * `serializer`_
-    * :ref:`enabled <reference-serializer-enabled>`
-    * :ref:`cache <reference-serializer-cache>`
-    * :ref:`enable_annotations <reference-serializer-enable_annotations>`
-    * :ref:`name_converter <reference-serializer-name_converter>`
+  * :ref:`cache <reference-serializer-cache>`
+  * :ref:`enable_annotations <reference-serializer-enable_annotations>`
+  * :ref:`enabled <reference-serializer-enabled>`
+  * :ref:`name_converter <reference-serializer-name_converter>`
+* `session`_
+  * `cookie_domain`_
+  * `cookie_httponly`_
+  * `cookie_lifetime`_
+  * `cookie_path`_
+  * `cookie_secure`_
+  * `gc_divisor`_
+  * `gc_maxlifetime`_
+  * `gc_probability`_
+  * `handler_id`_
+  * `metadata_update_threshold`_
+  * `name`_
+  * `save_path`_
+  * `storage_id`_
+  * `use_strict_mode`_
+* `templating`_
+  * :ref:`cache <reference-templating-cache>`
+  * `engines`_
+  * :ref:`form <reference-templating-form>`
+    * `resources`_
+  * `hinclude_default_template`_
+  * `loaders`_
+* `test`_
+* `translator`_
+  * :ref:`enabled <reference-translator-enabled>`
+  * `fallbacks`_
+  * `logging`_
+  * :ref:`paths <reference-translator-paths>`
+* `trusted_hosts`_
+* `trusted_proxies`_
+* `validation`_
+  * `api`_
+  * :ref:`cache <reference-validation-cache>`
+  * :ref:`enable_annotations <reference-validation-enable_annotations>`
+  * :ref:`enabled <reference-validation-enabled>`
+  * `strict_email`_
+  * `translation_domain`_
 
 secret
 ~~~~~~

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -28,59 +28,84 @@ Configuration
 .. class:: list-config-options list-config-options--complex
 
 * `annotations`_
+
   * :ref:`cache <reference-annotations-cache>`
   * `debug`_
   * `file_cache_dir`_
+
 * `assets`_
+
   * `base_path`_
   * `base_urls`_
   * `packages`_
   * `version_format`_
   * `version`_
+
 * `csrf_protection`_
+
   * :ref:`enabled <reference-csrf_protection-enabled>`
   * `field_name`_ (deprecated since 2.4)
+
 * `default_locale`_
 * `esi`_
+
   * :ref:`enabled <reference-esi-enabled>`
+
 * :ref:`form <reference-framework-form>`
+
   * :ref:`enabled <reference-form-enabled>`
+
 * `fragments`_
+
   * :ref:`enabled <reference-fragments-enabled>`
   * :ref:`path <reference-fragments-path>`
+
 * `http_method_override`_
 * `ide`_
 * `profiler`_
+
   * `collect`_
   * `dsn`_
   * :ref:`enabled <reference-profiler-enabled>`
   * `lifetime`_ (deprecated since 2.8)
   * `matcher`_
+
     * `ip`_
     * `service`_
     * :ref:`path <reference-profiler-matcher-path>`
+
   * `only_exceptions`_
   * `only_master_requests`_
   * `password`_ (deprecated since 2.8)
   * `username`_ (deprecated since 2.8)
+
 * `property_access`_
+
   * `magic_call`_
   * `throw_exception_on_invalid_index`_
+
 * `request`_:
+
   * `formats`_
+
 * `router`_
+
   * `http_port`_
   * `https_port`_
   * `resource`_
   * `strict_requirements`_
   * `type`_
+
 * `secret`_
 * `serializer`_
+
   * :ref:`cache <reference-serializer-cache>`
   * :ref:`enable_annotations <reference-serializer-enable_annotations>`
   * :ref:`enabled <reference-serializer-enabled>`
   * :ref:`name_converter <reference-serializer-name_converter>`
+
 * `session`_
+
   * `cookie_domain`_
   * `cookie_httponly`_
   * `cookie_lifetime`_
@@ -95,22 +120,30 @@ Configuration
   * `save_path`_
   * `storage_id`_
   * `use_strict_mode`_
+
 * `templating`_
+
   * :ref:`cache <reference-templating-cache>`
   * `engines`_
   * :ref:`form <reference-templating-form>`
+
     * `resources`_
+
   * `hinclude_default_template`_
   * `loaders`_
+
 * `test`_
 * `translator`_
+
   * :ref:`enabled <reference-translator-enabled>`
   * `fallbacks`_
   * `logging`_
   * :ref:`paths <reference-translator-paths>`
+
 * `trusted_hosts`_
 * `trusted_proxies`_
 * `validation`_
+
   * `api`_
   * :ref:`cache <reference-validation-cache>`
   * :ref:`enable_annotations <reference-validation-enable_annotations>`

--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -28,8 +28,10 @@ Configuration
 .. class:: list-config-options list-config-options--complex
 
 * `antiflood`_
+
   * `threshold`_
   * `sleep`_
+
 * `auth_mode`_
 * `command`_
 * `delivery_addresses`_
@@ -44,8 +46,10 @@ Configuration
 * `sender_address`_
 * `source_ip`_
 * `spool`_
+
   * `type`_
   * `path`_
+
 * `timeout`_
 * `transport`_
 * `url`_

--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -25,29 +25,31 @@ to :doc:`send emails </email>`. All these options are configured under the
 Configuration
 -------------
 
-* `url`_
-* `transport`_
-* `username`_
-* `password`_
-* `command`_
-* `host`_
-* `port`_
-* `timeout`_
-* `source_ip`_
-* `local_domain`_
-* `encryption`_
-* `auth_mode`_
-* `spool`_
-    * `type`_
-    * `path`_
-* `sender_address`_
+.. class:: list-config-options list-config-options--complex
+
 * `antiflood`_
-    * `threshold`_
-    * `sleep`_
+  * `threshold`_
+  * `sleep`_
+* `auth_mode`_
+* `command`_
 * `delivery_addresses`_
 * `delivery_whitelist`_
 * `disable_delivery`_
+* `encryption`_
+* `host`_
+* `local_domain`_
 * `logging`_
+* `password`_
+* `port`_
+* `sender_address`_
+* `source_ip`_
+* `spool`_
+  * `type`_
+  * `path`_
+* `timeout`_
+* `transport`_
+* `url`_
+* `username`_
 
 url
 ~~~

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -25,6 +25,29 @@ the ``twig`` key in your application configuration.
 Configuration
 -------------
 
+.. class:: list-config-options list-config-options--complex
+
+* `auto_reload`_
+* `autoescape`_
+* `autoescape_service`_
+* `autoescape_service_method`_
+* `base_template_class`_
+* `cache`_
+* `charset`_
+* `date`_
+  * `format`_
+  * `interval_format`_
+  * `timezone`_
+* `debug`_
+* `exception_controller`_
+* `number_format`_
+  * `decimals`_
+  * `decimal_point`_
+  * `thousands_separator`_
+* `optimizations`_
+* `paths`_
+* `strict_variables`_
+
 auto_reload
 ~~~~~~~~~~~
 

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -35,15 +35,19 @@ Configuration
 * `cache`_
 * `charset`_
 * `date`_
+
   * `format`_
   * `interval_format`_
   * `timezone`_
+
 * `debug`_
 * `exception_controller`_
 * `number_format`_
+
   * `decimals`_
   * `decimal_point`_
   * `thousands_separator`_
+
 * `optimizations`_
 * `paths`_
 * `strict_variables`_

--- a/reference/configuration/web_profiler.rst
+++ b/reference/configuration/web_profiler.rst
@@ -30,10 +30,12 @@ execution and displays it in both the web debug toolbar and the
 Configuration
 -------------
 
-* `toolbar`_
-* `position`_
-* `intercept_redirects`_
+.. class:: list-config-options
+
 * `excluded_ajax_paths`_
+* `intercept_redirects`_
+* `position`_
+* `toolbar`_
 * `verbose`_
 
 toolbar


### PR DESCRIPTION
Changes done:

* Added the missing options listing for TwigBundle
* Fixed indenting of sub-options (they were being generated as `<ul> + <dl> + <ul>` instead of `<ul> + <ul>`)
* Sorted lists of options alphabetically (very important for readers, especially for long lists of options. As we talked in the past, we only sort the list of options, not the option descriptions ... to avoid all the merging nightmares).
* Added some CSS classes to all the config option lists (so we can later improve how they look on symfony.com)