### PR TITLE
Fix custom logging formatter

### DIFF
--- a/logging/formatter.rst
+++ b/logging/formatter.rst
@@ -19,7 +19,7 @@ configure your handler to use it:
                 file:
                     type: stream
                     level: debug
-                    formatter: '@monolog.formatter.json'
+                    formatter: 'monolog.formatter.json'
 
     .. code-block:: xml
 


### PR DESCRIPTION
When I use the '@' in the service name, I get this kind of error:

```
In CheckExceptionOnInvalidReferenceBehaviorPass.php line 31:
                                                                                                                          
  The service "monolog.handler.deprecation" has a dependency on a non-existent service "@monolog.formatter.deprecation". 
```