### PR TITLE
List the minor requirements in requirements.rst

### DIFF
--- a/reference/requirements.rst
+++ b/reference/requirements.rst
@@ -3,19 +3,44 @@
 
 .. _requirements-for-running-symfony2:
 
-Requirements for Running Symfony
-================================
+Requirements for Running Symfony 4
+==================================
 
 Symfony 4 requires **PHP 7.1.3** or higher to run, in addition to other minor
-requirements. To make things simple, Symfony provides a tool to quickly check if
-your system meets all those requirements. Run this command to install the tool:
+requirements:
+
+PHP Extensions
+~~~~~~~~~~~~~~
+* The `Ctype`_ extension must be available
+* The `iconv`_ extension  must be available
+* The `JSON`_ extension must be available
+* The `PCRE`_ extension must be available (minimum version 8.0)
+* The `Session`_ extension must be available
+* The `SimpleXML`_ extension must be available
+* The `Tokenizer`_ extension must be available
+
+Please note that all these extensions are installed and enabled by default 
+in PHP 7+.
+
+Other Requirements
+~~~~~~~~~~~~~~~~~~
+* The cache directory must me writable by the web server
+* The logs directory must be writable by the web server
+
+Checking Requirements with Symfony Requirements Checker
+-------------------------------------------------------
+To make things simple, Symfony provides a tool to quickly check if
+your system meets these requirements. In addition, the tool will
+also provide recommendations if applicable.
+
+Run this command to install the tool:
 
 .. code-block:: terminal
 
     $ cd your-project/
     $ composer require symfony/requirements-checker
 
-Beware that PHP can define a different configuration for the command console and
+Beware that PHP may use different configurations for the command console and
 the web server, so you need to check requirements in both environments.
 
 Checking Requirements for the Web Server
@@ -38,4 +63,12 @@ Checking Requirements for the Command Console
 
 The requirements checker tool adds a script to your Composer configuration to
 check the requirements automatically. There's no need to execute any command; if
-there is any issue, you'll see them in the console output.
+there are any issues, you'll see them in the console output.
+
+.. _iconv: http://php.net/manual/en/book.iconv.php
+.. _JSON: http://php.net/manual/en/book.json.php
+.. _Session: http://php.net/manual/en/book.session.php
+.. _Ctype: http://php.net/manual/en/book.ctype.php
+.. _Tokenizer: http://php.net/manual/en/book.tokenizer.php
+.. _SimpleXML: http://php.net/manual/en/book.simplexml.php
+.. _PCRE: http://php.net/manual/en/book.pcre.php


### PR DESCRIPTION
I work for a development agency that doesn't do hosting themselves, so we rely on third party hosting (usually provided by the client). 
Whenever a new server for a Symfony application needs to be set up the hosting people naturally ask for the server requirements. I find myself unable to answer that question completely because the docs don't specify the mentioned "minor requirements".

I'm aware of the existince of `symfony/requirements-checker` but this can't be used if the server isn't available yet.

So I thought it would be useful and helpful to list the "minor requirements" on this docs page. I've extracted the requirements from https://github.com/symfony/requirements-checker/blob/master/src/SymfonyRequirements.php .
While looking up the URLs for the PHP extensions' manual pages I noticed that all of them are installed and enabled by default in PHP7, so I've added that as a note as well. I think this makes it clear that, for a default Symfony application, there are no extra requirements other than PHP 7.1.3.

I've also made a few minor improvements to other sentences as well.
