### PR TITLE
Add note about extra configuration for mod_xsendfile

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -523,6 +523,26 @@ if it should::
 
     BinaryFileResponse::trustXSendfileTypeHeader();
 
+.. note::
+
+    The ``BinaryFileResponse`` will only handle ``X-Sendfile`` if the particular header is present.
+    For Apache, this is not the default case.
+
+    To add the header use the ``mod_headers`` Apache module and add the following to the Apache configuration.
+
+    .. code-block:: apache
+
+      <IfModule mod_xsendfile.c>
+        # This is already present somewhere...
+        XSendFile on
+        XSendFilePath ...some path...
+
+        # This needs to be added:
+        <IfModule mod_headers.c>
+          RequestHeader set X-Sendfile-Type X-Sendfile
+        </IfModule>
+      </IfModule>
+
 With the ``BinaryFileResponse``, you can still set the ``Content-Type`` of the sent file,
 or change its ``Content-Disposition``::
 


### PR DESCRIPTION
I added a note about how (and why) to add the additional header for `BinaryFileResponse` to use the `mod_xsendfile` Apache module.

Fixes #10794