### PR TITLE
Recommend registering the error handler in prod

### DIFF
--- a/components/debug.rst
+++ b/components/debug.rst
@@ -41,8 +41,9 @@ tools.
 
 .. caution::
 
-    You should never enable the debug tools in a production environment as
-    they might disclose sensitive information to the user.
+    Apart from the error handler, you should never enable the debug
+    tools in a production environment as they might disclose sensitive
+    information to the user.
 
 Enabling the Error Handler
 --------------------------
@@ -55,6 +56,12 @@ fatal errors)::
     use Symfony\Component\Debug\ErrorHandler;
 
     ErrorHandler::register();
+
+.. note::
+
+    This one is fine to use in a production environment and will be
+    enabled if you use the framework bundle, so that you get better
+    logging.
 
 Enabling the Exception Handler
 ------------------------------


### PR DESCRIPTION
This is what currently happens when using Symfony in a standard way, and
people have been wondering online about alarming exceptions from the
Debug component in production.

See https://stackoverflow.com/questions/37431935/is-it-normal-to-have-symfony-component-debug-exception-fatalerrorexception-excep