### PR TITLE
Show example on using a DateTimeImmutable object

### DIFF
--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -69,6 +69,14 @@ field as **three different choice fields**::
 If your underlying date is *not* a ``DateTime`` object (e.g. it's a unix timestamp),
 configure the `input`_ option.
 
+When working with a ``DateTimeImmutable`` object, add this as an ``input`` option::
+
+    $builder->add('publishedAt', DateType::class, [
+        'widget' => 'choice',
+        'input'  => 'datetime_immutable'
+    ]);
+
+
 Rendering a single HTML5 Textbox
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add an example on using DateTimeImmutable through the `input` option.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
