### PR TITLE
Add asset versioning note

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -95,6 +95,11 @@ your layout. In Symfony, use the ``asset()`` helper:
         </body>
     </html>
 
+.. note::
+
+    Make sure to configure asset versioning for these `asset()` paths to work with Encore's `dev` and `production` outputs:
+    :doc:`Asset versioning </frontend/encore/versioning>`
+
 Requiring JavaScript Modules
 ----------------------------
 


### PR DESCRIPTION
Without enabling asset versioning the steps don't work, because `base.html.twig` uses `asset('build/app.css')` and `asset('build/app.js')` but those don't exist anymore because the last `yarn` call was (or could be) `yarn encore production`.