### PR TITLE
Added documentation for constraint message parameters

### DIFF
--- a/reference/constraints/Bic.rst
+++ b/reference/constraints/Bic.rst
@@ -95,6 +95,14 @@ message
 
 The default message supplied when the value does not pass the BIC check.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ value }}``  | The current (invalid) BIC value                |
++------------------+------------------------------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`Business Identifier Code (BIC)`: https://en.wikipedia.org/wiki/Business_Identifier_Code

--- a/reference/constraints/Blank.rst
+++ b/reference/constraints/Blank.rst
@@ -96,4 +96,12 @@ message
 
 This is the message that will be shown if the value is not blank.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ value }}``  | The current (invalid) value                    |
++------------------+------------------------------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/CardScheme.rst
+++ b/reference/constraints/CardScheme.rst
@@ -131,6 +131,14 @@ message
 
 The message shown when the value does not pass the ``CardScheme`` check.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ value }}``  | The current (invalid) value                    |
++------------------+------------------------------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`Wikipedia: Issuer identification number (IIN)`: https://en.wikipedia.org/wiki/Bank_card_number#Issuer_identification_number_.28IIN.29

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -335,6 +335,14 @@ This is the message that you will receive if the ``multiple`` option is
 set to ``false`` and the underlying value is not in the valid array of
 choices.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ value }}``  | The current (invalid) value                    |
++------------------+------------------------------------------------+
+
 multipleMessage
 ~~~~~~~~~~~~~~~
 
@@ -344,6 +352,14 @@ This is the message that you will receive if the ``multiple`` option is
 set to ``true`` and one of the values on the underlying array being checked
 is not in the array of valid choices.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ value }}``  | The current (invalid) value                    |
++------------------+------------------------------------------------+
+
 minMessage
 ~~~~~~~~~~
 
@@ -352,6 +368,14 @@ minMessage
 This is the validation error message that's displayed when the user chooses
 too few choices per the `min`_ option.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ limit }}``  | The lower limit of choices                     |
++------------------+------------------------------------------------+
+
 maxMessage
 ~~~~~~~~~~
 
@@ -359,6 +383,14 @@ maxMessage
 
 This is the validation error message that's displayed when the user chooses
 too many options per the `max`_ option.
+
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ limit }}``  | The upper limit of choices                     |
++------------------+------------------------------------------------+
 
 strict
 ~~~~~~

--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -319,6 +319,14 @@ extraFieldsMessage
 The message shown if `allowExtraFields`_ is false and an extra field is
 detected.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ field }}``  | The key of the extra field detected            |
++------------------+------------------------------------------------+
+
 allowMissingFields
 ~~~~~~~~~~~~~~~~~~
 
@@ -336,5 +344,13 @@ missingFieldsMessage
 
 The message shown if `allowMissingFields`_ is false and one or more fields
 are missing from the underlying collection.
+
+You can use the following parameters in this message:
+
++------------------+----------------------------------------------------+
+| Parameter        | Description                                        |
++==================+====================================================+
+| ``{{ field }}``  | The key of the missing field defined in ``fields`` |
++------------------+----------------------------------------------------+
 
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Count.rst
+++ b/reference/constraints/Count.rst
@@ -127,6 +127,16 @@ minMessage
 The message that will be shown if the underlying collection elements count
 is less than the `min`_ option.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ count }}``  | The current collection size                    |
++------------------+------------------------------------------------+
+| ``{{ limit }}``  | The lower limit                                |
++------------------+------------------------------------------------+
+
 maxMessage
 ~~~~~~~~~~
 
@@ -135,6 +145,16 @@ maxMessage
 The message that will be shown if the underlying collection elements count
 is more than the `max`_ option.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ count }}``  | The current collection size                    |
++------------------+------------------------------------------------+
+| ``{{ limit }}``  | The upper limit                                |
++------------------+------------------------------------------------+
+
 exactMessage
 ~~~~~~~~~~~~
 
@@ -142,5 +162,15 @@ exactMessage
 
 The message that will be shown if min and max values are equal and the underlying
 collection elements count is not exactly this value.
+
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ count }}``  | The current collection size                    |
++------------------+------------------------------------------------+
+| ``{{ limit }}``  | The exact expected collection size             |
++------------------+------------------------------------------------+
 
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Country.rst
+++ b/reference/constraints/Country.rst
@@ -85,6 +85,14 @@ message
 
 This message is shown if the string is not a valid country code.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ value }}``  | The current (invalid) country code             |
++------------------+------------------------------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes

--- a/reference/constraints/Currency.rst
+++ b/reference/constraints/Currency.rst
@@ -91,6 +91,14 @@ message
 
 This is the message that will be shown if the value is not a valid currency.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ value }}``  | The current (invalid) value                    |
++------------------+------------------------------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`3-letter ISO 4217`: https://en.wikipedia.org/wiki/ISO_4217

--- a/reference/constraints/Date.rst
+++ b/reference/constraints/Date.rst
@@ -87,4 +87,12 @@ message
 
 This message is shown if the underlying data is not a valid date.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ value }}``  | The current (invalid) value                    |
++------------------+------------------------------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/DateTime.rst
+++ b/reference/constraints/DateTime.rst
@@ -87,4 +87,12 @@ message
 
 This message is shown if the underlying data is not a valid datetime.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ value }}``  | The current (invalid) value                    |
++------------------+------------------------------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -109,6 +109,14 @@ message
 
 This message is shown if the underlying data is not a valid email address.
 
+You can use the following parameters in this message:
+
++------------------+------------------------------------------------+
+| Parameter        | Description                                    |
++==================+================================================+
+| ``{{ value }}``  | The current (invalid) value                    |
++------------------+------------------------------------------------+
+
 checkMX
 ~~~~~~~
 

--- a/reference/constraints/EqualTo.rst
+++ b/reference/constraints/EqualTo.rst
@@ -120,4 +120,16 @@ message
 
 This is the message that will be shown if the value is not equal.
 
+You can use the following parameters in this message:
+
++-------------------------------+-----------------------------+
+| Parameter                     | Description                 |
++===============================+=============================+
+| ``{{ value }}``               | The current (invalid) value |
++-------------------------------+-----------------------------+
+| ``{{ compared_value }}``      | The expected value          |
++-------------------------------+-----------------------------+
+| ``{{ compared_value_type }}`` | The expected value type     |
++-------------------------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Expression.rst
+++ b/reference/constraints/Expression.rst
@@ -252,4 +252,12 @@ message
 
 The default message supplied when the expression evaluates to false.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -302,6 +302,18 @@ message
 This is the message that will be shown if the value is not greater than the
 comparison value.
 
+You can use the following parameters in this message:
+
++-------------------------------+-----------------------------+
+| Parameter                     | Description                 |
++===============================+=============================+
+| ``{{ value }}``               | The current (invalid) value |
++-------------------------------+-----------------------------+
+| ``{{ compared_value }}``      | The lower limit             |
++-------------------------------+-----------------------------+
+| ``{{ compared_value_type }}`` | The expected value type     |
++-------------------------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`accepted by the DateTime constructor`: https://php.net/manual/en/datetime.formats.php

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -300,6 +300,18 @@ message
 This is the message that will be shown if the value is not greater than or equal
 to the comparison value.
 
+You can use the following parameters in this message:
+
++-------------------------------+-----------------------------+
+| Parameter                     | Description                 |
++===============================+=============================+
+| ``{{ value }}``               | The current (invalid) value |
++-------------------------------+-----------------------------+
+| ``{{ compared_value }}``      | The lower limit             |
++-------------------------------+-----------------------------+
+| ``{{ compared_value_type }}`` | The expected value type     |
++-------------------------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`accepted by the DateTime constructor`: https://php.net/manual/en/datetime.formats.php

--- a/reference/constraints/Iban.rst
+++ b/reference/constraints/Iban.rst
@@ -105,6 +105,14 @@ message
 
 The default message supplied when the value does not pass the Iban check.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`International Bank Account Number (IBAN)`: https://en.wikipedia.org/wiki/International_Bank_Account_Number

--- a/reference/constraints/IdenticalTo.rst
+++ b/reference/constraints/IdenticalTo.rst
@@ -114,4 +114,16 @@ message
 
 This is the message that will be shown if the value is not identical.
 
+You can use the following parameters in this message:
+
++-------------------------------+-----------------------------+
+| Parameter                     | Description                 |
++===============================+=============================+
+| ``{{ value }}``               | The current (invalid) value |
++-------------------------------+-----------------------------+
+| ``{{ compared_value }}``      | The expected value          |
++-------------------------------+-----------------------------+
+| ``{{ compared_value_type }}`` | The expected value type     |
++-------------------------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -328,6 +328,16 @@ Allowed maximum width is {{ max_width }}px.``
 
 The error message if the width of the image exceeds `maxWidth`_.
 
+You can use the following parameters in this message:
+
++---------------------+-----------------------------+
+| Parameter           | Description                 |
++=====================+=============================+
+| ``{{ width }}``     | The current (invalid) width |
++---------------------+-----------------------------+
+| ``{{ max_width }}`` | The maximum allowed width   |
++---------------------+-----------------------------+
+
 minWidthMessage
 ~~~~~~~~~~~~~~~
 
@@ -335,6 +345,16 @@ minWidthMessage
 Minimum width expected is {{ min_width }}px.``
 
 The error message if the width of the image is less than `minWidth`_.
+
+You can use the following parameters in this message:
+
++---------------------+-----------------------------+
+| Parameter           | Description                 |
++=====================+=============================+
+| ``{{ width }}``     | The current (invalid) width |
++---------------------+-----------------------------+
+| ``{{ min_width }}`` | The minimum required width  |
++---------------------+-----------------------------+
 
 maxHeightMessage
 ~~~~~~~~~~~~~~~~
@@ -344,6 +364,16 @@ Allowed maximum height is {{ max_height }}px.``
 
 The error message if the height of the image exceeds `maxHeight`_.
 
+You can use the following parameters in this message:
+
++----------------------+------------------------------+
+| Parameter            | Description                  |
++======================+==============================+
+| ``{{ height }}``     | The current (invalid) height |
++----------------------+------------------------------+
+| ``{{ max_height }}`` | The maximum allowed height   |
++----------------------+------------------------------+
+
 minHeightMessage
 ~~~~~~~~~~~~~~~~
 
@@ -351,6 +381,16 @@ minHeightMessage
 Minimum height expected is {{ min_height }}px.``
 
 The error message if the height of the image is less than `minHeight`_.
+
+You can use the following parameters in this message:
+
++----------------------+------------------------------+
+| Parameter            | Description                  |
++======================+==============================+
+| ``{{ height }}``     | The current (invalid) height |
++----------------------+------------------------------+
+| ``{{ min_height }}`` | The minimum required height  |
++----------------------+------------------------------+
 
 maxRatioMessage
 ~~~~~~~~~~~~~~~
@@ -360,6 +400,16 @@ Allowed maximum ratio is {{ max_ratio }}``
 
 The error message if the aspect ratio of the image exceeds `maxRatio`_.
 
+You can use the following parameters in this message:
+
++---------------------+-----------------------------+
+| Parameter           | Description                 |
++=====================+=============================+
+| ``{{ ratio }}``     | The current (invalid) ratio |
++---------------------+-----------------------------+
+| ``{{ max_ratio }}`` | The maximum allowed ratio   |
++---------------------+-----------------------------+
+
 minRatioMessage
 ~~~~~~~~~~~~~~~
 
@@ -367,6 +417,16 @@ minRatioMessage
 Minimum ratio expected is {{ min_ratio }}``
 
 The error message if the aspect ratio of the image is less than `minRatio`_.
+
+You can use the following parameters in this message:
+
++---------------------+-----------------------------+
+| Parameter           | Description                 |
++=====================+=============================+
+| ``{{ ratio }}``     | The current (invalid) ratio |
++---------------------+-----------------------------+
+| ``{{ min_ratio }}`` | The minimum required ratio  |
++---------------------+-----------------------------+
 
 allowSquareMessage
 ~~~~~~~~~~~~~~~~~~
@@ -376,6 +436,16 @@ Square images are not allowed``
 
 The error message if the image is square and you set `allowSquare`_ to ``false``.
 
+You can use the following parameters in this message:
+
++------------------+--------------------+
+| Parameter        | Description        |
++==================+====================+
+| ``{{ width }}``  | The current width  |
++------------------+--------------------+
+| ``{{ height }}`` | The current height |
++------------------+--------------------+
+
 allowLandscapeMessage
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -384,6 +454,16 @@ Landscape oriented images are not allowed``
 
 The error message if the image is landscape oriented and you set `allowLandscape`_ to ``false``.
 
+You can use the following parameters in this message:
+
++------------------+--------------------+
+| Parameter        | Description        |
++==================+====================+
+| ``{{ width }}``  | The current width  |
++------------------+--------------------+
+| ``{{ height }}`` | The current height |
++------------------+--------------------+
+
 allowPortraitMessage
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -391,5 +471,15 @@ allowPortraitMessage
 Portrait oriented images are not allowed``
 
 The error message if the image is portrait oriented and you set `allowPortrait`_ to ``false``.
+
+You can use the following parameters in this message:
+
++------------------+--------------------+
+| Parameter        | Description        |
++==================+====================+
+| ``{{ width }}``  | The current width  |
++------------------+--------------------+
+| ``{{ height }}`` | The current height |
++------------------+--------------------+
 
 .. _`IANA website`: http://www.iana.org/assignments/media-types/image/index.html

--- a/reference/constraints/Ip.rst
+++ b/reference/constraints/Ip.rst
@@ -132,4 +132,12 @@ message
 
 This message is shown if the string is not a valid IP address.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/IsFalse.rst
+++ b/reference/constraints/IsFalse.rst
@@ -112,4 +112,12 @@ message
 
 This message is shown if the underlying data is not false.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/IsNull.rst
+++ b/reference/constraints/IsNull.rst
@@ -90,4 +90,12 @@ message
 
 This is the message that will be shown if the value is not ``null``.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/IsTrue.rst
+++ b/reference/constraints/IsTrue.rst
@@ -126,4 +126,12 @@ message
 
 This message is shown if the underlying data is not true.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -125,6 +125,14 @@ message
 The message that will be shown if the value is not valid. If not ``null``,
 this message has priority over all the other messages.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 isbn10Message
 ~~~~~~~~~~~~~
 
@@ -132,6 +140,14 @@ isbn10Message
 
 The message that will be shown if the `type`_ option is ``isbn10`` and the given
 value does not pass the ISBN-10 check.
+
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
 
 isbn13Message
 ~~~~~~~~~~~~~
@@ -141,6 +157,14 @@ isbn13Message
 The message that will be shown if the `type`_ option is ``isbn13`` and the given
 value does not pass the ISBN-13 check.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 bothIsbnMessage
 ~~~~~~~~~~~~~~~
 
@@ -148,6 +172,14 @@ bothIsbnMessage
 
 The message that will be shown if the `type`_ option is ``null`` and the given
 value does not pass any of the ISBN checks.
+
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 

--- a/reference/constraints/Issn.rst
+++ b/reference/constraints/Issn.rst
@@ -91,6 +91,14 @@ message
 
 The message shown if the given value is not a valid ISSN.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 caseSensitive
 ~~~~~~~~~~~~~
 

--- a/reference/constraints/Language.rst
+++ b/reference/constraints/Language.rst
@@ -86,4 +86,12 @@ message
 
 This message is shown if the string is not a valid language code.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -18,6 +18,7 @@ Validates that a given string length is *between* some minimum and maximum value
 |                | - `minMessage`_                                                      |
 |                | - `maxMessage`_                                                      |
 |                | - `exactMessage`_                                                    |
+|                | - `charsetMessage`_                                                  |
 |                | - `payload`_                                                         |
 +----------------+----------------------------------------------------------------------+
 | Class          | :class:`Symfony\\Component\\Validator\\Constraints\\Length`          |
@@ -153,6 +154,16 @@ minMessage
 The message that will be shown if the underlying value's length is less
 than the `min`_ option.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+| ``{{ limit }}`` | The expected minimum length |
++-----------------+-----------------------------+
+
 maxMessage
 ~~~~~~~~~~
 
@@ -161,6 +172,16 @@ maxMessage
 The message that will be shown if the underlying value's length is more
 than the `max`_ option.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+| ``{{ limit }}`` | The expected maximum length |
++-----------------+-----------------------------+
+
 exactMessage
 ~~~~~~~~~~~~
 
@@ -168,5 +189,32 @@ exactMessage
 
 The message that will be shown if min and max values are equal and the underlying
 value's length is not exactly this value.
+
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+| ``{{ limit }}`` | The exact expected length   |
++-----------------+-----------------------------+
+
+charsetMessage
+~~~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``This value does not match the expected {{ charset }} charset.``
+
+The message that will be shown if the value is not using the given `charset`_.
+
+You can use the following parameters in this message:
+
++-------------------+-----------------------------+
+| Parameter         | Description                 |
++===================+=============================+
+| ``{{ value }}``   | The current (invalid) value |
++-------------------+-----------------------------+
+| ``{{ charset }}`` | The expected charset        |
++-------------------+-----------------------------+
 
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -301,6 +301,18 @@ message
 This is the message that will be shown if the value is not less than the
 comparison value.
 
+You can use the following parameters in this message:
+
++-------------------------------+-----------------------------+
+| Parameter                     | Description                 |
++===============================+=============================+
+| ``{{ value }}``               | The current (invalid) value |
++-------------------------------+-----------------------------+
+| ``{{ compared_value }}``      | The upper limit             |
++-------------------------------+-----------------------------+
+| ``{{ compared_value_type }}`` | The expected value type     |
++-------------------------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`accepted by the DateTime constructor`: https://php.net/manual/en/datetime.formats.php

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -299,6 +299,18 @@ message
 This is the message that will be shown if the value is not less than or equal
 to the comparison value.
 
+You can use the following parameters in this message:
+
++-------------------------------+-----------------------------+
+| Parameter                     | Description                 |
++===============================+=============================+
+| ``{{ value }}``               | The current (invalid) value |
++-------------------------------+-----------------------------+
+| ``{{ compared_value }}``      | The upper limit             |
++-------------------------------+-----------------------------+
+| ``{{ compared_value_type }}`` | The expected value type     |
++-------------------------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`accepted by the DateTime constructor`: https://php.net/manual/en/datetime.formats.php

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -90,6 +90,14 @@ message
 
 This message is shown if the string is not a valid locale.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

--- a/reference/constraints/Luhn.rst
+++ b/reference/constraints/Luhn.rst
@@ -97,6 +97,14 @@ message
 
 The default message supplied when the value does not pass the Luhn check.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`Luhn algorithm`: https://en.wikipedia.org/wiki/Luhn_algorithm

--- a/reference/constraints/NotBlank.rst
+++ b/reference/constraints/NotBlank.rst
@@ -94,4 +94,12 @@ message
 
 This is the message that will be shown if the value is blank.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/NotEqualTo.rst
+++ b/reference/constraints/NotEqualTo.rst
@@ -122,4 +122,16 @@ message
 
 This is the message that will be shown if the value is equal.
 
+You can use the following parameters in this message:
+
++-------------------------------+-----------------------------+
+| Parameter                     | Description                 |
++===============================+=============================+
+| ``{{ value }}``               | The current (invalid) value |
++-------------------------------+-----------------------------+
+| ``{{ compared_value }}``      | The expected value          |
++-------------------------------+-----------------------------+
+| ``{{ compared_value_type }}`` | The expected value type     |
++-------------------------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/NotIdenticalTo.rst
+++ b/reference/constraints/NotIdenticalTo.rst
@@ -123,4 +123,16 @@ message
 
 This is the message that will be shown if the value is identical.
 
+You can use the following parameters in this message:
+
++-------------------------------+-----------------------------+
+| Parameter                     | Description                 |
++===============================+=============================+
+| ``{{ value }}``               | The current (invalid) value |
++-------------------------------+-----------------------------+
+| ``{{ compared_value }}``      | The expected value          |
++-------------------------------+-----------------------------+
+| ``{{ compared_value_type }}`` | The expected value type     |
++-------------------------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/NotNull.rst
+++ b/reference/constraints/NotNull.rst
@@ -88,4 +88,12 @@ message
 
 This is the message that will be shown if the value is ``null``.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -341,6 +341,16 @@ minMessage
 The message that will be shown if the underlying value is less than the
 `min`_ option.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+| ``{{ limit }}`` | The lower limit             |
++-----------------+-----------------------------+
+
 maxMessage
 ~~~~~~~~~~
 
@@ -349,6 +359,16 @@ maxMessage
 The message that will be shown if the underlying value is more than the
 `max`_ option.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+| ``{{ limit }}`` | The upper limit             |
++-----------------+-----------------------------+
+
 invalidMessage
 ~~~~~~~~~~~~~~
 
@@ -356,6 +376,14 @@ invalidMessage
 
 The message that will be shown if the underlying value is not a number (per
 the `is_numeric`_ PHP function).
+
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 

--- a/reference/constraints/Regex.rst
+++ b/reference/constraints/Regex.rst
@@ -279,4 +279,12 @@ message
 
 This is the message that will be shown if this validator fails.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Time.rst
+++ b/reference/constraints/Time.rst
@@ -90,4 +90,12 @@ message
 
 This message is shown if the underlying data is not a valid time.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -160,6 +160,16 @@ message
 
 The message if the underlying data is not of the given type.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+| ``{{ type }}``  | The expected type           |
++-----------------+-----------------------------+
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _built-in PHP extension: https://php.net/book.ctype.php

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -141,6 +141,14 @@ message
 
 The message that's displayed when this constraint fails.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 em
 ~~
 

--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -88,6 +88,14 @@ message
 
 This message is shown if the URL is invalid.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 .. configuration-block::
 
     .. code-block:: php-annotations

--- a/reference/constraints/UserPassword.rst
+++ b/reference/constraints/UserPassword.rst
@@ -108,4 +108,6 @@ message
 This is the message that's displayed when the underlying string does *not*
 match the current user's password.
 
+This message has no parameters.
+
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Uuid.rst
+++ b/reference/constraints/Uuid.rst
@@ -90,6 +90,14 @@ message
 
 This message is shown if the string is not a valid UUID.
 
+You can use the following parameters in this message:
+
++-----------------+-----------------------------+
+| Parameter       | Description                 |
++=================+=============================+
+| ``{{ value }}`` | The current (invalid) value |
++-----------------+-----------------------------+
+
 strict
 ~~~~~~
 


### PR DESCRIPTION
After #10584, I checked the documentation for the other constraints and updated the possible parameters in messages.

I also added missing documentation for `charsetMessage` in the Length constraint.