### PR TITLE
Update Length constraint description (mb_strlen)

### DIFF
--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -143,9 +143,8 @@ charset
 **type**: ``string``  **default**: ``UTF-8``
 
 The charset to be used when computing value's length. The
-:phpfunction:`grapheme_strlen` PHP function is used if available. If not,
-the :phpfunction:`mb_strlen` PHP function is used if available. If neither
-are available, the :phpfunction:`strlen` PHP function is used.
+:phpfunction:`mb_check_encoding` and :phpfunction:`mb_strlen`
+PHP functions are used.
 
 minMessage
 ~~~~~~~~~~


### PR DESCRIPTION
The current implementation ([3.4] and [4.2]) uses only `mb_strlen` (after `mb_check_encoding`).

[3.4]: https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Validator/Constraints/LengthValidator.php#L42-L44
[4.2]: https://github.com/symfony/symfony/blob/4.2/src/Symfony/Component/Validator/Constraints/LengthValidator.php#L43-L45

History: [years ago][1] the `grapheme_strlen` attempt was replaced with `iconv_strlen` (and `preg_replace`), [later on][2] the whole implementation (including plain `strlen`) was reduced to keep only `iconv_strlen`, and [finally][3] (but still years ago) `iconv_strlen` was replaced with `mb_check_encoding` + `mb_strlen`.

[1]: https://github.com/symfony/symfony/commit/915fcd8dec2a5c52942496172e4240b2ad3e8199
[2]: https://github.com/symfony/symfony/commit/303f05baafc2267b72812c44670493433b7acb0f#diff-467932f4ce8a7100a8e0184cf9463e6a
[3]: https://github.com/symfony/symfony/commit/27f5f81eb3dd3ba2cf67eac359c3d09a04077c40#diff-467932f4ce8a7100a8e0184cf9463e6a