### PR TITLE
[Encore] Alternative way to enable PostCSS (package.json)

### DIFF
--- a/frontend/encore/postcss.rst
+++ b/frontend/encore/postcss.rst
@@ -24,6 +24,20 @@ Next, create a ``postcss.config.js`` file at the root of your project:
         }
     }
 
+Alternatively, you can add the following lines to your ``package.json`` file to avoid creating a ``postcss.config.js`` file:
+
+.. code-block:: diff
+    // package.json
+
+    {
+        // ...
+    +     "postcss": {
+    +         "plugins": {
+    +             "autoprefixer": {}
+    +         }
+    +     }
+    }
+
 Then, Enable the loader in Encore!
 
 .. code-block:: diff

--- a/frontend/encore/postcss.rst
+++ b/frontend/encore/postcss.rst
@@ -27,6 +27,7 @@ Next, create a ``postcss.config.js`` file at the root of your project:
 Alternatively, you can add the following lines to your ``package.json`` file to avoid creating a ``postcss.config.js`` file:
 
 .. code-block:: diff
+
     // package.json
 
     {


### PR DESCRIPTION
This method avoids creating a separate `postcss.config.js` file for PostCSS and (in this case) Autoprefixer.