### PR TITLE
Add necessary call to Form::isSubmitted and remove boilerplate

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -655,8 +655,12 @@ the relationship between the removed ``Tag`` and ``Task`` object.
         use Doctrine\Common\Collections\ArrayCollection;
 
         // ...
-        public function edit(Task $task, Request $request, EntityManagerInterface $entityManager)
+        public function edit($id, Request $request, EntityManagerInterface $entityManager)
         {
+            if (null === $task = $entityManager->getRepository(Task::class)->find($id)) {
+                throw $this->createNotFoundException('No task found for id '.$id);
+            }
+    
             $originalTags = new ArrayCollection();
 
             // Create an ArrayCollection of the current Tag objects in the database
@@ -669,7 +673,6 @@ the relationship between the removed ``Tag`` and ``Task`` object.
             $editForm->handleRequest($request);
 
             if ($editForm->isSubmitted() && $editForm->isValid()) {
-
                 // remove the relationship between the tag and the Task
                 foreach ($originalTags as $tag) {
                     if (false === $task->getTags()->contains($tag)) {

--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -655,15 +655,8 @@ the relationship between the removed ``Tag`` and ``Task`` object.
         use Doctrine\Common\Collections\ArrayCollection;
 
         // ...
-        public function edit($id, Request $request)
+        public function edit(Task $task, Request $request, EntityManagerInterface $entityManager)
         {
-            $entityManager = $this->getDoctrine()->getManager();
-            $task = $entityManager->getRepository(Task::class)->find($id);
-
-            if (!$task) {
-                throw $this->createNotFoundException('No task found for id '.$id);
-            }
-
             $originalTags = new ArrayCollection();
 
             // Create an ArrayCollection of the current Tag objects in the database
@@ -675,7 +668,7 @@ the relationship between the removed ``Tag`` and ``Task`` object.
 
             $editForm->handleRequest($request);
 
-            if ($editForm->isValid()) {
+            if ($editForm->isSubmitted() && $editForm->isValid()) {
 
                 // remove the relationship between the tag and the Task
                 foreach ($originalTags as $tag) {

--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -660,7 +660,7 @@ the relationship between the removed ``Tag`` and ``Task`` object.
             if (null === $task = $entityManager->getRepository(Task::class)->find($id)) {
                 throw $this->createNotFoundException('No task found for id '.$id);
             }
-    
+
             $originalTags = new ArrayCollection();
 
             // Create an ArrayCollection of the current Tag objects in the database


### PR DESCRIPTION
This code example was the last parts of the docs that wasn't calling `Form::isSubmitted()` as required as of Symfony 4.0.

Other than that I've simplified the action a little bit to remove some rather unnecessary noise in an already little more complicated example to ease reading and understanding it. If you want to keep the boilerplate, I'm more than happy to remove it from this PR :)