### PR TITLE
[Fix] Fixed the link to Functional Tests

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -48,7 +48,7 @@ Unit Tests
 
 A unit test is a test against a single PHP class, also called a *unit*. If you
 want to test the overall behavior of your application, see the section about
-`Functional Tests`_.
+:ref:`Functional Tests <functional-tests>`.
 
 Writing Symfony unit tests is no different from writing standard PHPUnit
 unit tests. Suppose, for example, that you have an *incredibly* simple class


### PR DESCRIPTION
Fixed a link to Functional Tests, was referring to `#id1` instead of  `#functional-tests`. See the Functional Tests link in the following paragraph: https://symfony.com/doc/current/testing.html#unit-tests