### PR TITLE
Update 4.2 deprecation

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -119,7 +119,7 @@ of text (called a *message*), use the
 for example, that you're translating a simple message from inside a controller::
 
     // ...
-    use Symfony\Component\Translation\TranslatorInterface;
+    use Symfony\Contracts\Translation\TranslatorInterface;
 
     public function index(TranslatorInterface $translator)
     {
@@ -197,7 +197,7 @@ Message Placeholders
 
 Sometimes, a message containing a variable needs to be translated::
 
-    use Symfony\Component\Translation\TranslatorInterface;
+    use Symfony\Contracts\Translation\TranslatorInterface;
 
     public function index(TranslatorInterface $translator, $name)
     {
@@ -229,6 +229,11 @@ method or the ``transchoice`` tag/filter in your :ref:`template <translation-tag
 
 For much more information, see :ref:`component-translation-pluralization`
 in the Translation component documentation.
+
+.. versionadded:: 4.2
+
+    In 4.2 the ``Translator::transChoice()`` method has been deprecated in favor of
+    using ``Translator::trans()`` with "%count%" as the parameter driving plurals.
 
 Translations in Templates
 -------------------------


### PR DESCRIPTION
The TranslatorInterface has been deprecated in favor of Symfony\Contracts\Translation\TranslatorInterface
The Translator::transChoice() method has been deprecated in favor of using Translator::trans() with "%count%" as the parameter driving plurals

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
