### PR TITLE
[Form] Add example for createNamed Form

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -676,7 +676,23 @@ choice is ultimately up to you.
 .. note::
 
     The form name is automatically generated from the type class name. If you want
-    to modify it, use the :method:`Symfony\\Component\\Form\\FormFactoryInterface::createNamed` method.
+    to modify it, use the :method:`Symfony\\Component\\Form\\FormFactoryInterface::createNamed` method::
+
+        // src/AppBundle/Controller/DefaultController.php
+        use AppBundle\Form\TaskType;
+        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+        class DefaultController extends AbstractController 
+        {
+            public function newAction()
+            {
+                $task = ...;
+                $form = $this->get('form.factory')->createNamed('name', TaskType::class, $task);
+
+                // ...
+            }
+        }
+
     You can even suppress the name completely by setting it to an empty string.
 
 Final Thoughts


### PR DESCRIPTION
The docs are not very clear where the FormFactory comes from and how to use this method

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
