### PR TITLE
Inform developers how to set their custom HTTP status code for kernel.exception event.

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -545,10 +545,10 @@ below for more details).
     When setting a response for the ``kernel.exception`` event, the propagation
     is stopped. This means listeners with lower priority won't be executed.
 
-.. note::
+.. tip::
 
     When setting a response for the ``kernel.exception`` event in order for the 
-    HttpKernel to use the Status Code of the response the :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent::allowCustomResponseCode` must be called inside your listener.
+    HttpKernel to use the Status Code of the response the :method:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent::allowCustomResponseCode` must be called inside your listener.
 
 .. sidebar:: ``kernel.exception`` in the Symfony Framework
 

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -548,7 +548,7 @@ below for more details).
 .. note::
 
     When setting a response for the ``kernel.exception`` event in order for the 
-    HttpKernel to use the Status Code of the response the :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent::allowCustomResponseCode` must be called first.
+    HttpKernel to use the Status Code of the response the :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent::allowCustomResponseCode` must be called inside your listener.
 
 .. sidebar:: ``kernel.exception`` in the Symfony Framework
 

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -545,6 +545,11 @@ below for more details).
     When setting a response for the ``kernel.exception`` event, the propagation
     is stopped. This means listeners with lower priority won't be executed.
 
+.. note::
+
+    When setting a response for the ``kernel.exception`` event in order for the 
+    HttpKernel to use the Status Code of the response the :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent::allowCustomResponseCode` must be called first.
+
 .. sidebar:: ``kernel.exception`` in the Symfony Framework
 
     There are two main listeners to ``kernel.exception`` when using the


### PR DESCRIPTION
Added a tip section that will inform users how to set their custom HTTP status code.