### PR TITLE
typo in sample of code

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -96,7 +96,7 @@ can do most of the work for you:
                 {{ encore_entry_link_tags('app') }}
 
                 <!-- Renders a link tag (if your module requires any CSS)
-                     <link rel="stylesheet" src="/build/app.css"> -->
+                     <link rel="stylesheet" href="/build/app.css"> -->
             {% endblock %}
         </head>
         <body>


### PR DESCRIPTION
Hello

While I test webpack encore on a little project in Symfony 3.4, I notice a typo in the documentation. (src instead of href in the link markup).
This typo is also present in the documentation of the youngest version of Symfony (4.0, 4.1, 4.2).
Do I have to submit a PR for each version ?

Thanks for your attention regarding this little bug.
Best regard
Arnaud

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
