### PR TITLE
Missing class file directory / location

### DIFF
--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -13,6 +13,10 @@ an *authenticated* token if the supplied credentials were found to be valid.
 The listener should then store the authenticated token using
 :class:`the token storage <Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface>`::
 
+    // src/EventListener/SomeAuthenticationListener.php
+    
+    namespace App\EventListener;
+
     use Symfony\Component\Security\Http\Firewall\ListenerInterface;
     use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
     use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;


### PR DESCRIPTION
Just stumbled on this on, as for example EventDispatcher gets this information (https://symfony.com/doc/current/event_dispatcher.html) but not the EventListener. The rest of the samples might have to follow the same info, though.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
