### PR TITLE
Fix a typo

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -202,4 +202,4 @@ If those entries include CSS/Sass files (e.g. ``homepage.js`` requires
 Keep Going!
 -----------
 
-Go back to the :ref:`Encore Toc List <encore-toc>` to learn more and add new features.
+Go back to the :ref:`List of Encore Articles <encore-toc>` to learn more and add new features.

--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -202,4 +202,4 @@ If those entries include CSS/Sass files (e.g. ``homepage.js`` requires
 Keep Going!
 -----------
 
-Go back to the :ref:`Encore Top List <encore-toc>` to learn more and add new features.
+Go back to the :ref:`Encore Toc List <encore-toc>` to learn more and add new features.


### PR DESCRIPTION
Maybe it would be better to name that link `Index` or just `Table of Contents`?

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
