### PR TITLE
[Serializer] Use pack to install

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -19,7 +19,7 @@ install the serializer before using it:
 
 .. code-block:: terminal
 
-    $ composer require symfony/serializer
+    $ composer require symfony/serializer-pack
 
 Using the Serializer Service
 ----------------------------


### PR DESCRIPTION
As [here](https://github.com/symfony/symfony/issues/31490#issuecomment-495954227), I also ran into issues using messenger with the Symfony Serializer, due to `symfony/property-access` missing and the `ObjectNormalizer` not being available due to that.

This change updates the docs to use the pack instead of the package to install the Serializer (which includes `symfony/property-access`).

~I also included a note for developers that already installed the Serializer directly and try to figure out why `ObjectNormalizer` wasn't available.~