### PR TITLE
Update github link to web-link instead of weblink

### DIFF
--- a/components/weblink.rst
+++ b/components/weblink.rst
@@ -15,7 +15,7 @@ Installation
 
     $ composer require symfony/web-link
 
-Alternatively, you can clone the `<https://github.com/symfony/weblink>`_ repository.
+Alternatively, you can clone the `<https://github.com/symfony/web-link>`_ repository.
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/contributing/code/core_team.rst
+++ b/contributing/code/core_team.rst
@@ -235,7 +235,7 @@ discretion of the **Project Leader**.
 .. _Workflow: https://github.com/symfony/workflow
 .. _Yaml: https://github.com/symfony/yaml
 .. _WebProfilerBundle: https://github.com/symfony/web-profiler-bundle
-.. _WebLink: https://github.com/symfony/weblink
+.. _WebLink: https://github.com/symfony/web-link
 .. _`symfony-docs repository`: https://github.com/symfony/symfony-docs
 .. _`fabpot`: https://github.com/fabpot/
 .. _`webmozart`: https://github.com/webmozart/


### PR DESCRIPTION
Update github link to web-link instead of weblink

It's https://github.com/symfony/web-link