### PR TITLE
Update multiple_buses.rst

### DIFF
--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -235,11 +235,11 @@ the correct tag:
 
             <services>
                 <!-- command handlers -->
-                <prototype namespace="App\MessageHandler\" resource="%kernel.project_dir%/src/MessageHandler/*CommandHandler.php">
+                <prototype namespace="App\MessageHandler\" resource="%kernel.project_dir%/src/MessageHandler/*CommandHandler.php" autoconfigure="false">
                     <tag name="messenger.message_handler" bus="messenger.bus.commands"/>
                 </service>
                 <!-- query handlers -->
-                <prototype namespace="App\MessageHandler\" resource="%kernel.project_dir%/src/MessageHandler/*QueryHandler.php">
+                <prototype namespace="App\MessageHandler\" resource="%kernel.project_dir%/src/MessageHandler/*QueryHandler.php" autoconfigure="false">
                     <tag name="messenger.message_handler" bus="messenger.bus.queries"/>
                 </service>
             </services>

--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -213,12 +213,14 @@ the correct tag:
         command_handlers:
             namespace: App\MessageHandler\
             resource: '%kernel.project_dir%/src/MessageHandler/*CommandHandler.php'
+            autoconfigure: false
             tags:
                 - { name: messenger.message_handler, bus: messenger.bus.commands }
 
         query_handlers:
             namespace: App\MessageHandler\
             resource: '%kernel.project_dir%/src/MessageHandler/*QueryHandler.php'
+            autoconfigure: false
             tags:
                 - { name: messenger.message_handler, bus: messenger.bus.queries }
 
@@ -250,11 +252,13 @@ the correct tag:
         // Command handlers
         $container->services()
             ->load('App\MessageHandler\\', '%kernel.project_dir%/src/MessageHandler/*CommandHandler.php')
+            ->autoconfigure(false)
             ->tag('messenger.message_handler', ['bus' => 'messenger.bus.commands']);
 
         // Query handlers
         $container->services()
             ->load('App\MessageHandler\\', '%kernel.project_dir%/src/MessageHandler/*QueryHandler.php')
+            ->autoconfigure(false)
             ->tag('messenger.message_handler', ['bus' => 'messenger.bus.queries']);
 
 Debugging the Buses


### PR DESCRIPTION
When you want to restrict handlers to a bus you have to `autoconfigure: false` otherwise they still are available for other buses.

**This change is not complete:**

- [x] the XML has to be updated to (dont know how its looks like in XML).

I add this docs because of issue https://github.com/symfony/symfony/issues/31909

So, this can be a work around or they go fix this in the compiler.