### PR TITLE
Make EOL == EOM for standard releases

### DIFF
--- a/contributing/community/releases.rst
+++ b/contributing/community/releases.rst
@@ -59,7 +59,7 @@ ones are considered **standard versions**:
 =======================  =====================  ================================
 Version Type             Bugs are fixed for...  Security issues are fixed for...
 =======================  =====================  ================================
-Standard                 8 months               14 months
+Standard                 8 months               8 months (14 months before 5.0)
 Long-Term Support (LTS)  3 years                4 years
 =======================  =====================  ================================
 


### PR DESCRIPTION
As of 5.0, I propose to make EOM (end of maintenance) and EOL (end of life) the same for standard releases (all minor releases except LTS versions).

So, Symfony 5.0 end of maintenance AND end of life would be July 2020. We won't have extra months of maintenance for security issues. The rationale behind this change is that backporting security fixes to these versions takes a huge amount of time for releases that nobody should be using anymore anyway as the goal when following these standard versions is to update fast.

LTS releases are not affected by this change.
