### PR TITLE
Fixing bad logic, caused by merge originally

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -553,10 +553,8 @@ can ignore this. Here is an example of good and bad behavior::
 
     public function supports(Request $request)
     {
-        // GOOD behavior: only authenticate on a specific route
-        if ($request->attributes->get('_route') !== 'login_route' || !$request->isMethod('POST')) {
-            return true;
-        }
+        // GOOD behavior: only authenticate (i.e. return true) on a specific route
+        return ($request->attributes->get('_route') === 'login_route' && $request->isMethod('POST'));
 
         // e.g. your login system authenticates by the user's IP address
         // BAD behavior: So, you decide to *always* return true so that


### PR DESCRIPTION
Caught by @fnash in Symfony Slack! Because the `supports()` method didn't exist in 2.8, this logic basically needed to be reversed when we merged to 3.4. But, that was not done correctly (by me).