### PR TITLE
Deprecated not passing the root node name to config tree builders

### DIFF
--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -175,10 +175,9 @@ The ``Configuration`` class to handle the sample configuration looks like::
     {
         public function getConfigTreeBuilder()
         {
-            $treeBuilder = new TreeBuilder();
-            $rootNode = $treeBuilder->root('acme_social');
+            $treeBuilder = new TreeBuilder('acme_social');
 
-            $rootNode
+            $treeBuilder->getRootNode()
                 ->children()
                     ->arrayNode('twitter')
                         ->children()
@@ -192,6 +191,9 @@ The ``Configuration`` class to handle the sample configuration looks like::
             return $treeBuilder;
         }
     }
+
+.. versionadded:: 4.2
+    Not passing the root node name to ``TreeBuilder`` was deprecated in Symfony 4.2.
 
 .. seealso::
 

--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -59,14 +59,17 @@ implements the :class:`Symfony\\Component\\Config\\Definition\\ConfigurationInte
     {
         public function getConfigTreeBuilder()
         {
-            $treeBuilder = new TreeBuilder();
-            $rootNode = $treeBuilder->root('database');
+            $treeBuilder = new TreeBuilder('database');
 
             // ... add node definitions to the root of the tree
+            // $treeBuilder->getRootNode()->...
 
             return $treeBuilder;
         }
     }
+
+.. versionadded:: 4.2
+    Not passing the root node name to ``TreeBuilder`` was deprecated in Symfony 4.2.
 
 Adding Node Definitions to the Tree
 -----------------------------------
@@ -534,10 +537,9 @@ tree with ``append()``::
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('database');
+        $treeBuilder = new TreeBuilder('database');
 
-        $rootNode
+        $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('connection')
                     ->children()
@@ -564,10 +566,9 @@ tree with ``append()``::
 
     public function addParametersNode()
     {
-        $treeBuilder = new TreeBuilder();
-        $node = $treeBuilder->root('parameters');
+        $treeBuilder = new TreeBuilder('parameters');
 
-        $node
+        $treeBuilder->getRootNode()
             ->isRequired()
             ->requiresAtLeastOneElement()
             ->useAttributeAsKey('name')
@@ -795,10 +796,9 @@ Configuring the Node Path Separator
 
 Consider the following config builder example::
 
-    $treeBuilder = new TreeBuilder();
-    $rootNode = $treeBuilder->root('database');
+    $treeBuilder = new TreeBuilder('database');
 
-    $rootNode
+    $treeBuilder->getRootNode()
         ->children()
             ->arrayNode('connection')
                 ->children()

--- a/configuration/using_parameters_in_dic.rst
+++ b/configuration/using_parameters_in_dic.rst
@@ -109,10 +109,9 @@ be injected with this parameter via the extension as follows::
 
         public function getConfigTreeBuilder()
         {
-            $treeBuilder = new TreeBuilder();
-            $rootNode = $treeBuilder->root('my_bundle');
+            $treeBuilder = new TreeBuilder('my_bundle');
 
-            $rootNode
+            $treeBuilder->getRootNode()
                 ->children()
                     // ...
                     ->booleanNode('logging')->defaultValue($this->debug)->end()
@@ -123,6 +122,9 @@ be injected with this parameter via the extension as follows::
             return $treeBuilder;
         }
     }
+
+.. versionadded:: 4.2
+    Not passing the root node name to ``TreeBuilder`` was deprecated in Symfony 4.2.
 
 And set it in the constructor of ``Configuration`` via the ``Extension`` class::
 


### PR DESCRIPTION
Fixes #10339.