### PR TITLE
[Messenger] Minor wording tweak regarding factories

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -609,7 +609,7 @@ Using Middleware Factories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some third-party bundles and libraries provide configurable middleware via
-factories. Using them requires a two-step configuration based on Symfony's
+factories. Defining such requires a two-step configuration based on Symfony's
 :doc:`dependency injection </service_container>` features:
 
 .. code-block:: yaml


### PR DESCRIPTION
As an end-user, the following DI config isn't the one for __using__ a middleware factory but for defining one using DI config instead.
Using an existing configurable middleware is described below in a `messenger` config sample.