### PR TITLE
default redis port

### DIFF
--- a/components/cache/adapters/redis_adapter.rst
+++ b/components/cache/adapters/redis_adapter.rst
@@ -92,7 +92,7 @@ array of ``key => value`` pairs representing option names and their respective v
     $client = RedisAdapter::createConnection(
 
         // provide a string dsn
-        'redis://localhost:6739',
+        'redis://localhost:6379',
 
         // associative array of configuration options
         array(


### PR DESCRIPTION
the default redis port is 6379

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
