### PR TITLE
[Form][Validation] User $user instead of $users

### DIFF
--- a/form/validation_groups.rst
+++ b/form/validation_groups.rst
@@ -10,7 +10,7 @@ Validation Groups
 If your object takes advantage of :doc:`validation groups </validation/groups>`,
 you'll need to specify which validation group(s) your form should use::
 
-    $form = $this->createFormBuilder($users, array(
+    $form = $this->createFormBuilder($user, array(
         'validation_groups' => array('registration'),
     ))->add(...);
 


### PR DESCRIPTION
Fixed example where it feels more natural to register only one user and not a collection of users