### PR TITLE
Persisting : forget a "use" statement ?

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -340,6 +340,8 @@ and save it!
     namespace App\Controller;
 
     // ...
+    use Symfony\Component\HttpFoundation\Response;
+    
     use App\Entity\Product;
 
     class ProductController extends AbstractController

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -388,17 +388,17 @@ Take a look at the previous example in more detail:
 
 .. _doctrine-entity-manager:
 
-* **line 16** The ``$this->getDoctrine()->getManager()`` method gets Doctrine's
+* **line 18** The ``$this->getDoctrine()->getManager()`` method gets Doctrine's
   *entity manager* object, which is the most important object in Doctrine. It's
   responsible for saving objects to, and fetching objects from, the database.
 
-* **lines 18-21** In this section, you instantiate and work with the ``$product``
+* **lines 20-23** In this section, you instantiate and work with the ``$product``
   object like any other normal PHP object.
 
-* **line 24** The ``persist($product)`` call tells Doctrine to "manage" the
+* **line 26** The ``persist($product)`` call tells Doctrine to "manage" the
   ``$product`` object. This does **not** cause a query to be made to the database.
 
-* **line 27** When the ``flush()`` method is called, Doctrine looks through
+* **line 29** When the ``flush()`` method is called, Doctrine looks through
   all of the objects that it's managing to see if they need to be persisted
   to the database. In this example, the ``$product`` object's data doesn't
   exist in the database, so the entity manager executes an ``INSERT`` query,


### PR DESCRIPTION
The `ProductController` created above (L332) by `$ php bin/console make:controller ProductController` use this generated code :
```php
    return $this->render('product/index.html.twig', [
      'controller_name' => 'ProductController',
    ]);
```

But we modify this to returns a `new Response('...')` :
```php
    return new Response('Saved new product with id '.$product->getId());
```
 so we must add a `use Symfony\Component\HttpFoundation\Response;` statement to work.

Not sure if it's better to force good habits of "search and debug", or just having a "cut n' paste" working example ? (-:
