### PR TITLE
[Messenger] Improve the Messenger Handler Example

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -46,14 +46,14 @@ Registering Handlers
 In order to do something when your message is dispatched, you need to create a
 message handler. It's a class with an ``__invoke`` method::
 
-    // src/MessageHandler/MyMessageHandler.php
+    // src/MessageHandler/SendNotificationHandler.php
     namespace App\MessageHandler;
 
     use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
-    class MyMessageHandler implements MessageHandlerInterface
+    class SendNotificationHandler implements MessageHandlerInterface
     {
-        public function __invoke(MyMessage $message)
+        public function __invoke(SendNotification $message)
         {
             // do something with it.
         }
@@ -72,7 +72,7 @@ If you're not using service autoconfiguration, then you need to add this config:
 
         # config/services.yaml
         services:
-            App\MessageHandler\MyMessageHandler:
+            App\MessageHandler\SendNotificationHandler:
                 tags: [messenger.message_handler]
 
     .. code-block:: xml
@@ -85,7 +85,7 @@ If you're not using service autoconfiguration, then you need to add this config:
                 http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="App\MessageHandler\MyMessageHandler">
+                <service id="App\MessageHandler\SendNotificationHandler">
                    <tag name="messenger.message_handler" />
                 </service>
             </services>
@@ -94,9 +94,9 @@ If you're not using service autoconfiguration, then you need to add this config:
     .. code-block:: php
 
         // config/services.php
-        use App\MessageHandler\MyMessageHandler;
+        use App\MessageHandler\SendNotificationHandler;
 
-        $container->register(MyMessageHandler::class)
+        $container->register(SendNotificationHandler::class)
             ->addTag('messenger.message_handler');
 
 .. note::

--- a/messenger.rst
+++ b/messenger.rst
@@ -30,11 +30,11 @@ requirement for a message::
 
     class SendNotification
     {
-        private $message;
+        private $content;
 
-        public function __construct(string $message)
+        public function __construct(string $content)
         {
-            $this->message = $message;
+            $this->content = $content;
         }
 
         // ...getters

--- a/messenger.rst
+++ b/messenger.rst
@@ -23,12 +23,13 @@ Message
 -------
 
 Before you can send a message, you must create it first. There is no specific
-requirement for a message::
+requirement for a message, except it should be serializable and unserializable
+by a Symfony Serializer instance::
 
-    // src/Message/SendNotification.php
+    // src/Message/SmsNotification.php
     namespace App\Message;
 
-    class SendNotification
+    class SmsNotification
     {
         private $content;
 
@@ -49,7 +50,7 @@ you need it, like in a controller::
     // src/Controller/DefaultController.php
     namespace App\Controller;
 
-    use App\Message\SendNotification;
+    use App\Message\SmsNotification;
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -57,7 +58,7 @@ you need it, like in a controller::
     {
         public function index(MessageBusInterface $bus)
         {
-            $bus->dispatch(new SendNotification('A string to be sent...'));
+            $bus->dispatch(new SmsNotification('A string to be sent...'));
         }
     }
 
@@ -67,15 +68,15 @@ Registering Handlers
 In order to do something when your message is dispatched, you need to create a
 message handler. It's a class with an ``__invoke`` method::
 
-    // src/MessageHandler/SendNotificationHandler.php
+    // src/MessageHandler/SmsNotificationHandler.php
     namespace App\MessageHandler;
 
-    use App\Message\SendNotification;
+    use App\Message\SmsNotification;
     use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
-    class SendNotificationHandler implements MessageHandlerInterface
+    class SmsNotificationHandler implements MessageHandlerInterface
     {
-        public function __invoke(SendNotification $message)
+        public function __invoke(SmsNotification $message)
         {
             // do something with it.
         }
@@ -94,7 +95,7 @@ If you're not using service autoconfiguration, then you need to add this config:
 
         # config/services.yaml
         services:
-            App\MessageHandler\SendNotificationHandler:
+            App\MessageHandler\SmsNotificationHandler:
                 tags: [messenger.message_handler]
 
     .. code-block:: xml
@@ -107,7 +108,7 @@ If you're not using service autoconfiguration, then you need to add this config:
                 http://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="App\MessageHandler\SendNotificationHandler">
+                <service id="App\MessageHandler\SmsNotificationHandler">
                    <tag name="messenger.message_handler" />
                 </service>
             </services>
@@ -116,9 +117,9 @@ If you're not using service autoconfiguration, then you need to add this config:
     .. code-block:: php
 
         // config/services.php
-        use App\MessageHandler\SendNotificationHandler;
+        use App\MessageHandler\SmsNotificationHandler;
 
-        $container->register(SendNotificationHandler::class)
+        $container->register(SmsNotificationHandler::class)
             ->addTag('messenger.message_handler');
 
 .. note::

--- a/messenger.rst
+++ b/messenger.rst
@@ -49,6 +49,7 @@ message handler. It's a class with an ``__invoke`` method::
     // src/MessageHandler/SendNotificationHandler.php
     namespace App\MessageHandler;
 
+    use App\Message\SendNotification;
     use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
     class SendNotificationHandler implements MessageHandlerInterface

--- a/messenger.rst
+++ b/messenger.rst
@@ -19,6 +19,27 @@ install messenger before using it:
 
     $ composer require messenger
 
+Message
+-------
+
+Before you can send a message, you must create it first. There is no specific
+requirement for a message::
+
+    // src/Message/SendNotification.php
+    namespace App\Message;
+
+    class SendNotification
+    {
+        private $message;
+
+        public function __construct(string $message)
+        {
+            $this->message = $message;
+        }
+
+        // ...getters
+    }
+
 Using the Messenger Service
 ---------------------------
 


### PR DESCRIPTION
If you follow the Examples on the Messenger Documentation, its confusing having a `SendNotification`-Message first and then a handler implementing `MyMessage`. This PR addresses this issue and changes the Handler-Example to match the Message-Dispatch-Example.