### PR TITLE
Remove a tip about Symfony setup and VMs

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -68,17 +68,6 @@ the server by pressing ``Ctrl+C`` from your terminal.
     If you want to use a virtual machine (VM) with Vagrant, check out
     :doc:`Homestead </setup/homestead>`.
 
-.. tip::
-
-    If you're using a VM, you may need to tell the server to bind to all IP addresses:
-
-    .. code-block:: terminal
-
-        $ php bin/console server:start 0.0.0.0:8000
-
-    You should **NEVER** listen to all interfaces on a computer that is
-    directly accessible from the Internet.
-
 Storing your Project in git
 ---------------------------
 


### PR DESCRIPTION
This is just a proposal. Why?

* We can't do this with the Symfony Local Server (@tucksaun please, confirm that this is true) so we must keep showing the old WebServerBundle, which is deprecated and we don't want to display it anywhere in the docs.
* The tip says: *"be careful with this because it's super dangerous"* Well, then we shouldn't display it at all.

What do you think? Thanks.