### PR TITLE
Document Default env processor with null fallback

### DIFF
--- a/configuration/external_parameters.rst
+++ b/configuration/external_parameters.rst
@@ -533,6 +533,8 @@ Symfony provides the following env var processors:
             $container->setParameter('private_key', '%env(default:raw_key:file:PRIVATE_KEY)%');
             $container->setParameter('raw_key', '%env(PRIVATE_KEY)%');
 
+    When the fallback parameter is ommited (ie. ``env(default::API_KEY)``), the value retrieved is ``null``.
+
     .. versionadded:: 4.3
 
         The ``default`` processor was introduced in Symfony 4.3.


### PR DESCRIPTION
Document the fallback to `null`

PR: https://github.com/symfony/symfony/pull/30504