### PR TITLE
[Process] Fix typo in Process object initialization

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -231,7 +231,7 @@ Before a process is started, you can specify its standard input using either the
 of the constructor. The provided input can be a string, a stream resource or a
 Traversable object::
 
-    $process = new Process('cat']);
+    $process = new Process('cat');
     $process->setInput('foobar');
     $process->run();
 


### PR DESCRIPTION
Hello!
This small typo does not exist in 2.8, so I did PR into 3.4.