### PR TITLE
Deprecate the templating.* options of FrameworkBundle

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1850,7 +1850,7 @@ package:
 templating
 ~~~~~~~~~~
 
-.. versionadded:: 4.3
+.. deprecated:: 4.3
 
     The integration of the Templating component in FrameworkBundle has been
     deprecated since version 4.3 and will be removed in 5.0. That's why all the

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1850,6 +1850,12 @@ package:
 templating
 ~~~~~~~~~~
 
+.. versionadded:: 4.3
+
+    The integration of the Templating component in FrameworkBundle has been
+    deprecated since version 4.3 and will be removed in 5.0. That's why all the
+    configuration options defined under ``framework.templating`` are deprecated too.
+
 .. _reference-templating-form:
 
 form


### PR DESCRIPTION
We're correctly removing them in 5.0 (#11621) but we forgot to add the deprecation notice in 4.3.