### PR TITLE
Use string instead of FQCN

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -323,7 +323,7 @@ type::
 entry_type
 ~~~~~~~~~~
 
-**type**: ``string`` **default**: ``Symfony\\Component\\Form\\Extension\\Core\\Type\\TextType``
+**type**: ``string`` **default**: ``'Symfony\Component\Form\Extension\Core\Type\TextType'``
 
 This is the field type for each item in this collection (e.g. ``TextType``,
 ``ChoiceType``, etc). For example, if you have an array of email addresses,


### PR DESCRIPTION
If the type is string, it should either be:

**type**: ``string`` **default**: ``'Symfony\Component\Form\Extension\Core\Type\TextType'``

or

**type**: ``string`` **default**: ``Symfony\Component\Form\Extension\Core\Type\TextType::class``

@xabbuh can you please give me some feedback here? Thanks