### PR TITLE
fix `HandlerLocator`'s use statement

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -61,7 +61,7 @@ Example::
 
     use App\Message\MyMessage;
     use Symfony\Component\Messenger\MessageBus;
-    use Symfony\Component\Messenger\HandlerLocator;
+    use Symfony\Component\Messenger\Handler\Locator\HandlerLocator;
     use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 
     $bus = new MessageBus([


### PR DESCRIPTION
I was just following the doc, founding this little issue. Hope this may help someone.