### PR TITLE
[Messenger] Fixing & improving autowireable names section

### DIFF
--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -24,16 +24,16 @@ an **event bus**. The event bus could have zero or more subscribers.
         framework:
             messenger:
                 # The bus that is going to be injected when injecting MessageBusInterface
-                default_bus: messenger.bus.commands
+                default_bus: command.bus
                 buses:
-                    messenger.bus.commands:
+                    command.bus:
                         middleware:
                             - validation
                             - doctrine_transaction
-                    messenger.bus.queries:
+                    query.bus:
                         middleware:
                             - validation
-                    messenger.bus.events:
+                    event.bus:
                         default_middleware: allow_no_handlers
                         middleware:
                             - validation
@@ -52,15 +52,15 @@ an **event bus**. The event bus could have zero or more subscribers.
 
             <framework:config>
                 <!-- The bus that is going to be injected when injecting MessageBusInterface -->
-                <framework:messenger default-bus="messenger.bus.commands">
-                    <framework:bus name="messenger.bus.commands">
+                <framework:messenger default-bus="command.bus">
+                    <framework:bus name="command.bus">
                         <framework:middleware id="validation"/>
                         <framework:middleware id="doctrine_transaction"/>
                     <framework:bus>
-                    <framework:bus name="messenger.bus.queries">
+                    <framework:bus name="query.bus">
                         <framework:middleware id="validation"/>
                     <framework:bus>
-                    <framework:bus name="messenger.bus.events" default-middleware="allow_no_handlers">
+                    <framework:bus name="event.bus" default-middleware="allow_no_handlers">
                         <framework:middleware id="validation"/>
                     <framework:bus>
                 </framework:messenger>
@@ -73,20 +73,20 @@ an **event bus**. The event bus could have zero or more subscribers.
         $container->loadFromExtension('framework', [
             'messenger' => [
                 // The bus that is going to be injected when injecting MessageBusInterface
-                'default_bus' => 'messenger.bus.commands',
+                'default_bus' => 'command.bus',
                 'buses' => [
-                    'messenger.bus.commands' => [
+                    'command.bus' => [
                         'middleware' => [
                             'validation',
                             'doctrine_transaction',
                         ],
                     ],
-                    'messenger.bus.queries' => [
+                    'query.bus' => [
                         'middleware' => [
                             'validation',
                         ],
                     ],
-                    'messenger.bus.events' => [
+                    'event.bus' => [
                         'default_middleware' => 'allow_no_handlers',
                         'middleware' => [
                             'validation',
@@ -98,62 +98,12 @@ an **event bus**. The event bus could have zero or more subscribers.
 
 This will create three new services:
 
-* ``messenger.bus.commands``: autowireable with the :class:`Symfony\\Component\\Messenger\\MessageBusInterface`
+* ``command.bus``: autowireable with the :class:`Symfony\\Component\\Messenger\\MessageBusInterface`
   type-hint (because this is the ``default_bus``);
 
-* ``messenger.bus.queries``: autowireable with the ``MessageBusInterface $messengerBusQueries``;
+* ``query.bus``: autowireable with ``MessageBusInterface $queryBus``;
 
-* ``messenger.bus.events``: autowireable with the ``MessageBusInterface $messengerBusEvents``.
-
-Type-hints and Auto-wiring
---------------------------
-
-Auto-wiring is a great feature that allows you to reduce the amount of configuration
-required for your service container to be created. By using ``MessageBusInterface``
-as argument type-hint in your services, the default configured bus will be injected
-(i.e ``messenger.bus.commands`` in above examples).
-
-When working with multiple buses, you can use the ``DependencyInjection`` component's
-binding capabilities to clarify which bus will be injected based on the argument's name:
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # config/services.yaml
-        services:
-            _defaults:
-                # ...
-
-                bind:
-                    $commandBus: '@messenger.bus.commands'
-                    $queryBus: '@messenger.bus.queries'
-                    $eventBus: '@messenger.bus.events'
-
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd">
-
-            <services>
-                <defaults>
-                   <bind key="$commandBus" type="service" id="messenger.bus.commands"/>
-                   <bind key="$queryBus" type="service" id="messenger.bus.queries"/>
-                   <bind key="$eventBus" type="service" id="messenger.bus.events"/>
-                </defaults>
-            </services>
-        </container>
-
-    .. code-block:: php
-
-        // config/services.php
-        $container->bind('$commandBus', 'messenger.bus.commands');
-        $container->bind('$queryBus', 'messenger.bus.queries');
-        $container->bind('$eventBus', 'messenger.bus.events');
+* ``event.bus``: autowireable with ``MessageBusInterface $eventBus``.
 
 Restrict Handlers per Bus
 -------------------------


### PR DESCRIPTION
tl;dr

In 4.3, you get automatic autowireable "names" for each message bus, so the second section is not needed at all. And by tweaking the bus names, we get better autowireable names than before.