### PR TITLE
Replace extra ...

### DIFF
--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -19,7 +19,7 @@ An Autowiring Example
 ---------------------
 
 Imagine you're building an API to publish statuses on a Twitter feed, obfuscated
-with `ROT13`_... a fun encoder that shifts all characters 13 letters forward in
+with `ROT13`_, a fun encoder that shifts all characters 13 letters forward in
 the alphabet.
 
 Start by creating a ROT13 transformer class::


### PR DESCRIPTION
I suppose this `...` should be replaced with simple comma. Also should be fixed in 3.3 documentation, but this branch is not allowed to be edited.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
