### PR TITLE
Small fix to syntax of Return Type Declaration

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -237,7 +237,7 @@ First, create your receiver::
            $this->filePath = $filePath;
        }
 
-       public function receive(callable $handler) : void
+       public function receive(callable $handler): void
        {
            $ordersFromCsv = $this->serializer->deserialize(file_get_contents($this->filePath), 'csv');
 


### PR DESCRIPTION
As in the PHP documentation: http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration