### PR TITLE
Explain dump server usage outside of Symfony

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -119,7 +119,7 @@ Inside a Symfony application, the output of the dump server is configured with
 the :ref:`dump_destination option <configuration-debug-dump_destination>` of the
 ``debug`` package.
 
-Outside a Symfony application, one is required to use the ServerDumper class:
+Outside a Symfony application, use the ``ServerDumper`` class:
 
     require __DIR__.'/vendor/autoload.php';
     

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -119,6 +119,20 @@ Inside a Symfony application, the output of the dump server is configured with
 the :ref:`dump_destination option <configuration-debug-dump_destination>` of the
 ``debug`` package.
 
+Outside a Symfony application, one is required to use the ServerDumper class:
+
+    require __DIR__.'/vendor/autoload.php';
+    
+    use Symfony\Component\VarDumper\VarDumper;
+    use Symfony\Component\VarDumper\Cloner\VarCloner;
+    use Symfony\Component\VarDumper\Dumper\ServerDumper;
+    
+    VarDumper::setHandler(function ($var) {
+      $cloner = new VarCloner();
+      $dumper = new ServerDumper('tcp://127.0.0.1:9912');     
+      $dumper->dump($cloner->cloneVar($var));
+    });
+
 DebugBundle and Twig Integration
 --------------------------------
 


### PR DESCRIPTION
Took hours for me to figure out how to use the dump server outside of Symfony, because there is no mention that it can be done, and one must use the ServerDumper class to make it work.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
