### PR TITLE
Fix template name reference

### DIFF
--- a/bundles/override.rst
+++ b/bundles/override.rst
@@ -45,7 +45,7 @@ extend from the original template, not from the overridden one:
 
     {# templates/bundles/FOSUserBundle/Registration/confirmed.html.twig #}
     {# the special '!' prefix avoids errors when extending from an overridden template #}
-    {% extends "@!FOSUserBundle/Registration/confirmed.html.twig" %}
+    {% extends "@!FOSUser/Registration/confirmed.html.twig" %}
 
     {% block some_block %}
         ...


### PR DESCRIPTION
As written here https://symfony.com/doc/current/templating.html#referencing-templates-in-a-bundle
it seems that `{% extends "@!FOSUserBundle/Registration/confirmed.html.twig" %}` is not correct.

> @AcmeBlog/Blog/index.html.twig: This syntax is used to specify a template for a specific page. The three parts of the string, each 
> separated by a slash (/), mean the following:
>
>    @AcmeBlog: is the bundle name **without** the Bundle suffix. This template lives in the AcmeBlogBundle (e.g. src/Acme/BlogBundle);

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
