### PR TITLE
Fix broken link to Security tutorial

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1348,4 +1348,4 @@ Other Security Related Topics
 .. _`frameworkextrabundle documentation`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html
 .. _`HWIOAuthBundle`: https://github.com/hwi/HWIOAuthBundle
 .. _`Symfony ACL bundle`: https://github.com/symfony/acl-bundle
-.. _`Symfony Security screencast series`: https://knpuniversity.com/screencast/symfony4-security
+.. _`Symfony Security screencast series`: https://knpuniversity.com/screencast/symfony-security


### PR DESCRIPTION
Affected Symfony 4 version only