### PR TITLE
[Validator] Update the propertyPath description of DivisibleBy

### DIFF
--- a/reference/constraints/DivisibleBy.rst
+++ b/reference/constraints/DivisibleBy.rst
@@ -115,15 +115,6 @@ comparison value.
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-propertyPath
-~~~~~~~~~~~~
-
-**type**: ``string``
-
-It defines the object property whose value is used to make the comparison.
-
-For example, if you want to compare the ``$value`` property of some object
-with regard to the ``$increments`` property of the same object, use
-``propertyPath="increments"`` in the comparison constraint of ``$value``.
+.. include:: /reference/constraints/_comparison-propertypath-option.rst.inc
 
 .. include:: /reference/constraints/_comparison-value-option.rst.inc


### PR DESCRIPTION
Although the current description is perfect ... it's not consistent with the other comparison constraints, which all of them include a standard description. This PR is needed to simplify other PRs, such as #11710.