### PR TITLE
[Validator] Explained how to use array constant in annotation

### DIFF
--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -210,7 +210,7 @@ constraint.
             }
         }
 
-If the callback is stored in a different class and is static, for example ``AppBundle\Entity\Genre``,
+If the callback is defined in a different class and is static, for example ``AppBundle\Entity\Genre``,
 you can pass the class name and the method as an array.
 
 .. configuration-block::
@@ -278,6 +278,35 @@ you can pass the class name and the method as an array.
                 )));
             }
         }
+
+Supplying the Choices from an Array Constant
+--------------------------------------------
+
+You can also directly provide a constant containing an array to the ``choices`` option in the annotation::
+
+    // src/AppBundle/Entity/Author.php
+    namespace AppBundle\Entity;
+
+    use Symfony\Component\Validator\Constraints as Assert;
+
+    class Author
+    {
+        const GENRES = ['action', 'comedy'];
+
+        /**
+         * @Assert\Choice(choices=Author::GENRES)
+         */
+        protected $genre;
+    }
+
+.. warning::
+
+  The constant in the option is used without quotes.
+
+.. note::
+
+  If the constant is defined in a different class, you can pass the fully qualified class name.
+
 
 Available Options
 -----------------

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -46,13 +46,17 @@ If your valid choice list is simple, you can pass them in directly via the
 
         class Author
         {
+            const GENRES = ['fiction', 'non-fiction'];
+
             /**
              * @Assert\Choice({"New York", "Berlin", "Tokyo"})
              */
             protected $city;
 
             /**
-             * @Assert\Choice(choices={"fiction", "non-fiction"}, message="Choose a valid genre.")
+             * You can also directly provide an array constant to the "choices" option in the annotation
+             *
+             * @Assert\Choice(choices=Author::GENRES, message="Choose a valid genre.")
              */
             protected $genre;
         }
@@ -278,35 +282,6 @@ you can pass the class name and the method as an array.
                 )));
             }
         }
-
-Supplying the Choices from an Array Constant
---------------------------------------------
-
-You can also directly provide a constant containing an array to the ``choices`` option in the annotation::
-
-    // src/AppBundle/Entity/Author.php
-    namespace AppBundle\Entity;
-
-    use Symfony\Component\Validator\Constraints as Assert;
-
-    class Author
-    {
-        const GENRES = ['action', 'comedy'];
-
-        /**
-         * @Assert\Choice(choices=Author::GENRES)
-         */
-        protected $genre;
-    }
-
-.. warning::
-
-  The constant in the option is used without quotes.
-
-.. note::
-
-  If the constant is defined in a different class, you can pass the fully qualified class name.
-
 
 Available Options
 -----------------


### PR DESCRIPTION
Hi,

few days ago i tried to add a new feature to the `choice` validator constraint, by adding a new `choicesFromConstant` option.
https://github.com/symfony/symfony/pull/29658
But then, i realized this was already supported.

I think this should be documented, as i think a lot of people don't know this feature.

thanks.
