### PR TITLE
use same order for all configuration-blocks

### DIFF
--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -67,15 +67,15 @@ is done just as before:
             </file>
         </xliff>
 
+    .. code-block:: yaml
+
+        'Hello %name%': Bonjour %name%
+
     .. code-block:: php
 
         return [
             'Hello %name%' => 'Bonjour %name%',
         ];
-
-    .. code-block:: yaml
-
-        'Hello %name%': Bonjour %name%
 
 .. note::
 

--- a/reference/constraints/Uuid.rst
+++ b/reference/constraints/Uuid.rst
@@ -25,14 +25,6 @@ Basic Usage
 
 .. configuration-block::
 
-    .. code-block:: yaml
-
-        # src/AppBundle/Resources/config/validation.yml
-        AppBundle\Entity\File:
-            properties:
-                identifier:
-                    - Uuid: ~
-
     .. code-block:: php-annotations
 
         // src/AppBundle/Entity/File.php
@@ -47,6 +39,14 @@ Basic Usage
              */
              protected $identifier;
         }
+
+    .. code-block:: yaml
+
+        # src/AppBundle/Resources/config/validation.yml
+        AppBundle\Entity\File:
+            properties:
+                identifier:
+                    - Uuid: ~
 
     .. code-block:: xml
 


### PR DESCRIPTION
ensure the following order of code-blocks in a `.. configuration-block::` directive:

1. `php-annotations`
2. `yaml`
3. `xml`
4. `php`