### PR TITLE
Update dotenv.rst

### DIFF
--- a/components/dotenv.rst
+++ b/components/dotenv.rst
@@ -17,7 +17,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require --dev symfony/dotenv
+    $ composer require --dev symfony/dotenv v3.4.21
 
 Alternatively, you can clone the `<https://github.com/symfony/dotenv>`_ repository.
 

--- a/components/dotenv.rst
+++ b/components/dotenv.rst
@@ -17,7 +17,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require --dev symfony/dotenv v3.4.21
+    $ composer require --dev symfony/dotenv:^3.4
 
 Alternatively, you can clone the `<https://github.com/symfony/dotenv>`_ repository.
 


### PR DESCRIPTION
By default it tries to install an incompatible version with SF 3.4:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: don't install symfony/symfony v3.4.22
    - Conclusion: remove symfony/symfony v3.4.21
...
```
