### PR TITLE
Fix tab content displaying

### DIFF
--- a/controller/service.rst
+++ b/controller/service.rst
@@ -80,7 +80,7 @@ Invokable Controllers
 
 Controllers can also define a single action using the ``__invoke()`` method,
 which is a common practice when following the `ADR pattern`_
-(Action-Domain-Responder)::
+(Action-Domain-Responder):
 
 .. configuration-block::
 


### PR DESCRIPTION
Apparently the double `:` leads to displaying `.. configuration-block::` instead of interprating it.

I tested in local with docker : 

Before
![](https://screenshotscdn.firefoxusercontent.com/images/da8667a4-3eba-42b0-b466-236eb129931b.png)

After

![](https://screenshotscdn.firefoxusercontent.com/images/dd4b3c66-99a2-4e1d-bf65-463ab4df69af.png)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
