### PR TITLE
Clarifying that .env can be used on production

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -125,16 +125,27 @@ B) Configure your Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Most Symfony applications read their configuration from environment variables.
-While developing locally, you'll usually store these in a ``.env`` file. But on
-production, instead of creating this file, you should set *real* environment variables.
+While developing locally, you'll usually store these in a ``.env`` file. On production,
+you have two options:
 
-How you set environment variables, depends on your setup: they can be set at the
-command line, in your Nginx configuration, or via other methods provided by your
-hosting service.
+1. Create "real" environment variables. How you set environment variables, depends
+   on your setup: they can be set at the command line, in your Nginx configuration,
+   or via other methods provided by your hosting service.
 
-At the very least you need to define the ``APP_ENV=prod`` environment variable
-to run the application in ``prod`` mode, but depending on your application you
-may need to define other env vars too.
+2. Or, create a ``.env`` file just like your local development (see note below)
+
+There is no significant advantage to either of the two options: use whatever is
+most natural in your hosting environment.
+
+.. note::
+
+    If you use the ``.env`` file on production, you may need to move your
+    ``symfony/dotenv`` dependency from ``require-dev`` to ``require`` in ``composer.json``:
+
+    .. code-block:: terminal
+
+        $ composer remove symfony/dotenv
+        $ composer reuire symfony/dotenv
 
 C) Install/Update your Vendors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Hi guys!

This is a question that I got repeatedly at a conference recently, so I think we need to make it clear: there is no real disadvantage to using a `.env` file on production and people should choose whatever option is most natural for their environment.

Cheers!