### PR TITLE
Fixing minor error

### DIFF
--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -207,9 +207,9 @@ loading all entities.
 
 .. caution::
 
-    The entity used in the ``FROM`` clause of the `query_builder`_ option
-    will always be validated against the class which you have specified with
-    the form's `class`_ option. If you return another entity instead of the
+    The entity used in the ``FROM`` clause of the `query_builder` option
+    will always be validated against the class which you have specified at the
+    `class`_ option. If you return another entity instead of the
     one used in your ``FROM`` clause (for instance if you return an entity
     from a joined table), it will break validation.
     


### PR DESCRIPTION
It's not the *form*'s class option, but the class option of the current field. Also removed the unnecessary self-referencing link.