### PR TITLE
Show how to change the Session Attribute Bag type

### DIFF
--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -207,6 +207,8 @@ Example::
     // ...
     $session->clear();
 
+.. _namespaced-attributes:
+
 Namespaced Attributes
 .....................
 

--- a/session.rst
+++ b/session.rst
@@ -17,5 +17,6 @@ More about Sessions
     session/locale_sticky_session
     session/php_bridge
     session/proxy_examples
+    session/attribute_bag
 
 * :doc:`/doctrine/pdo_session_storage`

--- a/session/attribute_bag.rst
+++ b/session/attribute_bag.rst
@@ -8,7 +8,7 @@ Symfony uses attribute bags to represent values stored in the session. It ships
 with the default :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBag`, 
 which stores key-value pairs, and the 
 :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\NamespacedAttributeBag`, 
-which allows you to :ref:`set and fetch values using character-separated paths <attribute-bag-interface>`.
+which allows you to :ref:`set and fetch values using character-separated paths <namespaced-attributes>`.
 
 This is fully documented :doc:`in the component documentation </components/http_foundation/sessions>`.
 

--- a/session/attribute_bag.rst
+++ b/session/attribute_bag.rst
@@ -1,0 +1,31 @@
+.. index::
+   single: Sessions, Attribute Bag
+
+Changing the Session Attribute Bag provider
+===========================================
+
+Symfony uses attribute bags to represent values stored in the session. It ships 
+with the default :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBag`, 
+which stores key-value pairs, and the 
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\NamespacedAttributeBag`, 
+which allows you to :ref:`set and fetch values using character-separated paths <attribute-bag-interface>`.
+
+This is fully documented :doc:`in the component documentation </components/http_foundation/sessions>`.
+
+Changing the attribute bag in Symfony
+-------------------------------------
+To use a different attribute bag for your sessions, override the service 
+definition. In this example, we switch the default ``AttributeBag`` to the 
+``NamespacedAttributeBag``:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+        session:
+            class: Symfony\Component\HttpFoundation\Session\Session
+            arguments: ["@session.storage", "@session.namespacedattributebag", "@session.flash_bag"]
+
+        session.namespacedattributebag:
+            class: Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag

--- a/session/attribute_bag.rst
+++ b/session/attribute_bag.rst
@@ -1,7 +1,7 @@
 .. index::
    single: Sessions, Attribute Bag
 
-Changing the Session Attribute Bag provider
+Changing the Session Attribute Bag Provider
 ===========================================
 
 Symfony uses attribute bags to represent values stored in the session. It ships 
@@ -12,8 +12,9 @@ which allows you to :ref:`set and fetch values using character-separated paths <
 
 This is fully documented :doc:`in the component documentation </components/http_foundation/sessions>`.
 
-Changing the attribute bag in Symfony
+Changing the Attribute Bag in Symfony
 -------------------------------------
+
 To use a different attribute bag for your sessions, override the service 
 definition. In this example, we switch the default ``AttributeBag`` to the 
 ``NamespacedAttributeBag``:
@@ -29,3 +30,4 @@ definition. In this example, we switch the default ``AttributeBag`` to the
 
         session.namespacedattributebag:
             class: Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag
+            


### PR DESCRIPTION
The Session component ships with two different attribute bag implementations, and the Symfony docs don't show how to change between them.

Fixes #10494 and StackOverflow issues like https://stackoverflow.com/questions/12279247/how-to-use-namespaced-sessions-in-symfony2

## Specific feedback requests
1. Is this the right location for it? Adding it to https://github.com/symfony/symfony-docs/blob/master/session.rst was my first idea, but everything else is sub-pages.
2. I only use YAML configuration, so if someone else can contribute/check the PHP/XML config that would be brilliant.
3. Hard line wrapping - you appear to use ~80 characters? I've got some lines that go over that but don't think paths to files can be split?