### PR TITLE
Php unit latest version not compatible with symfony 4.2

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -13,7 +13,7 @@ The PHPUnit Testing Framework
 
 Symfony integrates with an independent library called `PHPUnit`_ to give you a
 rich testing framework. This article won't cover PHPUnit itself, which has its
-own excellent `documentation`_.
+own excellent `documentation`_.  (Please note that latest relaesed version of Php Unit version 8.2 is not compactable with symfony 4.2)
 
 Before creating your first test, install the `PHPUnit Bridge component`_, which
 wraps the original PHPUnit binary to provide additional features:


### PR DESCRIPTION
The latest version of php unit test (Version 8.2) is not compactable with symfony 4.2

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
