### PR TITLE
Add a tip for interface use in ArgumentResolver

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -110,6 +110,14 @@ type-hinted method arguments:
             ),
         ));
 
+
+.. tip::
+    To keep Doctrine's `@ParamConverter` enabled, simply use an interface instead of an object.
+    
+    For example, using a `App\Interface\CustomUserInterface` instead of your `App\Entity\User`
+    will allow you to inject the interface while still using `@ParamConverter` for entities.
+
+
 Adding a new value resolver requires creating a class that implements
 :class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentValueResolverInterface`
 and defining a service for it. The interface defines two methods:


### PR DESCRIPTION
Add a tip to inform about the use of an interface for the ArgumentResolver, which allow the user to keep `@ParamConverter` enabled.
