### PR TITLE
exception during a command: more specific explanation of the behaviour

### DIFF
--- a/console/logging.rst
+++ b/console/logging.rst
@@ -11,7 +11,8 @@ listener for the console.
 Starting from Symfony 3.3, the Console component provides automatic error and
 exception logging.
 
-When an exception occurs during the execution of a command, you'll see a message like the following in your log file:
+When an exception occurs during the execution of a command, you'll see a message
+like the following in your log file:
 
 .. code-block:: terminal
 

--- a/console/logging.rst
+++ b/console/logging.rst
@@ -11,5 +11,19 @@ listener for the console.
 Starting from Symfony 3.3, the Console component provides automatic error and
 exception logging.
 
+When an exception occurs during the execution of a command, you'll see a message like the following in your log file:
+
+.. code-block:: terminal
+
+   [2017-02-15 09:34:42] app.ERROR: Exception thrown while running command:
+   "cache:clear -vvv". Message: "An error occured!" {"exception":"[object]
+   (RuntimeException(code: 0): An error occured! at vendor/symfony/symfony/
+   src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php:61)",
+   "command":"cache:clear -vvv","message":"An error occured!"} []
+
+In addition to logging exceptions, the new subscriber also listens to the console.terminate event to add a log message whenever a command doesn't finish with the 0 exit status.
+
+
+
 You can of course also access and use the :doc:`logger </logging>` service to
 log messages.

--- a/console/logging.rst
+++ b/console/logging.rst
@@ -22,7 +22,9 @@ like the following in your log file:
    src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php:61)",
    "command":"cache:clear -vvv","message":"An error occured!"} []
 
-In addition to logging exceptions, the new subscriber also listens to the console.terminate event to add a log message whenever a command doesn't finish with the 0 exit status.
+In addition to logging exceptions, the new subscriber also listens to the
+`console.terminate` event to add a log message whenever a command
+doesn't finish with the 0 exit status.
 
 
 


### PR DESCRIPTION
This section wasn't specific about the new behavior.

I added an explanation copy/pasted from symfony's blog explanation : https://symfony.com/blog/new-in-symfony-3-3-automatic-console-logging

