### PR TITLE
Add note about configuration root node

### DIFF
--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -92,6 +92,13 @@ bundle configuration would look like:
             'client_secret' => 'your_secret',
         ));
 
+
+.. tip::
+
+    The root node of your bundle configuration must match the name of your 
+    bundle without the 'Bundle' suffix in camel case. For example 
+    ``AcmeSocialBundle`` becomes ``acme_social``.
+
 .. seealso::
 
     Read more about the extension in :doc:`/bundles/extension`.


### PR DESCRIPTION
Adds a note on an issue I ran into myself, as well as a good few other people based on [this SO answer](https://stackoverflow.com/a/35505189/1196369)

This is my first contribution to symfony-docs, I copied another `tip::` block so hopefully the result should be the same, but I haven't tested this locally.