### PR TITLE
[WiP] Document Workflow 4.3 changes

### DIFF
--- a/workflow/state-machines.rst
+++ b/workflow/state-machines.rst
@@ -35,7 +35,7 @@ Below is the configuration for the pull request state machine.
                     type: 'state_machine'
                     supports:
                         - App\Entity\PullRequest
-                    initial_place: start
+                    initial_marking: [start]
                     places:
                         - start
                         - coding
@@ -79,7 +79,7 @@ Below is the configuration for the pull request state machine.
 
             <framework:config>
                 <framework:workflow name="pull_request" type="state_machine">
-                    <framework:marking-store type="single_state"/>
+                    <framework:initial-marking>start</framework:initial-marking>
 
                     <framework:support>App\Entity\PullRequest</framework:support>
 
@@ -147,6 +147,7 @@ Below is the configuration for the pull request state machine.
             'workflows' => [
                 'pull_request' => [
                   'type' => 'state_machine',
+                  'initial_marking' => ['start']
                   'supports' => ['App\Entity\PullRequest'],
                   'places' => [
                     'start',

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -43,13 +43,12 @@ like this:
                     audit_trail:
                         enabled: true
                     marking_store:
-                        type: 'method'
-                        arguments:
-                            - false
-                            - 'currentPlace'
+                        # Method will become the default value in Symfony 5.0
+                        type: method
+                        property: currentPlace
                     supports:
                         - App\Entity\BlogPost
-                    initial_places: [draft]
+                    initial_marking: [draft]
                     places:
                         - draft
                         - review
@@ -81,10 +80,9 @@ like this:
                 <framework:workflow name="blog_publishing" type="workflow">
                     <framework:audit-trail enabled="true"/>
 
-                    <framework:marking-store type="method">
-                      <framework:argument>false</framework:argument>
-                      <framework:argument>currentPlace</framework:argument>
-                    </framework:marking-store>
+                    <framework:initial-marking>draft</framework:initial-marking>
+                    <!-- Method will become the default value in Symfony 5.0 -->
+                    <framework:marking-store type="method" property="state" />
 
                     <framework:support>App\Entity\BlogPost</framework:support>
 
@@ -129,14 +127,12 @@ like this:
                         'enabled' => true
                     ],
                     'marking_store' => [
+                        // Method will become the default value in Symfony 5.0
                         'type' => 'method',
-                        'arguments' => [
-                            false,
-                            'currentPlace',
-                        ],
+                        'property' => 'currentPlace',
                     ],
                     'supports' => ['App\Entity\BlogPost'],
-                    'initial_places' => ['draft'],
+                    'initial_marking' => ['draft'],
                     'places' => [
                         'draft',
                         'review',
@@ -174,14 +170,18 @@ As configured, the following property is used by the marking store::
 .. note::
 
     The Workflow Component supports workflows that can be in one or multiple places
-    (states) at the same time. To restrict a workflow to a single state, set the first
-    argument to ``true`` when defining the ``marking_store``.
+    (states) at the same time.
+
+    If the subject can be in only on state: use a state machine. In that case, the
+    property (named ``marking`` by default) will be a string.
+
+    If the subject can be in many places: use a workflow. In that case, the property will be an array.
 
 .. tip::
 
-    The ``type`` (default value ``method``) and ``arguments`` (default
-    values ``false`` and ``marking``) attributes of the ``marking_store`` option are optional.
-    If omitted, their default values will be used.
+    The ``type`` (default value ``method``) and ``property`` (default
+    value ``marking``) attributes of the ``marking_store`` option are optional.
+    If omitted, the default values will be used.
 
 .. tip::
 

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -49,7 +49,7 @@ like this:
                             - 'currentPlace'
                     supports:
                         - App\Entity\BlogPost
-                    initial_place: draft
+                    initial_places: [draft]
                     places:
                         - draft
                         - review
@@ -136,6 +136,7 @@ like this:
                         ],
                     ],
                     'supports' => ['App\Entity\BlogPost'],
+                    'initial_places' => ['draft'],
                     'places' => [
                         'draft',
                         'review',


### PR DESCRIPTION
Document the changes in https://github.com/symfony/workflow/blob/master/CHANGELOG.md and https://github.com/symfony/symfony/blob/master/UPGRADE-4.3.md#workflow:

- [x] Deprecate `multiple_state` and `single_state`. Done, but pending outcome of https://github.com/symfony/symfony/issues/30656

- [x] `initial_place` is deprecated in favour of `initial_places`. Done, but pending outcome of https://github.com/symfony/symfony/issues/30656

- [ ] Transition styling via metadata for dumps (see https://github.com/symfony/symfony/pull/29538 for details / examples)

WiP, more to be added. Community input/commits _very_ welcome!