### PR TITLE
Use valid number of backslashes, depending on 1 or 2 ticks - 4.3

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -249,7 +249,7 @@ you can configure them to be sent to a transport:
             ],
         ]);
 
-Thanks to this, the ``App\\Message\\SmsNotification`` will be sent to the ``async``
+Thanks to this, the ``App\Message\SmsNotification`` will be sent to the ``async``
 transport and its handler(s) will *not* be called immediately. Any messages not
 matched under ``routing`` will still be handled immediately.
 

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -112,7 +112,7 @@ called to determine the default escaping applied to the template.
 base_template_class
 ~~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``'Twig\\Template'``
+**type**: ``string`` **default**: ``Twig\Template``
 
 Twig templates are compiled into PHP classes before using them to render
 contents. This option defines the base class from which all the template classes

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -324,7 +324,7 @@ type::
 entry_type
 ~~~~~~~~~~
 
-**type**: ``string`` **default**: ``Symfony\\Component\\Form\\Extension\\Core\\Type\\TextType``
+**type**: ``string`` **default**: ``Symfony\Component\Form\Extension\Core\Type\TextType``
 
 This is the field type for each item in this collection (e.g. ``TextType``,
 ``ChoiceType``, etc). For example, if you have an array of email addresses,


### PR DESCRIPTION
Needs rebase after #11771