### PR TITLE
[Monolog] Move ProcessorInterface to Monolog

### DIFF
--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -165,7 +165,7 @@ handler level or at the channel level instead of registering it globally
         The autoconfiguration of Monolog processors was introduced in Symfony 4.2.
 
     If you're using the :ref:`default services.yaml configuration <service-container-services-load-example>`,
-    processors implementing :class:`Symfony\\Bridge\\Monolog\\Processor\\ProcessorInterface`
+    processors implementing :class:`Monolog\\Processor\\ProcessorInterface`
     are automatically registered as services and tagged with ``monolog.processor``,
     so you can use them without adding any configuration. The same applies to the
     built-in :class:`Symfony\\Bridge\\Monolog\\Processor\\TokenProcessor` and


### PR DESCRIPTION
Since https://github.com/symfony/symfony/pull/27801 was reverted in https://github.com/symfony/symfony/pull/28845 and the new plan being to make this interface part of Monolog.