### PR TITLE
Always use latest Symfony version

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -111,7 +111,7 @@ Symfony application by executing the following command:
 
 .. code-block:: terminal
 
-    $ composer create-project symfony/skeleton:4.1.* my-project
+    $ composer create-project symfony/skeleton my-project
 
 .. note::
 


### PR DESCRIPTION
Removed the version number of the require command to avoid installing outdated requirements

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
