### PR TITLE
Add missing colon to reserved chars

### DIFF
--- a/components/cache/cache_items.rst
+++ b/components/cache/cache_items.rst
@@ -17,7 +17,7 @@ The **key** of a cache item is a plain string which acts as its
 identifier, so it must be unique for each cache pool. You can freely choose the
 keys, but they should only contain letters (A-Z, a-z), numbers (0-9) and the
 ``_`` and ``.`` symbols. Other common symbols (such as ``{``, ``}``, ``(``,
-``)``, ``/``, ``\`` and ``@``) are reserved by the PSR-6 standard for future
+``)``, ``/``, ``\``, ``@`` and ``:``) are reserved by the PSR-6 standard for future
 uses.
 
 The **value** of a cache item can be any data represented by a type which is


### PR DESCRIPTION
Colon is also a reserved char according to PSR-6

>Key - A string of at least one character that uniquely identifies a
cached item. Implementing libraries MUST support keys consisting of the
characters A-Z, a-z, 0-9, _, and . in any order in UTF-8 encoding and a
length of up to 64 characters. Implementing libraries MAY support additional
characters and encodings or longer lengths, but must support at least that
minimum. Libraries are responsible for their own escaping of key strings
as appropriate, but MUST be able to return the original unmodified key string.
The following characters are reserved for future extensions and MUST NOT be
supported by implementing libraries: {}()/\@: