### PR TITLE
Fix of old service ids styles to class name

### DIFF
--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -51,8 +51,8 @@ When overriding an existing definition, the original service is lost:
 Most of the time, that's exactly what you want to do. But sometimes,
 you might want to decorate the old one instead (i.e. apply the `Decorator pattern`_).
 In this case, the old service should be kept around to be able to reference
-it in the new one. This configuration replaces ``app.mailer`` with a new one,
-but keeps a reference of the old one as ``app.decorating_mailer.inner``:
+it in the new one. This configuration replaces ``App\Mailer`` with a new one,
+but keeps a reference of the old one as ``App\DecoratingMailer.inner``:
 
 .. configuration-block::
 


### PR DESCRIPTION
The docs for the service decoration used the old service ids while the FQCN ones are shown in the code examples. This PR fixed these.