### PR TITLE
Tip for referencing a service instead of a string

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -623,11 +623,12 @@ But, you can control this and pass in a different logger:
 This tells the container that the ``$logger`` argument to ``__construct`` should use
 service whose id is ``monolog.logger.request``.
 
-.. tip::
+.. note::
 
     The ``@`` symbol is important: that's what tells the container you want to pass
     the *service* whose id is ``monolog.logger.request``, and not just the *string*
     ``monolog.logger.request``.
+
 
 .. _container-debug-container:
 

--- a/service_container.rst
+++ b/service_container.rst
@@ -623,6 +623,12 @@ But, you can control this and pass in a different logger:
 This tells the container that the ``$logger`` argument to ``__construct`` should use
 service whose id is ``monolog.logger.request``.
 
+.. tip::
+
+    The ``@`` symbol is important: that's what tells the container you want to pass
+    the *service* whose id is ``monolog.logger.request``, and not just the *string*
+    ``monolog.logger.request``.
+
 .. _container-debug-container:
 
 For a full list of *all* possible services in the container, run:


### PR DESCRIPTION
It would be nice to explain why we need to prepend an @ symbol to reference a service. Symfony beginners who start Symfony development from 4.3 would be wondering why that symbol is there.