### PR TITLE
Add CORS_ALLOWED_ORIGINS to running mercure

### DIFF
--- a/mercure.rst
+++ b/mercure.rst
@@ -71,7 +71,7 @@ Run the following command to start it:
 
 .. code-block:: terminal
 
-    $ JWT_KEY='aVerySecretKey' ADDR='localhost:3000' ALLOW_ANONYMOUS=1 ./mercure
+    $ JWT_KEY='aVerySecretKey' ADDR='localhost:3000' ALLOW_ANONYMOUS=1 CORS_ALLOWED_ORIGINS=* ./mercure
 
 .. note::
 


### PR DESCRIPTION
I had some trouble to get the example running due to the simple fact that running mercure without a proper `CORS_ALLOWED_ORIGINS` value was preventing Firefox from connecting to the EventStream (instant close). Using chrome which keeps the connection but complains than with a proper error message hinting the to CORS_ALLOWED_ORIGIN finally helped me to figure out the problem.

So just adding the value to the example could reduce some headache.

Cheers
Matthias
