### PR TITLE
add support for custom headers when using a proxy

### DIFF
--- a/deployment/proxies.rst
+++ b/deployment/proxies.rst
@@ -78,3 +78,20 @@ other information.
 
 .. _`security groups`: http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-groups.html
 .. _`RFC 7239`: http://tools.ietf.org/html/rfc7239
+
+Custom Headers When Using a Reverse Proxy
+-----------------------------------------
+
+Some reverse proxies (like CloudFront with ``CloudFront-Forwarded-Proto``) may force you to use a custom header.
+For instance you have ``Custom-Forwarded-Proto`` instead of ``X-Forwarded-Proto``.
+
+In this case, you'll need to set the header ``X-Forwarded-Proto`` with the value of
+``Custom-Forwarded-Proto`` early enough in your application, i.e. before handling the request::
+
+    // web/app.php
+
+    // ...
+    $_SERVER['HEADER_X_FORWARDED_PROTO'] = $_SERVER['HEADER_CUSTOM_FORWARDED_PROTO'];
+    // ...
+    $response = $kernel->handle($request);
+


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->

See https://github.com/symfony/symfony/pull/32961 and https://github.com/symfony/symfony/issues/26333.

We should document how to use custom headers when using reverse proxies since `Request::setTrustedHeaderName()` has been deprecated.

