### PR TITLE
Fix minor upgrade procedure first command

### DIFF
--- a/setup/upgrade_minor.rst
+++ b/setup/upgrade_minor.rst
@@ -46,7 +46,7 @@ Next, use Composer to download new versions of the libraries:
 
 .. code-block:: terminal
 
-    $ composer update "symfony/*" --with-all-dependencies
+    $ composer update "symfony/*"
 
 .. include:: /setup/_update_dep_errors.rst.inc
 


### PR DESCRIPTION
Remove "--with-all-dependencies" of first "composer update" command

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
