### PR TITLE
stop using the deprecated @method annotation

### DIFF
--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -115,7 +115,6 @@ as its default value::
 
     // src/AppBundle/Controller/DefaultController.php
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
     // ...
 
@@ -154,7 +153,6 @@ option of the ``@Route()`` annotation::
 
     // src/AppBundle/Controller/DefaultController.php
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
     // ...
 

--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -29,7 +29,7 @@ Loading Routes
 The routes in a Symfony application are loaded by the
 :class:`Symfony\\Bundle\\FrameworkBundle\\Routing\\DelegatingLoader`.
 This loader uses several other loaders (delegates) to load resources of
-different types, for instance YAML files or ``@Route`` and ``@Method`` annotations
+different types, for instance YAML files or ``@Route`` annotations
 in controller files. The specialized loaders implement
 :class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`
 and therefore have two important methods:

--- a/routing/requirements.rst
+++ b/routing/requirements.rst
@@ -187,14 +187,12 @@ accomplished with the following route configuration:
         // src/AppBundle/Controller/BlogApiController.php
         namespace AppBundle\Controller;
 
-        use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
         // ...
 
         class BlogApiController extends Controller
         {
             /**
-             * @Route("/api/posts/{id}")
-             * @Method({"GET","HEAD"})
+             * @Route("/api/posts/{id}", methods={"GET","HEAD"})
              */
             public function showAction($id)
             {
@@ -202,8 +200,7 @@ accomplished with the following route configuration:
             }
 
             /**
-             * @Route("/api/posts/{id}")
-             * @Method("PUT")
+             * @Route("/api/posts/{id}", methods={"PUT"})
              */
             public function editAction($id)
             {

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -106,7 +106,6 @@ Here is a typical controller using the ``twitter_client`` service::
     namespace Acme\Controller;
 
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
@@ -115,8 +114,7 @@ Here is a typical controller using the ``twitter_client`` service::
     class DefaultController extends Controller
     {
         /**
-         * @Route("/tweet")
-         * @Method("POST")
+         * @Route("/tweet", methods={"POST"})
          */
         public function tweetAction(Request $request)
         {
@@ -259,7 +257,6 @@ transformer::
     namespace Acme\Controller;
 
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
@@ -268,8 +265,7 @@ transformer::
     class DefaultController extends Controller
     {
         /**
-         * @Route("/tweet")
-         * @Method("POST")
+         * @Route("/tweet", methods={"POST"})
          */
         public function tweetAction(Request $request)
         {
@@ -277,8 +273,7 @@ transformer::
         }
 
         /**
-         * @Route("/tweet-uppercase")
-         * @Method("POST")
+         * @Route("/tweet-uppercase", methods={"POST"})
          */
         public function tweetUppercaseAction(Request $request)
         {


### PR DESCRIPTION
I think we should use the `@Route` annotation from the Routing component instead of the one from SensioFrameworkExtraBundle (fixes #10142).