### PR TITLE
Update mailer.rst

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -453,7 +453,7 @@ called ``css`` that points to the directory where ``email.css`` lives:
 
         paths:
             # point this wherever your css files live
-            css: '%kernel.project_dir%/assets/css'
+            '%kernel.project_dir%/assets/css': css
 
 .. _mailer-markdown:
 


### PR DESCRIPTION
When defining twig paths the path must be the key and the namespace must be the value as per https://symfony.com/doc/current/templating/namespaced_paths.html#registering-your-own-namespaces

The current documentation throws an error that the 'css' directory does not exist.
