### PR TITLE
[Deployment] Updated building assets in favor of Encore over Assetic

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -108,16 +108,6 @@ Basic scripting
     You can of course use shell, `Ant`_ or any other build tool to script
     the deploying of your project.
 
-Common Pre-Deployment Tasks
-----------------------------
-
-Before deploying your Symfony project, there are a number of common tasks you might need to do:
-
-A) Building and Minifying your Assets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Follow these steps to get started building and minifying your assets: :ref:`how-do-i-deploy-my-encore-assets`.
-
 Common Post-Deployment Tasks
 ----------------------------
 
@@ -196,6 +186,7 @@ setup:
 * Running any database migrations
 * Clearing your APC cache
 * Add/edit CRON jobs
+* ref:`Building and minifying your assets <how-do-i-deploy-my-encore-assets>` with Webpack Encore
 * Pushing assets to a CDN
 * ...
 

--- a/deployment.rst
+++ b/deployment.rst
@@ -114,7 +114,7 @@ Common Pre-Deployment Tasks
 Before deploying your Symfony project, there are a number of common tasks you might need to do:
 
 A) Building and Minifying your Assets
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Follow these steps to get started building and minifying your assets: :ref:`how-do-i-deploy-my-encore-assets`.
 

--- a/deployment.rst
+++ b/deployment.rst
@@ -108,6 +108,16 @@ Basic scripting
     You can of course use shell, `Ant`_ or any other build tool to script
     the deploying of your project.
 
+Common Pre-Deployment Tasks
+----------------------------
+
+Before deploying your Symfony project, there are a number of common tasks you might need to do:
+
+A) Building and Minifying your Assets
+~~~~~~~~~~~~~~~~~~~~
+
+Follow these steps to get started building and minifying your assets: :ref:`how-do-i-deploy-my-encore-assets`.
+
 Common Post-Deployment Tasks
 ----------------------------
 
@@ -177,16 +187,7 @@ Make sure you clear and warm-up your Symfony cache:
 
     $ php bin/console cache:clear --env=prod --no-debug
 
-E) Dump your Assetic Assets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you're using Assetic, you'll also want to dump your assets:
-
-.. code-block:: terminal
-
-    $ php bin/console assetic:dump --env=prod --no-debug
-
-F) Other Things!
+E) Other Things!
 ~~~~~~~~~~~~~~~~
 
 There may be lots of other things that you need to do, depending on your
@@ -194,7 +195,6 @@ setup:
 
 * Running any database migrations
 * Clearing your APC cache
-* Running ``assets:install`` (already taken care of in ``composer install``)
 * Add/edit CRON jobs
 * Pushing assets to a CDN
 * ...

--- a/frontend/encore/faq.rst
+++ b/frontend/encore/faq.rst
@@ -1,6 +1,8 @@
 FAQ and Common Issues
 =====================
 
+.. _how-do-i-deploy-my-encore-assets:
+
 How do I deploy my Encore Assets?
 ---------------------------------
 


### PR DESCRIPTION
The deployment page isn't up-to-date since we're using Encore instead of Assetic. So in this PR I added a pre-deployment task referring to the explanation of deploying assets using Encore. I also removed the part about dumping the assets using Assetic. If someone could however take a look if I did the reference thing correct, that would be a great help. This PR would close #9887 and close #8094.