### PR TITLE
[Flex] Use Flex aliases for security-checker & requirements-checker

### DIFF
--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -13,7 +13,7 @@ your system meets all those requirements. Run this command to install the tool:
 .. code-block:: terminal
 
     $ cd your-project/
-    $ composer require requirements-checker
+    $ composer require req-check
 
 Beware that PHP can define a different configuration for the command console and
 the web server, so you need to check requirements in both environments.
@@ -31,7 +31,7 @@ to avoid leaking internal information about your application to visitors:
 .. code-block:: terminal
 
     $ cd your-project/
-    $ composer remove requirements-checker
+    $ composer remove req-check
 
 Checking Requirements for the Command Console
 ---------------------------------------------

--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -13,7 +13,7 @@ your system meets all those requirements. Run this command to install the tool:
 .. code-block:: terminal
 
     $ cd your-project/
-    $ composer require symfony/requirements-checker
+    $ composer require requirements-checker
 
 Beware that PHP can define a different configuration for the command console and
 the web server, so you need to check requirements in both environments.
@@ -31,7 +31,7 @@ to avoid leaking internal information about your application to visitors:
 .. code-block:: terminal
 
     $ cd your-project/
-    $ composer remove symfony/requirements-checker
+    $ composer remove requirements-checker
 
 Checking Requirements for the Command Console
 ---------------------------------------------

--- a/setup.rst
+++ b/setup.rst
@@ -121,7 +121,7 @@ command to install it in your application:
 .. code-block:: terminal
 
     $ cd my-project/
-    $ composer require sensiolabs/security-checker --dev
+    $ composer require security-checker --dev
 
 From now on, this utility will be run automatically whenever you install or
 update any dependency in the application. If a dependency contains a vulnerability,

--- a/setup.rst
+++ b/setup.rst
@@ -121,7 +121,7 @@ command to install it in your application:
 .. code-block:: terminal
 
     $ cd my-project/
-    $ composer require security-checker --dev
+    $ composer require sec-check --dev
 
 From now on, this utility will be run automatically whenever you install or
 update any dependency in the application. If a dependency contains a vulnerability,


### PR DESCRIPTION
Since we assume the user uses Flex by default since 4.1, I think it's a good idea to use the Flex aliases to shorten the commands to install the `security-checker` and `requirements-checker`.