### PR TITLE
MakerBundle v1.11.13 uses urlGenerator instead of Router

### DIFF
--- a/security/form_login_setup.rst
+++ b/security/form_login_setup.rst
@@ -295,7 +295,7 @@ be redirected after success:
 
     -     throw new \Exception('TODO: provide a valid redirect inside '.__FILE__);
     +     // redirect to some "app_homepage" route - of wherever you want
-    +     return new RedirectResponse($this->router->generate('app_homepage'));
+    +     return new RedirectResponse($this->urlGenerator->generate('app_homepage'));
     }
 
 Unless you have any other TODOs in that file, that's it! If you're loading users


### PR DESCRIPTION
Hello,

Since version 1.11.3 and PR [#349](https://github.com/symfony/maker-bundle/pull/349) MakerBundle uses `UrlGeneratorInterface` instead of `RouterInterface` when generating a new Guard for a login form, and the corresponding property changed. Hence the documentation code snippet is misleading.

I'm not totally sure of which branch to PR on; being a change from latest version of MakerBundle, I think this is especially important for new projects, so using the latest Symfony version.
