### PR TITLE
Use callable classes for custom Monolog processors

### DIFF
--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -30,7 +30,7 @@ using a processor::
             $this->session = $session;
         }
 
-        public function processRecord(array $record)
+        public function __invoke(array $record)
         {
             if (!$this->session->isStarted()) {
                 return $record;
@@ -61,7 +61,7 @@ using a processor::
                 class: AppBundle\Logger\SessionRequestProcessor
                 arguments:  ['@session']
                 tags:
-                    - { name: monolog.processor, method: processRecord }
+                    - { name: monolog.processor }
 
         monolog:
             handlers:
@@ -94,7 +94,7 @@ using a processor::
                     class="AppBundle\Logger\SessionRequestProcessor">
 
                     <argument type="service" id="session" />
-                    <tag name="monolog.processor" method="processRecord" />
+                    <tag name="monolog.processor" />
                 </service>
             </services>
 
@@ -122,7 +122,7 @@ using a processor::
         $container
             ->register('app.logger.session_request_processor', SessionRequestProcessor::class)
             ->addArgument(new Reference('session'))
-            ->addTag('monolog.processor', array('method' => 'processRecord'));
+            ->addTag('monolog.processor');
 
         $container->loadFromExtension('monolog', array(
             'handlers' => array(
@@ -157,7 +157,7 @@ the ``monolog.processor`` tag:
                 class: AppBundle\Logger\SessionRequestProcessor
                 arguments:  ['@session']
                 tags:
-                    - { name: monolog.processor, method: processRecord, handler: main }
+                    - { name: monolog.processor, handler: main }
 
     .. code-block:: xml
 
@@ -176,7 +176,7 @@ the ``monolog.processor`` tag:
                     class="AppBundle\Logger\SessionRequestProcessor">
 
                     <argument type="service" id="session" />
-                    <tag name="monolog.processor" method="processRecord" handler="main" />
+                    <tag name="monolog.processor" handler="main" />
                 </service>
             </services>
         </container>
@@ -192,7 +192,7 @@ the ``monolog.processor`` tag:
                 SessionRequestProcessor::class
             )
             ->addArgument(new Reference('session'))
-            ->addTag('monolog.processor', array('method' => 'processRecord', 'handler' => 'main'));
+            ->addTag('monolog.processor', array('handler' => 'main'));
 
 Registering Processors per Channel
 ----------------------------------
@@ -210,7 +210,7 @@ the ``monolog.processor`` tag:
                 class: AppBundle\Logger\SessionRequestProcessor
                 arguments:  ['@session']
                 tags:
-                    - { name: monolog.processor, method: processRecord, channel: main }
+                    - { name: monolog.processor, channel: main }
 
     .. code-block:: xml
 
@@ -229,7 +229,7 @@ the ``monolog.processor`` tag:
                     class="AppBundle\Logger\SessionRequestProcessor">
 
                     <argument type="service" id="session" />
-                    <tag name="monolog.processor" method="processRecord" channel="main" />
+                    <tag name="monolog.processor" channel="main" />
                 </service>
             </services>
         </container>
@@ -242,4 +242,4 @@ the ``monolog.processor`` tag:
         $container
             ->register('app.logger.session_request_processor', SessionRequestProcessor::class)
             ->addArgument(new Reference('session'))
-            ->addTag('monolog.processor', array('method' => 'processRecord', 'channel' => 'main'));
+            ->addTag('monolog.processor', array('channel' => 'main'));


### PR DESCRIPTION
The built-in Monolog processors all use callable classes with an `__invoke()` method, whereas the Symfony documentation uses a `processRecord()` method. Using `__invoke()` provides consistency with the standard processors and also removes the need to specify the method name in the service configuration.