### PR TITLE
Add XML encoder comment tip and docs

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -483,7 +483,7 @@ and :class:`Symfony\\Component\\Serializer\\Normalizer\\PropertyNormalizer`::
 
 .. note::
 
-    You can also implement 
+    You can also implement
     :class:`Symfony\\Component\\Serializer\\NameConverter\\AdvancedNameConverterInterface`
     to access to the current class name, format and context.
 
@@ -722,14 +722,16 @@ The ``XmlEncoder`` will encode this object like that::
         <bar>1</bar>
     </response>
 
-Be aware that this encoder will consider keys beginning with ``@`` as attributes::
+Be aware that this encoder will consider keys beginning with ``@`` as attributes, and will use
+the key  ``#comment`` for encoding XML comments::
 
     $encoder = new XmlEncoder();
-    $encoder->encode(array('foo' => array('@bar' => 'value')));
+    $encoder->encode(array('foo' => array('@bar' => 'value'), 'qux' => array('#comment' => 'A comment));
     // will return:
     // <?xml version="1.0"?>
     // <response>
     //     <foo bar="value" />
+    //     <qux><!-- A comment --!><qux>
     // </response>
 
 You can pass the context key ``as_collection`` in order to have the results
@@ -741,8 +743,12 @@ always as a collection.
 .. tip::
 
     XML comments are ignored by default when decoding contents, but this
-    behavior can be changed with the optional ``$ignoredNodeTypes`` argument of
+    behavior can be changed with the optional ``$decoderIgnoredNodeTypes`` argument of
     the ``XmlEncoder`` class constructor.
+
+    Data with ``#comment`` keys are encoded to XML comments by default. This can be
+    changed with the optional ``$encoderIgnoredNodeTypes`` argument of the
+    ``XmlEncoder`` class constructor.
 
     .. versionadded:: 4.1
         XML comments are ignored by default starting from Symfony 4.1.


### PR DESCRIPTION
Fix #10289

- Add docs for encoding / decoding XML comments.
- Add docs for additional XMLEncoder class constructor argument for ignoring comment encoding
