### PR TITLE
Update typo inside findAllGreaterThanPrice method in Databases and the Doctrine ORM

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -675,7 +675,7 @@ In addition to the query builder, you can also query with `Doctrine Query Langua
             FROM App\Entity\Product p
             WHERE p.price > :price
             ORDER BY p.price ASC'
-        )->setParameter('price', 1000);
+        )->setParameter('price', $price);
 
         // returns an array of Product objects
         return $query->execute();
@@ -696,7 +696,7 @@ Or directly with SQL if you need to::
             ORDER BY p.price ASC
             ';
         $stmt = $conn->prepare($sql);
-        $stmt->execute(['price' => 1000]);
+        $stmt->execute(['price' => $price]);
 
         // returns an array of arrays (i.e. a raw data set)
         return $stmt->fetchAll();


### PR DESCRIPTION
Hello everyone 😄,

I realized that the `findAllGreaterThanPrice()` does not use the `$price` parameter that it receives in the method example.

Then I thought maybe someone just didn't notice it while writing the docs, why not fix it right? I think it could generate some confusion.

Cheers!