### PR TITLE
Fix broken link to `vue-loader` documentation.

### DIFF
--- a/frontend/encore/vuejs.rst
+++ b/frontend/encore/vuejs.rst
@@ -27,7 +27,7 @@ also configure the `vue-loader options`_ via a callback:
 .. code-block:: javascript
 
     .enableVueLoader(function(options) {
-        // https://vue-loader.vuejs.org/en/configurations/advanced.html
+        // https://vue-loader.vuejs.org/options.html
 
         options.preLoaders = {
             js: '/path/to/custom/loader'
@@ -53,4 +53,4 @@ See :doc:`/frontend/encore/dev-server` for more details.
 
 .. _`babel-preset-react`: https://babeljs.io/docs/plugins/preset-react/
 .. _`Vue.js`: https://vuejs.org/
-.. _`vue-loader options`: https://vue-loader.vuejs.org/en/configurations/advanced.html
+.. _`vue-loader options`: https://vue-loader.vuejs.org/options.html


### PR DESCRIPTION
The page https://vue-loader.vuejs.org/en/configurations/advanced.html doesn't exist anymore, use that one instead: https://vue-loader.vuejs.org/options.html