### PR TITLE
action_method is missing $task variable

### DIFF
--- a/form/action_method.rst
+++ b/form/action_method.rst
@@ -27,6 +27,8 @@ form, you can use ``setAction()`` and ``setMethod()``:
         {
             public function new()
             {
+                // ...
+                
                 $form = $this->createFormBuilder($task)
                     ->setAction($this->generateUrl('target_route'))
                     ->setMethod('GET')


### PR DESCRIPTION
It's not clear from the docs, but user has to first create the `$task` variable.

In the second example bellow it's more clear thanks to `// ...`.

This makes it a bit more explicit here as well.
