### PR TITLE
Fixing error at Class Constraint Validator

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -178,15 +178,15 @@ with the necessary ``validator.constraint_validator``. This means you can
 Class Constraint Validator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Beside validating a class property, a constraint can have a class scope by
-providing a target in its ``Constraint`` class::
+Besides validating a single property, a constraint can have an entire class
+as its scope. Just add this to the ``Constraint`` class::
 
     public function getTargets()
     {
         return self::CLASS_CONSTRAINT;
     }
 
-With this, the validator ``validate()`` method gets an object as its first argument::
+With this, the validator's ``validate()`` method gets an object as its first argument::
 
     class ProtocolClassValidator extends ConstraintValidator
     {
@@ -206,7 +206,7 @@ With this, the validator ``validate()`` method gets an object as its first argum
     associated to. Use any :doc:`valid PropertyAccess syntax </components/property_access>`
     to define that property.
 
-Note that a class constraint validator is applied to the class itself, and
+A class constraint validator is applied to the class itself, and
 not to the property:
 
 .. configuration-block::
@@ -214,7 +214,7 @@ not to the property:
     .. code-block:: php-annotations
 
         /**
-         * @AcmeAssert\ProtocolClassValidator
+         * @AcmeAssert\ProtocolClass
          */
         class AcmeEntity
         {
@@ -226,11 +226,11 @@ not to the property:
         # src/AppBundle/Resources/config/validation.yml
         AppBundle\Entity\AcmeEntity:
             constraints:
-                - AppBundle\Validator\Constraints\ProtocolClassValidator: ~
+                - AppBundle\Validator\Constraints\ProtocolClass: ~
 
     .. code-block:: xml
 
         <!-- src/AppBundle/Resources/config/validation.xml -->
         <class name="AppBundle\Entity\AcmeEntity">
-            <constraint name="AppBundle\Validator\Constraints\ProtocolClassValidator"/>
+            <constraint name="AppBundle\Validator\Constraints\ProtocolClass"/>
         </class>


### PR DESCRIPTION
The correct annotation is `@AcmeAssert\ProtocolClass`, not `@AcmeAssert\ProtocolClassValidator`.

The other changes are just minor rewordings.

