### PR TITLE
using open_basedir will disable the realpath cache

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -103,6 +103,8 @@ such as Symfony projects, should use at least these values:
     ; save the results for 10 minutes (600 seconds)
     realpath_cache_ttl=600
 
+Note: using ``open_basedir`` will disable the realpath Cache.
+
 .. _performance-optimize-composer-autoloader:
 
 Optimize Composer Autoloader


### PR DESCRIPTION
as of PHP 7.3.0 this is unresolved, setting an open_basedir directory will disable realpath. This is slightly underdocumented (on php.net ini.core only in the comments). See https://github.com/php/php-src/blob/PHP-7.3.0/main/main.c#L1800 and https://bugs.php.net/bug.php?id=52312

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
