### PR TITLE
remove obsolete versionadded directives

### DIFF
--- a/best_practices/configuration.rst
+++ b/best_practices/configuration.rst
@@ -208,12 +208,6 @@ through environment variables:
             # ...
             password: "%env(DB_PASSWORD)%"
 
-.. versionadded:: 3.2
-
-    Support for runtime environment variables via the ``%env(...)%`` syntax
-    was added in Symfony 3.2. Prior to version 3.2, you needed to use the
-    :doc:`special SYMFONY__ variables </configuration/external_parameters>`.
-
 ----
 
 Next: :doc:`/best_practices/business-logic`

--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -139,10 +139,6 @@ Symfony creates a big ``classes.php`` file in the cache directory to aggregate
 the contents of the PHP classes that are used in every request. This reduces the
 I/O operations and increases the application performance.
 
-.. versionadded:: 3.2
-
-   The ``addAnnotatedClassesToCompile()`` method was added in Symfony 3.2.
-
 Your bundles can also add their own classes into this file thanks to the
 ``addClassesToCompile()`` and ``addAnnotatedClassesToCompile()`` methods (both
 work in the same way, but the second one is for classes that contain PHP
@@ -175,10 +171,6 @@ class names::
 
     If some class extends from other classes, all its parents are automatically
     included in the list of classes to compile.
-
-.. versionadded:: 3.2
-
-   The option to add classes to compile using patterns was introduced in Symfony 3.2.
 
 The classes to compile can also be added using file path patterns::
 

--- a/components/cache.rst
+++ b/components/cache.rst
@@ -14,10 +14,6 @@ The Cache Component
     adapters for the most common caching backends, including proxies for adapting
     from/to `Doctrine Cache`_.
 
-.. versionadded:: 3.3
-
-    The PSR-16 "Simple Cache" implementation was introduced in Symfony 3.3.
-
 Installation
 ------------
 

--- a/components/cache/adapters/memcached_adapter.rst
+++ b/components/cache/adapters/memcached_adapter.rst
@@ -7,10 +7,6 @@
 Memcached Cache Adapter
 =======================
 
-.. versionadded:: 3.3
-
-    The Memcached adapter was introduced in Symfony 3.3.
-
 This adapter stores the values in-memory using one (or more) `Memcached server`_
 instances. Unlike the :ref:`APCu adapter <apcu-adapter>`, and similarly to the
 :ref:`Redis adapter <redis-adapter>`, it is not limited to the current server's

--- a/components/cache/adapters/pdo_doctrine_dbal_adapter.rst
+++ b/components/cache/adapters/pdo_doctrine_dbal_adapter.rst
@@ -7,10 +7,6 @@
 PDO & Doctrine DBAL Cache Adapter
 =================================
 
-.. versionadded:: 3.2
-
-   The PDO & Doctrine DBAL adapter was introduced in Symfony 3.2.
-
 This adapter stores the cache items in an SQL database. It requires a `PDO`_,
 `Doctrine DBAL Connection`_, or `Data Source Name (DSN)`_ as its first parameter, and
 optionally a namespace, default cache lifetime, and options array as its second,

--- a/components/cache/cache_invalidation.rst
+++ b/components/cache/cache_invalidation.rst
@@ -20,10 +20,6 @@ The Symfony Cache component provides two mechanisms to help solving this problem
 Using Cache Tags
 ----------------
 
-.. versionadded:: 3.2
-
-    Tags-based invalidation was introduced in Symfony 3.2.
-
 To benefit from tags-based invalidation, you need to attach the proper tags to
 each cached item. Each tag is a plain string identifier that you can use at any
 time to trigger the removal of all items associated with this tag.

--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -187,21 +187,10 @@ Or you may define a prototype for each node inside an array node::
         ->end()
     ;
 
-.. versionadded:: 3.3
-
-    The ``arrayPrototype()`` method (and the related ``booleanPrototype()``
-    ``integerPrototype()``, ``floatPrototype()``, ``scalarPrototype()`` and
-    ``enumPrototype()``) was introduced in Symfony 3.3. In previous versions,
-    you needed to use ``prototype('array')``, ``prototype('boolean')``, etc.
-
 A prototype can be used to add a definition which may be repeated many times
 inside the current node. According to the prototype definition in the example
 above, it is possible to have multiple connection arrays (containing a ``driver``,
 ``host``, etc.).
-
-.. versionadded:: 3.3
-
-    The ``castToArray()`` helper was added in Symfony 3.3.
 
 Sometimes, to improve the user experience of your application or bundle, you may
 allow to use a simple string or numeric value where an array value is required.

--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -230,10 +230,6 @@ convenient for passwords::
             // ...
         }
 
-    .. versionadded:: 3.3
-
-        The ``QuestionHelper::disableStty()`` method was introduced in Symfony 3.3.
-
 Normalizing the Answer
 ----------------------
 
@@ -369,10 +365,6 @@ from the command line, you need to set the inputs that the command expects::
 
         // $this->assertRegExp('/.../', $commandTester->getDisplay());
     }
-
-.. versionadded:: 3.2
-
-    The ``CommandTester::setInputs()`` method was introduced in Symfony 3.2.
 
 By calling :method:`Symfony\\Component\\Console\\Tester\\CommandTester::setInputs`,
 you imitate what the console would do internally with all user input through the CLI.

--- a/components/console/logger.rst
+++ b/components/console/logger.rst
@@ -108,10 +108,6 @@ constructor::
 Errors
 ------
 
-.. versionadded:: 3.2
-
-    The ``hasErrored()`` method was introduced in Symfony 3.2.
-
 The Console logger includes a ``hasErrored()`` method which returns ``true`` as
 soon as any error message has been logged during the execution of the command.
 This is useful to decide which status code to return as the result of executing

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -423,10 +423,6 @@ been run, use::
         PassConfig::TYPE_AFTER_REMOVING
     );
 
-.. versionadded:: 3.2
-
-    The option to prioritize compiler passes was added in Symfony 3.2.
-
 You can also control the order in which compiler passes are run for each
 compilation phase. Use the optional third argument of ``addCompilerPass()`` to
 set the priority as an integer number. The default priority is ``0`` and the higher

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -300,11 +300,6 @@ and :phpclass:`DOMNode` objects::
 Expression Evaluation
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.2
-
-    The :method:`Symfony\\Component\\DomCrawler\\Crawler::evaluate` method was
-    introduced in Symfony 3.2.
-
 The ``evaluate()`` method evaluates the given XPath expression. The return
 value depends on the XPath expression. If the expression evaluates to a scalar
 value (e.g. HTML attributes), an array of results will be returned. If the
@@ -443,13 +438,6 @@ The :method:`Symfony\\Component\\DomCrawler\\Form::getUri` method does more
 than just return the ``action`` attribute of the form. If the form method
 is GET, then it mimics the browser's behavior and returns the ``action``
 attribute followed by a query string of all of the form's values.
-
-.. versionadded:: 3.3
-
-    Starting from Symfony 3.3, the optional ``formaction`` and ``formmethod``
-    button attributes are supported. The ``getUri()`` and ``getMethod()``
-    methods take into account those attributes to always return the right action
-    and method depending on the button used to get the form.
 
 You can virtually set and get values on the form::
 

--- a/components/dotenv.rst
+++ b/components/dotenv.rst
@@ -8,10 +8,6 @@ The Dotenv Component
     The Dotenv Component parses ``.env`` files to make environment variables
     stored in them accessible via ``getenv()``, ``$_ENV`` or ``$_SERVER``.
 
-.. versionadded:: 3.3
-
-    The Dotenv component was introduced in Symfony 3.3.
-
 Installation
 ------------
 

--- a/components/expression_language/caching.rst
+++ b/components/expression_language/caching.rst
@@ -37,13 +37,6 @@ ones and injecting this using the constructor::
     $cache = new RedisAdapter(...);
     $expressionLanguage = new ExpressionLanguage($cache);
 
-.. versionadded:: 3.2
-
-    PSR-6 caching support was introduced in Symfony 3.2. Prior to version 3.2,
-    a
-    :class:`Symfony\\Component\\ExpressionLanguage\\ParserCache\\ParserCacheInterface`
-    instance had to be injected.
-
 .. seealso::
 
     See the :doc:`/components/cache` documentation for more information about

--- a/components/expression_language/extending.rst
+++ b/components/expression_language/extending.rst
@@ -100,10 +100,6 @@ register::
 
         ExpressionFunction::fromPhp('My\strtoupper', 'my_strtoupper');
 
-    .. versionadded:: 3.3
-
-        The ``ExpressionFunction::fromPhp()`` method was introduced in Symfony 3.3.
-
 You can register providers using
 :method:`Symfony\\Component\\ExpressionLanguage\\ExpressionLanguage::registerProvider`
 or by using the second argument of the constructor::

--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -212,10 +212,6 @@ support symbolic links, a third boolean argument is available::
 readlink
 ~~~~~~~~
 
-.. versionadded:: 3.2
-
-    The :method:`Symfony\\Component\\Filesystem\\Filesystem::readlink` method was introduced in Symfony 3.2.
-
 :method:`Symfony\\Component\\Filesystem\\Filesystem::readlink` read links targets.
 
 PHP's ``readlink()`` function returns the target of a symbolic link. However, its behavior
@@ -306,11 +302,6 @@ The ``file.txt`` file contains ``Hello World`` now.
 
 appendToFile
 ~~~~~~~~~~~~
-
-.. versionadded:: 3.3
-
-    The :method:`Symfony\\Component\\Filesystem\\Filesystem::appendToFile`
-    method was introduced in Symfony 3.3.
 
 :method:`Symfony\\Component\\Filesystem\\Filesystem::appendToFile` adds new
 contents at the end of some file::

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -390,10 +390,6 @@ Note you can create a
 :class:`Symfony\\Component\\HttpFoundation\\Cookie` object from a raw header
 value using :method:`Symfony\\Component\\HttpFoundation\\Cookie::fromString`.
 
-.. versionadded:: 3.3
-
-    The ``Cookie::fromString()`` method was introduced in Symfony 3.3.
-
 Managing the HTTP Cache
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -539,10 +535,6 @@ It is possible to delete the file after the request is sent with the
 :method:`Symfony\\Component\\HttpFoundation\\BinaryFileResponse::deleteFileAfterSend` method.
 Please note that this will not work when the ``X-Sendfile`` header is set.
 
-.. versionadded:: 3.3
-
-    The ``Stream`` class was introduced in Symfony 3.3.
-
 If the size of the served file is unknown (e.g. because it's being generated on the fly,
 or because a PHP stream filter is registered on it, etc.), you can pass a ``Stream``
 instance to ``BinaryFileResponse``. This will disable ``Range`` and ``Content-Length``
@@ -593,11 +585,6 @@ class, which can make this even easier::
 
     // if the data to send is already encoded in JSON
     $response = JsonResponse::fromJsonString('{ "data": 123 }');
-
-.. versionadded:: 3.2
-
-    The :method:`Symfony\\Component\\HttpFoundation\\JsonResponse::fromJsonString`
-    method was added in Symfony 3.2.
 
 The ``JsonResponse`` class sets the ``Content-Type`` header to
 ``application/json`` and encodes your data to JSON when needed.

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -540,11 +540,6 @@ the namespaces of the tested classes in your phpunit.xml.dist
 Modified PHPUnit script
 -----------------------
 
-.. versionadded:: 3.2
-
-    This modified PHPUnit script was introduced in the 3.2 version of
-    this component.
-
 This bridge provides a modified version of PHPUnit that you can call by using
 its ``bin/simple-phpunit`` command. It has the following features:
 

--- a/components/process.rst
+++ b/components/process.rst
@@ -79,10 +79,6 @@ for new output before going to the next iteration::
             echo $data."\n";
         }
 
-    .. versionadded:: 3.2
-
-        The ``getIterator()`` method was introduced in Symfony 3.2.
-
 The ``mustRun()`` method is identical to ``run()``, except that it will throw
 a :class:`Symfony\\Component\\Process\\Exception\\ProcessFailedException`
 if the process couldn't be executed successfully (i.e. the process exited
@@ -102,11 +98,6 @@ with a non-zero code)::
     }
 
 .. tip::
-
-    .. versionadded:: 3.3
-
-        The ability to define commands as arrays of arguments was introduced in
-        Symfony 3.3.
 
     Using array of arguments is the recommended way to define commands. This
     saves you from any escaping and allows sending signals seamlessly
@@ -418,11 +409,6 @@ Use :method:`Symfony\\Component\\Process\\Process::disableOutput` and
 
     However, it is possible to pass a callback to the ``start``, ``run`` or ``mustRun``
     methods to handle process output in a streaming fashion.
-
-    .. versionadded:: 3.1
-
-        The ability to pass a callback to these methods when output is disabled
-        was added in Symfony 3.1.
 
 Finding the Executable PHP Binary
 ---------------------------------

--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -273,10 +273,6 @@ and plural property names::
     $propertyInfo->isWritable(SomeClass::class, 'analyses'); // returns true
     $propertyInfo->isWritable(SomeClass::class, 'feet');     // returns true
 
-.. versionadded:: 3.2
-
-    The support of adder/remover methods was introduced in Symfony 3.2.
-
 .. tip::
 
     The main :class:`Symfony\\Component\\PropertyInfo\\PropertyInfoExtractor`

--- a/components/routing.rst
+++ b/components/routing.rst
@@ -383,11 +383,6 @@ automatically in the background if you want to use it. A basic example of the
 Unicode Routing Support
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.2
-
-    UTF-8 support for route paths and requirements was introduced in
-    Symfony 3.2.
-
 The Routing component supports UTF-8 characters in route paths and requirements.
 Thanks to the ``utf8`` route option, you can make Symfony match and generate
 routes with UTF-8 characters:

--- a/components/security/firewall.rst
+++ b/components/security/firewall.rst
@@ -91,10 +91,6 @@ further than allowed.
 Firewall Config
 ~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.2
-
-    The ``FirewallConfig`` class was introduced in Symfony 3.2.
-
 The information about a given firewall, such as its name, provider, context,
 entry point and access denied URL, is provided by instances of the
 :class:`Symfony\\Bundle\\SecurityBundle\\Security\\FirewallConfig` class.

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -165,11 +165,6 @@ needs three parameters:
 #. The name of the class this information will be decoded to
 #. The encoder used to convert that information into an array
 
-.. versionadded:: 3.3
-
-    Support for the ``allow_extra_attributes`` key in the context was introduced
-    in Symfony 3.3.
-
 By default, additional attributes that are not mapped to the denormalized object
 will be ignored by the Serializer component. If you prefer to throw an exception
 when this happens, set the ``allow_extra_attributes`` context option to
@@ -624,11 +619,6 @@ There are several types of normalizers available:
     :phpclass:`DateTime` and :phpclass:`DateTimeImmutable`) into strings.
     By default it uses the RFC3339_ format.
 
-    .. versionadded:: 3.2
-
-        Support for specifying datetime format during denormalization was
-        introduced in the ``DateTimeNormalizer`` in Symfony 3.2.
-
 :class:`Symfony\\Component\\Serializer\\Normalizer\\DataUriNormalizer`
     This normalizer converts :phpclass:`SplFileInfo` objects into a data URI
     string (``data:...``) such that files can be embedded into serialized data.
@@ -663,10 +653,6 @@ The Serializer component supports many formats out of the box:
 
 All these encoders are enabled by default when using the Symfony Standard Edition
 with the serializer enabled.
-
-.. versionadded:: 3.2
-
-    The ``YamlEncoder`` and ``CsvEncoder`` encoders were introduced in Symfony 3.2
 
 .. _component-serializer-handling-circular-references:
 

--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -271,21 +271,6 @@ The second argument (``10`` in this example) is the *number* of objects being
 described and is used to determine which translation to use and also to populate
 the ``%count%`` placeholder.
 
-.. versionadded:: 3.2
-
-    Before Symfony 3.2, the placeholder used to select the plural (``%count%``
-    in this example) must be included in the third optional argument of the
-    ``transChoice()`` method::
-
-        $translator->transChoice(
-            'There is one apple|There are %count% apples',
-            10,
-            ['%count%' => 10]
-        );
-
-    Starting from Symfony 3.2, when the only placeholder is ``%count%``, you
-    don't have to pass this third argument.
-
 Based on the given number, the translator chooses the right plural form.
 In English, most words have a singular form when there is exactly one object
 and a plural form for all other numbers (0, 2, 3...). So, if ``count`` is

--- a/components/validator.rst
+++ b/components/validator.rst
@@ -64,10 +64,6 @@ If you have lots of validation errors, you can filter them by error code::
         // handle this specific error (display some message, send an email, etc.)
     }
 
-.. versionadded:: 3.3
-
-    The ``findByCodes()`` method was introduced in Symfony 3.3.
-
 Retrieving a Validator Instance
 -------------------------------
 

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -113,10 +113,6 @@ option. Read more about this and other options in
 
 .. tip::
 
-    .. versionadded:: 3.3
-
-        The local search box was introduced in Symfony 3.3.
-
     If the dumped contents are complex, consider using the local search box to
     look for specific variables or values. First, click anywhere on the dumped
     contents and then press ``Ctrl. + F`` or ``Cmd. + F`` to make the local

--- a/components/var_dumper/advanced.rst
+++ b/components/var_dumper/advanced.rst
@@ -85,10 +85,6 @@ Before dumping it, you can further limit the resulting
     Removes internal objects' handles for sparser output (useful for tests).
 
 :method:`Symfony\\Component\\VarDumper\\Cloner\\Data::seek`
-    .. versionadded:: 3.2
-
-        The ``seek()`` method was introduced in Symfony 3.2.
-
     Selects only subparts of already cloned arrays, objects or resources.
 
 Unlike the previous limits on cloners that remove data on purpose, these can
@@ -179,10 +175,6 @@ Another option for doing the same could be::
 
         $output = $dumper->dump($cloner->cloneVar($variable), true);
 
-    .. versionadded:: 3.2
-
-        The ability to return a string was introduced in Symfony 3.2.
-
 Dumpers implement the :class:`Symfony\\Component\\VarDumper\\Dumper\\DataDumperInterface`
 interface that specifies the
 :method:`dump(Data $data) <Symfony\\Component\\VarDumper\\Dumper\\DataDumperInterface::dump>`
@@ -208,11 +200,6 @@ method::
         'maxStringLength' => 160
     ]);
 
-.. versionadded:: 3.2
-
-    Support for passing display options to the ``dump()`` method was introduced
-    in Symfony 3.2.
-
 The output format of a dumper can be fine tuned by the two flags
 ``DUMP_STRING_LENGTH`` and ``DUMP_LIGHT_ARRAY`` which are passed as a bitmap
 in the third constructor argument. They can also be set via environment
@@ -228,11 +215,6 @@ output produced by the different casters.
 
     The ``$filter`` argument of ``assertDumpEquals()`` was introduced in
     Symfony 3.4.
-
-.. versionadded:: 3.1
-
-    The ``DUMP_STRING_LENGTH`` and ``DUMP_LIGHT_ARRAY`` flags were introduced
-    in Symfony 3.1.
 
 If ``DUMP_STRING_LENGTH`` is set, then the length of a string is displayed
 next to its content:
@@ -383,12 +365,6 @@ properties not in the class declaration).
 
 Adding Semantics with Metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 3.2
-
-    As of Symfony 3.2, casters can attach metadata attributes to
-    :class:`Symfony\\Component\\VarDumper\\Cloner\\Stub` objects to inform
-    dumpers about the precise type of the dumped values.
 
 Since casters are hooked on specific classes or interfaces, they know about the
 objects they manipulate. By altering the ``$stub`` object (the third argument of

--- a/components/workflow.rst
+++ b/components/workflow.rst
@@ -8,10 +8,6 @@ The Workflow Component
     The Workflow component provides tools for managing a workflow or finite
     state machine.
 
-.. versionadded:: 3.2
-
-    The Workflow component was introduced in Symfony 3.2.
-
 Installation
 ------------
 
@@ -57,12 +53,6 @@ these statuses are called **places**. You can define the workflow like this::
 
     $marking = new SingleStateMarkingStore('currentState');
     $workflow = new Workflow($definition, $marking);
-
-.. versionadded:: 3.3
-
-    The fluent interface for the ``DefinitionBuilder`` class was introduced in
-    Symfony 3.3. Before you had to call the ``addPlaces()``, ``addTransition()``
-    and ``build()`` methods separately.
 
 The ``Workflow`` can now help you to decide what actions are allowed
 on a blog post depending on what *place* it is in. This will keep your domain

--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -127,10 +127,6 @@ contents of the given file path and converts them to a PHP value::
 
     $value = Yaml::parseFile('/path/to/file.yml');
 
-.. versionadded:: 3.4
-
-    The ``parseFile()`` method was introduced in Symfony 3.4.
-
 If an error occurs during parsing, the parser throws a ``ParseException`` exception.
 
 .. _components-yaml-dump:
@@ -265,10 +261,6 @@ representation of the object.
 Parsing and Dumping Objects as Maps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.2
-
-    Support for parsing and dumping objects as maps was introduced in Symfony 3.2.
-
 You can dump objects as Yaml maps by using the ``DUMP_OBJECT_AS_MAP`` flag::
 
     $object = new \stdClass();
@@ -356,10 +348,6 @@ syntax to parse them as proper PHP constants::
 Parsing and Dumping of Binary Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.2
-
-    Support for parsing and dumping binary data was introduced in Symfony 3.2.
-
 You can dump binary data by using the ``DUMP_BASE64_BINARY_DATA`` flag::
 
     $imageContents = file_get_contents(__DIR__.'/images/logo.png');
@@ -376,10 +364,6 @@ Binary data is automatically parsed if they include the ``!!binary`` YAML tag
 
 Parsing and Dumping Custom Tags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 3.3
-
-    Support for parsing and dumping custom tags was introduced in Symfony 3.3.
 
 In addition to the built-in support of tags like ``!php/const`` and
 ``!!binary``, you can define your own custom YAML tags and parse them with the

--- a/configuration/external_parameters.rst
+++ b/configuration/external_parameters.rst
@@ -12,10 +12,6 @@ example. The flexibility of the Symfony service container allows you to do this.
 Environment Variables
 ---------------------
 
-.. versionadded:: 3.2
-
-    ``env()`` parameters were introduced in Symfony 3.2.
-
 You can reference environment variables by using special parameters named after
 the variables you want to use enclosed between ``env()``. Their actual values
 will be resolved at runtime (once per request), so that dumped containers can be
@@ -121,13 +117,6 @@ of the following:
         $ export DATABASE_PASSWORD=secret
 
 .. tip::
-
-    .. versionadded:: 3.3
-
-        The support of the special ``SYMFONY__`` environment variables was
-        deprecated in Symfony 3.3 and it will be removed in 4.0. Instead of
-        using those variables, define regular environment variables and get
-        their values using the ``%env(...)%`` syntax in your config files.
 
     You can also define the default value of any existing parameters using
     special environment variables named after their corresponding parameter

--- a/console/lockable_trait.rst
+++ b/console/lockable_trait.rst
@@ -1,10 +1,6 @@
 Prevent Multiple Executions of a Console Command
 ================================================
 
-.. versionadded:: 3.2
-
-    The ``LockableTrait`` was introduced in Symfony 3.2.
-
 A simple but effective way to prevent multiple executions of the same command in
 a single server is to use `locks`_. The :doc:`Lock component </components/lock>`
 provides multiple classes to create locks based on the filesystem (:ref:`FlockStore <lock-store-flock>`),

--- a/controller.rst
+++ b/controller.rst
@@ -154,10 +154,6 @@ and many others that you'll learn about next.
     Moreover, in Symfony 4.2 ``Controller`` was deprecated in favor of
     ``AbstractController``, so using the latter will make your apps future-proof.
 
-.. versionadded:: 3.3
-
-    The ``AbstractController`` class was added in Symfony 3.3.
-
 .. index::
    single: Controller; Redirecting
 
@@ -247,11 +243,6 @@ The Symfony templating system and Twig are explained more in the
 
 Fetching Services as Controller Arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 3.3
-
-    The ability to type-hint a controller argument in order to receive a service
-    was added in Symfony 3.3.
 
 Symfony comes *packed* with a lot of useful objects, called :doc:`services </service_container>`.
 These are used for rendering templates, sending emails, querying the database and
@@ -465,11 +456,6 @@ Symfony provides a nice session object that you can use to store information
 about the user between requests. By default, Symfony stores the token in a
 cookie and writes the attributes to a file by using native PHP sessions.
 
-.. versionadded:: 3.3
-
-    The ability to request a ``Session`` instance in controllers was introduced
-    in Symfony 3.3.
-
 To retrieve the session, add the :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionInterface`
 type-hint to your argument and Symfony will provide you with a session::
 
@@ -563,11 +549,6 @@ read any flash messages from the session using ``app.flashes()``:
             </div>
         {% endfor %}
     {% endfor %}
-
-.. versionadded:: 3.3
-
-    The ``app.flashes()`` Twig function was introduced in Symfony 3.3. Prior,
-    you had to use ``app.session.flashBag()``.
 
 .. note::
 

--- a/form/create_form_type_extension.rst
+++ b/form/create_form_type_extension.rst
@@ -109,11 +109,6 @@ the ``getExtendedType()`` method. As *soon* as you do this, any method that you'
 overridden (e.g. ``buildForm()``) will be called whenever *any* field of the given
 type (``FileType``) is built. Let's see an example next.
 
-.. versionadded:: 3.3
-
-    Prior to Symfony 3.3, you needed to define type extension services as ``public``.
-    Starting from Symfony 3.3, you can also define them as ``private``.
-
 .. tip::
 
     There is an optional tag attribute called ``priority``, which
@@ -121,10 +116,6 @@ type (``FileType``) is built. Let's see an example next.
     type extensions are loaded (the higher the priority, the earlier
     an extension is loaded). This is useful when you need to guarantee
     that one extension is loaded before or after another extension.
-
-    .. versionadded:: 3.2
-
-        The ``priority`` attribute was introduced in Symfony 3.2.
 
 Adding the extension Business Logic
 -----------------------------------

--- a/form/form_dependencies.rst
+++ b/form/form_dependencies.rst
@@ -139,11 +139,6 @@ manually and tag it with ``form.type``:
             ->addTag('form.type')
         ;
 
-.. versionadded:: 3.3
-
-    Prior to Symfony 3.3, you needed to define form type services as ``public``.
-    Starting from Symfony 3.3, you can also define them as ``private``.
-
 That's it! Your controller - where you create the form - doesn't need to change
 at all: Symfony is smart enough to load the ``TaskType`` from the container.
 

--- a/form/type_guesser.rst
+++ b/form/type_guesser.rst
@@ -216,11 +216,6 @@ and tag it with ``form.type_guesser``:
             ->addTag('form.type_guesser')
         ;
 
-.. versionadded:: 3.3
-
-    Prior to Symfony 3.3, you needed to define type guesser services as ``public``.
-    Starting from Symfony 3.3, you can also define them as ``private``.
-
 .. sidebar:: Registering a Type Guesser in the Component
 
     If you're using the Form component standalone in your PHP project, use

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -218,8 +218,3 @@ guessers using the :method:`Symfony\\Component\\Form\\Test\\FormIntegrationTestC
 :method:`Symfony\\Component\\Form\\Test\\FormIntegrationTestCase::getTypeExtensions`
 and :method:`Symfony\\Component\\Form\\Test\\FormIntegrationTestCase::getTypeGuessers`
 methods.
-
-.. versionadded:: 3.3
-
-    The ``getTypes()``, ``getTypeExtensions()`` and ``getTypeGuessers()``
-    methods were introduced in Symfony 3.3.

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -333,11 +333,6 @@ And you can display the flash message in the template like this:
         </div>
     {% endfor %}
 
-.. versionadded:: 3.3
-
-    The ``app.flashes()`` Twig function was introduced in Symfony 3.3. Prior,
-    you had to use ``app.session.flashBag()``.
-
 Final Thoughts
 --------------
 

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -141,9 +141,9 @@ you can access those choices for validation or for building a select form elemen
         }
     }
 
-.. versionadded:: 3.2
+.. note::
 
-    As of Symfony 3.2 the callback no longer needs to be static.
+    The callback does not need to be static!
 
 You can pass the name of this method to the `callback`_ option of the ``Choice``
 constraint.

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -181,10 +181,6 @@ fields configured in the ``fields`` option). The method should return a
 entityClass
 ~~~~~~~~~~~
 
-.. versionadded:: 3.2
-
-    The ``entityClass`` option was introduced in Symfony 3.2.
-
 **type**: ``string``
 
 By default, the query performed to ensure the uniqueness uses the repository of

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -192,11 +192,6 @@ The ``choice_loader`` can be used to only partially load the choices in cases wh
 a fully-loaded list is not necessary. This is only needed in advanced cases and
 would replace the ``choices`` option.
 
-.. versionadded:: 3.2
-
-    The :class:`Symfony\\Component\\Form\\ChoiceList\\Loader\\CallbackChoiceLoader`
-    was introduced in Symfony 3.2.
-
 You can use an instance of :class:`Symfony\\Component\\Form\\ChoiceList\\Loader\\CallbackChoiceLoader`
 if you want to take advantage of lazy loading::
 

--- a/reference/forms/types/dateinterval.rst
+++ b/reference/forms/types/dateinterval.rst
@@ -4,10 +4,6 @@
 DateIntervalType Field
 ======================
 
-.. versionadded:: 3.2
-
-   The DateIntervalType field type was introduced in Symfony 3.2.
-
 This field allows the user to select an *interval* of time. For example, if you want to
 allow the user to choose *how often* they receive a status email, they could use this
 field to choose intervals like every "10 minutes" or "3 days".
@@ -131,10 +127,6 @@ this format.
 
 labels
 ~~~~~~
-
-.. versionadded:: 3.3
-
-    The ``labels`` option was introduced in Symfony 3.3.
 
 **type**: ``array`` **default**: (see below)
 

--- a/reference/forms/types/number.rst
+++ b/reference/forms/types/number.rst
@@ -44,11 +44,6 @@ Field Options
 scale
 ~~~~~
 
-.. versionadded:: 2.7
-
-    The ``scale`` option was introduced in Symfony 2.7. Prior to Symfony 2.7,
-    it was known as ``precision``.
-
 **type**: ``integer`` **default**: Locale-specific (usually around ``3``)
 
 This specifies how many decimals will be allowed until the field rounds

--- a/routing.rst
+++ b/routing.rst
@@ -484,10 +484,6 @@ that are special: each adds a unique piece of functionality inside your applicat
     Used to set the fragment identifier, the optional last part of a URL that
     starts with a ``#`` character and is used to identify a portion of a document.
 
-    .. versionadded:: 3.2
-
-        The ``_fragment`` parameter was introduced in Symfony 3.2.
-
 ``_locale``
     Used to set the locale on the request (:ref:`read more <translation-locale-url>`).
 

--- a/security/form_login.rst
+++ b/security/form_login.rst
@@ -404,7 +404,3 @@ remove this variable, it's better to use the
 
     // equivalent to:
     // $targetPath = $request->getSession()->get('_security.'.$providerKey.'.target_path');
-
-.. versionadded:: 3.1
-
-    The ``TargetPathTrait`` was introduced in Symfony 3.1.

--- a/serializer/encoders.rst
+++ b/serializer/encoders.rst
@@ -30,12 +30,6 @@ The Serializer component provides built-in encoders:
 * :class:`Symfony\\Component\\Serializer\\Encoder\\XmlEncoder` to encode/decode XML
 * :class:`Symfony\\Component\\Serializer\\Encoder\\YamlEncoder` to encode/decode Yaml
 
-.. versionadded:: 3.2
-
-    The :class:`Symfony\\Component\\Serializer\\Encoder\\CsvEncoder` and the
-    :class:`Symfony\\Component\\Serializer\\Encoder\\YamlEncoder` were introduced in
-    Symfony 3.2.
-
 The ``JsonEncoder``
 ~~~~~~~~~~~~~~~~~~~
 

--- a/service_container.rst
+++ b/service_container.rst
@@ -48,12 +48,6 @@ service's class or interface name. Want to :doc:`log </logging>` something? No p
         // ...
     }
 
-.. versionadded:: 3.3
-
-    The ability to type-hint a service in order to receive it was added in Symfony 3.3.
-    See the :ref:`controller chapter <controller-service-arguments-tag>` for more
-    details.
-
 .. _container-debug-container:
 
 What other services are available? Find out by running:
@@ -246,11 +240,6 @@ each time you ask for it.
 
     If you'd prefer to manually wire your service, that's totally possible: see
     :ref:`services-explicitly-configure-wire-services`.
-
-    .. versionadded:: 3.3
-
-        The ``_defaults`` key *and* ability to load services from a directory were added
-        in Symfony 3.3.
 
 You can also fetch a service directly from the container via its "id", which will
 be its class name in this case::
@@ -509,12 +498,6 @@ pass here. No problem! In your configuration, you can explicitly set this argume
         // Explicitly configure the service
         $container->getDefinition(SiteUpdateManager::class)
             ->setArgument('$adminEmail', 'manager@example.com');
-
-.. versionadded:: 3.3
-
-    The ability to configure an argument by its name (``$adminEmail``) was added
-    in Symfony 3.3. Previously, you could configure it only by its index (``2`` in
-    this case) or by using empty quotes for the other arguments.
 
 Thanks to this, the container will pass ``manager@example.com`` as the third argument
 to ``__construct`` when creating the ``SiteUpdateManager`` service. The other arguments
@@ -791,10 +774,6 @@ For more details about autowiring, check out :doc:`/service_container/autowiring
 
 The autoconfigure Option
 ------------------------
-
-.. versionadded:: 3.3
-
-    The ``autoconfigure`` option was added in Symfony 3.3.
 
 Above, the ``services.yml`` file has ``autoconfigure: true`` in the ``_defaults``
 section so that it applies to all services defined in that file. With this setting,

--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -151,10 +151,6 @@ Anonymous Services
 
     Anonymous services are only supported by the XML and YAML configuration formats.
 
-.. versionadded:: 3.3
-
-    The feature to configure anonymous services in YAML was introduced in Symfony 3.3.
-
 In some cases, you may want to prevent a service being used as a dependency of
 other services. This can be achieved by creating an anonymous service. These
 services are like regular services but they don't define an ID and they are

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -437,11 +437,6 @@ with this interface will be passed the ``AppBundle\Util\Rot13Transformer`` servi
 But, you can also manually wire the *other* service by specifying the argument
 under the arguments key.
 
-.. versionadded:: 3.3
-
-    Using FQCN aliases to fix autowiring ambiguities was introduced in Symfony
-    3.3. Prior to version 3.3, you needed to use the ``autowiring_types`` key.
-
 Fixing Non-Autowireable Arguments
 ---------------------------------
 

--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -184,22 +184,6 @@ all the classes are already loaded as services. All you need to do is specify th
         $container->getDefinition(GreetingCardManager::class)
             ->setConfigurator([new Reference(EmailConfigurator::class), 'configure']);
 
-.. versionadded:: 3.2
-
-    The ``service_id:method_name`` syntax for the YAML configuration format
-    was introduced in Symfony 3.2.
-
-    The traditional configurator syntax in YAML files used an array to define
-    the service id and the method name:
-
-    .. code-block:: yaml
-
-        app.newsletter_manager:
-            # new syntax
-            configurator: 'AppBundle\Mail\EmailConfigurator:configure'
-            # old syntax
-            configurator: ['@AppBundle\Mail\EmailConfigurator', configure]
-
 That's it! When requesting the ``AppBundle\Mail\NewsletterManager`` or
 ``AppBundle\Mail\GreetingCardManager`` service, the created instance will first be
 passed to the ``EmailConfigurator::configure()`` method.

--- a/service_container/debug.rst
+++ b/service_container/debug.rst
@@ -40,7 +40,3 @@ its id:
 
     # to show the service arguments:
     $ php bin/console debug:container 'AppBundle\Service\Mailer' --show-arguments
-
-.. versionadded:: 3.3
-
-   The ``--show-arguments`` option was introduced in Symfony 3.3.

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -4,10 +4,6 @@
 Service Subscribers & Locators
 ==============================
 
-.. versionadded:: 3.3
-
-    Service subscribers and locators were introduced in Symfony 3.3.
-
 Sometimes, a service needs access to several other services without being sure
 that all of them will actually be used. In those cases, you may want the
 instantiation of the services to be lazy. However, that's not possible using

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -440,11 +440,6 @@ tags set for the current service and gives you the attributes.
 Reference Tagged Services
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.4
-
-    Support for the tagged service notation in YAML, XML and PHP was introduced
-    in Symfony 3.4.
-
 Symfony provides a shortcut to inject all services tagged with a specific tag,
 which is a common need in some applications, so you don't have to write a
 compiler pass just for that.

--- a/session/avoid_session_start.rst
+++ b/session/avoid_session_start.rst
@@ -36,8 +36,3 @@ access the flash messages:
             </div>
         {% endfor %}
     {% endif %}
-
-.. versionadded:: 3.3
-
-    The ``app.flashes()`` Twig function was introduced in Symfony 3.3. Prior,
-    you had to use ``app.session.flashBag()``.

--- a/translation/lint.rst
+++ b/translation/lint.rst
@@ -26,10 +26,6 @@ translation file using the ``lint:yaml`` and ``lint:xliff`` commands:
     $ php bin/console lint:yaml @AppBundle
     $ php bin/console lint:xliff @AppBundle
 
-.. versionadded:: 3.3
-
-    The ``lint:xliff`` command was introduced in Symfony 3.3.
-
 The linter results can be exported to JSON using the ``--format`` option:
 
 .. code-block:: terminal

--- a/validation/sequence_provider.rst
+++ b/validation/sequence_provider.rst
@@ -296,11 +296,6 @@ method, which should return an array of groups to use::
         }
     }
 
-.. versionadded:: 3.2
-
-    The feature to return a nested array to get violations from all groups was
-    introduced in Symfony 3.2.
-
 At last, you have to notify the Validator component that your ``User`` class
 provides a sequence of groups to be validated:
 

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -169,10 +169,6 @@ like this:
     Setting the ``audit_trail.enabled`` option to ``true`` makes the application
     generate detailed log messages for the workflow activity.
 
-    .. versionadded:: 3.3
-
-        The ``audit_trail`` option was introduced in Symfony 3.3.
-
 With this workflow named ``blog_publishing``, you can get help to decide
 what actions are allowed on a blog post::
 
@@ -375,10 +371,6 @@ This means that each event has access to the following information:
 :method:`Symfony\\Component\\Workflow\\Event\\Event::getWorkflowName`
     Returns a string with the name of the workflow that triggered the event.
 
-    .. versionadded:: 3.3
-
-        The ``getWorkflowName()`` method was introduced in Symfony 3.3.
-
 For Guard Events, there is an extended class :class:`Symfony\\Component\\Workflow\\Event\\GuardEvent`.
 This class has two more methods:
 
@@ -405,11 +397,6 @@ of domain logic in your templates:
 
 ``workflow_has_marked_place()``
     Returns ``true`` if the marking of the given object has the given state.
-
-.. versionadded:: 3.3
-
-    The ``workflow_marked_places()`` and ``workflow_has_marked_place()``
-    functions were introduced in Symfony 3.3.
 
 The following example shows these functions in action:
 


### PR DESCRIPTION
These are older than the current `3.4` version and should be removed.

@javiereguiluz is this what you meant?
I will proceed after I got some feedback from you

cc @weaverryan 