### PR TITLE
[Security] Fix wrong exception used in custom authentication provider example

### DIFF
--- a/security/custom_authentication_provider.rst
+++ b/security/custom_authentication_provider.rst
@@ -206,7 +206,6 @@ the ``PasswordDigest`` header value matches with the user's password::
     use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
     use Symfony\Component\Security\Core\User\UserProviderInterface;
     use Symfony\Component\Security\Core\Exception\AuthenticationException;
-    use Symfony\Component\Security\Core\Exception\NonceExpiredException;
     use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
     use App\Security\Authentication\Token\WsseUserToken;
 
@@ -259,7 +258,9 @@ the ``PasswordDigest`` header value matches with the user's password::
             // Validate that the nonce is *not* in cache
             // if it is, this could be a replay attack
             if ($cacheItem->isHit()) {
-                throw new NonceExpiredException('Previously used nonce detected');
+                // In a real world application you should throw a custom
+                // exception extending the AuthenticationException
+                throw new AuthenticationException('Previously used nonce detected');
             }
 
             // Store the item in cache for 5 minutes


### PR DESCRIPTION
Closes #10217

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
