### PR TITLE
Remove single quotes from namespace

### DIFF
--- a/doctrine/reverse_engineering.rst
+++ b/doctrine/reverse_engineering.rst
@@ -56,7 +56,7 @@ table fields.
 
 .. code-block:: terminal
 
-    $ php bin/console doctrine:mapping:import 'App\Entity' annotation --path=src/Entity
+    $ php bin/console doctrine:mapping:import App\Entity annotation --path=src/Entity
 
 This command line tool asks Doctrine to introspect the database and generate
 new PHP classes with annotation metadata into ``src/Entity``. This generates two
@@ -68,7 +68,7 @@ files: ``BlogPost.php`` and ``BlogComment.php``.
 
     .. code-block:: terminal
 
-        $ php bin/console doctrine:mapping:import 'App\Entity' xml --path=config/doctrine
+        $ php bin/console doctrine:mapping:import App\Entity xml --path=config/doctrine
 
 Generating the Getters & Setters or PHP Classes
 -----------------------------------------------


### PR DESCRIPTION
I was trying to migrate and old database and found that using this command with single quotes generates the entities but the files generated contains the namespace single-quoted:

```php
<?php

namespace 'App\Entity';
...
```

Removing the single quotes when running the command solves the problem.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
