### PR TITLE
Documented redis consumer group relation

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -904,10 +904,10 @@ serializer          How to serialize the final payload  ``Redis::SERIALIZER_PHP`
 
     At some point you'll likely want to scale the number of workers working on your queue.
     Make sure you assign the correct ``consumer`` and ``group`` values in that case.
-    The more likely case is that each worker shall work on the queue independently, reducing
+    The more likely case is that you want every worker to work on the queue independently, reducing
     the time needed to process the pending messages. In that case, every single worker
-    must have a different ``consumer`` configuration value. When working with Docker
-    containers one idea might be to use the ``HOSTNAME`` environment variable:
+    must have a different ``consumer`` option value so Redis can identify the different workers.
+    When working with Docker containers one idea might be to use the ``HOSTNAME`` environment variable:
 
     .. configuration-block::
 
@@ -922,6 +922,16 @@ serializer          How to serialize the final payload  ``Redis::SERIALIZER_PHP`
     The less likely case would be if you wanted to have every single worker to process every single message.
     That means messages would be processed multiple times. In that case, you must have different ``group``
     configurations.
+
+.. caution::
+
+    Be careful when using the ``HOSTNAME`` environment variable in orchestrated environments such as Kubernetes or
+    Docker Swarm. It usually contains a random unique identifier which means if you destroy a container while it was
+    working on a message, this message will remain in pending state forever as it is very unlikely there's ever going
+    to be another worker with exactly the same ``HOSTNAME`` as the one you destroyed. In other words, you have to
+    make sure you're using deterministic ``HOSTNAME`` values such as ``worker-1``, ``worker-2`` etc.
+    In case you are using Kubernetes to orchestrate your containers, consider using a ``StatefulSet`` rather than
+    a ``Deployment`` for example.
 
 In Memory Transport
 ~~~~~~~~~~~~~~~~~~~

--- a/messenger.rst
+++ b/messenger.rst
@@ -900,6 +900,29 @@ serializer          How to serialize the final payload  ``Redis::SERIALIZER_PHP`
                     ``Redis::OPT_SERIALIZER`` option)
 ==================  =================================== =======
 
+.. tip::
+
+    At some point you'll likely want to scale the number of workers working on your queue.
+    Make sure you assign the correct ``consumer`` and ``group`` values in that case.
+    The more likely case is that each worker shall work on the queue independently, reducing
+    the time needed to process the pending messages. In that case, every single worker
+    must have a different ``consumer`` configuration value. When working with Docker
+    containers one idea might be to use the ``HOSTNAME`` environment variable:
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # config/packages/messenger.yaml
+            framework:
+                messenger:
+                    transports:
+                        redis: 'redis://localhost:6379/messages/symfony/%env(HOSTNAME)%'
+
+    The less likely case would be if you wanted to have every single worker to process every single message.
+    That means messages would be processed multiple times. In that case, you must have different ``group``
+    configurations.
+
 In Memory Transport
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I've documented the relation of `consumer` and `group` in how they behave depending on your needs.

Slightly related:
One thing I just encouter in a project is that if you use the `HOSTNAME` variable it works just fine as long as you're not destroying the container while it's still working on a message. If I destroy the container, the next one gets a new `HOSTNAME` leaving the message that the previous container was working on in a pending state forever. In fact, it would be better to have something like `worker-1`, `worker-2` etc. but I have no idea how to build something like that in e.g. a k8s deployment where you just define the replicas.
If we can fix that somehow: ideas welcome 😄 
If not: Maybe we should document that here too?