### PR TITLE
Fix php config example for hinclude_default_template

### DIFF
--- a/templating/hinclude.rst
+++ b/templating/hinclude.rst
@@ -93,9 +93,7 @@ in your application configuration:
         $container->loadFromExtension('framework', [
             // ...
             'fragments' => [
-                'hinclude_default_template' => [
-                    'hinclude.html.twig',
-                ],
+                'hinclude_default_template' => 'hinclude.html.twig',
             ],
         ]);
 


### PR DESCRIPTION
In PHP example used the wrong type for parameter - `array`, instead of a correct `string`.

Other config examples are not affected. 