### PR TITLE
How to get more attention by the whole Symfony-Team to the documentation?

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# Console
+/console* @chalasr
+/components/console* @chalasr
+
+# Form
+/forms.rst @xabbuh
+/components/form* @xabbuh
+/reference/forms* @xabbuh
+
+# PropertyInfo
+/components/property_info* @dunglas
+
+# Security
+/security* @chalasr
+/components/security* @chalasr
+
+# Validator
+/validation/*
+/components/validator* @xabbuh
+/reference/constraints* @xabbuh
+
+# Workflow
+/workflow* @lyrixx
+/components/workflow* @lyrixx
+
+# Yaml
+/components/yaml* @xabbuh


### PR DESCRIPTION
We all know, documentation can make the difference for a good and a not so good framework 😄

I have an idea, I want to discuss:
GitHub already supports the CODEOWNERS file which is already used in `symfony/symfony`.

I propose to use it for the docs-repository, too and ask the team members if they would be willing to "take care" of their (and/or other components). In this case they would receive notification for specific ones instead of all or nothing.

This is just a starting point and we need to add more later, but first:

- [x] @lyrixx are you OK with it?
- [x] @chalasr are you OK with it?
- [x] @xabbuh are you OK with it?
- [x] @dunglas are you OK with it?

Thank you