### PR TITLE
Updated the Symfony Flex server

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -147,7 +147,7 @@ that Flex resolves to ``sensio/framework-extra-bundle``.
 
 Second, after this package was downloaded, Flex executed a *recipe*, which is a
 set of automated instructions that tell Symfony how to integrate an external
-package. Flex recipes exist for many packages (see `symfony.sh`_) and have the ability
+package. `Flex recipes`_ exist for many packages and have the ability
 to do a lot, like adding configuration files, creating directories, updating ``.gitignore``
 and adding new config to your ``.env`` file. Flex *automates* the installation of
 packages so you can get back to coding.
@@ -355,4 +355,4 @@ Go Deeper with HTTP & Framework Fundamentals
 .. _`Twig`: https://twig.symfony.com
 .. _`Composer`: https://getcomposer.org
 .. _`Stellar Development with Symfony`: https://knpuniversity.com/screencast/symfony/setup
-.. _`symfony.sh`: https://symfony.sh/
+.. _`Flex recipes`: https://flex.symfony.com

--- a/quick_tour/flex_recipes.rst
+++ b/quick_tour/flex_recipes.rst
@@ -53,7 +53,7 @@ It's a way for a library to automatically configure itself by adding and modifyi
 files. Thanks to recipes, adding features is seamless and automated: install a package
 and you're done!
 
-You can find a full list of recipes and aliases by going to `https://symfony.sh`_.
+You can find a full list of recipes and aliases by going to `https://flex.symfony.com`_.
 
 What did this recipe do? In addition to automatically enabling the feature in
 ``config/bundles.php``, it added 3 things:
@@ -258,6 +258,6 @@ and it's the most important yet. I want to show you how Symfony empowers you to 
 build features *without* sacrificing code quality or performance. It's all about
 the service container, and it's Symfony's super power. Read on: about :doc:`/quick_tour/the_architecture`.
 
-.. _`https://symfony.sh`: https://symfony.sh
+.. _`https://flex.symfony.com`: https://flex.symfony.com
 .. _`Api Platform`: https://api-platform.com/
 .. _`Twig`: https://twig.symfony.com/


### PR DESCRIPTION
`symfony.sh` is now `flex.symfony.com`. See https://github.com/symfony/flex/pull/380