### PR TITLE
[WIP] New Bundle directory structure

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -92,7 +92,7 @@ that automated tools can rely on:
   can use any of the markup formats supported by GitHub, such as ``README.rst``);
 * ``LICENSE``: The full contents of the license used by the code. Most third-party
   bundles are published under the MIT license, but you can `choose any license`_;
-* ``src/Resources/doc/index.rst``: The root file for the Bundle documentation.
+* ``docs/index.rst``: The root file for the Bundle documentation.
 
 The depth of subdirectories should be kept to a minimum for the most used
 classes and files. Two levels is the maximum.
@@ -258,10 +258,10 @@ Documentation
 
 All classes and functions must come with full PHPDoc.
 
-Extensive documentation should also be provided in the ``src/Resources/doc/``
+Extensive documentation should also be provided in the ``docs/``
 directory.
-The index file (for example ``src/Resources/doc/index.rst`` or
-``src/Resources/doc/index.md``) is the only mandatory file and must be the entry
+The index file (for example ``docs/index.rst`` or
+``docs/index.md``) is the only mandatory file and must be the entry
 point for the documentation. The
 :doc:`reStructuredText (rST) </contributing/documentation/format>` is the format
 used to render the documentation on symfony.com.

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -154,7 +154,7 @@ Tests
 -----
 
 A bundle should come with a test suite written with PHPUnit and stored under
-the ``Tests/`` directory. Tests should follow the following principles:
+the ``tests/`` directory. Tests should follow the following principles:
 
 * The test suite must be executable with a simple ``phpunit`` command run from
   a sample application;
@@ -258,10 +258,10 @@ Documentation
 
 All classes and functions must come with full PHPDoc.
 
-Extensive documentation should also be provided in the ``Resources/doc/``
+Extensive documentation should also be provided in the ``src/Resources/doc/``
 directory.
-The index file (for example ``Resources/doc/index.rst`` or
-``Resources/doc/index.md``) is the only mandatory file and must be the entry
+The index file (for example ``src/Resources/doc/index.rst`` or
+``src/Resources/doc/index.md``) is the only mandatory file and must be the entry
 point for the documentation. The
 :doc:`reStructuredText (rST) </contributing/documentation/format>` is the format
 used to render the documentation on symfony.com.
@@ -539,7 +539,7 @@ lets you override any resource/file of any bundle. See :ref:`http-kernel-resourc
 for more details about transforming physical paths into logical paths.
 
 Beware that templates use a simplified version of the logical path shown above.
-For example, an ``index.html.twig`` template located in the ``Resources/views/Default/``
+For example, an ``index.html.twig`` template located in the ``src/Resources/views/Default/``
 directory of the FooBundle, is referenced as ``@Foo/Default/index.html.twig``.
 
 Learn more

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -68,30 +68,32 @@ The basic directory structure of an AcmeBlogBundle must read as follows:
 .. code-block:: text
 
     <your-bundle>/
-    ├─ AcmeBlogBundle.php
-    ├─ Controller/
+    ├─ config/
+    ├─ src/
+    |   ├─ AcmeBlogBundle.php
+    |   ├─ Controller/
+    |   ├─ Resources/
+    |   |   ├─ config/
+    |   |   ├─ doc/
+    │   |   |   └─ index.rst
+    │   |   ├─ translations/
+    │   |   ├─ views/
+    │   |   └─ public/
+    ├─ tests/
     ├─ README.md
-    ├─ LICENSE
-    ├─ Resources/
-    │   ├─ config/
-    │   ├─ doc/
-    │   │  └─ index.rst
-    │   ├─ translations/
-    │   ├─ views/
-    │   └─ public/
-    └─ Tests/
+    └─ LICENSE
 
 **The following files are mandatory**, because they ensure a structure convention
 that automated tools can rely on:
 
-* ``AcmeBlogBundle.php``: This is the class that transforms a plain directory
+* ``src/AcmeBlogBundle.php``: This is the class that transforms a plain directory
   into a Symfony bundle (change this to your bundle's name);
 * ``README.md``: This file contains the basic description of the bundle and it
   usually shows some basic examples and links to its full documentation (it
   can use any of the markup formats supported by GitHub, such as ``README.rst``);
 * ``LICENSE``: The full contents of the license used by the code. Most third-party
   bundles are published under the MIT license, but you can `choose any license`_;
-* ``Resources/doc/index.rst``: The root file for the Bundle documentation.
+* ``src/Resources/doc/index.rst``: The root file for the Bundle documentation.
 
 The depth of subdirectories should be kept to a minimum for the most used
 classes and files. Two levels is the maximum.
@@ -107,19 +109,19 @@ and others are just conventions followed by most developers):
 ===================================================  ========================================
 Type                                                 Directory
 ===================================================  ========================================
-Commands                                             ``Command/``
-Controllers                                          ``Controller/``
-Service Container Extensions                         ``DependencyInjection/``
-Doctrine ORM entities (when not using annotations)   ``Entity/``
-Doctrine ODM documents (when not using annotations)  ``Document/``
-Event Listeners                                      ``EventListener/``
-Configuration (routes, services, etc.)               ``Resources/config/``
+Commands                                             ``src/Command/``
+Controllers                                          ``src/Controller/``
+Service Container Extensions                         ``src/DependencyInjection/``
+Doctrine ORM entities (when not using annotations)   ``src/Entity/``
+Doctrine ODM documents (when not using annotations)  ``src/Document/``
+Event Listeners                                      ``src/EventListener/``
+Configuration (routes, services, etc.)               ``config/``
 Web Assets (CSS, JS, images)                         ``Resources/public/``
 Translation files                                    ``Resources/translations/``
 Validation (when not using annotations)              ``Resources/config/validation/``
 Serialization (when not using annotations)           ``Resources/config/serialization/``
 Templates                                            ``Resources/views/``
-Unit and Functional Tests                            ``Tests/``
+Unit and Functional Tests                            ``tests/``
 ===================================================  ========================================
 
 Classes

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -68,7 +68,6 @@ The basic directory structure of an AcmeBlogBundle must read as follows:
 .. code-block:: text
 
     <your-bundle>/
-    ├─ config/
     ├─ src/
     |   ├─ AcmeBlogBundle.php
     |   ├─ Controller/
@@ -115,7 +114,7 @@ Service Container Extensions                         ``src/DependencyInjection/`
 Doctrine ORM entities (when not using annotations)   ``src/Entity/``
 Doctrine ODM documents (when not using annotations)  ``src/Document/``
 Event Listeners                                      ``src/EventListener/``
-Configuration (routes, services, etc.)               ``config/``
+Configuration (routes, services, etc.)               ``src/Resources/config/``
 Web Assets (CSS, JS, images)                         ``src/Resources/public/``
 Translation files                                    ``src/Resources/translations/``
 Validation (when not using annotations)              ``src/Resources/config/validation/``

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -116,11 +116,11 @@ Doctrine ORM entities (when not using annotations)   ``src/Entity/``
 Doctrine ODM documents (when not using annotations)  ``src/Document/``
 Event Listeners                                      ``src/EventListener/``
 Configuration (routes, services, etc.)               ``config/``
-Web Assets (CSS, JS, images)                         ``Resources/public/``
-Translation files                                    ``Resources/translations/``
-Validation (when not using annotations)              ``Resources/config/validation/``
-Serialization (when not using annotations)           ``Resources/config/serialization/``
-Templates                                            ``Resources/views/``
+Web Assets (CSS, JS, images)                         ``src/Resources/public/``
+Translation files                                    ``src/Resources/translations/``
+Validation (when not using annotations)              ``src/Resources/config/validation/``
+Serialization (when not using annotations)           ``src/Resources/config/serialization/``
+Templates                                            ``src/Resources/views/``
 Unit and Functional Tests                            ``tests/``
 ===================================================  ========================================
 

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -68,16 +68,16 @@ The basic directory structure of an AcmeBlogBundle must read as follows:
 .. code-block:: text
 
     <your-bundle>/
+    ├─ docs/
+    │   └─ index.rst
     ├─ src/
-    |   ├─ AcmeBlogBundle.php
     |   ├─ Controller/
     |   ├─ Resources/
     |   |   ├─ config/
-    |   |   ├─ doc/
-    │   |   |   └─ index.rst
     │   |   ├─ translations/
     │   |   ├─ views/
     │   |   └─ public/
+    |   └─ AcmeBlogBundle.php
     ├─ tests/
     ├─ README.md
     └─ LICENSE


### PR DESCRIPTION
It's been a long time since Symfony Bundles were invented, many versions of Symfony changed 
 and finally Symfony 4 and Flex was released. It brought us many changes in App coding style, but what about bundles? Current Bundle structure is out of date. I think it's time to move forward and update it to correspond... lets say flex way =)
### Current:
```
<your-bundle>/
├─ AcmeBlogBundle.php
├─ Controller/
├─ README.md
├─ LICENSE
├─ Resources/
│   ├─ config/
│   ├─ doc/
│   │  └─ index.rst
│   ├─ translations/
│   ├─ views/
│   └─ public/
└─ Tests/
```
### WIP state:
```
<your-bundle>/
├─ docs/
│   └─ index.rst
├─ src/
|   ├─ Controller/
|   ├─ Resources/
|   |   ├─ config/
│   |   ├─ translations/
│   |   ├─ views/
│   |   └─ public/
|   └─ AcmeBlogBundle.php
├─ tests/
├─ README.md
└─ LICENSE
```
### Target

This is what I think it should be in final variant. I'll update this message soon with some info about changes to reach this target.
```
<your-bundle>/
├─ assets/
├─ config/
├─ docs/
│   └─ index.rst
├─ src/
|   ├─ Controller/
|   └─ AcmeBlogBundle.php
├─ templates/
├─ tests/
├─ translations/
├─ README.md
└─ LICENSE
```
