### PR TITLE
Add stream_max_entries to full redis messenger dsn example

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -890,7 +890,7 @@ The Redis transport uses `streams`_ to queue messages.
     # .env
     MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
     # Full DSN Example
-    MESSENGER_TRANSPORT_DSN=redis://password@localhost:6379/messages/symfony/consumer?auto_setup=true&serializer=1
+    MESSENGER_TRANSPORT_DSN=redis://password@localhost:6379/messages/symfony/consumer?auto_setup=true&serializer=1&stream_max_entries=0
 
 To use the Redis transport, you will need the Redis PHP extension (^4.3) and
 a running Redis server (^5.0).


### PR DESCRIPTION
As introduced in: https://github.com/symfony/symfony-docs/pull/11870
Should also added to the full dsn example which was added in: https://github.com/symfony/symfony-docs/pull/11874