### PR TITLE
Update upload_file.rst

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -119,7 +119,8 @@ Finally, you need to update the code of the controller that handles the form::
             if ($form->isSubmitted() && $form->isValid()) {
                 // $file stores the uploaded PDF file
                 /** @var Symfony\Component\HttpFoundation\File\UploadedFile $file */
-                $file = $product->getBrochure();
+                //$file = $product->getBrochure();
+                $file = $form->get('brochure')->getData();
 
                 $fileName = $this->generateUniqueFileName().'.'.$file->guessExtension();
 


### PR DESCRIPTION
The existing code is wrong. The result of $product->getBrochure(); is simply a string, which will then throw an error on the $file->guessExtension() line.
See https://stackoverflow.com/questions/49604601/call-to-a-member-function-guessextension-on-string.
It should get the file object as such directly from form data, as the proposed code does.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
