### PR TITLE
Update dependency_injection.rst

### DIFF
--- a/create_framework/dependency_injection.rst
+++ b/create_framework/dependency_injection.rst
@@ -121,7 +121,7 @@ Create a new file to host the dependency injection container configuration::
         ->setArguments(array('UTF-8'))
     ;
     $containerBuilder->register('listener.exception', HttpKernel\EventListener\ExceptionListener::class)
-        ->setArguments(array('Calendar\Controller\ErrorController::exceptionAction'))
+        ->setArguments(array('Calendar\Controller\ErrorController::exception'))
     ;
     $containerBuilder->register('dispatcher', EventDispatcher\EventDispatcher::class)
         ->addMethodCall('addSubscriber', array(new Reference('listener.router')))


### PR DESCRIPTION
Remove suffix Action from path to ErrorController. Otherwise it doesn't work. Same problem as #10116.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
