### PR TITLE
Recommend FOSCKE instead of Ivory WYSIWYG editor

### DIFF
--- a/reference/forms/types/textarea.rst
+++ b/reference/forms/types/textarea.rst
@@ -35,7 +35,7 @@ Renders a ``textarea`` HTML element.
 .. tip::
 
     If you prefer to use an **advanced WYSIWYG editor** instead of a plain
-    textarea, consider using the IvoryCKEditorBundle community bundle. Read
+    textarea, consider using the FOSCKEditorBundle community bundle. Read
     `its documentation`_ to learn how to integrate it in your Symfony application.
 
 Inherited Options
@@ -79,4 +79,4 @@ The default value is ``''`` (the empty string).
 
 .. include:: /reference/forms/types/options/trim.rst.inc
 
-.. _`its documentation`: https://symfony.com/doc/current/bundles/IvoryCKEditorBundle/index.html
+.. _`its documentation`: https://symfony.com/doc/current/bundles/FOSCKEditorBundle/index.html


### PR DESCRIPTION
The Bundle IvoryCKEditorBundle was abandoned, it documentation automatically redirect to "https://symfony.com/doc/current/bundles/FOSCKEditorBundle/index.html" and this documentation contains an article explaining how to migrate from Ivory to Fos.

This PR fix Symfony Form documentation to point to FosCke instead of IvoryCke