### PR TITLE
Alias Monolog\Formatter\JsonFormatter instead of creating a new one

### DIFF
--- a/logging/formatter.rst
+++ b/logging/formatter.rst
@@ -17,7 +17,7 @@ configure your handler to use it:
         services:
             # ...
 
-            Monolog\Formatter\JsonFormatter: ~
+            Monolog\Formatter\JsonFormatter: '@monolog.formatter.json'
 
         # app/config/config_prod.yml (and/or config_dev.yml)
         monolog:


### PR DESCRIPTION
Let me know if I am wrong but I thought it would be more reliable to use MonologBundle service instead of creating a new one.