### PR TITLE
[WebLink] Remove chrome debug since it's no longer present

### DIFF
--- a/web_link.rst
+++ b/web_link.rst
@@ -79,11 +79,6 @@ the priority of the resource to download using the ``importance`` attribute:
         <link rel="stylesheet" href="{{ preload('/app.css', { as: 'style', importance: 'low' }) }}">
     </head>
 
-.. tip::
-
-    Google Chrome provides an interface to debug HTTP/2 connections. Browse
-    ``chrome://net-internals/#http2`` to see all the details.
-
 How does it work?
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
When accessing to [chrome://net-internals/#http2](chrome://net-internals/#http2)

> The net-internals events viewer and related functionality has been removed. Please use chrome://net-export to save netlogs and the external catapult netlog_viewer to view them.

I don't know if this section should be replaced because I don't know by what it has been replaced.
