### PR TITLE
Add attachment with url

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -200,6 +200,8 @@ Use the ``attachFromPath()`` method to attach files that exist on your file syst
         ->attachFromPath('/path/to/documents/privacy.pdf', 'Privacy Policy')
         // optionally you can provide an explicit MIME type (otherwise it's guessed)
         ->attachFromPath('/path/to/documents/contract.doc', 'Contract', 'application/msword')
+        // you can also use an absolute url
+        ->attachFromPath('http://example.com/path/to/documents/contract.doc', 'Contract', 'application/msword')
     ;
 
 Alternatively you can use the ``attach()`` method to attach contents from a stream::


### PR DESCRIPTION
Without this we may think (as I did until I tested) that it can only work with a file path and not with url

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
