### PR TITLE
[DomCrawler] Added return of element name in `extract()` method

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -220,6 +220,7 @@ Extract attribute and/or node values from the list of nodes::
 .. note::
 
     Special attribute ``_text`` represents a node value.
+    Special attribute ``_key`` represents a node key name.
 
 Call an anonymous function on each node of the list::
 

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -220,6 +220,7 @@ Extract attribute and/or node values from the list of nodes::
 .. note::
 
     Special attribute ``_text`` represents a node value, while ``_name`` represents element name.
+    Attribute ``_name`` will be added in version 4.3.
 
 Call an anonymous function on each node of the list::
 

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -219,7 +219,7 @@ Extract attribute and/or node values from the list of nodes::
 
 .. note::
 
-    Special attribute `_text` represents a node value, while `_name` represents element name.
+    Special attribute ``_text`` represents a node value, while ``_name`` represents element name.
 
 Call an anonymous function on each node of the list::
 

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -219,8 +219,7 @@ Extract attribute and/or node values from the list of nodes::
 
 .. note::
 
-    Special attribute ``_text`` represents a node value.
-    Special attribute ``_key`` represents a node key name.
+    Special attribute ``_text`` represents a node value and `_name`. for a element name.
 
 Call an anonymous function on each node of the list::
 

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -214,12 +214,12 @@ Extract attribute and/or node values from the list of nodes::
 
     $attributes = $crawler
         ->filterXpath('//body/p')
-        ->extract(array('_text', 'class'))
+        ->extract(array('_name', '_text', 'class'))
     ;
 
 .. note::
 
-    Special attribute ``_text`` represents a node value and `_name`. for a element name.
+    Special attribute `_text` represents a node value, while `_name` represents element name.
 
 Call an anonymous function on each node of the list::
 


### PR DESCRIPTION
See a PR: symfony/symfony#29127

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
