### PR TITLE
Update HttpFoundationExtension example

### DIFF
--- a/components/form.rst
+++ b/components/form.rst
@@ -91,9 +91,15 @@ object to read data off of the correct PHP superglobals (i.e. ``$_POST`` or
 
         use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension;
         use Symfony\Component\Form\Forms;
+        use Symfony\Component\HttpFoundation\Request;
+        use Symfony\Component\HttpFoundation\RequestStack;
+        use Symfony\Component\HttpFoundation\UrlHelper;
+        
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::createFromGlobals());
 
         $formFactory = Forms::createFormFactoryBuilder()
-            ->addExtension(new HttpFoundationExtension())
+            ->addExtension(new HttpFoundationExtension(new UrlHelper($requestStack)))
             ->getFormFactory();
 
     Now, when you process a form, you can pass the :class:`Symfony\\Component\\HttpFoundation\\Request`


### PR DESCRIPTION
The HttpFoundationExtension needs UrlHelper and indirectly RequestStack

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
