### PR TITLE
doctrine/doctrine-fixtures-bundle is a dev req

### DIFF
--- a/best_practices/business-logic.rst
+++ b/best_practices/business-logic.rst
@@ -309,7 +309,7 @@ the following command to install the Doctrine fixtures bundle:
 
 .. code-block:: terminal
 
-    $ composer require doctrine/doctrine-fixtures-bundle
+    $ composer require --dev doctrine/doctrine-fixtures-bundle
 
 Then, enable the bundle in ``AppKernel.php``, but only for the ``dev`` and
 ``test`` environments::


### PR DESCRIPTION
Update the command used to install doctrine/doctrine-fixtures-bundle to install it as a development requirement, and not an app requirement.

This command should be updated in branches 3.4, 4.2 and master, but I don't know if it is done automatically.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
