### PR TITLE
Added MessageHandlerInterface

### DIFF
--- a/best_practices/security.rst
+++ b/best_practices/security.rst
@@ -121,7 +121,7 @@ Using ``@Security``, this looks like:
      * Displays a form to create a new Post entity.
      *
      * @Route("/new", name="admin_post_new")
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("is_granted('ROLE_ADMIN')")
      */
     public function new()
     {

--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -97,14 +97,25 @@ make AJAX requests::
 Clicking Links
 ~~~~~~~~~~~~~~
 
-The ``Crawler`` object is capable of simulating link clicks. First, pass the
-text content of the link to the ``selectLink()`` method, which returns a
-``Link`` object. Then, pass this object to the ``click()`` method, which
-performs the needed HTTP GET request to simulate the link click::
+The ``Client`` object is capable of simulating link clicks. Pass the text
+content of the link and the client will perform the needed HTTP GET request to
+simulate the link click::
 
     use Acme\Client;
 
     $client = new Client();
+    $client->request('GET', '/product/123');
+
+    $crawler = $client->clickLink('Go elsewhere...');
+
+.. versionadded:: 4.2
+    The ``clickLink()`` method was introduced in Symfony 4.2.
+
+If you need the :class:`Symfony\\Component\\DomCrawler\\Link` object that
+provides access to the link properties (e.g. ``$link->getMethod()``,
+``$link->getUri()``), use this other method:
+
+    // ...
     $crawler = $client->request('GET', '/product/123');
     $link = $crawler->selectLink('Go elsewhere...')->link();
     $client->click($link);
@@ -112,26 +123,50 @@ performs the needed HTTP GET request to simulate the link click::
 Submitting Forms
 ~~~~~~~~~~~~~~~~
 
-The ``Crawler`` object is also capable of selecting forms. First, select any of
-the form's buttons with the ``selectButton()`` method. Then, use the ``form()``
-method to select the form which the button belongs to.
-
-After selecting the form, fill in its data and send it using the ``submit()``
-method (which makes the needed HTTP POST request to submit the form contents)::
+The ``Client`` object is also capable of submitting forms. First, select the
+form using any of its buttons and then override any of its properties (method,
+field values, etc.) before submitting it::
 
     use Acme\Client;
 
-    // make a real request to an external site
     $client = new Client();
     $crawler = $client->request('GET', 'https://github.com/login');
+
+    // find the form with the 'Log in' button and submit it
+    // 'Log in' can be the text content, id, value or name of a <button> or <input type="submit">
+    $client->submitForm('Log in');
+
+    // the second optional argument lets you override the default form field values
+    $client->submitForm('Log in', array(
+        'login' => 'my_user',
+        'password' => 'my_pass',
+        // to upload a file, the value must be the absolute file path
+        'file' => __FILE__,
+    ));
+
+    // you can override other form options too
+    $client->submitForm(
+        'Log in',
+        array('login' => 'my_user', 'password' => 'my_pass'),
+        // override the default form HTTP method
+        'PUT',
+        // override some $_SERVER parameters (e.g. HTTP headers)
+        array('HTTP_ACCEPT_LANGUAGE' => 'es')
+    );
+
+.. versionadded:: 4.2
+    The ``submitForm()`` method was introduced in Symfony 4.2.
+
+If you need the :class:`Symfony\\Component\\DomCrawler\\Form` object that
+provides access to the form properties (e.g. ``$form->getUri()``,
+``$form->getValues()``, ``$form->getFields()``), use this other method::
+
+    // ...
 
     // select the form and fill in some values
     $form = $crawler->selectButton('Log in')->form();
     $form['login'] = 'symfonyfan';
     $form['password'] = 'anypass';
-
-    // To upload a file, the value should be the absolute file path
-    $form['file'] = __FILE__;
 
     // submit that form
     $crawler = $client->submit($form);

--- a/components/cache/adapters/pdo_doctrine_dbal_adapter.rst
+++ b/components/cache/adapters/pdo_doctrine_dbal_adapter.rst
@@ -31,6 +31,15 @@ third, and forth parameters::
         $options = array()
     );
 
+.. versionadded:: 4.2
+    Automatic table creation was introduced in Symfony 4.2.
+
+The table where values are stored is created automatically on the first call to
+the :method:`Symfony\\Component\\Cache\\Adapter\\PdoAdapter::save` method.
+You can also create this table explicitly by calling the
+:method:`Symfony\\Component\\Cache\\Adapter\\PdoAdapter::createTable` method in
+your code.
+
 .. tip::
 
     When passed a `Data Source Name (DSN)`_ string (instead of a database connection

--- a/components/cache/adapters/redis_adapter.rst
+++ b/components/cache/adapters/redis_adapter.rst
@@ -96,9 +96,11 @@ array of ``key => value`` pairs representing option names and their respective v
 
         // associative array of configuration options
         array(
+            'compression' => true,
             'lazy' => false,
             'persistent' => 0,
             'persistent_id' => null,
+            'tcp_keepalive' => 0,
             'timeout' => 30,
             'read_timeout' => 0,
             'retry_interval' => 0,
@@ -113,6 +115,10 @@ Available Options
     Specifies the connection library to return, either ``\Redis`` or ``\Predis\Client``.
     If none is specified, it will return ``\Redis`` if the ``redis`` extension is
     available, and ``\Predis\Client`` otherwise.
+
+``compression`` (type: ``bool``, default: ``true``)
+    Enables or disables compression of items. This requires phpredis v4 or higher with
+    LZF support enabled.
 
 ``lazy`` (type: ``bool``, default: ``false``)
     Enables or disables lazy connections to the backend. It's ``false`` by
@@ -134,6 +140,10 @@ Available Options
     Specifies the delay (in milliseconds) between reconnection attempts in case the client
     loses connection with the server.
 
+``tcp_keepalive`` (type: ``int``, default: ``0``)
+    Specifies the TCP-keepalive timeout (in seconds) of the connection. This requires
+    phpredis v4 or higher and a TCP-keepalive enabled server.
+
 ``timeout`` (type: ``int``, default: ``30``)
     Specifies the time (in seconds) used to connect to a Redis server before the
     connection attempt times out.
@@ -149,3 +159,4 @@ Available Options
 .. _`RedisCluster`: https://github.com/phpredis/phpredis/blob/master/cluster.markdown#readme
 .. _`Predis`: https://packagist.org/packages/predis/predis
 .. _`Predis Connection Parameters`: https://github.com/nrk/predis/wiki/Connection-Parameters#list-of-connection-parameters
+.. _`TCP-keepalive`: https://redis.io/topics/clients#tcp-keepalive

--- a/components/cache/adapters/redis_adapter.rst
+++ b/components/cache/adapters/redis_adapter.rst
@@ -141,8 +141,8 @@ Available Options
     loses connection with the server.
 
 ``tcp_keepalive`` (type: ``int``, default: ``0``)
-    Specifies the TCP-keepalive timeout (in seconds) of the connection. This requires
-    phpredis v4 or higher and a TCP-keepalive enabled server.
+    Specifies the `TCP-keepalive`_ timeout (in seconds) of the connection. This
+    requires phpredis v4 or higher and a TCP-keepalive enabled server.
 
 ``timeout`` (type: ``int``, default: ``30``)
     Specifies the time (in seconds) used to connect to a Redis server before the

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -197,11 +197,12 @@ Restrict files by name with the
 
     $finder->files()->name('*.php');
 
-The ``name()`` method accepts globs, strings, regexes or an array of globs, strings or regexes::
+The ``name()`` method accepts globs, strings, regexes or an array of globs,
+strings or regexes::
 
     $finder->files()->name('/\.php$/');
 
-Multiple files names can be defined by chaining calls or using an array as parameter::
+Multiple files names can be defined by chaining calls or passing an array::
 
     $finder->files()->name('*.php')->name('*.twig');
 
@@ -212,7 +213,7 @@ The ``notName()`` method excludes files matching a pattern::
 
     $finder->files()->notName('*.rb');
 
-Multiple files names can be excluded by chaining calls or using an array as parameter::
+Multiple files names can be excluded by chaining calls or passing an array::
 
     $finder->files()->notName('*.rb')->notName('*.py');
 
@@ -220,7 +221,8 @@ Multiple files names can be excluded by chaining calls or using an array as para
     $finder->files()->notName(array('*.rb', '*.py'));
 
 .. versionadded:: 4.2
-    Passing an array as parameter for method ``name()`` and ``notName()`` was introduced in Symfony 4.2
+    Passing an array as parameter for method ``name()`` and ``notName()`` was
+    introduced in Symfony 4.2
 
 File Contents
 ~~~~~~~~~~~~~
@@ -251,12 +253,13 @@ Restrict files and directories by path with the
 
 On all platforms slash (i.e. ``/``) should be used as the directory separator.
 
-The ``path()`` method accepts a string, a regular expression or an array of strings or regulars expressions::
+The ``path()`` method accepts a string, a regular expression or an array of
+strings or regulars expressions::
 
     $finder->path('foo/bar');
     $finder->path('/^foo\/bar/');
 
-Multiple paths can be defined by chaining calls or using an array as parameter::
+Multiple paths can be defined by chaining calls or passing an array::
 
     $finder->path('data')->path('foo/bar');
 
@@ -264,7 +267,8 @@ Multiple paths can be defined by chaining calls or using an array as parameter::
     $finder->path(array('data', 'foo/bar'));
 
 .. versionadded:: 4.2
-    Passing an array as parameter for method ``path()`` and ``notPath()`` was introduced in Symfony 4.2
+    Passing an array as parameter for method ``path()`` and ``notPath()`` was
+    introduced in Symfony 4.2
 
 Internally, strings are converted into regular expressions by escaping slashes
 and adding delimiters:
@@ -278,7 +282,7 @@ The :method:`Symfony\\Component\\Finder\\Finder::notPath` method excludes files 
 
     $finder->notPath('other/dir');
 
-Multiple paths can be excluded by chaining calls or using an array as parameter::
+Multiple paths can be excluded by chaining calls or passing an array::
 
     $finder->notPath('first/dir')->notPath('other/dir');
 
@@ -296,7 +300,7 @@ Restrict files by size with the
 
     $finder->files()->size('< 1.5K');
 
-Restrict by a size range by chaining calls or using an array as argument::
+Restrict by a size range by chaining calls or passing an array::
 
     $finder->files()->size('>= 1K')->size('<= 2K');
 
@@ -321,7 +325,7 @@ Restrict files by last modified dates with the
 
     $finder->date('since yesterday');
 
-Restrict by a date range by chaining calls or using an array as argument::
+Restrict by a date range by chaining calls or passing an array::
 
     $finder->date('>= 2018-01-01')->size('<= 2018-12-31');
 
@@ -346,7 +350,7 @@ traversing with :method:`Symfony\\Component\\Finder\\Finder::depth`::
     $finder->depth('== 0');
     $finder->depth('< 3');
 
-Restrict by a depth range by chaining calls or using an array as argument::
+Restrict by a depth range by chaining calls or passing an array::
 
     $finder->depth('> 2')->depth('< 5');
 

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -197,13 +197,30 @@ Restrict files by name with the
 
     $finder->files()->name('*.php');
 
-The ``name()`` method accepts globs, strings, or regexes::
+The ``name()`` method accepts globs, strings, regexes or an array of globs, strings or regexes::
 
     $finder->files()->name('/\.php$/');
+
+Multiple files names can be defined by chaining calls or using an array as parameter::
+
+    $finder->files()->name('*.php')->name('*.twig');
+
+    // same as above
+    $finder->files()->name(array('*.php', '*.twig'));
 
 The ``notName()`` method excludes files matching a pattern::
 
     $finder->files()->notName('*.rb');
+
+Multiple files names can be excluded by chaining calls or using an array as parameter::
+
+    $finder->files()->notName('*.rb')->notName('*.py');
+
+    // same as above
+    $finder->files()->notName(array('*.rb', '*.py'));
+
+.. versionadded:: 4.2
+    Passing an array as parameter for method ``name()`` and ``notName()`` was introduced in Symfony 4.2
 
 File Contents
 ~~~~~~~~~~~~~
@@ -234,10 +251,20 @@ Restrict files and directories by path with the
 
 On all platforms slash (i.e. ``/``) should be used as the directory separator.
 
-The ``path()`` method accepts a string or a regular expression::
+The ``path()`` method accepts a string, a regular expression or an array of strings or regulars expressions::
 
     $finder->path('foo/bar');
     $finder->path('/^foo\/bar/');
+
+Multiple paths can be defined by chaining calls or using an array as parameter::
+
+    $finder->path('data')->path('foo/bar');
+
+    // same as above
+    $finder->path(array('data', 'foo/bar'));
+
+.. versionadded:: 4.2
+    Passing an array as parameter for method ``path()`` and ``notPath()`` was introduced in Symfony 4.2
 
 Internally, strings are converted into regular expressions by escaping slashes
 and adding delimiters:
@@ -251,6 +278,16 @@ The :method:`Symfony\\Component\\Finder\\Finder::notPath` method excludes files 
 
     $finder->notPath('other/dir');
 
+Multiple paths can be excluded by chaining calls or using an array as parameter::
+
+    $finder->notPath('first/dir')->notPath('other/dir');
+
+    // same as above
+    $finder->notPath(array('first/dir', 'other/dir'));
+
+.. versionadded:: 4.2
+    Passing an array as method parameter was introduced in Symfony 4.2
+
 File Size
 ~~~~~~~~~
 
@@ -259,9 +296,15 @@ Restrict files by size with the
 
     $finder->files()->size('< 1.5K');
 
-Restrict by a size range by chaining calls::
+Restrict by a size range by chaining calls or using an array as argument::
 
     $finder->files()->size('>= 1K')->size('<= 2K');
+
+    // same as above
+    $finder->files()->size(array('>= 1K', '<= 2K'));
+
+.. versionadded:: 4.2
+    Passing an array as method parameter was introduced in Symfony 4.2
 
 The comparison operator can be any of the following: ``>``, ``>=``, ``<``, ``<=``,
 ``==``, ``!=``.
@@ -278,6 +321,16 @@ Restrict files by last modified dates with the
 
     $finder->date('since yesterday');
 
+Restrict by a date range by chaining calls or using an array as argument::
+
+    $finder->date('>= 2018-01-01')->size('<= 2018-12-31');
+
+    // same as above
+    $finder->date(array('>= 2018-01-01', '<= 2018-12-31'));
+
+.. versionadded:: 4.2
+    Passing an array as method parameter was introduced in Symfony 4.2
+
 The comparison operator can be any of the following: ``>``, ``>=``, ``<``, ``<=``,
 ``==``. You can also use ``since`` or ``after`` as an alias for ``>``, and
 ``until`` or ``before`` as an alias for ``<``.
@@ -292,6 +345,16 @@ traversing with :method:`Symfony\\Component\\Finder\\Finder::depth`::
 
     $finder->depth('== 0');
     $finder->depth('< 3');
+
+Restrict by a depth range by chaining calls or using an array as argument::
+
+    $finder->depth('> 2')->depth('< 5');
+
+    // same as above
+    $finder->depth(array('> 2', '< 5'));
+
+.. versionadded:: 4.2
+    Passing an array as method parameter was introduced in Symfony 4.2
 
 Custom Filtering
 ~~~~~~~~~~~~~~~~

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -267,8 +267,7 @@ Multiple paths can be defined by chaining calls or passing an array::
     $finder->path(array('data', 'foo/bar'));
 
 .. versionadded:: 4.2
-    Passing an array as parameter for method ``path()`` and ``notPath()`` was
-    introduced in Symfony 4.2
+    Support for passing arrays to ``path()`` was introduced in Symfony 4.2
 
 Internally, strings are converted into regular expressions by escaping slashes
 and adding delimiters:
@@ -290,7 +289,8 @@ Multiple paths can be excluded by chaining calls or passing an array::
     $finder->notPath(array('first/dir', 'other/dir'));
 
 .. versionadded:: 4.2
-    Passing an array as method parameter was introduced in Symfony 4.2
+    Support for passing arrays to ``notPath()`` was introduced in Symfony
+    4.2
 
 File Size
 ~~~~~~~~~
@@ -308,7 +308,7 @@ Restrict by a size range by chaining calls or passing an array::
     $finder->files()->size(array('>= 1K', '<= 2K'));
 
 .. versionadded:: 4.2
-    Passing an array as method parameter was introduced in Symfony 4.2
+    Support for passing arrays to ``size()`` was introduced in Symfony 4.2
 
 The comparison operator can be any of the following: ``>``, ``>=``, ``<``, ``<=``,
 ``==``, ``!=``.
@@ -333,7 +333,7 @@ Restrict by a date range by chaining calls or passing an array::
     $finder->date(array('>= 2018-01-01', '<= 2018-12-31'));
 
 .. versionadded:: 4.2
-    Passing an array as method parameter was introduced in Symfony 4.2
+    Support for passing arrays to ``date()`` was introduced in Symfony 4.2
 
 The comparison operator can be any of the following: ``>``, ``>=``, ``<``, ``<=``,
 ``==``. You can also use ``since`` or ``after`` as an alias for ``>``, and
@@ -358,7 +358,7 @@ Restrict by a depth range by chaining calls or passing an array::
     $finder->depth(array('> 2', '< 5'));
 
 .. versionadded:: 4.2
-    Passing an array as method parameter was introduced in Symfony 4.2
+    Support for passing arrays to ``depth()`` was introduced in Symfony 4.2
 
 Custom Filtering
 ~~~~~~~~~~~~~~~~

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -202,7 +202,7 @@ strings or regexes::
 
     $finder->files()->name('/\.php$/');
 
-Multiple files names can be defined by chaining calls or passing an array::
+Multiple filenames can be defined by chaining calls or passing an array::
 
     $finder->files()->name('*.php')->name('*.twig');
 
@@ -213,7 +213,7 @@ The ``notName()`` method excludes files matching a pattern::
 
     $finder->files()->notName('*.rb');
 
-Multiple files names can be excluded by chaining calls or passing an array::
+Multiple filenames can be excluded by chaining calls or passing an array::
 
     $finder->files()->notName('*.rb')->notName('*.py');
 
@@ -221,8 +221,8 @@ Multiple files names can be excluded by chaining calls or passing an array::
     $finder->files()->notName(array('*.rb', '*.py'));
 
 .. versionadded:: 4.2
-    Passing an array as parameter for method ``name()`` and ``notName()`` was
-    introduced in Symfony 4.2
+    Support for passing arrays to ``name()`` and ``notName()`` was introduced
+    in Symfony 4.2
 
 File Contents
 ~~~~~~~~~~~~~

--- a/components/form.rst
+++ b/components/form.rst
@@ -747,6 +747,11 @@ method to access the list of errors. It returns a
     // a FormErrorIterator instance representing the form tree structure
     $errors = $form->getErrors(true, false);
 
+Clearing Form Errors
+~~~~~~~~~~~~~~~~~~~~
+
+Any errors can be manually cleared using the :method:`Symfony\\Component\\Form\\ClearableErrorsInterface::clearErrors` method. This is useful when you'd like to validate the form without showing validation errors to the user (i.e. during a partial AJAX submission or :doc:`dynamic form modification </form/dynamic_form_modification>`).
+
 Learn more
 ----------
 

--- a/components/form.rst
+++ b/components/form.rst
@@ -752,6 +752,8 @@ Clearing Form Errors
 
 Any errors can be manually cleared using the :method:`Symfony\\Component\\Form\\ClearableErrorsInterface::clearErrors` method. This is useful when you'd like to validate the form without showing validation errors to the user (i.e. during a partial AJAX submission or :doc:`dynamic form modification </form/dynamic_form_modification>`).
 
+Because clearing the errors makes the form valid,  ``clearErrors()`` should only be called after testing whether the form is valid.
+
 Learn more
 ----------
 

--- a/components/form.rst
+++ b/components/form.rst
@@ -750,9 +750,17 @@ method to access the list of errors. It returns a
 Clearing Form Errors
 ~~~~~~~~~~~~~~~~~~~~
 
-Any errors can be manually cleared using the :method:`Symfony\\Component\\Form\\ClearableErrorsInterface::clearErrors` method. This is useful when you'd like to validate the form without showing validation errors to the user (i.e. during a partial AJAX submission or :doc:`dynamic form modification </form/dynamic_form_modification>`).
+.. versionadded:: 4.2
+    The ``clearErrors()`` method was introduced in Symfony 4.2.
 
-Because clearing the errors makes the form valid,  ``clearErrors()`` should only be called after testing whether the form is valid.
+Any errors can be manually cleared using the
+:method:`Symfony\\Component\\Form\\ClearableErrorsInterface::clearErrors`
+method. This is useful when you'd like to validate the form without showing
+validation errors to the user (i.e. during a partial AJAX submission or
+:doc:`dynamic form modification </form/dynamic_form_modification>`).
+
+Because clearing the errors makes the form valid, ``clearErrors()`` should only
+be called after testing whether the form is valid.
 
 Learn more
 ----------

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -290,6 +290,21 @@ by using the following methods:
 :method:`Symfony\\Component\\HttpFoundation\\Request::getAcceptableContentTypes`
     Returns the list of accepted content types ordered by descending quality.
 
+:method:`Symfony\\Component\\HttpFoundation\\Request::getAcceptableFormats`
+    Returns the list of accepted client formats associated with the request.
+
+Note that
+:method:`Symfony\\Component\\HttpFoundation\\Request::getAcceptableFormats`
+will use the data from
+:method:`Symfony\\Component\\HttpFoundation\\Request::getAcceptableContentTypes`
+and return the client acceptable formats::
+
+    $request->getAcceptableContentTypes();
+    // returns ['text/html', 'application/xhtml+xml', 'application/xml', '*/*']
+
+    $request->getAcceptableFormats();
+    // returns ['html', 'xml']
+
 :method:`Symfony\\Component\\HttpFoundation\\Request::getLanguages`
     Returns the list of accepted languages ordered by descending quality.
 

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -634,6 +634,43 @@ let you find out which options are defined::
         }
     }
 
+Deprecating the Option
+~~~~~~~~~~~~~~~~~~~~~~
+
+Once an option is outdated or you decided not to maintain it anymore, you can deprecate it
+using the :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::setDeprecated`
+method::
+
+    $resolver
+        ->setDefined(array('hostname', 'host'))
+        // this outputs the following generic deprecation message:
+        // The option "hostname" is deprecated.
+        ->setDeprecated('hostname')
+
+        // you can also pass a custom deprecation message
+        ->setDeprecated('hostname', 'The option "hostname" is deprecated, use "host" instead.')
+    ;
+
+Instead of passing the message, you may also pass a closure which returns
+a string (the deprecation message) or an empty string to ignore the deprecation.
+This closure is specially useful to deprecate allowed types or values of the
+defined option::
+
+    $resolver
+        ->setDefault('port', null)
+        ->setAllowedTypes('port', array('null', 'int'))
+        ->setDeprecated('port', function ($value) {
+            if (null === $value) {
+                return 'Passing "null" to option "port" is deprecated, pass an integer instead.';
+            }
+
+            return '';
+        })
+    ;
+
+This closure receives as argument the value of the option after validating it
+and before normalize it when the option is being resolved.
+
 Performance Tweaks
 ~~~~~~~~~~~~~~~~~~
 

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -637,8 +637,11 @@ let you find out which options are defined::
 Deprecating the Option
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Once an option is outdated or you decided not to maintain it anymore, you can deprecate it
-using the :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::setDeprecated`
+.. versionadded:: 4.2
+    The ``setDeprecated()`` method was introduced in Symfony 4.2.
+
+Once an option is outdated or you decided not to maintain it anymore, you can
+deprecate it using the :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::setDeprecated`
 method::
 
     $resolver
@@ -653,8 +656,8 @@ method::
 
 Instead of passing the message, you may also pass a closure which returns
 a string (the deprecation message) or an empty string to ignore the deprecation.
-This closure is specially useful to deprecate allowed types or values of the
-defined option::
+This closure is useful to only deprecate some of the allowed types or values of
+the option::
 
     $resolver
         ->setDefault('port', null)
@@ -669,7 +672,7 @@ defined option::
     ;
 
 This closure receives as argument the value of the option after validating it
-and before normalize it when the option is being resolved.
+and before normalizing it when the option is being resolved.
 
 Performance Tweaks
 ~~~~~~~~~~~~~~~~~~

--- a/configuration/external_parameters.rst
+++ b/configuration/external_parameters.rst
@@ -453,6 +453,18 @@ Symfony provides the following env var processors:
                 'auth' => '%env(file:AUTH_FILE)%',
             ));
 
+``env(key:FOO:BAR)``
+    Retrieves key ``FOO`` from array value ``BAR``:
+
+    .. code-block:: yaml
+
+        parameters:
+            env(APP_SECRETS): "{\"database_password\": \"secret\"}"
+            database_password: '%env(key:database_password:json:APP_SECRETS)%'
+
+    .. versionadded:: 4.2
+        The ``key`` processor was introduced in Symfony 4.2.
+
 It is also possible to combine any number of processors:
 
 .. code-block:: yaml

--- a/configuration/external_parameters.rst
+++ b/configuration/external_parameters.rst
@@ -454,13 +454,42 @@ Symfony provides the following env var processors:
             ));
 
 ``env(key:FOO:BAR)``
-    Retrieves key ``FOO`` from array value ``BAR``:
+    Retrieves the value associated with the key ``FOO`` from the array whose
+    contents are stored in the ``BAR`` env var:
 
-    .. code-block:: yaml
+    .. configuration-block::
 
-        parameters:
-            env(APP_SECRETS): "{\"database_password\": \"secret\"}"
-            database_password: '%env(key:database_password:json:APP_SECRETS)%'
+        .. code-block:: yaml
+
+            # config/services.yaml
+            parameters:
+                env(SECRETS_FILE): '/opt/application/.secrets.json'
+                database_password: '%env(key:database_password:json:file:SECRETS_FILE)%'
+                # if SECRETS_FILE contents are: {"database_password": "secret"} it returns "secret"
+
+        .. code-block:: xml
+
+            <!-- config/services.xml -->
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <container xmlns="http://symfony.com/schema/dic/services"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:framework="http://symfony.com/schema/dic/symfony"
+                xsi:schemaLocation="http://symfony.com/schema/dic/services
+                    http://symfony.com/schema/dic/services/services-1.0.xsd
+                    http://symfony.com/schema/dic/symfony
+                    http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+                <parameters>
+                    <parameter key="env(SECRETS_FILE)">/opt/application/.secrets.json</parameter>
+                    <parameter key="database_password">%env(key:database_password:json:file:SECRETS_FILE)%</parameter>
+                </parameters>
+            </container>
+
+        .. code-block:: php
+
+            // config/services.php
+            $container->setParameter('env(SECRETS_FILE)', '/opt/application/.secrets.json');
+            $container->setParameter('database_password', '%env(key:database_password:json:file:SECRETS_FILE)%');
 
     .. versionadded:: 4.2
         The ``key`` processor was introduced in Symfony 4.2.

--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -172,14 +172,44 @@ handler level or at the channel level instead of registering it globally
     :class:`Symfony\\Bridge\\Monolog\\Processor\\WebProcessor` processors, which
     can be enabled as follows:
 
-    .. code-block:: yaml
+    .. configuration-block::
 
-        # config/services.yaml
-        services:
-            # Adds the current security token to log entries
-            Symfony\Bridge\Monolog\Processor\TokenProcessor: ~
-            # Adds the real client IP to log entries
-            Symfony\Bridge\Monolog\Processor\WebProcessor: ~
+        .. code-block:: yaml
+
+            # config/services.yaml
+            services:
+                # Adds the current security token to log entries
+                Symfony\Bridge\Monolog\Processor\TokenProcessor: ~
+                # Adds the real client IP to log entries
+                Symfony\Bridge\Monolog\Processor\WebProcessor: ~
+
+        .. code-block:: xml
+
+            <!-- config/services.xml -->
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <container xmlns="http://symfony.com/schema/dic/services"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://symfony.com/schema/dic/services
+                    http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+                <services>
+                    <!-- Adds the current security token to log entries -->
+                    <service id="Symfony\Bridge\Monolog\Processor\TokenProcessor" />
+                    <!-- Adds the real client IP to log entries -->
+                    <service id="Symfony\Bridge\Monolog\Processor\WebProcessor" />
+                </services>
+            </container>
+
+        .. code-block:: php
+
+            // config/services.php
+            use Symfony\Bridge\Monolog\Processor\TokenProcessor;
+            use Symfony\Bridge\Monolog\Processor\WebProcessor;
+
+            // Adds the current security token to log entries
+            $container->register(TokenProcessor::class);
+            // Adds the real client IP to log entries
+            $container->register(WebProcessor::class);
 
 Registering Processors per Handler
 ----------------------------------

--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -159,6 +159,28 @@ If you use several handlers, you can also register a processor at the
 handler level or at the channel level instead of registering it globally
 (see the following sections).
 
+.. tip::
+
+    .. versionadded:: 4.2
+        Processors can be autoconfigured since Symfony 4.2.
+
+    Processors implementing :class:`Symfony\\Bridge\\Monolog\\Processor\\ProcessorInterface`
+    can have their ``monolog.processor`` tag added for you by Symfony when autoconfiguration
+    is enabled. In this situation, this means creating a processor class might be all you
+    need do to to have it up and running. It also means enabling the
+    :class:`Symfony\\Bridge\\Monolog\\Processor\\TokenProcessor` or the
+    :class:`Symfony\\Bridge\\Monolog\\Processor\\WebProcessor` in your Flex-enabled app is a
+    one-liner:
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+        services:
+            # Adds the current security token to log entries
+            Symfony\Bridge\Monolog\Processor\TokenProcessor: ~
+            # Adds the real client IP to log entries
+            Symfony\Bridge\Monolog\Processor\WebProcessor: ~
+
 Registering Processors per Handler
 ----------------------------------
 

--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -162,15 +162,15 @@ handler level or at the channel level instead of registering it globally
 .. tip::
 
     .. versionadded:: 4.2
-        Processors can be autoconfigured since Symfony 4.2.
+        The autoconfiguration of Monolog processors was introduced in Symfony 4.2.
 
-    Processors implementing :class:`Symfony\\Bridge\\Monolog\\Processor\\ProcessorInterface`
-    can have their ``monolog.processor`` tag added for you by Symfony when autoconfiguration
-    is enabled. In this situation, this means creating a processor class might be all you
-    need do to to have it up and running. It also means enabling the
-    :class:`Symfony\\Bridge\\Monolog\\Processor\\TokenProcessor` or the
-    :class:`Symfony\\Bridge\\Monolog\\Processor\\WebProcessor` in your Flex-enabled app is a
-    one-liner:
+    If you're using the :ref:`default services.yaml configuration <service-container-services-load-example>`,
+    processors implementing :class:`Symfony\\Bridge\\Monolog\\Processor\\ProcessorInterface`
+    are automatically registered as services and tagged with ``monolog.processor``,
+    so you can use them without adding any configuration. The same applies to the
+    built-in :class:`Symfony\\Bridge\\Monolog\\Processor\\TokenProcessor` and
+    :class:`Symfony\\Bridge\\Monolog\\Processor\\WebProcessor` processors, which
+    can be enabled as follows:
 
     .. code-block:: yaml
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -48,8 +48,10 @@ message handler. It's a class with an ``__invoke`` method::
 
     // src/MessageHandler/MyMessageHandler.php
     namespace App\MessageHandler;
+    
+    use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
-    class MyMessageHandler
+    class MyMessageHandler implements MessageHandlerInterface
     {
         public function __invoke(MyMessage $message)
         {
@@ -57,7 +59,7 @@ message handler. It's a class with an ``__invoke`` method::
         }
     }
 
-Once you've created your handler, you need to register it:
+Once you've created your handler, you need to register it (this is done automatically if you have implemented the MessageHandlerInterface):
 
 .. configuration-block::
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -50,6 +50,7 @@ Configuration
   * :ref:`app <reference-cache-app>`
   * `default_doctrine_provider`_
   * `default_memcached_provider`_
+  * `default_pdo_provider`_
   * `default_psr6_provider`_
   * `default_redis_provider`_
   * `directory`_
@@ -1834,7 +1835,7 @@ app
 The cache adapter used by the ``cache.app`` service. The FrameworkBundle
 ships with multiple adapters: ``cache.adapter.apcu``, ``cache.adapter.doctrine``,
 ``cache.adapter.system``, ``cache.adapter.filesystem``, ``cache.adapter.psr6``,
-``cache.adapter.redis`` and ``cache.adapter.memcached``.
+``cache.adapter.redis``, ``cache.adapter.memcached`` and ``cache.adapter.pdo``.
 
 There's also a special adapter called ``cache.adapter.array`` which stores
 contents in memory using a PHP array and it's used to disable caching (mostly on
@@ -1899,6 +1900,14 @@ default_memcached_provider
 
 The DSN to use by the Memcached provider. The provider is available as the ``cache.memcached``
 service.
+
+default_pdo_provider
+..........................
+
+**type**: ``string`` **default**: ``doctrine.dbal.default_connection``
+
+The service id of the database connection, which should be either a PDO or a
+Doctrine DBAL instance.
 
 pools
 .....

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1902,7 +1902,7 @@ The DSN to use by the Memcached provider. The provider is available as the ``cac
 service.
 
 default_pdo_provider
-..........................
+....................
 
 **type**: ``string`` **default**: ``doctrine.dbal.default_connection``
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -182,7 +182,7 @@ LDAP functionality
 ------------------
 
 There are several options for connecting against an LDAP server,
-using the ``form_login_ldap`` and ``http_basic_ldap`` authentication
+using the ``form_login_ldap``, ``http_basic_ldap`` and ``json_login_ldap`` authentication
 providers or the ``ldap`` user provider.
 
 For even more details, see :doc:`/security/ldap`.
@@ -191,8 +191,8 @@ Authentication
 ~~~~~~~~~~~~~~
 
 You can authenticate to an LDAP server using the LDAP variants of the
-``form_login`` and ``http_basic`` authentication providers. Simply use
-``form_login_ldap`` and ``http_basic_ldap``, which will attempt to
+``form_login``, ``http_basic`` and ``json_login`` authentication providers. Simply use
+``form_login_ldap``, ``http_basic_ldap`` and ``json_login_ldap``, which will attempt to
 ``bind`` against a LDAP server instead of using password comparison.
 
 Both authentication providers have the same arguments as their normal
@@ -231,8 +231,8 @@ User provider
 
 Users will still be fetched from the configured user provider. If you
 wish to fetch your users from a LDAP server, you will need to use the
-``ldap`` user provider, in addition to one of the two authentication
-providers (``form_login_ldap`` or ``http_basic_ldap``).
+``ldap`` user provider, in addition to one of the three authentication
+providers (``form_login_ldap`` or ``http_basic_ldap`` or ``json-login-ldap``).
 
 .. configuration-block::
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -195,6 +195,9 @@ You can authenticate to an LDAP server using the LDAP variants of the
 ``form_login_ldap``, ``http_basic_ldap`` and ``json_login_ldap``, which will attempt to
 ``bind`` against a LDAP server instead of using password comparison.
 
+.. versionadded:: 4.2
+    The ``json_login_ldap`` authentication provider was introduced in Symfony 4.2.
+
 Both authentication providers have the same arguments as their normal
 counterparts, with the addition of two configuration keys:
 

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -637,6 +637,27 @@ file_link
 Generates a link to the provided file and line number using
 a preconfigured scheme.
 
+file_relative
+~~~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ file|file_relative }}
+
+``file``
+    **type**: ``string``
+
+Returns the relative path from the passed absolute file path. For example,
+assume you've a project in the following directory: ``/var/www/blog/``.
+
+.. code-block:: twig
+
+    {{ '/var/www/blog/templates/admin/index.html.twig'|file_relative }}
+    {# templates/admin/index.html.twig #}
+
+If the passed path doesn't match the project directory, a ``null`` value
+will be returned.
+
 .. _reference-twig-tags:
 
 Tags

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -640,7 +640,7 @@ a preconfigured scheme.
 file_relative
 ~~~~~~~~~~~~~
 
-.. versionadded::
+.. versionadded:: 4.2
     The ``file_relative`` filter was introduced in Symfony 4.2.
 
 .. code-block:: twig

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -640,6 +640,9 @@ a preconfigured scheme.
 file_relative
 ~~~~~~~~~~~~~
 
+.. versionadded::
+    The ``file_relative`` filter was introduced in Symfony 4.2.
+
 .. code-block:: twig
 
     {{ file|file_relative }}
@@ -647,15 +650,15 @@ file_relative
 ``file``
     **type**: ``string``
 
-Returns the relative path from the passed absolute file path. For example,
-assume you've a project in the following directory: ``/var/www/blog/``.
+It transforms the given absolute file path into a relative file path from the
+project's root directory:
 
 .. code-block:: twig
 
     {{ '/var/www/blog/templates/admin/index.html.twig'|file_relative }}
-    {# templates/admin/index.html.twig #}
+    {# if project root dir is '/var/www/blog/', it returns 'templates/admin/index.html.twig' #}
 
-If the passed path doesn't match the project directory, a ``null`` value
+If the given file path is out of the project directory, a ``null`` value
 will be returned.
 
 .. _reference-twig-tags:

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -650,7 +650,7 @@ file_relative
 ``file``
     **type**: ``string``
 
-It transforms the given absolute file path into a relative file path from the
+It transforms the given absolute file path into a new file path relative to
 project's root directory:
 
 .. code-block:: twig

--- a/security.rst
+++ b/security.rst
@@ -901,7 +901,7 @@ using annotations::
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
     /**
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("is_granted('ROLE_ADMIN')")
      */
     public function hello($name)
     {

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -265,7 +265,7 @@ key:
             access_control:
                 -
                     path: ^/_internal/secure
-                    allow_if: "'127.0.0.1' == request.getClientIp() or has_role('ROLE_ADMIN')"
+                    allow_if: "'127.0.0.1' == request.getClientIp() or is_granted('ROLE_ADMIN')"
 
     .. code-block:: xml
 
@@ -279,7 +279,7 @@ key:
 
             <config>
                 <rule path="^/_internal/secure"
-                    allow-if="'127.0.0.1' == request.getClientIp() or has_role('ROLE_ADMIN')" />
+                    allow-if="'127.0.0.1' == request.getClientIp() or is_granted('ROLE_ADMIN')" />
             </config>
         </srv:container>
 
@@ -288,7 +288,7 @@ key:
             'access_control' => array(
                 array(
                     'path' => '^/_internal/secure',
-                    'allow_if' => '"127.0.0.1" == request.getClientIp() or has_role("ROLE_ADMIN")',
+                    'allow_if' => '"127.0.0.1" == request.getClientIp() or is_granted("ROLE_ADMIN")',
                 ),
             ),
 

--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -61,9 +61,11 @@ Additionally, you have access to a number of functions inside the expression:
     Similar, but not equal to ``IS_AUTHENTICATED_REMEMBERED``, see below.
 ``is_fully_authenticated``
     Similar, but not equal to ``IS_AUTHENTICATED_FULLY``, see below.
-``has_role``
-    Checks to see if the user has the given role - equivalent to an expression like
-    ``'ROLE_ADMIN' in roles``.
+``is_granted``
+    Checks if the user has the given permission. Optionally accepts a second argument
+    with the object where permission is checked on. It's equivalent to using
+    the :doc:`isGranted() method </security/securing_services>` from the authorization
+    checker service.
 
 .. sidebar:: ``is_remember_me`` is different than checking ``IS_AUTHENTICATED_REMEMBERED``
 

--- a/security/remember_me.rst
+++ b/security/remember_me.rst
@@ -114,6 +114,10 @@ The ``remember_me`` firewall defines the following configuration options:
     through the HTTP protocol. This means that the cookie won't be accessible
     by scripting languages, such as JavaScript.
 
+``samesite`` (default value: ``null``)
+    If set to ``strict``, the cookie associated with this feature will not
+    be send along with cross-site requests, even when following a regular link.
+
 ``remember_me_parameter`` (default value: ``_remember_me``)
     The name of the form field checked to decide if the "Remember Me" feature
     should be enabled or not. Keep reading this article to know how to enable

--- a/security/remember_me.rst
+++ b/security/remember_me.rst
@@ -116,7 +116,7 @@ The ``remember_me`` firewall defines the following configuration options:
 
 ``samesite`` (default value: ``null``)
     If set to ``strict``, the cookie associated with this feature will not
-    be send along with cross-site requests, even when following a regular link.
+    be sent along with cross-site requests, even when following a regular link.
 
 ``remember_me_parameter`` (default value: ``_remember_me``)
     The name of the form field checked to decide if the "Remember Me" feature

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -379,3 +379,99 @@ will share identical locators amongst all the services referencing them::
     }
 
 .. _`Command pattern`: https://en.wikipedia.org/wiki/Command_pattern
+
+Service Subscriber Trait
+------------------------
+
+.. versionadded:: 4.2
+    The :class:`Symfony\\Component\\DependencyInjection\\ServiceSubscriberTrait`
+    was introduced in Symfony 4.2.
+
+The :class:`Symfony\\Component\\DependencyInjection\\ServiceSubscriberTrait`
+provides an implementation for
+:class:`Symfony\\Component\\DependencyInjection\\ServiceSubscriberInterface`
+that looks through all methods in your class that have no arguments and a return
+type. It provides a ``ServiceLocator`` for the services of those return types.
+The service id is ``__METHOD__``. This allows you to easily add dependencies
+to your services based on type-hinted helper methods::
+
+    // src/Service/MyService.php
+    namespace App\Service;
+
+    use Psr\Log\LoggerInterface;
+    use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
+    use Symfony\Component\DependencyInjection\ServiceSubscriberTrait;
+    use Symfony\Component\Routing\RouterInterface;
+
+    class MyService implements ServiceSubscriberInterface
+    {
+        use ServiceSubscriberTrait;
+
+        public function doSomething()
+        {
+            // $this->router() ...
+            // $this->logger() ...
+        }
+
+        private function router(): RouterInterface
+        {
+            return $this->container->get(__METHOD__);
+        }
+
+        private function logger(): LoggerInterface
+        {
+            return $this->container->get(__METHOD__);
+        }
+    }
+
+This  allows you to create helper traits like RouterAware, LoggerAware, etc...
+and compose your services with them::
+
+    // src/Service/LoggerAware.php
+    namespace App\Service;
+
+    use Psr\Log\LoggerInterface;
+
+    trait LoggerAware
+    {
+        private function logger(): LoggerInterface
+        {
+            return $this->container->get(__CLASS__.'::'.__FUNCTION__);
+        }
+    }
+
+    // src/Service/RouterAware.php
+    namespace App\Service;
+
+    use Symfony\Component\Routing\RouterInterface;
+
+    trait RouterAware
+    {
+        private function router(): RouterInterface
+        {
+            return $this->container->get(__CLASS__.'::'.__FUNCTION__);
+        }
+    }
+
+    // src/Service/MyService.php
+    namespace App\Service;
+
+    use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
+    use Symfony\Component\DependencyInjection\ServiceSubscriberTrait;
+
+    class MyService implements ServiceSubscriberInterface
+    {
+        use ServiceSubscriberTrait, LoggerAware, RouterAware;
+
+        public function doSomething()
+        {
+            // $this->router() ...
+            // $this->logger() ...
+        }
+    }
+
+.. caution::
+
+    When creating these helper traits, the service id cannot be ``__METHOD__``
+    as this will include the trait name, not the class name. Instead, use
+    ``__CLASS__.'::'.__FUNCTION__`` as the service id.

--- a/testing.rst
+++ b/testing.rst
@@ -422,21 +422,17 @@ returns a ``Crawler`` instance.
 Use the crawler to find DOM elements in the response. These elements can then
 be used to click on links and submit forms::
 
-    $link = $crawler->selectLink('Go elsewhere...')->link();
-    $crawler = $client->click($link);
+    $crawler = $client->clickLink('Go elsewhere...');
 
-    $form = $crawler->selectButton('validate')->form();
-    $crawler = $client->submit($form, array('name' => 'Fabien'));
+    $crawler = $client->submitForm('validate', array('name' => 'Fabien'));
 
-The ``click()`` and ``submit()`` methods both return a ``Crawler`` object.
+The ``clickLink()`` and ``submitForm()`` methods both return a ``Crawler`` object.
 These methods are the best way to browse your application as it takes care
 of a lot of things for you, like detecting the HTTP method from a form and
 giving you a nice API for uploading files.
 
-.. tip::
-
-    You will learn more about the ``Link`` and ``Form`` objects in the
-    :ref:`Crawler <testing-crawler>` section below.
+.. versionadded:: 4.2
+    The ``clickLink()`` and ``submitForm()`` methods were introduced in Symfony 4.2.
 
 The ``request()`` method can also be used to simulate form submissions directly
 or perform more complex requests. Some useful examples::
@@ -715,31 +711,39 @@ The Crawler can extract information from the nodes::
 Links
 ~~~~~
 
-To select links, you can use the traversing methods above or the convenient
-``selectLink()`` shortcut::
+Use the ``clickLink()`` method to click on the first link that contains the
+given text (or the first clickable image with that ``alt`` attribute)::
 
-    $crawler->selectLink('Click here');
+    $client = static::createClient();
+    $client->request('GET', '/post/hello-world');
 
-This selects all links that contain the given text, or clickable images for
-which the ``alt`` attribute contains the given text. Like the other filtering
-methods, this returns another ``Crawler`` object.
+    $client->clickLink('Click here');
 
-Once you've selected a link, you have access to a special ``Link`` object,
-which has helpful methods specific to links (such as ``getMethod()`` and
-``getUri()``). To click on the link, use the Client's ``click()`` method
-and pass it a ``Link`` object::
+If you need access to the :class:`Symfony\\Component\\DomCrawler\\Link` object
+that provides helpful methods specific to links (such as ``getMethod()`` and
+``getUri()``), use the ``selectLink()`` method instead:
+
+    $client = static::createClient();
+    $crawler = $client->request('GET', '/post/hello-world');
 
     $link = $crawler->selectLink('Click here')->link();
-
     $client->click($link);
 
 Forms
 ~~~~~
 
-Forms can be selected using their buttons, which can be selected with the
-``selectButton()`` method, just like links::
+Use the ``submitForm()`` method to submit the form that contains the given button::
 
-    $buttonCrawlerNode = $crawler->selectButton('submit');
+    $client = static::createClient();
+    $client->request('GET', '/post/hello-world');
+
+    $crawler = $client->submitForm('Add comment', array(
+       'comment_form[content]' => '...',
+    ));
+
+The first argument of ``submitForm()`` is the text content, ``id``, ``value`` or
+``name`` of any ``<button>`` or ``<input type="submit">`` included in the form.
+The second optional argument is used to override the default form field values.
 
 .. note::
 
@@ -747,33 +751,28 @@ Forms can be selected using their buttons, which can be selected with the
     buttons; if you use the traversing API, keep in mind that you must look for a
     button.
 
-The ``selectButton()`` method can select ``button`` tags and submit ``input``
-tags. It uses several parts of the buttons to find them:
+If you need access to the :class:`Symfony\\Component\\DomCrawler\\Form` object
+that provides helpful methods specific to forms (such as ``getUri()``,
+``getValues()`` and ``getFields()``) use the ``selectButton()`` method instead::
 
-* The ``value`` attribute value;
-* The ``id`` or ``alt`` attribute value for images;
-* The ``id`` or ``name`` attribute value for ``button`` tags.
+    $client = static::createClient();
+    $crawler = $client->request('GET', '/post/hello-world');
 
-Once you have a Crawler representing a button, call the ``form()`` method
-to get a ``Form`` instance for the form wrapping the button node::
+    $buttonCrawlerNode = $crawler->selectButton('submit');
 
+    // select the form that contains this button
     $form = $buttonCrawlerNode->form();
 
-When calling the ``form()`` method, you can also pass an array of field values
-that overrides the default ones::
-
+    // you can also pass an array of field values that overrides the default ones
     $form = $buttonCrawlerNode->form(array(
         'my_form[name]'    => 'Fabien',
         'my_form[subject]' => 'Symfony rocks!',
     ));
 
-And if you want to simulate a specific HTTP method for the form, pass it as a
-second argument::
-
+    // you can pass a second argument to override the form HTTP method
     $form = $buttonCrawlerNode->form(array(), 'DELETE');
 
-The Client can submit ``Form`` instances::
-
+    // submit the Form object
     $client->submit($form);
 
 The field values can also be passed as a second argument of the ``submit()``
@@ -819,10 +818,11 @@ their type::
 
 .. tip::
 
-    The ``submit()`` method defines a third optional argument to add custom
-    HTTP headers when submitting the form::
+    The ``submit()`` and ``submitForm()`` methods define optional arguments to
+    add custom server parameters and HTTP headers when submitting the form::
 
         $client->submit($form, array(), array('HTTP_ACCEPT_LANGUAGE' => 'es'));
+        $client->submitForm($button, array(), 'POST', array('HTTP_ACCEPT_LANGUAGE' => 'es'));
 
     .. versionadded:: 4.1
         The feature to add custom HTTP headers was introduced in Symfony 4.1.


### PR DESCRIPTION
I think that we should tell that we can implement directly the `MessageHandlerInterface`, to avoid more configuration and to encourage type hinting!

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
