### PR TITLE
Change dsn env var name

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -123,7 +123,7 @@ the messenger component, the following configuration should have been created:
         framework:
             messenger:
                 transports:
-                    amqp: "%env(MESSENGER_DSN)%"
+                    amqp: "%env(MESSENGER_TRANSPORT_DSN)%"
 
     .. code-block:: xml
 
@@ -139,7 +139,7 @@ the messenger component, the following configuration should have been created:
 
             <framework:config>
                 <framework:messenger>
-                    <framework:transport name="amqp" dsn="%env(MESSENGER_DSN)%" />
+                    <framework:transport name="amqp" dsn="%env(MESSENGER_TRANSPORT_DSN)%" />
                 </framework:messenger>
             </framework:config>
         </container>
@@ -150,7 +150,7 @@ the messenger component, the following configuration should have been created:
         $container->loadFromExtension('framework', array(
             'messenger' => array(
                 'transports' => array(
-                    'amqp' => '%env(MESSENGER_DSN)%',
+                    'amqp' => '%env(MESSENGER_TRANSPORT_DSN)%',
                 ),
             ),
         ));


### PR DESCRIPTION
Since the flex receipe uses MESSENGER_TRANSPORT_DSN as env var name we should change this also in the documentation.

https://github.com/symfony/recipes/tree/master/symfony/messenger/4.1