### PR TITLE
[WCM] Documenting the support for disable_type_enforcement in DateTimeNormalizer

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1045,6 +1045,8 @@ will be thrown. The type enforcement of the properties can be disabled by settin
 the serializer context option ``ObjectNormalizer::DISABLE_TYPE_ENFORCEMENT``
 to ``true``.
 
+Be aware that disabling type enforcement when denormalizing will not throw any exception if you try to cast a non well formatted datetime string into a real ``DateTimeInterface`` !
+
 Learn more
 ----------
 


### PR DESCRIPTION
I've submitted a PR (see https://github.com/symfony/symfony/pull/32638) which aims to support disable_type_enforcement in DateTimeNormalizer::denormalize() by NOT throwing an exception when a non well formatted string is casted into a DateTimeInterface if disable_type_enforcement is set to true in the $context.

This PR documents this change.