### PR TITLE
Update testing.rst

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -652,7 +652,7 @@ narrow down your node selection by chaining the method calls::
     $crawler
         ->filter('h1')
         ->reduce(function ($node, $i) {
-            if (!$node->getAttribute('class')) {
+            if (!$node->attr('class')) {
                 return false;
             }
         })


### PR DESCRIPTION
getAttribute function doesn't exist in Crawler class: use attr() instead: Error: Call to undefined method Symfony\Component\DomCrawler\Crawler::getAttribute()

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
