### PR TITLE
server fails to run on this tutorial

### DIFF
--- a/security/custom_authentication_provider.rst
+++ b/security/custom_authentication_provider.rst
@@ -322,7 +322,7 @@ create a class which implements
             $providerId = 'security.authentication.provider.wsse.'.$id;
             $container
                 ->setDefinition($providerId, new ChildDefinition(WsseProvider::class))
-                ->replaceArgument(0, new Reference($userProvider))
+                ->setArgument(0, new Reference($userProvider))
             ;
 
             $listenerId = 'security.authentication.listener.wsse.'.$id;


### PR DESCRIPTION
I received error when following this tutorial:

```
  [Symfony\Component\DependencyInjection\Exception\OutOfBoundsException]
  Service "security.authentication.provider.wsse.wsse_secured": The argument "0" doesn't exist.

php bin/console server:run -v stack trace:
Exception trace:
 Symfony\Component\DependencyInjection\Definition->replaceArgument() at C:\xampp\htdocs\stopky\vendor\symfony\dependency-injection\Compiler\ResolveChildDefinitionsPass.php:150
 Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass->doResolveDefinition() at C:\xampp\htdocs\stopky\vendor\symfony\dependency-injection\Compiler\ResolveChildDefinitionsPass.php:58
 Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass->resolveDefinition() at C:\xampp\htdocs\stopky\vendor\symfony\dependency-injection\Compiler\ResolveChildDefinitionsPass.php:39
 Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass->processValue() at C:\xampp\htdocs\stopky\vendor\symfony\dependency-injection\Compiler\AbstractRecursivePass.php:60
 Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass->processValue() at C:\xampp\htdocs\stopky\vendor\symfony\dependency-injection\Compiler\ResolveChildDefinitionsPass.php:31
 Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass->processValue() at C:\xampp\htdocs\stopky\vendor\symfony\dependency-injection\Compiler\AbstractRecursivePass.php:39
 Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass->process() at C:\xampp\htdocs\stopky\vendor\symfony\dependency-injection\Compiler\Compiler.php:95
 Symfony\Component\DependencyInjection\Compiler\Compiler->compile() at C:\xampp\htdocs\stopky\vendor\symfony\dependency-injection\ContainerBuilder.php:736
 Symfony\Component\DependencyInjection\ContainerBuilder->compile() at C:\xampp\htdocs\stopky\vendor\symfony\http-kernel\Kernel.php:519
 Symfony\Component\HttpKernel\Kernel->initializeContainer() at C:\xampp\htdocs\stopky\vendor\symfony\http-kernel\Kernel.php:123
 Symfony\Component\HttpKernel\Kernel->boot() at C:\xampp\htdocs\stopky\vendor\symfony\framework-bundle\Console\Application.php:65
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at C:\xampp\htdocs\stopky\vendor\symfony\console\Application.php:145
 Symfony\Component\Console\Application->run() at C:\xampp\htdocs\stopky\bin\console:39
```

Playing a bit and using search-fu I've made my way to this:
https://stackoverflow.com/a/46408007/7973475

I did not make the proposed change to services.yml (or services.yaml in my case) and server started, everything looks ok.