### PR TITLE
[DependencyInjection] Fluent PHP DI Documentation

### DIFF
--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -288,17 +288,21 @@ config files:
 
     .. code-block:: php
 
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-        $container->setParameter('mailer.transport', 'sendmail');
-        $container
-            ->register('mailer', 'Mailer')
-            ->addArgument('%mailer.transport%');
+        return function(ContainerConfigurator $configurator) {
+            $configurator->parameters()
+                ->set('mailer.transport', 'sendmail');
 
-        $container
-            ->register('newsletter_manager', 'NewsletterManager')
-            ->addMethodCall('setMailer', [new Reference('mailer')]);
+            $container = $configurator->services();
+
+            $container->set('mailer', 'Mailer')
+                ->args(['%mailer.transport%']);
+
+            $container->set('newsletter_manager', 'NewsletterManager')
+                ->call('setMailer', [ref('mailer')]);
+        };
+
 
 Learn More
 ----------

--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -81,8 +81,31 @@ what the file looks like in Symfony 4):
             </services>
         </container>
 
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services()
+                ->defaults()
+                ->autowire()
+                ->autoconfigure()
+                ->private();
+
+            $container->load('App\\', '../src/*')
+                ->exclude('../src/{Entity,Migrations,Tests}');
+
+            $container->load('App\\Controller\\', '../src/Controller')
+                ->tag('controller.service_arguments');
+        };
+
 This small bit of configuration contains a paradigm shift of how services
 are configured in Symfony.
+
+.. versionadded:: 3.4
+
+    PHP Fluent DI was introduced in Symfony 3.4.
 
 .. _`service-33-changes-automatic-registration`:
 
@@ -125,6 +148,18 @@ thanks to the following config:
                 <prototype namespace="App\" resource="../src/*" exclude="../src/{Entity,Migrations,Tests}"/>
             </services>
         </container>
+
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return function(ContainerConfigurator $configurator) {
+            // ...
+
+            $container->load('App\\', '../src/*')
+                ->exclude('../src/{Entity,Migrations,Tests}');
+        };
 
 This means that every class in ``src/`` is *available* to be used as a
 service. And thanks to the ``_defaults`` section at the top of the file, all of
@@ -319,11 +354,15 @@ The third big change is that, in a new Symfony 3.3 project, your controllers are
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
+        return function(ContainerConfigurator $configurator) {
+            // ...
 
-        $definition->addTag('controller.service_arguments');
-        $this->registerClasses($definition, 'App\\Controller\\', '../src/Controller/*');
+            $container->load('App\\Controller\\', '../src/Controller')
+                ->tag('controller.service_arguments');
+        };
+
 
 But, you might not even notice this. First, your controllers *can* still extend
 the same base controller class (``AbstractController``).
@@ -463,6 +502,21 @@ inherited from an abstract definition:
                 </instanceof>
             </services>
         </container>
+
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\Domain\LoaderInterface;
+
+        return function(ContainerConfigurator $configurator) {
+            // ...
+
+            $container->instanceof(LoaderInterface::class
+                ->public()
+                ->tag('app.domain_loader');
+        };
 
 What about Performance
 ----------------------

--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -55,10 +55,15 @@ You can also control the ``public`` option on a service-by-service basis:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Service\Foo;
 
-        $container->register(Foo::class)
-            ->setPublic(false);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(Foo::class)
+                ->private();
+        };
 
 .. _services-why-private:
 
@@ -123,12 +128,16 @@ services.
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Mail\PhpMailer;
 
-        $container->register(PhpMailer::class)
-            ->setPublic(false);
-
-        $container->setAlias('app.mailer', PhpMailer::class);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(PhpMailer::class)
+                ->private();
+            $container->alias('app.mailer', PhpMailer::class);
+        };
 
 This means that when using the container directly, you can access the
 ``PhpMailer`` service by asking for the ``app.mailer`` service like this::
@@ -214,7 +223,15 @@ Anonymous Services
 
 .. note::
 
-    Anonymous services are only supported by the XML and YAML configuration formats.
+    Anonymous services are only supported by the XML, YAML, and PHP Fluent configuration formats.
+
+.. versionadded:: 3.3
+
+    The feature to configure anonymous services in YAML was introduced in Symfony 3.3.
+
+.. versionadded:: 4.1
+
+    The feaature to configure anonymous services in PHP Fluent was introduced in Symfony 3.4.
 
 In some cases, you may want to prevent a service being used as a dependency of
 other services. This can be achieved by creating an anonymous service. These
@@ -252,6 +269,26 @@ The following example shows how to inject an anonymous service into another serv
             </services>
         </container>
 
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\Foo;
+        use App\AnonymousBar;
+
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+
+            $container->set(Foo::class)
+                ->args([inline(AnonymousBar::class)])
+        };
+
+.. note::
+
+    Anonymous services do *NOT* inherit the definitions provided from the defaults defined in the configuration. So you'll
+    need to explicitly mark service as autowired or autoconfigured when doing an anonymous service e.g.: `inline(Foo::class)->autowire()->autoconfigure()`.
+
 Using an anonymous service as a factory looks like this:
 
 .. configuration-block::
@@ -280,6 +317,21 @@ Using an anonymous service as a factory looks like this:
                 </service>
             </services>
         </container>
+
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\Foo;
+        use App\AnonymousBar;
+
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+
+            $container->set(Foo::class)
+                ->factory([inline(AnonymousBar::class), 'constructFoo'])
+        };
 
 Deprecating Services
 --------------------
@@ -313,15 +365,16 @@ or you decided not to maintain it anymore), you can deprecate its definition:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Service\OldService;
 
-        $container
-            ->register(OldService::class)
-            ->setDeprecated(
-                true,
-                'The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.'
-            )
-        ;
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+
+            $container->set(OldService::class)
+                ->deprecate('The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.');
+        };
 
 Now, every time this service is used, a deprecation warning is triggered,
 advising you to stop or to change your uses of that service.

--- a/service_container/calls.rst
+++ b/service_container/calls.rst
@@ -66,8 +66,13 @@ To configure the container to call the ``setLogger`` method, use the ``calls`` k
     .. code-block:: php
 
         // config/services.php
-        use App\Service\MessageGenerator;
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        $container->register(MessageGenerator::class)
-            ->addMethodCall('setLogger', [new Reference('logger')]);
+        use App\Service\MessageGenerator;
+
+        return function(ContainerConfigurator $configurator) {
+            // ...
+            $container->set(MessageGenerator::class)
+                ->call('setLogger', [ref('logger')]);
+        };
+

--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -166,23 +166,22 @@ all the classes are already loaded as services. All you need to do is specify th
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\Mail\EmailConfigurator;
         use App\Mail\GreetingCardManager;
         use App\Mail\NewsletterManager;
-        use Symfony\Component\DependencyInjection\Definition;
-        use Symfony\Component\DependencyInjection\Reference;
 
-        // Same as before
-        $definition = new Definition();
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
 
-        $definition->setAutowired(true);
+            $container->load('App\', '../src/*');
+            $container->set(NewsletterManager::class)
+                ->configurator(ref(EmailConfigurator::class), 'configure');
 
-        $this->registerClasses($definition, 'App\\', '../src/*');
-
-        $container->getDefinition(NewsletterManager::class)
-            ->setConfigurator([new Reference(EmailConfigurator::class), 'configure']);
-
-        $container->getDefinition(GreetingCardManager::class)
-            ->setConfigurator([new Reference(EmailConfigurator::class), 'configure']);
+            $container->set(GreetingCardManager::class)
+                ->configurator(ref(EmailConfigurator::class), 'configure');
+        };
 
 .. _configurators-invokable:
 

--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -53,14 +53,19 @@ to another service: ``App\Mailer``. One way to do this is with an expression:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Mail\MailerConfiguration;
         use App\Mailer;
-        use Symfony\Component\ExpressionLanguage\Expression;
 
-        $container->autowire(MailerConfiguration::class);
+        return function(ContainerConfigurator $configurator) {
+            // ...
+            $container->set(MailerConfiguration::class);
 
-        $container->autowire(Mailer::class)
-            ->addArgument(new Expression('service("App\\\\Mail\\\\MailerConfiguration").getMailerMethod()'));
+            $container->set(Mailer::class)
+                ->args([expr(sprintf('service(%s).getMailerMethod()', MailerConfiguration::class))]);
+        };
+
 
 To learn more about the expression language syntax, see :doc:`/components/expression_language/syntax`.
 
@@ -102,13 +107,16 @@ via a ``container`` variable. Here's another example:
     .. code-block:: php
 
         // config/services.php
-        use App\Mailer;
-        use Symfony\Component\ExpressionLanguage\Expression;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        $container->autowire(Mailer::class)
-            ->addArgument(new Expression(
-                "container.hasParameter('some_param') ? parameter('some_param') : 'default_value'"
-            ));
+        use App\Mailer;
+
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+
+            $container->set(Mailer::class)
+                ->args([expr("container.hasParameter('some_param') ? parameter('some_param') : 'default_value'")]);
+        };
 
 Expressions can be used in ``arguments``, ``properties``, as arguments with
 ``configurator`` and as arguments to ``calls`` (method calls).

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -69,13 +69,18 @@ configure the service container to use the
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerStaticFactory;
-        // ...
 
-        $container->register(NewsletterManager::class)
-            // call the static method
-            ->setFactory([NewsletterManagerStaticFactory::class, 'createNewsletterManager']);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+
+            $container->set(NewsletterManager::class)
+                ->factory([NewsletterManagerStaticFactory::class, 'createNewsletterManager']);
+        };
+
 
 .. note::
 
@@ -130,19 +135,17 @@ Configuration of the service container then looks like this:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerFactory;
-        use Symfony\Component\DependencyInjection\Reference;
-        // ...
 
-        $container->register(NewsletterManagerFactory::class);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
 
-        $container->register(NewsletterManager::class)
-            // call a method on the specified factory service
-            ->setFactory([
-                new Reference(NewsletterManagerFactory::class),
-                'createNewsletterManager',
-            ]);
+            $container->set(NewsletterManager::class)
+                ->factory([ref(NewsletterManagerFactory::class), 'createNewsletterManager']);
+        };
 
 .. _factories-invokable:
 
@@ -259,14 +262,16 @@ example takes the ``templating`` service as an argument:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerFactory;
-        use Symfony\Component\DependencyInjection\Reference;
 
-        // ...
-        $container->register(NewsletterManager::class)
-            ->addArgument(new Reference('templating'))
-            ->setFactory([
-                new Reference(NewsletterManagerFactory::class),
-                'createNewsletterManager',
-            ]);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+
+            $container->set(NewsletterManager::class)
+                ->args([ref('templating')])
+                ->factory([ref(NewsletterManagerFactory::class), 'createNewsletterManager']);
+        };
+

--- a/service_container/import.rst
+++ b/service_container/import.rst
@@ -117,19 +117,21 @@ a relative or absolute path to the imported file:
     .. code-block:: php
 
         // config/services.php
-        use Symfony\Component\DependencyInjection\Definition;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        $loader->import('services/mailer.php');
+        return function(ContainerConfigurator $configurator) {
+            $configurator->import('services/mailer.php');
 
-        $definition = new Definition();
-        $definition
-            ->setAutowired(true)
-            ->setAutoconfigured(true)
-            ->setPublic(false)
-        ;
+            $container = $configurator->services()
+                ->defaults()
+                    ->autowire()
+                    ->autoconfigure()
+                    ->private()
+                ;
 
-        $this->registerClasses($definition, 'App\\', '../src/*',
-            '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}');
+            $container->load('App\\', '../src/*')
+                    ->exclude('../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}');
+        };
 
 When loading a configuration file, Symfony loads first the imported files and
 then it processes the parameters and services defined in the file. If you use the

--- a/service_container/injection_types.rst
+++ b/service_container/injection_types.rst
@@ -69,12 +69,16 @@ service container configuration:
     .. code-block:: php
 
         // config/services.php
-        use App\Mail\NewsletterManager;
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-        $container->register(NewsletterManager::class)
-            ->addArgument(new Reference('mailer'));
+        use App\Mail\NewsletterManager;
+
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(NewsletterManager::class)
+                ->args(ref('mailer'));
+        };
+
 
 .. tip::
 
@@ -155,12 +159,15 @@ that accepts the dependency::
     .. code-block:: php
 
         // config/services.php
-        use App\Mail\NewsletterManager;
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-        $container->register('app.newsletter_manager', NewsletterManager::class)
-            ->addMethodCall('setMailer', [new Reference('mailer')]);
+        use App\Mail\NewsletterManager;
+
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(NewsletterManager::class)
+                ->call('setMailer', [ref('mailer')]);
+        };
 
 This time the advantages are:
 
@@ -228,12 +235,15 @@ Another possibility is setting public fields of the class directly::
     .. code-block:: php
 
         // config/services.php
-        use App\Mail\NewsletterManager;
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-        $container->register('newsletter_manager', NewsletterManager::class)
-            ->setProperty('mailer', new Reference('mailer'));
+        use App\Mail\NewsletterManager;
+
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set('app.newsletter_manager, NewsletterManager::class)
+                ->property('mailer', ref('mailer'));
+        };
 
 There are mainly only disadvantages to using property injection, it is similar
 to setter injection but with these additional important problems:

--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -64,10 +64,15 @@ You can mark the service as ``lazy`` by manipulating its definition:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Twig\AppExtension;
 
-        $container->register(AppExtension::class)
-            ->setLazy(true);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(AppExtension::class)->lazy();
+        };
+
 
 Once you inject the service into another service, a virtual `proxy`_ with the
 same signature of the class representing the service should be injected. The

--- a/service_container/optional_dependencies.rst
+++ b/service_container/optional_dependencies.rst
@@ -34,17 +34,16 @@ if the service does not exist:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Newsletter\NewsletterManager;
-        use Symfony\Component\DependencyInjection\ContainerInterface;
-        use Symfony\Component\DependencyInjection\Reference;
 
-        // ...
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(NewsletterManager::class)
+                ->args([ref('logger')->nullOnInvalid()]);
+        };
 
-        $container->register(NewsletterManager::class)
-            ->addArgument(new Reference(
-                'logger',
-                ContainerInterface::NULL_ON_INVALID_REFERENCE
-            ));
 
 .. note::
 
@@ -91,19 +90,16 @@ call if the service exists and remove the method call if it does not:
     .. code-block:: php
 
         // config/services.php
-        use App\Newsletter\NewsletterManager;
-        use Symfony\Component\DependencyInjection\ContainerInterface;
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        $container
-            ->register(NewsletterManager::class)
-            ->addMethodCall('setLogger', [
-                new Reference(
-                    'logger',
-                    ContainerInterface::IGNORE_ON_INVALID_REFERENCE
-                ),
-            ])
-        ;
+        use App\Newsletter\NewsletterManager;
+
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(NewsletterManager::class)
+                ->call('setLogger', [ref('logger')->ignoreOnInvalid()])
+            ;
+        };
 
 .. note::
 

--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -39,14 +39,20 @@ When overriding an existing definition, the original service is lost:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Mailer;
         use App\NewMailer;
 
-        $container->register(Mailer::class);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
 
-        // this replaces the old App\Mailer definition with the new one, the
-        // old definition is lost
-        $container->register(Mailer::class, NewMailer::class);
+            $container->set(Mailer::class);
+
+            // this replaces the old App\Mailer definition with the new one, the
+            // old definition is lost
+            $container->set(Mailer::class, NewMailer::class);
+        };
 
 Most of the time, that's exactly what you want to do. But sometimes,
 you might want to decorate the old one instead (i.e. apply the `Decorator pattern`_).
@@ -88,15 +94,18 @@ but keeps a reference of the old one as ``App\DecoratingMailer.inner``:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\DecoratingMailer;
         use App\Mailer;
-        use Symfony\Component\DependencyInjection\Reference;
 
-        $container->register(Mailer::class);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
 
-        $container->register(DecoratingMailer::class)
-            ->setDecoratedService(Mailer::class)
-        ;
+            $container->set(Mailer::class);
+            $container->set(DecoratingMailer::class)
+                ->decorate(Mailer::class);
+        };
 
 The ``decorates`` option tells the container that the ``App\DecoratingMailer``
 service replaces the ``App\Mailer`` service. If you're using the
@@ -145,16 +154,20 @@ automatically changed to ``decorating_service_id + '.inner'``):
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\DecoratingMailer;
         use App\Mailer;
-        use Symfony\Component\DependencyInjection\Reference;
 
-        $container->register(Mailer::class);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
 
-        $container->register(DecoratingMailer::class)
-            ->setDecoratedService(Mailer::class)
-            ->addArgument(new Reference(DecoratingMailer::class.'.inner'))
-        ;
+            $container->set(Mailer::class);
+            $container->set(DecoratingMailer::class)
+                ->decorate(Mailer::class)
+                ->args([ref(DecoratingMailer::class.'.inner')]);
+        };
+
 
 .. tip::
 
@@ -206,14 +219,19 @@ automatically changed to ``decorating_service_id + '.inner'``):
         .. code-block:: php
 
             // config/services.php
-            use App\DecoratingMailer;
-            use Symfony\Component\DependencyInjection\Reference;
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            $container->register(DecoratingMailer::class)
-                ->setDecoratedService(App\Mailer, DecoratingMailer::class.'.wooz')
-                ->addArgument(new Reference(DecoratingMailer::class.'.wooz'))
-                // ...
-            ;
+            use App\DecoratingMailer;
+            use App\Mailer;
+
+            return function(ContainerConfigurator $configurator) {
+                $container = $configurator->services();
+
+                $container->set(Mailer::class);
+                $container->set(DecoratingMailer::class)
+                    ->decorate(Mailer::class, DecoratingMailer::class.'.wooz')
+                    ->args([ref(DecoratingMailer::class.'.wooz')]);
+            };
 
 Decoration Priority
 -------------------
@@ -266,19 +284,24 @@ the ``decoration_priority`` option. Its value is an integer that defaults to
     .. code-block:: php
 
         // config/services.php
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        $container->register(Foo::class)
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
 
-        $container->register(Bar::class)
-            ->addArgument(new Reference(Bar::class.'.inner'))
-            ->setPublic(false)
-            ->setDecoratedService(Foo::class, null, 5);
+            $container->set(Foo::class);
 
-        $container->register(Baz::class)
-            ->addArgument(new Reference(Baz::class.'.inner'))
-            ->setPublic(false)
-            ->setDecoratedService(Foo::class, null, 1);
+            $container->set(Bar::class)
+                ->decorate(Foo::class, null, 5)
+                ->private()
+                ->args([ref(Bar::class.'.inner')]);
+
+            $container->set(Baz::class)
+                ->decorate(Foo::class, null, 1)
+                ->private()
+                ->args([ref(Baz::class.'.inner')]);
+        };
+
 
 The generated code will be the following::
 

--- a/service_container/shared.rst
+++ b/service_container/shared.rst
@@ -32,10 +32,16 @@ in your service definition:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\SomeNonSharedService;
 
-        $container->register(SomeNonSharedService::class)
-            ->setShared(false);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+
+            $container->set(SomeNonSharedService::class)
+                ->share(false);
+        };
 
 Now, whenever you request the ``App\SomeNonSharedService`` from the container,
 you will be passed a new instance.

--- a/service_container/synthetic_services.rst
+++ b/service_container/synthetic_services.rst
@@ -64,10 +64,14 @@ configuration:
     .. code-block:: php
 
         // config/services.php
-        // synthetic services don't specify a class
-        $container->register('app.synthetic_service')
-            ->setSynthetic(true)
-        ;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set('app.synthetic_service')
+                ->synthetic();
+        };
+
 
 Now, you can inject the instance in the container using
 :method:`Container::set() <Symfony\\Component\\DependencyInjection\\Container::set>`::

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -38,11 +38,17 @@ example:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Twig\AppExtension;
 
-        $container->register(AppExtension::class)
-            ->setPublic(false)
-            ->addTag('twig.extension');
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(AppExtension::class)
+                ->private()
+                ->tag('twig.extension');
+        };
+
 
 Services tagged with the ``twig.extension`` tag are collected during the
 initialization of TwigBundle and added to Twig as extensions.
@@ -96,13 +102,17 @@ If you want to apply tags automatically for your own services, use the
     .. code-block:: php
 
         // config/services.php
-        use App\Security\CustomInterface;
-        // ...
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // services whose classes are instances of CustomInterface will be tagged automatically
-        $container->registerForAutoconfiguration(CustomInterface::class)
-            ->addTag('app.custom_tag')
-            ->setAutowired(true);
+        use App\Security\CustomInterface;
+
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->instanceof(CustomInterface::class)
+                ->autowire()
+                ->tag('app.custom_tag');
+        };
+
 
 For more advanced needs, you can define the automatic tags using the
 :method:`Symfony\\Component\\DependencyInjection\\ContainerBuilder::registerForAutoconfiguration`
@@ -182,9 +192,15 @@ Then, define the chain as a service:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Mail\TransportChain;
 
-        $container->autowire(TransportChain::class);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(TransportChain::class);
+        };
+
 
 Define Services with a Custom Tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -231,12 +247,17 @@ For example, you may add the following transports as services:
     .. code-block:: php
 
         // config/services.php
-        $container->register(\Swift_SmtpTransport::class)
-            ->addArgument('%mailer_host%')
-            ->addTag('app.mail_transport');
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        $container->register(\Swift_SendmailTransport::class)
-            ->addTag('app.mail_transport');
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(\Swift_SmtpTransport::class)
+                ->args(['%mailer_host%'])
+                ->tag('app.mail_transport');
+
+            $container->set(\Swift_SendmailTransport::class)
+                ->tag('app.mail_transport');
+        };
 
 Notice that each service was given a tag named ``app.mail_transport``. This is
 the custom tag that you'll use in your compiler pass. The compiler pass is what
@@ -387,12 +408,17 @@ To answer this, change the service declaration:
     .. code-block:: php
 
         // config/services.php
-        $container->register(\Swift_SmtpTransport::class)
-            ->addArgument('%mailer_host%')
-            ->addTag('app.mail_transport', ['alias' => 'smtp']);
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        $container->register(\Swift_SendmailTransport::class)
-            ->addTag('app.mail_transport', ['alias' => 'sendmail']);
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(\Swift_SmtpTransport::class)
+                ->args(['%mailer_host%'])
+                ->tag('app.mail_transport', ['alias' => 'smtp']);
+
+            $container->set(\Swift_SendmailTransport::class)
+                ->tag('app.mail_transport', ['alias' => 'sendmail']);
+        };
 
 .. tip::
 
@@ -500,17 +526,20 @@ first  constructor argument to the ``App\HandlerCollection`` service:
     .. code-block:: php
 
         // config/services.php
-        use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        $container->register(App\Handler\One::class)
-            ->addTag('app.handler');
+        return function(ContainerConfigurator $configurator) {
+            $container = $configurator->services();
+            $container->set(App\Handler\One::class)
+                ->tag('app.handler');
 
-        $container->register(App\Handler\Two::class)
-            ->addTag('app.handler');
+            $container->set(App\Handler\Two::class)
+                ->tag('app.handler');
 
-        $container->register(App\HandlerCollection::class)
-            // inject all services tagged with app.handler as first argument
-            ->addArgument(new TaggedIteratorArgument('app.handler'));
+            $container->set(App\HandlerCollection::class)
+                // inject all services tagged with app.handler as first argument
+                ->args([tagged('app.handler')]);
+        };
 
 After compilation the ``HandlerCollection`` service is able to iterate over your
 application handlers::
@@ -558,7 +587,12 @@ application handlers::
         .. code-block:: php
 
             // config/services.php
-            $container->register(App\Handler\One::class)
-                ->addTag('app.handler', ['priority' => 20]);
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return function(ContainerConfigurator $configurator) {
+                $container = $configurator->services();
+                $container->set(App\Handler\One::class)
+                    ->tag('app.handler', ['priority' => 20]);
+            };
 
     Note that any other custom attributes will be ignored by this feature.


### PR DESCRIPTION
- Updated service_container.rst to include php-fluent-di
- Updated _build/conf.py to include codeblock for php-fluent-di
- Updated existing di resource loading to refer to latest sf 4.2
  excludes

Remaining: need to update the rest of the service_container files

Signed-off-by: RJ Garcia <rj@bighead.net>