### PR TITLE
Missed setting the return value

### DIFF
--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -568,7 +568,7 @@ tree with ``append()``::
     {
         $treeBuilder = new TreeBuilder('parameters');
 
-        $treeBuilder->getRootNode()
+        $node = $treeBuilder->getRootNode()
             ->isRequired()
             ->requiresAtLeastOneElement()
             ->useAttributeAsKey('name')


### PR DESCRIPTION
The line setting the return variable was stripped changing from `4.1` to `4.2`
