### PR TITLE
Added example for direct form submit with validation

### DIFF
--- a/form/direct_submit.rst
+++ b/form/direct_submit.rst
@@ -89,3 +89,8 @@ method, pass the submitted data directly to
     "PATCH" method, the validation extension will only handle the submitted
     fields. If the underlying data needs to be validated, this should be done
     manually, i.e. using the validator.
+    
+    When you need validation for some fields you can extend your data array with the required ones so that they will be validated.
+    i.e.::
+    
+        $form->submit(array_merge(['email' => null, 'username' => null], $request->request->all()), false);


### PR DESCRIPTION
See https://github.com/symfony/symfony/issues/25331.

I had the same issue.
My registration form is filled via an API call and this call contains only filled fields.
But when the user is missing all fields its an empty array and then the username and email will not be validated.
After I found out that this is the behaviour I want to share this knowledge ;-)