### PR TITLE
Making sentence not show up in code block

### DIFF
--- a/configuration/dot-env-changes.rst
+++ b/configuration/dot-env-changes.rst
@@ -82,7 +82,7 @@ changes can be made to any Symfony 3.4 or higher app:
        $ mv .env .env.local
        $ git mv .env.dist .env
 
-    You can also update the `comment on the top of .env`_ to reflect the new changes.
+   You can also update the `comment on the top of .env`_ to reflect the new changes.
 
 #. If you're using PHPUnit, you will also need to `create a new .env.test`_ file
    and update your `phpunit.xml.dist file`_ so it loads the ``config/bootstrap.php``


### PR DESCRIPTION
See the last code block here: https://symfony.com/doc/current/configuration/dot-env-changes.html

The last sentence is being included in the code block. I'm not sure if this will fix it, but I believe it will - it changes the indentation from 4 spaces (which apparently was enough to be included in the code block) to 3, which lines it up with how we usually "continue bullet points". 