### PR TITLE
Updated the lexer used to highlight terminal blocks

### DIFF
--- a/_build/_themes/_exts/symfonycom/sphinx/lexer.py
+++ b/_build/_themes/_exts/symfonycom/sphinx/lexer.py
@@ -10,7 +10,7 @@ class TerminalLexer(RegexLexer):
     tokens = {
         'root': [
             ('^\$', Generic.Prompt, 'bash-prompt'),
-            ('^[^\n>]+>', Generic.Prompt, 'dos-prompt'),
+            ('^C:\\[^\n>]+>', Generic.Prompt, 'dos-prompt'),
             ('^#.+$', Comment.Single),
             ('^.+$', Generic.Output),
         ],


### PR DESCRIPTION
This should fix #12060 and all the related issues which were reported in the past.

Now we only consider something is a Windows prompt if it starts with `C:\` and ends with `>`, so `C:\>`, `C:\Users\Administrator>`, `C:\Users\Someone\Projects\AcmeProject>`, etc. 