### PR TITLE
Fix markup

### DIFF
--- a/contributing/code/pull_requests.rst
+++ b/contributing/code/pull_requests.rst
@@ -129,7 +129,7 @@ work:
   </contributing/code/maintenance>` (you may have to choose a higher branch if
   the feature you are fixing was introduced in a later version);
 
- * ``master``, if you are adding a new feature.
+* ``master``, if you are adding a new feature.
 
 .. note::
 


### PR DESCRIPTION
The extra indentation made it a blockquote:

![symfony_doc_markup](https://user-images.githubusercontent.com/439401/59041189-6eed2880-8878-11e9-8345-d128098c9936.png)
