### PR TITLE
Fix app.css comment syntax

### DIFF
--- a/frontend/encore/installation-no-flex.rst
+++ b/frontend/encore/installation-no-flex.rst
@@ -94,7 +94,7 @@ And the new ``assets/css/app.css`` file:
 
 .. code-block:: css
 
-    // assets/css/app.css
+    /* assets/css/app.css */
     body {
         background-color: lightgray;
     }


### PR DESCRIPTION
This PR fixes the css comment syntax in installation without Flex doc.