### PR TITLE
Update mailer.rst - fix twig path configuration

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -376,7 +376,7 @@ image files as usual. First, to simplify things, define a Twig namespace called
 
         paths:
             # point this wherever your images live
-            images: '%kernel.project_dir%/assets/images'
+            '%kernel.project_dir%/assets/images': images
 
 Now, use the special ``email.image()`` Twig helper to embed the images inside
 the email contents:


### PR DESCRIPTION
Same problem as #11673 but I missed this one! When defining twig paths the path must be the key and the namespace must be the value.