### PR TITLE
Add item to troubleshoot about Out of memory and SELinux

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -238,7 +238,7 @@ kernel and return your project's root directory::
 Out of memory when accessing /web/app.php
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Some UNIX systems make use of SELinux, specially Red Hat distributions, like CentOS. By default SELinux is set to enforcing as it should be. If you deploy with app_dev.php you will see some weird permission errors even if you set 777 to `var` directory inside your project's folder. To resolve this, either set SELinux configuration correctly or disable it.
+Some UNIX systems make use of SELinux, specially Red Hat distributions, like CentOS. By default SELinux is set to enforcing as it should be. If you deploy with app_dev.php you will see some weird permission errors even if you set 777 to `var` directory inside your project's folder. To resolve this set SELinux configuration correctly.
 
 .. _`Capifony`: https://github.com/everzet/capifony
 .. _`Capistrano`: http://capistranorb.com/

--- a/deployment.rst
+++ b/deployment.rst
@@ -235,6 +235,11 @@ kernel and return your project's root directory::
         }
     }
 
+Out of memory when accessing /web/app.php
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some UNIX systems make use of SELinux, specially Red Hat distributions, like CentOS. By default SELinux is set to enforcing as it should be. If you deploy with app_dev.php you will see some weird permission errors even if you set 777 to `var` directory inside your project's folder. To resolve this, either set SELinux configuration correctly or disable it.
+
 .. _`Capifony`: https://github.com/everzet/capifony
 .. _`Capistrano`: http://capistranorb.com/
 .. _`sf2debpkg`: https://github.com/liip/sf2debpkg


### PR DESCRIPTION
While deploying in a CentOS, I've had problems with SELinux and no hint about it being the problem while trying to write in var directory inside my project's folder. This commit adds and item in Troubleshooting section so developers can have some hint abou this same problem.

