### PR TITLE
Remove CustomUserMessageAuthenticationException

### DIFF
--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -38,11 +38,6 @@ are not met, an exception should be thrown which extends the
             // user is deleted, show a generic Account Not Found message.
             if ($user->isDeleted()) {
                 throw new AccountDeletedException('...');
-
-                // or to customize the message shown
-                throw new CustomUserMessageAuthenticationException(
-                    'Your account was deleted. Sorry about that!'
-                );
             }
         }
 


### PR DESCRIPTION
Remove the use of `CustomUserMessageAuthenticationException`, as this is not compatible with the `@throws` tag of the interface.
Since `AccountDeletedException` is implemented by the user here, they could let it take a custom message.

This statement is only in the 4.2 docs, not the 3.4

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
