### PR TITLE
[Forms] Fixed TextType empty_data value explanation

### DIFF
--- a/reference/forms/types/text.rst
+++ b/reference/forms/types/text.rst
@@ -44,7 +44,9 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/empty_data.rst.inc
     :end-before: DEFAULT_PLACEHOLDER
 
-The default value is ``''`` (the empty string).
+From an HTTP perspective, submitted data is always a string or an array of strings.
+So by default, the form will treat any empty string as null. If you prefer to get
+an empty string, explicitly set the ``empty_data`` option to an empty string.
 
 .. include:: /reference/forms/types/options/empty_data.rst.inc
     :start-after: DEFAULT_PLACEHOLDER


### PR DESCRIPTION
#SymfonyConHackDay

See https://github.com/symfony/symfony/pull/18357 that introduced a way to use an empty string in models, so setter does not have to be nullable. Usage example: https://github.com/EnMarche/en-marche.fr/blob/master/src/Form/TypeExtension/TextTypeExtension.php#L28

Thanx to @HeahDude for helping me with this PR.