### PR TITLE
Added ignoreFalse option to UniqueEntity constraint

### DIFF
--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -15,6 +15,7 @@ using an email address that already exists in the system.
 |                | - `entityClass`_                                                                    |
 |                | - `errorPath`_                                                                      |
 |                | - `ignoreNull`_                                                                     |
+|                | - `ignoreFalse`_                                                                    |
 |                | - `payload`_                                                                        |
 +----------------+-------------------------------------------------------------------------------------+
 | Class          | :class:`Symfony\\Bridge\\Doctrine\\Validator\\Constraints\\UniqueEntity`            |
@@ -285,6 +286,16 @@ If this option is set to ``true``, then the constraint will allow multiple
 entities to have a ``null`` value for a field without failing validation.
 If set to ``false``, only one ``null`` value is allowed - if a second entity
 also has a ``null`` value, validation would fail.
+
+ignoreFalse
+~~~~~~~~~~~
+
+**type**: ``boolean`` **default**: ``false``
+
+If this option is set to ``true``, then the constraint will allow multiple
+entities to have a ``false`` value for a boolean field without failing validation.
+If set to ``false``, only one ``false`` value is allowed - if a second entity
+also has a ``false`` value, validation would fail.
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 


### PR DESCRIPTION
Add a new option to `UniqueEnitity` to allow use it with `boolean` type field.