### PR TITLE
Update IsTrue.rst

### DIFF
--- a/reference/constraints/IsTrue.rst
+++ b/reference/constraints/IsTrue.rst
@@ -13,9 +13,9 @@ Also see :doc:`IsFalse <IsFalse>`.
 | Options        | - `message`_                                                        |
 |                | - `payload`_                                                        |
 +----------------+---------------------------------------------------------------------+
-| Class          | :class:`Symfony\\Component\\Validator\\Constraints\\True`           |
+| Class          | :class:`Symfony\\Component\\Validator\\Constraints\\IsTrue`         |
 +----------------+---------------------------------------------------------------------+
-| Validator      | :class:`Symfony\\Component\\Validator\\Constraints\\TrueValidator`  |
+| Validator      | :class:`Symfony\\Component\\Validator\\Constraints\\IsTrueValidator`|
 +----------------+---------------------------------------------------------------------+
 
 Basic Usage


### PR DESCRIPTION
Correct class names for Validator and Constraint classes for `IsTrue` is `IsTrue` (not just `True`).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
