### PR TITLE
Update json_login_setup.rst

### DIFF
--- a/security/json_login_setup.rst
+++ b/security/json_login_setup.rst
@@ -123,7 +123,7 @@ path:
 
         return $routes;
 
-When you submit a ``POST`` request to the ``/login`` URL with the following JSON
+When you submit a ``POST`` request, with the header ``Content-Type: application/json``, to the ``/login`` URL with the following JSON
 document as the body, the security system intercepts the requests.
 It takes care of authenticating the user with the submitted username and password
 or triggers an error in case the authentication process fails.


### PR DESCRIPTION
As stated in https://stackoverflow.com/questions/47972237/symfony-4-json-authentication-not-working/49071038#49071038, which helped me to find why it did not work, the POST Request only works with the header `Content-Type: application/json`, so just adding it will make it clear to everyone.
