### PR TITLE
Fixed subscribe JWT claim parameter

### DIFF
--- a/mercure.rst
+++ b/mercure.rst
@@ -400,7 +400,7 @@ And here is the controller::
             $username = $this->getUser()->getUsername(); // Retrieve the username of the current user
             $token = (new Builder())
                 // set other appropriate JWT claims, such as an expiration date
-                ->set('mercure', ['subscribe' => "http://example.com/user/$username"]) // could also include the security roles, or anything else
+                ->set('mercure', ['subscribe' => ["http://example.com/user/$username"]]) // could also include the security roles, or anything else
                 ->sign(new Sha256(), $this->getParameter('mercure_secret_key')) // don't forget to set this parameter! Test value: aVerySecretKey
                 ->getToken();
 


### PR DESCRIPTION
If you follow current guide and set claim mercure `subscribe` with single string - you get following error from mercure: `json: cannot unmarshal string into Go struct field mercureClaim.subscribe of type []string`

Subscribe parameter is array, not single string.
You can verfiy it by decoding JWT in these official examples: 
1. https://github.com/dunglas/mercure/blob/master/examples/publisher-php.php 
2. https://github.com/dunglas/mercure/blob/master/hub/authorization_test.go
