### PR TITLE
There is no public folder in 3.4

### DIFF
--- a/frontend/encore/installation-no-flex.rst
+++ b/frontend/encore/installation-no-flex.rst
@@ -39,7 +39,7 @@ Next, create a new ``webpack.config.js`` file at the root of your project:
 
     Encore
         // directory where compiled assets will be stored
-        .setOutputPath('public/build/')
+        .setOutputPath('web/build/')
         // public path used by the web server to access the output path
         .setPublicPath('/build')
         // only needed for CDN's or sub-directory deploy


### PR DESCRIPTION
There is no public/ folder in 3.4 instead there is web/ folder.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
