### PR TITLE
Update pdo_session_storage.rts

### DIFF
--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -23,7 +23,7 @@ To use it, first register a new handler service:
 
             Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
                 arguments:
-                    - 'mysql:dbname=mydatabase, host=myhost'
+                    - 'mysql:dbname=mydatabase; host=myhost; port=myport'
                     - { db_username: myuser, db_password: mypassword }
 
                     # If you're using Doctrine & want to re-use that connection, then:
@@ -61,7 +61,7 @@ To use it, first register a new handler service:
 
         $storageDefinition = $container->autowire(PdoSessionHandler::class)
             ->setArguments(array(
-                'mysql:dbname=mydatabase, host=myhost',
+                'mysql:dbname=mydatabase; host=myhost; port=myport',
                 array('db_username' => 'myuser', 'db_password' => 'mypassword'),
             ))
         ;
@@ -123,7 +123,7 @@ a second array argument to ``PdoSessionHandler``:
 
             Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
                 arguments:
-                    - 'mysql:dbname=mydatabase, host=myhost'
+                    - 'mysql:dbname=mydatabase; host=myhost; port=myport'
                     - { db_table: 'sessions', db_username: 'myuser', db_password: 'mypassword' }
 
     .. code-block:: xml
@@ -156,7 +156,7 @@ a second array argument to ``PdoSessionHandler``:
 
         $container->autowire(PdoSessionHandler::class)
             ->setArguments(array(
-                'mysql:dbname=mydatabase, host=myhost',
+                'mysql:dbname=mydatabase; host=myhost; port=myport',
                 array('db_table' => 'sessions', 'db_username' => 'myuser', 'db_password' => 'mypassword')
             ))
         ;


### PR DESCRIPTION
Argument `DSN` for `PdoSessionHandler` should be seperated by semicolon instead of comma.
Source: `http://php.net/manual/en/pdo.connections.php`

Also added extra parameter example `port`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
