### PR TITLE
validator: comparison constraints value

### DIFF
--- a/reference/constraints/EqualTo.rst
+++ b/reference/constraints/EqualTo.rst
@@ -75,7 +75,7 @@ and that the ``age`` is ``20``, you could do the following:
             <class name="App\Entity\Person">
                 <property name="firstName">
                     <constraint name="EqualTo">
-                        <value>Mary</value>
+                        Mary
                     </constraint>
                 </property>
                 <property name="age">

--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -74,7 +74,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
                 <property name="siblings">
                     <constraint name="GreaterThan">
-                        <value>5</value>
+                        5
                     </constraint>
                 </property>
                 <property name="age">

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -72,7 +72,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
                 <property name="siblings">
                     <constraint name="GreaterThanOrEqual">
-                        <value>5</value>
+                        5
                     </constraint>
                 </property>
                 <property name="age">

--- a/reference/constraints/IdenticalTo.rst
+++ b/reference/constraints/IdenticalTo.rst
@@ -78,7 +78,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
                 <property name="firstName">
                     <constraint name="IdenticalTo">
-                        <value>Mary</value>
+                        Mary
                     </constraint>
                 </property>
                 <property name="age">

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -74,7 +74,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
                 <property name="siblings">
                     <constraint name="LessThan">
-                        <value>5</value>
+                        5
                     </constraint>
                 </property>
                 <property name="age">

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -72,7 +72,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
                 <property name="siblings">
                     <constraint name="LessThanOrEqual">
-                        <value>5</value>
+                        5
                     </constraint>
                 </property>
                 <property name="age">

--- a/reference/constraints/NotEqualTo.rst
+++ b/reference/constraints/NotEqualTo.rst
@@ -77,7 +77,7 @@ the following:
             <class name="App\Entity\Person">
                 <property name="firstName">
                     <constraint name="NotEqualTo">
-                        <value>Mary</value>
+                        Mary
                     </constraint>
                 </property>
                 <property name="age">

--- a/reference/constraints/NotIdenticalTo.rst
+++ b/reference/constraints/NotIdenticalTo.rst
@@ -78,7 +78,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
             <property name="firstName">
                     <constraint name="NotIdenticalTo">
-                        <value>Mary</value>
+                        Mary
                     </constraint>
                 </property>
                 <property name="age">


### PR DESCRIPTION
When the comparison constraints have 1 or more <value> nodes, a ConstraintDefinitionException error is thrown in https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Validator/Constraints/AbstractComparison.php because the keys of the array in the constructor do not have a value