### PR TITLE
Update Symfony server docs to be more highlighted

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -264,24 +264,25 @@ use it. First, make sure to expose the container ports:
 
         # ...
 
-Then, check your service names and update them if needed (Symfony creates
-environment variables following the name of the services so they can be
-autoconfigured):
+.. note::
 
-.. code-block:: yaml
+    Symfony creates environment variables following the **name of the ``docker-compose`` services**.
 
-    # docker-compose.yaml
-    services:
-        # DATABASE_URL
-        database: ...
-        # MONGODB_DATABASE, MONGODB_SERVER
-        mongodb: ...
-        # REDIS_URL
-        redis: ...
-        # ELASTISEARCH_HOST, ELASTICSEARCH_PORT
-        elasticsearch: ...
-        # RABBITMQ_DSN
-        rabbitmq: ...
+    Here is the list of services you can autoconfigure with their environment variable name:
+
+    .. code-block:: yaml
+
+        # docker-compose.yaml
+        services:
+            database: # DATABASE_URL
+
+            mongodb: # MONGODB_DATABASE, MONGODB_SERVER
+
+            redis: # REDIS_URL
+
+            elasticsearch: # ELASTISEARCH_HOST, ELASTICSEARCH_PORT
+
+            rabbitmq: # RABBITMQ_DSN
 
 If your ``docker-compose.yaml`` file doesn't use the environment variable names
 expected by Symfony (e.g. you use ``MYSQL_URL`` instead of ``DATABASE_URL``)


### PR DESCRIPTION
I found the Docker-based setup very useful, and it was not really obvious to me that service names needed to be specific in order for the CLI to change the associated env vars.

That's why I thought adding a `note` tag to it would highlight it a bit more in order for it to be clear. Especially because this note shows the list of service names that are mandatory for Symfony CLI to adapt.

WDYT?