### PR TITLE
[Messenger][WIP] Show how to configure multiple buses

### DIFF
--- a/messenger/multiple-buses.rst
+++ b/messenger/multiple-buses.rst
@@ -1,0 +1,34 @@
+.. index::
+    single: Messenger; Multiple buses
+
+Multiple Buses
+==============
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        framework:
+            messenger:
+                transports:
+                    default: enqueue://default
+                default_bus: messenger.bus.command
+                buses:
+                    messenger.bus.command:
+                        middleware:
+                            #- messenger.middleware.exactly_one_handler
+                            - messenger.middleware.validation
+                            - messenger.middleware.handles_recorded_messages: ['@messenger.bus.event']
+                            - doctrine_transaction_middleware: ['default']
+                    messenger.bus.query:
+                        middleware:
+                            #- messenger.middleware.exactly_one_handler
+                            - messenger.middleware.validation
+                    messenger.bus.event:
+                        middleware:
+                            - messenger.middleware.allow_no_handler
+                            - messenger.middleware.validation
+
+                routing:
+                    # Route your messages to the transports
+                    # 'App\Message\YourMessage': amqp

--- a/messenger/multiple-buses.rst
+++ b/messenger/multiple-buses.rst
@@ -4,31 +4,38 @@
 Multiple Buses
 ==============
 
+A common architecture when building application is to separate commands from
+queries. Commands are actions that do something and queries fetches data. This
+is called CQRS (Command Query Responsibility Segregation). See Martin Fowler's
+`article about CQRS`_ to learn more. This architecture could be used together
+with the messenger component by defining multiple buses.
+
+A **command bus** is a little different form a **query bus**. As example,
+command buses must not return anything and query buses are rarely asynchronous.
+You can configure these buses and their rules by using middlewares.
+
+It might also be a good idea to separate actions from reactions by introducing
+an **event bus**. The event bus could have zero or more subscribers.
+
 .. configuration-block::
 
     .. code-block:: yaml
 
         framework:
             messenger:
-                transports:
-                    default: enqueue://default
                 default_bus: messenger.bus.command
                 buses:
                     messenger.bus.command:
                         middleware:
-                            #- messenger.middleware.exactly_one_handler
                             - messenger.middleware.validation
                             - messenger.middleware.handles_recorded_messages: ['@messenger.bus.event']
                             - doctrine_transaction_middleware: ['default']
                     messenger.bus.query:
                         middleware:
-                            #- messenger.middleware.exactly_one_handler
                             - messenger.middleware.validation
                     messenger.bus.event:
                         middleware:
                             - messenger.middleware.allow_no_handler
                             - messenger.middleware.validation
 
-                routing:
-                    # Route your messages to the transports
-                    # 'App\Message\YourMessage': amqp
+.. _article about CQRS: https://martinfowler.com/bliki/CQRS.html


### PR DESCRIPTION
We do currently have no example configuration with the framework bundle. I think it is a good idea to show of how to use middleware's and how to define multiple buses. 

This PR could be rewritten as a part of an existing page. 

I know the configuration is not very different between the buses. When https://github.com/symfony/symfony/issues/27839 and https://github.com/symfony/symfony/issues/27840 is implemented, this config will make more sense. 