### PR TITLE
Class name is wrong according to the other examples

### DIFF
--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -157,7 +157,7 @@ or you decided not to maintain it anymore), you can deprecate its definition:
     .. code-block:: yaml
 
         app.mailer:
-            alias: '@AppBundle\Mail\PhpMailer'
+            alias: '@App\Mail\PhpMailer'
 
             # this will display a generic deprecation message...
             deprecated: true


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
