### PR TITLE
[Messenger] Multiple buses: type-o

### DIFF
--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -103,7 +103,7 @@ This will create three new services:
 
 * ``messenger.bus.queries``: autowireable with the ``MessageBusInterface $messengerBusQueries``;
 
-* ``messenger.bus.queries``: autowireable with the ``MessageBusInterface $messengerBusEvents``.
+* ``messenger.bus.events``: autowireable with the ``MessageBusInterface $messengerBusEvents``.
 
 Type-hints and Auto-wiring
 --------------------------


### PR DESCRIPTION
Fix autowireable eventbus type-o

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
