### PR TITLE
update documentation to add hattip to new crossorigin configuration 

### DIFF
--- a/frontend/encore/cdn.rst
+++ b/frontend/encore/cdn.rst
@@ -38,3 +38,7 @@ You *do* need to make sure that the ``script`` and ``link`` tags you include on 
 pages also use the CDN. Fortunately, the
 :ref:`entrypoints.json <encore-entrypointsjson-simple-description>` paths are updated
 to include the full URL to the CDN.
+
+If you are using ``Encore.enableIntegrityHashes()`` and your CDN and your domain are not the [same-origin](https://en.wikipedia.org/wiki/Same-origin_policy)
+then you might need to set the ``crossorigin`` configuration value in your webpack_encore.yaml configuration 
+to ``anonymous`` or ``use-credentials`` to overcome CORS errors.


### PR DESCRIPTION
Update documentation to add hattip to new crossorigin configuration param
as per https://github.com/symfony/recipes/pull/562/files

will update this page https://symfony.com/doc/current/frontend/encore/cdn.html