### PR TITLE
Updated some console commands

### DIFF
--- a/_build/_themes/_exts/symfonycom/sphinx/lexer.py
+++ b/_build/_themes/_exts/symfonycom/sphinx/lexer.py
@@ -10,7 +10,7 @@ class TerminalLexer(RegexLexer):
     tokens = {
         'root': [
             ('^\$', Generic.Prompt, 'bash-prompt'),
-            ('^C:\\[^\n>]+>', Generic.Prompt, 'dos-prompt'),
+            ('^>', Generic.Prompt, 'dos-prompt'),
             ('^#.+$', Comment.Single),
             ('^.+$', Generic.Output),
         ],

--- a/best_practices/creating-the-project.rst
+++ b/best_practices/creating-the-project.rst
@@ -25,14 +25,21 @@ Now that everything is correctly set up, you can create a new project based on
 Symfony. In your command console, browse to a directory where you have permission
 to create files and execute the following commands:
 
+**Linux and macOS systems**:
+
+.. class:: command-linux
 .. code-block:: terminal
 
     $ cd projects/
     $ symfony new blog 3.4
 
-    # Windows
-    c:\> cd projects/
-    c:\projects\> php symfony new blog 3.4
+**Windows systems**:
+
+.. class:: command-windows
+.. code-block:: terminal
+
+    > cd projects/
+    > php symfony new blog 3.4
 
 .. note::
 

--- a/setup.rst
+++ b/setup.rst
@@ -20,15 +20,21 @@ Symfony provides a dedicated application called the **Symfony Installer** to eas
 the creation of Symfony applications. This installer is a PHP 5.4 compatible
 executable that needs to be installed on your system only once:
 
+**Linux and macOS systems**:
+
+.. class:: command-linux
 .. code-block:: terminal
 
-    # Linux and macOS systems
     $ sudo mkdir -p /usr/local/bin
     $ sudo curl -LsS https://symfony.com/installer -o /usr/local/bin/symfony
     $ sudo chmod a+x /usr/local/bin/symfony
 
-    # Windows systems
-    c:\> php -r "file_put_contents('symfony', file_get_contents('https://symfony.com/installer'));"
+**Windows systems**:
+
+.. class:: command-windows
+.. code-block:: terminal
+
+    > php -r "file_put_contents('symfony', file_get_contents('https://symfony.com/installer'));"
 
 .. note::
 
@@ -37,21 +43,22 @@ executable that needs to be installed on your system only once:
     environment variable and create a ``symfony.bat`` file to create the global
     command or move it to any other directory convenient for you:
 
+    .. class:: command-windows
     .. code-block:: terminal
 
         # for example, if WAMP is used ...
-        c:\> move symfony c:\wamp\bin\php
+        > move symfony c:\wamp\bin\php
         # create symfony.bat in the same folder
-        c:\> cd c:\wamp\bin\php
-        c:\> (echo @ECHO OFF & echo php "%~dp0symfony" %*) > symfony.bat
+        > cd c:\wamp\bin\php
+        > (echo @ECHO OFF & echo php "%~dp0symfony" %*) > symfony.bat
         # ... then, execute the command as:
-        c:\> symfony
+        > symfony
 
         # moving it to your projects folder ...
-        c:\> move symfony c:\projects
+        > move symfony c:\projects
         # ... then, execute the command as
-        c:\> cd projects
-        c:\projects\> php symfony
+        > cd projects
+        > php symfony
 
 .. _installation-creating-the-app:
 


### PR DESCRIPTION
This makes two changes:

* I was told on Symfony Slack that using `c:\>` is wrong for Windows. Better use `>` (even if you have run a `cd ...` command before)
* On symfony.com the console decoration changes depending on your operating system. But in the docs, some commands are only for Windows or only for Linux/macOS. In those special cases, we cannot change the console decoration, so let's apply a CSS class to tell that they are Windows-only or Linux-only commands.