### PR TITLE
Change port in example MAILER_URL

### DIFF
--- a/email.rst
+++ b/email.rst
@@ -45,7 +45,7 @@ environment variable in the ``.env`` file:
     MAILER_URL=null://localhost
 
     # use this to configure a traditional SMTP server
-    MAILER_URL=smtp://localhost:25?encryption=ssl&auth_mode=login&username=&password=
+    MAILER_URL=smtp://localhost:465?encryption=ssl&auth_mode=login&username=&password=
 
 .. caution::
 


### PR DESCRIPTION
The example URL for a SMTP configuration uses "encryption=ssl". Therefore it should use the SSL port for SMTP which is 465.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
