### PR TITLE
Updated link to Event Listeners page

### DIFF
--- a/doctrine/event_listeners_subscribers.rst
+++ b/doctrine/event_listeners_subscribers.rst
@@ -157,7 +157,7 @@ entity), you should check for the entity's class type in your method
 
     In Doctrine 2.4, a feature called Entity Listeners was introduced.
     It is a lifecycle listener class used for an entity. See
-    :doc:`Entity Listeners </entity-listeners>
+    https://symfony.com/doc/current/bundles/DoctrineBundle/entity-listeners.html
     
 
 Creating the Subscriber Class

--- a/doctrine/event_listeners_subscribers.rst
+++ b/doctrine/event_listeners_subscribers.rst
@@ -156,9 +156,8 @@ entity), you should check for the entity's class type in your method
 .. tip::
 
     In Doctrine 2.4, a feature called Entity Listeners was introduced.
-    It is a lifecycle listener class used for an entity. See
-    https://symfony.com/doc/current/bundles/DoctrineBundle/entity-listeners.html
-    
+    It is a lifecycle listener class used for an entity. You can read
+    about it in `the Doctrine Documentation`_.
 
 Creating the Subscriber Class
 -----------------------------
@@ -270,3 +269,4 @@ to the tag like so:
     definitions which are described :doc:`in their own article </service_container/lazy_services>`
 
 .. _`The Event System`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/events.html
+.. _`the Doctrine Documentation`: https://symfony.com/doc/current/bundles/DoctrineBundle/entity-listeners.html

--- a/doctrine/event_listeners_subscribers.rst
+++ b/doctrine/event_listeners_subscribers.rst
@@ -156,8 +156,9 @@ entity), you should check for the entity's class type in your method
 .. tip::
 
     In Doctrine 2.4, a feature called Entity Listeners was introduced.
-    It is a lifecycle listener class used for an entity. You can read
-    about it in `the Doctrine Documentation`_.
+    It is a lifecycle listener class used for an entity. See
+    :doc:`Entity Listeners </entity-listeners>
+    
 
 Creating the Subscriber Class
 -----------------------------
@@ -269,4 +270,3 @@ to the tag like so:
     definitions which are described :doc:`in their own article </service_container/lazy_services>`
 
 .. _`The Event System`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/events.html
-.. _`the Doctrine Documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/events.html#entity-listeners


### PR DESCRIPTION
Not sure if I got it right (preview isn't showing it) - the page I wanted to link to is https://symfony.com/doc/current/bundles/DoctrineBundle/entity-listeners.html

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
