### PR TITLE
[Security] Fix stateless mention

### DIFF
--- a/security/user_provider.rst
+++ b/security/user_provider.rst
@@ -379,7 +379,7 @@ command will generate a nice skeleton to get you started::
          * called. Your job is to make sure the user's data is still fresh by,
          * for example, re-querying for fresh User data.
          *
-         * If your firewall is "stateless: false" (for a pure API), this
+         * If your firewall is "stateless: true" (for a pure API), this
          * method is not called.
          *
          * @return UserInterface


### PR DESCRIPTION
According to https://github.com/symfony/symfony/blob/5aa0967f9f0ab803ededefb040d48a0ebc7a27a6/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php#L43 Firewall of pure API should have `stateless` to `true`  in fact

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
