### PR TITLE
Update property_info.rst - added missing variable $accessExtractors

### DIFF
--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -59,10 +59,13 @@ provide it with a set of information extractors.
     // list of PropertyDescriptionExtractorInterface (any iterable)
     $descriptionExtractors = array($phpDocExtractor);
 
+    // array of PropertyAccessExtractorInterface
+    $accessExtractors = array($reflectionExtractor);
+
     // list of PropertyInitializableExtractorInterface (any iterable)
     $propertyInitializableExtractors = array($reflectionExtractor);
 
-    // list of PropertyAccessExtractorInterface (any iterable)
+
 
     $propertyInfo = new PropertyInfoExtractor(
         $listExtractors,


### PR DESCRIPTION
Added variable $accessExtractors from Doku v 4.1.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
