### PR TITLE
Fix phpunit command

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -29,7 +29,24 @@ command:
 
 .. code-block:: terminal
 
-    $ ./vendor/bin/simple-phpunit
+    $ ./bin/phpunit
+
+.. note::
+
+    If your project is missing the phpunit command in the ./bin directory, Symfony
+    may have not executed the required PhPUnitBridge recipes. This may occurs when
+    the bundle symfony/phpunit-bridge is part of your composer.json file and your 
+    starting project contains a symfony.lock file.
+    
+    Two options can be used to fix that problem:
+    
+        * Remove the symfony.lock file before doing the first ``composer install``
+        * Remove and require again the symfony/phpunit-bridge bundle:
+    
+.. code-block:: terminal
+
+        $ composer remove symfony/phpunit-bridge
+        $ composer require --dev symfony/phpunit-bridge
 
 PHPUnit is configured by the ``phpunit.xml.dist`` file in the root of your
 Symfony application.
@@ -101,13 +118,13 @@ Running tests for a given file or directory is also very easy:
 .. code-block:: terminal
 
     # run all tests of the application
-    $ ./vendor/bin/simple-phpunit
+    $ ./bin/phpunit
 
     # run all tests in the Util/ directory
-    $ ./vendor/bin/simple-phpunit tests/Util
+    $ ./bin/phpunit tests/Util
 
     # run tests for the Calculator class
-    $ ./vendor/bin/simple-phpunit tests/Util/CalculatorTest.php
+    $ ./bin/phpunit tests/Util/CalculatorTest.php
 
 .. index::
    single: Tests; Functional tests

--- a/testing.rst
+++ b/testing.rst
@@ -29,7 +29,7 @@ command:
 
 .. code-block:: terminal
 
-    $ ./bin/phpunit
+    $ ./vendor/bin/simple-phpunit
 
 PHPUnit is configured by the ``phpunit.xml.dist`` file in the root of your
 Symfony application.
@@ -101,13 +101,13 @@ Running tests for a given file or directory is also very easy:
 .. code-block:: terminal
 
     # run all tests of the application
-    $ ./bin/phpunit
+    $ ./vendor/bin/simple-phpunit
 
     # run all tests in the Util/ directory
-    $ ./bin/phpunit tests/Util
+    $ ./vendor/bin/simple-phpunit tests/Util
 
     # run tests for the Calculator class
-    $ ./bin/phpunit tests/Util/CalculatorTest.php
+    $ ./vendor/bin/simple-phpunit tests/Util/CalculatorTest.php
 
 .. index::
    single: Tests; Functional tests


### PR DESCRIPTION
replace missing command  ./bin/phpunit with ./vendor/bin/simple-phpunit 

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
