### PR TITLE
[Front-end] Change public folder to web for 3.4

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -55,7 +55,7 @@ of your project. It already holds the basic config you need:
 They *key* part is ``addEntry()``: this tells Encore to load the ``assets/js/app.js``
 file and follow *all* of the ``require`` statements. It will then package everything
 together and - thanks to the first ``app`` argument - output final ``app.js`` and
-``app.css`` files into the ``public/build`` directory.
+``app.css`` files into the ``web/build`` directory.
 
 .. _encore-build-assets:
 
@@ -158,8 +158,8 @@ To import values, use ``import``:
     // assets/js/app.js
     - var $ = require('jquery');
     + import $ from 'jquery';
-    
-    - require('../css/app.css');    
+
+    - require('../css/app.css');
     + import '../css/app.css';
 
 .. _multiple-javascript-entries:


### PR DESCRIPTION
As there is no `public` folder in 3.4, changed to `web`.