### PR TITLE
Describe things more precisely

### DIFF
--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -338,9 +338,10 @@ dealing with the ``TransformerInterface``.
 
 .. tip::
 
-    As long as there is only one class implementing the interface and that class
-    is part of the same namespace configuring the alias is not mandatory and Symfony
-    will automatically create one.
+    When using a `service definition prototype`_, if only one service is
+    discovered that implements an interface, and that interface is also
+    discovered at the same time, configuring the alias is not mandatory
+    and Symfony will automatically create one.
 
 Dealing with Multiple Implementations of the Same Type
 ------------------------------------------------------
@@ -500,3 +501,4 @@ Public bundles should explicitly configure their services and not rely on autowi
 
 .. _Rapid Application Development: https://en.wikipedia.org/wiki/Rapid_application_development
 .. _ROT13: https://en.wikipedia.org/wiki/ROT13
+.. _service definition prototype: https://symfony.com/blog/new-in-symfony-3-3-psr-4-based-service-discovery


### PR DESCRIPTION
Here, namespace is referring to that kind of thing:

    App\Namespace\:
        resource: '../../src/App/Namespace/*'

And it looks as if there is no word yet to name that kind of
configuration block. I propose to use namespace resource declaration,
but please do suggest better alternatives, (glob resouce declaration?).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
