### PR TITLE
[Syntax] Remove unnecessary semicolons

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -189,7 +189,7 @@ instead::
     use Symfony\Component\Process\PhpProcess;
 
     $process = new PhpProcess(<<<EOF
-        <?php echo 'Hello World'; ?>
+        <?php echo 'Hello World' ?>
     EOF
     );
     $process->run();

--- a/security.rst
+++ b/security.rst
@@ -967,7 +967,7 @@ You can also use expressions inside your templates:
             '"ROLE_ADMIN" in roles or (not is_anonymous() and user.isSuperAdmin())'
         ))): ?>
             <a href="...">Delete</a>
-        <?php endif; ?>
+        <?php endif ?>
 
 For more details on expressions and security, see :doc:`/security/expressions`.
 

--- a/templating/PHP.rst
+++ b/templating/PHP.rst
@@ -407,7 +407,7 @@ Now that you've created the customized form template, you need to tell Symfony
 to use it. Inside the template where you're actually rendering your form,
 tell Symfony to use the theme via the ``setTheme()`` helper method::
 
-    <?php $view['form']->setTheme($form, array(':form')); ?>
+    <?php $view['form']->setTheme($form, array(':form')) ?>
 
     <?php $view['form']->widget($form['age']) ?>
 
@@ -418,7 +418,7 @@ the ``div`` element.
 If you want to apply a theme to a specific child form, pass it to the ``setTheme()``
 method::
 
-    <?php $view['form']->setTheme($form['child'], ':form'); ?>
+    <?php $view['form']->setTheme($form['child'], ':form') ?>
 
 .. note::
 
@@ -545,7 +545,7 @@ your template file rather than adding the template as a resource:
 
 .. code-block:: html+php
 
-    <?php $view['form']->setTheme($form, array('FrameworkBundle:FormTable')); ?>
+    <?php $view['form']->setTheme($form, array('FrameworkBundle:FormTable')) ?>
 
 Note that the ``$form`` variable in the above code is the form view variable
 that you passed to your template.


### PR DESCRIPTION
Remove unnecessary semicolons to stay in line with the rest of the docs.