### PR TITLE
Update service_decoration.rst

### DIFF
--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -50,7 +50,7 @@ Most of the time, that's exactly what you want to do. But sometimes,
 you might want to decorate the old one instead (i.e. apply the `Decorator pattern`_).
 In this case, the old service should be kept around to be able to reference
 it in the new one. This configuration replaces ``app.mailer`` with a new one,
-but keeps a reference of the old one  as ``app.decorating_mailer.inner``:
+but keeps a reference of the old one as ``app.decorating_mailer.inner``:
 
 .. configuration-block::
 

--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -4,8 +4,7 @@
 How to Decorate Services
 ========================
 
-When overriding an existing definition (e.g. when applying the `Decorator pattern`_),
-the original service is lost:
+When overriding an existing definition, the original service is lost:
 
 .. configuration-block::
 
@@ -18,7 +17,7 @@ the original service is lost:
             # this replaces the old app.mailer definition with the new one, the
             # old definition is lost
             app.mailer:
-                class: AppBundle\DecoratingMailer
+                class: AppBundle\NewMailer
 
     .. code-block:: xml
 
@@ -32,26 +31,26 @@ the original service is lost:
 
                 <!-- this replaces the old app.mailer definition with the new
                      one, the old definition is lost -->
-                <service id="app.mailer" class="AppBundle\DecoratingMailer" />
+                <service id="app.mailer" class="AppBundle\NewMailer" />
             </services>
         </container>
 
     .. code-block:: php
 
         use AppBundle\Mailer;
-        use AppBundle\DecoratingMailer;
+        use AppBundle\NewMailer;
 
         $container->register('app.mailer', Mailer::class);
 
         // this replaces the old app.mailer definition with the new one, the
         // old definition is lost
-        $container->register('app.mailer', DecoratingMailer::class);
+        $container->register('app.mailer', NewMailer::class);
 
 Most of the time, that's exactly what you want to do. But sometimes,
-you might want to decorate the old one instead. In this case, the
-old service should be kept around to be able to reference it in the
-new one. This configuration replaces ``app.mailer`` with a new one, but keeps
-a reference of the old one  as ``app.decorating_mailer.inner``:
+you might want to decorate the old one instead (i.e. apply the `Decorator pattern`_).
+In this case, the old service should be kept around to be able to reference
+it in the new one. This configuration replaces ``app.mailer`` with a new one,
+but keeps a reference of the old one  as ``app.decorating_mailer.inner``:
 
 .. configuration-block::
 


### PR DESCRIPTION
Make it clear that the first paragraph is *not* about decorating a service, but completely overriding it. Decorating is explained in the next paragraph, so the reference to the decorator pattern has been moved there. Otherwise it's easy to get confused when reading the doc.

The original text was clear, but then the meaning changed when the file was moved, in commit https://github.com/symfony/symfony-docs/commit/141e922e0c1a1bf3d0b62cc8bf343ccb848f71a9#diff-ebbbc2e2adacde7254ce22cf2a32198c

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
