### PR TITLE
Shorten ternary operator

### DIFF
--- a/reference/forms/twig_reference.rst
+++ b/reference/forms/twig_reference.rst
@@ -340,7 +340,7 @@ done by using a public ``vars`` property on the
 .. code-block:: html+twig
 
     <label for="{{ form.name.vars.id }}"
-        class="{{ form.name.vars.required ? 'required' : '' }}">
+        class="{{ form.name.vars.required ? 'required' }}">
         {{ form.name.vars.label }}
     </label>
 


### PR DESCRIPTION
Small fix, shorten the ternary operator as it does exactly the same: https://github.com/twigphp/Twig/blob/2.x/doc/templates.rst#other-operators (see ternary)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
