### PR TITLE
the product category must be nullable

### DIFF
--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -146,7 +146,6 @@ the ``Product`` entity (and getter & setter methods):
 
             /**
              * @ORM\ManyToOne(targetEntity="App\Entity\Category", inversedBy="products")
-             * @ORM\JoinColumn(nullable=false)
              */
             private $category;
 
@@ -155,7 +154,7 @@ the ``Product`` entity (and getter & setter methods):
                 return $this->category;
             }
 
-            public function setCategory(Category $category): self
+            public function setCategory(?Category $category): self
             {
                 $this->category = $category;
 


### PR DESCRIPTION
At first I wanted to sync the return type of `getCategory()` with the changes done in #9951. Though while looking at the rest of the chapter I noticed that we indeed call `setCategory()` with `null` in a follow-up example. So I decided to allow the property to become `null` instead.