### PR TITLE
Update http_kernel_httpkernel_class.rst

### DIFF
--- a/create_framework/http_kernel_httpkernel_class.rst
+++ b/create_framework/http_kernel_httpkernel_class.rst
@@ -82,7 +82,7 @@ display. It can take any valid controller as an exception handler, so you can
 create an ErrorController class instead of using a Closure::
 
     $listener = new HttpKernel\EventListener\ExceptionListener(
-        'Calendar\Controller\ErrorController::exceptionAction'
+        'Calendar\Controller\ErrorController::exception'
     );
     $dispatcher->addSubscriber($listener);
 


### PR DESCRIPTION
Remove suffix Action from path to ErrorController. Otherwise it doesn't work.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
