### PR TITLE
opcode optimizations

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -45,7 +45,7 @@ includes some simple default logic::
     // in the base Symfony\Component\Validator\Constraint class
     public function validatedBy()
     {
-        return get_class($this).'Validator';
+        return \get_class($this).'Validator';
     }
 
 In other words, if you create a custom ``Constraint`` (e.g. ``MyConstraint``),


### PR DESCRIPTION
Using '\get_class(...)' would enable some of the opcode optimizations and result in fewer lookups.
