### PR TITLE
[Messenger] Adds tip for handler misconfiguration

### DIFF
--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -200,7 +200,7 @@ known by the ``messenger.bus.commands`` bus.
 .. tip::
 
     If you manually restrict handlers be sure to have ``autoconfigure`` disabled,
-    or not implement the ``Symfony\Component\Messenger\MessageHandlerInterface``
+    or not implement the ``Symfony\Component\Messenger\Handler\MessageHandlerInterface``
     as this might cause your handler to be registered twice.
 
     See :ref:`autoconfigure <services-autoconfigure>` for more information.

--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -197,6 +197,14 @@ you can restrict each handler to a specific bus using the ``messenger.message_ha
 This way, the ``App\MessageHandler\SomeCommandHandler`` handler will only be
 known by the ``messenger.bus.commands`` bus.
 
+.. tip::
+
+    If you manually restrict handlers be sure to have ``autoconfigure`` disabled,
+    or not implement the ``Symfony\Component\Messenger\MessageHandlerInterface``
+    as this might cause your handler to be registered twice.
+
+    See :ref:`autoconfigure <services-autoconfigure>` for more information.
+
 You can also automatically add this tag to a number of classes by following
 a naming convention and registering all of the handler services by name with
 the correct tag:


### PR DESCRIPTION
When using tags and autoconfigure you might end up with multiple handlers being registered to a bus.

Adding a tip to the documentation will help people find out about this behavior without running into the issue.

See symfony/symfony#31909