### PR TITLE
fix typo `spaccer` => `spacer`

### DIFF
--- a/components/mime.rst
+++ b/components/mime.rst
@@ -549,7 +549,7 @@ contents from Inky to HTML:
         <container>
             <row class="header">
                 <columns>
-                    <spaccer size="16"></spacer>
+                    <spacer size="16"></spacer>
                     <h1 class="text-center">Welcome {{ username }}!</h1>
                 </columns>
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
