### PR TITLE
[Command] No need to register the command manually

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -276,10 +276,8 @@ console::
     {
         public function testExecute()
         {
-            $kernel = self::bootKernel();
+            $kernel = static::createKernel();
             $application = new Application($kernel);
-
-            $application->add(new CreateUserCommand());
 
             $command = $application->find('app:create-user');
             $commandTester = new CommandTester($command);
@@ -311,39 +309,6 @@ console::
     When using the Console component in a standalone project, use
     :class:`Symfony\\Component\\Console\\Application <Symfony\\Component\\Console\\Application>`
     and extend the normal ``\PHPUnit\Framework\TestCase``.
-
-To be able to use the fully set up service container for your console tests
-you can extend your test from
-:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase`::
-
-    // ...
-    use Symfony\Component\Console\Tester\CommandTester;
-    use Symfony\Bundle\FrameworkBundle\Console\Application;
-    use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-
-    class CreateUserCommandTest extends KernelTestCase
-    {
-        public function testExecute()
-        {
-            $kernel = static::createKernel();
-            $kernel->boot();
-
-            $application = new Application($kernel);
-            $application->add(new CreateUserCommand());
-
-            $command = $application->find('app:create-user');
-            $commandTester = new CommandTester($command);
-            $commandTester->execute(array(
-                'command'  => $command->getName(),
-                'username' => 'Wouter',
-            ));
-
-            $output = $commandTester->getDisplay();
-            $this->assertContains('Username: Wouter', $output);
-
-            // ...
-        }
-    }
 
 Learn More
 ----------


### PR DESCRIPTION
Hey guys!

Basically, when instantiating the `Application` from FrameworkBundle, you do not need to manually add the command manually. We also had a second, duplicated section that talked about testing with the kernel/container... but we do that already in the first code block. I think just got out of sync over years of updating & refactoring. I did test that we do NOT need to manually instantiate/add the command and we do NOT need to call `$kernel->boot()`.