### PR TITLE
Use the new HandlersLocator and initialise it correctly.

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -83,12 +83,12 @@ Example::
 
     use App\Message\MyMessage;
     use Symfony\Component\Messenger\MessageBus;
-    use Symfony\Component\Messenger\Handler\Locator\HandlerLocator;
+    use Symfony\Component\Messenger\Handler\HandlersLocator;
     use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 
     $bus = new MessageBus([
-        new HandleMessageMiddleware(new HandlerLocator([
-            MyMessage::class => $handler,
+        new HandleMessageMiddleware(new HandlersLocator([
+            MyMessage::class => ['dummy' => $handler],
         ])),
     ]);
 


### PR DESCRIPTION
It looks like the HandlerLocator is replaced with the HandlersLocator in 4.2.

Here you can check the initialisation of the `HandlersLocator`: https://github.com/symfony/symfony/blob/4.2/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
