### PR TITLE
Fixed the highlighting of some form Twig code examples

### DIFF
--- a/form/action_method.rst
+++ b/form/action_method.rst
@@ -117,7 +117,7 @@ options:
 Finally, you can override the action and method in the template by passing them
 to the ``form()`` or the ``form_start()`` helper functions:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {# templates/default/new.html.twig #}
     {{ form_start(form, {'action': path('target_route'), 'method': 'GET'}) }}

--- a/form/bootstrap4.rst
+++ b/form/bootstrap4.rst
@@ -95,7 +95,7 @@ Bootstrap 4 has a feature called "`custom forms`_". You can enable that on your
 Symfony Form ``RadioType`` and ``CheckboxType`` by adding a class called ``radio-custom``
 and ``checkbox-custom`` respectively.
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {{ form_row(form.myRadio, {label_attr: {class: 'radio-custom'} }) }}
     {{ form_row(form.myCheckbox, {label_attr: {class: 'checkbox-custom'} }) }}

--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -295,7 +295,7 @@ new "tag" forms. To render it, make the following change to your template:
     on it. You could even choose to render only one of its fields (e.g. the
     ``name`` field):
 
-    .. code-block:: html+twig
+    .. code-block:: twig
 
         {{ form_widget(form.tags.vars.prototype.name)|e }}
 

--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -86,7 +86,7 @@ Some of the Twig functions mentioned in the previous section allow to pass
 variables to configure their behavior. For example, the ``form_label()``
 function lets you define a custom label to override the one defined in the form:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {{ form_label(form.task, 'My Custom Task Label') }}
 
@@ -96,7 +96,7 @@ type, but one common option is ``attr``, which allows you to modify HTML
 attributes on the form element. The following would add the ``task_field`` CSS
 class to the rendered input text field:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {{ form_widget(form.task, {'attr': {'class': 'task_field'}}) }}
 
@@ -116,7 +116,7 @@ If you need to render form fields "by hand" then you can access individual
 values for fields (such as the ``id``, ``name`` and ``label``) using its
 ``vars``  property. For example to get the ``id``:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {{ form.task.vars.id }}
 

--- a/form/form_themes.rst
+++ b/form/form_themes.rst
@@ -102,7 +102,7 @@ Although most of the times you'll apply form themes globally, you may need to
 apply a theme only to some specific form. You can do that with the
 :ref:`form_theme Twig tag <reference-twig-tag-form-theme>`:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {# this form theme will be applied only to the form of this template #}
     {% form_theme form 'foundation_5_layout.html.twig' %}
@@ -137,7 +137,7 @@ Applying Different Themes to Child Forms
 
 You can also apply a form theme to a specific child of your form:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {% form_theme form.a_child_form 'form/my_custom_theme.html.twig' %}
 
@@ -161,7 +161,7 @@ can be installed on different Symfony apps (and so you can't control what themes
 are enabled globally). To do that, add the ``only`` keyword after the list of
 form themes:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {% form_theme form with ['foundation_5_layout.html.twig'] only %}
 
@@ -175,7 +175,7 @@ form themes:
     yourself, or extend one of the built-in form themes with Twig's ``use``
     keyword instead of ``extends`` to re-use the original theme contents.
 
-    .. code-block:: html+twig
+    .. code-block:: twig
 
         {# templates/form/common.html.twig #}
         {% use "form_div_layout.html.twig" %}
@@ -192,7 +192,7 @@ with one or more of those blocks that you want to use when rendering a form.
 Consider for example a form field that represents an integer property called
 ``age``. If you add this to the template:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {{ form_widget(form.age) }}
 
@@ -377,7 +377,7 @@ rules to know which Twig blocks to define.
 For example, if your form theme is simple and you only want to override the
 ``<input type="integer">`` elements, create this template:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {# templates/form/my_theme.html.twig #}
     {% block integer_widget %}
@@ -429,7 +429,7 @@ you want to apply the theme globally to all forms, define the
 
 If you only want to apply it to some specific forms, use the ``form_theme`` tag:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {% form_theme form 'form/my_theme.html.twig' %}
 
@@ -453,7 +453,7 @@ built-in themes using the `Twig "use" tag`_ instead of the ``extends`` tag so
 you can inherit all its blocks (if you are unsure, extend from the default
 ``form_div_layout.html.twig`` theme):
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {# templates/form/my_theme.html.twig #}
     {% use 'form_div_layout.html.twig' %}


### PR DESCRIPTION
There are some errors when the example only contains Twig code but it's highlighted as "HTML + Twig":

![highlighting](https://user-images.githubusercontent.com/73419/53000433-abf7f100-3428-11e9-9b00-8e24823f5613.png)
