### PR TITLE
Remove `allowNull` option

### DIFF
--- a/reference/constraints/NotBlank.rst
+++ b/reference/constraints/NotBlank.rst
@@ -2,15 +2,13 @@ NotBlank
 ========
 
 Validates that a value is not blank - meaning not equal to a blank string,
-a blank array, ``false`` or ``null`` (null behavior is configurable). To check
-that a value is not equal to ``null``, see the
-:doc:`/reference/constraints/NotNull` constraint.
+a blank array, ``false`` or ``null``. To check that a value is not equal to
+``null``, see the :doc:`/reference/constraints/NotNull` constraint.
 
 +----------------+------------------------------------------------------------------------+
 | Applies to     | :ref:`property or method <validation-property-target>`                 |
 +----------------+------------------------------------------------------------------------+
-| Options        | - `allowNull`_                                                         |
-|                | - `message`_                                                           |
+| Options        | - `message`_                                                           |
 |                | - `payload`_                                                           |
 +----------------+------------------------------------------------------------------------+
 | Class          | :class:`Symfony\\Component\\Validator\\Constraints\\NotBlank`          |
@@ -82,18 +80,6 @@ class were not blank, you could do the following:
 
 Options
 -------
-
-allowNull
-~~~~~~~~~
-
-**type**: ``bool`` **default**: ``false``
-
-If set to ``true``, ``null`` values are considered valid and won't trigger a
-constraint violation.
-
-.. versionadded:: 4.3
-
-    The ``allowNull`` option was introduced in Symfony 4.3.
 
 message
 ~~~~~~~


### PR DESCRIPTION
The option `allowNull` for constraint `NotBlank` is introduced in Symfony 4.3 but appears in the documentation of version 4.2, which can be confusing.