### PR TITLE
Add tag name for MongoDB event listener

### DIFF
--- a/doctrine/event_listeners_subscribers.rst
+++ b/doctrine/event_listeners_subscribers.rst
@@ -85,6 +85,11 @@ managers that use this connection.
             ->addTag('doctrine.event_subscriber', ['connection' => 'default'])
         ;
 
+.. tip::
+
+    If you're using Doctrine with MongoDB, you should use ``doctrine_mongodb.odm.event_listener``
+    as the tag name for the event listener service.
+
 Creating the Listener Class
 ---------------------------
 


### PR DESCRIPTION
I spent a couple of hours today trying to work out why my event listener wasn't working. It turns out that the tag name for the event listener service is different when using MongoDB, and it would be really useful to have this referenced in the documentation.
