### PR TITLE
Remove beta command since skeleton isn't tagged

### DIFF
--- a/setup/unstable_versions.rst
+++ b/setup/unstable_versions.rst
@@ -14,11 +14,8 @@ execute the following command:
 
 .. code-block:: terminal
 
-    # Download the latest beta version
-    $ composer create-project symfony/skeleton my_project "4.0.*" -s beta
-
     # Download the absolute latest commit
-    $ composer create-project symfony/skeleton my_project "4.0.*" -s dev
+    $ composer create-project symfony/skeleton my_project -s dev
 
 Once the command finishes its execution, you'll have a new Symfony project created
 in the ``my_project/`` directory.


### PR DESCRIPTION
`symfony/skeleton` isn't tagged for beta releases so the command no longer works.

See symfony/symfony#29242 for context.
