### PR TITLE
Fix for incorrect require statement

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -101,7 +101,7 @@ routes. To do this, install the annotations package:
 
 .. code-block:: terminal
 
-    $ composer require annotations
+    $ composer require doctrine/annotations
 
 You can now add your route directly *above* the controller:
 


### PR DESCRIPTION
I was trying out the getting started section and noticed this one

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
