### PR TITLE
Update Collection.rst

### DIFF
--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -94,7 +94,8 @@ following:
                 profileData:
                     - Collection:
                         fields:
-                            personal_email: Email
+                            personal_email: 
+                                - Email: ~
                             short_bio:
                                 - NotBlank: ~
                                 - Length:


### PR DESCRIPTION
The line:  
**`personal_email: Email`**
contains a mistake, as every constraint name should start on a new line and with the - symbol.
If I use the code sample in the yaml file, it would throw an exception: 
`The value Email is not an instance of Constraint in constraint Symfony\Component\Validator\Constraints\Required"`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
