### PR TITLE
Fix the YAML syntax highlighting

### DIFF
--- a/console/request_context.rst
+++ b/console/request_context.rst
@@ -33,9 +33,9 @@ will override the defaults.
 
         # app/config/parameters.yml
         parameters:
-            router.request_context.host: example.org
-            router.request_context.scheme: https
-            router.request_context.base_url: my/path
+            router.request_context.host: 'example.org'
+            router.request_context.scheme: 'https'
+            router.request_context.base_url: 'my/path'
 
     .. code-block:: xml
 


### PR DESCRIPTION
In 3.4 this example doesn't show proper highlighting because of not wrapping some values with quotes. So let's fix it since 2.8, although it's not strictly necessary for 2.8.