### PR TITLE
Update upload_file.rst

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -29,7 +29,6 @@ in the ``Product`` entity::
          * @ORM\Column(type="string")
          *
          * @Assert\NotBlank(message="Please, upload the product brochure as a PDF file.")
-         * @Assert\File(mimeTypes={ "application/pdf" })
          */
         private $brochure;
 
@@ -167,8 +166,8 @@ controller to specify the directory in which the brochures should be stored:
 
 There are some important things to consider in the code of the above controller:
 
-#. When the form is uploaded, the ``brochure`` property contains the whole PDF
-   file contents. Since this property stores just the file name, you must set
+#. When the form is uploaded, the ``brochure`` property contains the full temporary path
+   to the file. Once you define the definitive file name ( line 123 above )you must set
    its new value before persisting the changes of the entity;
 #. In Symfony applications, uploaded files are objects of the
    :class:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile` class. This class


### PR DESCRIPTION
I have proposed this change: Update upload_file.rst #10143, but then realized the same wrong assumption was also part of the Entity and the comments. The wrong assumption being that the file contents are temporarily stored in the instance of the class. That's not the case. Only the full path to the temporary directory is initially stored in the instance. One can argue that that is also unnecessary, but it is a moot point as the code sets the final file name to that property once that is known.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
