### PR TITLE
[Console] Remove invalid note about empty input options

### DIFF
--- a/console/input.rst
+++ b/console/input.rst
@@ -261,10 +261,4 @@ Now check the value of the option and keep in mind that ``false !== null``::
     $yell = ($optionValue !== false);
     $yellLouder = ($optionValue === 'louder');
 
-.. caution::
-
-    Due to a PHP limitation, passing an empty string is indistinguishable from
-    not passing any value at all. In ``command --prefix`` and ``command --prefix=''``
-    cases, the value of the ``prefix`` option will be ``null``.
-
 .. _`docopt standard`: http://docopt.org/


### PR DESCRIPTION
Fixed in 3.3 (see https://github.com/symfony/symfony/pull/21228/files#diff-8bbcbda2558530b2b02669482549da17R49)
