### PR TITLE
FOSUserBundle overwritten

### DIFF
--- a/bundles/override.rst
+++ b/bundles/override.rst
@@ -45,7 +45,7 @@ extend from the original template, not from the overridden one:
 
     {# templates/bundles/FOSUserBundle/Registration/confirmed.html.twig #}
     {# the special '!' prefix avoids errors when extending from an overridden template #}
-    {% extends "@!FOSUserBundle/Registration/confirmed.html.twig" %}
+    {% extends "@!FOSUser/Registration/confirmed.html.twig" %}
 
     {% block some_block %}
         ...


### PR DESCRIPTION
I had to use "FOSUser" and not "FOSUserBundle" when overwriting the The Default login.html.twig, otherwise Symfony would raise the " there are no registered paths for namespace "!FOSUserBundle"" error.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
