### PR TITLE
Http kernel controller arguments

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,7 +29,7 @@ You can build the doc locally with these commands:
 # build the image...
 $ docker build . -t symfony-docs
 
-# ...and serve it locally on http//:127.0.0.1:8080
+# ...and serve it locally on http://127.0.0.1:8080
 # (if it's already in use, change the '8080' port by any other port)
 $ docker run --rm -p 8080:80 symfony-docs
 ```

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -604,17 +604,18 @@ each event has their own event object:
 
 .. _component-http-kernel-event-table:
 
-=====================  ================================  ===================================================================================
-Name                   ``KernelEvents`` Constant         Argument passed to the listener
-=====================  ================================  ===================================================================================
-kernel.request         ``KernelEvents::REQUEST``         :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent`
-kernel.controller      ``KernelEvents::CONTROLLER``      :class:`Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent`
-kernel.view            ``KernelEvents::VIEW``            :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForControllerResultEvent`
-kernel.response        ``KernelEvents::RESPONSE``        :class:`Symfony\\Component\\HttpKernel\\Event\\FilterResponseEvent`
-kernel.finish_request  ``KernelEvents::FINISH_REQUEST``  :class:`Symfony\\Component\\HttpKernel\\Event\\FinishRequestEvent`
-kernel.terminate       ``KernelEvents::TERMINATE``       :class:`Symfony\\Component\\HttpKernel\\Event\\PostResponseEvent`
-kernel.exception       ``KernelEvents::EXCEPTION``       :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent`
-=====================  ================================  ===================================================================================
+===========================  ======================================  ===================================================================================
+Name                         ``KernelEvents`` Constant               Argument passed to the listener
+===========================  ======================================  ===================================================================================
+kernel.request               ``KernelEvents::REQUEST``               :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent`
+kernel.controller            ``KernelEvents::CONTROLLER``            :class:`Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent`
+kernel.controller_arguments  ``KernelEvents::CONTROLLER_ARGUMENTS``  :class:`Symfony\\Component\\HttpKernel\\Event\\FilterControllerArgumentsEvent`
+kernel.view                  ``KernelEvents::VIEW``                  :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForControllerResultEvent`
+kernel.response              ``KernelEvents::RESPONSE``              :class:`Symfony\\Component\\HttpKernel\\Event\\FilterResponseEvent`
+kernel.finish_request        ``KernelEvents::FINISH_REQUEST``        :class:`Symfony\\Component\\HttpKernel\\Event\\FinishRequestEvent`
+kernel.terminate             ``KernelEvents::TERMINATE``             :class:`Symfony\\Component\\HttpKernel\\Event\\PostResponseEvent`
+kernel.exception             ``KernelEvents::EXCEPTION``             :class:`Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent`
+===========================  ======================================  ===================================================================================
 
 .. _http-kernel-working-example:
 

--- a/reference/events.rst
+++ b/reference/events.rst
@@ -142,10 +142,9 @@ their priorities:
 
 **Event Class**: :class:`Symfony\\Component\\HttpKernel\\Event\\FinishRequestEvent`
 
-This event is dispatched after a :ref:`sub request <http-kernel-sub-requests>`
-has finished. It's useful to reset the global state of the application (for
-example, the translator listener resets the translator's locale to the one of
-the parent request)::
+This event is dispatched after the ``kernel.response`` event. It's useful to reset
+the global state of the application (for example, the translator listener resets
+the translator's locale to the one of the parent request)::
 
     public function onKernelFinishRequest(FinishRequestEvent $event)
     {


### PR DESCRIPTION
Hi,
I saw the issue #6854, and I can not write full & clear doc to describe the `kernel.controller_arguments` event.
But I think that it will be nice to have this event in the list of all Kernel events.

I fix the `kernel.finish_request` event description. This event is triggered after `kernel.response` event (not only for a sub-request).