### PR TITLE
Move range to the comparison constraint types

### DIFF
--- a/reference/constraints.rst
+++ b/reference/constraints.rst
@@ -23,8 +23,6 @@ Validation Constraints Reference
    constraints/Ip
    constraints/Uuid
 
-   constraints/Range
-
    constraints/EqualTo
    constraints/NotEqualTo
    constraints/IdenticalTo
@@ -33,6 +31,7 @@ Validation Constraints Reference
    constraints/LessThanOrEqual
    constraints/GreaterThan
    constraints/GreaterThanOrEqual
+   constraints/Range
 
    constraints/Date
    constraints/DateTime

--- a/reference/constraints/map.rst.inc
+++ b/reference/constraints/map.rst.inc
@@ -22,11 +22,6 @@ String Constraints
 * :doc:`Ip </reference/constraints/Ip>`
 * :doc:`Uuid</reference/constraints/Uuid>`
 
-Number Constraints
-~~~~~~~~~~~~~~~~~~
-
-* :doc:`Range </reference/constraints/Range>`
-
 Comparison Constraints
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -38,6 +33,7 @@ Comparison Constraints
 * :doc:`LessThanOrEqual </reference/constraints/LessThanOrEqual>`
 * :doc:`GreaterThan </reference/constraints/GreaterThan>`
 * :doc:`GreaterThanOrEqual </reference/constraints/GreaterThanOrEqual>`
+* :doc:`Range </reference/constraints/Range>`
 
 Date Constraints
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As the [Range](http://symfony.com/doc/3.4/reference/constraints/Range.html) constraint also work for **date** fields  the section headline [Number Constraints](http://symfony.com/doc/3.4/reference/constraints.html#number-constraints) is misleading. As I first thought that the Range will work only for numbers then.

fixes #10229