### PR TITLE
Add instructions for installing AMQP #SymfonyConHackDay2018

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -138,6 +138,14 @@ transports communicate with your application via queuing systems or third partie
 The built-in AMQP transport allows you to communicate with most of the AMQP
 brokers such as RabbitMQ.
 
+For AMQP support, AMQP bundle needs to be installed. If using
+:doc:`Symfony Flex </setup/flex>`, run this command to install it (it will require
+the AMQP PHP extension to be installed):
+
+.. code-block:: terminal
+
+    $ composer require amqp
+
 .. note::
 
     If you need more message brokers, you should have a look at `Enqueue's transport`_


### PR DESCRIPTION
Messenger component would throw an exception if amqp was enabled in
configuration, but amqp bundle (flex recipe) was not installed.

This can be confusing for someone following the documentation for setting up the
Messenger component with AMQP support (including me).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
