### PR TITLE
[Workflow] Update the article about dumping workflows

### DIFF
--- a/workflow/dumping-workflows.rst
+++ b/workflow/dumping-workflows.rst
@@ -4,38 +4,38 @@
 How to Dump Workflows
 =====================
 
-To help you debug your workflows, you can dump a representation of your workflow
-with the use of a ``DumperInterface``. Use the ``GraphvizDumper`` to create a
-PNG or SVG image of the workflow defined above::
+To help you debug your workflows, you can generate a visual representation of
+them as SVG or PNG images. First, download and install the `Graphviz project`_,
+an open source graph visualization software which provides the ``dot`` command
+needed to generate the images.
 
-    // dump-graph.php
-    $dumper = new GraphvizDumper();
-    echo $dumper->dump($definition);
+If you are defining the workflow inside a Symfony application, run this command
+to dump it as an image:
 
 .. code-block:: terminal
 
-    $ php dump-graph.php | dot -Tsvg -o graph.svg
+    $ php bin/console workflow:dump workflow-name | dot -Tsvg -o graph.svg
 
     # run this command if you prefer PNG images:
-    # $ php dump-graph.php | dot -Tpng -o graph.png
+    $ php bin/console workflow:dump workflow-name | dot -Tpng -o graph.png
+
+    # highlight 'place1' and 'place2' in the dumped workflow
+    $ php bin/console workflow:dump workflow-name place1 place2 | dot -Tsvg -o graph.svg
 
 The result will look like this:
 
 .. image:: /_images/components/workflow/blogpost.png
 
-If you have configured your workflow with the Symfony framework, you may dump the dot file
-with the ``WorkflowDumpCommand``:
+If you are creating workflows outside of a Symfony application, use the
+``GraphvizDumper`` class to dump the workflow representation::
+
+    // Add this code to a PHP script; for example: dump-graph.php
+    $dumper = new GraphvizDumper();
+    echo $dumper->dump($definition);
 
 .. code-block:: terminal
 
-    $ php bin/console workflow:dump name | dot -Tsvg -o graph.svg
+    # replace 'dump-graph.php' by the name of your PHP script
+    $ php dump-graph.php | dot -Tsvg -o graph.svg
 
-    # highlight 'place1' and 'place2' in the dumped workflow
-    $ php bin/console workflow:dump name place1 place2 | dot -Tsvg -o graph.svg
-
-.. note::
-
-    The ``dot`` command is part of Graphviz. You can download it and read
-    more about it on `Graphviz.org`_.
-
-.. _Graphviz.org: http://www.graphviz.org
+.. _`Graphviz project`: http://www.graphviz.org


### PR DESCRIPTION
I think it's better to display first the Symfony command ... and let the manual setup for the end of the article.