### PR TITLE
Improved some deprecation message

### DIFF
--- a/bundles/inheritance.rst
+++ b/bundles/inheritance.rst
@@ -4,10 +4,11 @@
 How to Use Bundle Inheritance to Override Parts of a Bundle
 ===========================================================
 
-.. caution::
+.. deprecated:: 3.4
 
     Bundle inheritance is deprecated since Symfony 3.4 and will be removed in
-    4.0.
+    4.0, but you can :doc:`override any part of a bundle </bundles/override>`
+    without using bundle inheritance.
 
 When working with third-party bundles, you'll probably come across a situation
 where you want to override a file in that third-party bundle with a file


### PR DESCRIPTION
Some user complained on Symfony's Slack about this ... and he is right.

The deprecation message in 4.x is useful: https://symfony.com/doc/4.3/bundles/inheritance.html

But in 3.4 is not that useful: https://symfony.com/doc/3.4/bundles/inheritance.html
