### PR TITLE
Update serializer.rst

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -39,9 +39,11 @@ Usage
 
 .. seealso::
 
-    This article explains how to use the Serializer features as an independent
-    component in any PHP application. Read the :doc:`/serializer` article to
-    learn about how to use it in Symfony applications.
+    This article explains the philosophy of the Serializer and gets you familiar
+    with the concepts of normalizers and encoders. The examples provided assume 
+    that you use the Serializer as an independent component. If you intend to use
+    the Serializer in the Symfony application, please read :doc:`/serializer`
+    after you finish this article.
 
 To use the Serializer component, set up the
 :class:`Symfony\\Component\\Serializer\\Serializer` specifying which encoders


### PR DESCRIPTION
you created an endless loop because of not saying in this article that it must be read first: 
- this article sends to the 'How to Use the Serializer' article, saying smth like 'if you use the Serializer as a Symfony component, go read there', without saying that this article must be read first, 
- and the 'How to Use the Serializer' sends back to this article saying it must be read first

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
