### PR TITLE
Removed the deprecated factory YAML config

### DIFF
--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -136,10 +136,10 @@ all the classes are already loaded as services. All you need to do is specify th
 
             # override the services to set the configurator
             AppBundle\Mail\NewsletterManager:
-                configurator: 'AppBundle\Mail\EmailConfigurator:configure'
+                configurator: ['@AppBundle\Mail\EmailConfigurator', 'configure']
 
             AppBundle\Mail\GreetingCardManager:
-                configurator: 'AppBundle\Mail\EmailConfigurator:configure'
+                configurator: ['@AppBundle\Mail\EmailConfigurator', 'configure']
 
     .. code-block:: xml
 
@@ -183,22 +183,6 @@ all the classes are already loaded as services. All you need to do is specify th
 
         $container->getDefinition(GreetingCardManager::class)
             ->setConfigurator([new Reference(EmailConfigurator::class), 'configure']);
-
-.. versionadded:: 3.2
-
-    The ``service_id:method_name`` syntax for the YAML configuration format
-    was introduced in Symfony 3.2.
-
-    The traditional configurator syntax in YAML files used an array to define
-    the service id and the method name:
-
-    .. code-block:: yaml
-
-        app.newsletter_manager:
-            # new syntax
-            configurator: 'AppBundle\Mail\EmailConfigurator:configure'
-            # old syntax
-            configurator: ['@AppBundle\Mail\EmailConfigurator', configure]
 
 That's it! When requesting the ``AppBundle\Mail\NewsletterManager`` or
 ``AppBundle\Mail\GreetingCardManager`` service, the created instance will first be

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -41,7 +41,7 @@ configure the service container to use the
 
             AppBundle\Email\NewsletterManager:
                 # call the static method that creates the object
-                factory: ['AppBundle\Email\NewsletterManagerStaticFactory', createNewsletterManager]
+                factory: ['AppBundle\Email\NewsletterManagerStaticFactory', 'createNewsletterManager']
                 # define the class of the created object
                 class: AppBundle\Email\NewsletterManager
 
@@ -107,7 +107,7 @@ Configuration of the service container then looks like this:
 
             AppBundle\Email\NewsletterManager:
                 # call a method on the specified factory service
-                factory: 'AppBundle\Email\NewsletterManagerFactory:createNewsletterManager'
+                factory: ['@AppBundle\Email\NewsletterManagerFactory', 'createNewsletterManager']
                 class: AppBundle\Email\NewsletterManager
 
     .. code-block:: xml
@@ -149,21 +149,6 @@ Configuration of the service container then looks like this:
                 new Reference(NewsletterManagerFactory::class),
                 'createNewsletterManager',
             ]);
-
-.. note::
-
-    The traditional configuration syntax in YAML files used an array to define
-    the factory service and the method name:
-
-    .. code-block:: yaml
-
-        # app/config/services.yml
-        AppBundle\Email\NewsletterManager:
-            class: AppBundle\Email\NewsletterManager
-            # new syntax
-            factory: 'AppBundle\Email\NewsletterManagerFactory:createNewsletterManager'
-            # old syntax
-            factory: ['@AppBundle\Email\NewsletterManagerFactory', createNewsletterManager]
 
 .. _factories-passing-arguments-factory-method:
 


### PR DESCRIPTION
This backports #11589 to 3.4 so all versions use the same syntax.