### PR TITLE
Fix wrong parentheses match in documentation

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -129,7 +129,7 @@ like this:
                     'marking_store' => [
                         'type' => 'multiple_state', // or 'single_state'
                         'arguments' => ['currentPlace'],
-                    ),
+                    ],
                     'supports' => ['App\Entity\BlogPost'],
                     'places' => [
                         'draft',


### PR DESCRIPTION
There is a typo in the documentation, a squared bracket is opened, and then a bracket was closed.