### PR TITLE
Framework configuration > Cache pools > Fix FQCN

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2026,7 +2026,7 @@ settings from the base pool as defaults.
 
 .. note::
 
-    Your service MUST implement the ``Psr\\Cache\\CacheItemPoolInterface`` interface.
+    Your service MUST implement the ``Psr\Cache\CacheItemPoolInterface`` interface.
 
 public
 """"""


### PR DESCRIPTION
Namespace was escaped so this fixes it.