### PR TITLE
correct a typo in a namespace loading

### DIFF
--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -35,8 +35,8 @@ but usually you would simply extend the
     // src/Acme/HelloBundle/DependencyInjection/AcmeHelloExtension.php
     namespace Acme\HelloBundle\DependencyInjection;
 
-    use Symfony\Component\HttpKernel\DependencyInjection\Extension;
     use Symfony\Component\DependencyInjection\ContainerBuilder;
+    use Symfony\Component\DependencyInjection\Extension\Extension;
 
     class AcmeHelloExtension extends Extension
     {


### PR DESCRIPTION
the correct namespace is not `Symfony\Component\HttpKernel\DependencyInjection\Extension` but `Symfony\Component\DependencyInjection\Extension\Extension`.

The mistake is present on all versions of the doc I checked, so I propose the correction on the oldest LTS but ie the 4.2 also have the typo.


If using the typo, the code still works because `Symfony\Component\HttpKernel\DependencyInjection\Extension` extends `Symfony\Component\DependencyInjection\Extension\Extension`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
