### PR TITLE
Point to tests folder directly in command line example

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -47,7 +47,7 @@ what's going on and if the tests are broken because of the new code.
 
     .. code-block:: terminal
 
-        $ php ./phpunit src/Symfony/Component/Finder/
+        $ php ./phpunit src/Symfony/Component/Finder/Tests
 
 .. tip::
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
Hello,

When trying to run tests like described in the doc, I stumbled upon this error:
```
php ./phpunit src/Symfony/Component/HttpKernel --exclude-group tty,benchmark,intl-data
#!/usr/bin/env php
PHP Fatal error:  Class 'PHPUnit_Framework_TestCase' not found in /home/philippe/www/symfony/src/Symfony/Component/HttpKernel/vendor/psr/log/Psr/Log/Test/LoggerInterfaceTest.php on line 12
PHP Stack trace:
PHP   1. {main}() /home/philippe/www/symfony/phpunit:0
PHP   2. require() /home/philippe/www/symfony/phpunit:14
PHP   3. require() /home/philippe/www/symfony/vendor/symfony/phpunit-bridge/bin/simple-phpunit:13
PHP   4. include() /home/philippe/www/symfony/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php:262
PHP   5. PHPUnit\TextUI\Command::main() /home/philippe/www/symfony/.phpunit/phpunit-6.5/phpunit:17
PHP   6. Symfony\Bridge\PhpUnit\Legacy\CommandForV6->run() /home/philippe/www/symfony/.phpunit/phpunit-6.5/src/TextUI/Command.php:148
PHP   7. PHPUnit\TextUI\TestRunner->getTest() /home/philippe/www/symfony/.phpunit/phpunit-6.5/src/TextUI/Command.php:169
PHP   8. PHPUnit\Framework\TestSuite->addTestFiles() /home/philippe/www/symfony/.phpunit/phpunit-6.5/src/Runner/BaseTestRunner.php:65
PHP   9. PHPUnit\Framework\TestSuite->addTestFile() /home/philippe/www/symfony/.phpunit/phpunit-6.5/src/Framework/TestSuite.php:403
PHP  10. PHPUnit\Util\Fileloader::checkAndLoad() /home/philippe/www/symfony/.phpunit/phpunit-6.5/src/Framework/TestSuite.php:325
PHP  11. PHPUnit\Util\Fileloader::load() /home/philippe/www/symfony/.phpunit/phpunit-6.5/src/Util/Fileloader.php:48
PHP  12. include_once() /home/philippe/www/symfony/.phpunit/phpunit-6.5/src/Util/Fileloader.php:64
```

I was wondering why a test in a vendor library was considered when executing phpunit and figured out that targeting the actual Tests folder of my component would be more correct.