### PR TITLE
fix encore multiple configuration build paths

### DIFF
--- a/frontend/encore/advanced-config.rst
+++ b/frontend/encore/advanced-config.rst
@@ -63,8 +63,8 @@ state of the current configuration to build a new one:
 
     // define the first configuration
     Encore
-        .setOutputPath('public/build/')
-        .setPublicPath('/build')
+        .setOutputPath('public/build/first_build/')
+        .setPublicPath('/build/first_build')
         .addEntry('app', './assets/js/app.js')
         .addStyleEntry('global', './assets/css/global.scss')
         .enableSassLoader()
@@ -83,8 +83,8 @@ state of the current configuration to build a new one:
 
     // define the second configuration
     Encore
-        .setOutputPath('public/build/')
-        .setPublicPath('/build')
+        .setOutputPath('public/build/second_build/')
+        .setPublicPath('/build/second_build')
         .addEntry('mobile', './assets/js/mobile.js')
         .addStyleEntry('mobile', './assets/css/mobile.less')
         .enableLessLoader()
@@ -113,10 +113,10 @@ Next, define the output directories of each build:
 
     # config/packages/webpack_encore.yaml
     webpack_encore:
-        output_path: '%kernel.public_dir%/public/default_build'
+        output_path: '%kernel.project_dir%/public/default_build'
         builds:
-            firstConfig: '%kernel.public_dir%/public/first_build'
-            secondConfig: '%kernel.public_dir%/public/second_build'
+            firstConfig: '%kernel.project_dir%/public/first_build'
+            secondConfig: '%kernel.project_dir%/public/second_build'
 
 Finally, use the third optional parameter of the ``encore_entry_*_tags()``
 functions to specify which build to use:


### PR DESCRIPTION
This PR fix two things:

- `%kernel.public_dir%` does not exists and `%kernel.project_dir%/public` is the correct path.
- As mentioned here https://github.com/symfony/webpack-encore/issues/477,  the multiple config will overwrite the `entrypoint.js`. The solution is to use two build directories, but this needs two different paths in the `webpack.config.js`.

Now someone can just copy&paste the code lines and it should work.


