### PR TITLE
Remove strict true === $user['showEmail'] on preSubmit

### DIFF
--- a/form/events.rst
+++ b/form/events.rst
@@ -287,7 +287,7 @@ Creating and binding an event listener to the form::
             // checks whether the user has chosen to display their email or not.
             // If the data was submitted previously, the additional value that is
             // included in the request variables needs to be removed.
-            if (true === $user['showEmail']) {
+            if (isset($user['showEmail']) && $user['showEmail']) {
                 $form->add('email', EmailType::class);
             } else {
                 unset($user['email']);
@@ -383,7 +383,7 @@ Consider the following example of a form event subscriber::
             // checks whether the user has chosen to display their email or not.
             // If the data was submitted previously, the additional value that
             // is included in the request variables needs to be removed.
-            if (true === $user['showEmail']) {
+            if (isset($user['showEmail']) && $user['showEmail']) {
                 $form->add('email', EmailType::class);
             } else {
                 unset($user['email']);


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->

On the pre submit example. Strict condition will be used. `true === $user['showEmail']`.

In pre submit value of data are not normalized. Strict operator `true === $user['showEmail']` is wrong.

If we want used strict operator we can use: `'1' === $user['showEmail']`. but in case of checkbox is not checked the key `showEmail` is not set.

I prefere use this condition: `isset($user['showEmail']) && $user['showEmail']` or maybe `false === empty($user['showEmail'])` ?
