### PR TITLE
Don't use AbstractController in 3.4 branch

### DIFF
--- a/routing/conditions.rst
+++ b/routing/conditions.rst
@@ -15,10 +15,10 @@ define arbitrary matching logic, use the ``conditions`` routing option:
         // src/Controller/DefaultController.php
         namespace App\Controller;
 
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Bundle\FrameworkBundle\Controller\Controller;
         use Symfony\Component\Routing\Annotation\Route;
 
-        class DefaultController extends AbstractController
+        class DefaultController extends Controller
         {
             /**
              * @Route(
@@ -27,7 +27,7 @@ define arbitrary matching logic, use the ``conditions`` routing option:
              *     condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'"
              * )
              *
-             * expressions can also include config parameters 
+             * expressions can also include config parameters
              * condition: "request.headers.get('User-Agent') matches '%app.allowed_browsers%'"
              */
             public function contact()

--- a/web_link.rst
+++ b/web_link.rst
@@ -153,10 +153,10 @@ You can also add links to the HTTP response directly from controllers and servic
 
     use Fig\Link\GenericLinkProvider;
     use Fig\Link\Link;
+    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use Symfony\Component\HttpFoundation\Request;
-    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
-    class BlogController extends AbstractController
+    class BlogController extends Controller
     {
         public function index(Request $request)
         {


### PR DESCRIPTION
In 3.4 we always extend from Controller instead of AbstractController, so this PR fixes the wrong occurrences. The only remaining occurrence is one which explicitly explains something about AbstractController.