### PR TITLE
[Documentation] Fix bad output folder

### DIFF
--- a/frontend/encore/installation.rst
+++ b/frontend/encore/installation.rst
@@ -57,7 +57,7 @@ is the main config file for both Webpack and Webpack Encore:
 
     Encore
         // directory where compiled assets will be stored
-        .setOutputPath('web/build/')
+        .setOutputPath('public/build/')
         // public path used by the web server to access the output path
         .setPublicPath('/build')
         // only needed for CDN's or sub-directory deploy


### PR DESCRIPTION
Default folder is now "public" and not "web"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
