### PR TITLE
HTTP Cache - update for index.php snippet

### DIFF
--- a/http_cache.rst
+++ b/http_cache.rst
@@ -99,13 +99,9 @@ caching kernel:
     use App\Kernel;
 
     // ...
-    $env = $_SERVER['APP_ENV'] ?? 'dev';
-    $debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env));
-    // ...
-    $kernel = new Kernel($env, $debug);
-
+    $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
     + // Wrap the default Kernel with the CacheKernel one in 'prod' environment
-    + if ('prod' === $env) {
+    + if ('prod' === $kernel->getEnvironment()) {
     +     $kernel = new CacheKernel($kernel);
     + }
 


### PR DESCRIPTION
New index.php does not contains `$env` variable. Some developers might copy-paste blindly (like I did) and waste some time figuring-out why CacheKernel is not in use even when app is in `prod`.
