### PR TITLE
Removed interface

### DIFF
--- a/session/locale_sticky_session.rst
+++ b/session/locale_sticky_session.rst
@@ -145,7 +145,6 @@ event::
     // src/EventSubscriber/UserLocaleSubscriber.php
     namespace App\EventSubscriber;
 
-    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
     use Symfony\Component\HttpFoundation\Session\SessionInterface;
     use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
     use Symfony\Component\Security\Http\SecurityEvents;
@@ -154,7 +153,7 @@ event::
      * Stores the locale of the user in the session after the
      * login. This can be used by the LocaleSubscriber afterwards.
      */
-    class UserLocaleSubscriber implements EventSubscriberInterface
+    class UserLocaleSubscriber
     {
         private $session;
 


### PR DESCRIPTION
You don't have to use that interface for this case. Even if you add it, you need to implement `getSubscribedEvents()` method.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
