### PR TITLE
Fixing typo for .env.local file

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -256,7 +256,7 @@ sensible, non-secret *default* values for all of your environment variables and
 *should* be commited to your repository.
 
 To override these variables with machine-specific or sensitive values, create a
-``env.local`` file. This file is **not committed to the shared repository** and
+``.env.local`` file. This file is **not committed to the shared repository** and
 is only stored on your machine. In fact, the ``.gitignore`` file that comes with
 Symfony prevents it from being committed.
 


### PR DESCRIPTION
It was probably just a typo.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
