### PR TITLE
Remove example of register a service where its id match to its class

### DIFF
--- a/service_container/definitions.rst
+++ b/service_container/definitions.rst
@@ -38,9 +38,6 @@ There are some helpful methods for working with the service definitions::
     // shortcut for the previous method
     $container->register('app.number_generator', \App\NumberGenerator::class);
 
-    // or create a service whose id matches its class
-    $container->register(\App\NumberGenerator::class);
-
 Working with a Definition
 -------------------------
 


### PR DESCRIPTION
`ResolveClassPass` which resolve service definitions where class match to the service id is one of the first compiler pass processed (priority 100 in beforeOptimizationPasses phase). When adding a custom compiler pass, it is by default added to the beforeOptimizationPasses but with the default priority of 0. So the `ResolveClassPass` has already been executed and our custom service definition class isn't resolved.