### PR TITLE
#11607 Removed IBAN docs, not available in version 4.2

### DIFF
--- a/reference/constraints/Bic.rst
+++ b/reference/constraints/Bic.rst
@@ -9,9 +9,6 @@ check that the BIC is associated with a given IBAN.
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`
 Options     - `groups`_
-            - `iban`_
-            - `ibanMessage`_
-            - `ibanPropertyPath`_
             - `message`_
             - `payload`_
 Class       :class:`Symfony\\Component\\Validator\\Constraints\\Bic`
@@ -86,31 +83,6 @@ Available Options
 -----------------
 
 .. include:: /reference/constraints/_groups-option.rst.inc
-
-iban
-~~~~
-
-**type**: ``string`` **default**: ``null``
-
-An IBAN value to validate that the BIC is associated with it.
-
-ibanMessage
-~~~~~~~~~~~
-
-**type**: ``string`` **default**: ``This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.``
-
-The default message supplied when the value does not pass the combined BIC/IBAN check.
-
-ibanPropertyPath
-~~~~~~~~~~~~~~~~
-
-**type**: ``string`` **default**: ``null``
-
-It defines the object property whose value stores the IBAN used to check the BIC with.
-
-For example, if you want to compare the ``$bic`` property of some object
-with regard to the ``$iban`` property of the same object, use
-``propertyPath="iban"`` in the comparison constraint of ``$bic``.
 
 message
 ~~~~~~~


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->

The IBAN information was removed from the docs, as this feature was only introduced in `symfony 4.3`.

This should close issue #11607
