### PR TITLE
Update dispatch example

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -70,7 +70,7 @@ Example::
         ])),
     ]);
 
-    $result = $bus->dispatch(new MyMessage(/* ... */));
+    $bus->dispatch(new MyMessage(/* ... */));
 
 .. note::
 


### PR DESCRIPTION
Dispatch method returns `void`. The change fixes confusion that bus can return things.