### PR TITLE
Duplicate composer require in Your First Functional Test chapter

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -143,13 +143,6 @@ utilities used in the functional tests:
 
 Your First Functional Test
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-First, install the BrowserKit component in your project:
-
-.. code-block:: terminal
-
-    $ composer require --dev symfony/browser-kit
-
 Functional tests are PHP files that typically live in the ``tests/Controller``
 directory for your bundle. If you want to test the pages handled by your
 ``PostController`` class, start by creating a new ``PostControllerTest.php``


### PR DESCRIPTION
The `composer require --dev symfony/browser-kit` command is duplicated at the beginning of _Your First Functional Test chapter_.
