### PR TITLE
Add flock:// option to framework lock configuration reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2762,11 +2762,12 @@ A list of lock stores to be created by the framework extension.
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # config/packages/lock.yml
         framework:
             # these are all the supported lock stores
             lock: ~
             lock: 'flock'
+            lock: 'flock:///path/to/file'
             lock: 'semaphore'
             lock: 'memcached://m1.docker'
             lock: ['memcached://m1.docker', 'memcached://m2.docker']
@@ -2781,7 +2782,7 @@ A list of lock stores to be created by the framework extension.
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml -->
+        <!-- config/packages/lock.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -2794,6 +2795,8 @@ A list of lock stores to be created by the framework extension.
                 <framework:lock>
                     <!-- these are all the supported lock stores -->
                     <framework:resource>flock</framework:resource>
+
+                    <framework:resource>flock:///path/to/file</framework:resource>
 
                     <framework:resource>semaphore</framework:resource>
 
@@ -2819,11 +2822,12 @@ A list of lock stores to be created by the framework extension.
 
     .. code-block:: php
 
-        // app/config/config.php
+        // config/packages/lock.php
         $container->loadFromExtension('framework', [
             // these are all the supported lock stores
             'lock' => null,
             'lock' => 'flock',
+            'lock' => 'flock:///path/to/file',
             'lock' => 'semaphore',
             'lock' => 'memcached://m1.docker',
             'lock' => ['memcached://m1.docker', 'memcached://m2.docker'],
@@ -2837,6 +2841,10 @@ A list of lock stores to be created by the framework extension.
                 'report' => 'semaphore',
             ],
         ]);
+
+.. versionadded:: 4.2
+
+    The ``flock://`` store was introduced in Symfony 4.2.
 
 .. _reference-lock-resources-name:
 


### PR DESCRIPTION
Fixes #9779 & extends #11465 .

Documents the `flock://` option which was added with https://github.com/symfony/symfony/pull/26923 .

**NOTE 1**: The xml configuration doesn't currently work, see https://github.com/symfony/symfony/issues/31197
**NOTE 2**: This PR has all the changes that #11465 has plus some symfony 4.2 specific additions, so #11465 should probably be merged first.