### PR TITLE
config/validator/validation.yaml fix

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -336,7 +336,7 @@ object.
 
     .. code-block:: yaml
 
-        # config/validation.yaml
+        # config/validator/validation.yaml
         App\Entity\Task:
             properties:
                 task:


### PR DESCRIPTION
Validations in yaml will not work for a student passing through this section, since # config/validation.yaml was set while in the documentation for the component https://symfony.com/doc/current/validation.html#the-basics- Of-validation clearly states that: "These rules are usually defined using PHP code or annotations but they can also be defined as a validation.yaml or validation.xml file inside the config/validator/ directory:"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
