### PR TITLE
Consistency in form widget names

### DIFF
--- a/form/create_custom_field_type.rst
+++ b/form/create_custom_field_type.rst
@@ -237,7 +237,7 @@ one of your forms::
     {
         public function buildForm(FormBuilderInterface $builder, array $options)
         {
-            $builder->add('shipping_code', ShippingType::class, [
+            $builder->add('shippingCode', ShippingType::class, [
                 'placeholder' => 'Choose a delivery option',
             ]);
         }

--- a/form/events.rst
+++ b/form/events.rst
@@ -271,7 +271,7 @@ method of the ``FormFactory``::
 
     $form = $formFactory->createBuilder()
         ->add('username', TextType::class)
-        ->add('show_email', CheckboxType::class)
+        ->add('showEmail', CheckboxType::class)
         ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $user = $event->getData();
             $form = $event->getForm();
@@ -283,7 +283,7 @@ method of the ``FormFactory``::
             // checks whether the user has chosen to display their email or not.
             // If the data was submitted previously, the additional value that is
             // included in the request variables needs to be removed.
-            if (true === $user['show_email']) {
+            if (true === $user['showEmail']) {
                 $form->add('email', EmailType::class);
             } else {
                 unset($user['email']);
@@ -312,7 +312,7 @@ callback for better readability::
         {
             $builder
                 ->add('username', TextType::class)
-                ->add('show_email', CheckboxType::class)
+                ->add('showEmail', CheckboxType::class)
                 ->addEventListener(
                     FormEvents::PRE_SET_DATA,
                     [$this, 'onPreSetData']
@@ -379,7 +379,7 @@ Consider the following example of a form event subscriber::
             // checks whether the user has chosen to display their email or not.
             // If the data was submitted previously, the additional value that
             // is included in the request variables needs to be removed.
-            if (true === $user['show_email']) {
+            if (true === $user['showEmail']) {
                 $form->add('email', EmailType::class);
             } else {
                 unset($user['email']);
@@ -398,7 +398,7 @@ To register the event subscriber, use the ``addEventSubscriber()`` method::
 
     $form = $formFactory->createBuilder()
         ->add('username', TextType::class)
-        ->add('show_email', CheckboxType::class)
+        ->add('showEmail', CheckboxType::class)
         ->addEventSubscriber(new AddEmailFieldListener())
         ->getForm();
 

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -309,7 +309,7 @@ type::
     use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
     // ...
 
-    $builder->add('favorite_cities', CollectionType::class, [
+    $builder->add('favoriteCities', CollectionType::class, [
         'entry_type'   => ChoiceType::class,
         'entry_options'  => [
             'choices'  => [

--- a/reference/forms/types/options/date_format.rst.inc
+++ b/reference/forms/types/options/date_format.rst.inc
@@ -16,7 +16,7 @@ For more information on valid formats, see `Date/Time Format Syntax`_::
     use Symfony\Component\Form\Extension\Core\Type\DateType;
     // ...
 
-    $builder->add('date_created', DateType::class, [
+    $builder->add('dateCreated', DateType::class, [
         'widget' => 'single_text',
         // this is actually the default format for single_text
         'format' => 'yyyy-MM-dd',

--- a/reference/forms/types/options/help.rst.inc
+++ b/reference/forms/types/options/help.rst.inc
@@ -6,6 +6,6 @@ help
 Allows you to define a help message for the form field, which by default is
 rendered below the field::
 
-    $builder->add('zip_code', null, [
+    $builder->add('zipCode', null, [
         'help' => 'The ZIP/Postal code for your credit card\'s billing address.',
     ]);

--- a/reference/forms/types/options/invalid_message_parameters.rst.inc
+++ b/reference/forms/types/options/invalid_message_parameters.rst.inc
@@ -7,7 +7,7 @@ When setting the ``invalid_message`` option, you may need to
 include some variables in the string. This can be done by adding placeholders
 to that option and including the variables in this option::
 
-    $builder->add('some_field', SomeFormType::class, [
+    $builder->add('someField', SomeFormType::class, [
         // ...
         'invalid_message' => 'You entered an invalid value, it should include %num% letters',
         'invalid_message_parameters' => ['%num%' => 6],


### PR DESCRIPTION
Was working with `symfony/form` and was using form widget names with `snake_case`.
I needed some help with a simple bug and @lyrixx told me that we should not use `snake_case`.

But since I saw `snake_case` from the docs and I also saw `camelCase` I just made a pass to have `camelCase` everywhere for form widget names.