### PR TITLE
fixes missing "use" declaration for the ClockMock

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -455,6 +455,7 @@ different class, do it explicitly using ``ClockMock::register(MyClass::class)``:
 
     use App\MyClass;
     use PHPUnit\Framework\TestCase;
+    use Symfony\Bridge\PhpUnit\ClockMock; 
 
     /**
      * @group time-sensitive


### PR DESCRIPTION
so that one can reuse that example out of the box.
may be wise to also patch older maintained branches to guarantee consistency in the docs.