### PR TITLE
Removed useless parentheses in Assert annotations

### DIFF
--- a/best_practices/forms.rst
+++ b/best_practices/forms.rst
@@ -169,7 +169,7 @@ blank, add the following in the ``Post`` object::
     class Post
     {
         /**
-         * @Assert\NotBlank()
+         * @Assert\NotBlank
          */
         public $title;
     }

--- a/components/validator/resources.rst
+++ b/components/validator/resources.rst
@@ -100,7 +100,7 @@ prefixed classes included in doc block comments (``/** ... */``). For example::
     class User
     {
         /**
-        * @Assert\NotBlank()
+        * @Assert\NotBlank
         */
         protected $name;
     }

--- a/doctrine/registration_form.rst
+++ b/doctrine/registration_form.rst
@@ -63,19 +63,19 @@ With some validation added, your class may look something like this::
 
         /**
          * @ORM\Column(type="string", length=255, unique=true)
-         * @Assert\NotBlank()
-         * @Assert\Email()
+         * @Assert\NotBlank
+         * @Assert\Email
          */
         private $email;
 
         /**
          * @ORM\Column(type="string", length=255, unique=true)
-         * @Assert\NotBlank()
+         * @Assert\NotBlank
          */
         private $username;
 
         /**
-         * @Assert\NotBlank()
+         * @Assert\NotBlank
          * @Assert\Length(max=4096)
          */
         private $plainPassword;

--- a/form/embedded.rst
+++ b/form/embedded.rst
@@ -25,7 +25,7 @@ of course, by creating the ``Category`` object::
     class Category
     {
         /**
-         * @Assert\NotBlank()
+         * @Assert\NotBlank
          */
         public $name;
     }
@@ -40,7 +40,7 @@ Next, add a new ``category`` property to the ``Task`` class::
 
         /**
          * @Assert\Type(type="AppBundle\Entity\Category")
-         * @Assert\Valid()
+         * @Assert\Valid
          */
         protected $category;
 

--- a/forms.rst
+++ b/forms.rst
@@ -334,12 +334,12 @@ object.
         class Task
         {
             /**
-             * @Assert\NotBlank()
+             * @Assert\NotBlank
              */
             public $task;
 
             /**
-             * @Assert\NotBlank()
+             * @Assert\NotBlank
              * @Assert\Type("\DateTime")
              */
             protected $dueDate;

--- a/reference/constraints/Bic.rst
+++ b/reference/constraints/Bic.rst
@@ -37,7 +37,7 @@ will contain a Business Identifier Code (BIC).
         class Transaction
         {
             /**
-             * @Assert\Bic()
+             * @Assert\Bic
              */
             protected $businessIdentifierCode;
         }

--- a/reference/constraints/Blank.rst
+++ b/reference/constraints/Blank.rst
@@ -42,7 +42,7 @@ of an ``Author`` class were blank, you could do the following:
         class Author
         {
             /**
-             * @Assert\Blank()
+             * @Assert\Blank
              */
             protected $firstName;
         }

--- a/reference/constraints/Country.rst
+++ b/reference/constraints/Country.rst
@@ -29,7 +29,7 @@ Basic Usage
         class User
         {
             /**
-             * @Assert\Country()
+             * @Assert\Country
              */
              protected $country;
         }

--- a/reference/constraints/Date.rst
+++ b/reference/constraints/Date.rst
@@ -31,7 +31,7 @@ Basic Usage
         class Author
         {
             /**
-             * @Assert\Date()
+             * @Assert\Date
              */
              protected $birthday;
         }

--- a/reference/constraints/DateTime.rst
+++ b/reference/constraints/DateTime.rst
@@ -31,7 +31,7 @@ Basic Usage
         class Author
         {
             /**
-             * @Assert\DateTime()
+             * @Assert\DateTime
              */
              protected $createdAt;
         }

--- a/reference/constraints/IsNull.rst
+++ b/reference/constraints/IsNull.rst
@@ -36,7 +36,7 @@ of an ``Author`` class exactly equal to ``null``, you could do the following:
         class Author
         {
             /**
-             * @Assert\IsNull()
+             * @Assert\IsNull
              */
             protected $firstName;
         }

--- a/reference/constraints/Language.rst
+++ b/reference/constraints/Language.rst
@@ -30,7 +30,7 @@ Basic Usage
         class User
         {
             /**
-             * @Assert\Language()
+             * @Assert\Language
              */
              protected $preferredLanguage;
         }

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -34,7 +34,7 @@ Basic Usage
         class User
         {
             /**
-             * @Assert\Locale()
+             * @Assert\Locale
              */
              protected $locale;
         }

--- a/reference/constraints/NotBlank.rst
+++ b/reference/constraints/NotBlank.rst
@@ -40,7 +40,7 @@ class were not blank, you could do the following:
         class Author
         {
             /**
-             * @Assert\NotBlank()
+             * @Assert\NotBlank
              */
             protected $firstName;
         }

--- a/reference/constraints/NotNull.rst
+++ b/reference/constraints/NotNull.rst
@@ -34,7 +34,7 @@ class were not strictly equal to ``null``, you would:
         class Author
         {
             /**
-             * @Assert\NotNull()
+             * @Assert\NotNull
              */
             protected $firstName;
         }

--- a/reference/constraints/Time.rst
+++ b/reference/constraints/Time.rst
@@ -34,7 +34,7 @@ of the day when the event starts:
         class Event
         {
             /**
-             * @Assert\Time()
+             * @Assert\Time
              */
              protected $startsAt;
         }

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -52,7 +52,7 @@ your user table:
              * @var string $email
              *
              * @ORM\Column(name="email", type="string", length=255, unique=true)
-             * @Assert\Email()
+             * @Assert\Email
              */
             protected $email;
 

--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -32,7 +32,7 @@ Basic Usage
         class Author
         {
             /**
-             * @Assert\Url()
+             * @Assert\Url
              */
              protected $bioUrl;
         }

--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -57,7 +57,7 @@ stores an ``Address`` instance in the ``$address`` property::
         class Address
         {
             /**
-             * @Assert\NotBlank()
+             * @Assert\NotBlank
              */
             protected $street;
 

--- a/validation.rst
+++ b/validation.rst
@@ -52,7 +52,7 @@ following:
         class Author
         {
             /**
-             * @Assert\NotBlank()
+             * @Assert\NotBlank
              */
             public $name;
         }
@@ -536,7 +536,7 @@ class to have at least 3 characters.
         class Author
         {
             /**
-             * @Assert\NotBlank()
+             * @Assert\NotBlank
              * @Assert\Length(min=3)
              */
             private $firstName;

--- a/validation/sequence_provider.rst
+++ b/validation/sequence_provider.rst
@@ -178,7 +178,7 @@ entity and a new constraint group called ``Premium``:
         class User
         {
             /**
-             * @Assert\NotBlank()
+             * @Assert\NotBlank
              */
             private $name;
 


### PR DESCRIPTION
To be consistent, this PR removes the useless empty parentheses in the `@Assert` annotations for constraints.

Sometimes `@Assert` annotations for constraints without options were used with empty parentheses, sometimes without parentheses.