### PR TITLE
[Console] uncomment the "Before" code part

### DIFF
--- a/console/style.rst
+++ b/console/style.rst
@@ -365,10 +365,11 @@ of your commands to change their appearance::
         protected function execute(InputInterface $input, OutputInterface $output)
         {
             // Before
-            // $io = new SymfonyStyle($input, $output);
+            $io = new SymfonyStyle($input, $output);
 
             // After
             $io = new CustomStyle($input, $output);
+
             // ...
         }
     }


### PR DESCRIPTION
for better syntax highlighting

The current version:
![Screenshot 2019-03-29 10 58 30](https://user-images.githubusercontent.com/995707/55224862-a48aeb00-5211-11e9-8139-e7bac0f566c8.png)
