### PR TITLE
Fix small typo in mime doc example

### DIFF
--- a/components/mime.rst
+++ b/components/mime.rst
@@ -398,7 +398,7 @@ simplify things later::
     // ...
 
     $templateLoader = new FilesystemLoader(__DIR__.'/templates');
-    $templatedLoader->addPath(__DIR__.'/images', 'images');
+    $templateLoader->addPath(__DIR__.'/images', 'images');
     $twig = new Environment($templateLoader);
 
 Now, use the special ``email.image()`` Twig helper to embed the images inside


### PR DESCRIPTION
I think it's a typo here and it should be `$templateLoader`.
*see changes*