### PR TITLE
Update unit_testing.rst

### DIFF
--- a/create_framework/unit_testing.rst
+++ b/create_framework/unit_testing.rst
@@ -57,13 +57,13 @@ resolver. Modify the framework to make use of them::
     class Framework
     {
         protected $matcher;
-        protected $resolver;
+        protected $controllerResolver;
         protected $argumentResolver;
 
         public function __construct(UrlMatcherInterface $matcher, ControllerResolverInterface $resolver, ArgumentResolverInterface $argumentResolver)
         {
             $this->matcher = $matcher;
-            $this->resolver = $resolver;
+            $this->controllerResolver = $resolver;
             $this->argumentResolver = $argumentResolver;
         }
 


### PR DESCRIPTION
While following the tutorial changing the property from $controllerResolver to $resolver generated a bug because in previous example from httpkernel in the file the property was called like this 
$controller = $this->controllerResolver->getController($request);
It is not a fix but it could help the people that follow the tutorial not get stuck :+1:

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
