### PR TITLE
Update micro_kernel_trait.rst

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -55,7 +55,7 @@ Next, create an ``index.php`` file that defines the kernel class and executes it
         {
             // kernel is a service that points to this class
             // optional 3rd argument is the route name
-            $routes->add('/random/{limit}', 'Kernel::randomNumber');
+            $routes->add('/random/{limit}', 'kernel::randomNumber');
         }
 
         public function randomNumber($limit)


### PR DESCRIPTION
Fixes #10858

this was previously (in 4.0) kernel:randomNumber, it was changed to Kernel::randomNumber but that doesn't work

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
