### PR TITLE
Replace interface in custom normalizer

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -21,10 +21,10 @@ to customize the normalized data. To do that, leverage the ``ObjectNormalizer``:
 
     use App\Entity\Topic;
     use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-    use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+    use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
     use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
-    class TopicNormalizer implements NormalizerInterface
+    class TopicNormalizer implements ContextAwareNormalizerInterface
     {
         private $router;
         private $normalizer;


### PR DESCRIPTION
Replace NormalizerInterface by ContextAwareNormalizerInterface to use `context` parameter in supportNormalization method