### PR TITLE
[Testing] CollectionType file upload

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -876,7 +876,9 @@ In order to test that multiple files can be uploaded, here's one of the availabl
     $files = array(
          'some_type' => array(
              'files' => array(
-                 0 => new UploadedFile('/path/to/file.extension', 'file.extension')
+                 0 => array(
+                     'file' => new UploadedFile('/path/to/file.extension', 'file.extension')
+                 ),
               ),
           ),
      );

--- a/testing.rst
+++ b/testing.rst
@@ -829,7 +829,6 @@ Let's imagine a simple form which define a collection of FileType::
     namespace App\Form;
 
     use App\Entity\Entity;
-    use App\Form\MultipleFileType;
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
     use Symfony\Component\OptionsResolver\OptionsResolver;

--- a/testing.rst
+++ b/testing.rst
@@ -867,7 +867,7 @@ Let's imagine a simple form which define a collection of FileType::
 Testing this type can be hard as explained earlier, trying to use UploadedFile isn't possible 
 due to PHP limitations when it comes to stream serialization.
 
-In order to test that multiple files can be uploaded, here's one of the available solutions:
+In order to test that multiple files can be uploaded, here's one of the available solutions::
 
     // get the values if you need to define new ones
     $values = $form->getPhpValues();
@@ -887,7 +887,7 @@ In order to test that multiple files can be uploaded, here's one of the availabl
      $crawler = $client->request('POST', '/uri', $values, $files);
 
 If you use a dedicated Type in the `entry_type` option, just add the name of the Type along
-with the field name:
+with the field name::
 
     $files = array(
         'some_type' => array(


### PR DESCRIPTION
Hi everyone, 

Recently, I've been blocked by a CollectionType which define a child form (using VichUploaderBundle but the logic stay the same for default FileType), I wasn't able to test it during functional tests, I've found a way to do it and I think it can a good idea to improve the doc in order to explain how to do it.

Thanks for the feedback 😊 

PS: Some work must be done in the sentences