### PR TITLE
Remove useless $request

### DIFF
--- a/security/form_login_setup.rst
+++ b/security/form_login_setup.rst
@@ -91,7 +91,6 @@ configuration (``login``):
         // src/Controller/SecurityController.php
 
         // ...
-        use Symfony\Component\HttpFoundation\Request;
         use Symfony\Component\Routing\Annotation\Route;
 
         class SecurityController extends Controller
@@ -99,7 +98,7 @@ configuration (``login``):
             /**
              * @Route("/login", name="login")
              */
-            public function login(Request $request)
+            public function login()
             {
             }
         }
@@ -144,7 +143,7 @@ Great! Next, add the logic to ``login()`` that displays the login form::
     // src/Controller/SecurityController.php
     use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
-    public function login(Request $request, AuthenticationUtils $authenticationUtils)
+    public function login(AuthenticationUtils $authenticationUtils)
     {
         // get the login error if there is one
         $error = $authenticationUtils->getLastAuthenticationError();


### PR DESCRIPTION
AFAICS the Request class doesn't needs to be injected in the login action, in the example we don't use it.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
