### PR TITLE
Add DirectoryIndex to Apache configuration

### DIFF
--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -93,6 +93,8 @@ and increase web server performance:
         ServerAlias www.domain.tld
 
         DocumentRoot /var/www/project/public
+        DirectoryIndex /index.php
+        
         <Directory /var/www/project/public>
             AllowOverride None
             Order Allow,Deny


### PR DESCRIPTION
If you have defined "FallbackResource /index.php" without defining a directory index, then your main page("/") will keep loading until the request times up


