### PR TITLE
Fixed additional '@' in DoctrineTokenProvider service in 'Remember Me' functionality

### DIFF
--- a/security/remember_me.rst
+++ b/security/remember_me.rst
@@ -263,7 +263,7 @@ service you just created:
                     # ...
                     remember_me:
                         # ...
-                        token_provider: '@Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider'
+                        token_provider: 'Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider'
 
     .. code-block:: xml
 
@@ -282,7 +282,7 @@ service you just created:
                     <!-- ... -->
 
                     <remember-me
-                        token_profider="@Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider"
+                        token_profider="Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider"
                         />
                 </firewall>
             </config>
@@ -299,7 +299,7 @@ service you just created:
                     // ...
                     'remember_me' => [
                         // ...
-                        'token_provider' => '@Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider',
+                        'token_provider' => 'Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider',
                     ],
                 ],
             ],


### PR DESCRIPTION
In current version we have to add the following line into our firewall definitions:
```yaml
token_provider: '@Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider'
```
but with this we'll get error:
```
The service "security.authentication.rememberme.services.persistent.main" has a dependency on a non-existent service "@Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider".
```
To fix this we need to remove `@` character from service definition so finally it should looks like:
```yaml
token_provider: 'Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider'
```

P.S. I have already commit for `master` branch too so if this change will be accepted, I'll create pull request for `master` too.