### PR TITLE
Update parent_services.rst code snippet to match its description

### DIFF
--- a/service_container/parent_services.rst
+++ b/service_container/parent_services.rst
@@ -70,12 +70,12 @@ duplicated service definitions:
             AppBundle\Repository\BaseDoctrineRepository:
                 abstract:  true
                 arguments: ['@doctrine.orm.entity_manager']
-                calls:
-                    - [setLogger, ['@logger']]
 
             AppBundle\Repository\DoctrineUserRepository:
                 # extend the AppBundle\Repository\BaseDoctrineRepository service
                 parent: AppBundle\Repository\BaseDoctrineRepository
+                calls:
+                    - [setLogger, ['@logger']]
 
             AppBundle\Repository\DoctrinePostRepository:
                 parent: AppBundle\Repository\BaseDoctrineRepository
@@ -93,16 +93,16 @@ duplicated service definitions:
             <services>
                 <service id="AppBundle\Repository\BaseDoctrineRepository" abstract="true">
                     <argument type="service" id="doctrine.orm.entity_manager" />
+                </service>
+
+                <!-- extends the AppBundle\Repository\BaseDoctrineRepository service -->
+                <service id="AppBundle\Repository\DoctrineUserRepository"
+                    parent="AppBundle\Repository\BaseDoctrineRepository">
 
                     <call method="setLogger">
                         <argument type="service" id="logger" />
                     </call>
                 </service>
-
-                <!-- extends the AppBundle\Repository\BaseDoctrineRepository service -->
-                <service id="AppBundle\Repository\DoctrineUserRepository"
-                    parent="AppBundle\Repository\BaseDoctrineRepository"
-                />
 
                 <service id="AppBundle\Repository\DoctrinePostRepository"
                     parent="AppBundle\Repository\BaseDoctrineRepository"
@@ -123,12 +123,12 @@ duplicated service definitions:
         $container->register(BaseDoctrineRepository::class)
             ->setAbstract(true)
             ->addArgument(new Reference('doctrine.orm.entity_manager'))
-            ->addMethodCall('setLogger', array(new Reference('logger')))
         ;
 
         // extend the AppBundle\Repository\BaseDoctrineRepository service
         $definition = new ChildDefinition(BaseDoctrineRepository::class);
         $definition->setClass(DoctrineUserRepository::class);
+        $definition->addMethodCall('setLogger', array(new Reference('logger')))
         $container->setDefinition(DoctrineUserRepository::class, $definition);
 
         $definition = new ChildDefinition(BaseDoctrineRepository::class);


### PR DESCRIPTION
The code did not correspond to the description on line 143 (of the edited version). If the setter setLogger is declared on the parent service, it will be called for all child services just as if it was in constructor and therefore lacks sense. The call should be declared on those child services, that actually use the Logger, in this case AppBundle\Repository\DoctrineUserRepository. 
This change is also in harmony with setter injection intended for optional injections as stated in https://symfony.com/doc/current/service_container/injection_types.html#setter-injection