### PR TITLE
fixed wrong closing </> tag

### DIFF
--- a/console/coloring.rst
+++ b/console/coloring.rst
@@ -43,7 +43,7 @@ It is possible to define your own styles using the
     $outputStyle = new OutputFormatterStyle('red', 'yellow', ['bold', 'blink']);
     $output->getFormatter()->setStyle('fire', $outputStyle);
 
-    $output->writeln('<fire>foo</>');
+    $output->writeln('<fire>foo</fire>');
 
 Available foreground and background colors are: ``black``, ``red``, ``green``,
 ``yellow``, ``blue``, ``magenta``, ``cyan`` and ``white``.


### PR DESCRIPTION
replaced `<fire>foo</>` with `<fire>foo</fire>`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
