### PR TITLE
fix varnish comment

### DIFF
--- a/http_cache/varnish.rst
+++ b/http_cache/varnish.rst
@@ -134,9 +134,10 @@ using Varnish 3:
     .. code-block:: varnish3
 
         sub vcl_fetch {
-            /* By default, Varnish3 ignores Cache-Control: no-cache and private
-               https://www.varnish-cache.org/docs/3.0/tutorial/increasing_your_hitrate.html#cache-control
-             */
+            /*
+                By default, Varnish3 ignores Cache-Control: no-cache and private
+                https://www.varnish-cache.org/docs/3.0/tutorial/increasing_your_hitrate.html#cache-control
+            */
             if (beresp.http.Cache-Control ~ "private" ||
                 beresp.http.Cache-Control ~ "no-cache" ||
                 beresp.http.Cache-Control ~ "no-store"


### PR DESCRIPTION
according to this link:
https://varnish-cache.org/docs/trunk/reference/vcl.html#comments

a multiline comment should not start on the "/*"-line

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
