### PR TITLE
Update heroku official documentation link

### DIFF
--- a/deployment/heroku.rst
+++ b/deployment/heroku.rst
@@ -7,6 +7,6 @@ Deploying to Heroku
 ===================
 
 To deploy to Heroku, see their official documentation:
-`Getting Started with Symfony on Heroku`_.
+`Deploying Symfony 4 Apps on Heroku`_.
 
-.. _`Getting Started with Symfony on Heroku`: https://devcenter.heroku.com/articles/getting-started-with-symfony
+.. _`Deploying Symfony 4 Apps on Heroku`: https://devcenter.heroku.com/articles/deploying-symfony4


### PR DESCRIPTION
update the link to point directly to the documentation of Symfony 4 _(and not version 3)_

Actual page: https://symfony.com/doc/current/deployment/heroku.html