### PR TITLE
Fixing broken sentence

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -602,8 +602,8 @@ For more information, see the `FrameworkExtraBundle documentation`_.
 Access Control in Templates
 ...........................
 
-If you want to check if the current access inside a template, use
-the built-in ``is_granted()`` helper function:
+If you want to check if the current user has a certain role, you can use
+the built-in ``is_granted()`` helper function in any Twig template:
 
 .. code-block:: html+twig
 


### PR DESCRIPTION
Basically resetting it to where it was in v3.4: https://symfony.com/doc/3.4/security.html#access-control-in-templates

Questions:

1. Is there an easy way to check if access is granted to the *current* user (without hard-coding the role)? Anything shorter than:?

```twig
{% for role in app.user.roles|default(null) %}
    {% if is_granted(role) %}
        ...
    {% endif %}
{% endfor %}
```

2. For building a "dynamic" navbar, it would be nice to check if a certain *path* is accessible by the current user. Is this possible?
