### PR TITLE
Update templating.rst - remove view[slots] variable

### DIFF
--- a/templating.rst
+++ b/templating.rst
@@ -412,9 +412,8 @@ ease the work of the template designer. In PHP, the templating system provides
 an extensible *helper* system that provides useful features in a template
 context.
 
-You've already seen a few built-in Twig tags (``{% block %}`` & ``{% extends %}``)
-as well as an example of a PHP helper (``$view['slots']``). Here you will learn a
-few more.
+You've already seen a few built-in Twig tags like (``{% block %}`` & ``{% extends %}``). 
+Here you will learn a few more.
 
 .. index::
    single: Templating; Including other templates


### PR DESCRIPTION
Remove information about unused `$view['slots']` variable. It is removed since 2.8 version documentation.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
