### PR TITLE
Fix encore advanced config watchOptions example

### DIFF
--- a/frontend/encore/advanced-config.rst
+++ b/frontend/encore/advanced-config.rst
@@ -18,7 +18,7 @@ modify the config after fetching it from Encore:
 
     // fetch the config, then modify it!
     var config = Encore.getWebpackConfig();
-    config.watchOptions = { poll: true, ignored: /node_modules/ };
+    config.devServer.watchOptions = { poll: true, ignored: /node_modules/ };
 
     // other examples: add an alias or extension
     // config.resolve.alias.local = path.resolve(__dirname, './resources/src');


### PR DESCRIPTION
I've been struggling with this for some time and couldn't get `watchOptions` to work. After a long investigation I added `devServer` to the config and it started working.

So I guess this is the correct example of adding watchOptions to the config.