### PR TITLE
Add weeks in the options 'labels'

### DIFF
--- a/reference/forms/types/dateinterval.rst
+++ b/reference/forms/types/dateinterval.rst
@@ -146,6 +146,7 @@ are ``null``, so they display the "humanized version" of the child names (``Inve
         'invert' => null,
         'years' => null,
         'months' => null,
+        'weeks' => null,
         'days' => null,
         'hours' => null,
         'minutes' => null,


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
Hi there,

In the documentation about [DateIntervalType](https://symfony.com/doc/current/reference/forms/types/dateinterval.html#labels), weeks is missing from the code example. I added it to avoid any confusion.

It is my first contribution, not very familiar with all the tools.