### PR TITLE
[Routing] Be consistent in custom route loader doc

### DIFF
--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -139,8 +139,8 @@ extend or implement any special class, but the called method must return a
 
 .. versionadded:: 4.3
 
-    The support of the ``__invoke()`` method to create invokable route loader
-    services was introduced in Symfony 4.3.
+    The support of the ``__invoke()`` method to create invokable service route
+    loaders was introduced in Symfony 4.3.
 
 Creating a custom Loader
 ------------------------


### PR DESCRIPTION
To be consistent with the above name "The routes defined using service route loaders will be automatically..." + cf https://github.com/symfony/symfony/pull/32598#discussion_r304916782