### PR TITLE
Update to micro_kernel_trait.rst

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -131,7 +131,7 @@ section of the composer.json file will not be in effect until you run the follow
 
 .. code-block:: bash
 
-    $ composer dumpautoload
+    $ composer dump-autoload
     
     
 Now, suppose you want to use Twig and load routes via annotations. Instead of

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -126,6 +126,14 @@ your ``composer.json`` file to load from there:
         }
     }
 
+Before going any further, you need to regenerate the autoload files! Your changes in the "autoload"
+section of the composer.json file will not be in effect until you run the following command:
+
+.. code-block:: bash
+
+    $ composer dumpautoload
+    
+    
 Now, suppose you want to use Twig and load routes via annotations. Instead of
 putting *everything* in ``index.php``, create a new ``app/AppKernel.php`` to
 hold the kernel. Now it looks like this::

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -127,7 +127,7 @@ your ``composer.json`` file to load from there:
     }
 
 Before going any further, you need to regenerate the autoload files! Your changes in the "autoload"
-section of the composer.json file will not be in effect until you run the following command:
+section of the ``composer.json`` file will not be in effect until you run the following command:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Whenever you make a change to the "autoload' section of the composer.json file (amongst others), you need to regenerate the autoload files using composer dumpautoload, otherwise your changes will not be seen.

More info :
https://getcomposer.org/doc/03-cli.md#dump-autoload-dumpautoload-

Sorry if the proposed changes are not marked up properly, haven't gotten the hang of Markup language just yet :)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
