### PR TITLE
Remove redundant example configuration value

### DIFF
--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -174,7 +174,6 @@ The following example shows how to inject an anonymous service into another serv
                 arguments:
                     - !service
                         class: AppBundle\AnonymousBar
-                        autowire: true
 
     .. code-block:: xml
 


### PR DESCRIPTION
Fixes a small issue that was pointed out by @xabbuh in https://github.com/symfony/symfony-docs/pull/10041#pullrequestreview-136273571
