### PR TITLE
Re-added a note about configuration imports

### DIFF
--- a/configuration/configuration_organization.rst
+++ b/configuration/configuration_organization.rst
@@ -124,6 +124,8 @@ When the configuration values are dynamic, you can use the PHP configuration
 file to execute your own logic. In addition, you can define your own services
 to load configurations from databases or web services.
 
+.. include:: /components/dependency_injection/_imports-parameters-note.rst.inc
+
 Global Configuration Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Somehow we lost this useful note is the process, still present in 3.4 though.
