### PR TITLE
Detailed AMQP dependency

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -202,12 +202,12 @@ This will also configure the following services for you:
 
 .. note::
 
-    In order to use Symfony's built-in AMQP transport, you will need the Serializer
-    Component. Ensure that it is installed with:
+    In order to use Symfony's built-in AMQP transport, you will need the AMQP
+    PHP extension and the Serializer Component. Ensure that they are installed with:
 
     .. code-block:: terminal
 
-        $ composer require symfony/serializer-pack
+        $ composer require symfony/amqp-pack
 
 Routing
 -------


### PR DESCRIPTION
Installing the Serializer bundle is not sufficient, you must also have the AMQP PHP extension.
Both the Serializer bundle and the AMQP PHP extension are required by the `amqp-pack`.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
