### PR TITLE
Implement EventSubscriberInterface in ExceptionListener example

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -29,8 +29,10 @@ The most common way to listen to an event is to register an **event listener**::
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
     use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Component\HttpKernel\KernelEvents;
 
-    class ExceptionListener
+    class ExceptionListener implements EventSubscriberInterface
     {
         public function onKernelException(GetResponseForExceptionEvent $event)
         {
@@ -57,6 +59,15 @@ The most common way to listen to an event is to register an **event listener**::
 
             // sends the modified response object to the event
             $event->setResponse($response);
+        }
+        
+        public static function getSubscribedEvents()
+        {
+            return [
+                KernelEvents::EXCEPTION => [
+                    ['onKernelException', 128],
+                ],
+            ];
         }
     }
 


### PR DESCRIPTION
This patch updates the example for ExceptionListener by implementing Symfony\Component\EventDispatcher\EventSubscriberInterface and declaring the usage of Symfony\Component\HttpKernel\KernelEvents;.

A sample getSubscribedEvents() is also defined as required by the interface.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
