### PR TITLE
Added MessageHandlerInterface

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -49,7 +49,9 @@ message handler. It's a class with an ``__invoke`` method::
     // src/MessageHandler/MyMessageHandler.php
     namespace App\MessageHandler;
 
-    class MyMessageHandler
+    use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+    class MyMessageHandler implements MessageHandlerInterface
     {
         public function __invoke(MyMessage $message)
         {
@@ -57,7 +59,7 @@ message handler. It's a class with an ``__invoke`` method::
         }
     }
 
-Once you've created your handler, you need to register it:
+Once you've created your handler, you need to register it (this is done automatically if you have implemented the MessageHandlerInterface):
 
 .. configuration-block::
 


### PR DESCRIPTION
Related to #10212, you can delete this one, I don't know how I've done it but I totally messed up with my branches, so I've made a new one here, sorry!

I think that we should tell that we can implement directly the `MessageHandlerInterface`, to avoid more configuration and to encourage type hinting!

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
