### PR TITLE
Update search location of serializer configuration

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -137,10 +137,12 @@ In addition to the ``@Groups`` annotation, the Serializer component also
 supports YAML or XML files. These files are automatically loaded when being
 stored in one of the following locations:
 
+* All ``*.yaml`` and ``*.xml`` files in the ``config/serializer/``
+  directory.
 * The ``serialization.yaml`` or ``serialization.xml`` file in
   the ``Resources/config/`` directory of a bundle;
-* All ``*.yaml`` and ``*.xml`` files in the ``Resources/config/serializer/``
-  directory of a bundle.
+* All ``*.yaml`` and ``*.xml`` files in the ``Resources/config/serialization/``
+  directory of a bundle.  
 
 .. _serializer-enabling-metadata-cache:
 

--- a/serializer.rst
+++ b/serializer.rst
@@ -139,7 +139,7 @@ stored in one of the following locations:
 
 * The ``serialization.yaml`` or ``serialization.xml`` file in
   the ``Resources/config/`` directory of a bundle;
-* All ``*.yaml`` and ``*.xml`` files in the ``Resources/config/serialization/``
+* All ``*.yaml`` and ``*.xml`` files in the ``Resources/config/serializer/``
   directory of a bundle.
 
 .. _serializer-enabling-metadata-cache:

--- a/serializer.rst
+++ b/serializer.rst
@@ -142,7 +142,7 @@ stored in one of the following locations:
 * The ``serialization.yaml`` or ``serialization.xml`` file in
   the ``Resources/config/`` directory of a bundle;
 * All ``*.yaml`` and ``*.xml`` files in the ``Resources/config/serialization/``
-  directory of a bundle.  
+  directory of a bundle.
 
 .. _serializer-enabling-metadata-cache:
 


### PR DESCRIPTION
(Docs change) Symfony 4.1 uses the 'serializer' directory, not 'serialization'.