### PR TITLE
[Syntax] Change to short php echo tags

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -312,7 +312,7 @@ instead::
     use Symfony\Component\Process\PhpProcess;
 
     $process = new PhpProcess(<<<EOF
-        <?php echo 'Hello World'; ?>
+        <?= 'Hello World'; ?>
     EOF
     );
     $process->run();

--- a/components/templating.rst
+++ b/components/templating.rst
@@ -54,7 +54,7 @@ which uses the template reference to actually find and load the template::
 .. code-block:: html+php
 
     <!-- views/hello.php -->
-    Hello, <?php echo $firstname ?>!
+    Hello, <?= $firstname ?>!
 
 The :method:`Symfony\\Component\\Templating\\PhpEngine::render` method parses
 the ``views/hello.php`` file and returns the output text. The second argument
@@ -85,7 +85,7 @@ to render the template originally) inside the template to render another templat
 
     <?php $names = array('Fabien', ...) ?>
     <?php foreach ($names as $name) : ?>
-        <?php echo $view->render('hello.php', array('firstname' => $name)) ?>
+        <?= $view->render('hello.php', array('firstname' => $name)) ?>
     <?php endforeach ?>
 
 Global Variables
@@ -103,7 +103,7 @@ In a template:
 
 .. code-block:: html+php
 
-    <p>The google tracking code is: <?php echo $ga_tracking ?></p>
+    <p>The google tracking code is: <?= $ga_tracking ?></p>
 
 .. caution::
 
@@ -123,13 +123,13 @@ JavaScript code isn't written out to your page. This will prevent things like
 XSS attacks. To do this, use the
 :method:`Symfony\\Component\\Templating\\PhpEngine::escape` method::
 
-    <?php echo $view->escape($firstname) ?>
+    <?= $view->escape($firstname) ?>
 
 By default, the ``escape()`` method assumes that the variable is outputted
 within an HTML context. The second argument lets you change the context. For
 example, to output something inside JavaScript, use the ``js`` context::
 
-    <?php echo $view->escape($var, 'js') ?>
+    <?= $view->escape($var, 'js') ?>
 
 The component comes with an HTML and JS escaper. You can register your own
 escaper using the

--- a/components/templating/slotshelper.rst
+++ b/components/templating/slotshelper.rst
@@ -67,10 +67,10 @@ set in a slot is in the ``_content`` slot.
     <?php $view['slots']->set('title', $page->title) ?>
 
     <h1>
-        <?php echo $page->title ?>
+        <?= $page->title ?>
     </h1>
     <p>
-        <?php echo $page->body ?>
+        <?= $page->body ?>
     </p>
 
 .. note::

--- a/create_framework/front_controller.rst
+++ b/create_framework/front_controller.rst
@@ -190,7 +190,7 @@ And the ``hello.php`` script can now be converted to a template::
     <!-- example.com/src/pages/hello.php -->
     <?php $name = $request->get('name', 'World') ?>
 
-    Hello <?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8') ?>
+    Hello <?= htmlspecialchars($name, ENT_QUOTES, 'UTF-8') ?>
 
 We have the first version of our framework::
 

--- a/create_framework/routing.rst
+++ b/create_framework/routing.rst
@@ -33,7 +33,7 @@ As we now extract the request query parameters, simplify the ``hello.php``
 template as follows::
 
     <!-- example.com/src/pages/hello.php -->
-    Hello <?php echo htmlspecialchars(isset($name) ? $name : 'World', ENT_QUOTES, 'UTF-8') ?>
+    Hello <?= htmlspecialchars(isset($name) ? $name : 'World', ENT_QUOTES, 'UTF-8') ?>
 
 Now, we are in good shape to add new features.
 
@@ -166,7 +166,7 @@ There are a few new things in the code:
 * Request attributes are extracted to keep our templates simple::
 
       <!-- example.com/src/pages/hello.php -->
-      Hello <?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8') ?>
+      Hello <?= htmlspecialchars($name, ENT_QUOTES, 'UTF-8') ?>
 
 * Route configuration has been moved to its own file::
 

--- a/introduction/from_flat_php_to_symfony2.rst
+++ b/introduction/from_flat_php_to_symfony2.rst
@@ -593,7 +593,7 @@ database and the Templating component to render a template and return a
     <ul>
         <?php foreach ($posts as $post): ?>
         <li>
-            <a href="<?php echo $view['router']->path(
+            <a href="<?= $view['router']->path(
                 'blog_show',
                 array('id' => $post->getId())
             ) ?>">

--- a/reference/forms/types/options/button_label.rst.inc
+++ b/reference/forms/types/options/button_label.rst.inc
@@ -14,4 +14,4 @@ be directly set inside the template:
 
     .. code-block:: html+php
 
-        <?php echo $view['form']->widget($form['save'], array('label' => 'Click me')) ?>
+        <?= $view['form']->widget($form['save'], array('label' => 'Click me')) ?>

--- a/reference/forms/types/options/preferred_choices.rst.inc
+++ b/reference/forms/types/options/preferred_choices.rst.inc
@@ -60,6 +60,6 @@ when rendering the field:
 
     .. code-block:: php
 
-        <?php echo $view['form']->widget($form['publishAt'], array(
+        <?= $view['form']->widget($form['publishAt'], array(
                   'separator' => '====='
         )) ?>

--- a/templating.rst
+++ b/templating.rst
@@ -35,13 +35,13 @@ template - a text file parsed by PHP that contains a mix of text and PHP code:
             <title>Welcome to Symfony!</title>
         </head>
         <body>
-            <h1><?php echo $page_title ?></h1>
+            <h1><?= $page_title ?></h1>
 
             <ul id="navigation">
                 <?php foreach ($navigation as $item): ?>
                     <li>
-                        <a href="<?php echo $item->getHref() ?>">
-                            <?php echo $item->getCaption() ?>
+                        <a href="<?= $item->getHref() ?>">
+                            <?= $item->getCaption() ?>
                         </a>
                     </li>
                 <?php endforeach ?>

--- a/templating/PHP.rst
+++ b/templating/PHP.rst
@@ -136,7 +136,7 @@ the ``extend()`` call:
     <!-- app/Resources/views/Hello/index.html.php -->
     <?php $view->extend('AppBundle::layout.html.php') ?>
 
-    Hello <?php echo $name ?>!
+    Hello <?= $name ?>!
 
 The ``AppBundle::layout.html.php`` notation sounds familiar, doesn't it? It
 is the same notation used to reference a template. The ``::`` part simply
@@ -200,7 +200,7 @@ decorating the template. In the ``index.html.php`` template, define a
 
     <?php $view['slots']->set('title', 'Hello World Application') ?>
 
-    Hello <?php echo $name ?>!
+    Hello <?= $name ?>!
 
 The base layout already has the code to output the title in the header:
 
@@ -238,7 +238,7 @@ Create a ``hello.html.php`` template:
 .. code-block:: html+php
 
     <!-- app/Resources/views/Hello/hello.html.php -->
-    Hello <?php echo $name ?>!
+    Hello <?= $name ?>!
 
 And change the ``index.html.php`` template to include it:
 
@@ -247,7 +247,7 @@ And change the ``index.html.php`` template to include it:
     <!-- app/Resources/views/Hello/index.html.php -->
     <?php $view->extend('AppBundle::layout.html.php') ?>
 
-    <?php echo $view->render('AppBundle:Hello:hello.html.php', array('name' => $name)) ?>
+    <?= $view->render('AppBundle:Hello:hello.html.php', array('name' => $name)) ?>
 
 The ``render()`` method evaluates and returns the content of another template
 (this is the exact same method as the one used in the controller).
@@ -268,7 +268,7 @@ If you create a ``fancy`` action, and want to include it into the
 .. code-block:: html+php
 
     <!-- app/Resources/views/Hello/index.html.php -->
-    <?php echo $view['actions']->render(
+    <?= $view['actions']->render(
         new \Symfony\Component\HttpKernel\Controller\ControllerReference('AppBundle:Hello:fancy', array(
             'name'  => $name,
             'color' => 'green',
@@ -320,7 +320,7 @@ updated by changing the configuration:
 
 .. code-block:: html+php
 
-    <a href="<?php echo $view['router']->path('hello', array('name' => 'Thomas')) ?>">
+    <a href="<?= $view['router']->path('hello', array('name' => 'Thomas')) ?>">
         Greet Thomas!
     </a>
 
@@ -344,9 +344,9 @@ Symfony provides the ``assets`` tag to deal with them easily:
 
 .. code-block:: html+php
 
-    <link href="<?php echo $view['assets']->getUrl('css/blog.css') ?>" rel="stylesheet" type="text/css" />
+    <link href="<?= $view['assets']->getUrl('css/blog.css') ?>" rel="stylesheet" type="text/css" />
 
-    <img src="<?php echo $view['assets']->getUrl('images/logo.png') ?>" />
+    <img src="<?= $view['assets']->getUrl('images/logo.png') ?>" />
 
 The ``assets`` helper's main purpose is to make your application more
 portable. Thanks to this helper, you can move the application root directory
@@ -374,13 +374,13 @@ Output Escaping
 When using PHP templates, escape variables whenever they are displayed to the
 user::
 
-    <?php echo $view->escape($var) ?>
+    <?= $view->escape($var) ?>
 
 By default, the ``escape()`` method assumes that the variable is outputted
 within an HTML context. The second argument lets you change the context. For
 instance, to output something in a JavaScript script, use the ``js`` context::
 
-    <?php echo $view->escape($var, 'js') ?>
+    <?= $view->escape($var, 'js') ?>
 
 Form Theming in PHP
 -------------------
@@ -396,7 +396,7 @@ file in order to customize the ``integer_widget`` fragment.
 
     <!-- app/Resources/views/form/integer_widget.html.php -->
     <div class="integer_widget">
-        <?php echo $view['form']->block(
+        <?= $view['form']->block(
             $form,
             'form_widget_simple',
             array('type' => isset($type) ? $type : "number")
@@ -567,7 +567,7 @@ original template:
     <?php if ($required) { $label_attr['class'] = trim((isset($label_attr['class']) ? $label_attr['class'] : '').' required'); } ?>
     <?php if (!$compound) { $label_attr['for'] = $id; } ?>
     <?php if (!$label) { $label = $view['form']->humanize($name); } ?>
-    <label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?></label>
+    <label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?= $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?></label>
 
     <!-- customization -->
     <?php if ($required) : ?>
@@ -588,14 +588,14 @@ original template:
 
     <!-- Original content -->
     <input
-        type="<?php echo isset($type) ? $view->escape($type) : 'text' ?>"
-        <?php if (!empty($value)): ?>value="<?php echo $view->escape($value) ?>"<?php endif ?>
-        <?php echo $view['form']->block($form, 'widget_attributes') ?>
+        type="<?= isset($type) ? $view->escape($type) : 'text' ?>"
+        <?php if (!empty($value)): ?>value="<?= $view->escape($value) ?>"<?php endif ?>
+        <?= $view['form']->block($form, 'widget_attributes') ?>
     />
 
     <!-- Customization -->
     <?php if (isset($help)) : ?>
-        <span class="help"><?php echo $view->escape($help) ?></span>
+        <span class="help"><?= $view->escape($help) ?></span>
     <?php endif ?>
 
 .. _`@Template`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/view

--- a/templating/escaping.rst
+++ b/templating/escaping.rst
@@ -76,7 +76,7 @@ use output escaping, use the special ``escape()`` view method:
 
 .. code-block:: html+php
 
-    Hello <?php echo $view->escape($name) ?>
+    Hello <?= $view->escape($name) ?>
 
 By default, the ``escape()`` method assumes that the variable is being rendered
 within an HTML context (and thus the variable is escaped to be safe for HTML).
@@ -85,7 +85,7 @@ in a JavaScript string, use the ``js`` context:
 
 .. code-block:: html+php
 
-    var myMsg = 'Hello <?php echo $view->escape($name, 'js') ?>';
+    var myMsg = 'Hello <?= $view->escape($name, 'js') ?>';
 
 .. _`Cross Site Scripting`: https://en.wikipedia.org/wiki/Cross-site_scripting
 .. _`Output Escaping`: https://twig.symfony.com/doc/2.x/api.html#escaper-extension

--- a/translation.rst
+++ b/translation.rst
@@ -318,9 +318,9 @@ The translator service is accessible in PHP templates through the
 
 .. code-block:: html+php
 
-    <?php echo $view['translator']->trans('Symfony is great') ?>
+    <?= $view['translator']->trans('Symfony is great') ?>
 
-    <?php echo $view['translator']->transChoice(
+    <?= $view['translator']->transChoice(
         '{0} There are no apples|{1} There is one apple|]1,Inf[ There are %count% apples',
         10,
         array('%count%' => 10)


### PR DESCRIPTION
Changed occurrences of `<?php echo` to `<?=`, see discussion about this topic here: #6664

Targeted 3.4 because 2.8 requires PHP 5.3.9 at minimum while the short PHP echo tags are enabled by default at PHP 5.4.