### PR TITLE
Mentioned the deprecation of kernel.root_dir

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -614,6 +614,11 @@ Generates the file path inside an ``<a>`` element. If the path is inside
 the kernel root directory, the kernel root directory path is replaced by
 ``kernel.root_dir`` (showing the full path in a tooltip on hover).
 
+.. versionadded:: 4.2
+    The ``kernel.root_dir`` parameter, which stores the directory where the
+    Symfony kernel class is located. was deprecated in Symfony 4.2 and replaced
+    by ``kernel.project_dir``, which stores the main directory of the project.
+
 format_file_from_text
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -612,12 +612,7 @@ format_file
 
 Generates the file path inside an ``<a>`` element. If the path is inside
 the kernel root directory, the kernel root directory path is replaced by
-``kernel.root_dir`` (showing the full path in a tooltip on hover).
-
-.. versionadded:: 4.2
-    The ``kernel.root_dir`` parameter, which stores the directory where the
-    Symfony kernel class is located. was deprecated in Symfony 4.2 and replaced
-    by ``kernel.project_dir``, which stores the main directory of the project.
+``kernel.project_dir`` (showing the full path in a tooltip on hover).
 
 format_file_from_text
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This fixes #10503.

@ro0NL I need your help here. This is the only mention to `kernel.root_dir` in the docs (`getRootDir()` was not even mentioned). I'd like to remove this one too, but it looks like Symfony's code is using it:

* Injected here: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml#L84-L90
* Used in this Twig extension here: https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Twig/Extension/CodeExtension.php#L180

Can't we fix the code to remove this occurrence? Thanks!