### PR TITLE
Corrected wrong class used in "Locating Resources"

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -759,10 +759,10 @@ directory of AppBundle.
 The HttpKernel component provides a method called :method:`Symfony\\Component\\HttpKernel\\Kernel::locateResource`
 which can be used to transform logical paths into physical paths::
 
-    use Symfony\Component\HttpKernel\HttpKernel;
+    use Symfony\Component\HttpKernel\Kernel;
 
     // ...
-    $kernel = new HttpKernel($dispatcher, $resolver);
+    $kernel = new Kernel($dispatcher, $resolver);
     $path = $kernel->locateResource('@AppBundle/Resources/config/services.xml');
 
 Learn more


### PR DESCRIPTION
HttpKernel does not contain a locateResource method.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
