### PR TITLE
#21571 updated "Authentication Success and Failure Events" section

### DIFF
--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -289,9 +289,9 @@ Authentication Success and Failure Events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a provider authenticates the user, a ``security.authentication.success``
-event is dispatched. But beware - this event will fire, for example, on *every*
-request if you have session-based authentication. See ``security.interactive_login``
-below if you need to do something when a user *actually* logs in.
+event is dispatched. But beware - this event may fire, for example, on *every*
+request if you have session-based authentication, if ``always_authenticate_before_granting`` is enabled or if token is not authenticated before AccessListener is invoked.
+See ``security.interactive_login`` below if you need to do something when a user *actually* logs in.
 
 When a provider attempts authentication but fails (i.e. throws an ``AuthenticationException``),
 a ``security.authentication.failure`` event is dispatched. You could listen on


### PR DESCRIPTION
Updated "Authentication Success and Failure Events"

`security.authentication.success` can be dispatched in the following cases:
- if `always_authenticate_before_granting` is enabled and `isGranted` is called
- if a token is not authenticated before `AccessListener` is invoked
- if customer submitted credentials (actual authentication)

symfony/symfony#21571