### PR TITLE
Update twig_extension.rst to reflect changes in the use of filter option during debug:twig command

### DIFF
--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -99,7 +99,7 @@ successfully registered:
 
 .. code-block:: terminal
 
-    $ php bin/console debug:twig --filter=price
+    $ php bin/console debug:twig price
 
 You can now start using your filter in any Twig template.
 


### PR DESCRIPTION
In newer versions `--filter=` is used differently it's an optional array argument like so `debug:twig [options] [--] [<filter>]`, just wanted to update the docs to reflect that.

