### PR TITLE
Resolve parameters during config resolution in PrependExtensionInterface::prepend()

### DIFF
--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -83,6 +83,7 @@ in case a specific other bundle is not registered::
 
         // process the configuration of AcmeHelloExtension
         $configs = $container->getExtensionConfig($this->getAlias());
+        $configs = $container->getParameterBag()->resolveValue($configs);
         // use the Configuration class to generate a config array with
         // the settings "acme_hello"
         $config = $this->processConfiguration(new Configuration(), $configs);


### PR DESCRIPTION
This is an alternative "fix" for https://github.com/symfony/symfony/pull/31609#discussion_r287421895, making the parameter resolution a user concern. Im really skeptical about doing it out-of-the-box in `getExtensionConfig` and change behavior globally.

This way we meet in the middle, where sf core only needs to set the env placeholder before calling `prepend()`.