### PR TITLE
Fix mismatched list items

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -562,8 +562,10 @@ The problem occurs when your browser-based authenticator tries to authenticate
 the user on *every* request - like in the IP address-based example above. There
 are two possible fixes:
 
-1. If you do *not* need authentication to be stored in the session, set ``stateless: true`` under your firewall.
-2. Update your authenticator to avoid authentication if the user is already authenticated:
+1. If you do *not* need authentication to be stored in the session, set
+   ``stateless: true`` under your firewall.
+2. Update your authenticator to avoid authentication if the user is already
+   authenticated:
 
 .. code-block:: diff
 

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -562,10 +562,8 @@ The problem occurs when your browser-based authenticator tries to authenticate
 the user on *every* request - like in the IP address-based example above. There
 are two possible fixes:
 
-1) If you do *not* need authentication to be stored in the session, set ``stateless: true``
-under your firewall.
-
-2) Update your authenticator to avoid authentication if the user is already authenticated:
+1. If you do *not* need authentication to be stored in the session, set ``stateless: true`` under your firewall.
+2. Update your authenticator to avoid authentication if the user is already authenticated:
 
 .. code-block:: diff
 


### PR DESCRIPTION
Item one was displaying with a "1)" while item two shows up as "2."

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
