### PR TITLE
Show console table examples in a console terminal

### DIFF
--- a/components/console/helpers/table.rst
+++ b/components/console/helpers/table.rst
@@ -6,7 +6,7 @@ Table
 
 When building a console application it may be useful to display tabular data:
 
-.. code-block:: text
+.. code-block:: terminal
 
     +---------------+--------------------------+------------------+
     | ISBN          | Title                    | Author           |
@@ -54,7 +54,7 @@ You can add a table separator anywhere in the output by passing an instance of
         array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
     ));
 
-.. code-block:: text
+.. code-block:: terminal
 
     +---------------+--------------------------+------------------+
     | ISBN          | Title                    | Author           |
@@ -78,7 +78,7 @@ The table style can be changed to any built-in styles via
 
 This code results in:
 
-.. code-block:: text
+.. code-block:: terminal
 
      ISBN          Title                    Author
      99921-58-10-7 Divine Comedy            Dante Alighieri
@@ -93,7 +93,7 @@ You can also set the style to ``borderless``::
 
 which outputs:
 
-.. code-block:: text
+.. code-block:: terminal
 
      =============== ========================== ==================
       ISBN            Title                      Author
@@ -169,7 +169,7 @@ To make a table cell that spans multiple columns you can use a :class:`Symfony\\
 
 This results in:
 
-.. code-block:: text
+.. code-block:: terminal
 
     +---------------+---------------+-----------------+
     | ISBN          | Title         | Author          |
@@ -192,7 +192,7 @@ This results in:
 
     This generates:
 
-    .. code-block:: text
+    .. code-block:: terminal
 
         +-------+-------+--------+
         | Main table title       |
@@ -223,7 +223,7 @@ In a similar way you can span multiple rows::
 
 This outputs:
 
-.. code-block:: text
+.. code-block:: terminal
 
     +----------------+---------------+---------------------+
     | ISBN           | Title         | Author              |


### PR DESCRIPTION
I think it looks better this way.

## Before

![before](https://user-images.githubusercontent.com/73419/42892907-3fb96038-8ab3-11e8-84f4-d6f23c8d966b.png)

## After

![after](https://user-images.githubusercontent.com/73419/42892911-4293b678-8ab3-11e8-9baf-ecfb95edbace.png)
