### PR TITLE
Made ChoiceType callback parameters consistent

### DIFF
--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -94,18 +94,17 @@ method::
             new Category('Cat3'),
             new Category('Cat4'),
         ],
-        'choice_label' => function($category, $key, $value) {
-            /** @var Category $category */
+        'choice_label' => function(Category $category, $key, $value) {
             return strtoupper($category->getName());
         },
-        'choice_attr' => function($category, $key, $value) {
+        'choice_attr' => function(Category $category, $key, $value) {
             return ['class' => 'category_'.strtolower($category->getName())];
         },
-        'group_by' => function($category, $key, $value) {
+        'group_by' => function(Category $category, $key, $value) {
             // randomly assign things into 2 groups
             return rand(0, 1) == 1 ? 'Group A' : 'Group B';
         },
-        'preferred_choices' => function($category, $key, $value) {
+        'preferred_choices' => function(Category $category, $key, $value) {
             return $category->getName() == 'Cat2' || $category->getName() == 'Cat3';
         },
     ]);

--- a/reference/forms/types/options/choice_attr.rst.inc
+++ b/reference/forms/types/options/choice_attr.rst.inc
@@ -19,7 +19,7 @@ If an array, the keys of the ``choices`` array must be used as keys::
             'No' => false,
             'Maybe' => null,
         ],
-        'choice_attr' => function($choiceValue, $key, $value) {
+        'choice_attr' => function($choice, $key, $value) {
             // adds a class like attending_yes, attending_no, etc
             return ['class' => 'attending_'.strtolower($key)];
         },

--- a/reference/forms/types/options/choice_label.rst.inc
+++ b/reference/forms/types/options/choice_label.rst.inc
@@ -16,8 +16,8 @@ more control::
             'no' => false,
             'maybe' => null,
         ],
-        'choice_label' => function ($value, $key, $choiceValue) {
-            if (true === $value) {
+        'choice_label' => function ($choice, $key, $value) {
+            if (true === $choice) {
                 return 'Definitely!';
             }
 
@@ -28,8 +28,8 @@ more control::
         },
     ]);
 
-This method is called for *each* choice, passing you the ``$value`` and 
-``$key`` from the choices array (additional ``$choiceValue`` is related to `choice_value`_). 
+This method is called for *each* choice, passing you the ``$choice`` and
+``$key`` from the choices array (additional ``$value`` is related to `choice_value`_).
 This will give you:
 
 .. image:: /_images/reference/form/choice-example2.png

--- a/reference/forms/types/options/group_by.rst.inc
+++ b/reference/forms/types/options/group_by.rst.inc
@@ -22,8 +22,8 @@ Take the following example::
             '1 week' => new \DateTime('+1 week'),
             '1 month' => new \DateTime('+1 month'),
         ],
-        'group_by' => function($choiceValue, $key, $value) {
-            if ($choiceValue <= new \DateTime('+3 days')) {
+        'group_by' => function($choice, $key, $value) {
+            if ($choice <= new \DateTime('+3 days')) {
                 return 'Soon';
             } else {
                 return 'Later';

--- a/reference/forms/types/options/preferred_choices.rst.inc
+++ b/reference/forms/types/options/preferred_choices.rst.inc
@@ -33,9 +33,9 @@ be especially useful if your values are objects::
             '1 week' => new \DateTime('+1 week'),
             '1 month' => new \DateTime('+1 month'),
         ],
-        'preferred_choices' => function ($value, $key) {
+        'preferred_choices' => function ($choice, $key, $value) {
             // prefer options within 3 days
-            return $value <= new \DateTime('+3 days');
+            return $choice <= new \DateTime('+3 days');
         },
     ]);
 


### PR DESCRIPTION
Renamed the parameters in the callback functions of ChoiceType to make them more consistent with each other and the code.

Closes #6144.
