### PR TITLE
[HttpClient] Service name

### DIFF
--- a/components/http_client.rst
+++ b/components/http_client.rst
@@ -483,11 +483,11 @@ has a unique service named after its configuration.
         # ...
 
         # whenever a service type-hints HttpClientInterface, inject the GitHub client
-        Symfony\Contracts\HttpClient\HttpClientInterface: '@api_client.github'
+        Symfony\Contracts\HttpClient\HttpClientInterface: '@some_api.client'
 
         # inject the HTTP client called 'crawler' into this argument of this service
         App\Some\Service:
-            $someArgument: '@http_client.crawler'
+            $someArgument: '@crawler.client'
 
 Testing HTTP Clients and Responses
 ----------------------------------


### PR DESCRIPTION
Hi everyone 👋 

I've tried to use multiples clients and it seems that the services are named as the configuration (ex: `@crawler.client`) declares it and not using the `@http_client.client` syntax, I don't know if it's a normal behaviour or just an error on the documentation 🙁 

Thanks for the feedback