### PR TITLE
[Encore] Fix vue-loader installation

### DIFF
--- a/frontend/encore/vuejs.rst
+++ b/frontend/encore/vuejs.rst
@@ -5,7 +5,7 @@ Want to use `Vue.js`_? No problem! First, install Vue and some dependencies:
 
 .. code-block:: terminal
 
-    $ yarn add --dev vue vue-loader vue-template-compiler
+    $ yarn add --dev vue vue-loader@^14 vue-template-compiler
 
 Then, activate the ``vue-loader`` in ``webpack.config.js``:
 


### PR DESCRIPTION
Encore isn't compatible yet with `vue-loader` 15 (https://github.com/symfony/webpack-encore/issues/311). It leads to a broken install with a non-obvious error message.

In the meantime, we should hint users to install v14.