### PR TITLE
[Security] Fix wrong usage in custom authenticator checking if password is invalid

### DIFF
--- a/security/custom_password_authenticator.rst
+++ b/security/custom_password_authenticator.rst
@@ -69,7 +69,7 @@ the user::
                 if ('' === ($givenPassword = $token->getCredentials())) {
                     throw new BadCredentialsException('The given password cannot be empty.');
                 }
-                if (!$this->encoder->isPasswordValid($user->getPassword(), $givenPassword, $user->getSalt())) {
+                if (!$this->encoder->isPasswordValid($user, $givenPassword)) {
                     throw new BadCredentialsException('The given password is invalid.');
                 }
             }


### PR DESCRIPTION
```Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface::isPasswordValid``` expects an UserInterface and a password, but example arguments was provided like for `Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface`
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
