### PR TITLE
[Security] Fixed a minor RST syntax issue

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -959,7 +959,6 @@ Frequently Asked Questions
     the log message:
 
 **Cannot refresh token because user has changed**
-
     If you see this, there are two possible causes. First, there may be a problem
     loading your User from the session. See :ref:`user_session_refresh`. Second,
     if certain user information was changed in the database since the last page


### PR DESCRIPTION
Blank lines are not supported here ... otherwise, it's displayed as a blockquote:

![image](https://user-images.githubusercontent.com/73419/61464021-da491080-a975-11e9-9d4c-0b6c9cab76a7.png)
