### PR TITLE
Remove $context argument from supportsNormalization in example

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -47,7 +47,7 @@ to customize the normalized data. To do that, leverage the ``ObjectNormalizer``:
             return $data;
         }
 
-        public function supportsNormalization($data, $format = null, array $context = [])
+        public function supportsNormalization($data, $format = null)
         {
             return $data instanceof Topic;
         }


### PR DESCRIPTION
This PR removes `$context` argument from supportsNormalization() method.

`NormalizerInterface` defines only `$data` and `$format` arguments (see https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php#L51)