### PR TITLE
Document Transition Blockers

### DIFF
--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -510,9 +510,9 @@ was blocked. You can access the message from Twig. Here's an example:
 
         public static function getSubscribedEvents()
         {
-            return array(
-                'workflow.blogpost.guard.publish' => array('guardPublish'),
-            );
+            return [
+                'workflow.blogpost.guard.publish' => ['guardPublish'],
+            ];
         }
     }
 

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -511,7 +511,7 @@ was blocked. You can access the message from Twig. Here's an example:
         public static function getSubscribedEvents()
         {
             return array(
-                'workflow.blogpost.guard.to_publish' => array('guardPublish'),
+                'workflow.blogpost.guard.publish' => array('guardPublish'),
             );
         }
     }

--- a/workflow/usage.rst
+++ b/workflow/usage.rst
@@ -475,3 +475,70 @@ The following example shows these functions in action:
     {% if 'waiting_some_approval' in workflow_marked_places(post) %}
         <span class="label">PENDING</span>
     {% endif %}
+
+Transition Blockers
+-------------------
+
+.. versionadded:: 4.1
+    Transition Blockers were introduced in Symfony 4.1.
+
+Transition Blockers provide a simple way to return a human-readable message for why a transition
+was blocked. You can access the message from Twig. Here's an example:
+
+
+.. code-block:: php
+
+    use Symfony\Component\Workflow\Event\GuardEvent;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    class BlogPostPublishListener implements EventSubscriberInterface
+    {
+        public function guardPublish(GuardEvent $event)
+        {
+            /** @var \App\Entity\BlogPost $post */
+            $post = $event->getSubject();
+
+            // If it's after 9pm, prevent publication
+            if (date('H') > 21) {
+                $event->addTransitionBlocker(
+                    new TransitionBlocker(
+                        "You can not publish this blog post because it's too late. Try again tomorrow morning."
+                    )
+                );
+            }
+        }
+
+        public static function getSubscribedEvents()
+        {
+            return array(
+                'workflow.blogpost.guard.to_publish' => array('guardPublish'),
+            );
+        }
+    }
+
+.. code-block:: html+twig
+
+    <h2>Publication was blocked because:</h2>
+    <ul>
+        {% for transition in workflow_all_transitions(article) %}
+            {% if not workflow_can(article, transition.name) %}
+                <li>
+                    <strong>{{ transition.name }}</strong>:
+                    <ul>
+                    {% for blocker in workflow_build_transition_blocker_list(article, transition.name) %}
+                        <li>
+                            {{ blocker.message }}
+                            {% if blocker.parameters.expression is defined %}
+                                <code>{{ blocker.parameters.expression }}</code>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+        {% endfor %}
+    </ul>
+
+Don't need a human-readable message? You can still use::
+
+    $event->setBlocked('true');


### PR DESCRIPTION
The explanation needs expanding; the example is full-fledged.

Question: do the second and third parameters to `new TransitionBlocker()` need to be demonstrated in the example?