### PR TITLE
Remove GitHub references

### DIFF
--- a/components/mercure.rst
+++ b/components/mercure.rst
@@ -20,8 +20,6 @@ Installation
 
     $ composer require symfony/mercure
 
-Alternatively, you can clone the `<https://github.com/symfony/mercure>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage

--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -24,8 +24,6 @@ Installation
 
     $ composer require symfony/messenger
 
-Alternatively, you can clone the `<https://github.com/symfony/messenger>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Concepts

--- a/components/var_exporter.rst
+++ b/components/var_exporter.rst
@@ -16,8 +16,6 @@ Installation
 
     $ composer require --dev symfony/var-exporter
 
-Alternatively, you can clone the `<https://github.com/symfony/var-exporter>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Exporting/Serializing Variables

--- a/components/web_link.rst
+++ b/components/web_link.rst
@@ -15,8 +15,6 @@ Installation
 
     $ composer require symfony/web-link
 
-Alternatively, you can clone the `<https://github.com/symfony/web-link>`_ repository.
-
 .. include:: /components/require_autoload.rst.inc
 
 Usage


### PR DESCRIPTION
Fixes #11295 for #EUFOSSA

See also #11306 aimed at 3.4 for the remaining references.