### PR TITLE
When overriding `session` service definition, make it public

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -180,6 +180,7 @@ the default ``AttributeBag`` by the ``NamespacedAttributeBag``:
 
         # config/services.yaml
         session:
+            public: true
             class: Symfony\Component\HttpFoundation\Session\Session
             arguments: ['@session.storage', '@session.namespacedattributebag', '@session.flash_bag']
 


### PR DESCRIPTION
`Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait::addFlash()` relies on getting the `session` service from the service container.

Since 3.4 services defined in `services.yaml` are private by default. When overriding the `session`  service definition, it has to be explicitly marked as public.

The 4.2 documentation branch was the earliest I found containing this example service definition.