### PR TITLE
Update security_checker.rst

### DIFF
--- a/security/security_checker.rst
+++ b/security/security_checker.rst
@@ -30,7 +30,8 @@ FriendsOfPHP organization.
     Earlier versions of this command used a tool hosted at a now deprecated URL,
     with the tool having since been moved to a new location, which has been 
     reflected in newer versions of the bundle. Use the latest version of the 
-    command to avoid getting exit code zero and breaking existing build plans.  
+    command to avoid getting exit code zero and breaking existing build plans
+    if the command has been integrated into project build process.
     
 .. note::
 

--- a/security/security_checker.rst
+++ b/security/security_checker.rst
@@ -25,6 +25,13 @@ FriendsOfPHP organization.
     This way you can add it to your project build process and your continuous
     integration workflows to make them fail when there are vulnerabilities.
 
+.. tip::
+
+    Earlier versions of this command used a tool hosted at a now deprecated URL,
+    with the tool having since been moved to a new location, which has been 
+    reflected in newer versions of the bundle. Use the latest version of the 
+    command to avoid getting exit code zero and breaking existing build plans.  
+    
 .. note::
 
     To enable the ``security:check`` command, make sure the


### PR DESCRIPTION
Adding a small note advising users to always use the latest version of the command, as old versions will now break existing build plans because change of composer.lock checking tool.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
