### PR TITLE
Refactor documentation - Do not add annotation configuration if you are using Symfony Flex

### DIFF
--- a/best_practices/controllers.rst
+++ b/best_practices/controllers.rst
@@ -47,7 +47,7 @@ this suffix is neither required nor recommended, so you can safely remove it.
 Routing Configuration
 ---------------------
 
-To load routes defined as annotations in your controllers, run the following command :
+To load routes defined as annotations in your controllers, run the following command:
 
 .. code-block:: terminal
 

--- a/best_practices/controllers.rst
+++ b/best_practices/controllers.rst
@@ -47,8 +47,13 @@ this suffix is neither required nor recommended, so you can safely remove it.
 Routing Configuration
 ---------------------
 
-To load routes defined as annotations in your controllers and if you are not using Symfony Flex, add the following
-configuration to the annotation routing configuration file:
+To load routes defined as annotations in your controllers, run the following command :
+
+.. code-block:: terminal
+
+    $ composer require doctrine/annotations
+
+Thanks to the :doc:`Flex recipe</setup/flex>`, a ``config/routes/annotations.yaml`` file will be created:
 
 .. code-block:: yaml
 

--- a/best_practices/controllers.rst
+++ b/best_practices/controllers.rst
@@ -47,14 +47,14 @@ this suffix is neither required nor recommended, so you can safely remove it.
 Routing Configuration
 ---------------------
 
-To load routes defined as annotations in your controllers, add the following
-configuration to the main routing configuration file:
+To load routes defined as annotations in your controllers and if you are not using Symfony Flex, add the following
+configuration to the annotation routing configuration file:
 
 .. code-block:: yaml
 
-    # config/routes.yaml
+    # config/routes/annotations.yaml
     controllers:
-        resource: '../src/Controller/'
+        resource: '../../src/Controller/'
         type:     annotation
 
 This configuration will load annotations from any controller stored inside the


### PR DESCRIPTION
Do not add annotation routing configuration if your project uses Symfony Flex since the recipe already added the annotations.yaml file with the config inside.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
