### PR TITLE
Fix list of core cache warmers

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -590,9 +590,23 @@ Core Cache Warmers
 +===========================================================================================+===========+
 | :class:`Symfony\\Bundle\\FrameworkBundle\\CacheWarmer\\TemplatePathsCacheWarmer`          | 20        |
 +-------------------------------------------------------------------------------------------+-----------+
+| :class:`Symfony\\Component\\HttpKernel\\CacheWarmer\\CacheWarmerAggregate`                | 0         |
++-------------------------------------------------------------------------------------------+-----------+
 | :class:`Symfony\\Bundle\\FrameworkBundle\\CacheWarmer\\RouterCacheWarmer`                 | 0         |
 +-------------------------------------------------------------------------------------------+-----------+
+| :class:`Symfony\\Bundle\\FrameworkBundle\\CacheWarmer\\ValidatorCacheWarmer`              | 0         |
++-------------------------------------------------------------------------------------------+-----------+
+| :class:`Symfony\\Bundle\\FrameworkBundle\\CacheWarmer\\SerializerCacheWarmer`             | 0         |
++-------------------------------------------------------------------------------------------+-----------+
+| :class:`Symfony\\Bundle\\FrameworkBundle\\CacheWarmer\\TranslationsCacheWarmer`           | 0         |
++-------------------------------------------------------------------------------------------+-----------+
+| :class:`Symfony\\Bundle\\FrameworkBundle\\CacheWarmer\\AnnotationsCacheWarmer`            | 0         |
++-------------------------------------------------------------------------------------------+-----------+
+| :class:`Symfony\\Bundle\\SecurityBundle\\CacheWarmer\\ExpressionCacheWarmer`              | 0         |
++-------------------------------------------------------------------------------------------+-----------+
 | :class:`Symfony\\Bundle\\TwigBundle\\CacheWarmer\\TemplateCacheCacheWarmer`               | 0         |
++-------------------------------------------------------------------------------------------+-----------+
+| :class:`Symfony\\Bundle\\TwigBundle\\CacheWarmer\\TemplateCacheWarmer`                    | 0         |
 +-------------------------------------------------------------------------------------------+-----------+
 
 .. _dic-tags-kernel-event-listener:


### PR DESCRIPTION
Currently there are many core cache warmers missing in the documentation:

```bash
Symfony Container Services Tagged with "kernel.cache_warmer" Tag
================================================================

 ----------------------------------------------------- ---------- -----------------------------------------------------------------------
  Service ID                                            priority   Class name
 ----------------------------------------------------- ---------- -----------------------------------------------------------------------
  annotations.cache_warmer                                         Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer
  doctrine.orm.proxy_cache_warmer                                  Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer
  router.cache_warmer                                              Symfony\Bundle\FrameworkBundle\CacheWarmer\RouterCacheWarmer
  serializer.mapping.cache_warmer                                  Symfony\Bundle\FrameworkBundle\CacheWarmer\SerializerCacheWarmer
  templating.cache_warmer.template_paths                20         Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplatePathsCacheWarmer
  translation.warmer                                               Symfony\Bundle\FrameworkBundle\CacheWarmer\TranslationsCacheWarmer
  twig.cache_warmer                                                Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheCacheWarmer
  twig.template_cache_warmer                                       Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheWarmer
  validator.mapping.cache_warmer                                   Symfony\Bundle\FrameworkBundle\CacheWarmer\ValidatorCacheWarmer
 ----------------------------------------------------- ---------- -----------------------------------------------------------------------
```