### PR TITLE
Doctrine Section -- Change CodeBlock terminal to CodeBlock console

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -84,7 +84,7 @@ you need a ``Product`` object to represent those products.
 You can use the ``make:entity`` command to create this class and any fields you
 need. The command will ask you some questions - answer them like done below:
 
-.. code-block:: terminal
+.. code-block:: console
 
     $ php bin/console make:entity
 
@@ -246,7 +246,7 @@ But what if you need to add a new field property to ``Product``, like a
 ``description``? You can edit the class to add the new property. But, you can
 also use ``make:entity`` again:
 
-.. code-block:: terminal
+.. code-block:: console
 
     $ php bin/console make:entity
 


### PR DESCRIPTION
In Symfony Docs if you use code block terminal the text color change  "New property name (press <return>" is different to "to stop adding fields):" 

Example : https://symfony.com/doc/current/doctrine.html#creating-an-entity-class

With code block console this color difference is not applied.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
