### PR TITLE
Add documentation for using DTOs in form handling

### DIFF
--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -351,5 +351,5 @@ Replace the ``$task`` argument with ``$taskData`` in the ``createForm()`` call, 
         ]);
     }
 
-Now, when the user submits data, it is first validated using ``TaskData`` and only after successfull validation passed onto the ``Task`` entity.
-``Task`` entites will always be valid.
+Now, when the user submits data, it is first validated using ``TaskData`` and only after successful validation passed onto the ``Task`` entity.
+``Task`` entities will always be valid.

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -57,20 +57,20 @@ the setters fluent.
     +    * @ORM\GeneratedValue()
     +    * @ORM\Column(type="integer")
     +    */
-    +   protected $id;
+    +   private $id;
 
         /**
     +    * @ORM\Column(type="string", length=255)
          * @Assert\NotBlank()
          */
-        protected $task;
+        private $task;
 
         /**
     +   * @ORM\Column(type="datetime", nullable=true)
         * @Assert\NotBlank()
         * @Assert\Type("\DateTime")
         */
-        protected $dueDate;
+        private $dueDate;
 
     +   public function getId()
     +   {

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -129,7 +129,7 @@ following ``TaskData`` class:
 
         /**
         * @Assert\NotBlank()
-        * @Assert\Type()
+        * @Assert\Type(type="\DateTime")
         */
         public $dueDate;
 

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -243,14 +243,7 @@ Replace this with ``TaskData`` to prevent the aforementioned problems with an in
 
     class TaskType extends AbstractType
     {
-        public function buildForm(FormBuilderInterface $builder, array $options)
-        {
-            $builder
-                ->add('task')
-    -           ->add('dueDate')
-    +           ->add('dueDate', DateType::class)
-            ;
-        }
+        // ...
 
         public function configureOptions(OptionsResolver $resolver)
         {
@@ -260,9 +253,6 @@ Replace this with ``TaskData`` to prevent the aforementioned problems with an in
             ]);
         }
     }
-
-For this specific example, we also need to explicitly set the ``DateType`` for
-the ``dueDate`` field, as the form component can not guess it from the entity.
 
 .. index::
    single: Using the DTO in the Controller

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -122,9 +122,6 @@ Now, create a Data Transfer Object for the ``Task`` entity using the maker:
     Omit generation of getters/setters? (yes/no) [yes]:
     >
 
-    Omit Id field in DTO? (yes/no) [yes]:
-    >
-
 .. tip::
 
     Ignore the next steps suggested by the command for now, you will generate a

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -1,0 +1,317 @@
+.. index::
+   single: Form; Data Transfer Objects
+
+How to use Data Transfer Objects (DTO)
+======================================
+
+Data transfer objects can be used by forms to separate entitites from the
+validation logic of forms.
+Entities should always have a valid state.
+When entities are used as data classes for a form, the data is injected into
+the entity and validated.
+When the validation fails, the invalid data is still left in the entity.
+This can lead to invalid data being saved in the database.
+
+You will use the Maker bundle to highlight the differences between using DTOs
+and entities.
+
+.. index::
+   single: Installation
+
+Installation
+~~~~~~~~~~~~
+
+In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
+install the maker bundle before using it:
+
+.. code-block:: terminal
+
+    $ composer require maker --dev
+
+You will also need these packages in order to proceed with creating a crud
+example:
+
+.. code-block:: terminal
+
+    $ composer require form validator twig-bundle orm-pack security-csrf annotations
+
+Use the example ``Task`` entity from :doc:`the main forms tutorial </forms>`,
+make it a doctrine entity (this requires adding a primary key) and add a
+validation by adding annotations.
+
+.. code-block:: diff
+
+    // src/Entity/Task.php
+    namespace App\Entity;
+
+    + use Symfony\Component\Validator\Constraints as Assert;
+    + use Doctrine\ORM\Mapping as ORM;
+
+    + /**
+    + * @ORM\Entity
+    + */
+    class Task
+    {
+    +    /**
+    +     * @ORM\Id()
+    +     * @ORM\GeneratedValue()
+    +     * @ORM\Column(type="integer")
+    +     */
+    +    protected $id;
+
+    +    /**
+    +     * @ORM\Column(type="string", length=255)
+    +     * @Assert\NotBlank()
+    +     */
+        protected $task;
+
+    +    /**
+    +    * @ORM\Column(type="datetime", nullable=true)
+    +    */
+        protected $dueDate;
+
+        public function getTask()
+        {
+            return $this->task;
+        }
+
+        public function setTask($task)
+        {
+            $this->task = $task;
+        }
+
+        public function getDueDate()
+        {
+            return $this->dueDate;
+        }
+
+        public function setDueDate(\DateTime $dueDate = null)
+        {
+            $this->dueDate = $dueDate;
+        }
+    }
+
+.. index::
+   single: Creating a data transfer object
+
+Creating a data transfer object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Now, create a data transfer object for the ``Task`` entity using the maker:
+
+.. code-block:: terminal
+
+    $ php bin/console make:dto Task Task
+
+.. tip::
+
+    Ignore the next steps suggested by the command for now, you will generate a
+    complete CRUD with a different maker instead of a form in the next step.
+
+If you used the defaults during the dialogue, you will end up with the
+following ``TaskData`` class:
+
+.. code-block:: php
+
+    // src/Form/Data/TaskData.php
+    namespace App\Form\Data;
+
+    use App\Entity\Task;
+    use Symfony\Component\Validator\Constraints as Assert;
+
+    /**
+    * Data transfer object for Task.
+    * Add your constraints as annotations to the properties.
+    */
+    class TaskData
+    {
+        /**
+        * @Assert\NotBlank(message="This value should not be blank.", payload=null)
+        */
+        public $task;
+
+        public $dueDate;
+
+        /**
+        * Create DTO, optionally extracting data from a model.
+        *
+        * @param Task|null $task
+        */
+        public function __construct(? Task $task = null)
+        {
+            if ($task instanceof Task) {
+                $this->extract($task);
+            }
+        }
+
+        /**
+        * Fill entity with data from the DTO.
+        *
+        * @param Task $task
+        */
+        public function fill(Task $task): Task
+        {
+            $task
+                ->setTask($this->getTask())
+                ->setDueDate($this->getDueDate())
+            ;
+
+            return $task;
+        }
+
+        /**
+        * Extract data from entity into the DTO.
+        *
+        * @param Task $task
+        */
+        public function extract(Task $task): self
+        {
+            $this->setTask($task->getTask());
+            $this->setDueDate($task->getDueDate());
+
+            return $this;
+        }
+    }
+
+Notice the assert annotation? This was copied from the Task entity.
+The ``extract`` and ``fill`` methods can be used to populate the DTO with data
+from the entity and vice versa.
+
+.. caution::
+
+    During the generation of a DTO, validation annotations are copied from the
+    Entity.
+    You must ensure that changes to the validations are added in both places
+    when the entity is used with forms in other places (like
+    ``SonataAdminBundle`` or ``EasyAdminBundle``).
+    If the entity is not used at all, it is recommended to move all validations
+    into the DTO, removing them from the entity class.
+
+.. index::
+   single: Using the DTO in the Form
+
+Using the DTO in the Form
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the maker to create a simple CRUD application.
+
+.. code-block:: terminal
+
+    $ php bin/console make:crud Task
+
+This will generate a bunch of templates, a controller and a form.
+First, take a look at the generated ``TaskType`` form.
+
+Notice that it uses the ``Task`` entity by default.
+This means that the form data is injected into the ``Task`` entity directly and validated with the annotations.
+
+Replace this with ``TaskData`` to prevent the aforementioned problems with an invalid entity.
+
+.. code-block:: diff
+
+    // src/Form/TaskType.php
+    namespace App\Form;
+
+    - use App\Entity\Task;
+    + use App\Form\Data\TaskData;
+
+    ...
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+    -       'data_class' => Task::class,
+    +       'data_class' => TaskData::class,
+        ]);
+    }
+
+.. index::
+   single: Using the DTO in the Controller
+
+Using the DTO in the Controller
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Now, look at the ``App\Controller\TaskController`` class, that was generated by ``make:crud`` earlier.
+It also uses the ``Task`` entity directly.
+This is fine for the ``index()`` and ``show()`` methods, as no data is written there.
+
+Replace the ``Task`` entity with ``TaskData`` in the ``new()`` and ``edit()`` methods, using the ``fill()`` helper.
+
+.. code-block:: diff
+
+    // src/Controller/TaskController.php
+    namespace App\Controller;
+
+    use App\Entity\Task;
+    + use App\Form\Data\TaskData;
+
+    ...
+
+    /**
+    * @Route("/task")
+    */
+    class TaskController extends AbstractController
+    {
+
+    ...
+
+      /**
+      * @Route("/new", name="task_new", methods="GET|POST")
+      */
+      public function new(Request $request): Response
+      {
+    -     $task = new Task();
+    -     $form = $this->createForm(TaskType::class, $task);
+    +     $taskData = new TaskData();
+    +     $form = $this->createForm(TaskType::class, $taskData);
+          $form->handleRequest($request);
+
+          if ($form->isSubmitted() && $form->isValid()) {
+    +         $task = $taskData->fill(new Task());
+              $em = $this->getDoctrine()->getManager();
+              $em->persist($task);
+              $em->flush();
+
+              return $this->redirectToRoute('task_index');
+          }
+
+          return $this->render('task/new.html.twig', [
+              'task' => $task,
+              'form' => $form->createView(),
+          ]);
+      }
+
+The form handles the data using ``TaskData``, the ``Task`` entity now is only created after validation.
+
+In ``edit()``, the ``Task`` entity is injected by Symfony's ``ParamConverter``.
+Create a new ``TaskData`` object and pass it the ``Task`` entity (internally, the ``extract()`` helper will populate the DTO).
+Replace the ``$task`` argument with ``$taskData`` in the ``createForm()`` call, so that the form uses the DTO.
+
+.. code-block:: diff
+
+    /**
+     * @Route("/{id}/edit", name="task_edit", methods="GET|POST")
+     */
+    public function edit(Request $request, Task $task): Response
+    {
+    -   $form = $this->createForm(TaskType::class, $task);
+    +   $taskData = new TaskData($task);
+    +   $form = $this->createForm(TaskType::class, $taskData);
+    +
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+    +       $task = $taskData->fill($task);
+            $this->getDoctrine()->getManager()->flush();
+
+            return $this->redirectToRoute('task_edit', ['id' => $task->getId()]);
+        }
+
+        return $this->render('task/edit.html.twig', [
+            'task' => $task,
+            'form' => $form->createView(),
+        ]);
+    }
+
+Now, when the user submits data, it is first validated using ``TaskData`` and only after successfull validation passed onto the ``Task`` entity.
+``Task`` entites will always be valid.

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -35,9 +35,8 @@ example:
 
     $ composer require form validator twig-bundle orm-pack security-csrf annotations
 
-Use the example ``Task`` entity from :doc:`the main forms tutorial </forms>`,
-make it a doctrine entity (this requires adding a primary key ``id``) and make
-the setters fluent.
+Use the example ``Task`` entity from :doc:`the main forms tutorial </forms>`
+and make it a doctrine entity (this requires adding a primary key ``id``).
 
 .. code-block:: diff
 
@@ -76,30 +75,8 @@ the setters fluent.
     +   {
     +       return $this->id;
     +   }
-    +
-        public function getTask()
-        {
-            return $this->task;
-        }
 
-        public function setTask($task)
-        {
-            $this->task = $task;
-    +
-    +       return $this;
-        }
-
-        public function getDueDate()
-        {
-            return $this->dueDate;
-        }
-
-        public function setDueDate(\DateTime $dueDate = null)
-        {
-            $this->dueDate = $dueDate;
-    +
-    +       return $this;
-        }
+        // ...
     }
 
 .. index::
@@ -171,10 +148,8 @@ following ``TaskData`` class:
         */
         public function fill(Task $task): Task
         {
-            $task
-                ->setTask($this->task)
-                ->setDueDate($this->dueDate)
-            ;
+            $task->setTask($this->task);
+            $task->setDueDate($this->dueDate)
 
             return $task;
         }

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -6,14 +6,14 @@ How to use Data Transfer Objects (DTOs)
 
 Data Transfer Objects can be used by forms to separate entities from the
 validation logic of forms.
-Entities should always have a valid state.
-When entities are used as data classes for a form, the data is injected into
-the entity and validated.
-When the validation fails, the invalid data is still left in the entity.
-This can lead to invalid data being saved in the database or unexpected exceptions.
+When entities are used as data classes for a form, validation happens after the
+form data has been injected into the entities.
+When the validation fails, the invalid data is still left in the entities.
+This can lead to invalid data being saved in the database or unexpected
+exceptions.
 
-You will use the Maker bundle to highlight the differences between using DTOs
-and entities.
+Let's use the Maker bundle to highlight the differences between using DTOs and
+entities.
 
 .. index::
    single: Installation
@@ -36,15 +36,15 @@ example:
     $ composer require form validator twig-bundle orm-pack security-csrf annotations
 
 Use the example ``Task`` entity from :doc:`the main forms tutorial </forms>`
-and make it a doctrine entity (this requires adding a primary key ``id``).
+and make it a Doctrine entity (this requires adding a primary key ``id``).
 
 .. code-block:: diff
 
     // src/Entity/Task.php
     namespace App\Entity;
 
-    + use Symfony\Component\Validator\Constraints as Assert;
     + use Doctrine\ORM\Mapping as ORM;
+    + use Symfony\Component\Validator\Constraints as Assert;
 
     + /**
     + * @ORM\Entity

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -10,7 +10,7 @@ Entities should always have a valid state.
 When entities are used as data classes for a form, the data is injected into
 the entity and validated.
 When the validation fails, the invalid data is still left in the entity.
-This can lead to invalid data being saved in the database.
+This can lead to invalid data being saved in the database or unexpected exceptions.
 
 You will use the Maker bundle to highlight the differences between using DTOs
 and entities.

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -2,7 +2,7 @@
    single: Form; Data Transfer Objects
 
 How to use Data Transfer Objects (DTOs)
-======================================
+=======================================
 
 Data Transfer Objects can be used by forms to separate entities from the
 validation logic of forms.

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -1,10 +1,10 @@
 .. index::
    single: Form; Data Transfer Objects
 
-How to use Data Transfer Objects (DTO)
+How to use Data Transfer Objects (DTOs)
 ======================================
 
-Data transfer objects can be used by forms to separate entitites from the
+Data Transfer Objects can be used by forms to separate entities from the
 validation logic of forms.
 Entities should always have a valid state.
 When entities are used as data classes for a form, the data is injected into
@@ -22,13 +22,13 @@ Installation
 ~~~~~~~~~~~~
 
 In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
-install the maker bundle before using it:
+install the Maker bundle before using it:
 
 .. code-block:: terminal
 
     $ composer require maker --dev
 
-You will also need these packages in order to proceed with creating a crud
+You will also need these packages in order to proceed with creating a CRUD
 example:
 
 .. code-block:: terminal
@@ -102,12 +102,12 @@ setters fluent and add a validation by adding annotations.
     }
 
 .. index::
-   single: Creating a data transfer object
+   single: Creating a Data Transfer Object
 
-Creating a data transfer object
+Creating a Data Transfer Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Now, create a data transfer object for the ``Task`` entity using the maker:
+Now, create a Data Transfer Object for the ``Task`` entity using the maker:
 
 .. code-block:: terminal
 
@@ -240,7 +240,7 @@ Replace this with ``TaskData`` to prevent the aforementioned problems with an in
     - use App\Entity\Task;
     + use App\Form\Data\TaskData;
     + use Symfony\Component\Form\Extension\Core\Type\DateType;
-    ...
+    // ...
 
     class TaskType extends AbstractType
     {
@@ -285,7 +285,7 @@ Replace the ``Task`` entity with ``TaskData`` in the ``new()`` and ``edit()`` me
     use App\Entity\Task;
     + use App\Form\Data\TaskData;
 
-    ...
+    // ...
 
     /**
     * @Route("/task")
@@ -293,7 +293,7 @@ Replace the ``Task`` entity with ``TaskData`` in the ``new()`` and ``edit()`` me
     class TaskController extends AbstractController
     {
 
-    ...
+    // ...
 
       /**
       * @Route("/new", name="task_new", methods="GET|POST")

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -36,8 +36,8 @@ example:
     $ composer require form validator twig-bundle orm-pack security-csrf annotations
 
 Use the example ``Task`` entity from :doc:`the main forms tutorial </forms>`,
-make it a doctrine entity (this requires adding a primary key ``id``), make the
-setters fluent and add a validation by adding annotations.
+make it a doctrine entity (this requires adding a primary key ``id``) and make
+the setters fluent.
 
 .. code-block:: diff
 
@@ -59,16 +59,17 @@ setters fluent and add a validation by adding annotations.
     +    */
     +   protected $id;
 
-    +   /**
+        /**
     +    * @ORM\Column(type="string", length=255)
-    +    * @Assert\NotBlank()
-    +    */
+         * @Assert\NotBlank()
+         */
         protected $task;
 
-    +   /**
+        /**
     +   * @ORM\Column(type="datetime", nullable=true)
-    +   * @Assert\DateTime()
-    +   */
+        * @Assert\NotBlank()
+        * @Assert\Type("\DateTime")
+        */
         protected $dueDate;
 
     +   public function getId()
@@ -150,7 +151,8 @@ following ``TaskData`` class:
         public $task;
 
         /**
-        * @Assert\DateTime(format="Y-m-d H:i:s", message="This value is not a valid datetime.", payload=null)
+        * @Assert\NotBlank(message="This value should not be blank.", payload=null)
+        * @Assert\Type(message="This value should be of type {{ type }}.", type="\DateTime", payload=null)
         */
         public $dueDate;
 

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -291,9 +291,9 @@ Replace the ``Task`` entity with ``TaskData`` in the ``new()`` and ``edit()`` me
 
           if ($form->isSubmitted() && $form->isValid()) {
     +         $task = $taskData->fill(new Task());
-              $em = $this->getDoctrine()->getManager();
-              $em->persist($task);
-              $em->flush();
+              $entityManager = $this->getDoctrine()->getManager();
+              $entityManager->persist($task);
+              $entityManager->flush();
 
               return $this->redirectToRoute('task_index');
           }

--- a/form/data_transfer_objects.rst
+++ b/form/data_transfer_objects.rst
@@ -146,22 +146,20 @@ following ``TaskData`` class:
     class TaskData
     {
         /**
-        * @Assert\NotBlank(message="This value should not be blank.", payload=null)
+        * @Assert\NotBlank()
         */
         public $task;
 
         /**
-        * @Assert\NotBlank(message="This value should not be blank.", payload=null)
-        * @Assert\Type(message="This value should be of type {{ type }}.", type="\DateTime", payload=null)
+        * @Assert\NotBlank()
+        * @Assert\Type()
         */
         public $dueDate;
 
         /**
         * Create DTO, optionally extracting data from a model.
-        *
-        * @param Task|null $task
         */
-        public function __construct(? Task $task = null)
+        public function __construct(?Task $task = null)
         {
             if ($task instanceof Task) {
                 $this->extract($task);
@@ -170,8 +168,6 @@ following ``TaskData`` class:
 
         /**
         * Fill entity with data from the DTO.
-        *
-        * @param Task $task
         */
         public function fill(Task $task): Task
         {
@@ -185,8 +181,6 @@ following ``TaskData`` class:
 
         /**
         * Extract data from entity into the DTO.
-        *
-        * @param Task $task
         */
         public function extract(Task $task): self
         {

--- a/forms.rst
+++ b/forms.rst
@@ -46,8 +46,8 @@ going to need to build a form. But before you begin, first focus on the generic
 
     class Task
     {
-        protected $task;
-        protected $dueDate;
+        private $task;
+        private $dueDate;
 
         public function getTask()
         {
@@ -338,13 +338,13 @@ object.
             /**
              * @Assert\NotBlank()
              */
-            public $task;
+            private $task;
 
             /**
              * @Assert\NotBlank()
              * @Assert\Type("\DateTime")
              */
-            protected $dueDate;
+            private $dueDate;
         }
 
     .. code-block:: yaml

--- a/forms.rst
+++ b/forms.rst
@@ -695,11 +695,11 @@ the choice is ultimately up to you.
     to modify it, use the :method:`Symfony\\Component\\Form\\FormFactoryInterface::createNamed` method.
     You can even suppress the name completely by setting it to an empty string.
 
-Using data transfer objects
+Using Data Transfer Objects
 ---------------------------
 
 There are some problems when using entities as directly mapped data classes for forms.
-These problems can be circumvented by using data transfer objects.
+These problems can be circumvented by using Data Transfer Objects.
 See
 :doc:`/form/data_transfer_objects` for info.
 

--- a/forms.rst
+++ b/forms.rst
@@ -695,6 +695,14 @@ the choice is ultimately up to you.
     to modify it, use the :method:`Symfony\\Component\\Form\\FormFactoryInterface::createNamed` method.
     You can even suppress the name completely by setting it to an empty string.
 
+Using data transfer objects
+---------------------------
+
+There are some problems when using entities as directly mapped data classes for forms.
+These problems can be circumvented by using data transfer objects.
+See
+:doc:`/form/data_transfer_objects` for info.
+
 Final Thoughts
 --------------
 


### PR DESCRIPTION
Add a short article about using data transfer objects in form handling.
The docs use a new make:dto command.
Merge when [make:dto](https://github.com/symfony/maker-bundle/pull/303) is merged.