### PR TITLE
[Encore] unify the name of app file

### DIFF
--- a/frontend/encore/advanced-config.rst
+++ b/frontend/encore/advanced-config.rst
@@ -53,7 +53,7 @@ state of the current configuration to build a new one:
     Encore
         .setOutputPath('web/build/')
         .setPublicPath('/build')
-        .addEntry('app', './assets/js/main.js')
+        .addEntry('app', './assets/js/app.js')
         .addStyleEntry('global', './assets/css/global.scss')
         .enableSassLoader()
         .autoProvidejQuery()

--- a/frontend/encore/page-specific-assets.rst
+++ b/frontend/encore/page-specific-assets.rst
@@ -14,7 +14,7 @@ a new ``checkout`` entry:
 
     Encore
         // an existing entry
-        .addEntry('app', './assets/js/main.js')
+        .addEntry('app', './assets/js/app.js')
         // a global styles entry
         .addStyleEntry('global', './assets/css/global.scss')
 

--- a/frontend/encore/shared-entry.rst
+++ b/frontend/encore/shared-entry.rst
@@ -13,8 +13,8 @@ Update your code to use ``createSharedEntry()``:
 
     Encore
         // ...
-    -     .addEntry('app', 'assets/js/app.js')
-    +     .createSharedEntry('app', 'assets/js/app.js')
+    -     .addEntry('app', './assets/js/app.js')
+    +     .createSharedEntry('app', './assets/js/app.js')
         .addEntry('homepage', './assets/js/homepage.js')
         .addEntry('blog', './assets/js/blog.js')
         .addEntry('store', './assets/js/store.js')


### PR DESCRIPTION
Hello.
I found 2 problems related to app file in WebPack config:
1) Relative path was not used in one place (`'assets/js/app.js'` instead of `'./assets/js/app.js'`) - what caused an error in my case.
2) In some cases there was `main.js` instead of `app.js`, but everywhere in text I found references only to `app.js` file. I guess it should be unified. 