### PR TITLE
custom encoders interface signature

### DIFF
--- a/serializer/custom_encoders.rst
+++ b/serializer/custom_encoders.rst
@@ -32,7 +32,7 @@ create your own encoder that uses the
             return Yaml::dump($data);
         }
 
-        public function supportsEncoding($format, array $context = [])
+        public function supportsEncoding($format)
         {
             return 'yaml' === $format;
         }
@@ -42,12 +42,18 @@ create your own encoder that uses the
             return Yaml::parse($data);
         }
 
-        public function supportsDecoding($format, array $context = [])
+        public function supportsDecoding($format)
         {
             return 'yaml' === $format;
         }
     }
 
+.. tip::
+
+    If you need access to ``$context`` in your ``supportsDecoding`` or ``supportsEncoding`` method, make sure
+    to implements ``Symfony\Component\Serializer\Encoder\ContextAwareEncoderInterface`` or ``Symfony\Component\Serializer\Encoder\ContextAwareEncoderInterface`` interface
+    
+    
 Registering it in your app
 --------------------------
 


### PR DESCRIPTION
Fixes the documentation about encoders that was wrong.
Using `Symfony\Component\Serializer\Encoder\EncoderInterface` no `$context` parameter is passed to `supportsEncoding` method. You have to use the ContextAware version of it.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
