### PR TITLE
Remove useless use statements

### DIFF
--- a/security/impersonating_user.rst
+++ b/security/impersonating_user.rst
@@ -93,8 +93,6 @@ In some cases you may need to get the object that represents the impersonator
 user rather than the impersonated user. Use the following snippet to iterate
 over the user's roles until you find one that is a ``SwitchUserRole`` object::
 
-    use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-    use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
     use Symfony\Component\Security\Core\Role\SwitchUserRole;
     use Symfony\Component\Security\Core\Security;
     // ...


### PR DESCRIPTION
While browsing the documentation, I found out that these 2 statements where not used.