### PR TITLE
Documentation: copy-files.rst: fix missing code-block

### DIFF
--- a/frontend/encore/copy-files.rst
+++ b/frontend/encore/copy-files.rst
@@ -54,6 +54,8 @@ include a hash based on their content.
 
 To render inside Twig, use the ``asset()`` function:
 
+.. code-block:: twig
+
     {# assets/images/logo.png was copied to public/build/logo.png #}
     <img src="{{ asset('build/logo.png') }}"
 

--- a/frontend/encore/copy-files.rst
+++ b/frontend/encore/copy-files.rst
@@ -54,7 +54,7 @@ include a hash based on their content.
 
 To render inside Twig, use the ``asset()`` function:
 
-.. code-block:: twig
+.. code-block:: html+twig
 
     {# assets/images/logo.png was copied to public/build/logo.png #}
     <img src="{{ asset('build/logo.png') }}"


### PR DESCRIPTION
The latest code block in [Copying & Referencing Images](https://symfony.com/doc/current/frontend/encore/copy-files.html) is missing a `code-block`