### PR TITLE
Update console.rst: reversing constants (logical purpose)

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -92,7 +92,7 @@ available in the ``configure()`` method::
         {
             $this
                 // ...
-                ->addArgument('password', !$this->requirePassword ? InputArgument::OPTIONAL : InputArgument::REQUIRED, 'User password')
+                ->addArgument('password', $this->requirePassword ? InputArgument::REQUIRED : InputArgument::OPTIONAL, 'User password')
             ;
         }
     }

--- a/console.rst
+++ b/console.rst
@@ -92,7 +92,7 @@ available in the ``configure()`` method::
         {
             $this
                 // ...
-                ->addArgument('password', $this->requirePassword ? InputArgument::OPTIONAL : InputArgument::REQUIRED, 'User password')
+                ->addArgument('password', !$this->requirePassword ? InputArgument::OPTIONAL : InputArgument::REQUIRED, 'User password')
             ;
         }
     }


### PR DESCRIPTION
For logical purpose, I added a `!` right before `$this->requirePassword` in the `configure()` method, otherwise the requirePassword argument would be set as REQUIRED instead of OPTIONAL.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
