### PR TITLE
[Messenger] Fix hidden section title

### DIFF
--- a/messenger/handler_results.rst
+++ b/messenger/handler_results.rst
@@ -26,7 +26,7 @@ The :method:`Symfony\\Component\\Messenger\\HandleTrait::handle` method ensures
 there is exactly one handler registered and returns its result.
 
 Working with Command & Query Buses
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Messenger component can be used in CQRS architectures where command & query
 buses are central pieces of the application. Read Martin Fowler's


### PR DESCRIPTION
Problem is this section title is hidden on https://symfony.com/doc/current/messenger/handler_results.html (as every other `.section h1`)