### PR TITLE
Use Request::METHOD_POST constant

### DIFF
--- a/security/form_login_setup.rst
+++ b/security/form_login_setup.rst
@@ -204,7 +204,7 @@ a traditional HTML form that submits to ``/login``:
         public function supports(Request $request)
         {
             return 'app_login' === $request->attributes->get('_route')
-                && $request->isMethod('POST');
+                && $request->isMethod(Request::METHOD_POST);
         }
 
         public function getCredentials(Request $request)


### PR DESCRIPTION
I prefer to use constants wherever possible. Maybe this is a good change for others too.