### PR TITLE
Removed old versionadded/deprecated directives

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -376,10 +376,6 @@ To get the best of both worlds you may use a chain of adapters. The idea is to
 first look at the quick adapter and then move on to slower adapters. In the worst
 case the value needs to be recalculated.
 
-.. versionadded:: 4.4
-
-    Support for configuring a chain using ``framework.cache.pools`` was introduced in Symfony 4.4.
-
 .. configuration-block::
 
     .. code-block:: yaml

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -615,19 +615,6 @@ kernel.terminate             ``KernelEvents::TERMINATE``             :class:`Sym
 kernel.exception             ``KernelEvents::EXCEPTION``             :class:`Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent`
 ===========================  ======================================  ========================================================================
 
-.. deprecated:: 4.3
-
-    Since Symfony 4.3, most of the event classes were renamed.
-    The following old classes were deprecated:
-
-    * `GetResponseEvent` renamed to :class:`Symfony\\Component\\HttpKernel\\Event\\RequestEvent`
-    * `FilterControllerEvent` renamed to :class:`Symfony\\Component\\HttpKernel\\Event\\ControllerEvent`
-    * `FilterControllerArgumentsEvent` renamed to :class:`Symfony\\Component\\HttpKernel\\Event\\ControllerArgumentsEvent`
-    * `GetResponseForControllerResultEvent` renamed to :class:`Symfony\\Component\\HttpKernel\\Event\\ViewEvent`
-    * `FilterResponseEvent` renamed to :class:`Symfony\\Component\\HttpKernel\\Event\\ResponseEvent`
-    * `PostResponseEvent` renamed to :class:`Symfony\\Component\\HttpKernel\\Event\\TerminateEvent`
-    * `GetResponseForExceptionEvent` renamed to :class:`Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent`
-
 .. _http-kernel-working-example:
 
 A full Working Example

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -254,11 +254,6 @@ The ``VarDumperTestTrait`` also includes these other methods:
     is called automatically after each case to reset the custom configuration
     made in ``setUpVarDumper()``.
 
-.. versionadded:: 4.4
-
-    The ``setUpVarDumper()`` and ``tearDownVarDumper()`` methods were introduced
-    in Symfony 4.4.
-
 Example::
 
     use PHPUnit\Framework\TestCase;

--- a/translation.rst
+++ b/translation.rst
@@ -347,13 +347,6 @@ For more options, see :ref:`component-translator-message-catalogs`.
     :class:`Symfony\\Component\\Translation\\Loader\\LoaderInterface` interface.
     See the :ref:`dic-tags-translation-loader` tag for more information.
 
-.. versionadded:: 4.3
-
-    Starting from Symfony 4.3, when you create a new translation file (or
-    install a bundle that includes translation files), you don't have to clear
-    the cache with the command ``php bin/console cache:clear`` as you had to do
-    in previous Symfony versions.
-
 Handling the User's Locale
 --------------------------
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
