### PR TITLE
Remove occurrences of "performant"

### DIFF
--- a/components/cache/adapters/php_array_cache_adapter.rst
+++ b/components/cache/adapters/php_array_cache_adapter.rst
@@ -5,7 +5,7 @@
 Php Array Cache Adapter
 =======================
 
-This adapter is a highly performant way to cache static data (e.g. application configuration)
+This adapter is a high performance cache for static data (e.g. application configuration)
 that is optimized and preloaded into OPcache memory storage::
 
     use Symfony\Component\Cache\Adapter\PhpArrayAdapter;

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -243,9 +243,9 @@ for debugging information about cache hits and misses.
 
     The URI of the request is used as the cache key (unless you :doc:`vary </http_cache/cache_vary>`).
 
-This is *super* performant and simple to use. But, cache *invalidation* is not supported.
-If your content change, you'll need to wait until your cache expires for the page
-to update.
+This provides great performance and is simple to use. But, cache *invalidation*
+is not supported. If your content change, you'll need to wait until your cache
+expires for the page to update.
 
 .. tip::
 


### PR DESCRIPTION
"performant" is not a real word and it generates some debate (see https://english.stackexchange.com/questions/38945/what-is-wrong-with-the-word-performant) so let's reword it.