### PR TITLE
Improve is_granted documentation

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -310,8 +310,8 @@ is_granted
 
 Returns ``true`` if the current user has the required role, if only one 
 is passed; if more than one is passed, with an array, the behavior depends
-on how the :ref:`authorization <access-decision-manager>` is configured; 
-by default, the user has to have at least one of the passed roles.
+on how the :ref:`Access Decision Manager <components-security-access-decision-manager>`
+is configured; by default, the user has to have at least one of the passed roles.
 
 Optionally, an object can be pasted to be used by the voter. More information
 can be found in :ref:`security-template`.

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -302,15 +302,19 @@ is_granted
     {{ is_granted(role, object = null, field = null) }}
 
 ``role``
-    **type**: ``string``
+    **type**: ``string``, ``string[]``
 ``object`` *(optional)*
     **type**: ``object``
 ``field`` *(optional)*
     **type**: ``string``
 
-Returns ``true`` if the current user has the required role. Optionally,
-an object can be pasted to be used by the voter. More information can be
-found in :ref:`security-template`.
+Returns ``true`` if the current user has the required role, if only one 
+is passed; if more than one is passed, with an array, the behavior depends
+on how the :ref:`authorization <access-decision-manager>` is configured; 
+by default, the user has to have at least one of the passed roles.
+
+Optionally, an object can be pasted to be used by the voter. More information
+can be found in :ref:`security-template`.
 
 .. note::
 


### PR DESCRIPTION
This improves the doc for the `is_granted` Twig function. Under the hood, it calls `AuthorizationChecker::isGranted()` which accepts multiple attributes to be checked, but that's not clear. I've referred to the only other part of the doc where this is clear.