### PR TITLE
Fix the example about overriding the getProjectDir method

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -231,7 +231,7 @@ kernel and return your project's root directory::
 
         public function getProjectDir()
         {
-            return __DIR__.'/..';
+            return dirname(__DIR__);
         }
     }
 


### PR DESCRIPTION
This method must return the canonical path for things to work fine everywhere.
