### PR TITLE
Fixed a minor syntax issue in a link

### DIFF
--- a/console/coloring.rst
+++ b/console/coloring.rst
@@ -9,9 +9,9 @@ output (e.g. important messages, titles, comments, etc.).
     By default, the Windows command console doesn't support output coloring. The
     Console component disables output coloring for Windows systems, but if your
     commands invoke other scripts which emit color sequences, they will be
-    wrongly displayed as raw escape characters. Install the `Cmder`_, `ConEmu`_, `ANSICON`_
-    ,`Mintty`_ (used by default in GitBash and Cygwin) or `Hyper`_ free applications
-    to add coloring support to your Windows command console.
+    wrongly displayed as raw escape characters. Install the `Cmder`_, `ConEmu`_,
+    `ANSICON`_, `Mintty`_ (used by default in GitBash and Cygwin) or `Hyper`_
+    free applications to add coloring support to your Windows command console.
 
 Using Color Styles
 ------------------


### PR DESCRIPTION
The "Mintty" link looks wrong in this page: https://symfony.com/doc/3.4/console/coloring.html

![link-error](https://user-images.githubusercontent.com/73419/50485904-7110a880-09f7-11e9-8a5c-5580fbb7572e.png)

I guess it's because of not adding a white space between the comma and the link.