### PR TITLE
[Console] Remove mentions about the deprecated ContainerAwareCommand

### DIFF
--- a/console/commands_as_services.rst
+++ b/console/commands_as_services.rst
@@ -13,12 +13,6 @@ recommended setup.
     You can also manually register your command as a service by configuring the service
     and :doc:`tagging it </service_container/tags>` with ``console.command``.
 
-In either case, if your class extends :class:`Symfony\\Bundle\\FrameworkBundle\\Command\\ContainerAwareCommand`,
-you can access public services via ``$this->getContainer()->get('SERVICE_ID')``.
-
-But if your class is registered as a service, you can instead access services by
-using normal :ref:`dependency injection <services-constructor-injection>`.
-
 For example, suppose you want to log something from within your command::
 
     namespace App\Command;

--- a/console/commands_as_services.rst
+++ b/console/commands_as_services.rst
@@ -60,6 +60,13 @@ works! You can call the ``app:sunshine`` command and start logging.
     work (e.g. making database queries), as that code will be run, even if you're using
     the console to execute a different command.
 
+.. note::
+
+    In previous Symfony versions, you could make the command class extend from
+    :class:`Symfony\\Bundle\\FrameworkBundle\\Command\\ContainerAwareCommand` to
+    get services via ``$this->getContainer()->get('SERVICE_ID')``. This is
+    deprecated in Symfony 4.2 and it won't work in future Symfony versions.
+
 .. _console-command-service-lazy-loading:
 
 Lazy Loading

--- a/console/style.rst
+++ b/console/style.rst
@@ -13,11 +13,11 @@ Consider for example the code used to display the title of the following command
     // src/Command/GreetCommand.php
     namespace App\Command;
 
-    use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+    use Symfony\Component\Console\Command\Command;
     use Symfony\Component\Console\Input\InputInterface;
     use Symfony\Component\Console\Output\OutputInterface;
 
-    class GreetCommand extends ContainerAwareCommand
+    class GreetCommand extends Command
     {
         // ...
 
@@ -53,12 +53,12 @@ title of the command::
     // src/Command/GreetCommand.php
     namespace App\Command;
 
-    use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+    use Symfony\Component\Console\Command\Command;
     use Symfony\Component\Console\Style\SymfonyStyle;
     use Symfony\Component\Console\Input\InputInterface;
     use Symfony\Component\Console\Output\OutputInterface;
 
-    class GreetCommand extends ContainerAwareCommand
+    class GreetCommand extends Command
     {
         // ...
 
@@ -355,10 +355,11 @@ of your commands to change their appearance::
     namespace App\Console;
 
     use App\Console\CustomStyle;
+    use Symfony\Component\Console\Command\Command;
     use Symfony\Component\Console\Input\InputInterface;
     use Symfony\Component\Console\Output\OutputInterface;
 
-    class GreetCommand extends ContainerAwareCommand
+    class GreetCommand extends Command
     {
         // ...
 


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/pull/28415