### PR TITLE
Changed an example

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -341,8 +341,8 @@ test
 **type**: ``boolean``
 
 If this configuration setting is present (and not ``false``), then the services
-related to testing your application (e.g. ``test.client``) are loaded. This
-setting should be present in your ``test`` environment (usually via
+related to testing your application (e.g. ``test.session.listener``) are loaded.
+This setting should be present in your ``test`` environment (usually via
 ``config/packages/test/framework.yaml``).
 
 .. seealso::


### PR DESCRIPTION
As `test.client` is going to be removed, let's change the example (see symfony/symfony#30060)