### PR TITLE
Rename UserFixture to UserFixtures

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -177,18 +177,18 @@ create dummy database users:
     $ php bin/console make:fixtures
 
     The class name of the fixtures to create (e.g. AppFixtures):
-    > UserFixture
+    > UserFixtures
 
 Use this service to encode the passwords:
 
 .. code-block:: diff
 
-    // src/DataFixtures/UserFixture.php
+    // src/DataFixtures/UserFixtures.php
 
     + use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
     // ...
 
-    class UserFixture extends Fixture
+    class UserFixtures extends Fixture
     {
     +     private $passwordEncoder;
 


### PR DESCRIPTION
Just a quick question, the fixtures are named with plural in this page :

https://symfony.com/doc/current/security.html

```
For example, by using DoctrineFixturesBundle, you can create dummy database users:

...

The class name of the fixtures to create (e.g. AppFixtures):
```

Why don't use `UserFixtures` instead of `UserFixture` to follow the same logic?