### PR TITLE
Fixed the "learn more" section of Testing article

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -973,11 +973,10 @@ Learn more
     :glob:
 
     testing/*
-
-* :ref:`Testing a console command <console-testing-commands>`
-* :doc:`The chapter about tests in the Symfony Framework Best Practices </best_practices/tests>`
-* :doc:`/components/dom_crawler`
-* :doc:`/components/css_selector`
+    :ref:`Testing a console command <console-testing-commands>`
+    :doc:`The chapter about tests in the Symfony Framework Best Practices </best_practices/tests>`
+    :doc:`/components/dom_crawler`
+    :doc:`/components/css_selector`
 
 .. _`PHPUnit`: https://phpunit.de/
 .. _`documentation`: https://phpunit.readthedocs.io/

--- a/testing.rst
+++ b/testing.rst
@@ -973,10 +973,9 @@ Learn more
     :glob:
 
     testing/*
-    :ref:`Testing a console command <console-testing-commands>`
-    :doc:`The chapter about tests in the Symfony Framework Best Practices </best_practices/tests>`
-    :doc:`/components/dom_crawler`
-    :doc:`/components/css_selector`
+    /best_practices/tests
+    /components/dom_crawler
+    /components/css_selector
 
 .. _`PHPUnit`: https://phpunit.de/
 .. _`documentation`: https://phpunit.readthedocs.io/


### PR DESCRIPTION
Reported by @jmsche in Symfony's Slack. This is how it looks before this fix:

![testing-error](https://user-images.githubusercontent.com/73419/51758071-269d4d00-20c5-11e9-9439-096c89083fd4.png)
