### PR TITLE
Correct method name in example

### DIFF
--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -45,11 +45,11 @@ Create a class that extends ``AbstractExtension`` and fill in the logic::
         public function getFilters()
         {
             return [
-                new TwigFilter('price', [$this, 'formatPrice']),
+                new TwigFilter('price', [$this, 'priceFilter']),
             ];
         }
 
-        public function formatPrice($number, $decimals = 0, $decPoint = '.', $thousandsSep = ',')
+        public function priceFilter($number, $decimals = 0, $decPoint = '.', $thousandsSep = ',')
         {
             $price = number_format($number, $decimals, $decPoint, $thousandsSep);
             $price = '$'.$price;


### PR DESCRIPTION
The "new in 1.26" example references a method in the initial example that was named "formatPrice" yet the documentation referred to it as "priceFilter".

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
