### PR TITLE
Add missing container argument for ServiceLocatorTagPass::register() call

### DIFF
--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -362,7 +362,7 @@ will share identical locators amongst all the services referencing them::
             'logger' => new Reference('logger'),
         );
 
-        $myService->addArgument(ServiceLocatorTagPass::register($locateableServices));
+        $myService->addArgument(ServiceLocatorTagPass::register($container, $locateableServices));
     }
 
 .. _`Command pattern`: https://en.wikipedia.org/wiki/Command_pattern


### PR DESCRIPTION
The last example on the service locator doc page is missing an argument for the ServiceLocatorTagPass::register() call.