### PR TITLE
[PhpUnitBridge] ClockMock does not mock gmdate()

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -325,7 +325,7 @@ Clock Mocking
 
 The :class:`Symfony\\Bridge\\PhpUnit\\ClockMock` class provided by this bridge
 allows you to mock the PHP's built-in time functions ``time()``,
-``microtime()``, ``sleep()`` and ``usleep()``. Additionally the function
+``microtime()``, ``sleep()``, ``usleep()`` and``gmdate``. Additionally the function
 ``date()`` is mocked so it uses the mocked time if no timestamp is specified.
 Other functions with an optional timestamp parameter that defaults to ``time()``
 will still use the system time instead of the mocked time.

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -325,7 +325,7 @@ Clock Mocking
 
 The :class:`Symfony\\Bridge\\PhpUnit\\ClockMock` class provided by this bridge
 allows you to mock the PHP's built-in time functions ``time()``,
-``microtime()``, ``sleep()``, ``usleep()`` and``gmdate``. Additionally the function
+``microtime()``, ``sleep()``, ``usleep()`` and ``gmdate``. Additionally the function
 ``date()`` is mocked so it uses the mocked time if no timestamp is specified.
 Other functions with an optional timestamp parameter that defaults to ``time()``
 will still use the system time instead of the mocked time.


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->

This is a new feature proposed to the master branch, with the following doc update.
