### PR TITLE
use "behavior" instead of "behaviour"

### DIFF
--- a/contributing/code_of_conduct/concrete_example_document.rst
+++ b/contributing/code_of_conduct/concrete_example_document.rst
@@ -2,7 +2,7 @@ Code of Conduct: Concrete Example Document
 ==========================================
 
 This is a living document that serves to give concrete examples of
-unwanted behaviour. These examples have all taken place somewhere in the
+unwanted behavior. These examples have all taken place somewhere in the
 PHP community in the past, and are clear code of conduct violations
 according to the Symfony code of conduct.
 

--- a/contributing/diversity/governance.rst
+++ b/contributing/diversity/governance.rst
@@ -121,7 +121,7 @@ management systems should be set up and monitored.
 Openness and Accountability
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The behaviour and conduct of the initiative's guidance team sets the tone for
+The behavior and conduct of the initiative's guidance team sets the tone for
 the rest of the community. The guidance team should lead by example to create a
 culture that enables members to feel it is safe to suggest, question and
 challenge - rather than avoid - difficult ideas and topics. The team should

--- a/contributing/documentation/format.rst
+++ b/contributing/documentation/format.rst
@@ -175,7 +175,7 @@ If you are documenting a brand new feature, a change or a deprecation that's
 been made in Symfony, you should precede your description of the change with
 the corresponding directive and a short description:
 
-For a new feature or a behaviour change use the ``.. versionadded:: 3.x``
+For a new feature or a behavior change use the ``.. versionadded:: 3.x``
 directive:
 
 .. code-block:: rst

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -792,7 +792,7 @@ strict_requirements
 
 **type**: ``mixed`` **default**: ``true``
 
-Determines the routing generator behaviour. When generating a route that
+Determines the routing generator behavior. When generating a route that
 has specific :doc:`requirements </routing/requirements>`, the generator
 can behave differently in case the used parameters do not meet these requirements.
 


### PR DESCRIPTION
We use **behavior** many more then **behaviour** throughout the documentation.