### PR TITLE
Update Custom Constraints documentation

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -219,7 +219,7 @@ not to the property:
     .. code-block:: php-annotations
 
         /**
-         * @AcmeAssert\ProtocolClassValidator
+         * @AcmeAssert\ProtocolClass
          */
         class AcmeEntity
         {
@@ -231,11 +231,11 @@ not to the property:
         # config/validator/validation.yaml
         App\Entity\AcmeEntity:
             constraints:
-                - App\Validator\Constraints\ProtocolClassValidator: ~
+                - App\Validator\Constraints\ProtocolClass: ~
 
     .. code-block:: xml
 
         <!-- config/validator/validation.xml -->
         <class name="App\Entity\AcmeEntity">
-            <constraint name="App\Validator\Constraints\ProtocolClassValidator" />
+            <constraint name="App\Validator\Constraints\ProtocolClass" />
         </class>


### PR DESCRIPTION
In the Class Constraint Validator section, the example that shows how to apply the custom validator to the whole class it's wrong, it applies the ConstraintValidator class instead of the Constraint class to validation.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
