### PR TITLE
#11627 Minor/Patch version fix

### DIFF
--- a/setup/upgrade_minor.rst
+++ b/setup/upgrade_minor.rst
@@ -21,9 +21,10 @@ There are two steps to upgrading a minor version:
 1) Update the Symfony Library via Composer
 ------------------------------------------
 
-Your ``composer.json`` file should already be configured to allow your Symfony
-packages to be upgraded to minor versions. But, if a package was not upgraded,
-check that the version constrains of your Symfony dependencies are like this:
+The ``composer.json`` file is configured to allow Symfony packages to be
+upgraded to patch versions. But, if you would like the packages to be upgraded
+to minor versions, check that the version constrains of the Symfony dependencies
+are like this:
 
 .. code-block:: json
 
@@ -40,6 +41,18 @@ check that the version constrains of your Symfony dependencies are like this:
             "...": "..."
         },
         "...": "...",
+    }
+
+At the bottom of your ``composer.json`` file, in the `extra`` block you can
+find a data setting for the symfony version. Make sure to also upgrade
+this one.
+
+.. code-block:: json
+    "extra": {
+        "symfony": {
+            "allow-contrib": false,
+            "require": "4.3.*"
+        }
     }
 
 Next, use Composer to download new versions of the libraries:


### PR DESCRIPTION
According to the docs the composer.json file is setup for automatic minor version upgrades. This is not the case, its setup for patch version upgrades.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
