### PR TITLE
Add reference for importing routes when using external formats

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -290,6 +290,8 @@ with a locale. This can be done by defining a different prefix for each locale
             ;
         };
 
+If you're not defining routes with annotations - see :doc:`/routing/external_resources`.
+
 .. _routing-requirements:
 
 Adding {wildcard} Requirements


### PR DESCRIPTION
Currently, the [locale prefix configuration ](https://symfony.com/doc/current/routing.html#localized-routing-i18n) examples only describe how to configure routes defined with annotations, not other formats.

For example, if the user keeps route definitions in `config/routes/app/`, the file that imports those definitions and add prefixes, `config/routes/routes.yaml` must point to `app/` and define its `type: directory`.

The `directory` type is currently not mentioned in this page.

```
routes:
    resource: 'app/'
    type: directory
    prefix:
        en: ''
        pt: '/pt'
```

Should we include an example like the above too (showing how to configure the prefix), or keep only a reference to routing/external_resources? The reference only shows the `type: directory` configuration, not prefixes.