### PR TITLE
Add Symfony version to symfony new command of Symfony Installer

### DIFF
--- a/best_practices/creating-the-project.rst
+++ b/best_practices/creating-the-project.rst
@@ -28,11 +28,11 @@ to create files and execute the following commands:
 .. code-block:: terminal
 
     $ cd projects/
-    $ symfony new blog
+    $ symfony new blog 3.4
 
     # Windows
     c:\> cd projects/
-    c:\projects\> php symfony new blog
+    c:\projects\> php symfony new blog 3.4
 
 .. note::
 


### PR DESCRIPTION
Using the Symfony Installer without version parameter leads to an error:

```
$ ./symfony new blog



  [RuntimeException]
  The Symfony Installer is not compatible with Symfony 4.x or newer versions.
  Run this other command to install Symfony using Composer instead:
  composer create-project symfony/skeleton blog



new <directory> [<version>]
```

