### PR TITLE
added requirements for {_format}

### DIFF
--- a/templating/formats.rst
+++ b/templating/formats.rst
@@ -51,7 +51,7 @@ be configured so that ``/about-us`` sets the request format to ``html`` while
 special ``_format`` placeholder in your route definition::
 
     /**
-     * @Route("/{slug}.{_format}", defaults={"_format"="html"})
+     * @Route("/{slug}.{_format}", defaults={"_format"="html"}, requirements={"_format"="html|xml"}))
      */
     public function showAction(Request $request, $slug)
     {


### PR DESCRIPTION
I added requirements for the `{_format}` parameter: in this example `_format` should be `xml` or `html`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
