### PR TITLE
Update error_pages.rst

### DIFF
--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -208,7 +208,7 @@ configuration option to point to it:
 
         # config/packages/twig.yaml
         twig:
-            exception_controller: App\Controller\ExceptionController::showException
+            exception_controller: App\Controller\ExceptionController::showAction
 
     .. code-block:: xml
 
@@ -223,7 +223,7 @@ configuration option to point to it:
                 http://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
             <twig:config>
-                <twig:exception-controller>App\Controller\ExceptionController::showException</twig:exception-controller>
+                <twig:exception-controller>App\Controller\ExceptionController::showAction</twig:exception-controller>
             </twig:config>
 
         </container>
@@ -232,7 +232,7 @@ configuration option to point to it:
 
         // config/packages/twig.php
         $container->loadFromExtension('twig', array(
-            'exception_controller' => 'App\Controller\ExceptionController::showException',
+            'exception_controller' => 'App\Controller\ExceptionController::showAction',
             // ...
         ));
 


### PR DESCRIPTION
The function `ExceptionController::showException` does not exist in Symfony 4.1 ; `ExceptionController::showAction` does.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
