### PR TITLE
Replace more occurrences of Controller by AbstractController

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -120,7 +120,7 @@ and many others that you'll learn about next.
 Generating URLs
 ~~~~~~~~~~~~~~~
 
-The :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerTrait::generateUrl`
+The :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController::generateUrl`
 method is just a helper method that generates the URL for a given route::
 
     $url = $this->generateUrl('app_lucky_number', array('max' => 10));
@@ -328,7 +328,7 @@ special type of exception::
         return $this->render(...);
     }
 
-The :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerTrait::createNotFoundException`
+The :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController::createNotFoundException`
 method is just a shortcut to create a special
 :class:`Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException`
 object, which ultimately triggers a 404 HTTP response inside Symfony.
@@ -581,7 +581,7 @@ the :phpfunction:`json_encode` function is used.
 Streaming File Responses
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can use the :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::file`
+You can use the :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController::file`
 helper to serve a file from inside a controller::
 
     public function download()

--- a/controller/forwarding.rst
+++ b/controller/forwarding.rst
@@ -5,7 +5,7 @@ How to Forward Requests to another Controller
 =============================================
 
 Though not very common, you can also forward to another controller internally
-with the :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::forward`
+with the :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController::forward`
 method. Instead of redirecting the user's browser, this makes an "internal"
 sub-request and calls the defined controller. The ``forward()`` method returns
 the :class:`Symfony\\Component\\HttpFoundation\\Response` object that is returned

--- a/security/csrf.rst
+++ b/security/csrf.rst
@@ -279,7 +279,7 @@ token and store it as a hidden field of the form:
     </form>
 
 Then, get the value of the CSRF token in the controller action and use the
-:method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller::isCsrfTokenValid`
+:method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController::isCsrfTokenValid`
 to check its validity::
 
     use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
This continues #10030.

I also propose to replace some `ControllerTrait::` by `AbstractController::`. Let's not be pedantic about this. The helper methods are technically defined in the trait, but most people use them via the Abstract base controller. People advanced enough to not use `AbstractController` know perfectly how to use this trait.