### PR TITLE
kernel.debug is a boolean, not a string

### DIFF
--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -55,7 +55,7 @@ Configuration
 auto_reload
 ~~~~~~~~~~~
 
-**type**: ``boolean`` **default**: ``'%kernel.debug%'``
+**type**: ``boolean`` **default**: ``%kernel.debug%``
 
 If ``true``, whenever a template is rendered, Symfony checks first if its source
 code has changed since it was compiled. If it has changed, the template is
@@ -174,7 +174,7 @@ specific timezone is passed as argument.
 debug
 ~~~~~
 
-**type**: ``boolean`` **default**: ``'%kernel.debug%'``
+**type**: ``boolean`` **default**: ``%kernel.debug%``
 
 If ``true``, the compiled templates include a ``__toString()`` method that can
 be used to display their nodes.


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
