### PR TITLE
change the meaning of the sentence

### DIFF
--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -425,8 +425,8 @@ been run, use::
 
 You can also control the order in which compiler passes are run for each
 compilation phase. Use the optional third argument of ``addCompilerPass()`` to
-set the priority as an integer number. The default priority is ``0`` and the higher
-its value, the earlier it's executed::
+set the priority as an integer number. The default priority is ``0`` and the smaller
+the value is, the earlier it's executed::
 
     // ...
     // FirstPass is executed after SecondPass because its priority is lower


### PR DESCRIPTION
The initial sentence indicates the opposite of the reality

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
