### PR TITLE
Use the --dev option consistently for Composer and Yarn

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -14,7 +14,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/var-dumper --dev
+    $ composer require --dev symfony/var-dumper
 
 Alternatively, you can clone the `<https://github.com/symfony/var-dumper>`_ repository.
 

--- a/frontend/encore/postcss.rst
+++ b/frontend/encore/postcss.rst
@@ -8,7 +8,7 @@ First, download ``postcss-loader`` and any plugins you want, like ``autoprefixer
 
 .. code-block:: terminal
 
-    $ yarn add --dev postcss-loader autoprefixer
+    $ yarn add postcss-loader autoprefixer --dev
 
 Next, create a ``postcss.config.js`` file at the root of your project:
 

--- a/frontend/encore/url-loader.rst
+++ b/frontend/encore/url-loader.rst
@@ -10,7 +10,7 @@ it's disabled by default. First, add the URL loader to your project:
 
 .. code-block:: terminal
 
-    $ yarn add --dev url-loader
+    $ yarn add url-loader --dev
 
 Then enable it in your ``webpack.config.js``:
 


### PR DESCRIPTION
This fixes #10933.

This changes Symfony Docs to use these patterns:

* `composer require --dev ...`
* `yarn add ... --dev`

Yarn's pattern is the one recommended and used by them in their official docs: https://yarnpkg.com/lang/en/docs/cli/add/