### PR TITLE
Add missing imports and remove useless

### DIFF
--- a/profiler/wdt_follow_ajax.rst
+++ b/profiler/wdt_follow_ajax.rst
@@ -21,6 +21,10 @@ Ideally this header should only be set during development and not for
 production. This can be accomplished by setting the header in a
 :ref:`kernel.response <component-http-kernel-kernel-response>` event listener::
 
+    use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+    // ...
+
     public function onKernelResponse(FilterResponseEvent $event)
     {
         $response = $event->getResponse();

--- a/translation.rst
+++ b/translation.rst
@@ -119,7 +119,6 @@ of text (called a *message*), use the
 for example, that you're translating a simple message from inside a controller::
 
     // ...
-    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Translation\TranslatorInterface;
 
     public function index(TranslatorInterface $translator)
@@ -198,7 +197,6 @@ Message Placeholders
 
 Sometimes, a message containing a variable needs to be translated::
 
-    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Translation\TranslatorInterface;
 
     public function index(TranslatorInterface $translator, $name)


### PR DESCRIPTION
I added importing of classes where it's quite important to provide it and removed where class is imported and not used in code block.

This PR is similar to #10817, but here are changes that are actual for v4.1 and aren't for v3.4.