### PR TITLE
[Validator] Fix `@Valid` regarding property `traverse` 

### DIFF
--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -261,8 +261,8 @@ traverse
 
 **type**: ``boolean`` **default**: ``true``
 
-If this constraint is applied to a property that holds an array of objects,
-then each object in that array will be validated only if this option is
-set to ``true``.
+If this constraint is applied to a ``Traversable``, then all containing values
+will be validated if this option is set to ``true``. This option is ignored on
+arrays: Arrays are traversed in either case. Keys are not validated.
 
 .. include:: /reference/constraints/_payload-option.rst.inc


### PR DESCRIPTION
While researching for symfony/symfony#27090, the constraint reference turned out to be incorrect.