### PR TITLE
Uncomment some code in the "Configuring Babel" example

### DIFF
--- a/frontend/encore/babel.rst
+++ b/frontend/encore/babel.rst
@@ -18,17 +18,19 @@ Need to extend the Babel configuration further? The easiest way is via
 
         .configureBabel(function(babelConfig) {
             // add additional presets
-            // babelConfig.presets.push('@babel/preset-flow');
+            babelConfig.presets.push('@babel/preset-flow');
 
             // no plugins are added by default, but you can add some
-            // babelConfig.plugins.push('styled-jsx/babel');
+            babelConfig.plugins.push('styled-jsx/babel');
         }, {
             // node_modules is not processed through Babel by default
             // but you can whitelist specific modules to process
-            // include_node_modules: ['foundation-sites']
+            include_node_modules: ['foundation-sites'],
 
-            // or completely control the exclude
-            // exclude: /bower_components/
+            // or completely control the exclude rule (note that you
+            // can't use both "include_node_modules" and "exclude" at
+            // the same time)
+            exclude: /bower_components/
         })
     ;
 


### PR DESCRIPTION
This PR uncomment some lines of code in the `Encore.configureBabel(...)` example based on a feedback given in https://github.com/symfony/webpack-encore/issues/528#issuecomment-466206142.