### PR TITLE
Added php opening tag to sample controller

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -44,6 +44,7 @@ Suppose you want to create a page - ``/lucky/number`` - that generates a lucky (
 random) number and prints it. To do that, create a "Controller class" and a
 "controller" method inside of it::
 
+    <?php
     // src/Controller/LuckyController.php
     namespace App\Controller;
 


### PR DESCRIPTION
It took me a while to figure out why the sample didn't seem to work, despite being experimented in php ; i checked many times namespace, uses and class declaration before finding that i just missed the opening tag. Think it would help others (even more if unexperimented) discovering symfony by copy/pasting sample code from the doc !

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
