### PR TITLE
Added a missing redirection for a deleted article

### DIFF
--- a/_build/redirection_map
+++ b/_build/redirection_map
@@ -422,3 +422,4 @@
 /configuration/environments /configuration
 /configuration/configuration_organization /configuration
 /contributing/community/other /contributing/community
+/profiler/storage /profiler


### PR DESCRIPTION
@linaori reported on Symfony Slack that some Google result has a link to https://symfony.com/doc/4.1/profiler/storage.html, which no longer exists (it existed in 3.4 and before).

Apparently we forgot to add the redirection when we removed this page. We can't fix 4.1 (because that branch is no longer supported), but at least we can fix it in 4.2 and later.