### PR TITLE
[Logger] [Processor] additional info on processor

### DIFF
--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -1,9 +1,9 @@
 How to Add extra Data to Log Messages via a Processor
 =====================================================
 
-Monolog allows you to process the record before logging it to add some
-extra data. A processor can be applied for the whole handler stack or
-only for a specific handler.
+Monolog allows you to process every record before logging it by adding some
+extra data. This is the role of a processor, which can be applied for the whole
+handler stack or only for a specific handler or channel.
 
 A processor is a callable receiving the record as its first argument.
 Processors are configured using the ``monolog.processor`` DIC tag. See the
@@ -30,6 +30,8 @@ using a processor::
             $this->session = $session;
         }
 
+        // This method is called for each log record and process it.
+        // Keep it optimized process, to not introduce any overhead.
         public function __invoke(array $record)
         {
             if (!$this->session->isStarted()) {
@@ -184,6 +186,9 @@ Symfony's MonologBridge provides processors that can be registered inside your a
     The ``RouteProcessor`` and the ``ConsoleCommandProcessor`` were introduced
     in Symfony 4.3.
 
+Monolog_ also have built in processors ready to use inside your application.
+Read the librairy documentation to learn more.
+
 Registering Processors per Handler
 ----------------------------------
 
@@ -271,3 +276,5 @@ the ``monolog.processor`` tag:
         $container
             ->register(SessionRequestProcessor::class)
             ->addTag('monolog.processor', ['channel' => 'main']);
+
+.. _Monolog: https://github.com/Seldaek/monolog


### PR DESCRIPTION
Hi,

I was reading doc around log/monolog and testing some features (processor here).
I think this is an addition to have in the doc.

Edit : 
I also have a question, I can see that monolog, which is the main php logger lib, is not "actively maintained", maybe the maintainer(s) are busy on other projects which is normal

Question is: do you think it can be included as it is as a symfony component ? so that it can get more visibility/documentation and so community maintainers

just asking like that :)