### PR TITLE
Return false if not login route

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -555,7 +555,7 @@ can ignore this. Here is an example of good and bad behavior::
     {
         // GOOD behavior: only authenticate on a specific route
         if ($request->attributes->get('_route') !== 'login_route' || !$request->isMethod('POST')) {
-            return true;
+            return false;
         }
 
         // e.g. your login system authenticates by the user's IP address

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -554,7 +554,10 @@ can ignore this. Here is an example of good and bad behavior::
     public function supports(Request $request)
     {
         // GOOD behavior: only authenticate on a specific route
-        if ($request->attributes->get('_route') !== 'login_route' || !$request->isMethod('POST')) {
+        $isLoginRoute = 'login_route' === $request->attributes->get('_route');
+        if ($isLoginRoute && $request->isMethod('POST')) {
+            return true;
+        } else {
             return false;
         }
 

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -554,8 +554,7 @@ can ignore this. Here is an example of good and bad behavior::
     public function supports(Request $request)
     {
         // GOOD behavior: only authenticate on a specific route
-        $isLoginRoute = 'login_route' === $request->attributes->get('_route');
-        if ($isLoginRoute && $request->isMethod('POST')) {
+        if ('login_route' === $request->attributes->get('_route') && $request->isMethod('POST')) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
Regarding the check for a specific route in order to avoid authenticating the browser on every request, it should read "return false" instead of "return true", I think: If the route doesn't match the login route (or if it is not a POST request), then the authenticator is not supported, thus, the method should return false.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
