### PR TITLE
Typo

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -345,7 +345,7 @@ and use that when configuring the pool.
                 factory: ['Symfony\Component\Cache\Adapter\RedisAdapter', 'createConnection']
                 arguments:
                     - 'redis://localhost'
-                    - [ retry_interval: 2, timeout: 10 ]
+                    - { retry_interval: 2, timeout: 10 }
 
     .. code-block:: xml
 


### PR DESCRIPTION
According to https://symfony.com/doc/current/components/yaml/yaml_format.html#collections, mappings uses `{ }` instead of `[ ]`
