### PR TITLE
Add deprecation notice for --env and --no-debug

### DIFF
--- a/configuration/environments.rst
+++ b/configuration/environments.rst
@@ -178,8 +178,12 @@ Selecting the Environment for Console Commands
 
 By default, Symfony commands are executed in whatever environment is defined by
 the ``APP_ENV`` environment variable (usually configured in your ``.env`` file).
+You can override this by changing the value it before your command executes.
 
-Use the ``--env`` and ``--no-debug`` options to modify this behavior:
+.. versionadded:: 4.2
+    In Symfony 4.2 the command line options ``--env`` and ``--no-debug`` have been deprecated.
+    Use the environment variables ``APP_ENV`` to set the environment and ``APP_DEBUG`` (set
+    to the value ``0``) to disable debugging instead.
 
 .. code-block:: terminal
 
@@ -187,10 +191,10 @@ Use the ``--env`` and ``--no-debug`` options to modify this behavior:
     $ php bin/console command_name
 
     # 'prod' environment (debug is always disabled for 'prod')
-    $ php bin/console command_name --env=prod
+    $ APP_ENV=prod php bin/console command_name
 
     # 'test' environment and debug disabled
-    $ php bin/console command_name --env=test --no-debug
+    $ APP_ENV=test APP_DEBUG=0 php bin/console command_name
 
 .. index::
    single: Environments; Creating a new environment

--- a/deployment.rst
+++ b/deployment.rst
@@ -168,7 +168,7 @@ Make sure you clear and warm-up your Symfony cache:
 
 .. code-block:: terminal
 
-    $ php bin/console cache:clear --env=prod --no-debug
+    $ APP_ENV=prod APP_DEBUG=0 php bin/console cache:clear
 
 E) Other Things!
 ~~~~~~~~~~~~~~~~

--- a/email/spool.rst
+++ b/email/spool.rst
@@ -127,19 +127,19 @@ There is a console command to send the messages in the spool:
 
 .. code-block:: terminal
 
-    $ php bin/console swiftmailer:spool:send --env=prod
+    $ APP_ENV=prod php bin/console swiftmailer:spool:send
 
 It has an option to limit the number of messages to be sent:
 
 .. code-block:: terminal
 
-    $ php bin/console swiftmailer:spool:send --message-limit=10 --env=prod
+    $ APP_ENV=prod php bin/console swiftmailer:spool:send --message-limit=10
 
 You can also set the time limit in seconds:
 
 .. code-block:: terminal
 
-    $ php bin/console swiftmailer:spool:send --time-limit=10 --env=prod
+    $ APP_ENV=prod php bin/console swiftmailer:spool:send --time-limit=10
 
 Of course you will not want to run this manually in reality. Instead, the
 console command should be triggered by a cron job or scheduled task and run

--- a/testing/bootstrap.rst
+++ b/testing/bootstrap.rst
@@ -12,9 +12,9 @@ To do this, first add a file that executes your bootstrap work::
     if (isset($_ENV['BOOTSTRAP_CLEAR_CACHE_ENV'])) {
         // executes the "php bin/console cache:clear" command
         passthru(sprintf(
-            'php "%s/../bin/console" cache:clear --env=%s --no-warmup',
-            __DIR__,
-            $_ENV['BOOTSTRAP_CLEAR_CACHE_ENV']
+            'APP_ENV=%s php "%s/../bin/console" cache:clear --no-warmup',
+            $_ENV['BOOTSTRAP_CLEAR_CACHE_ENV'],
+            __DIR__
         ));
     }
 


### PR DESCRIPTION
Fix #10444.

- Add deprecation notice for `--env` and `--no-debug`.
- Update some command examples to use the `APP_ENV` & `APP_DEBUG` environment variables.