### PR TITLE
Fixed more wrong white spaces

### DIFF
--- a/components/class_loader/class_map_generator.rst
+++ b/components/class_loader/class_map_generator.rst
@@ -19,12 +19,12 @@ manually. For example, imagine a library with the following directory structure:
 
     library/
     ├── bar/
-    │   ├── baz/
-    │   │   └── Boo.php
-    │   └── Foo.php
+    │   ├── baz/
+    │   │   └── Boo.php
+    │   └── Foo.php
     └── foo/
         ├── bar/
-        │   └── Foo.php
+        │   └── Foo.php
         └── Bar.php
 
 These files contain the following classes:

--- a/components/filesystem/lock_handler.rst
+++ b/components/filesystem/lock_handler.rst
@@ -5,7 +5,7 @@ LockHandler
 
     The ``LockHandler`` class was deprecated in Symfony 3.4 and it will be
     removed in Symfony 4.0. Use :ref:`SemaphoreStore <lock-store-semaphore>`
-    or :ref:`FlockStore <lock-store-flock>` from the Lock component instead.
+    or :ref:`FlockStore <lock-store-flock>` from the Lock component instead.
 
 What is a Lock?
 ---------------

--- a/components/ldap.rst
+++ b/components/ldap.rst
@@ -40,7 +40,7 @@ following options:
     The encryption protocol: ``ssl``, ``tls`` or ``none`` (default)
 
 ``connection_string``
-    You may use this option instead of ``host`` and ``port`` to connect to the
+    You may use this option instead of ``host`` and ``port`` to connect to the
     LDAP server
 
 ``optReferrals``

--- a/components/yaml/yaml_format.rst
+++ b/components/yaml/yaml_format.rst
@@ -325,7 +325,7 @@ The following YAML features are not supported by the Symfony Yaml component:
 * Complex mapping keys and complex values starting with ``?``;
 * Tagged values as keys;
 * The following tags and types: `!!set`, `!!omap`, `!!pairs`, `!!set`, `!!seq`,
-  `!!bool`, `!!int`, `!!merge`, `!!null`, `!!timestamp`, `!!value`, `!!yaml`;
+  `!!bool`, `!!int`, `!!merge`, `!!null`, `!!timestamp`, `!!value`, `!!yaml`;
 * Tags (``TAG`` directive; example: ``%TAG ! tag:example.com,2000:app/``)
   and tag references (example: ``!<tag:example.com,2000:app/foo>``);
 * Using sequence-like syntax for mapping elements (example: ``{foo, bar}``; use

--- a/deployment.rst
+++ b/deployment.rst
@@ -164,8 +164,8 @@ as you normally do:
 .. caution::
 
     If you get a "class not found" error during this step, you may need to
-    run ``export SYMFONY_ENV=prod`` (or ``export APP_ENV=prod`` if you're
-    using :doc:`Symfony Flex </setup/flex>`) before running this command so
+    run ``export SYMFONY_ENV=prod`` (or ``export APP_ENV=prod`` if you're
+    using :doc:`Symfony Flex </setup/flex>`) before running this command so
     that the ``post-install-cmd`` scripts run in the ``prod`` environment.
 
 D) Clear your Symfony Cache

--- a/doctrine/event_listeners_subscribers.rst
+++ b/doctrine/event_listeners_subscribers.rst
@@ -238,7 +238,7 @@ to the tag like so:
 
 .. note::
 
-    Marking an event listener as ``lazy`` has nothing to do with lazy service
+    Marking an event listener as ``lazy`` has nothing to do with lazy service
     definitions which are described :doc:`in their own article </service_container/lazy_services>`
 
 Priorities for Event Listeners

--- a/frontend/assetic/php.rst
+++ b/frontend/assetic/php.rst
@@ -46,27 +46,27 @@ and some regular CSS and JavaScript application files (called ``main.css`` and
 
     web/assets/
     ├── css
-    │   ├── main.css
-    │   └── code-highlight.css
+    │   ├── main.css
+    │   └── code-highlight.css
     ├── js
-    │   ├── bootstrap.js
-    │   ├── jquery.js
-    │   └── main.js
+    │   ├── bootstrap.js
+    │   ├── jquery.js
+    │   └── main.js
     └── scss
         ├── bootstrap
-        │   ├── _alerts.scss
-        │   ├── ...
-        │   ├── _variables.scss
-        │   ├── _wells.scss
-        │   └── mixins
-        │       ├── _alerts.scss
-        │       ├── ...
-        │       └── _vendor-prefixes.scss
+        │   ├── _alerts.scss
+        │   ├── ...
+        │   ├── _variables.scss
+        │   ├── _wells.scss
+        │   └── mixins
+        │       ├── _alerts.scss
+        │       ├── ...
+        │       └── _vendor-prefixes.scss
         ├── bootstrap.scss
         ├── font-awesome
-        │   ├── _animated.scss
-        │   ├── ...
-        │   └── _variables.scss
+        │   ├── _animated.scss
+        │   ├── ...
+        │   └── _variables.scss
         └── font-awesome.scss
 
 Combining and Minimizing CSS Files and Compiling SCSS Files

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -116,10 +116,10 @@ The following block shows all possible configuration keys:
     to find your PostgreSQL version and ``mysql -V`` to get your MySQL
     version).
 
-    If you are running a MariaDB database, you must prefix the ``server_version``
+    If you are running a MariaDB database, you must prefix the ``server_version``
     value with ``mariadb-`` (e.g. ``server_version: mariadb-10.2.12``).
 
-    Always wrap the server version number with quotes to parse it as a string
+    Always wrap the server version number with quotes to parse it as a string
     instead of a float number. Otherwise, the floating-point representation
     issues can make your version be considered a different number (e.g. ``5.6``
     will be rounded as ``5.5999999999999996447286321199499070644378662109375``).

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -207,12 +207,12 @@ loading all entities.
 
 .. caution::
 
-    The entity used in the ``FROM`` clause of the ``query_builder`` option
+    The entity used in the ``FROM`` clause of the ``query_builder`` option
     will always be validated against the class which you have specified at the
     `class`_ option. If you return another entity instead of the
     one used in your ``FROM`` clause (for instance if you return an entity
     from a joined table), it will break validation.
-    
+
 Overridden Options
 ------------------
 

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -18,7 +18,7 @@ describe these extra features.
 
 .. tip::
 
-    Technically, most of the extensions live in the `Twig Bridge`_. That code
+    Technically, most of the extensions live in the `Twig Bridge`_. That code
     might give you some ideas when you need to write your own Twig extension
     as described in :doc:`/templating/twig_extension`.
 
@@ -30,7 +30,7 @@ describe these extra features.
 
 .. tip::
 
-    The `Twig Extensions repository`_ contains some additional Twig extensions
+    The `Twig Extensions repository`_ contains some additional Twig extensions
     that do not belong to the Twig core, so you might want to have a look at
     the `Twig Extensions documentation`_.
 

--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -573,7 +573,7 @@ Start by updating the service ids to class names:
     Services associated with global PHP classes (i.e. not using PHP namespaces)
     must maintain the ``class`` parameter. For example, when using the old Twig
     classes (e.g. ``Twig_Extensions_Extension_Intl`` instead of ``Twig\Extensions\IntlExtension``),
-    you can't redefine the service as ``Twig_Extensions_Extension_Intl: ~`` and
+    you can't redefine the service as ``Twig_Extensions_Extension_Intl: ~`` and
     you must keep the original ``class`` parameter.
 
 .. caution::

--- a/setup/file_permissions.rst
+++ b/setup/file_permissions.rst
@@ -55,7 +55,7 @@ following script to determine your web server user and grant the needed permissi
 
 .. note::
 
-    The first ``setfacl`` command sets permissions for future files and folders,
+    The first ``setfacl`` command sets permissions for future files and folders,
     while the second one sets permissions on the existing files and folders.
     Both of these commands assign permissions for the system user and the Apache
     user.

--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -133,15 +133,15 @@ following directory structure, which is the same used by default in Symfony 4:
 
     your-project/
     ├── config/
-    │   ├── bundles.php
-    │   ├── packages/
-    │   ├── routes.yaml
-    │   └── services.yaml
+    │   ├── bundles.php
+    │   ├── packages/
+    │   ├── routes.yaml
+    │   └── services.yaml
     ├── public/
-    │   └── index.php
+    │   └── index.php
     ├── src/
-    │   ├── ...
-    │   └── Kernel.php
+    │   ├── ...
+    │   └── Kernel.php
     ├── templates/
     └── vendor/
 

--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -49,7 +49,7 @@ Create a class that extends ``AbstractExtension`` and fill in the logic::
 
 .. note::
 
-    Prior to Twig 1.26, your extension had to define an additional ``getName()``
+    Prior to Twig 1.26, your extension had to define an additional ``getName()``
     method that returned a string with the extension's internal name (e.g.
     ``app.my_extension``). When your extension needs to be compatible with Twig
     versions before 1.26, include this method which is omitted in the example


### PR DESCRIPTION
This continues the work made by @OskarStark in #11480. I looked for more occurrences of the "strange white space" ... and there were a lot of them.

Oskar, in case you can create a validation rule about this, I opened the file using an hexadecimal editor and saw that:

* "normal white space" = `0x20`
* "weird white space" = `0xA0` (see http://www.fileformat.info/info/unicode/char/00a0/index.htm)