### PR TITLE
Remove extra time for security fixes on standard versions

### DIFF
--- a/contributing/community/releases.rst
+++ b/contributing/community/releases.rst
@@ -59,7 +59,7 @@ ones are considered **standard versions**:
 =======================  =====================  ================================
 Version Type             Bugs are fixed for...  Security issues are fixed for...
 =======================  =====================  ================================
-Standard                 8 months               14 months
+Standard                 8 months               8 months
 Long-Term Support (LTS)  3 years                4 years
 =======================  =====================  ================================
 


### PR DESCRIPTION
Fixing security issues on standard versions is complicated as the branches diverged a lot. In any case, if someone wants to stick to standard versions (which I would highly recommend), there is already time to do so. So, the extra time for security issues does serve any purpose IMHO.
