### PR TITLE
Replaces ProtocolClassValidator for the second example

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -219,7 +219,7 @@ not to the property:
     .. code-block:: php-annotations
 
         /**
-         * @AcmeAssert\ContainsAlphanumeric
+         * @AcmeAssert\ProtocolClassValidator
          */
         class AcmeEntity
         {
@@ -231,11 +231,11 @@ not to the property:
         # config/validator/validation.yaml
         App\Entity\AcmeEntity:
             constraints:
-                - App\Validator\Constraints\ContainsAlphanumeric: ~
+                - App\Validator\Constraints\ProtocolClassValidator: ~
 
     .. code-block:: xml
 
         <!-- config/validator/validation.xml -->
         <class name="App\Entity\AcmeEntity">
-            <constraint name="App\Validator\Constraints\ContainsAlphanumeric" />
+            <constraint name="App\Validator\Constraints\ProtocolClassValidator" />
         </class>


### PR DESCRIPTION
Examples for Class Constraint Validator use ContainsAlphanumeric that was added as property validator. It will not work for a class. 
The intention of the second example seems to be the usage of ProtocolClassValidator introduced in this section (chapter).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
