### PR TITLE
Fixing inconcistency - subscribr to listener

### DIFF
--- a/session/locale_sticky_session.rst
+++ b/session/locale_sticky_session.rst
@@ -139,22 +139,20 @@ want to use this as the locale for the given user. To accomplish this,
 you can hook into the login process and update the user's session with this
 locale value before they are redirected to their first page.
 
-To do this, you need an event subscriber on the ``security.interactive_login``
+To do this, you need an event listener on the ``security.interactive_login``
 event::
 
-    // src/EventSubscriber/UserLocaleSubscriber.php
+    // src/EventSubscriber/UserLocaleListener.php
     namespace App\EventSubscriber;
 
-    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
     use Symfony\Component\HttpFoundation\Session\SessionInterface;
     use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
-    use Symfony\Component\Security\Http\SecurityEvents;
 
     /**
      * Stores the locale of the user in the session after the
      * login. This can be used by the LocaleSubscriber afterwards.
      */
-    class UserLocaleSubscriber implements EventSubscriberInterface
+    class UserLocaleListener
     {
         private $session;
 


### PR DESCRIPTION
There was incomplete subscriber  class that looked like leftover. It has been provided with config snippet for listener.
I'm guessing recommendation changed from subscriber to listener, as it makes more sense here.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
