### PR TITLE
use e.g. instead of i.e.

### DIFF
--- a/best_practices/security.rst
+++ b/best_practices/security.rst
@@ -1,7 +1,7 @@
 Security
 ========
 
-Authentication and Firewalls (i.e. Getting the User's Credentials)
+Authentication and Firewalls (e.g. Getting the User's Credentials)
 ------------------------------------------------------------------
 
 You can configure Symfony to authenticate your users using any method you
@@ -77,7 +77,7 @@ which uses a login form to load users from the database:
 
     The source code for our project contains comments that explain each part.
 
-Authorization (i.e. Denying Access)
+Authorization (e.g. Denying Access)
 -----------------------------------
 
 Symfony gives you several ways to enforce authorization, including the ``access_control``

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -37,7 +37,7 @@ A namespace becomes a bundle as soon as you add a bundle class to it. The
 bundle class name must follow these simple rules:
 
 * Use only alphanumeric characters and underscores;
-* Use a StudlyCaps name (i.e. camelCase with the first letter uppercased);
+* Use a StudlyCaps name (e.g. camelCase with the first letter uppercased);
 * Use a descriptive and short name (no more than two words);
 * Prefix the name with the concatenation of the vendor (and optionally the
   category namespaces);

--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -116,7 +116,7 @@ Other available loaders are the ``YamlFileLoader``, ``PhpFileLoader`` and
 
 .. caution::
 
-    If you removed the default file with service definitions (i.e.
+    If you removed the default file with service definitions (e.g.
     ``app/config/services.yml``), make sure to also remove it from the
     ``imports`` key in ``app/config/config.yml``.
 

--- a/components/cache/adapters/apcu_adapter.rst
+++ b/components/cache/adapters/apcu_adapter.rst
@@ -27,7 +27,7 @@ and cache items version string as constructor arguments::
         $namespace = '',
 
         // the default lifetime (in seconds) for cache items that do not define their
-        // own lifetime, with a value 0 causing items to be stored indefinitely (i.e.
+        // own lifetime, with a value 0 causing items to be stored indefinitely (e.g.
         // until the APCu memory is cleared)
         $defaultLifetime = 0,
 

--- a/components/cache/adapters/array_cache_adapter.rst
+++ b/components/cache/adapters/array_cache_adapter.rst
@@ -18,7 +18,7 @@ toggles serialization as its second parameter::
     $cache = new ArrayAdapter(
 
         // the default lifetime (in seconds) for cache items that do not define their
-        // own lifetime, with a value 0 causing items to be stored indefinitely (i.e.
+        // own lifetime, with a value 0 causing items to be stored indefinitely (e.g.
         // until the current PHP process finishes)
         $defaultLifetime = 0,
 

--- a/components/cache/adapters/doctrine_adapter.rst
+++ b/components/cache/adapters/doctrine_adapter.rst
@@ -29,7 +29,7 @@ third parameters::
         $namespace = '',
 
         // the default lifetime (in seconds) for cache items that do not define their
-        // own lifetime, with a value 0 causing items to be stored indefinitely (i.e.
+        // own lifetime, with a value 0 causing items to be stored indefinitely (e.g.
         // until the database table is truncated or its rows are otherwise deleted)
         $defaultLifetime = 0
     );

--- a/components/cache/adapters/filesystem_adapter.rst
+++ b/components/cache/adapters/filesystem_adapter.rst
@@ -30,7 +30,7 @@ and cache root path as constructor parameters::
         $namespace = '',
 
         // the default lifetime (in seconds) for cache items that do not define their
-        // own lifetime, with a value 0 causing items to be stored indefinitely (i.e.
+        // own lifetime, with a value 0 causing items to be stored indefinitely (e.g.
         // until the files are deleted)
         $defaultLifetime = 0,
 

--- a/components/cache/adapters/memcached_adapter.rst
+++ b/components/cache/adapters/memcached_adapter.rst
@@ -38,7 +38,7 @@ the second and third parameters::
         $namespace = '',
 
         // the default lifetime (in seconds) for cache items that do not define their
-        // own lifetime, with a value 0 causing items to be stored indefinitely (i.e.
+        // own lifetime, with a value 0 causing items to be stored indefinitely (e.g.
         // until MemcachedAdapter::clear() is invoked or the server(s) are restarted)
         $defaultLifetime = 0
     );

--- a/components/cache/adapters/pdo_doctrine_dbal_adapter.rst
+++ b/components/cache/adapters/pdo_doctrine_dbal_adapter.rst
@@ -27,7 +27,7 @@ third, and forth parameters::
         $namespace = '',
 
         // the default lifetime (in seconds) for cache items that do not define their
-        // own lifetime, with a value 0 causing items to be stored indefinitely (i.e.
+        // own lifetime, with a value 0 causing items to be stored indefinitely (e.g.
         // until the database table is truncated or its rows are otherwise deleted)
         $defaultLifetime = 0,
 

--- a/components/cache/adapters/php_files_adapter.rst
+++ b/components/cache/adapters/php_files_adapter.rst
@@ -51,7 +51,7 @@ directory path as constructor arguments::
         $namespace = '',
 
         // the default lifetime (in seconds) for cache items that do not define their
-        // own lifetime, with a value 0 causing items to be stored indefinitely (i.e.
+        // own lifetime, with a value 0 causing items to be stored indefinitely (e.g.
         // until the files are deleted)
         $defaultLifetime = 0,
 

--- a/components/cache/adapters/proxy_adapter.rst
+++ b/components/cache/adapters/proxy_adapter.rst
@@ -27,7 +27,7 @@ and optionally a namespace and default cache lifetime as its second and third pa
         $namespace = '',
 
         // the default lifetime (in seconds) for cache items that do not define their
-        // own lifetime, with a value 0 causing items to be stored indefinitely (i.e.
+        // own lifetime, with a value 0 causing items to be stored indefinitely (e.g.
         // until the cache is cleared)
         $defaultLifetime = 0
     );

--- a/components/cache/adapters/redis_adapter.rst
+++ b/components/cache/adapters/redis_adapter.rst
@@ -34,7 +34,7 @@ as the second and third parameters::
         $namespace = '',
 
         // the default lifetime (in seconds) for cache items that do not define their
-        // own lifetime, with a value 0 causing items to be stored indefinitely (i.e.
+        // own lifetime, with a value 0 causing items to be stored indefinitely (e.g.
         // until RedisAdapter::clear() is invoked or the server(s) are purged)
         $defaultLifetime = 0
     );

--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -335,7 +335,7 @@ the Symfony Config component treats arrays as lists by default.
 .. note::
 
     As of writing this, there is an inconsistency: if only one file provides the
-    configuration in question, the keys (i.e. ``sf_connection`` and ``default``)
+    configuration in question, the keys (e.g. ``sf_connection`` and ``default``)
     are *not* lost. But if more than one file provides the configuration, the keys
     are lost as described above.
 

--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -37,7 +37,7 @@ number of units, and advance the progress as the command executes::
 
 .. tip::
 
-    You can also regress the progress bar (i.e. step backwards) by calling
+    You can also regress the progress bar (e.g. step backwards) by calling
     ``$progress->advance()`` with a negative value. For example, if you call
     ``$progress->advance(-2)`` then it will regress the progress bar 2 steps.
 

--- a/components/console/usage.rst
+++ b/components/console/usage.rst
@@ -153,7 +153,7 @@ can run it with:
     # php application.php de:Gr Fabien
     # php application.php DE:Gre Fabien
 
-If you enter a short command that's ambiguous (i.e. there are more than one
+If you enter a short command that's ambiguous (e.g. there are more than one
 command that match), then no command will be run and some suggestions of
 the possible commands to choose from will be output.
 

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -42,7 +42,7 @@ event - ``kernel.response``. Here's how it works:
   the ``kernel.response`` event, passing with it an ``Event`` object that
   has access to the ``Response`` object;
 
-* The dispatcher notifies (i.e. calls a method on) all listeners of the
+* The dispatcher notifies (e.g. calls a method on) all listeners of the
   ``kernel.response`` event, allowing each of them to make modifications
   to the ``Response`` object.
 
@@ -405,7 +405,7 @@ Stopping Event Flow/Propagation
 In some cases, it may make sense for a listener to prevent any other listeners
 from being called. In other words, the listener needs to be able to tell
 the dispatcher to stop all propagation of the event to future listeners
-(i.e. to not notify any more listeners). This can be accomplished from
+(e.g. to not notify any more listeners). This can be accomplished from
 inside a listener via the
 :method:`Symfony\\Component\\EventDispatcher\\Event::stopPropagation` method::
 
@@ -460,7 +460,7 @@ specifically pass one::
     $dispatcher->dispatch('order.placed');
 
 Moreover, the event dispatcher always returns whichever event object that
-was dispatched, i.e. either the event that was passed or the event that
+was dispatched, e.g. either the event that was passed or the event that
 was created internally by the dispatcher. This allows for nice shortcuts::
 
     if (!$dispatcher->dispatch('foo.event')->isPropagationStopped()) {

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -234,7 +234,7 @@ Restrict files and directories by path with the
     // for example this will match data/*.xml and data.xml if they exist
     $finder->path('data')->name('*.xml');
 
-On all platforms slash (i.e. ``/``) should be used as the directory separator.
+On all platforms slash (e.g. ``/``) should be used as the directory separator.
 
 The ``path()`` method accepts a string or a regular expression::
 

--- a/components/form.rst
+++ b/components/form.rst
@@ -75,7 +75,7 @@ method::
     $form->handleRequest();
 
 Behind the scenes, this uses a :class:`Symfony\\Component\\Form\\NativeRequestHandler`
-object to read data off of the correct PHP superglobals (i.e. ``$_POST`` or
+object to read data off of the correct PHP superglobals (e.g. ``$_POST`` or
 ``$_GET``) based on the HTTP method configured on the form (POST is default).
 
 .. seealso::
@@ -231,7 +231,7 @@ always to add the :class:`Symfony\\Bridge\\Twig\\Extension\\FormExtension`
 to Twig, which gives you access to the Twig functions for rendering forms.
 To do this, you first need to create a :class:`Symfony\\Bridge\\Twig\\Form\\TwigRendererEngine`,
 where you define your :ref:`form themes <form-customization-form-themes>`
-(i.e. resources/files that define form HTML markup).
+(e.g. resources/files that define form HTML markup).
 
 For general details on rendering forms, see :doc:`/form/form_customization`.
 
@@ -649,7 +649,7 @@ method:
 
 This defines a common form "workflow", which contains 3 different possibilities:
 
-1) On the initial GET request (i.e. when the user "surfs" to your page),
+1) On the initial GET request (e.g. when the user "surfs" to your page),
    build your form and render it;
 
 If the request is a POST, process the submitted data (via ``handleRequest()``).

--- a/components/http_foundation/session_configuration.rst
+++ b/components/http_foundation/session_configuration.rst
@@ -132,7 +132,7 @@ Configuring Garbage Collection
 When a session opens, PHP will call the ``gc`` handler randomly according to the
 probability set by ``session.gc_probability`` / ``session.gc_divisor``. For
 example if these were set to ``5/100`` respectively, it would mean a probability
-of 5%. Similarly, ``3/4`` would mean a 3 in 4 chance of being called, i.e. 75%.
+of 5%. Similarly, ``3/4`` would mean a 3 in 4 chance of being called, e.g. 75%.
 
 If the garbage collection handler is invoked, PHP will pass the value stored in
 the ``php.ini`` directive ``session.gc_maxlifetime``. The meaning in this context is

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -215,10 +215,10 @@ attributes).
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Assuming that no ``kernel.request`` listener was able to create a ``Response``,
-the next step in HttpKernel is to determine and prepare (i.e. resolve) the
+the next step in HttpKernel is to determine and prepare (e.g. resolve) the
 controller. The controller is the part of the end-application's code that
 is responsible for creating and returning the ``Response`` for a specific page.
-The only requirement is that it is a PHP callable - i.e. a function, method
+The only requirement is that it is a PHP callable - e.g. a function, method
 on an object or a ``Closure``.
 
 But *how* you determine the exact controller for a request is entirely up

--- a/components/process.rst
+++ b/components/process.rst
@@ -85,7 +85,7 @@ for new output before going to the next iteration::
 
 The ``mustRun()`` method is identical to ``run()``, except that it will throw
 a :class:`Symfony\\Component\\Process\\Exception\\ProcessFailedException`
-if the process couldn't be executed successfully (i.e. the process exited
+if the process couldn't be executed successfully (e.g. the process exited
 with a non-zero code)::
 
     use Symfony\Component\Process\Exception\ProcessFailedException;

--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -204,7 +204,7 @@ own, it just needs to follow these rules:
    :method:`Symfony\\Component\\Security\\Core\\Encoder\\PasswordEncoderInterface::encodePassword`
    and
    :method:`Symfony\\Component\\Security\\Core\\Encoder\\PasswordEncoderInterface::isPasswordValid`
-   must first of all make sure the password is not too long, i.e. the password length is no longer
+   must first of all make sure the password is not too long, e.g. the password length is no longer
    than 4096 characters. This is for security reasons (see `CVE-2013-5750`_), and you can use the
    :method:`Symfony\\Component\\Security\\Core\\Encoder\\BasePasswordEncoder::isPasswordTooLong`
    method for this check::
@@ -293,7 +293,7 @@ event is dispatched. But beware - this event will fire, for example, on *every*
 request if you have session-based authentication. See ``security.interactive_login``
 below if you need to do something when a user *actually* logs in.
 
-When a provider attempts authentication but fails (i.e. throws an ``AuthenticationException``),
+When a provider attempts authentication but fails (e.g. throws an ``AuthenticationException``),
 a ``security.authentication.failure`` event is dispatched. You could listen on
 the ``security.authentication.failure`` event, for example, in order to log
 failed login attempts.

--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -11,7 +11,7 @@ in the :class:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storag
 using its :method:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface::setToken`
 method.
 
-From then on, the user is authenticated, i.e. identified. Now, other parts
+From then on, the user is authenticated, e.g. identified. Now, other parts
 of the application can use the token to decide whether or not the user may
 request a certain URI, or modify a certain object. This decision will be made
 by an instance of :class:`Symfony\\Component\\Security\\Core\\Authorization\\AccessDecisionManagerInterface`.
@@ -88,7 +88,7 @@ manager to use them:
 ``vote(TokenInterface $token, $object, array $attributes)``
     this method will do the actual voting and return a value equal to one
     of the class constants of :class:`Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface`,
-    i.e. ``VoterInterface::ACCESS_GRANTED``, ``VoterInterface::ACCESS_DENIED``
+    e.g. ``VoterInterface::ACCESS_GRANTED``, ``VoterInterface::ACCESS_DENIED``
     or ``VoterInterface::ACCESS_ABSTAIN``;
 
 The Security component contains some standard voters which cover many use
@@ -100,7 +100,7 @@ AuthenticatedVoter
 The :class:`Symfony\\Component\\Security\\Core\\Authorization\\Voter\\AuthenticatedVoter`
 voter supports the attributes ``IS_AUTHENTICATED_FULLY``, ``IS_AUTHENTICATED_REMEMBERED``,
 and ``IS_AUTHENTICATED_ANONYMOUSLY`` and grants access based on the current
-level of authentication, i.e. is the user fully authenticated, or only based
+level of authentication, e.g. is the user fully authenticated, or only based
 on a "remember-me" cookie, or even authenticated anonymously?
 
 .. code-block:: php

--- a/components/security/firewall.rst
+++ b/components/security/firewall.rst
@@ -135,7 +135,7 @@ which will eventually result in an "HTTP/1.1 403: Access Denied" response.
 Entry Points
 ~~~~~~~~~~~~
 
-When the user is not authenticated at all (i.e. when the token storage
+When the user is not authenticated at all (e.g. when the token storage
 has no token yet), the firewall's entry point will be called to "start"
 the authentication process. An entry point should implement
 :class:`Symfony\\Component\\Security\\Http\\EntryPoint\\AuthenticationEntryPointInterface`,

--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -157,7 +157,7 @@ recommended format. These files are parsed by one of the loader classes.
     In the second method, messages are actually "keywords" that convey the
     idea of the message. The keyword message is then used as the "id" for
     any translations. In this case, translations must be made for the default
-    locale (i.e. to translate ``symfony.great`` to ``Symfony is great``).
+    locale (e.g. to translate ``symfony.great`` to ``Symfony is great``).
 
     The second method is handy because the message key won't need to be changed
     in every translation file if you decide that the message should actually

--- a/components/var_dumper/advanced.rst
+++ b/components/var_dumper/advanced.rst
@@ -394,13 +394,13 @@ can use:
 * :class:`Symfony\\Component\\VarDumper\\Caster\\ConstStub` to wrap a value that is
   best represented by a PHP constant;
 * :class:`Symfony\\Component\\VarDumper\\Caster\\ClassStub` to wrap a PHP identifier
-  (*i.e.* a class name, a method name, an interface, *etc.*);
+  (*e.g.* a class name, a method name, an interface, *etc.*);
 * :class:`Symfony\\Component\\VarDumper\\Caster\\CutStub` to replace big noisy
   objects/strings/*etc.* by ellipses;
 * :class:`Symfony\\Component\\VarDumper\\Caster\\CutArrayStub` to keep only some
   useful keys of an array;
 * :class:`Symfony\\Component\\VarDumper\\Caster\\EnumStub` to wrap a set of virtual
-  values (*i.e.* values that do not exist as properties in the original PHP data
+  values (*e.g.* values that do not exist as properties in the original PHP data
   structure, but are worth listing alongside with real ones);
 * :class:`Symfony\\Component\\VarDumper\\Caster\\LinkStub` to wrap strings that can
   be turned into links by dumpers;

--- a/components/workflow.rst
+++ b/components/workflow.rst
@@ -34,7 +34,7 @@ the action to get from one place to another.
 .. image:: /_images/components/workflow/states_transitions.png
 
 A set of places and transitions creates a **definition**. A workflow needs
-a ``Definition`` and a way to write the states to the objects (i.e. an
+a ``Definition`` and a way to write the states to the objects (e.g. an
 instance of a :class:`Symfony\\Component\\Workflow\\MarkingStore\\MarkingStoreInterface`).
 
 Consider the following example for a blog post. A post can have one of a number

--- a/configuration.rst
+++ b/configuration.rst
@@ -91,7 +91,7 @@ The main configuration file is called ``config.yml``:
         // ...
 
 Most top-level keys - like ``framework`` and ``twig`` - are configuration for a
-specific bundle (i.e. ``FrameworkBundle`` and ``TwigBundle``).
+specific bundle (e.g. ``FrameworkBundle`` and ``TwigBundle``).
 
 .. sidebar:: Configuration Formats
 

--- a/configuration/override_dir_structure.rst
+++ b/configuration/override_dir_structure.rst
@@ -53,7 +53,7 @@ in the ``AppKernel`` class of your application::
         }
     }
 
-In this code, ``$this->environment`` is the current environment (i.e. ``dev``).
+In this code, ``$this->environment`` is the current environment (e.g. ``dev``).
 In this case you have changed the location of the cache directory to
 ``var/{environment}/cache``.
 

--- a/contributing/code_of_conduct/reporting_guidelines.rst
+++ b/contributing/code_of_conduct/reporting_guidelines.rst
@@ -53,7 +53,7 @@ to how to respond. Responses may include:
 * Nothing (if we determine no Code of Conduct violation occurred).
 * A private reprimand from the Code of Conduct response team to the individual(s)
   involved.
-* An imposed vacation (i.e. asking someone to "take a week off" from a mailing
+* An imposed vacation (e.g. asking someone to "take a week off" from a mailing
   list or Slack).
 * A permanent or temporary ban from some or all Symfony conference/community
   spaces (events, meetings, mailing lists, IRC, Slack, etc.)

--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -164,7 +164,7 @@ In addition, documentation follows these rules:
 
 * **Punctuation**: avoid the use of `Serial (Oxford) Commas`_;
 * **Pronouns**: avoid the use of `nosism`_ and always use *you* instead of *we*.
-  (i.e. avoid the first person point of view: use the second instead);
+  (e.g. avoid the first person point of view: use the second instead);
 * **Gender-neutral language**: when referencing a hypothetical person, such as
   *"a user with a session cookie"*, use gender-neutral pronouns (they/their/them).
   For example, instead of:

--- a/controller.rst
+++ b/controller.rst
@@ -426,7 +426,7 @@ HTTP status code::
     throw new \Exception('Something went wrong!');
 
 In every case, an error page is shown to the end user and a full debug
-error page is shown to the developer (i.e. when you're using the ``app_dev.php``
+error page is shown to the developer (e.g. when you're using the ``app_dev.php``
 front controller - see :ref:`page-creation-environments`).
 
 You'll want to customize the error page your user sees. To do that, see

--- a/controller/soap_web_service.rst
+++ b/controller/soap_web_service.rst
@@ -19,7 +19,7 @@ create one from scratch or use a 3rd party generator.
     be applicable to other implementations.
 
 SOAP works by exposing the methods of a PHP object to an external entity
-(i.e. the person using the SOAP service). To start, create a class - ``HelloService`` -
+(e.g. the person using the SOAP service). To start, create a class - ``HelloService`` -
 which represents the functionality that you'll expose in your SOAP service.
 In this case, the SOAP service will allow the client to call a method called
 ``hello``, which happens to send an email::

--- a/deployment.rst
+++ b/deployment.rst
@@ -146,7 +146,7 @@ define other env vars too.
 C) Install/Update your Vendors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Your vendors can be updated before transferring your source code (i.e.
+Your vendors can be updated before transferring your source code (e.g.
 update the ``vendor/`` directory, then transfer that with your source
 code) or afterwards on the server. Either way, just update your vendors
 as you normally do:

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -530,7 +530,7 @@ a controller, this is pretty easy. Add the following method to the
         // tells Doctrine you want to (eventually) save the Product (no queries yet)
         $entityManager->persist($product);
 
-        // actually executes the queries (i.e. the INSERT query)
+        // actually executes the queries (e.g. the INSERT query)
         $entityManager->flush();
 
         return new Response('Saved new product with id '.$product->getId());
@@ -590,7 +590,7 @@ issue an ``UPDATE`` query if the entity already exists in the database.
 .. tip::
 
     Doctrine provides a library that allows you to programmatically load testing
-    data into your project (i.e. "fixture data"). For information, see
+    data into your project (e.g. "fixture data"). For information, see
     the "`DoctrineFixturesBundle`_" documentation.
 
 Fetching Objects from the Database
@@ -632,7 +632,7 @@ repository object for an entity class via::
 .. note::
 
     You can also use ``AppBundle:Product`` syntax. This string is a shortcut you can use anywhere
-    in Doctrine instead of the full class name of the entity (i.e. ``AppBundle\Entity\Product``).
+    in Doctrine instead of the full class name of the entity (e.g. ``AppBundle\Entity\Product``).
     As long as your entity lives under the ``Entity`` namespace of your bundle,
     this will work.
 

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -305,7 +305,7 @@ you.
 
 What's important is the fact that you have easy access to the product's related
 category, but the category data isn't actually retrieved until you ask for
-the category (i.e. it's "lazily loaded").
+the category (e.g. it's "lazily loaded").
 
 You can also query in the other direction::
 
@@ -322,7 +322,7 @@ You can also query in the other direction::
 
 In this case, the same things occur: you first query out for a single ``Category``
 object, and then Doctrine makes a second query to retrieve the related ``Product``
-objects, but only once/if you ask for them (i.e. when you call ``getProducts()``).
+objects, but only once/if you ask for them (e.g. when you call ``getProducts()``).
 The ``$products`` variable is an array of all ``Product`` objects that relate
 to the given ``Category`` object via their ``category_id`` value.
 

--- a/doctrine/lifecycle_callbacks.rst
+++ b/doctrine/lifecycle_callbacks.rst
@@ -26,7 +26,7 @@ callbacks. This is not necessary if you're using YAML or XML for your mapping.
 
 Now, you can tell Doctrine to execute a method on any of the available lifecycle
 events. For example, suppose you want to set a ``createdAt`` date column to
-the current date, only when the entity is first persisted (i.e. inserted):
+the current date, only when the entity is first persisted (e.g. inserted):
 
 .. configuration-block::
 

--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -166,7 +166,7 @@ for each entity manager.
 
     When working with multiple connections and entity managers, you should be
     explicit about which configuration you want. If you *do* omit the name of
-    the connection or entity manager, the default (i.e. ``default``) is used.
+    the connection or entity manager, the default (e.g. ``default``) is used.
 
 When working with multiple connections to create your databases:
 
@@ -189,7 +189,7 @@ When working with multiple entity managers to update your schema:
     $ php bin/console doctrine:schema:update --force --em=customer
 
 If you *do* omit the entity manager's name when asking for it,
-the default entity manager (i.e. ``default``) is returned::
+the default entity manager (e.g. ``default``) is returned::
 
     // ...
 

--- a/form/create_custom_field_type.rst
+++ b/form/create_custom_field_type.rst
@@ -124,7 +124,7 @@ the class name of your type. For more information, see :ref:`form-customization-
 In this case, since the parent field is ``ChoiceType``, you don't *need* to do
 any work as the custom field type will automatically be rendered like a ``ChoiceType``.
 But for the sake of this example, suppose that when your field is "expanded"
-(i.e. radio buttons or checkboxes, instead of a select field), you want to
+(e.g. radio buttons or checkboxes, instead of a select field), you want to
 always render it in a ``ul`` element. In your form theme template (see above
 link for details), create a ``shipping_widget`` block to handle this:
 
@@ -300,7 +300,7 @@ add a ``__construct()`` method like normal::
         // use $this->entityManager down anywhere you want ...
     }
 
-If you're using the default ``services.yml`` configuration (i.e. services from the
+If you're using the default ``services.yml`` configuration (e.g. services from the
 ``Form/`` are loaded and ``autoconfigure`` is enabled), this will already work!
 See :ref:`service-container-creating-service` for more details.
 

--- a/form/create_form_type_extension.rst
+++ b/form/create_form_type_extension.rst
@@ -275,7 +275,7 @@ Generic Form Type Extensions
 You can modify several form types at once by specifying their common parent
 (:doc:`/reference/forms/types`). For example, several form types inherit from the
 ``TextType`` form type (such as ``EmailType``, ``SearchType``, ``UrlType``, etc.).
-A form type extension applying to ``TextType`` (i.e. whose ``getExtendedType()``
+A form type extension applying to ``TextType`` (e.g. whose ``getExtendedType()``
 method returns ``TextType::class``) would apply to all of these form types.
 
 In the same way, since **most** form types natively available in Symfony inherit

--- a/form/data_transformers.rst
+++ b/form/data_transformers.rst
@@ -118,7 +118,7 @@ slightly::
 Harder Example: Transforming an Issue Number into an Issue Entity
 -----------------------------------------------------------------
 
-Say you have a many-to-one relation from the Task entity to an Issue entity (i.e. each
+Say you have a many-to-one relation from the Task entity to an Issue entity (e.g. each
 Task has an optional foreign key to its related Issue). Adding a listbox with all
 possible issues could eventually get *really* long and take a long time to load.
 Instead, you decide you want to add a textbox, where the user can enter the issue number.

--- a/form/direct_submit.rst
+++ b/form/direct_submit.rst
@@ -88,4 +88,4 @@ method, pass the submitted data directly to
     When the second parameter ``$clearMissing`` is ``false``, like with the
     "PATCH" method, the validation extension will only handle the submitted
     fields. If the underlying data needs to be validated, this should be done
-    manually, i.e. using the validator.
+    manually, e.g. using the validator.

--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -395,7 +395,7 @@ sport like this::
                 function (FormEvent $event) {
                     $form = $event->getForm();
 
-                    // this would be your entity, i.e. SportMeetup
+                    // this would be your entity, e.g. SportMeetup
                     $data = $event->getData();
 
                     $sport = $data->getSport();
@@ -467,7 +467,7 @@ The type would now look like::
             $builder->addEventListener(
                 FormEvents::PRE_SET_DATA,
                 function (FormEvent $event) use ($formModifier) {
-                    // this would be your entity, i.e. SportMeetup
+                    // this would be your entity, e.g. SportMeetup
                     $data = $event->getData();
 
                     $formModifier($event->getForm(), $data->getSport());

--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -85,7 +85,7 @@ fragment needed to render every part of a form:
   styles.
 * `bootstrap_3_horizontal_layout.html.twig`_, it's similar to the previous theme,
   but the CSS classes applied are the ones used to display the forms horizontally
-  (i.e. the label and the widget in the same row).
+  (e.g. the label and the widget in the same row).
 * `bootstrap_4_layout.html.twig`_, same as ``bootstrap_3_layout.html.twig``, but
   updated for `Bootstrap 4 CSS framework`_ styles.
 * `bootstrap_4_horizontal_layout.html.twig`_, same as ``bootstrap_3_horizontal_layout.html.twig``
@@ -682,7 +682,7 @@ of PHP templates). For example: ``text_errors`` (or ``text_errors.html.php``).
     See :ref:`form-template-blocks` to find out which specific block or file you
     have to customize.
 
-Certain errors that are more global to your form (i.e. not specific to just one
+Certain errors that are more global to your form (e.g. not specific to just one
 field) are rendered separately, usually at the top of your form:
 
 .. code-block:: twig

--- a/form/without_class.rst
+++ b/form/without_class.rst
@@ -65,7 +65,7 @@ Adding Validation
 
 The only missing piece is validation. Usually, when you call ``$form->handleRequest($request)``,
 the object is validated by reading the constraints that you applied to that
-class. If your form is mapped to an object (i.e. you're using the ``data_class``
+class. If your form is mapped to an object (e.g. you're using the ``data_class``
 option or passing an object to your form), this is almost always the approach
 you want to use. See :doc:`/validation` for more details.
 

--- a/forms.rst
+++ b/forms.rst
@@ -62,7 +62,7 @@ going to need to build a form. But before you begin, first focus on the generic
 
 This class is a "plain-old-PHP-object" because, so far, it has nothing
 to do with Symfony or any other library. It's a normal PHP object that
-directly solves a problem inside *your* application (i.e. the need to
+directly solves a problem inside *your* application (e.g. the need to
 represent a task in your application). Of course, by the end of this article,
 you'll be able to submit data to a ``Task`` instance (via an HTML form), validate
 its data and persist it to the database.
@@ -183,7 +183,7 @@ That's it! Just three lines are needed to render the complete form:
     You'll learn how to do that in the ":doc:`/form/rendering`" section.
 
 Before moving on, notice how the rendered ``task`` input field has the value
-of the ``task`` property from the ``$task`` object (i.e. "Write a blog post").
+of the ``task`` property from the ``$task`` object (e.g. "Write a blog post").
 This is the first job of a form: to take data from an object and translate
 it into a format that's suitable for being rendered in an HTML form.
 
@@ -545,8 +545,8 @@ the correct values of a number of field options.
     field type options can then be guessed from that information.
 
 ``required``
-    The ``required`` option can be guessed based on the validation rules (i.e. is
-    the field ``NotBlank`` or ``NotNull``) or the Doctrine metadata (i.e. is the
+    The ``required`` option can be guessed based on the validation rules (e.g. is
+    the field ``NotBlank`` or ``NotNull``) or the Doctrine metadata (e.g. is the
     field ``nullable``). This is very useful, as your client-side validation will
     automatically match your validation rules.
 
@@ -558,7 +558,7 @@ the correct values of a number of field options.
 .. caution::
 
   These field options are *only* guessed if you're using Symfony to guess
-  the field type (i.e. omit or pass ``null`` as the second argument to ``add()``).
+  the field type (e.g. omit or pass ``null`` as the second argument to ``add()``).
 
 If you'd like to change one of the guessed values, you can override it by
 passing the option in the options field array::
@@ -622,7 +622,7 @@ the choice is ultimately up to you.
     Every form needs to know the name of the class that holds the underlying
     data (e.g. ``AppBundle\Entity\Task``). Usually, this is just guessed
     based off of the object passed to the second argument to ``createForm()``
-    (i.e. ``$task``). Later, when you begin embedding forms, this will no
+    (e.g. ``$task``). Later, when you begin embedding forms, this will no
     longer be sufficient. So, while not always necessary, it's generally a
     good idea to explicitly specify the ``data_class`` option by adding the
     following to your form type class::

--- a/frontend/assetic/uglifyjs.rst
+++ b/frontend/assetic/uglifyjs.rst
@@ -300,7 +300,7 @@ helper:
     {% endstylesheets %}
 
 Just like with the ``uglifyjs2`` filter, if you prefix the filter name with
-``?`` (i.e. ``?uglifycss``), the minification will only happen when you're
+``?`` (e.g. ``?uglifycss``), the minification will only happen when you're
 not in debug mode.
 
 .. _`UglifyJS`: https://github.com/mishoo/UglifyJS

--- a/frontend/encore/faq.rst
+++ b/frontend/encore/faq.rst
@@ -58,7 +58,7 @@ You *should* commit all of your source asset files, ``package.json`` and ``yarn.
 My App Lives under a Subdirectory
 ---------------------------------
 
-If your app does not live at the root of your web server (i.e. it lives under a subdirectory,
+If your app does not live at the root of your web server (e.g. it lives under a subdirectory,
 like ``/myAppSubdir``), you just need to configure that when calling ``Encore.setPublicPrefix()``:
 
 .. code-block:: diff

--- a/frontend/encore/page-specific-assets.rst
+++ b/frontend/encore/page-specific-assets.rst
@@ -17,7 +17,7 @@ you need.
 However, it's pretty common to need to include some global JavaScript and CSS on
 every page. For that reason, it usually makes sense to have one entry (e.g. ``app``)
 that contains this global code (both JavaScript & CSS) and is included on every
-page (i.e. it's included in the *layout* of your app). This means that you will
+page (e.g. it's included in the *layout* of your app). This means that you will
 always have one, global entry on every page (e.g. ``app``) and you *may* have one
 page-specific JavaScript and CSS file from a page-specific entry (e.g. ``checkout``).
 

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -12,7 +12,7 @@ to be lightning fast, you need HTTP caching.
 Caching on the Shoulders of Giants
 ----------------------------------
 
-With HTTP Caching, you cache the full output of a page (i.e. the response) and bypass
+With HTTP Caching, you cache the full output of a page (e.g. the response) and bypass
 your application *entirely* on subsequent requests. Of course, caching entire responses
 isn't always possible for highly dynamic sites, or is it? With
 :doc:`Edge Side Includes (ESI) </http_cache/esi>`, you can use the power of HTTP caching
@@ -69,7 +69,7 @@ as `Varnish`_, `Squid in reverse proxy mode`_, and the Symfony reverse proxy.
 Symfony Reverse Proxy
 ~~~~~~~~~~~~~~~~~~~~~
 
-Symfony comes with a reverse proxy (i.e. gateway cache) written in PHP.
+Symfony comes with a reverse proxy (e.g. gateway cache) written in PHP.
 :ref:`It's not a fully-featured reverse proxy cache like Varnish <http-cache-symfony-versus-varnish>`,
 but is a great way to start.
 

--- a/http_cache/esi.rst
+++ b/http_cache/esi.rst
@@ -47,7 +47,7 @@ or requests the page fragment from the backend application again. When all
 the ESI tags have been resolved, the gateway cache merges each into the main
 page and sends the final content to the client.
 
-All of this happens transparently at the gateway cache level (i.e. outside
+All of this happens transparently at the gateway cache level (e.g. outside
 of your application). As you'll see, if you choose to take advantage of ESI
 tags, Symfony makes the process of including them almost effortless.
 
@@ -139,14 +139,14 @@ if there is no gateway cache installed.
 .. tip::
 
     As you'll see below, the ``maxPerPage`` variable you pass is available
-    as an argument to your controller (i.e. ``$maxPerPage``). The variables
+    as an argument to your controller (e.g. ``$maxPerPage``). The variables
     passed through ``render_esi`` also become part of the cache key so that
     you have unique caches for each combination of variables and values.
 
 When using the default ``render()`` function (or setting the renderer to
 ``inline``), Symfony merges the included page content into the main one
 before sending the response to the client. But if you use the ``esi`` renderer
-(i.e. call ``render_esi()``) *and* if Symfony detects that it's talking to a
+(e.g. call ``render_esi()``) *and* if Symfony detects that it's talking to a
 gateway cache that supports ESI, it generates an ESI include tag. But if there
 is no gateway cache or if it does not support ESI, Symfony will just merge
 the included page content within the main one as it would have done if you had

--- a/introduction/http_fundamentals.rst
+++ b/introduction/http_fundamentals.rst
@@ -239,7 +239,7 @@ have all the request information at your fingertips::
 As a bonus, the ``Request`` class does a lot of work in the background that
 you'll never need to worry about. For example, the ``isSecure()`` method
 checks the *three* different values in PHP that can indicate whether or not
-the user is connecting via a secured connection (i.e. HTTPS).
+the user is connecting via a secured connection (e.g. HTTPS).
 
 Symfony Response Object
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -385,7 +385,7 @@ Here's what we've learned so far:
 #. Internally, Symfony uses *routes* and *controllers* to create the Response for
    the page (we'll learn about these soon!);
 #. Symfony turns your ``Response`` object into the text headers and content
-   (i.e. the HTTP response), which are sent back to the client.
+   (e.g. the HTTP response), which are sent back to the client.
 
 .. _`xkcd`: http://xkcd.com/
 .. _`XMLHttpRequest`: https://en.wikipedia.org/wiki/XMLHttpRequest

--- a/logging.rst
+++ b/logging.rst
@@ -74,7 +74,7 @@ and ``config_prod.yml``.
 By default, log entries are written to the ``var/logs/dev.log`` file when you're in
 the ``dev`` environment. In the ``prod`` environment, logs are written to ``var/logs/prod.log``,
 but *only* during a request where an error or high-priority log entry was made
-(i.e. ``error()`` , ``critical()``, ``alert()`` or ``emergency()``).
+(e.g. ``error()`` , ``critical()``, ``alert()`` or ``emergency()``).
 
 To control this, you'll configure different *handlers* that handle log entries, sometimes
 modify them, and ultimately store them.

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -185,7 +185,7 @@ So what about the other directories in the project?
     (``var/cache/``), logs (``var/logs/``) and sessions (``var/sessions/``).
 
 ``vendor/``
-    Third-party (i.e. "vendor") libraries live here! These are downloaded via the `Composer`_
+    Third-party (e.g. "vendor") libraries live here! These are downloaded via the `Composer`_
     package manager.
 
 ``web/``

--- a/performance.rst
+++ b/performance.rst
@@ -63,7 +63,7 @@ For more details, see :doc:`/components/class_loader/cache_class_loader`.
 .. note::
 
     When using the APC autoloader, if you add new classes, they will be found
-    automatically and everything will work the same as before (i.e. no
+    automatically and everything will work the same as before (e.g. no
     reason to "clear" the cache). However, if you change the location of a
     particular namespace or prefix, you'll need to flush your APC cache. Otherwise,
     the autoloader will still be looking at the old location for all classes
@@ -94,7 +94,7 @@ using the bootstrap file. To be sure, open your front controller (usually
 Note that there are two disadvantages when using a bootstrap file:
 
 * the file needs to be regenerated whenever any of the original sources change
-  (i.e. when you update the Symfony source or vendor libraries);
+  (e.g. when you update the Symfony source or vendor libraries);
 
 * when debugging, one will need to place break points inside the bootstrap file.
 
@@ -158,7 +158,7 @@ possible solutions:
 
 1. Restart the web server;
 2. Call the ``apc_clear_cache()`` or ``opcache_reset()`` functions via the
-   web server (i.e. by having these in a script that you execute over the web);
+   web server (e.g. by having these in a script that you execute over the web);
 3. Use the `cachetool`_ utility to control APC and OPcache from the CLI.
 
 .. _performance-configure-realpath-cache:

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -187,7 +187,7 @@ SwiftmailerBundle.
 
 Each environment can override the default configuration by providing a
 specific configuration file. For example, the ``dev`` environment loads
-the ``config_dev.yml`` file, which loads the main configuration (i.e.
+the ``config_dev.yml`` file, which loads the main configuration (e.g.
 ``config.yml``) and then modifies it to add some debugging tools:
 
 .. code-block:: yaml

--- a/reference/configuration/kernel.rst
+++ b/reference/configuration/kernel.rst
@@ -40,7 +40,7 @@ method and return another charset, for instance::
 Kernel Name
 ~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``app`` (i.e. the directory name holding
+**type**: ``string`` **default**: ``app`` (e.g. the directory name holding
 the kernel class)
 
 To change this setting, override the :method:`Symfony\\Component\\HttpKernel\\Kernel::getName`

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -415,7 +415,7 @@ This is the route or path that your login form must submit to. The firewall
 will intercept any requests (``POST`` requests only, by default) to this
 URL and process the submitted login credentials.
 
-Be sure that this URL is covered by your main firewall (i.e. don't create
+Be sure that this URL is covered by your main firewall (e.g. don't create
 a separate firewall just for ``check_path`` URL).
 
 use_forward

--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -1,7 +1,7 @@
 Collection
 ==========
 
-This constraint is used when the underlying data is a collection (i.e. an
+This constraint is used when the underlying data is a collection (e.g. an
 array or an object that implements ``Traversable`` and ``ArrayAccess``),
 but you'd like to validate different keys of that collection in different
 ways. For example, you might validate the ``email`` key using the ``Email``

--- a/reference/constraints/Count.rst
+++ b/reference/constraints/Count.rst
@@ -1,7 +1,7 @@
 Count
 =====
 
-Validates that a given collection's (i.e. an array or an object that implements
+Validates that a given collection's (e.g. an array or an object that implements
 Countable) element count is *between* some minimum and maximum value.
 
 +----------------+---------------------------------------------------------------------+

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -257,7 +257,7 @@ disallowEmptyMessage
 
 **type**: ``string`` **default**: ``An empty file is not allowed.``
 
-This constraint checks if the uploaded file is empty (i.e. 0 bytes). If it is,
+This constraint checks if the uploaded file is empty (e.g. 0 bytes). If it is,
 this message is displayed.
 
 You can use the following parameters in this message:

--- a/reference/forms/types/button.rst
+++ b/reference/forms/types/button.rst
@@ -26,7 +26,7 @@ The following options are defined in the
 :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\BaseType` class.
 The ``BaseType`` class is the parent class for both the ``button`` type
 and the :doc:`FormType </reference/forms/types/form>`, but it is not part
-of the form type tree (i.e. it cannot be used as a form type on its own).
+of the form type tree (e.g. it cannot be used as a form type on its own).
 
 attr
 ~~~~

--- a/reference/forms/types/dateinterval.rst
+++ b/reference/forms/types/dateinterval.rst
@@ -119,7 +119,7 @@ input
 
 **type**: ``string`` **default**: ``dateinterval``
 
-The format of the *input* data - i.e. the format that the interval is stored on
+The format of the *input* data - e.g. the format that the interval is stored on
 your underlying object. Valid values are:
 
 * ``string`` (a string formatted with `ISO 8601`_ standard, e.g. ``P7Y6M5DT12H15M30S``)

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -111,7 +111,7 @@ format
 **type**: ``string`` **default**: ``Symfony\Component\Form\Extension\Core\Type\DateTimeType::HTML5_FORMAT``
 
 If the ``widget`` option is set to ``single_text``, this option specifies
-the format of the input, i.e. how Symfony will interpret the given input
+the format of the input, e.g. how Symfony will interpret the given input
 as a datetime string. It defaults to the `datetime local`_ format which is
 used by the HTML5 ``datetime-local`` field. Keeping the default value will
 cause the field to be rendered as an ``input`` field with ``type="datetime-local"``.
@@ -126,7 +126,7 @@ input
 
 **type**: ``string`` **default**: ``datetime``
 
-The format of the *input* data - i.e. the format that the date is stored
+The format of the *input* data - e.g. the format that the date is stored
 on your underlying object. Valid values are:
 
 * ``string`` (e.g. ``2011-06-05 12:15:00``)

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -288,8 +288,8 @@ of entity objects::
     ]);
 
 The preferred choices are only meaningful when rendering a ``select`` element
-(i.e. ``expanded`` false). The preferred choices and normal choices are separated
-visually by a set of dotted lines (i.e. ``-------------------``). This can be customized
+(e.g. ``expanded`` false). The preferred choices and normal choices are separated
+visually by a set of dotted lines (e.g. ``-------------------``). This can be customized
 when rendering the field:
 
 .. code-block:: twig

--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -140,7 +140,7 @@ The following options are defined in the
 :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\BaseType` class.
 The ``BaseType`` class is the parent class for both the ``form`` type and
 the :doc:`ButtonType </reference/forms/types/button>`, but it is not part
-of the form type tree (i.e. it cannot be used as a form type on its own).
+of the form type tree (e.g. it cannot be used as a form type on its own).
 
 .. include:: /reference/forms/types/options/attr.rst.inc
 

--- a/reference/forms/types/options/action.rst.inc
+++ b/reference/forms/types/options/action.rst.inc
@@ -5,5 +5,5 @@ action
 
 This option specifies where to send the form's data on submission (usually
 a URI). Its value is rendered as the ``action`` attribute of the ``form``
-element. An empty value is considered a same-document reference, i.e. the
+element. An empty value is considered a same-document reference, e.g. the
 form will be submitted to the same URI that rendered the form.

--- a/reference/forms/types/options/date_input.rst.inc
+++ b/reference/forms/types/options/date_input.rst.inc
@@ -3,7 +3,7 @@ input
 
 **type**: ``string`` **default**: ``datetime``
 
-The format of the *input* data - i.e. the format that the date is stored
+The format of the *input* data - e.g. the format that the date is stored
 on your underlying object. Valid values are:
 
 * ``string`` (e.g. ``2011-06-05``)

--- a/reference/forms/types/options/invalid_message.rst.inc
+++ b/reference/forms/types/options/invalid_message.rst.inc
@@ -4,7 +4,7 @@ invalid_message
 **type**: ``string`` **default**: ``This value is not valid``
 
 This is the validation error message that's used if the data entered into
-this field doesn't make sense (i.e. fails validation).
+this field doesn't make sense (e.g. fails validation).
 
 This might happen, for example, if the user enters a nonsense string into
 a :doc:`TimeType </reference/forms/types/time>` field that cannot be converted

--- a/reference/forms/types/options/preferred_choices.rst.inc
+++ b/reference/forms/types/options/preferred_choices.rst.inc
@@ -48,8 +48,8 @@ Finally, if your values are objects, you can also specify a property path string
 on the object that will return true or false.
 
 The preferred choices are only meaningful when rendering a ``select`` element
-(i.e. ``expanded`` false). The preferred choices and normal choices are separated
-visually by a set of dotted lines (i.e. ``-------------------``). This can be customized
+(e.g. ``expanded`` false). The preferred choices and normal choices are separated
+visually by a set of dotted lines (e.g. ``-------------------``). This can be customized
 when rendering the field:
 
 .. configuration-block::

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -114,7 +114,7 @@ input
 
 **type**: ``string`` **default**: ``datetime``
 
-The format of the *input* data - i.e. the format that the date is stored
+The format of the *input* data - e.g. the format that the date is stored
 on your underlying object. Valid values are:
 
 * ``string`` (e.g. ``12:17:26``)

--- a/reference/forms/types/timezone.rst
+++ b/reference/forms/types/timezone.rst
@@ -57,7 +57,7 @@ input
 
 **type**: ``string`` **default**: ``string``
 
-The format of the *input* data - i.e. the format that the timezone is stored
+The format of the *input* data - e.g. the format that the timezone is stored
 on your underlying object. Valid values are:
 
 * ``string`` (e.g. ``America/New_York``)

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -441,7 +441,7 @@ humanize
 ``text``
     **type**: ``string``
 
-Makes a technical name human readable (i.e. replaces underscores by spaces
+Makes a technical name human readable (e.g. replaces underscores by spaces
 or transforms camelCase text like ``helloWorld`` to ``hello world``
 and then capitalizes the string).
 

--- a/routing.rst
+++ b/routing.rst
@@ -729,7 +729,7 @@ This happens when your controller method has an argument (e.g. ``$slug``)::
 
 But your route path does *not* have a ``{slug}`` wildcard (e.g. it is ``/blog/show``).
 Add a ``{slug}`` to your route path: ``/blog/show/{slug}`` or give the argument
-a default value (i.e. ``$slug = null``).
+a default value (e.g. ``$slug = null``).
 
     Some mandatory parameters are missing ("slug") to generate a URL for route
     "blog_show".

--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -110,7 +110,7 @@ extend or implement any special class, but the called method must return a
 Creating a custom Loader
 ------------------------
 
-To load routes from some custom source (i.e. from something other than annotations,
+To load routes from some custom source (e.g. from something other than annotations,
 YAML or XML files), you need to create a custom route loader. This loader
 has to implement :class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`.
 

--- a/routing/optional_placeholders.rst
+++ b/routing/optional_placeholders.rst
@@ -196,9 +196,9 @@ URL          Route     Parameters
     Of course, you can have more than one optional placeholder (e.g. ``/blog/{slug}/{page}``),
     but everything after an optional placeholder must be optional. For example,
     ``/{page}/blog`` is a valid path, but ``page`` will always be required
-    (i.e. ``/blog`` will not match this route).
+    (e.g. ``/blog`` will not match this route).
 
 .. tip::
 
     Routes with optional parameters at the end will not match on requests
-    with a trailing slash (i.e. ``/blog/`` will not match, ``/blog`` will match).
+    with a trailing slash (e.g. ``/blog/`` will not match, ``/blog`` will match).

--- a/routing/requirements.rst
+++ b/routing/requirements.rst
@@ -72,7 +72,7 @@ a routing ``{wildcard}`` to only match some regular expression:
 
         return $routes;
 
-Thanks to the ``\d+`` requirement (i.e. a "digit" of any length), ``/blog/2`` will
+Thanks to the ``\d+`` requirement (e.g. a "digit" of any length), ``/blog/2`` will
 match this route but ``/blog/some-string`` will *not* match.
 
 .. sidebar:: Earlier Routes Always Win
@@ -186,7 +186,7 @@ Adding HTTP Method Requirements
 -------------------------------
 
 In addition to the URL, you can also match on the *method* of the incoming
-request (i.e. GET, HEAD, POST, PUT, DELETE). Suppose you create an API for
+request (e.g. GET, HEAD, POST, PUT, DELETE). Suppose you create an API for
 your blog and you have 2 routes: One for displaying a post (on a GET or HEAD
 request) and one for updating a post (on a PUT request). This can be
 accomplished with the following route configuration:

--- a/security.rst
+++ b/security.rst
@@ -658,7 +658,7 @@ in your table.
 
     All roles you assign to a user **must** begin with the ``ROLE_`` prefix.
     Otherwise, they won't be handled by Symfony's security system in the
-    normal way (i.e. unless you're doing something advanced, assigning a
+    normal way (e.g. unless you're doing something advanced, assigning a
     role like ``FOO`` to a user and then checking for ``FOO`` as described
     :ref:`below <security-role-authorization>` will not work).
 
@@ -890,7 +890,7 @@ Securing other Services
 .......................
 
 Anything in Symfony can be protected by doing something similar to the code
-used to secure a controller. For example, suppose you have a service (i.e. a
+used to secure a controller. For example, suppose you have a service (e.g. a
 PHP class) whose job is to send emails. You can restrict use of this class - no
 matter where it's being used from - to only certain users.
 

--- a/security/acl.rst
+++ b/security/acl.rst
@@ -36,7 +36,7 @@ Symfony, two basic approaches are (non-exhaustive):
   reference inside each ``Comment`` to all users who have access, and then
   compare these users to the provided ``Token``.
 - *Enforce security with roles*: In this approach, you would add a role for
-  each ``Comment`` object, i.e. ``ROLE_COMMENT_1``, ``ROLE_COMMENT_2``, etc.
+  each ``Comment`` object, e.g. ``ROLE_COMMENT_1``, ``ROLE_COMMENT_2``, etc.
 
 Both approaches are perfectly valid. However, they couple your authorization
 logic to your business code which makes it less reusable elsewhere, and also

--- a/security/api_key_authentication.rst
+++ b/security/api_key_authentication.rst
@@ -144,7 +144,7 @@ In this specific example, the following things happen in ``authenticateToken()``
    corresponds to the ``$apiKey``;
 #. Second, you use the ``$userProvider`` again to load or create a ``User``
    object for the ``$username``;
-#. Finally, you create an *authenticated token* (i.e. a token with at least one
+#. Finally, you create an *authenticated token* (e.g. a token with at least one
    role) that has the proper roles and the User object attached to it.
 
 The goal is ultimately to use the ``$apiKey`` to find or create a ``User``
@@ -158,7 +158,7 @@ The User Provider
 The ``$userProvider`` can be any user provider (see :doc:`/security/custom_provider`).
 In this example, the ``$apiKey`` is used to somehow find the username for
 the user. This work is done in a ``getUsernameForApiKey()`` method, which
-is created entirely custom for this use-case (i.e. this isn't a method that's
+is created entirely custom for this use-case (e.g. this isn't a method that's
 used by Symfony's core user provider system).
 
 The ``$userProvider`` might look something like this::
@@ -232,7 +232,7 @@ would allow you to have custom data on the ``User`` object.
 Finally, just make sure that ``supportsClass()`` returns ``true`` for User
 objects with the same class as whatever user you return in ``loadUserByUsername()``.
 
-If your authentication is stateless like in this example (i.e. you expect
+If your authentication is stateless like in this example (e.g. you expect
 the user to send the API key with every request and so you don't save the
 login to the session), then you can simply throw the ``UnsupportedUserException``
 exception in ``refreshUser()``.
@@ -469,7 +469,7 @@ configuration or set it to ``false``:
         ]);
 
 Even though the token is being stored in the session, the credentials - in this
-case the API key (i.e. ``$token->getCredentials()``) - are not stored in the session
+case the API key (e.g. ``$token->getCredentials()``) - are not stored in the session
 for security reasons. To take advantage of the session, update ``ApiKeyAuthenticator``
 to see if the stored token has a valid User object that can be used::
 

--- a/security/custom_password_authenticator.rst
+++ b/security/custom_password_authenticator.rst
@@ -10,7 +10,7 @@ How to Create a Custom Form Password Authenticator
     flexible way to accomplish custom authentication tasks like this.
 
 Imagine you want to allow access to your website only between 2pm and 4pm
-UTC. In this article, you'll learn how to do this for a login form (i.e. where
+UTC. In this article, you'll learn how to do this for a login form (e.g. where
 your user submits their username and password).
 
 The Password Authenticator
@@ -135,7 +135,7 @@ and the current time.
     requirements.
 
 Ultimately, your job is to return a *new* token object that is "authenticated"
-(i.e. it has at least 1 role set on it) and which has the ``User`` object
+(e.g. it has at least 1 role set on it) and which has the ``User`` object
 inside of it.
 
 Inside this method, the password encoder is needed to check the password's validity::

--- a/security/entity_provider.rst
+++ b/security/entity_provider.rst
@@ -335,7 +335,7 @@ and password ``admin`` (which has been encoded).
 Forbid Inactive Users (AdvancedUserInterface)
 ---------------------------------------------
 
-If a User's ``isActive`` property is set to ``false`` (i.e. ``is_active``
+If a User's ``isActive`` property is set to ``false`` (e.g. ``is_active``
 is 0 in the database), the user will still be able to login to the site
 normally.
 

--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -54,7 +54,7 @@ Additionally, you have access to a number of functions inside the expression:
 
 ``is_authenticated``
     Returns ``true`` if the user is authenticated via "remember-me" or authenticated
-    "fully" - i.e. returns true if the user is "logged in".
+    "fully" - e.g. returns true if the user is "logged in".
 ``is_anonymous``
     Equal to using ``IS_AUTHENTICATED_ANONYMOUSLY`` with the ``isGranted()`` function.
 ``is_remember_me``
@@ -86,7 +86,7 @@ Additionally, you have access to a number of functions inside the expression:
     behavior of ``IS_AUTHENTICATED_REMEMBERED`` and ``IS_AUTHENTICATED_FULLY``,
     the ``is_remember_me()`` function *only* returns true if the user is authenticated
     via a remember-me cookie and ``is_fully_authenticated`` *only* returns
-    true if the user has actually logged in during this session (i.e. is
+    true if the user has actually logged in during this session (e.g. is
     full-fledged).
 
 Learn more

--- a/security/form_login.rst
+++ b/security/form_login.rst
@@ -14,14 +14,14 @@ learn of the possible customization options.
 Redirecting after Success
 -------------------------
 
-By default, the form will redirect to the URL the user requested (i.e. the URL
+By default, the form will redirect to the URL the user requested (e.g. the URL
 which triggered the login form being shown). For example, if the user requested
 ``http://www.example.com/admin/post/18/edit``, then after they have successfully
 logged in, they will be sent back to ``http://www.example.com/admin/post/18/edit``.
 
 This is done by storing the requested URL in the session. If no URL is present
 in the session (perhaps the user went directly to the login page), then the user
-is redirected to ``/`` (i.e. the homepage). You can change this behavior in
+is redirected to ``/`` (e.g. the homepage). You can change this behavior in
 several ways.
 
 Changing the default Page

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -445,7 +445,7 @@ Customizing Error Messages
 When ``onAuthenticationFailure()`` is called, it is passed an ``AuthenticationException``
 that describes *how* authentication failed via its ``$exception->getMessageKey()`` (and
 ``$exception->getMessageData()``) method. The message will be different based on *where*
-authentication fails (i.e. ``getUser()`` versus ``checkCredentials()``).
+authentication fails (e.g. ``getUser()`` versus ``checkCredentials()``).
 
 But, you can easily return a custom message by throwing a
 :class:`Symfony\\Component\\Security\\Core\\Exception\\CustomUserMessageAuthenticationException`.
@@ -555,7 +555,7 @@ can ignore this. Here is an example of good and bad behavior::
 
     public function supports(Request $request)
     {
-        // GOOD behavior: only authenticate (i.e. return true) on a specific route
+        // GOOD behavior: only authenticate (e.g. return true) on a specific route
         return 'login_route' === $request->attributes->get('_route') && $request->isMethod('POST');
 
         // e.g. your login system authenticates by the user's IP address

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -254,7 +254,7 @@ calling ``isGranted()`` from a controller or other places
 .. note::
 
     If you need to check access in any non-voter service, use the ``security.authorization_checker``
-    service (i.e. type-hint ``Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface``)
+    service (e.g. type-hint ``Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface``)
     instead of the ``security.access.decision_manager`` service shown here.
 
 .. _security-voters-change-strategy:

--- a/service_container.rst
+++ b/service_container.rst
@@ -772,7 +772,7 @@ argument for *any* service defined in this file! You can bind arguments by name
 (e.g. ``$adminEmail``) or by type (e.g. ``Psr\Log\LoggerInterface``).
 
 The ``bind`` config can also be applied to specific services or when loading many
-services at once (i.e. :ref:`service-psr4-loader`).
+services at once (e.g. :ref:`service-psr4-loader`).
 
 .. _services-autowire:
 

--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -136,7 +136,7 @@ thanks to the following config:
 
 This means that every class in ``src/AppBundle/`` is *available* to be used as a
 service. And thanks to the ``_defaults`` section at the top of the file, all of
-these services are **autowired** and **private** (i.e. ``public: false``).
+these services are **autowired** and **private** (e.g. ``public: false``).
 
 The service ids are equal to the class name (e.g. ``AppBundle\Service\InvoiceGenerator``).
 And that's another change you'll notice in Symfony 3.3: we recommend that you use
@@ -172,7 +172,7 @@ result in the container needing to be rebuilt less-often in the ``dev`` environm
 
 The second big change is that autowiring is enabled (via ``_defaults``) for all
 services you register. This also means that service id's are now *less* important
-and "types" (i.e. class or interface names) are now *more* important.
+and "types" (e.g. class or interface names) are now *more* important.
 
 For example, before Symfony 3.3 (and this is still allowed), you could pass one
 service as an argument to another with the following config:
@@ -570,7 +570,7 @@ Start by updating the service ids to class names:
 
 .. caution::
 
-    Services associated with global PHP classes (i.e. not using PHP namespaces)
+    Services associated with global PHP classes (e.g. not using PHP namespaces)
     must maintain the ``class`` parameter. For example, when using the old Twig
     classes (e.g. ``Twig_Extensions_Extension_Intl`` instead of ``Twig\Extensions\IntlExtension``),
     you can't redefine the service as ``Twig_Extensions_Extension_Intl: ~`` and

--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -49,7 +49,7 @@ When overriding an existing definition, the original service is lost:
         $container->register(Mailer::class, NewMailer::class);
 
 Most of the time, that's exactly what you want to do. But sometimes,
-you might want to decorate the old one instead (i.e. apply the `Decorator pattern`_).
+you might want to decorate the old one instead (e.g. apply the `Decorator pattern`_).
 In this case, the old service should be kept around to be able to reference
 it in the new one. This configuration replaces ``App\Mailer`` with a new one,
 but keeps a reference of the old one as ``App\DecoratingMailer.inner``:

--- a/session/locale_sticky_session.rst
+++ b/session/locale_sticky_session.rst
@@ -52,7 +52,7 @@ correct locale however you want::
         public static function getSubscribedEvents()
         {
             return [
-                // must be registered before (i.e. with a higher priority than) the default Locale listener
+                // must be registered before (e.g. with a higher priority than) the default Locale listener
                 KernelEvents::REQUEST => [['onKernelRequest', 20]],
             ];
         }

--- a/setup/_vendor_deps.rst.inc
+++ b/setup/_vendor_deps.rst.inc
@@ -53,7 +53,7 @@ script to ensure that all of the needed vendor libraries are downloaded.
     their state in the latest Symfony Standard Edition.
 
     Of course, if you've added new entries to ``composer.json``, be sure
-    to replace only the original parts (i.e. be sure not to also delete any of
+    to replace only the original parts (e.g. be sure not to also delete any of
     your custom entries).
 
 .. _Composer: https://getcomposer.org/

--- a/setup/built_in_web_server.rst
+++ b/setup/built_in_web_server.rst
@@ -72,7 +72,7 @@ can change the socket passing an IP address and a port as a command-line argumen
     # passing a specific IP and port
     $ php bin/console server:start 192.168.0.1:8080
 
-    # passing '*' as the IP means to use 0.0.0.0 (i.e. any local IP address)
+    # passing '*' as the IP means to use 0.0.0.0 (e.g. any local IP address)
     $ php bin/console server:start *:8080
 
 .. versionadded:: 3.4
@@ -100,7 +100,7 @@ can change the socket passing an IP address and a port as a command-line argumen
 
     If you want to use the built-in web server from inside a virtual machine
     and then load the site from a browser on your host machine, you'll need
-    to listen on the ``0.0.0.0:8000`` address (i.e. on all IP addresses that
+    to listen on the ``0.0.0.0:8000`` address (e.g. on all IP addresses that
     are assigned to the virtual machine):
 
     .. code-block:: terminal

--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -326,7 +326,7 @@ The **minimum configuration** to get your application running under Nginx is:
 .. caution::
 
     After you deploy to production, make sure that you **cannot** access the ``app_dev.php``
-    or ``config.php`` scripts (i.e. ``http://example.com/app_dev.php`` and ``http://example.com/config.php``).
+    or ``config.php`` scripts (e.g. ``http://example.com/app_dev.php`` and ``http://example.com/config.php``).
     If you *can* access these, be sure to remove the ``DEV`` section from the above configuration.
 
 .. note::

--- a/templating.rst
+++ b/templating.rst
@@ -314,7 +314,7 @@ By default, templates can live in two different locations:
 
 ``app/Resources/views/``
     The application's ``views`` directory can contain application-wide base templates
-    (i.e. your application's layouts and templates of the application bundle) as
+    (e.g. your application's layouts and templates of the application bundle) as
     well as templates that override third party bundle templates
     (see :doc:`/templating/overriding`).
 
@@ -464,7 +464,7 @@ you set `with_context`_ to false).
 .. tip::
 
     The ``{'article': article}`` syntax is the standard Twig syntax for hash
-    maps (i.e. an array with named keys). If you needed to pass in multiple
+    maps (e.g. an array with named keys). If you needed to pass in multiple
     elements, it would look like this: ``{'foo': foo, 'bar': bar}``.
 
 .. index::

--- a/templating/embedding_controllers.rst
+++ b/templating/embedding_controllers.rst
@@ -59,7 +59,7 @@ the controller:
     {% endfor %}
 
 Finally, call the controller from any template using the ``render()`` function
-and the common syntax for controllers (i.e. **bundle**:**controller**:**action**):
+and the common syntax for controllers (e.g. **bundle**:**controller**:**action**):
 
 .. code-block:: html+twig
 

--- a/templating/global_variables.rst
+++ b/templating/global_variables.rst
@@ -1,7 +1,7 @@
 .. index::
    single: Templating; Global variables
 
-How to Inject Variables into all Templates (i.e. global Variables)
+How to Inject Variables into all Templates (e.g. global Variables)
 ==================================================================
 
 Sometimes you want a variable to be accessible to all the templates you use.

--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -104,7 +104,7 @@ is the simplest way to create extensions. However, Twig must initialize all
 extensions before rendering any template, even if the template doesn't use an
 extension.
 
-If extensions don't define dependencies (i.e. if you don't inject services in
+If extensions don't define dependencies (e.g. if you don't inject services in
 them) performance is not affected. However, if extensions define lots of complex
 dependencies (e.g. those making database connections), the performance loss can
 be significant.

--- a/testing/bootstrap.rst
+++ b/testing/bootstrap.rst
@@ -48,5 +48,5 @@ cache to be cleared:
         </php>
     </phpunit>
 
-This now becomes an environment variable (i.e. ``$_ENV``) that's available
+This now becomes an environment variable (e.g. ``$_ENV``) that's available
 in the custom bootstrap file (``tests/bootstrap.php``).

--- a/translation.rst
+++ b/translation.rst
@@ -7,7 +7,7 @@ Translations
 The term "internationalization" (often abbreviated `i18n`_) refers to the
 process of abstracting strings and other locale-specific pieces out of your
 application into a layer where they can be translated and converted based
-on the user's locale (i.e. language and country). For text, this means
+on the user's locale (e.g. language and country). For text, this means
 wrapping each with a function capable of translating the text (or "message")
 into the language of the user::
 
@@ -36,7 +36,7 @@ to learn even more. Overall, the process has several steps:
 #. :ref:`Enable and configure <translation-configuration>` Symfony's
    translation service;
 
-#. Abstract strings (i.e. "messages") by wrapping them in calls to the
+#. Abstract strings (e.g. "messages") by wrapping them in calls to the
    ``Translator`` (":ref:`translation-basic`");
 
 #. :ref:`Create translation resources/files <translation-resources>`
@@ -358,7 +358,7 @@ with these tasks:
 Translation Resource/File Names and Locations
 ---------------------------------------------
 
-Symfony looks for message files (i.e. translations) in the following default locations:
+Symfony looks for message files (e.g. translations) in the following default locations:
 
 * the ``translations/`` directory (at the root of the project);
 

--- a/translation/locale.rst
+++ b/translation/locale.rst
@@ -15,7 +15,7 @@ via the ``Request`` object::
     }
 
 To set the user's locale, you may want to create a custom event listener so
-that it's set before any other parts of the system (i.e. the translator) need
+that it's set before any other parts of the system (e.g. the translator) need
 it::
 
         public function onKernelRequest(GetResponseEvent $event)

--- a/validation.rst
+++ b/validation.rst
@@ -112,7 +112,7 @@ Using the ``validator`` Service
 
 Next, to actually validate an ``Author`` object, use the ``validate()`` method
 on the ``validator`` service (class :class:`Symfony\\Component\\Validator\\Validator`).
-The job of the ``validator`` is easy: to read the constraints (i.e. rules)
+The job of the ``validator`` is easy: to read the constraints (e.g. rules)
 of a class and verify if the data on the object satisfies those
 constraints. If validation fails, a non-empty list of errors
 (class :class:`Symfony\\Component\\Validator\\ConstraintViolationList`) is
@@ -275,7 +275,7 @@ previous configuration by the following:
 Constraints
 -----------
 
-The ``validator`` is designed to validate objects against *constraints* (i.e.
+The ``validator`` is designed to validate objects against *constraints* (e.g.
 rules). In order to validate an object, simply map one or more constraints
 to its class and then pass it to the ``validator`` service.
 

--- a/validation/groups.rst
+++ b/validation/groups.rst
@@ -169,9 +169,9 @@ the class name or the string ``Default``.
     object that's actually the one being validated.
 
     If you have inheritance (e.g. ``User extends BaseUser``) and you validate
-    with the class name of the subclass (i.e. ``User``), then all constraints
+    with the class name of the subclass (e.g. ``User``), then all constraints
     in the ``User`` and ``BaseUser`` will be validated. However, if you
-    validate using the base class (i.e. ``BaseUser``), then only the default
+    validate using the base class (e.g. ``BaseUser``), then only the default
     constraints in the ``BaseUser`` class will be validated.
 
 To tell the validator to use a specific group, pass one or more group names

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -11,7 +11,7 @@ to that describes the action to get from one place to another.
 .. image:: /_images/components/workflow/states_transitions.png
 
 A set of places and transitions creates a **definition**. A workflow needs
-a ``Definition`` and a way to write the states to the objects (i.e. an
+a ``Definition`` and a way to write the states to the objects (e.g. an
 instance of a :class:`Symfony\\Component\\Workflow\\MarkingStore\\MarkingStoreInterface`.)
 
 Consider the following example for a blog post. A post can have places:
@@ -197,7 +197,7 @@ Using Events
 
 To make your workflows more flexible, you can construct the ``Workflow``
 object with an ``EventDispatcher``. You can now create event listeners to
-block transitions (i.e. depending on the data in the blog post) and do
+block transitions (e.g. depending on the data in the blog post) and do
 additional actions when a workflow operation happened (e.g. sending
 announcements).
 


### PR DESCRIPTION
Refs https://github.com/symfony/symfony-docs/pull/11078#discussion_r268124778

Before this change there were **~550** occurences of `e.g.` and only **~150** occurences of `i.e.` in the docs.
@javiereguiluz told me (and his feeling seems to be correct), that `e.g.` is used most of the time.

This PR brings consistency about this.