### PR TITLE
remove brackets for tagged service reference

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -466,7 +466,7 @@ first  constructor argument to the ``App\HandlerCollection`` service:
 
             AppBundle\HandlerCollection:
                 # inject all services tagged with app.handler as first argument
-                arguments: [!tagged app.handler]
+                arguments: !tagged app.handler
 
     .. code-block:: xml
 


### PR DESCRIPTION
When using the `!tagged` syntax in service arguments, wrapping it in brackets results in an array containing a generator being passed to a service. I would argue that most users want a direct reference to the generator.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
