### PR TITLE
Note how to use multiple Guard Authenticators with different User Providers

### DIFF
--- a/security/multiple_guard_authenticators.rst
+++ b/security/multiple_guard_authenticators.rst
@@ -78,6 +78,9 @@ This is how your security configuration can look in action:
             ),
         ));
 
+If your authenticators need separate providers, you will need to create a 
+:doc:`chain of user providers </security/multiple_user_providers>`.
+
 There is one limitation with this approach - you have to use exactly one entry point.
 
 Multiple Authenticators with Separate Entry Points


### PR DESCRIPTION
If multiple guard authenticators have different providers, link to the details on chaining providers together.