### PR TITLE
Redis 4.3 is required

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -877,7 +877,7 @@ The Redis transport uses `streams`_ to queue messages.
     # .env
     MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
 
-To use the Redis transport, you will need the Redis PHP extension (^4.2) and
+To use the Redis transport, you will need the Redis PHP extension (^4.3) and
 a running Redis server (^5.0).
 
 .. caution::


### PR DESCRIPTION
See https://github.com/symfony/symfony/pull/31872

But also the conversation on https://github.com/symfony/messenger/commit/47d2b91e111da96045208cceb86d4732c39d385e

So, I'm not actually sure if that commit is correct and the docs should be updated, or if that commit is wrong. Opening this up to at least have some placeholder to figure that out.