### PR TITLE
Replace utf8_bin collation with utf8mb4_bin in example

### DIFF
--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -255,7 +255,7 @@ MySQL
         `sess_data` BLOB NOT NULL,
         `sess_time` INTEGER UNSIGNED NOT NULL,
         `sess_lifetime` MEDIUMINT NOT NULL
-    ) COLLATE utf8_bin, ENGINE = InnoDB;
+    ) COLLATE utf8mb4_bin, ENGINE = InnoDB;
 
 .. note::
 


### PR DESCRIPTION
Symfony docs recommend using `utf8mb4` charset and collation already