### PR TITLE
Improved the example about Choice constraint callback

### DIFF
--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -207,8 +207,8 @@ constraint.
             }
         }
 
-If the static callback is stored in a different class, for example ``Util``,
-you can pass the class name and the method as an array.
+If the static callback is stored in a different class, for example ``AppBundle\Entity\Genre``,
+you can pass the fully-qualified class and the method as an array.
 
 .. configuration-block::
 
@@ -222,7 +222,7 @@ you can pass the class name and the method as an array.
         class Author
         {
             /**
-             * @Assert\Choice(callback={"Util", "getGenres"})
+             * @Assert\Choice(callback={"AppBundle\Entity\Genre", "getGenres"})
              */
             protected $genre;
         }
@@ -233,7 +233,7 @@ you can pass the class name and the method as an array.
         AppBundle\Entity\Author:
             properties:
                 genre:
-                    - Choice: { callback: [Util, getGenres] }
+                    - Choice: { callback: [AppBundle\Entity\Genre, getGenres] }
 
     .. code-block:: xml
 
@@ -247,7 +247,7 @@ you can pass the class name and the method as an array.
                 <property name="genre">
                     <constraint name="Choice">
                         <option name="callback">
-                            <value>Util</value>
+                            <value>AppBundle\Entity\Genre</value>
                             <value>getGenres</value>
                         </option>
                     </constraint>
@@ -260,6 +260,7 @@ you can pass the class name and the method as an array.
         // src/AppBundle/Entity/Author.php
         namespace AppBundle\Entity;
 
+        use AppBundle\Entity\Genre;
         use Symfony\Component\Validator\Mapping\ClassMetadata;
         use Symfony\Component\Validator\Constraints as Assert;
 
@@ -270,7 +271,7 @@ you can pass the class name and the method as an array.
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
                 $metadata->addPropertyConstraint('genre', new Assert\Choice(array(
-                    'callback' => array('Util', 'getGenres'),
+                    'callback' => array(Genre::class, 'getGenres'),
                 )));
             }
         }


### PR DESCRIPTION
I don't know if this is 100% correct, but in a real Symfony project, the `callback` without the FQCN didn't work (at least when using the PHP annotations).