### PR TITLE
[Serializer] XmlEncoder example fix

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -802,7 +802,7 @@ Be aware that this encoder will consider keys beginning with ``@`` as attributes
 the key  ``#comment`` for encoding XML comments::
 
     $encoder = new XmlEncoder();
-    $encoder->encode(array('foo' => array('@bar' => 'value'), 'qux' => array('#comment' => 'A comment));
+    $encoder->encode(array('foo' => array('@bar' => 'value'), 'qux' => array('#comment' => 'A comment')), 'xml');
     // will return:
     // <?xml version="1.0"?>
     // <response>


### PR DESCRIPTION
Currently in example:
```
$encoder = new XmlEncoder();
$encoder->encode(array('foo' => array('@bar' => 'value'), 'qux' => array('#comment' => 'A comment));
```
we'll get `Parse error: syntax error, unexpected '', $serialized); ' (T_CONSTANT_ENCAPSED_STRING), expecting ')'`.
After close `A comment` string and add missing `$format`, it works correctly.
```
$encoder->encode(array('foo' => array('@bar' => 'value'), 'qux' => array('#comment' => 'A comment')), 'xml');
```