### PR TITLE
Fix example for collection form type

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -158,7 +158,7 @@ you need is this JavaScript code:
             // Increase the counter
             counter++;
             // And store it, the length cannot be used if deleting widgets is allowed
-            list.data(' widget-counter', counter);
+            list.data('widget-counter', counter);
 
             // create a new list element and add it to the list
             var newElem = jQuery(list.attr('data-widget-tags')).html(newWidget);

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -146,10 +146,8 @@ you need is this JavaScript code:
     jQuery(document).ready(function () {
         jQuery('.add-another-collection-widget').click(function (e) {
             var list = jQuery(jQuery(this).attr('data-list'));
-            // Try to find the counter of the list
+            // Try to find the counter of the list or use the length of the list
             var counter = list.data('widget-counter') | list.children().length;
-            // If the counter does not exist, use the length of the list
-            if (!counter) { counter = list.children().length; }
 
             // grab the prototype template
             var newWidget = list.attr('data-prototype');


### PR DESCRIPTION
If I am correct

```
 | list.children().length;
```

does the same thing as the line I removed.