### PR TITLE
Add documentation for the kernel.controller_arguments event

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -315,6 +315,13 @@ on the event object that's passed to listeners on this event.
 4) Getting the Controller Arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Once the controller has been resolved, the ``HttpKernel::handle()`` dispatches
+the ``kernel.controller_arguments`` event. It subclasses 
+:class:`Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent`
+and provides the :method:`FilterControllerArgumentsEvent::getArguments <Symfony\\Component\\HttpKernel\\Event\\FilterControllerArgumentsEvent::getArguments>`
+method. This is a useful point to access the controller arguments and make decisions
+based upon them.
+
 Next, ``HttpKernel::handle()`` calls
 :method:`ArgumentResolverInterface::getArguments() <Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverInterface::getArguments>`.
 Remember that the controller returned in ``getController()`` is a callable.

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -315,13 +315,6 @@ on the event object that's passed to listeners on this event.
 4) Getting the Controller Arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once the controller has been resolved, the ``HttpKernel::handle()`` dispatches
-the ``kernel.controller_arguments`` event. It subclasses 
-:class:`Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent`
-and provides the :method:`FilterControllerArgumentsEvent::getArguments <Symfony\\Component\\HttpKernel\\Event\\FilterControllerArgumentsEvent::getArguments>`
-method. This is a useful point to access the controller arguments and make decisions
-based upon them.
-
 Next, ``HttpKernel::handle()`` calls
 :method:`ArgumentResolverInterface::getArguments() <Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolverInterface::getArguments>`.
 Remember that the controller returned in ``getController()`` is a callable.
@@ -332,6 +325,13 @@ is a good example.
 
 At this point the kernel has a PHP callable (the controller) and an array
 of arguments that should be passed when executing that callable.
+
+Once the controller has been resolved, the ``HttpKernel::handle()`` dispatches
+the ``kernel.controller_arguments`` event. It subclasses 
+:class:`Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent`
+and provides the :method:`FilterControllerArgumentsEvent::getArguments <Symfony\\Component\\HttpKernel\\Event\\FilterControllerArgumentsEvent::getArguments>`
+method. This is a useful point to access the controller arguments and make decisions
+based upon them.
 
 .. sidebar:: Getting the Controller Arguments in the Symfony Framework
 


### PR DESCRIPTION
So far, undocumented, the `kernel.controller_arguments` event is a good place to dispatch app-level events and react accordingly. This is an attempt to let developers know the point at which this event will be dispatched.
