### PR TITLE
Update upload_file.rst

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -66,7 +66,7 @@ Then, add a new ``brochure`` field to the form that manages the ``Product`` enti
         {
             $builder
                 // ...
-                ->add('brochure', FileType::class, ['label' => 'Brochure (PDF file)'])
+                ->add('brochure', FileType::class, ['label' => 'Brochure (PDF file)', 'data_class' => null])
                 // ...
             ;
         }
@@ -101,6 +101,7 @@ Finally, you need to update the code of the controller that handles the form::
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\HttpFoundation\File\Exception\FileException;
+    use Symfony\Component\HttpFoundation\File\UploadedFile;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\Routing\Annotation\Route;
     use App\Entity\Product;
@@ -119,8 +120,8 @@ Finally, you need to update the code of the controller that handles the form::
 
             if ($form->isSubmitted() && $form->isValid()) {
                 // $file stores the uploaded PDF file
-                /** @var Symfony\Component\HttpFoundation\File\UploadedFile $file */
-                $file = $product->getBrochure();
+                /** @var UploadedFile $file */
+                $file = $form->get('brochure')->getData();
 
                 $fileName = $this->generateUniqueFileName().'.'.$file->guessExtension();
 


### PR DESCRIPTION
In the previose version it throwed exception during calling the $file->guessExtension() on NULL. The file is not stored in object $product yet, but in form data instead.

Also the 'data_class' => null is required for the form field.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
