### PR TITLE
Also requiring annotations so they can be used

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -19,7 +19,7 @@ install the validator before using it:
 
 .. code-block:: terminal
 
-    $ composer require symfony/validator
+    $ composer require symfony/validator doctrine/annotations
 
 .. index::
    single: Validation; The basics


### PR DESCRIPTION
It's an edge case, as most people use the `website-skeleton` or install the `annotations` (SensioFWExtra) package, but just in case, the user *does* need `doctrine/annotations` in order to support using annotations with validation - https://github.com/symfony/symfony/blob/f96753b9ab497a42f7a76188e2de4911b50f5407/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php#L744

Cheers!