### PR TITLE
[RFC][Proof PR] use "deprecated" and "versionchanged" directives

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -129,7 +129,7 @@ If you're *not* using Symfony, you can ignore the ``entrypoints.json`` file and
 point to the final, built file directly. ``entrypoints.json`` is only required for
 some optional features.
 
-.. versionadded:: 0.21.0
+.. versionchanged:: 0.21.0
 
     The ``encore_entry_link_tags()`` comes from WebpackEncoreBundle and relies
     on a feature in Encore that was first introduced in version 0.21.0. Previously,

--- a/security/acl.rst
+++ b/security/acl.rst
@@ -4,7 +4,7 @@
 How to Use Access Control Lists (ACLs)
 ======================================
 
-.. versionadded:: 3.4
+.. deprecated:: 3.4
 
     ACL support was deprecated in Symfony 3.4 and will be removed in 4.0. Install
     the `Symfony ACL bundle`_ if you want to keep using ACL.


### PR DESCRIPTION
I have a small proposal regarding the `versionadded` directives. We are using this directive for `new stuff`, `deprecated stuff` and we are using it for example for `new/changed stuff regarding other librariers` (for example Swiftmailer, Webpack, Twig etc.)

If I read this correct, RST supports the following directives out of the box: `.. versionadded::` (for sure), `.. versionchanged::` and  `.. deprecated::`:
https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html?highlight=versionadded

<img width="827" alt="Screenshot 2019-03-14 08 58 46" src="https://user-images.githubusercontent.com/995707/54472707-36840400-47cd-11e9-8c07-69bb861a9aed.png">

My proposal: use `versionadded` only for new Symfony stuff, use `versionchanged` as versionadded, but only for external libs/projects and do not use `versionadded` for deprecations anymore, lets use the `deprecated` directive.

This PR shows, that the build is 💚 , the only thing left is to check the final markup, if it fits the Symfony website style.

- [x] `.. deprecated::` -> https://github.com/symfony/symfony-docs/pull/11178
- [ ] `.. versionchanged::`

What do you think?