### PR TITLE
docker-compose autobuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM  python:2-stretch as builder
+
+WORKDIR /www
+
+COPY ./_build/.requirements.txt _build/
+
+RUN pip install  pip==9.0.1 wheel==0.29.0 \
+    && pip install -r _build/.requirements.txt
+
+COPY . /www
+
+RUN make -C _build html
+
+FROM  nginx:latest
+
+COPY --from=builder /www/_build/html /usr/share/nginx/html
+
+

--- a/README.markdown
+++ b/README.markdown
@@ -19,3 +19,20 @@ Platform.sh
 -----------
 
 Pull requests are automatically built by [Platform.sh](https://platform.sh).
+
+Docker
+------
+
+If you have Docker 17.05+ installed, you can build an image.
+
+```
+$ docker build . -t symfony-docs
+```
+
+The built image may be served locally on [http//:127.0.0.1](http//:127.0.0.1) by running the command below.
+
+```
+$ docker run --rm -p80:80 symfony-docs
+```
+
+


### PR DESCRIPTION
docker-compose
- local setup  127.0.0.1:8000
- autobuild using watchman

Requirements:

- docker-compose 1.10.0+ and latest docker engine


How to run:
docker-compose up