### PR TITLE
Add missing bracket on a php code example

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -566,7 +566,7 @@ placeholder:
         use App\Controller\BlogController;
 
         return function (RoutingConfigurator $routes) {
-            $routes->add('blog_list', '/blog/{page<\d+>?1')
+            $routes->add('blog_list', '/blog/{page<\d+>?1}')
                 ->controller([BlogController::class, 'list'])
             ;
         };


### PR DESCRIPTION
This fixes a typo that seems to have appeared in the docs v4.2.