### PR TITLE
Update Multiple_kernels.rst

### DIFF
--- a/configuration/multiple_kernels.rst
+++ b/configuration/multiple_kernels.rst
@@ -119,7 +119,7 @@ to your ``composer.json`` autoload section:
         }
     }
 
-Then, run ``composer install`` to dump your new autoload config.
+Then, run ``composer dumpautoload`` to dump your new autoload config.
 
 Step 3) Define the Kernel Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/configuration/multiple_kernels.rst
+++ b/configuration/multiple_kernels.rst
@@ -119,7 +119,7 @@ to your ``composer.json`` autoload section:
         }
     }
 
-Then, run ``composer dumpautoload`` to dump your new autoload config.
+Then, run ``composer dump-autoload`` to dump your new autoload config.
 
 Step 3) Define the Kernel Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I would like to propose to change the following:

After a change in the classmap in composer.json, I would recommend using 'composer dumpautoload', instead of doing a 'composer install'. 
The main reasoning behind this is that after a 'composer install' the parameters.yml file is regenerated, and your own parameters stored there are gone (learned this the hard way :) )

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
