### PR TITLE
Update encore/copy-files.rst: add note about using versioning with custom target path

### DIFF
--- a/frontend/encore/copy-files.rst
+++ b/frontend/encore/copy-files.rst
@@ -52,6 +52,11 @@ This will copy all files from ``assets/images`` into ``web/build`` (the output
 path). If you have :doc:`versioning enabled <versioning>`, the copied files will
 include a hash based on their content.
 
+.. note::
+
+    If order to use versioning with with custom target path (``to``), you need to
+    update to path to include the file hash: ``images/[path][name].[hash:8].[ext]``.
+
 To render inside Twig, use the ``asset()`` function:
 
 .. code-block:: html+twig


### PR DESCRIPTION
Improving https://symfony.com/doc/current/frontend/encore/copy-files.html#referencing-image-files-from-a-template

If the versioning is enabled in Encore and you want to use custom target path, you need to manually include the hash in the target filename.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
