### PR TITLE
Config error on controller/error_pages.html

### DIFF
--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -207,7 +207,7 @@ configuration option to point to it:
 
         # app/config/config.yml
         twig:
-            exception_controller: AppBundle:Exception:showException
+            exception_controller: AppBundle:Exception:showAction
 
     .. code-block:: xml
 
@@ -222,7 +222,7 @@ configuration option to point to it:
                 https://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
             <twig:config>
-                <twig:exception-controller>AppBundle:Exception:showException</twig:exception-controller>
+                <twig:exception-controller>AppBundle:Exception:showAction</twig:exception-controller>
             </twig:config>
 
         </container>
@@ -231,7 +231,7 @@ configuration option to point to it:
 
         // app/config/config.php
         $container->loadFromExtension('twig', [
-            'exception_controller' => 'AppBundle:Exception:showException',
+            'exception_controller' => 'AppBundle:Exception:showAction',
             // ...
         ]);
 


### PR DESCRIPTION
This appears to be a typo, as showException gives an error on Symfony 4.2 that reports confusion between showAction and showException.  Setting the twig config to showAction fixes the problem and displays the correct result.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
