### PR TITLE
use bin/console instead of 'symfony'

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -50,7 +50,7 @@ Once installed, move into your new project and start the local web server:
 .. code-block:: terminal
 
     $ cd my-project
-    $ symfony server:start
+    $ php bin/console server:start
 
 Open your browser and navigate to ``http://localhost:8000/``. If everything is
 working, you'll see a welcome page. Later, when you are finished working, stop


### PR DESCRIPTION
The symfony installer does not support 'server:start'

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
