### PR TITLE
Clarify using chained filterXPath

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -78,6 +78,17 @@ Node Filtering
 Using XPath expressions is really easy::
 
     $crawler = $crawler->filterXPath('descendant-or-self::body/p');
+    
+    // To chained "filterXPath" : be aware that filterXPath is evaluated in the context of the crawler
+    $crawler->filterXPath('parent')->each(function (Crawler $parentCrawler, $i) {
+        // NOK : Direct child can not be found
+        $childCrawler = $parentCrawler->filterXPath('child-tag/sub-child-tag');
+        
+        // OK : You must specify parent tag
+        $subChildCrawler = $parentCrawler->filterXPath('parent/child-tag/sub-child-tag');
+        $subChildCrawler = $parentCrawler->filterXPath('node()/child-tag/sub-child-tag');
+    });
+    
 
 .. tip::
 


### PR DESCRIPTION
filterXpath() return a crawler that is considered as a fake parent of the elements inside it.
So we must re-specify the parent node to access direct children.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
