### PR TITLE
[Testing] Fix wrong include in custom bootstrap for tests

### DIFF
--- a/testing/bootstrap.rst
+++ b/testing/bootstrap.rst
@@ -18,7 +18,7 @@ To do this, first add a file that executes your bootstrap work::
         ));
     }
 
-    require __DIR__.'/../vendor/autoload.php';
+    require __DIR__.'/../config/bootstrap.php';
 
 Then, configure ``phpunit.xml.dist`` to execute this ``bootstrap.php`` file
 before running the tests:


### PR DESCRIPTION
Hello.

There is a wrong include in custom `tests/bootstrap.php` for tests. Till 4.3 it was ok, but from 4.3 following the article you will receive next error:
```
LogicException: You must set the KERNEL_CLASS environment variable to the fully-qualified class name of your Kernel in phpunit.xml / phpunit.xml.dist or override the App\Tests\Foo\BarTest::createKernel() or App\Tests\Foo\BaTest::getKernelClass() method.
```
The problem exists, because the sequence of bootstrap is changes:
`phpunit.dist.xml -> config/bootstrap.php -> vendor/autoload.php`
and normally if something is injected in phpunit config, it should respect the sequence:
`phpunit.dist.xml ->  tests/bootstrap.php (CUSTOM) -> config/bootstrap.php -> vendor/autoload.php`
Actual state in documentation (wrong one)
`phpunit.dist.xml ->  tests/bootstrap.php -> vendor/autoload.php`

Red to recipe: https://github.com/symfony/recipes/blob/master/phpunit/phpunit/4.7/phpunit.xml.dist#L8

Thanks, Vlad.