### PR TITLE
[HttpClient] Add buffer configuration option to http_client

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -93,6 +93,7 @@ Configuration
   * :ref:`default_options <reference-http-client-default-options>`
 
     * `bindto`_
+    * `buffer`_
     * `cafile`_
     * `capath`_
     * `ciphers`_
@@ -118,6 +119,7 @@ Configuration
     * `auth_bearer`_
     * `base_uri`_
     * `bindto`_
+    * `buffer`_
     * `cafile`_
     * `capath`_
     * `ciphers`_
@@ -778,6 +780,16 @@ bindto
 
 A network interface name, IP address, a host name or a UNIX socket to use as the
 outgoing network interface.
+
+buffer
+......
+
+**type**: ``bool`` | ``string``
+
+Option that allows to buffer the content of the response and access it multiple times without performing the request again. 
+If boolean value given, request will be buffered or not according to the boolean value. If a string is given, this should 
+be a regex matching the response content-types that
+should be buffered
 
 cafile
 ......


### PR DESCRIPTION
In PR https://github.com/symfony/symfony/pull/32565, a regex value was added as a check to automatically buffer the content of a call. Since this is a new feature, the documentation of the http_client configuration true frameworkbundle is updated
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
