### PR TITLE
 Remove GitHub references

### DIFF
--- a/components/asset.rst
+++ b/components/asset.rst
@@ -46,8 +46,6 @@ Installation
 
     $ composer require symfony/asset
 
-Alternatively, you can clone the `<https://github.com/symfony/asset>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -21,8 +21,6 @@ Installation
 
     $ composer require symfony/browser-kit
 
-Alternatively, you can clone the `<https://github.com/symfony/browser-kit>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Basic Usage

--- a/components/cache.rst
+++ b/components/cache.rst
@@ -25,8 +25,6 @@ Installation
 
     $ composer require symfony/cache
 
-Alternatively, you can clone the `<https://github.com/symfony/cache>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Cache (PSR-6) Versus Simple Cache (PSR-16)

--- a/components/config.rst
+++ b/components/config.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/config
 
-Alternatively, you can clone the `<https://github.com/symfony/config>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Learn More

--- a/components/console.rst
+++ b/components/console.rst
@@ -19,8 +19,6 @@ Installation
 
     $ composer require symfony/console
 
-Alternatively, you can clone the `<https://github.com/symfony/console>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Creating a Console Application

--- a/components/css_selector.rst
+++ b/components/css_selector.rst
@@ -14,8 +14,6 @@ Installation
 
     $ composer require symfony/css-selector
 
-Alternatively, you can clone the `<https://github.com/symfony/css-selector>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/debug.rst
+++ b/components/debug.rst
@@ -14,8 +14,6 @@ Installation
 
     $ composer require symfony/debug
 
-Alternatively, you can clone the `<https://github.com/symfony/debug>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -19,8 +19,6 @@ Installation
 
     $ composer require symfony/dependency-injection
 
-Alternatively, you can clone the `<https://github.com/symfony/dependency-injection>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Basic Usage

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -19,8 +19,6 @@ Installation
 
     $ composer require symfony/dom-crawler
 
-Alternatively, you can clone the `<https://github.com/symfony/dom-crawler>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/dotenv.rst
+++ b/components/dotenv.rst
@@ -19,8 +19,6 @@ Installation
 
     $ composer require --dev symfony/dotenv
 
-Alternatively, you can clone the `<https://github.com/symfony/dotenv>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -56,8 +56,6 @@ Installation
 
     $ composer require symfony/event-dispatcher
 
-Alternatively, you can clone the `<https://github.com/symfony/event-dispatcher>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/expression_language.rst
+++ b/components/expression_language.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/expression-language
 
-Alternatively, you can clone the `<https://github.com/symfony/expression-language>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 How can the Expression Engine Help Me?

--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -13,8 +13,6 @@ Installation
 
     $ composer require symfony/filesystem
 
-Alternatively, you can clone the `<https://github.com/symfony/filesystem>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -15,8 +15,6 @@ Installation
 
     $ composer require symfony/finder
 
-Alternatively, you can clone the `<https://github.com/symfony/finder>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/form.rst
+++ b/components/form.rst
@@ -20,8 +20,6 @@ Installation
 
     $ composer require symfony/form
 
-Alternatively, you can clone the `<https://github.com/symfony/form>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Configuration

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -23,8 +23,6 @@ Installation
 
     $ composer require symfony/http-foundation
 
-Alternatively, you can clone the `<https://github.com/symfony/http-foundation>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 .. seealso::

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -18,8 +18,6 @@ Installation
 
     $ composer require symfony/http-kernel
 
-Alternatively, you can clone the `<https://github.com/symfony/http-kernel>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 The Workflow of a Request

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -26,8 +26,6 @@ Installation
 
     $ composer require symfony/intl
 
-Alternatively, you can clone the `<https://github.com/symfony/intl>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 If you install the component via Composer, the following classes and functions

--- a/components/ldap.rst
+++ b/components/ldap.rst
@@ -14,8 +14,6 @@ Installation
 
     $ composer require symfony/ldap
 
-Alternatively, you can clone the `<https://github.com/symfony/ldap>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/lock.rst
+++ b/components/lock.rst
@@ -19,8 +19,6 @@ Installation
 
     $ composer require symfony/lock
 
-Alternatively, you can clone the `<https://github.com/symfony/lock>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/options-resolver
 
-Alternatively, you can clone the `<https://github.com/symfony/options-resolver>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -30,8 +30,6 @@ Installation
 
     $ composer require --dev "symfony/phpunit-bridge:*"
 
-Alternatively, you can clone the `<https://github.com/symfony/phpunit-bridge>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 .. note::

--- a/components/polyfill_apcu.rst
+++ b/components/polyfill_apcu.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-apcu
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-apcu>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_ctype.rst
+++ b/components/polyfill_ctype.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-ctype
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-ctype>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_iconv.rst
+++ b/components/polyfill_iconv.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-iconv
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-iconv>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_intl_grapheme.rst
+++ b/components/polyfill_intl_grapheme.rst
@@ -17,8 +17,6 @@ Installation
 
     $ composer require symfony/polyfill-intl-grapheme
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-intl-grapheme>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_intl_icu.rst
+++ b/components/polyfill_intl_icu.rst
@@ -17,8 +17,6 @@ Installation
 
     $ composer require symfony/polyfill-intl-icu
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-intl-icu>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_intl_idn.rst
+++ b/components/polyfill_intl_idn.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-intl-idn
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-intl-idn>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_intl_messageformatter.rst
+++ b/components/polyfill_intl_messageformatter.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-intl-messageformatter
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-intl-messageformatter>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_intl_normalizer.rst
+++ b/components/polyfill_intl_normalizer.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-intl-normalizer
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-intl-normalizer>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_mbstring.rst
+++ b/components/polyfill_mbstring.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-mbstring
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-mbstring>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_php54.rst
+++ b/components/polyfill_php54.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-php54
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-php54>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_php55.rst
+++ b/components/polyfill_php55.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-php55
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-php55>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_php56.rst
+++ b/components/polyfill_php56.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-php56
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-php56>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_php70.rst
+++ b/components/polyfill_php70.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-php70
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-php70>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_php71.rst
+++ b/components/polyfill_php71.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-php71
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-php71>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_php72.rst
+++ b/components/polyfill_php72.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-php72
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-php72>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/polyfill_php73.rst
+++ b/components/polyfill_php73.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require symfony/polyfill-php73
 
-Alternatively, you can clone the `<https://github.com/symfony/polyfill-php73>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/process.rst
+++ b/components/process.rst
@@ -14,7 +14,6 @@ Installation
 
     $ composer require symfony/process
 
-Alternatively, you can clone the `<https://github.com/symfony/process>`_ repository.
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/property_access.rst
+++ b/components/property_access.rst
@@ -15,8 +15,6 @@ Installation
 
     $ composer require symfony/property-access
 
-Alternatively, you can clone the `<https://github.com/symfony/property-access>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -23,8 +23,6 @@ Installation
 
     $ composer require symfony/property-info
 
-Alternatively, you can clone the `<https://github.com/symfony/property-info>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Additional dependencies may be required for some of the

--- a/components/psr7.rst
+++ b/components/psr7.rst
@@ -15,8 +15,6 @@ Installation
 
     $ composer require symfony/psr-http-message-bridge
 
-Alternatively, you can clone the `<https://github.com/symfony/psr-http-message-bridge>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 The bridge also needs a PSR-7 and `PSR-17`_ implementation to convert

--- a/components/routing.rst
+++ b/components/routing.rst
@@ -15,8 +15,6 @@ Installation
 
     $ composer require symfony/routing
 
-Alternatively, you can clone the `<https://github.com/symfony/routing>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/security.rst
+++ b/components/security.rst
@@ -18,8 +18,6 @@ Installation
 
     $ composer require symfony/security
 
-Alternatively, you can clone the `<https://github.com/symfony/security>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 The Security component is divided into several smaller sub-components which can

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -28,8 +28,6 @@ Installation
 
     $ composer require symfony/serializer
 
-Alternatively, you can clone the `<https://github.com/symfony/serializer>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 To use the ``ObjectNormalizer``, the :doc:`PropertyAccess component </components/property_access>`

--- a/components/stopwatch.rst
+++ b/components/stopwatch.rst
@@ -14,8 +14,6 @@ Installation
 
     $ composer require symfony/stopwatch
 
-Alternatively, you can clone the `<https://github.com/symfony/stopwatch>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/templating.rst
+++ b/components/templating.rst
@@ -20,8 +20,6 @@ Installation
 
     $ composer require symfony/templating
 
-Alternatively, you can clone the `<https://github.com/symfony/templating>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/translation.rst
+++ b/components/translation.rst
@@ -15,8 +15,6 @@ Installation
 
     $ composer require symfony/translation
 
-Alternatively, you can clone the `<https://github.com/symfony/translation>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 .. seealso::

--- a/components/validator.rst
+++ b/components/validator.rst
@@ -15,8 +15,6 @@ Installation
 
     $ composer require symfony/validator
 
-Alternatively, you can clone the `<https://github.com/symfony/validator>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require --dev symfony/var-dumper
 
-Alternatively, you can clone the `<https://github.com/symfony/var-dumper>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 .. note::

--- a/components/web_link.rst
+++ b/components/web_link.rst
@@ -15,8 +15,6 @@ Installation
 
     $ composer require symfony/web-link
 
-Alternatively, you can clone the `<https://github.com/symfony/weblink>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/workflow.rst
+++ b/components/workflow.rst
@@ -19,8 +19,6 @@ Installation
 
     $ composer require symfony/workflow
 
-Alternatively, you can clone the `<https://github.com/symfony/workflow>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Creating a Workflow

--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -33,8 +33,6 @@ Installation
 
     $ composer require symfony/yaml
 
-Alternatively, you can clone the `<https://github.com/symfony/yaml>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Why?


### PR DESCRIPTION
Fixes #11295 for #EUFOSSA

I will open a second PR for 4.2 as there are some new components that need to be changed as well, namely:

* Mercure
* Messenger
* VarExporter
* WebLink