### PR TITLE
feature: move hinclude from template to fragments

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -608,6 +608,19 @@ path
 The path prefix for fragments. The fragment listener will only be executed
 when the request starts with this path.
 
+hinclude_default_template
+.........................
+
+**type**: ``string`` **default**: ``null``
+
+Sets the content shown during the loading of the fragment or when JavaScript
+is disabled. This can be either a template name or the content itself.
+
+.. seealso::
+
+    See :doc:`/templating/hinclude` for more information about hinclude.
+
+
 profiler
 ~~~~~~~~
 
@@ -1536,18 +1549,6 @@ package:
 
 templating
 ~~~~~~~~~~
-
-hinclude_default_template
-.........................
-
-**type**: ``string`` **default**: ``null``
-
-Sets the content shown during the loading of the fragment or when JavaScript
-is disabled. This can be either a template name or the content itself.
-
-.. seealso::
-
-    See :doc:`/templating/hinclude` for more information about hinclude.
 
 .. _reference-templating-form:
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->

This is linked to the recent changes on hinclude which has been moved from Templating to Fragments

Refs https://github.com/symfony/symfony/pull/30959