### PR TITLE
Update usage.rst

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -467,7 +467,7 @@ The following example shows these functions in action:
     {% endfor %}
 
     {# Check if the object is in some specific place #}
-    {% if workflow_has_marked_place(post, 'to_review') %}
+    {% if workflow_has_marked_place(post, 'review') %}
         <p>This post is ready for review.</p>
     {% endif %}
 


### PR DESCRIPTION
`to_review` is a name of a transitions in this doc page.

But in the `workflow_has_marked_place` we pass a `place`, in this context it should be `review` instead of `to_review`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
