### PR TITLE
Update the example how to fetch an envelope stamp

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -163,7 +163,7 @@ Hence you can inspect the envelope content and its stamps, or add any::
     {
         public function handle(Envelope $envelope, StackInterface $stack): Envelope
         {
-            if (null !== $envelope->get(ReceivedStamp::class)) {
+            if (null !== $envelope->last(ReceivedStamp::class)) {
                 // Message just has been received...
 
                 // You could for example add another stamp.


### PR DESCRIPTION
`get` was replaced with `last`: https://github.com/symfony/messenger/commit/7ae60a29282a4e4bd618508fd80fd04f95a02cb8

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
