### PR TITLE
Frontend: fix class name when using Vue/JSX/Styles

### DIFF
--- a/frontend/encore/vuejs.rst
+++ b/frontend/encore/vuejs.rst
@@ -129,7 +129,7 @@ a workaround, you can use `CSS Modules`_ by suffixing import paths with
         color: red
     }
 
-The output will be something like ``<h1 class="h1_a3dKp">Hello World</h1>``.
+The output will be something like ``<h1 class="title_a3dKp">Hello World</h1>``.
 
 Using images
 ~~~~~~~~~~~~


### PR DESCRIPTION
Fixing a typo.

The CSS selector is `.title`, so `<h1 class={styles.title}>` will output something like `<h1 class="title_a3dKp">`, not `<h1 class="h1_a3dKp">`.

Thanks! :)
