### PR TITLE
[Serializer] Updated the list of loaded encoders

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -52,6 +52,8 @@ Encoders supporting the following formats are enabled:
 
 * JSON: :class:`Symfony\\Component\\Serializer\\Encoder\\JsonEncoder`
 * XML: :class:`Symfony\\Component\\Serializer\\Encoder\\XmlEncoder`
+* CSV: :class:`Symfony\\Component\\Serializer\\Encoder\\CsvEncoder`
+* YAML: :class:`Symfony\\Component\\Serializer\\Encoder\\YamlEncoder`
 
 As well as the following normalizers:
 


### PR DESCRIPTION
Framework bundle preloads encoders https://github.com/symfony/framework-bundle/blob/master/Resources/config/serializer.xml#L102
but not all were added in doc page https://symfony.com/doc/master/serializer.html#adding-normalizers-and-encoders