### PR TITLE
[Console] Fix duplicated text in console events

### DIFF
--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -94,17 +94,6 @@ event listeners, the ``ConsoleEvents::ERROR`` event is dispatched. A listener
 can wrap or change the exception or do anything useful before the exception is
 thrown by the application.
 
-The ``ConsoleEvents::ERROR`` Event
-----------------------------------
-
-**Typical Purposes**: Handle exceptions thrown during the execution of a
-command.
-
-Whenever an exception is thrown by a command, including those triggered from
-event listeners, the ``ConsoleEvents::ERROR`` event is dispatched. A listener
-can wrap or change the exception or do anything useful before the exception is
-thrown by the application.
-
 Listeners receive a
 :class:`Symfony\\Component\\Console\\Event\\ConsoleErrorEvent` event::
 


### PR DESCRIPTION
In the [documentation for console events](https://symfony.com/doc/4.1/components/console/events.html#the-consoleevents-error-event), block about `ConsoleEvents::ERROR` is duplicated twice. Duplication appeared in branch 4.1 and still present in master

![duplication](https://user-images.githubusercontent.com/815865/50646442-bba59e00-0f7e-11e9-8a2c-99c9a3f8a513.png)
