### PR TITLE
Fix #10250 - remove manual class discriminator configuration

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1217,9 +1217,14 @@ between the possible objects. In practice, when using the Serializer component,
 pass a :class:`Symfony\\Component\\Serializer\\Mapping\\ClassDiscriminatorResolverInterface`
 implementation to the :class:`Symfony\\Component\\Serializer\\Normalizer\\ObjectNormalizer`.
 
-Consider an application that defines an abstract ``CodeRepository`` class
-extended by ``GitHubCodeRepository`` and ``BitBucketCodeRepository`` classes.
-This example shows how to serialize and deserialize those objects::
+The Serializer component provides an implementation of ``ClassDiscriminatorResolverInterface``
+called :class:`Symfony\\Component\\Serializer\\Mapping\\ClassDiscriminatorFromClassMetadata`
+which uses the class metadata factory and a mapping configuration to serialize
+and deserialize objects of the correct class.
+
+When using the Symfony Standard Edition and the class metadata factory is enabled
+as explained in the :ref:`Attributes Groups section <component-serializer-attributes-groups>`,
+this is already set up and you only need to provide the configuration. Otherwise::
 
     // ...
     use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -1237,15 +1242,9 @@ This example shows how to serialize and deserialize those objects::
         array('json' => new JsonEncoder())
     );
 
-    $serialized = $serializer->serialize(new GitHubCodeRepository());
-    // {"type": "github"}
-
-    $repository = $serializer->deserialize($serialized, CodeRepository::class, 'json');
-    // instanceof GitHubCodeRepository
-
-If the class metadata factory is enabled as explained in the
-:ref:`Attributes Groups section <component-serializer-attributes-groups>`, you
-can use this simpler configuration:
+Now configure your discriminator class mapping. Consider an application that
+defines an abstract ``CodeRepository`` class extended by ``GitHubCodeRepository``
+and ``BitBucketCodeRepository`` classes:
 
 .. configuration-block::
 
@@ -1290,6 +1289,16 @@ can use this simpler configuration:
                 </discriminator-map>
             </class>
         </serializer>
+
+
+Once configured, the serializer uses the mapping to pick the correct class::
+
+    $serialized = $serializer->serialize(new GitHubCodeRepository());
+    // {"type": "github"}
+
+    $repository = $serializer->deserialize($serialized, CodeRepository::class, 'json');
+    // instanceof GitHubCodeRepository
+
 
 Learn more
 ----------

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1231,10 +1231,6 @@ This example shows how to serialize and deserialize those objects::
     $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
 
     $discriminator = new ClassDiscriminatorFromClassMetadata($classMetadataFactory);
-    $discriminator->addClassMapping(CodeRepository::class, new ClassDiscriminatorMapping('type', [
-        'github' => GitHubCodeRepository::class,
-        'bitbucket' => BitBucketCodeRepository::class,
-    ]));
 
     $serializer = new Serializer(
         array(new ObjectNormalizer($classMetadataFactory, null, null, null, $discriminator)),

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -424,7 +424,7 @@ Converting Property Names when Serializing and Deserializing
 Sometimes serialized attributes must be named differently than properties
 or getter/setter methods of PHP classes.
 
-The Serializer Component provides a handy way to translate or map PHP field
+The Serializer component provides a handy way to translate or map PHP field
 names to serialized names: The Name Converter System.
 
 Given you have the following object::
@@ -582,7 +582,7 @@ There are several types of normalizers available:
     ``firstName``).
 
     The ``ObjectNormalizer`` is the most powerful normalizer. It is configured by
-    default when using the Symfony Standard Edition with the serializer enabled.
+    default in Symfony applications with the Serializer component enabled.
 
 :class:`Symfony\\Component\\Serializer\\Normalizer\\GetSetMethodNormalizer`
     This normalizer reads the content of the class by calling the "getters"
@@ -672,8 +672,8 @@ The Serializer component provides several built-in encoders:
 :class:`Symfony\\Component\\Serializer\\Encoder\\CsvEncoder`
     This encoder encodes and decodes data in CSV_.
 
-All these encoders are enabled by default when using the Symfony Standard Edition
-with the serializer enabled.
+All these encoders are enabled by default when using the Serializer component 
+in a Symfony application.
 
 The ``JsonEncoder``
 ~~~~~~~~~~~~~~~~~~~
@@ -908,8 +908,8 @@ Here, we set it to 2 for the ``$child`` property:
         </serializer>
 
 The metadata loader corresponding to the chosen format must be configured in
-order to use this feature. It is done automatically when using the Symfony
-Standard Edition. When using the standalone component, refer to
+order to use this feature. It is done automatically when using the Serializer component
+in a Symfony application. When using the standalone component, refer to
 :ref:`the groups documentation <component-serializer-attributes-groups>` to
 learn how to do that.
 
@@ -1138,11 +1138,11 @@ context option::
 Recursive Denormalization and Type Safety
 -----------------------------------------
 
-The Serializer Component can use the :doc:`PropertyInfo Component </components/property_info>` to denormalize
+The Serializer component can use the :doc:`PropertyInfo Component </components/property_info>` to denormalize
 complex types (objects). The type of the class' property will be guessed using the provided
 extractor and used to recursively denormalize the inner data.
 
-When using the Symfony Standard Edition, all normalizers are automatically configured to use the registered extractors.
+When using this component in a Symfony application, all normalizers are automatically configured to use the registered extractors.
 When using the component standalone, an implementation of :class:`Symfony\\Component\\PropertyInfo\\PropertyTypeExtractorInterface`,
 (usually an instance of :class:`Symfony\\Component\\PropertyInfo\\PropertyInfoExtractor`) must be passed as the 4th
 parameter of the ``ObjectNormalizer``::
@@ -1222,7 +1222,7 @@ called :class:`Symfony\\Component\\Serializer\\Mapping\\ClassDiscriminatorFromCl
 which uses the class metadata factory and a mapping configuration to serialize
 and deserialize objects of the correct class.
 
-When using the Symfony Standard Edition and the class metadata factory is enabled
+When using this component inside a Symfony application and the class metadata factory is enabled
 as explained in the :ref:`Attributes Groups section <component-serializer-attributes-groups>`,
 this is already set up and you only need to provide the configuration. Otherwise::
 
@@ -1311,7 +1311,7 @@ Learn more
 
 .. seealso::
 
-    A popular alternative to the Symfony Serializer Component is the third-party
+    A popular alternative to the Symfony Serializer component is the third-party
     library, `JMS serializer`_ (versions before ``v1.12.0`` were released under
     the Apache license, so incompatible with GPLv2 projects).
 


### PR DESCRIPTION
As discussed in #10250, the documentation refers to functionality that sadly does not exist ([yet!](https://github.com/symfony/symfony/pull/28351))
To fix this:

* I've removed the reference to `addClassMap()`
* Rearranged the section slightly to reflect that the `ClassDiscriminatorFromClassMetadata` resolver is already set up when using the Symfony framework.
* Split the example into separate setup and example usage blocks.

I think this is the first time I've done more to the symfony docs than fix a typo, so I'm sorry and please be gentle with me if I've messed anything up :)