### PR TITLE
Fix bad link

### DIFF
--- a/create_framework/front_controller.rst
+++ b/create_framework/front_controller.rst
@@ -153,7 +153,7 @@ web root directory:
 Now, configure your web server root directory to point to ``web/`` and all
 other files won't be accessible from the client anymore.
 
-To test your changes in a browser (``http://localhost:4321/hello/?name=Fabien``), run
+To test your changes in a browser (``http://localhost:4321/hello?name=Fabien``), run
 the PHP built-in server:
 
 .. code-block:: terminal


### PR DESCRIPTION
The link  http://localhost:4321/hello/?name=Fabien is not valid because it does not match the route /hello but the route /hello/ and therefore returns a 404 error.

It must be written this way:

http://localhost:4321/hello?name=Fabien

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
