### PR TITLE
Missing root node in yaml example

### DIFF
--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -18,20 +18,21 @@ be a boolean value"):
 
 .. code-block:: yaml
 
-    auto_connect: true
-    default_connection: mysql
-    connections:
-        mysql:
-            host:     localhost
-            driver:   mysql
-            username: user
-            password: pass
-        sqlite:
-            host:     localhost
-            driver:   sqlite
-            memory:   true
-            username: user
-            password: pass
+    database:
+        auto_connect: true
+        default_connection: mysql
+        connections:
+            mysql:
+                host:     localhost
+                driver:   mysql
+                username: user
+                password: pass
+            sqlite:
+                host:     localhost
+                driver:   sqlite
+                memory:   true
+                username: user
+                password: pass
 
 When loading multiple configuration files, it should be possible to merge
 and overwrite some values. Other values should not be merged and stay as


### PR DESCRIPTION
The `database` root node which is present in `getConfigTreeBuilder` is not visible in the yaml chunk above.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
