### PR TITLE
Elegant array syntax for consistency

### DIFF
--- a/components/form.rst
+++ b/components/form.rst
@@ -397,9 +397,9 @@ is created from the form factory.
             ->add('dueDate', DateType::class)
             ->getForm();
 
-        var_dump($twig->render('new.html.twig', array(
+        var_dump($twig->render('new.html.twig', [
             'form' => $form->createView(),
-        )));
+        ]));
 
     .. code-block:: php-symfony
 
@@ -423,9 +423,9 @@ is created from the form factory.
                     ->add('dueDate', DateType::class)
                     ->getForm();
 
-                return $this->render('task/new.html.twig', array(
+                return $this->render('task/new.html.twig', [
                     'form' => $form->createView(),
-                ));
+                ]);
             }
         }
 

--- a/components/templating.rst
+++ b/components/templating.rst
@@ -49,7 +49,7 @@ which uses the template reference to actually find and load the template::
 
     $templating = new PhpEngine(new TemplateNameParser(), $filesystemLoader);
 
-    echo $templating->render('hello.php', array('firstname' => 'Fabien'));
+    echo $templating->render('hello.php', ['firstname' => 'Fabien']);
 
 .. code-block:: html+php
 
@@ -85,7 +85,7 @@ to render the template originally) inside the template to render another templat
 
     <?php $names = array('Fabien', ...) ?>
     <?php foreach ($names as $name) : ?>
-        <?php echo $view->render('hello.php', array('firstname' => $name)) ?>
+        <?php echo $view->render('hello.php', ['firstname' => $name]) ?>
     <?php endforeach ?>
 
 Global Variables

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -261,9 +261,9 @@ has one file in it::
         {
             $number = rand(0, $limit);
 
-            return $this->render('micro/random.html.twig', array(
+            return $this->render('micro/random.html.twig', [
                 'number' => $number
-            ));
+            ]);
         }
     }
 

--- a/controller.rst
+++ b/controller.rst
@@ -171,7 +171,7 @@ method renders a template **and** puts that content into a ``Response``
 object for you::
 
     // renders templates/lucky/number.html.twig
-    return $this->render('lucky/number.html.twig', array('number' => $number));
+    return $this->render('lucky/number.html.twig', ['number' => $number]);
 
 Templating and Twig are explained more in the
 :doc:`Creating and Using Templates article </templating>`.

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -112,7 +112,7 @@ service and use it directly::
         {
             $content = $this->twig->render(
                 'hello/index.html.twig',
-                array('name' => $name)
+                ['name' => $name]
             );
 
             return new Response($content);

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -138,9 +138,9 @@ Finally, you need to update the code of the controller that handles the form::
                 return $this->redirect($this->generateUrl('app_product_list'));
             }
 
-            return $this->render('product/new.html.twig', array(
+            return $this->render('product/new.html.twig', [
                 'form' => $form->createView(),
-            ));
+            ]);
         }
 
         /**

--- a/doctrine/registration_form.rst
+++ b/doctrine/registration_form.rst
@@ -282,7 +282,7 @@ into the database::
 
             return $this->render(
                 'registration/register.html.twig',
-                array('form' => $form->createView())
+                ['form' => $form->createView()]
             );
         }
     }

--- a/form/direct_submit.rst
+++ b/form/direct_submit.rst
@@ -24,9 +24,9 @@ submissions::
             return $this->redirectToRoute('task_success');
         }
 
-        return $this->render('product/new.html.twig', array(
+        return $this->render('product/new.html.twig', [
             'form' => $form->createView(),
-        ));
+        ]);
     }
 
 .. tip::
@@ -63,9 +63,9 @@ method, pass the submitted data directly to
             }
         }
 
-        return $this->render('product/new.html.twig', array(
+        return $this->render('product/new.html.twig', [
             'form' => $form->createView(),
-        ));
+        ]);
     }
 
 .. tip::

--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -523,7 +523,7 @@ your application. Assume that you have a sport meetup creation controller::
 
             return $this->render(
                 'meetup/create.html.twig',
-                array('form' => $form->createView())
+                ['form' => $form->createView()]
             );
         }
 

--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -178,9 +178,9 @@ In your controller, you'll create a new form from the ``TaskType``::
                 // ... maybe do some form processing, like saving the Task and Tag objects
             }
 
-            return $this->render('task/new.html.twig', array(
+            return $this->render('task/new.html.twig', [
                 'form' => $form->createView(),
-            ));
+            ]);
         }
     }
 

--- a/forms.rst
+++ b/forms.rst
@@ -113,9 +113,9 @@ from inside a controller::
                 ->add('save', SubmitType::class, array('label' => 'Create Task'))
                 ->getForm();
 
-            return $this->render('default/new.html.twig', array(
+            return $this->render('default/new.html.twig', [
                 'form' => $form->createView(),
-            ));
+            ]);
         }
     }
 
@@ -253,9 +253,9 @@ your controller::
             return $this->redirectToRoute('task_success');
         }
 
-        return $this->render('default/new.html.twig', array(
+        return $this->render('default/new.html.twig', [
             'form' => $form->createView(),
-        ));
+        ]);
     }
 
 .. caution::

--- a/http_cache/validation.rst
+++ b/http_cache/validation.rst
@@ -216,10 +216,10 @@ exposing a simple and efficient pattern::
             $comments = ...;
 
             // or render a template with the $response you've already started
-            return $this->render('article/show.html.twig', array(
+            return $this->render('article/show.html.twig', [
                 'article' => $article,
                 'comments' => $comments,
-            ), $response);
+            ], $response);
         }
     }
 

--- a/security/form_login_setup.rst
+++ b/security/form_login_setup.rst
@@ -151,10 +151,10 @@ Great! Next, add the logic to ``login()`` that displays the login form::
         // last username entered by the user
         $lastUsername = $authenticationUtils->getLastUsername();
 
-        return $this->render('security/login.html.twig', array(
+        return $this->render('security/login.html.twig', [
             'last_username' => $lastUsername,
             'error'         => $error,
-        ));
+        ]);
     }
 
 .. note::

--- a/templating/PHP.rst
+++ b/templating/PHP.rst
@@ -76,9 +76,9 @@ below renders the ``index.html.php`` template::
     public function index($name)
     {
         // template is stored in src/Resources/views/hello/index.html.php
-        return $this->render('hello/index.html.php', array(
+        return $this->render('hello/index.html.php', [
             'name' => $name
-        ));
+        ]);
     }
 
 .. caution::
@@ -230,7 +230,7 @@ And change the ``index.html.php`` template to include it:
     <!-- src/Resources/views/hello/index.html.php -->
     <?php $view->extend('layout.html.php') ?>
 
-    <?php echo $view->render('hello/hello.html.php', array('name' => $name)) ?>
+    <?php echo $view->render('hello/hello.html.php', ['name' => $name]) ?>
 
 The ``render()`` method evaluates and returns the content of another template
 (this is the exact same method as the one used in the controller).

--- a/templating/PHP.rst
+++ b/templating/PHP.rst
@@ -254,10 +254,10 @@ If you create a ``fancy`` action, and want to include it into the
     <?php echo $view['actions']->render(
         new \Symfony\Component\HttpKernel\Controller\ControllerReference(
             'App\Controller\HelloController::fancy',
-            array(
+            [
                 'name'  => $name,
                 'color' => 'green',
-            )
+            ]
         )
     ) ?>
 

--- a/templating/embedding_controllers.rst
+++ b/templating/embedding_controllers.rst
@@ -41,7 +41,7 @@ First, create a controller that renders a certain number of recent articles::
 
             return $this->render(
                 'article/recent_list.html.twig',
-                array('articles' => $articles)
+                ['articles' => $articles]
             );
         }
     }

--- a/templating/formats.rst
+++ b/templating/formats.rst
@@ -37,9 +37,9 @@ pattern is to do the following::
 
             $format = $request->getRequestFormat();
 
-            return $this->render('article/show.'.$format.'.twig', array(
+            return $this->render('article/show.'.$format.'.twig', [
                 'article' => $article,
-            ));
+            ]);
         }
     }
 

--- a/validation.rst
+++ b/validation.rst
@@ -177,9 +177,9 @@ will appear.
 You could also pass the collection of errors into a template::
 
     if (count($errors) > 0) {
-        return $this->render('author/validation.html.twig', array(
+        return $this->render('author/validation.html.twig', [
             'errors' => $errors,
-        ));
+        ]);
     }
 
 Inside the template, you can output the list of errors exactly as needed:


### PR DESCRIPTION
Updated multiple files to use the short and elegant array syntax for consistency in all occurrences of Twig's `render()` function.

Using the 4.1 branch as this commit with the same fix for short array syntax was also merged to 4.1: https://github.com/symfony/symfony-docs/commit/1bbaa64e4631b25e1a07b4b7724748a2e2faa6c0