### PR TITLE
Improve now what sentence

### DIFF
--- a/components/using_components.rst
+++ b/components/using_components.rst
@@ -72,7 +72,7 @@ may not actually need.
 Now what?
 ---------
 
-Now that the component is installed and autoloaded, read the specific component's
+Now, the component is installed and autoloaded. Read the specific component's
 documentation to find out more about how to use it.
 
 And have fun!


### PR DESCRIPTION
The "Now What?" section means 2 things:
+ Tell the developers that the component is ready.
+ Tell the developers to go through a specific documentation.

Therefore, I think it should be separated into two sentences for readable reason. By the way, I just remove unnecessary word "that" and add a comma.