### PR TITLE
Require Dotenv component without --dev

### DIFF
--- a/components/dotenv.rst
+++ b/components/dotenv.rst
@@ -17,7 +17,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require --dev symfony/dotenv
+    $ composer require symfony/dotenv
 
 .. include:: /components/require_autoload.rst.inc
 


### PR DESCRIPTION
Looks like according to these changes: https://github.com/symfony/recipes/pull/501 - Dotenv component is suggested to be added to `require` section of `composer.json`. Both `symfony/skeleton` and `symfony/website-skeleton` require it on prod
