### PR TITLE
Undefined variable $userName in example

### DIFF
--- a/security/custom_provider.rst
+++ b/security/custom_provider.rst
@@ -144,6 +144,8 @@ Here's an example of how this might look::
                 );
             }
 
+            $username = $user->getUsername();
+
             return $this->fetchUser($username);
         }
 


### PR DESCRIPTION
The $username variable in the `WebServiceUserProvider` example is not set, since the user object must implement the `UserInterface` (according to best practice) we can set the variable by calling `$user->getUsername()`.
