### PR TITLE
Revert a change related to flash messages and sessions

### DIFF
--- a/session/avoid_session_start.rst
+++ b/session/avoid_session_start.rst
@@ -29,7 +29,7 @@ access the flash messages:
 
 .. code-block:: html+twig
 
-    {% if app.request.method == 'POST' %}
+    {% if app.request.hasPreviousSession %}
         {% for message in app.flashes('notice') %}
             <div class="flash-notice">
                 {{ message }}


### PR DESCRIPTION
This was done a few days ago (e6ce2f4) but there's an ongoing discussion about it in Symfony (https://github.com/symfony/symfony/issues/28804) and some people are complaining on slack about the changed code. So let's revert for now to the original code.