### PR TITLE
Update Range.rst

### DIFF
--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -320,7 +320,7 @@ Options
 min
 ~~~
 
-**type**: ``int`` or ``string`` (date format)
+**type**: ``numeric`` or ``string`` (date format)
 
 This required option is the "min" value. Validation will fail if the given
 value is **less** than this min value.
@@ -328,7 +328,7 @@ value is **less** than this min value.
 max
 ~~~
 
-**type**: ``int`` or ``string`` (date format)
+**type**: ``numeric`` or ``string`` (date format)
 
 This required option is the "max" value. Validation will fail if the given
 value is **greater** than this max value.


### PR DESCRIPTION
I think that `int` is kind of misleading here as any `is_numeric` value evaluated to `true` is accepted (other than strings). 
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Validator/Constraints/RangeValidator.php#L36
I've done this PR for 3.4 but I think it should be reported to all next versions as well.
