### PR TITLE
[Encore] Make title in FAQ more clear

### DIFF
--- a/frontend/encore/faq.rst
+++ b/frontend/encore/faq.rst
@@ -8,7 +8,7 @@ How do I deploy my Encore Assets?
 
 There are two important things to remember when deploying your assets.
 
-**1) Run ``encore production``**
+**1) Run "encore production"**
 
 Optimize your assets for production by running:
 

--- a/frontend/encore/faq.rst
+++ b/frontend/encore/faq.rst
@@ -8,7 +8,7 @@ How do I deploy my Encore Assets?
 
 There are two important things to remember when deploying your assets.
 
-**1) Run "encore production"**
+**1) Compile assets for production**
 
 Optimize your assets for production by running:
 


### PR DESCRIPTION
The current command in the bold text looks a little odd, because monospaced text can't be combined with bold text in RST:

![image](https://user-images.githubusercontent.com/14876024/45815287-75cb0f80-bcd8-11e8-933c-d67f61e82a15.png)

It makes more sense to use double quotes:

![image](https://user-images.githubusercontent.com/14876024/45815313-867b8580-bcd8-11e8-87ee-2115ae1154b7.png)

See: https://symfony.com/doc/master/frontend/encore/faq.html#how-do-i-deploy-my-encore-assets