### PR TITLE
[REFACTOR] Messenger - Serializer groups

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -139,6 +139,11 @@ through the transport layer, use the ``SerializerStamp`` stamp::
         ]))
     );
 
+.. note::
+
+    As the groups are applied to the whole message,
+    be sure to define the group for every embedded object. 
+
 At the moment, the Symfony Messenger has the following built-in envelope stamps:
 
 #. :class:`Symfony\\Component\\Messenger\\Stamp\\SerializerStamp`,


### PR DESCRIPTION
Hi everyone, 

I've faced some problems yesterday due to groups definition (mainly about embedded objects) and I think it could be a good idea to add a tip (or even a note?) about the `groups` usage. 

Any idea? 

Thanks :)