### PR TITLE
[Messenger] Added documentation about DispatchAfterCurrentBusMiddleware

### DIFF
--- a/messenger/message-recorder.rst
+++ b/messenger/message-recorder.rst
@@ -77,7 +77,7 @@ buses. For the example, the middleware must be loaded for both the command and e
 
     .. code-block:: xml
 
-        <!-- config/packages/cache.xml -->
+        <!-- config/packages/messenger.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/messenger/message-recorder.rst
+++ b/messenger/message-recorder.rst
@@ -101,7 +101,7 @@ buses. For the example, the middleware must be loaded for both the command and e
 
     .. code-block:: php
 
-        // config/packages/cache.php
+        // config/packages/messenger.php
         $container->loadFromExtension('framework', [
             'messenger' => [
                 'default_bus' => 'messenger.bus.command',

--- a/messenger/message-recorder.rst
+++ b/messenger/message-recorder.rst
@@ -53,7 +53,7 @@ sure ``dispatch_after_current_bus`` is registered before ``doctrine_transaction`
 in the middleware chain.
 
 **Note:** The ``dispatch_after_current_bus`` middleware must be loaded for *all* of the
-buses. For the example, the middleware must be loaded for both the command and event buses.
+buses. For the example, the middleware must be loaded for both the command and event bus.
 
 .. configuration-block::
 
@@ -75,6 +75,47 @@ buses. For the example, the middleware must be loaded for both the command and e
                             - validation
                             - doctrine_transaction
 
+    .. code-block:: xml
+
+        <!-- config/packages/cache.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <framework:config>
+                <framework:messenger default_bus="messenger.bus.command">
+                  <framework:bus name="messenger.bus.command">
+                      <framework:middleware id="validation">
+                      <framework:middleware id="doctrine_transaction">
+                  </framework:bus>
+                  <framework:bus name="messenger.bus.command" default_middleware="allow_no_handlers">
+                      <framework:middleware id="validation">
+                      <framework:middleware id="doctrine_transaction">
+                  </framework:bus>
+                </framework:messenger>
+            </framework:config>
+        </container>
+
+    .. code-block:: php
+
+        // config/packages/cache.php
+        $container->loadFromExtension('framework', [
+            'messenger' => [
+                'default_bus' => 'messenger.bus.command',
+                'buses' => [
+                    'messenger.bus.command' => [
+                        'middleware' => ['validation', 'doctrine_transaction'],
+                    ],
+                    'messenger.bus.event' => [
+                        'default_middleware' => 'allow_no_handlers',
+                        'middleware' => ['validation', 'doctrine_transaction'],
+                    ],
+                ],
+            ],
+        ]);
 
 .. code-block:: php
 

--- a/messenger/message-recorder.rst
+++ b/messenger/message-recorder.rst
@@ -1,7 +1,7 @@
 .. index::
     single: Messenger; Record messages; Transaction messages
 
-Transactional Messages: Handle Events After CommandHandler Is Done
+Transactional Messages: Handle Events After CommandHandler is Done
 ==================================================================
 
 A message handler can ``dispatch`` new messages during execution, to either the same or

--- a/messenger/message-recorder.rst
+++ b/messenger/message-recorder.rst
@@ -1,0 +1,69 @@
+.. index::
+    single: Messenger; Record messages
+
+Record Events Produced by a Handler
+===================================
+
+In a example application there is a command (a CQRS message) named ``CreateUser``.
+That command is handled by the ``CreateUserHandler``. The command handler creates
+a ``User`` object, stores that object to a database and dispatches an ``UserCreatedEvent``.
+That event is also a normal message but is handled by an *event* bus.
+
+There are many subscribers to the ``UserCreatedEvent``, one subscriber may send
+a welcome email to the new user. Since we are using the ``DoctrineTransactionMiddleware``
+we wrap all database queries in one database transaction and rollback that transaction
+if an exception is thrown. That would mean that if an exception is thrown when sending
+the welcome email, then the user will not be created.
+
+The solution to this issue is to not dispatch the ``UserCreatedEvent`` in the
+``CreateUserHandler`` but to just "record" the events. The recorded events will
+be dispatched after ``DoctrineTransactionMiddleware`` has committed the transaction.
+
+To enable this, you simply just add the ``messenger.middleware.handles_recorded_messages``
+middleware. Make sure it is registered before ``DoctrineTransactionMiddleware``
+in the middleware chain.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/workflow.yaml
+        framework:
+            messenger:
+                default_bus: messenger.bus.command
+                buses:
+                    messenger.bus.command:
+                        middleware:
+                            - messenger.middleware.validation
+                            - messenger.middleware.handles_recorded_messages: ['@messenger.bus.event']
+                              # Doctrine transaction must be after handles_recorded_messages middleware
+                            - app.doctrine_transaction_middleware: ['default']
+                    messenger.bus.event:
+                        middleware:
+                            - messenger.middleware.allow_no_handler
+                            - messenger.middleware.validation
+
+.. code-block:: php
+
+    use Doctrine\ORM\EntityManagerInterface;
+    use Symfony\Component\Messenger\MessageRecorderInterface;
+
+    class CreateUserHandler
+    {
+        private $em;
+        private $eventRecorder;
+
+        public function __construct(MessageRecorderInterface $eventRecorder, EntityManagerInterface $em)
+        {
+            $this->eventRecorder = $eventRecorder;
+            $this->em = $em;
+        }
+
+        public function __invoke(CreateUser $command)
+        {
+            $user = new User($command->getUuid(), $command->getName(), $command->getEmail());
+            $this->em->persist($user);
+
+            $this->eventRecorder->record(new UserCreatedEvent($command->getUuid());
+        }
+    }

--- a/messenger/message-recorder.rst
+++ b/messenger/message-recorder.rst
@@ -6,7 +6,7 @@ Record Events Produced by a Handler
 
 In an example application there is a command (a CQRS message) named ``CreateUser``.
 That command is handled by the ``CreateUserHandler`` which creates
-a ``User`` object, stores that object to a database and dispatches an ``UserCreatedEvent``.
+a ``User`` object, stores that object to a database and dispatches a ``UserCreatedEvent``.
 That event is also a normal message but is handled by an *event* bus.
 
 There are many subscribers to the ``UserCreatedEvent``, one subscriber may send

--- a/messenger/message-recorder.rst
+++ b/messenger/message-recorder.rst
@@ -4,15 +4,15 @@
 Record Events Produced by a Handler
 ===================================
 
-In a example application there is a command (a CQRS message) named ``CreateUser``.
-That command is handled by the ``CreateUserHandler``. The command handler creates
+In an example application there is a command (a CQRS message) named ``CreateUser``.
+That command is handled by the ``CreateUserHandler`` which creates
 a ``User`` object, stores that object to a database and dispatches an ``UserCreatedEvent``.
 That event is also a normal message but is handled by an *event* bus.
 
 There are many subscribers to the ``UserCreatedEvent``, one subscriber may send
 a welcome email to the new user. Since we are using the ``DoctrineTransactionMiddleware``
 we wrap all database queries in one database transaction and rollback that transaction
-if an exception is thrown. That would mean that if an exception is thrown when sending
+if an exception is thrown. That means that if an exception is thrown when sending
 the welcome email, then the user will not be created.
 
 The solution to this issue is to not dispatch the ``UserCreatedEvent`` in the
@@ -27,7 +27,7 @@ in the middleware chain.
 
     .. code-block:: yaml
 
-        # config/packages/workflow.yaml
+        # config/packages/messenger.yaml
         framework:
             messenger:
                 default_bus: messenger.bus.command
@@ -45,6 +45,11 @@ in the middleware chain.
 
 .. code-block:: php
 
+    namespace App\Messenger\CommandHandler;
+
+    use App\Entity\User;
+    use App\Messenger\Command\CreateUser;
+    use App\Messenger\Event\UserCreatedEvent;
     use Doctrine\ORM\EntityManagerInterface;
     use Symfony\Component\Messenger\MessageRecorderInterface;
 

--- a/messenger/message-recorder.rst
+++ b/messenger/message-recorder.rst
@@ -11,8 +11,8 @@ such as:
 
 - If using the ``DoctrineTransactionMiddleware`` and a dispatched message throws an exception,
   then any database transactions in the original handler will be rolled back.
-- If the message is dispatched to a different bus, then the dispatched message can still
-  be handled even if the original handler encounters an exception.
+- If the message is dispatched to a different bus, then dispatched message will be
+  handled even if the current handler throws an exception.
 
 An Example ``RegisterUser`` Process
 -----------------------------------
@@ -68,12 +68,10 @@ buses. For the example, the middleware must be loaded for both the command and e
                     messenger.bus.command:
                         middleware:
                             - validation
-                            - doctrine_transaction
                     messenger.bus.event:
                         default_middleware: allow_no_handlers
                         middleware:
                             - validation
-                            - doctrine_transaction
 
     .. code-block:: xml
 
@@ -153,6 +151,8 @@ buses. For the example, the middleware must be loaded for both the command and e
                 (new Envelope($event))
                     ->with(new DispatchAfterCurrentBusStamp())
             );
+
+            // ...
         }
     }
 

--- a/messenger/message-recorder.rst
+++ b/messenger/message-recorder.rst
@@ -175,7 +175,7 @@ buses. For the example, the middleware must be loaded for both the command and e
             $this->em = $em;
         }
 
-        public function __invoke(UserSignedUp $eent)
+        public function __invoke(UserSignedUp $event)
         {
             $user = $this->em->getRepository(User::class)->find(new User($event->getUuid()));
 


### PR DESCRIPTION
Documentation to PR: https://github.com/symfony/symfony/pull/27844













![Screenshot 2019-03-17 at 11 43 23](https://user-images.githubusercontent.com/1275206/54489171-edee4880-48a9-11e9-8028-ac501e62dfcb.png)
![Screenshot 2019-03-17 at 11 43 34](https://user-images.githubusercontent.com/1275206/54489173-edee4880-48a9-11e9-877f-f749f242b502.png)

![Screenshot 2019-03-17 at 11 43 39](https://user-images.githubusercontent.com/1275206/54489172-edee4880-48a9-11e9-84f1-d78e68474c7a.png)
