### PR TITLE
Fixed the default value of php_errors.log option

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1821,7 +1821,7 @@ log
 .. versionadded:: 3.2
     The ``log`` option was introduced in Symfony 3.2.
 
-**type**: ``boolean`` **default**: ``false``
+**type**: ``boolean`` **default**: ``%kernel.debug%``
 
 Use the application logger instead of the PHP logger for logging PHP errors.
 


### PR DESCRIPTION
See:

https://github.com/symfony/symfony/blob/5e28ac31504e3a7cd2d16b0216182d767f37ad41/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php#L900-L907