### PR TITLE
Added the $context argument to supports* methods

### DIFF
--- a/serializer/custom_encoders.rst
+++ b/serializer/custom_encoders.rst
@@ -32,7 +32,7 @@ create your own encoder that uses the
             return Yaml::dump($data);
         }
 
-        public function supportsEncoding($format)
+        public function supportsEncoding($format, array $context = [])
         {
             return 'yaml' === $format;
         }
@@ -42,7 +42,7 @@ create your own encoder that uses the
             return Yaml::parse($data);
         }
 
-        public function supportsDecoding($format)
+        public function supportsDecoding($format, array $context = [])
         {
             return 'yaml' === $format;
         }

--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -47,7 +47,7 @@ to customize the normalized data. To do that, leverage the ``ObjectNormalizer``:
             return $data;
         }
 
-        public function supportsNormalization($data, $format = null)
+        public function supportsNormalization($data, $format = null, array $context = [])
         {
             return $data instanceof Topic;
         }


### PR DESCRIPTION
Fixes #7541.

No need to explain it in details because anyone reading the serializer docs knows what the $context is. Also, no need for "versionadded" directive because it was introduced in Symfony 3.3.