### PR TITLE
[Cache] Updated invalid pdo service name

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2016,7 +2016,8 @@ default_pdo_provider
 **type**: ``string`` **default**: ``doctrine.dbal.default_connection``
 
 The service id of the database connection, which should be either a PDO or a
-Doctrine DBAL instance.
+Doctrine DBAL instance. The provider is available as the ``cache.default_pdo_provider``
+service.
 
 pools
 .....


### PR DESCRIPTION
This will fix #8406

This is similar to #11370. I made two PRs because PDO was not introduced in 3.4. I think this will be easier to merge. 

See https://github.com/symfony/symfony/blob/4.2/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1640