### PR TITLE
Updated the explanation about Symfony server dependencies

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -14,9 +14,9 @@ PHP application and even with HTML/SPA (single page applications).
 Installation
 ------------
 
-The Symfony server is distributed as a free installable binary, without any
-dependency, and has support for Linux, macOS and Windows. Go to `symfony.com/download`_
-and follow the instructions for your operating system.
+The Symfony server is distributed as a free installable binary and has support
+for Linux, macOS and Windows. Go to `symfony.com/download`_ and follow the
+instructions for your operating system.
 
 .. note::
 


### PR DESCRIPTION
The deleted statement was not entirely true because if you try for example to create a new Symfony project, you need to install the Git dependency.