### PR TITLE
Update the installation instructions for components

### DIFF
--- a/components/asset.rst
+++ b/components/asset.rst
@@ -44,7 +44,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/asset
+    $ composer require symfony/asset:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 
@@ -153,7 +153,7 @@ corresponding output file:
         "...": "..."
     }
 
-In those cases, use the 
+In those cases, use the
 :class:`Symfony\\Component\\Asset\\VersionStrategy\\JsonManifestVersionStrategy`::
 
     use Symfony\Component\Asset\Package;

--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -19,7 +19,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/browser-kit
+    $ composer require symfony/browser-kit:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/cache.rst
+++ b/components/cache.rst
@@ -23,7 +23,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/cache
+    $ composer require symfony/cache:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/class_loader.rst
+++ b/components/class_loader.rst
@@ -44,7 +44,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/class-loader
+    $ composer require symfony/class-loader:^3.4
 
 Alternatively, you can clone the `<https://github.com/symfony/class-loader>`_ repository.
 

--- a/components/config.rst
+++ b/components/config.rst
@@ -14,7 +14,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/config
+    $ composer require symfony/config:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/console.rst
+++ b/components/console.rst
@@ -17,7 +17,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/console
+    $ composer require symfony/console:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/css_selector.rst
+++ b/components/css_selector.rst
@@ -12,7 +12,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/css-selector
+    $ composer require symfony/css-selector:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/debug.rst
+++ b/components/debug.rst
@@ -12,7 +12,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/debug
+    $ composer require symfony/debug:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -17,7 +17,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/dependency-injection
+    $ composer require symfony/dependency-injection:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -17,7 +17,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/dom-crawler
+    $ composer require symfony/dom-crawler:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/dotenv.rst
+++ b/components/dotenv.rst
@@ -17,7 +17,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/dotenv
+    $ composer require symfony/dotenv:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -54,7 +54,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/event-dispatcher
+    $ composer require symfony/event-dispatcher:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/expression_language.rst
+++ b/components/expression_language.rst
@@ -14,7 +14,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/expression-language
+    $ composer require symfony/expression-language:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -11,7 +11,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/filesystem
+    $ composer require symfony/filesystem:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -13,7 +13,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/finder
+    $ composer require symfony/finder:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/form.rst
+++ b/components/form.rst
@@ -18,7 +18,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/form
+    $ composer require symfony/form:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 
@@ -114,7 +114,7 @@ use the built-in support, first install the Security CSRF component:
 
 .. code-block:: terminal
 
-    $ composer require symfony/security-csrf
+    $ composer require symfony/security-csrf:^3.4
 
 The following snippet adds CSRF protection to the form factory::
 
@@ -172,7 +172,7 @@ between Twig and several Symfony components:
 
 .. code-block:: terminal
 
-    $ composer require symfony/twig-bridge
+    $ composer require symfony/twig-bridge:^3.4
 
 The TwigBridge integration provides you with several :doc:`Twig Functions </reference/forms/twig_reference>`
 that help you render the HTML widget, label and error for each field
@@ -260,7 +260,7 @@ installed:
 
 .. code-block:: terminal
 
-    $ composer require symfony/translation symfony/config
+    $ composer require symfony/translation:^3.4 symfony/config:^3.4
 
 Next, add the :class:`Symfony\\Bridge\\Twig\\Extension\\TranslationExtension`
 to your ``Twig\\Environment`` instance::
@@ -305,7 +305,7 @@ it's installed in your application:
 
 .. code-block:: terminal
 
-    $ composer require symfony/validator
+    $ composer require symfony/validator:^3.4
 
 If you're not familiar with Symfony's Validator component, read more about
 it: :doc:`/validation`. The Form component comes with a

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -21,7 +21,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/http-foundation
+    $ composer require symfony/http-foundation:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -16,7 +16,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/http-kernel
+    $ composer require symfony/http-kernel:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -24,7 +24,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/intl
+    $ composer require symfony/intl:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/ldap.rst
+++ b/components/ldap.rst
@@ -12,7 +12,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/ldap
+    $ composer require symfony/ldap:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/lock.rst
+++ b/components/lock.rst
@@ -17,7 +17,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/lock
+    $ composer require symfony/lock:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -15,7 +15,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/options-resolver
+    $ composer require symfony/options-resolver:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -29,7 +29,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require --dev "symfony/phpunit-bridge:*"
+    $ composer require --dev "symfony/phpunit-bridge::^3.4"
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/process.rst
+++ b/components/process.rst
@@ -12,7 +12,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/process
+    $ composer require symfony/process:^3.4
 
 
 .. include:: /components/require_autoload.rst.inc

--- a/components/property_access.rst
+++ b/components/property_access.rst
@@ -13,7 +13,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/property-access
+    $ composer require symfony/property-access:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -21,7 +21,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/property-info
+    $ composer require symfony/property-info:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/psr7.rst
+++ b/components/psr7.rst
@@ -13,7 +13,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/psr-http-message-bridge
+    $ composer require symfony/psr-http-message-bridge:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/routing.rst
+++ b/components/routing.rst
@@ -13,7 +13,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/routing
+    $ composer require symfony/routing:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/security.rst
+++ b/components/security.rst
@@ -16,7 +16,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/security
+    $ composer require symfony/security:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -26,7 +26,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/serializer
+    $ composer require symfony/serializer:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/stopwatch.rst
+++ b/components/stopwatch.rst
@@ -12,7 +12,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/stopwatch
+    $ composer require symfony/stopwatch:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/templating.rst
+++ b/components/templating.rst
@@ -18,7 +18,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/templating
+    $ composer require symfony/templating:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/translation.rst
+++ b/components/translation.rst
@@ -13,7 +13,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/translation
+    $ composer require symfony/translation:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/using_components.rst
+++ b/components/using_components.rst
@@ -24,7 +24,7 @@ Using the Finder Component
 
 .. code-block:: terminal
 
-    $ composer require symfony/finder
+    $ composer require symfony/finder:^3.4
 
 The name ``symfony/finder`` is written at the top of the documentation for
 whatever component you want.
@@ -64,7 +64,7 @@ them one by one, you can include the ``symfony/symfony`` package:
 
 .. code-block:: terminal
 
-    $ composer require symfony/symfony
+    $ composer require symfony/symfony:^3.4
 
 This will also include the Bundle and Bridge libraries, which you may or
 may not actually need.

--- a/components/validator.rst
+++ b/components/validator.rst
@@ -13,7 +13,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/validator
+    $ composer require symfony/validator:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -14,7 +14,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require --dev symfony/var-dumper
+    $ composer require --dev symfony/var-dumper:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/web_link.rst
+++ b/components/web_link.rst
@@ -13,7 +13,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/web-link
+    $ composer require symfony/web-link:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/workflow.rst
+++ b/components/workflow.rst
@@ -17,7 +17,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/workflow
+    $ composer require symfony/workflow:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 

--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -31,7 +31,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/yaml
+    $ composer require symfony/yaml:^3.4
 
 .. include:: /components/require_autoload.rst.inc
 
@@ -408,7 +408,7 @@ First, install the Console component:
 
 .. code-block:: terminal
 
-    $ composer require symfony/console
+    $ composer require symfony/console:^3.4
 
 Create a console application with ``lint:yaml`` as its only command::
 


### PR DESCRIPTION
This is based on #10971. My questions:

* Is it OK to apply this to all components?
* Is it OK to leave the Polyfills out of this change?
* If this is accepted, when upmerging to other branches, what should we do? Replace `^3.4` by each branch? In all of them except "current"? Should we use "dev-master" for master?