### PR TITLE
Update psr4_class_loader.rst to fix incorrect path in directory structure

### DIFF
--- a/components/class_loader/psr4_class_loader.rst
+++ b/components/class_loader/psr4_class_loader.rst
@@ -27,7 +27,7 @@ The directory structure will look like this:
 
 .. code-block:: text
 
-    libs/
+    lib/
         ClassLoader/
             Psr4ClassLoader.php
             ...


### PR DESCRIPTION
Incorrect path shown in directory structure. demo.php refers to /lib/ but directory structure asks to add downloaded components to /libs/

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
