### PR TITLE
Adds documentation for monolog processors.

### DIFF
--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -160,6 +160,16 @@ If you use several handlers, you can also register a processor at the
 handler level or at the channel level instead of registering it globally
 (see the following sections).
 
+Symfony's MonologBridge provides processors that can be registered inside your application.
+
+* :class:`Symfony\\Bridge\\Monolog\\Processor\\DebugProcessor` adds additional information useful for debugging like a timestamp or an error message to the record.
+* :class:`Symfony\\Bridge\\Monolog\\Processor\\TokenProcessor` adds information from the current user's token to the record namely username, roles and whether the user is authenticated.
+* :class:`Symfony\\Bridge\\Monolog\\Processor\\WebProcessor` overrides data from the request using the data inside Symfony's request object.
+
+.. versionadded:: 3.4
+
+    The :class:`Symfony\\Bridge\\Monolog\\Processor\\TokenProcessor` class was added in Symfony 3.4.
+
 Registering Processors per Handler
 ----------------------------------
 


### PR DESCRIPTION
Adds both a short description for existing processors as well as a note for the newly added TokenProcessor added in 3.4. I tried not to interfere with #10244 as this introduces documentation for more processors added in 4.3, so that PR hopefully can build on this one.

Replaces #8156

EUFOSSA