### PR TITLE
remove invalid array type

### DIFF
--- a/reference/forms/types/options/group_by.rst.inc
+++ b/reference/forms/types/options/group_by.rst.inc
@@ -1,7 +1,7 @@
 group_by
 ~~~~~~~~
 
-**type**: ``array``, ``callable`` or ``string`` **default**: ``null``
+**type**: ``string`` or ``callable`` **default**: ``null``
 
 You can group the ``<option>`` elements of a ``<select>`` into ``<optgroup>``
 by passing a multi-dimensional array to ``choices``. See the


### PR DESCRIPTION
This is not true before Symfony 4.3 (spotted while looking into how to document symfony/symfony#30429).