### PR TITLE
Document logout success_handler configuration

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -167,7 +167,7 @@ option to ``false`` in every firewall and the user will only be logged out from
 the current firewall and not the other ones.
 
 success_handler
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``'security.logout.success_handler'``
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -154,7 +154,7 @@ Logout Configuration
 --------------------
 
 invalidate_session
-....................
+~~~~~~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``true``
 
@@ -167,7 +167,7 @@ option to ``false`` in every firewall and the user will only be logged out from
 the current firewall and not the other ones.
 
 success_handler
-....................
+~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``'security.logout.success_handler'``
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -154,7 +154,7 @@ Logout Configuration
 --------------------
 
 invalidate_session
-~~~~~~~~~~~~~~~~~~
+....................
 
 **type**: ``boolean`` **default**: ``true``
 
@@ -165,6 +165,14 @@ all the other firewalls.
 The ``invalidate_session`` option allows to redefine this behavior. Set this
 option to ``false`` in every firewall and the user will only be logged out from
 the current firewall and not the other ones.
+
+success_handler
+....................
+
+**type**: ``string`` **default**: ``'security.logout.success_handler'``
+
+The service ID used for handling a successful logout. The service must implement
+:class:`Symfony\\Component\\Security\\Http\\Logout\\LogoutSuccessHandlerInterface`.
 
 .. _reference-security-ldap:
 


### PR DESCRIPTION
The [Security docs](https://symfony.com/doc/current/security.html#logging-out) tell how to control what happens after logging out, but the security configuration reference is missing documentation on the logout success_handler.

_Partially_ related to #4258