### PR TITLE
Bug fix: Update collection.rst

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -182,7 +182,7 @@ And update the template as follows:
         <ul id="email-fields-list"
             data-prototype="{{ form_widget(form.emails.vars.prototype)|e }}"
             data-widget-tags="{{ '<li></li>'|e }}"
-            data-widget-counter="{{ form.children|length }}">
+            data-widget-counter="{{ form.emails|length }}">
         {% for emailField in form.emails %}
             <li>
                 {{ form_errors(emailField) }}


### PR DESCRIPTION
form.children returns the children of the parent form, but at this point we need the length of children of the childform.

Example: 
If form.children|length returns 3 and you add some childs the counter count up the data-widget-counter attribute. But after submit (with validation errors) the attribute has "3" again.

Steps to reproduce:
1. Add form with child form as collection type like the documentation mentioned
2. Add validation to those fields
3. Check value of data-widget-counter
5. Click the "add" button and and some child fields (check value of data-widget-counter again)
5. Leave empty and submit the form
6. Now you see those fields with validation errors - check value of data-widget-counter - it has the same value from beginning (without fields added) and not the length of fields from child form

