### PR TITLE
Remove deleted RoleInterface

### DIFF
--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -168,8 +168,8 @@ Roles
 -----
 
 Roles are objects that give expression to a certain right the user has.
-The only requirement is that they implement :class:`Symfony\\Component\\Security\\Core\\Role\\RoleInterface`,
-which means they should also have a :method:`Symfony\\Component\\Security\\Core\\Role\\RoleInterface::getRole`
+The only requirement is that they extend :class:`Symfony\\Component\\Security\\Core\\Role\\Role`,
+which means they have a :method:`Symfony\\Component\\Security\\Core\\Role\\Role::getRole`
 method that returns a string representation of the role itself. The default
 :class:`Symfony\\Component\\Security\\Core\\Role\\Role` simply returns its
 first constructor argument::

--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -167,12 +167,11 @@ role::
 Roles
 -----
 
-Roles are objects that give expression to a certain right the user has.
-The only requirement is that they extend :class:`Symfony\\Component\\Security\\Core\\Role\\Role`,
-which means they have a :method:`Symfony\\Component\\Security\\Core\\Role\\Role::getRole`
-method that returns a string representation of the role itself. The default
-:class:`Symfony\\Component\\Security\\Core\\Role\\Role` simply returns its
-first constructor argument::
+Roles are objects that give expression to a certain right the user has. The only
+requirement is that they must define a ``getRole()`` method that returns a
+string representation of the role itself. To do so, you can optionally extend
+from the default :class:`Symfony\\Component\\Security\\Core\\Role\\Role` class,
+which returns its first constructor argument in this method::
 
     use Symfony\Component\Security\Core\Role\Role;
 


### PR DESCRIPTION
As the master branch of symfony/symfony deleted the Symfony\Component\Security\Core\Role\RoleInterface as of 4.0, this update remove the interface to only mention the base class.
