### PR TITLE
Fix usage of StaticJwtProvider

### DIFF
--- a/components/mercure.rst
+++ b/components/mercure.rst
@@ -31,11 +31,11 @@ The following example shows the component in action::
     define('HUB_URL', 'https://demo.mercure.rocks/hub');
     define('JWT', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyJmb28iLCJiYXIiXSwicHVibGlzaCI6WyJmb28iXX19.LRLvirgONK13JgacQ_VbcjySbVhkSmHy3IznH3tA9PM');
 
-    use Symfony\Component\Mercure\Jwt\StaticJwtProvide;
+    use Symfony\Component\Mercure\Jwt\StaticJwtProvider;
     use Symfony\Component\Mercure\Publisher;
     use Symfony\Component\Mercure\Update;
 
-    $publisher = new Publisher(HUB_URL, new StaticJwtProvide(JWT));
+    $publisher = new Publisher(HUB_URL, new StaticJwtProvider(JWT));
     // Serialize the update, and dispatch it to the hub, that will broadcast it to the clients
     $id = $publisher(new Update('https://example.com/books/1.jsonld', 'Hi from Symfony!', ['target1', 'target2']));
 


### PR DESCRIPTION
Wrong call to `StaticJwtProvider`, there seems to be no such thing as `StaticJwtProvide`
