### PR TITLE
Fixing typo

### DIFF
--- a/components/finder.rst
+++ b/components/finder.rst
@@ -51,7 +51,7 @@ the Finder instance.
 
 .. tip::
 
-    A Finder instance is a PHP :phpclass:`Iterator`. So, in addition to iterating over the
+    A Finder instance is a PHP :phpclass:`IteratorAggregate`. So, in addition to iterating over the
     Finder with ``foreach``, you can also convert it to an array with the
     :phpfunction:`iterator_to_array` method, or get the number of items with
     :phpfunction:`iterator_count`.


### PR DESCRIPTION
According to https://github.com/symfony/finder/blob/master/Finder.php#L38, Finder class is an IteratorAggregate