### PR TITLE
Add missing RuntimeExtensionInterface

### DIFF
--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -137,6 +137,9 @@ previous ``priceFilter()`` method::
         }
     }
 
+ .. versionadded:: 3.4
+     The ``RuntimeExtensionInterface`` was introduced in Symfony 3.4.
+
 If you're using the default ``services.yaml`` configuration, this will already
 work! Otherwise, :ref:`create a service <service-container-creating-service>`
 for this class and :doc:`tag your service </service_container/tags>` with ``twig.runtime``.

--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -118,7 +118,7 @@ previous ``priceFilter()`` method::
     // src/Twig/AppRuntime.php
     namespace App\Twig;
     
-    use use Twig\Extension\RuntimeExtensionInterface;
+    use Twig\Extension\RuntimeExtensionInterface;
 
     class AppRuntime implements RuntimeExtensionInterface
     {

--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -117,8 +117,10 @@ previous ``priceFilter()`` method::
 
     // src/Twig/AppRuntime.php
     namespace App\Twig;
+    
+    use use Twig\Extension\RuntimeExtensionInterface;
 
-    class AppRuntime
+    class AppRuntime implements RuntimeExtensionInterface
     {
         public function __construct()
         {


### PR DESCRIPTION
If the Twig runtime class does not implement RuntimeExtensionInterface, the autoconfigure feature of the container will not tag it with `twig.runtime`, and an exception will be thrown ("Unable to load the "App\Twig\AppRuntime" runtime.")

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
