### PR TITLE
Update the link to DynamicRouter documentation

### DIFF
--- a/routing/routing_from_database.rst
+++ b/routing/routing_from_database.rst
@@ -38,4 +38,4 @@ loader, e.g. for another database type or a REST API or anything else.
 The DynamicRouter is explained in the `Symfony CMF documentation`_.
 
 .. _FrameworkExtraBundle: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
-.. _`Symfony CMF documentation`: https://symfony.com/doc/master/cmf/book/routing.html
+.. _`Symfony CMF documentation`: https://symfony.com/doc/current/cmf/bundles/routing/dynamic.html


### PR DESCRIPTION
The "https://symfony.com/doc/master/cmf/book/routing.html" redirects to "/doc/master/routing.html" instead of to CMF documentation.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
