### PR TITLE
Replace Controller with AbstractController

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -534,8 +534,8 @@ You can also fetch parameters directly from the container::
     {
         // ...
 
-        // this ONLY works if you extend the base Controller
-        $adminEmail = $this->container->getParameter('admin_email');
+        // this ONLY works if you extend the base AbstractController
+        $adminEmail = $this->container->get('parameter_bag')->get('admin_email');
 
         // or a shorter way!
         // $adminEmail = $this->getParameter('admin_email');


### PR DESCRIPTION
As of Symfony 4.2 Symfony\Bundle\FrameworkBundle\Controller\Controller is depreciated in favor of Symfony\Bundle\FrameworkBundle\Controller\AbstractController. To reflect this update I tweaked the section of getting parameter, as it slightly changed, and getParameter is no longer there on the container,

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
