### PR TITLE
add $context argument to supportsNormalization()

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -47,7 +47,7 @@ to customize the normalized data. To do that, leverage the ``ObjectNormalizer``:
             return $data;
         }
 
-        public function supportsNormalization($data, $format = null)
+        public function supportsNormalization($data, $format = null, array $context = [])
         {
             return $data instanceof Topic;
         }


### PR DESCRIPTION
reverts #11613, the context will actually be passed as the third argument here (see https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Serializer/Serializer.php#L242)