### PR TITLE
Updated class reference in Callback validator from the deprecated to the current class.

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -300,5 +300,5 @@ Concrete callbacks receive an :class:`Symfony\\Component\\Validator\\Context\\Ex
 instance as only argument.
 
 Static or closure callbacks receive the validated object as the first argument
-and the :class:`Symfony\\Component\\Validator\\ExecutionContextInterface`
+and the :class:`Symfony\\Component\\Validator\\Context\\ExecutionContextInterface`
 instance as the second argument.


### PR DESCRIPTION
This updates the class reference in the documentation for `ExecutionContextInterface` on the `Callback` validator.

This actually affects the documentation from v2.5 to master