### PR TITLE
[Console] Replace useless usage of ContainerAwareCommand

### DIFF
--- a/console/request_context.rst
+++ b/console/request_context.rst
@@ -78,12 +78,14 @@ router service and override its settings::
     use Symfony\Component\Routing\RouterInterface;
     // ...
 
-    class DemoCommand extends ContainerAwareCommand
+    class DemoCommand extends Command
     {
         private $router;
 
         public function __construct(RouterInterface $router)
         {
+            parent::__construct();
+        
             $this->router = $router;
         }
 


### PR DESCRIPTION
Hello.
Since SF 4.0 there is no need to use `ContainerAwareCommand` and injection through constructor. I removed usage of `ContainerAwareCommand` and added call of parent `constructor` because there is an error without it:
```
[WARNING] Some commands could not be registered:                                                                       
Command class "App\Command\CommandName" is not correctly initialized. You probably forgot to call the parent constructor.  
```