### PR TITLE
update composer autoloader section

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -201,14 +201,13 @@ deployment process too):
 
 .. code-block:: terminal
 
-    $ composer dump-autoload --optimize --no-dev --classmap-authoritative
+    $ composer dump-autoload --no-dev --classmap-authoritative
 
-* ``--optimize`` dumps every PSR-0 and PSR-4 compatible class used in your
-  application;
 * ``--no-dev`` excludes the classes that are only needed in the development
-  environment (e.g. tests);
-* ``--classmap-authoritative`` prevents Composer from scanning the file
-  system for classes that are not found in the class map.
+  environment (i.e. ``require-dev`` dependencies and ``autoload-dev`` rules);
+* ``--classmap-authoritative`` creates a class map for PSR-0 and PSR-4 compatible classes
+  used in your application and prevents Composer from scanning the file system for
+  classes that are not found in the class map. (see: `Composer's autoloader optimization`_).
 
 Learn more
 ----------


### PR DESCRIPTION
the `--optimize` option is implied by `--classmap-authoritative` and hence surplus
show documentation link (it was already in rst)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
