### PR TITLE
Fix syntax error in decorating services example

### DIFF
--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -239,6 +239,6 @@ the ``decoration_priority`` option. Its value is an integer that defaults to
 
 The generated code will be the following::
 
-    $this->services[Foo:class] = new Baz(new Bar(new Foo()));
+    $this->services[Foo::class] = new Baz(new Bar(new Foo()));
 
 .. _decorator pattern: https://en.wikipedia.org/wiki/Decorator_pattern


### PR DESCRIPTION
There was a small error in the example for decorating services. This won't bother anybody since it is only an example of generated code, but it still looks weird :slightly_smiling_face: 

#SymfonyConHackday2018