### PR TITLE
Fix sample of use of SYMFONY_DEPRECATIONS_HELPER for regex

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -369,7 +369,7 @@ Running the following command will display the full stack trace:
 
 .. code-block:: terminal
 
-    $ SYMFONY_DEPRECATIONS_HELPER='regex=/Doctrine\\Common\\ClassLoader is deprecated\./' ./vendor/bin/simple-phpunit
+    $ SYMFONY_DEPRECATIONS_HELPER='/Doctrine\\Common\\ClassLoader is deprecated\./' ./vendor/bin/simple-phpunit
 
 Time-sensitive Tests
 --------------------


### PR DESCRIPTION
The sample of use of regex for `SYMFONY_DEPRECATIONS_HELPER` is wrong. 

See https://github.com/symfony/symfony/pull/33012#issuecomment-519063950