### PR TITLE
added mentoring and speaker mentoring sections

### DIFF
--- a/contributing/community/index.rst
+++ b/contributing/community/index.rst
@@ -7,4 +7,6 @@ Community
     releases
     review-comments
     reviews
+    mentoring
+    speaker-mentoring
     other

--- a/contributing/community/mentoring.rst
+++ b/contributing/community/mentoring.rst
@@ -1,0 +1,15 @@
+Mentoring
+=========
+
+Reading the :doc:`contributing </contributing/index>` is already a great way
+to get started on becoming a Symfony contributor. However, sometimes
+it might still seem overwhelming - contributing can be complex! For this
+purpose we created a dedicated `Symfony Slack`_ channel called `#mentoring`_
+to connect new contributors to long-time contributors. This is a great way
+to get one-on-one advice on the entire process. These long-time contributors
+do really want to helpl new contributors - so feel free to ask anything!
+
+.. _`Symfony Slack`: https://symfony.com/slack-invite
+.. _`#mentoring`:    https://symfony-devs.slack.com/messages/mentoring
+
+

--- a/contributing/community/speaker-mentoring.rst
+++ b/contributing/community/speaker-mentoring.rst
@@ -1,0 +1,44 @@
+Speaker Mentoring
+=================
+
+The Symfony community benefits greatly when as many people as possible
+sharing their knowledge and experience with others. Every different
+point of view adds to our collective understanding of how to best use
+and evolve the code, design patterns and architecture provided within
+the Symfony community. Because of this, we specifically want to hear
+from long-time contributors and new users, who often come across entirely
+different challenges with a totally fresh new look and perspective.
+
+How to get started
+------------------
+
+Giving a first talk at a conference can seem quite intimidating. But
+don't worry! At one time, every speaker went through the same process.
+And so, we want to make sure that as many people as possible are empowered
+to take this path if they are motivated. We have collected a few resources
+with advice to get started. More importantly, we can connect experienced
+speakers with people who are just taking their first steps in this area:
+
+.. tip::
+
+    A good first step might be to give a talk at a local user group to a
+    smaller crowd that one knows more intimately. A next step could be to
+    give a talk at conference in your first language.
+
+The best way to find people that can review your talk idea or slides is
+the `#speaker-mentoring`_ channel on `Symfony Slack`_. There are many
+seasoned speakers with knowledge in various parts of Symfony that are
+motivated to help you get started on your path towards becoming a
+public speaker. They can even do practice runs via video chat!
+Furthermore, they can also be an ally when it comes to the day of
+giving the talk at a conference!
+
+A great resource with advice on everything related to`public speaking`_
+is a collection of links maintained by VM (Vicky) Brasseur. It covers
+everything from finding a conference call for proposals, how to
+refine a proposal, to how to put together slide decks to practical
+tips for preparation and talk delivery.
+
+.. _`#speaker-mentoring`: https://symfony-devs.slack.com/messages/speaker-mentoring
+.. _`Symfony Slack`:      https://symfony.com/slack-invite
+.. _`public speaking`:    https://github.com/vmbrasseur/Public_Speaking


### PR DESCRIPTION
I decided to have separate sections for code/doc mentoring and speaker mentoring mostly because I wanted `speaker mentoring` to show up in the index.
