### PR TITLE
Remove short factories/configurators examples

### DIFF
--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -28,7 +28,7 @@ To use it, first register a new handler service:
 
                     # If you're using Doctrine & want to re-use that connection, then:
                     # comment-out the above 2 lines and uncomment the line below
-                    # - !service { class: PDO, factory: 'database_connection:getWrappedConnection' }
+                    # - !service { class: PDO, factory: ['@database_connection', getWrappedConnection] }
                     # If you get transaction issues (e.g. after login) uncomment the line below
                     # - { lock_mode: 1 }
 

--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -136,10 +136,10 @@ all the classes are already loaded as services. All you need to do is specify th
 
             # override the services to set the configurator
             App\Mail\NewsletterManager:
-                configurator: 'App\Mail\EmailConfigurator:configure'
+                configurator: ['@App\Mail\EmailConfigurator', configure]
 
             App\Mail\GreetingCardManager:
-                configurator: 'App\Mail\EmailConfigurator:configure'
+                configurator: ['@App\Mail\EmailConfigurator', configure]
 
     .. code-block:: xml
 
@@ -183,17 +183,6 @@ all the classes are already loaded as services. All you need to do is specify th
 
         $container->getDefinition(GreetingCardManager::class)
             ->setConfigurator([new Reference(EmailConfigurator::class), 'configure']);
-
-The traditional configurator syntax in YAML files used an array to define
-the service id and the method name:
-
-.. code-block:: yaml
-
-    app.newsletter_manager:
-        # new syntax
-        configurator: 'App\Mail\EmailConfigurator:configure'
-        # old syntax
-        configurator: ['@App\Mail\EmailConfigurator', configure]
 
 That's it! When requesting the ``App\Mail\NewsletterManager`` or
 ``App\Mail\GreetingCardManager`` service, the created instance will first be

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -104,7 +104,7 @@ Configuration of the service container then looks like this:
 
             App\Email\NewsletterManager:
                 # call a method on the specified factory service
-                factory: 'App\Email\NewsletterManagerFactory:createNewsletterManager'
+                factory: ['@App\Email\NewsletterManagerFactory', createNewsletterManager]
 
     .. code-block:: xml
 
@@ -144,20 +144,6 @@ Configuration of the service container then looks like this:
                 'createNewsletterManager',
             ]);
 
-.. note::
-
-    The traditional configuration syntax in YAML files used an array to define
-    the factory service and the method name:
-
-    .. code-block:: yaml
-
-        # config/services.yaml
-        App\Email\NewsletterManager:
-            # new syntax
-            factory: 'App\Email\NewsletterManagerFactory:createNewsletterManager'
-            # old syntax
-            factory: ['@App\Email\NewsletterManagerFactory', createNewsletterManager]
-
 .. _factories-passing-arguments-factory-method:
 
 Passing Arguments to the Factory Method
@@ -181,7 +167,7 @@ example takes the ``templating`` service as an argument:
             # ...
 
             App\Email\NewsletterManager:
-                factory:   'App\Email\NewsletterManagerFactory:createNewsletterManager'
+                factory:   ['@App\Email\NewsletterManagerFactory', createNewsletterManager]
                 arguments: ['@templating']
 
     .. code-block:: xml


### PR DESCRIPTION
This PR reverts #7203, as short factories are more confusing than useful.
I'm proposing to deprecate them in https://github.com/symfony/symfony/pull/31543
Note that some of this patch can (should) be adapted to 3.4 also.