### PR TITLE
Typo fix

### DIFF
--- a/components/finder.rst
+++ b/components/finder.rst
@@ -53,7 +53,7 @@ the Finder instance.
 
     A Finder instance is a PHP :phpclass:`Iterator`. So, in addition to iterating over the
     Finder with ``foreach``, you can also convert it to an array with the
-    :phpfunction:`iterator_to_array` method, or get the number of items with
+    :phpfunction:`iterator_to_array` function, or get the number of items with
     :phpfunction:`iterator_count`.
 
 .. caution::


### PR DESCRIPTION
iterator_to_array is not a method, it's a function.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
