### PR TITLE
Fix code for getting the uploaded file

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -120,7 +120,7 @@ Finally, you need to update the code of the controller that handles the form::
             if ($form->isSubmitted() && $form->isValid()) {
                 // $file stores the uploaded PDF file
                 /** @var Symfony\Component\HttpFoundation\File\UploadedFile $file */
-                $file = $product->getBrochure();
+                $file = $form->get('brochure')->getData();
 
                 $fileName = $this->generateUniqueFileName().'.'.$file->guessExtension();
 


### PR DESCRIPTION
I think the example code is wrong. If you call $product->getBrochure(); you will get a string, not the uploaded file.