### PR TITLE
[Messenger] Transport not mandatory

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -100,9 +100,11 @@ Once you've created your handler, you need to register it:
 Transports
 ----------
 
-The communication with queuing systems or third parties is delegated to
-libraries for now. The built-in AMQP transport allows you to communicate with
-most of the AMQP brokers such as RabbitMQ.
+By default, messages are processed as soon as they are dispatched. If you prefer
+to process messages asynchronously, you must configure a transport. These
+transports communicate your application with queuing systems or third parties.
+The built-in AMQP transport allows you to communicate with most of the AMQP
+brokers such as RabbitMQ.
 
 .. note::
 
@@ -159,10 +161,6 @@ the messenger component, the following configuration should have been created:
     ###> symfony/messenger ###
     MESSENGER_DSN=amqp://guest:guest@localhost:5672/%2f/messages
     ###< symfony/messenger ###
-
-.. note::
-
-    Transport doesn't have to be set if you don't need asynchronous messaging.
 
 This is enough to allow you to route your message to the ``amqp`` transport.
 This will also configure the following services for you:

--- a/messenger.rst
+++ b/messenger.rst
@@ -160,6 +160,10 @@ the messenger component, the following configuration should have been created:
     MESSENGER_DSN=amqp://guest:guest@localhost:5672/%2f/messages
     ###< symfony/messenger ###
 
+.. note::
+
+    Transport doesn't have to be set if you don't need asynchronous messaging.
+
 This is enough to allow you to route your message to the ``amqp`` transport.
 This will also configure the following services for you:
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -102,7 +102,7 @@ Transports
 
 By default, messages are processed as soon as they are dispatched. If you prefer
 to process messages asynchronously, you must configure a transport. These
-transports communicate your application with queuing systems or third parties.
+transports communicate with your application via queuing systems or third parties.
 The built-in AMQP transport allows you to communicate with most of the AMQP
 brokers such as RabbitMQ.
 


### PR DESCRIPTION
After reading the documentation a few days ago I thought that async is the only way this library works, after seeing the discussion today in #general on slack, @sroze explained it. Hopefully, this will help others if they find themselves in the same problem.