### PR TITLE
Update 3.3-di-changes.rst

### DIFF
--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -577,6 +577,13 @@ Start by updating the service ids to class names:
     account when looking up for services.
     Furthermore it is always recommended to check for definition existence
     using ``has()`` function.
+    
+.. note::
+
+    If you get rid of deprecations and extend `AbstractController` instead of `Controller` for
+    your controllers, you can skip the rest of this step as `AbstractController` won't provide 
+    a containe where you can get the services directly. All services need to be injected as 
+    explained in `Step 5 Cleanup`_
 
 But, this change will break our app! The old service ids (e.g. ``app.github_notifier``)
 no longer exist. The simplest way to fix this is to find all your old service ids
@@ -790,3 +797,5 @@ can be autowired. The final configuration looks like this:
 You can now take advantage of the new features going forward.
 
 .. _`FrameworkExtension for 3.3.0`: https://github.com/symfony/symfony/blob/7938fdeceb03cc1df277a249cf3da70f0b50eb98/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L247-L284
+
+.. _`Step 5 Cleanup`: https://github.com/symfony/symfony-docs/blob/master/service_container/3.3-di-changes.rst#step-5-cleanup

--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -580,10 +580,10 @@ Start by updating the service ids to class names:
     
 .. note::
 
-    If you get rid of deprecations and extend `AbstractController` instead of `Controller` for
-    your controllers, you can skip the rest of this step as `AbstractController` won't provide 
-    a containe where you can get the services directly. All services need to be injected as 
-    explained in `Step 5 Cleanup`_
+    If you get rid of deprecations and extend ``AbstractController`` instead of ``Controller`` for
+    your controllers, you can skip the rest of this step as `AbstractController` won't provide a 
+    container where you can get the services directly. All services need to be injected as explained 
+    in the :ref:`step 5 of this article <step-5>`.
 
 But, this change will break our app! The old service ids (e.g. ``app.github_notifier``)
 no longer exist. The simplest way to fix this is to find all your old service ids
@@ -796,6 +796,4 @@ can be autowired. The final configuration looks like this:
 
 You can now take advantage of the new features going forward.
 
-.. _`FrameworkExtension for 3.3.0`: https://github.com/symfony/symfony/blob/7938fdeceb03cc1df277a249cf3da70f0b50eb98/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L247-L284
-
-.. _`Step 5 Cleanup`: https://github.com/symfony/symfony-docs/blob/master/service_container/3.3-di-changes.rst#step-5-cleanup
+.. _`FrameworkExtension for 3.3.0`: https://github.com/symfony/symfony/blob/7938fdeceb03cc1df277a249cf3da70f0b50eb98/src/Symfony/Bundle/FrameworkBundle/Dependen

--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -715,6 +715,8 @@ will be used. If you *don't* have this, the auto-registration feature will try t
 register a third ``ApiClient`` service and use that for autowiring (which will fail,
 because the class has a non-autowireable argument).
 
+.. _step-5:
+
 Step 5) Cleanup!
 ~~~~~~~~~~~~~~~~
 

--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -796,4 +796,4 @@ can be autowired. The final configuration looks like this:
 
 You can now take advantage of the new features going forward.
 
-.. _`FrameworkExtension for 3.3.0`: https://github.com/symfony/symfony/blob/7938fdeceb03cc1df277a249cf3da70f0b50eb98/src/Symfony/Bundle/FrameworkBundle/Dependen
+.. _`FrameworkExtension for 3.3.0`: https://github.com/symfony/symfony/blob/7938fdeceb03cc1df277a249cf3da70f0b50eb98/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L247-L284


### PR DESCRIPTION
Looking at deprecations of 4.2, I noticed that extending `AbstractController` will prevent you from getting the services (even public ones) from container. This should be reported.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
