### PR TITLE
Fix: make class clickable

### DIFF
--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -4,9 +4,9 @@ Getting Started
 .. toctree::
     :maxdepth: 1
 
-    ../setup
-    ../page_creation
-    ../routing
-    ../controller
-    ../templating
-    ../configuration
+    /setup
+    /page_creation
+    /routing
+    /controller
+    /templating
+    /configuration

--- a/serializer/normalizers.rst
+++ b/serializer/normalizers.rst
@@ -28,7 +28,7 @@ Symfony includes the following normalizers but you can also
   normalize PHP object using the :doc:`PropertyAccessor component </components/property_access>`;
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\CustomNormalizer` to
   normalize PHP object using an object that implements
-  ``:class:`Symfony\\Component\\Serializer\\Normalizer\\NormalizableInterface``;
+  :class:`Symfony\\Component\\Serializer\\Normalizer\\NormalizableInterface`;
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\GetSetMethodNormalizer` to
   normalize PHP object using the getter and setter methods of the object;
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\PropertyNormalizer` to


### PR DESCRIPTION
Small fix that makes the `Symfony\Component\Serializer\Normalizer\NormalizableInterface` class clickable to see the api.

This affects the maintained branches 3.4, 4.2 and master.