### PR TITLE
Fix wrong usage of https in the monolog.xml file

### DIFF
--- a/logging.rst
+++ b/logging.rst
@@ -120,7 +120,7 @@ to write logs using the :phpfunction:`syslog` function:
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/monolog
-                https://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+                http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
 
             <monolog:config>
                 <monolog:handler
@@ -199,7 +199,7 @@ one of the messages reaches an ``action_level``. Take this example:
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/monolog
-                https://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+                http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
 
             <monolog:config>
                 <monolog:handler
@@ -305,7 +305,7 @@ option of your handler to ``rotating_file``:
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/monolog
-                https://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+                http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
 
             <monolog:config>
                 <!-- "max_files": max number of log files to keep


### PR DESCRIPTION
The `monolog.xml` examples mixup 'http' and http**s**, which results in the XML configuration being invalid.

The mixup results in the [XmlFileLoader](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php) being unable to properly replace the URL with the actual local path, so he tries to load the actual URL, which is not available.

This also happened for the `services`.xsd - but since it's also available via URL, that's not an actual issue.

Should I also change that?