### PR TITLE
Fix supervisor: need to use the group:* to start all processes in this group

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -619,7 +619,7 @@ config and start your workers:
 
     $ sudo supervisorctl update
 
-    $ sudo supervisorctl start messenger-consume
+    $ sudo supervisorctl start messenger-consume:*
 
 See the `Supervisor docs`_ for more details.
 


### PR DESCRIPTION
Tested locally - ran into this when setting up supervisor for the SymfonyCasts tutorial today :). The typo was originally mine.