### PR TITLE
Remove typo in example constructor

### DIFF
--- a/workflow/state-machines.rst
+++ b/workflow/state-machines.rst
@@ -201,7 +201,7 @@ you can get this state machine by injecting the Workflow registry service::
     {
         private $workflows;
 
-        public function __constructor(Registry $workflows)
+        public function __construct(Registry $workflows)
         {
             $this->workflows = $workflows;
         }


### PR DESCRIPTION
There was a small typo in the constructor usage in an example. It said '__constructor' instead of '__construct'. This commit simply changes that.


