### PR TITLE
document "choices" wildcard in Choice validation constraint

### DIFF
--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -375,11 +375,17 @@ too few choices per the `min`_ option.
 
 You can use the following parameters in this message:
 
-+------------------+------------------------------------------------+
-| Parameter        | Description                                    |
-+==================+================================================+
-| ``{{ limit }}``  | The lower limit of choices                     |
-+------------------+------------------------------------------------+
++--------------------+-------------------------------------------------------+
+| Parameter          | Description                                           |
++====================+=======================================================+
+| ``{{ value }}``    | The current (invalid) value                           |
++--------------------+-------------------------------------------------------+
+| ``{{ choices }}``  | String list of available choices, separated by comas  |
++--------------------+-------------------------------------------------------+
+
+.. versionadded:: 4.3
+
+    The ``{{ choices }}`` parameter was introduced in Symfony 4.3.
 
 maxMessage
 ~~~~~~~~~~
@@ -391,11 +397,17 @@ too many options per the `max`_ option.
 
 You can use the following parameters in this message:
 
-+------------------+------------------------------------------------+
-| Parameter        | Description                                    |
-+==================+================================================+
-| ``{{ limit }}``  | The upper limit of choices                     |
-+------------------+------------------------------------------------+
++--------------------+-------------------------------------------------------+
+| Parameter          | Description                                           |
++====================+=======================================================+
+| ``{{ value }}``    | The current (invalid) value                           |
++--------------------+-------------------------------------------------------+
+| ``{{ choices }}``  | String list of available choices, separated by comas  |
++--------------------+-------------------------------------------------------+
+
+.. versionadded:: 4.3
+
+    The ``{{ choices }}`` parameter was introduced in Symfony 4.3.
 
 strict
 ~~~~~~


### PR DESCRIPTION
Hello,

here is a little doc update in order to document the `choices` wildcard introduced by https://github.com/symfony/symfony/pull/29658

