### PR TITLE
Add section about anonymous services in YAML

### DIFF
--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -149,7 +149,7 @@ Anonymous Services
 
 .. note::
 
-    Anonymous services are only supported by the XML configuration format.
+    Anonymous services are only supported by the XML and YAML configuration formats.
 
 In some cases, you may want to prevent a service being used as a dependency of
 other services. This can be achieved by creating an anonymous service. These
@@ -158,23 +158,74 @@ created where they are used.
 
 The following example shows how to inject an anonymous service into another service:
 
-.. code-block:: xml
+.. configuration-block::
 
-    <!-- app/config/services.xml -->
-    <?xml version="1.0" encoding="UTF-8" ?>
-    <container xmlns="http://symfony.com/schema/dic/services"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://symfony.com/schema/dic/services
-            http://symfony.com/schema/dic/services/services-1.0.xsd">
+    .. code-block:: yaml
 
-        <services>
-            <service id="foo" class="AppBundle\Foo">
-                <argument type="service">
-                    <service class="AppBundle\AnonymousBar" />
-                </argument>
-            </service>
-        </services>
-    </container>
+        # app/config/services.yml
+        services:
+            _defaults:
+                autowire: true
+
+            AppBundle\Foo:
+                arguments:
+                    - !service
+                        class: AppBundle\AnonymousBar
+                        autowire: true
+
+    .. code-block:: xml
+
+        <!-- app/config/services.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <defaults autowire="true" />
+
+                <service id="foo" class="AppBundle\Foo">
+                    <argument type="service">
+                        <service class="AppBundle\AnonymousBar" />
+                    </argument>
+                </service>
+            </services>
+        </container>
+
+Using an anonymous service as a factory looks like this:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/services.yml
+        services:
+            _defaults:
+                autowire: true
+
+            AppBundle\Foo:
+                factory: [ !service { class: AppBundle\FooFactory }, 'constructFoo' ]
+
+    .. code-block:: xml
+
+        <!-- app/config/services.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <services>
+                <defaults autowire="true" />
+
+                <service id="foo" class="AppBundle\Foo">
+                    <factory method="constructFoo">
+                        <service class="App\FooFactory"/>
+                    </factory>
+                </service>
+            </services>
+        </container>
 
 Deprecating Services
 --------------------
@@ -186,8 +237,8 @@ or you decided not to maintain it anymore), you can deprecate its definition:
 
     .. code-block:: yaml
 
-       AppBundle\Service\OldService:
-           deprecated: The "%service_id%" service is deprecated since 2.8 and will be removed in 3.0.
+        AppBundle\Service\OldService:
+            deprecated: The "%service_id%" service is deprecated since 2.8 and will be removed in 3.0.
 
     .. code-block:: xml
 


### PR DESCRIPTION
Fixes #7694.

This is a continuation of #9909 which added some information about anonymous services in XML to the docs, next will be a commit that describes configuring anonymous services in PHP for the `master` branch. For further information about the issue, see #5854.
