### PR TITLE
Minor change

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -315,7 +315,7 @@ Using a Doctrine Listener
 
 If you are using Doctrine to store the Product entity, you can create a
 :doc:`Doctrine listener </doctrine/event_listeners_subscribers>` to
-automatically upload the file when persisting the entity::
+automatically move the file when persisting the entity::
 
     // src/AppBundle/EventListener/BrochureUploadListener.php
     namespace AppBundle\EventListener;


### PR DESCRIPTION
"upload" was the wrong term, since an upload is initiated by the end-user, not by Symfony.

Question: Is a Doctrine Listener preferred over a view transformer? I'm wondering, since the error message recommends a view transformer:

> The form's view data is expected to be an instance of class Symfony\Component\HttpFoundation\File\File, but is a(n) string. You can avoid this error by setting the "data_class" option to null or by adding a view transformer that transforms a(n) string to an instance of Symfony\Component\HttpFoundation\File\File.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
