### PR TITLE
Update dotenv.rst

### DIFF
--- a/components/dotenv.rst
+++ b/components/dotenv.rst
@@ -6,7 +6,7 @@ The Dotenv Component
 ====================
 
     The Dotenv Component parses ``.env`` files to make environment variables
-    stored in them accessible via ``getenv()``, ``$_ENV`` or ``$_SERVER``.
+    stored in them accessible via ``$_ENV`` or ``$_SERVER``.
 
 .. versionadded:: 3.3
 
@@ -55,10 +55,10 @@ Given the following ``.env`` file content:
     DB_USER=root
     DB_PASS=pass
 
-Access the value with ``getenv()`` in your code::
+Access the value with ``$_ENV`` in your code::
 
-    $dbUser = getenv('DB_USER');
-    // you can also use ``$_ENV`` or ``$_SERVER``
+    $dbUser = $_ENV['DB_USER'];
+    // you can also use ``$_SERVER``
 
 .. note::
 


### PR DESCRIPTION
it seems standard practice is to no longer use `getenv()` due to it not being thread safe.

https://github.com/symfony/symfony/commit/21a909a189c1f42767c606c0e7607e4af54d8f11

Updated the docs to remove reference to that function.  Would we want to go so far as to add a note to **not** use `getenv()`?
