### PR TITLE
Doc CompiledUrlMatcherDumper instead of PhpMatcherDumper

### DIFF
--- a/create_framework/routing.rst
+++ b/create_framework/routing.rst
@@ -217,6 +217,12 @@ generate absolute URLs::
     highly optimized URL matcher class that can replace the default
     ``UrlMatcher``::
 
-        $dumper = new Routing\Matcher\Dumper\PhpMatcherDumper($routes);
+        use Symfony\Component\Routing\Matcher\CompiledUrlMatcher;
+        use Symfony\Component\Routing\Matcher\Dumper\CompiledUrlMatcherDumper;
 
-        echo $dumper->dump();
+        // $compiledRoutes is a plain PHP array that describes
+        // all routes using a performant data format
+        // you can and SHOULD cache it, typically by exporting it to a PHP file
+        $compiledRoutes = (new CompiledUrlMatcherDumper($routes))->getCompiledRoutes();
+
+        $matcher = new CompiledUrlMatcher($compiledRoutes, $context);


### PR DESCRIPTION
Needed after https://github.com/symfony/symfony/pull/28865