### PR TITLE
Added explanation how non-scalar or non-unique choice values are handled

### DIFF
--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -188,6 +188,11 @@ is the item's label and the array value is the item's value::
         'choices_as_values' => true,
     ));
 
+If there are choice values that are not scalar or the stringified
+representation is not unique Symfony will use incrementing integers
+as values. When the form gets submitted the correct values with the
+correct types will be assigned to the model.
+
 .. include:: /reference/forms/types/options/choice_attr.rst.inc
 
 .. _reference-form-choice-label:


### PR DESCRIPTION
This is not clear in the current documentation and can lead to confusion under some circumstances.

This change is related to symfony/symfony#19953.
