### PR TITLE
Replace the PHP built-in server with the Symfony CLI one

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -74,11 +74,12 @@ Next, create an ``index.php`` file that creates a kernel class and executes it::
     $response->send();
     $kernel->terminate($request, $response);
 
-That's it! To test it, you can start the built-in web server:
+That's it! To test it, start the :doc:`Symfony Local Web Server
+</setup/symfony_server>`:
 
 .. code-block:: terminal
 
-    $ php -S localhost:8000
+    $ symfony server:start
 
 Then see the JSON response in your browser:
 
@@ -335,12 +336,13 @@ this:
     ├─ composer.json
     └─ composer.lock
 
-As before you can use PHP built-in server:
+As before you can use the :doc:`Symfony Local Web Server
+</setup/symfony_server>`:
 
 .. code-block:: terminal
 
     cd web/
-    $ php -S localhost:8000
+    $ symfony server:start
 
 Then see webpage in browser:
 

--- a/create_framework/front_controller.rst
+++ b/create_framework/front_controller.rst
@@ -153,12 +153,12 @@ web root directory:
 Now, configure your web server root directory to point to ``web/`` and all
 other files won't be accessible from the client anymore.
 
-To test your changes in a browser (``http://localhost:4321/hello?name=Fabien``), run
-the PHP built-in server:
+To test your changes in a browser (``http://localhost:4321/hello?name=Fabien``),
+run the :doc:`Symfony Local Web Server </setup/symfony_server>`:
 
 .. code-block:: terminal
 
-    $ php -S 127.0.0.1:4321 -t web/ web/front.php
+    $ symfony server:start --port=4321 --passthru=front.php
 
 .. note::
 

--- a/create_framework/introduction.rst
+++ b/create_framework/introduction.rst
@@ -101,14 +101,13 @@ start with the simplest web application we can think of in PHP::
 
     printf('Hello %s', $name);
 
-You can use the PHP built-in server to test this great application in a browser
-(``http://localhost:4321/index.php?name=Fabien``):
+You can use the :doc:`Symfony Local Web Server </setup/symfony_server>` to test
+this great application in a browser
+(``http://localhost:8000/index.php?name=Fabien``):
 
 .. code-block:: terminal
 
-    $ php -S 127.0.0.1:4321
-
-Otherwise, you can always use your own server (Apache, Nginx, etc.).
+    $ symfony server:start
 
 In the :doc:`next chapter </create_framework/http_foundation>`, we are going to
 introduce the HttpFoundation Component and see what it brings us.


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->

I think it makes sense as the built-in web server has many limitations, but also because it seems to not work on PHP 7.3 (see symfony/symfony#30471).
