### PR TITLE
Removes quotation marks from terminal command example

### DIFF
--- a/service_container/debug.rst
+++ b/service_container/debug.rst
@@ -29,7 +29,7 @@ its id:
 
 .. code-block:: terminal
 
-    $ php bin/console debug:container 'App\Service\Mailer'
+    $ php bin/console debug:container App\Service\Mailer
 
     # to show the service arguments:
-    $ php bin/console debug:container 'App\Service\Mailer' --show-arguments
+    $ php bin/console debug:container App\Service\Mailer --show-arguments


### PR DESCRIPTION
I'm not sure about this commit, maybe I missed something. But for me (Symfony 4.3) removing the quotation marks also eliminates this error:

 [ERROR] No autowirable classes or interfaces found matching "App\Service\Mailer"
