### PR TITLE
Update Package name of React Preset for Babel

### DIFF
--- a/frontend/encore/reactjs.rst
+++ b/frontend/encore/reactjs.rst
@@ -5,7 +5,7 @@ Using React? First enable support for it in ``webpack.config.js``:
 
 .. code-block:: terminal
 
-    $ yarn add --dev babel-preset-react
+    $ yarn add --dev @babel/preset-react
     $ yarn add react react-dom prop-types
 
 Enable react in your ``webpack.config.js``:


### PR DESCRIPTION
Seems the React Preset for Babel has been renamed and the previous package discontinued (at least that's my interpretation seeing v7+ only available in the new one). 

Ran into this issue by simply following this guide and getting:

```
root@afb35030f337:/var/www/code# yarn encore dev
yarn run v1.10.1
warning package.json: No license field
$ /var/www/code/node_modules/.bin/encore dev
Running webpack ...

  Error: Install @babel/preset-react to use enableReactPreset()
    yarn add @babel/preset-react@^7.0.0 --dev

```

After swapping dependencies ("babel-preset-react" to "@babel/preset-react"), it works as expected:
```
root@afb35030f337:/var/www/code# yarn encore dev
yarn run v1.10.1
warning package.json: No license field
$ /var/www/code/node_modules/.bin/encore dev
Running webpack ...

 DONE  Compiled successfully in 518ms    
```

No code examples shared since you literally just need to follow the "Installing Encore" guide (with or without Flex) and then this "Enabling React.js" guide to run into the issue.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
