### PR TITLE
remove the mention of .yml

### DIFF
--- a/configuration/configuration_organization.rst
+++ b/configuration/configuration_organization.rst
@@ -78,7 +78,7 @@ Mix and Match Configuration Formats
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Configuration files can import files defined with any other built-in configuration
-format (``.yaml`` or ``.yml``, ``.xml``, ``.php``, ``.ini``):
+format (``.yaml``, ``.xml``, ``.php``, ``.ini``):
 
 .. configuration-block::
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -705,7 +705,7 @@ type
 
 The type of the resource to hint the loaders about the format. This isn't
 needed when you use the default routers with the expected file extensions
-(``.xml``, ``.yml`` or ``.yaml``, ``.php``).
+(``.xml``, ``.yaml``, ``.php``).
 
 http_port
 .........


### PR DESCRIPTION
we should not promote the usage of .yml anymore

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
