### PR TITLE
Fix and improve JSON login docs

### DIFF
--- a/security/json_login_setup.rst
+++ b/security/json_login_setup.rst
@@ -80,6 +80,12 @@ path:
              */
             public function loginAction(Request $request)
             {
+                $user = $this->getUser();
+
+                return $this->json(array(
+                    'username' => $user->getUsername(),
+                    'roles' => $user->getRoles(),
+                ));
             }
         }
 

--- a/security/json_login_setup.rst
+++ b/security/json_login_setup.rst
@@ -123,11 +123,11 @@ path:
 
         return $routes;
 
-Don't let this empty controller confuse you. When you submit a ``POST`` request
-to the ``/login`` URL with the following JSON document as the body, the security
-system intercepts the requests. It takes care of authenticating the user with
-the submitted username and password or triggers an error in case the authentication
-process fails:
+When you submit a ``POST`` request to the ``/login`` URL with the following JSON document as the body,
+the security system intercepts the requests.
+It takes care of authenticating the user with the submitted username and password or triggers an error
+in case the authentication process fails.
+If the authentication is successful, the controller defined earlier will be executed. 
 
 .. code-block:: json
 


### PR DESCRIPTION
Since symfony/symfony#22494, it's mandatory to return a valid response in the controller to prevent a 500 error.

I've updated the docs accordingly, and added an example of what can be returned.

This PR is similar to #9611 (that was right, sorry I just noticed).

ping @vincentchalamon