### PR TITLE
Fix Psr6Cache classname for 3.4 and 4.2

### DIFF
--- a/components/cache/psr6_psr16_adapters.rst
+++ b/components/cache/psr6_psr16_adapters.rst
@@ -74,13 +74,13 @@ the class instead. No problem! The Cache component provides the
 this use-case::
 
     use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-    use Symfony\Component\Cache\Simple\Psr16Cache;
+    use Symfony\Component\Cache\Simple\Psr6Cache;
 
     // the PSR-6 cache object that you want to use
     $psr6Cache = new FilesystemAdapter();
 
     // a PSR-16 cache that uses your cache internally!
-    $psr16Cache = new Psr16Cache($psr6Cache);
+    $psr16Cache = new Psr6Cache($psr6Cache);
 
     // now use this wherever you want
     $githubApiClient = new GitHubApiClient($psr16Cache);


### PR DESCRIPTION
This PR will fix a wrong class name that was added in #11830.

This PR affects only the branches 3.4 and 4.2. 

In 4.3 the class was deprecated and moved to `Symfony\Component\Cache\Psr16Cache`, so the branches 4.3 and 4.4 are not affected.
