### PR TITLE
Updated related to Symfony installation and Symfony Flex

### DIFF
--- a/bundles.rst
+++ b/bundles.rst
@@ -37,7 +37,7 @@ file::
 
 .. tip::
 
-    In a default Symfony application that uses :doc:`Symfony Flex </setup/flex>`,
+    In a default Symfony application that uses :ref:`Symfony Flex <symfony-flex>`,
     bundles are enabled/disabled automatically for you when installing/removing
     them, so you don't need to look at or edit this ``bundles.php`` file.
 

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -246,7 +246,7 @@ Installation
 ------------
 
 Bundles should set ``"type": "symfony-bundle"`` in their ``composer.json`` file.
-With this, :doc:`Symfony Flex </setup/flex>` will be able to automatically
+With this, :ref:`Symfony Flex <symfony-flex>` will be able to automatically
 enable your bundle when it's installed.
 
 If your bundle requires any setup (e.g. configuration, new files, changes to

--- a/configuration.rst
+++ b/configuration.rst
@@ -30,7 +30,7 @@ stores the configuration of every package installed in your application.
 Packages (also called "bundles" in Symfony and "plugins/modules" in other
 projects) add ready-to-use features to your projects.
 
-When using :doc:`Symfony Flex </setup/flex>`, which is enabled by default in
+When using :ref:`Symfony Flex <symfony-flex>`, which is enabled by default in
 Symfony applications, packages update the ``bundles.php`` file and create new
 files in ``config/packages/`` automatically during their installation. For
 example, this is the default file created by the "API Platform" package:
@@ -555,7 +555,7 @@ This is for example the content of the ``.env`` file to define the value of the
 
 In addition to your own env vars, this ``.env`` file also contains the env vars
 defined by the third-party packages installed in your application (they are
-added automatically by :doc:`Symfony Flex </setup/flex>` when installing packages).
+added automatically by :ref:`Symfony Flex <symfony-flex>` when installing packages).
 
 .. _configuration-env-var-in-prod:
 
@@ -565,7 +565,7 @@ Configuring Environment Variables in Production
 In production, the ``.env`` files are also parsed and loaded on each request so
 you can override the env vars already defined in the server. In order to improve
 performance, you can run the ``dump-env`` command (available when using
-:doc:`Symfony Flex </setup/flex>` 1.2 or later).
+:ref:`Symfony Flex <symfony-flex>` 1.2 or later).
 
 This command parses all the ``.env`` files once and compiles their contents into
 a new PHP-optimized file called  ``.env.local.php``. From that moment, Symfony

--- a/contributing/code/security.rst
+++ b/contributing/code/security.rst
@@ -169,8 +169,7 @@ Security Advisories
 .. tip::
 
     You can check your Symfony application for known security vulnerabilities
-    using the ``security:check`` command provided by the
-    :ref:`Symfony security checker <security-checker>`.
+    using :ref:`the security:check command <security-checker>`.
 
 Check the `Security Advisories`_ blog category for a list of all security
 vulnerabilities that were fixed in Symfony releases, starting from Symfony

--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -150,7 +150,7 @@ Fortunately, the default ``ExceptionController`` allows you to preview your
 *error* pages during development.
 
 To use this feature, you need to load some special routes provided by TwigBundle
-(if the application uses :doc:`Symfony Flex </setup/flex>` they are loaded
+(if the application uses :ref:`Symfony Flex <symfony-flex>` they are loaded
 automatically when installing Twig support):
 
 .. configuration-block::

--- a/deployment.rst
+++ b/deployment.rst
@@ -170,7 +170,7 @@ as you normally do:
 
     If you get a "class not found" error during this step, you may need to
     run ``export APP_ENV=prod`` (or ``export SYMFONY_ENV=prod`` if you're not
-    using :doc:`Symfony Flex </setup/flex>`) before running this command so
+    using :ref:`Symfony Flex <symfony-flex>`) before running this command so
     that the ``post-install-cmd`` scripts run in the ``prod`` environment.
 
 D) Clear your Symfony Cache

--- a/email.rst
+++ b/email.rst
@@ -17,7 +17,7 @@ own mail servers as well as using popular email providers like `Mandrill`_,
 Installation
 ------------
 
-In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
+In applications using :ref:`Symfony Flex <symfony-flex>`, run this command to
 install the Swift Mailer based mailer before using it:
 
 .. code-block:: terminal

--- a/forms.rst
+++ b/forms.rst
@@ -17,7 +17,7 @@ learning the most important features of the form library along the way.
 Installation
 ------------
 
-In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
+In applications using :ref:`Symfony Flex <symfony-flex>`, run this command to
 install the form feature before using it:
 
 .. code-block:: terminal

--- a/frontend/encore/installation.rst
+++ b/frontend/encore/installation.rst
@@ -16,7 +16,7 @@ project:
     $ composer require symfony/webpack-encore-bundle
     $ yarn install
 
-If you are using :doc:`Symfony Flex </setup/flex>`, this will install and enable
+If you are using :ref:`Symfony Flex <symfony-flex>`, this will install and enable
 the `WebpackEncoreBundle`_, create the ``assets/`` directory, add a
 ``webpack.config.js`` file, and add ``node_modules/`` to ``.gitignore``. You can
 skip the rest of this article and go write your first JavaScript and CSS by

--- a/mailer.rst
+++ b/mailer.rst
@@ -50,9 +50,9 @@ Postmark            ``composer require symfony/postmark-mailer``
 SendGrid            ``composer require symfony/sendgrid-mailer``
 ==================  =============================================
 
-Each library includes a :ref:`Flex recipe <flex-recipe>` that will add example configuration
-to your ``.env`` file. For example, suppose you want to use SendGrid. First,
-install it:
+Each library includes a :ref:`Symfony Flex recipe <symfony-flex>` that will add
+example configuration to your ``.env`` file. For example, suppose you want to
+use SendGrid. First, install it:
 
 .. code-block:: terminal
 

--- a/mercure.rst
+++ b/mercure.rst
@@ -47,7 +47,7 @@ Installation
 Installing the Symfony Component
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
+In applications using :ref:`Symfony Flex <symfony-flex>`, run this command to
 install the Mercure support before using it:
 
 .. code-block:: terminal

--- a/messenger.rst
+++ b/messenger.rst
@@ -12,7 +12,7 @@ handle them immediately in your application or send them through transports
 Installation
 ------------
 
-In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
+In applications using :ref:`Symfony Flex <symfony-flex>`, run this command to
 install messenger:
 
 .. code-block:: terminal

--- a/migration.rst
+++ b/migration.rst
@@ -52,7 +52,7 @@ faster on fixing deprecations to be able to upgrade.
 .. tip::
 
     When upgrading to Symfony you might be tempted to also use
-    :doc:`Flex </setup/flex>`. Please keep in mind that it primarily
+    :ref:`Flex <symfony-flex>`. Please keep in mind that it primarily
     focuses on bootstrapping a new Symfony application according to best
     practices regarding the directory structure. When you work in the
     constraints of an existing application you might not be able to

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -133,7 +133,7 @@ Auto-Installing Recipes with Symfony Flex
 
 You may not have noticed, but when you ran ``composer require annotations``, two
 special things happened, both thanks to a powerful Composer plugin called
-:doc:`Flex </setup/flex>`.
+:ref:`Flex <symfony-flex>`.
 
 First, ``annotations`` isn't a real package name: it's an *alias* (i.e. shortcut)
 that Flex resolves to ``sensio/framework-extra-bundle``.
@@ -144,9 +144,6 @@ package. `Flex recipes`_ exist for many packages and have the ability
 to do a lot, like adding configuration files, creating directories, updating ``.gitignore``
 and adding new config to your ``.env`` file. Flex *automates* the installation of
 packages so you can get back to coding.
-
-You can learn more about Flex by reading ":doc:`/setup/flex`". But that's not necessary:
-Flex works automatically in the background when you add packages.
 
 The bin/console Command
 -----------------------

--- a/profiler.rst
+++ b/profiler.rst
@@ -8,7 +8,7 @@ environments as it will lead to major security vulnerabilities in your project.
 Installation
 ------------
 
-In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
+In applications using :ref:`Symfony Flex <symfony-flex>`, run this command to
 install the profiler before using it:
 
 .. code-block:: terminal

--- a/security.rst
+++ b/security.rst
@@ -30,7 +30,7 @@ A few other important topics are discussed after.
 1) Installation
 ---------------
 
-In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
+In applications using :ref:`Symfony Flex <symfony-flex>`, run this command to
 install the security feature before using it:
 
 .. code-block:: terminal

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -37,7 +37,7 @@ This means that the following scenarios will work:
 Installation
 ------------
 
-In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
+In applications using :ref:`Symfony Flex <symfony-flex>`, run this command to
 install the Ldap component before using it:
 
 .. code-block:: terminal

--- a/serializer.rst
+++ b/serializer.rst
@@ -14,7 +14,7 @@ its philosophy and the normalizers and encoders terminology.
 Installation
 ------------
 
-In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
+In applications using :ref:`Symfony Flex <symfony-flex>`, run this command to
 install the serializer before using it:
 
 .. code-block:: terminal

--- a/setup.rst
+++ b/setup.rst
@@ -10,57 +10,67 @@ Installing & Setting up the Symfony Framework
     Do you prefer video tutorials? Check out the `Stellar Development with Symfony`_
     screencast series.
 
-Installing Symfony
-------------------
+Technical Requirements
+----------------------
 
-Before creating your first Symfony application, make sure to meet the following
-requirements:
+Before creating your first Symfony application you must:
 
-* Your server has PHP 7.1 or higher installed (and :doc:`these PHP extensions </reference/requirements>`
+* Make sure to have PHP 7.1 or higher installed (and :doc:`these PHP extensions </reference/requirements>`
   which are installed and enabled by default by PHP);
-* You have `installed Composer`_, which is used to install PHP packages;
-* You have installed the :doc:`Symfony local web server </setup/symfony_server>`,
-  which provides all the tools you need to develop your application locally.
+* `Install Composer`_, which is used to install PHP packages;
+* `Install Symfony`_, which creates in your computer a binary called ``symfony``
+  that provides all the tools you need to develop your application locally.
 
-Once these requirements are installed, open your terminal and run any of these
-commands to create the Symfony application:
+.. _creating-symfony-applications:
+
+Creating Symfony Applications
+-----------------------------
+
+Open your console terminal and run any of these commands to create a new Symfony
+application:
 
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ symfony new --full my_project
+    $ symfony new --full my_project_name
 
     # run this if you are building a microservice, console application or API
-    $ symfony new my-project
+    $ symfony new my_project_name
 
 The only difference between these two commands is the number of packages
-installed. The ``--full`` option installs all the packages that you usually
-need to build web applications. Therefore, the installation size will be much bigger.
+installed by default. The ``--full`` option installs all the packages that you
+usually need to build web applications, so the installation size will be bigger.
 
-Both commands will create a new ``my-project/`` directory, download some
-dependencies into it and even generate the basic directories and files you'll
-need to get started. In other words, your new app is ready!
+If you can't or don't want to `install Symfony`_ for any reason, run these
+commands to create the new Symfony application using Composer:
 
-.. seealso::
+.. code-block:: terminal
 
-    If you can't use the ``symfony`` command provided by the Symfony local web
-    server, use the alternative installation commands based on Composer and
-    displayed on the `Symfony download page`_.
+    # run this if you are building a traditional web application
+    $ composer create-project symfony/website-skeleton my_project_name
 
-Running your Symfony Application
---------------------------------
+    # run this if you are building a microservice, console application or API
+    $ composer create-project symfony/skeleton my_project_name
+
+No matter which command you run to create the Symfony application. All of them
+will create a new ``my_project_name/`` directory, download some dependencies
+into it and even generate the basic directories and files you'll need to get
+started. In other words, your new application is ready!
+
+Running Symfony Applications
+----------------------------
 
 On production, you should use a web server like Nginx or Apache (see
 :doc:`configuring a web server to run Symfony </setup/web_server_configuration>`).
 But for development, it's more convenient to use the
-:doc:`Symfony Local Web Server </setup/symfony_server>` installed earlier.
+:doc:`local web server </setup/symfony_server>` provided by Symfony.
 
 This local server provides support for HTTP/2, TLS/SSL, automatic generation of
 security certificates and many other features. It works with any PHP application,
 not only Symfony projects, so it's a very useful development tool.
 
-Open your terminal, move into your new project directory and start the local web
-server as follows:
+Open your console terminal, move into your new project directory and start the
+local web server as follows:
 
 .. code-block:: terminal
 
@@ -77,36 +87,15 @@ the server by pressing ``Ctrl+C`` from your terminal.
     some technical requirements. Use the :doc:`Symfony Requirements Checker </reference/requirements>`
     tool to make sure your system is set up.
 
-.. note::
-
-    If you want to use a virtual machine (VM) with Vagrant, check out
-    :doc:`Homestead </setup/homestead>`.
-
-Storing your Project in git
----------------------------
-
-Storing your project in services like GitHub, GitLab and Bitbucket works like with
-any other code project! Init a new repository with ``Git`` and you are ready to push
-to your remote:
-
-.. code-block:: terminal
-
-    $ git init
-    $ git add .
-    $ git commit -m "Initial commit"
-
-Your project already has a sensible ``.gitignore`` file. And as you install more
-packages, a system called :ref:`Flex <flex-quick-intro>` will add more lines to
-that file when needed.
-
 .. _install-existing-app:
 
 Setting up an Existing Symfony Project
 --------------------------------------
 
-If you're working on an existing Symfony application, you only need to get the
-project code and install the dependencies with Composer. Assuming your team uses Git,
-setup your project with the following commands:
+In addition to creating new Symfony projects, you will also work on projects
+already created by other developers. In that case, you only need to get the
+project code and install the dependencies with Composer. Assuming your team uses
+Git, setup your project with the following commands:
 
 .. code-block:: terminal
 
@@ -118,14 +107,111 @@ setup your project with the following commands:
     $ cd my-project/
     $ composer install
 
-You'll probably also need to customize your :ref:`.env <config-dot-env>` and do a
-few other project-specific tasks (e.g. creating database schema). When working
-on a existing Symfony app for the first time, it may be useful to run this
-command which displays information about the app:
+You'll probably also need to customize your :ref:`.env file <config-dot-env>`
+and do a few other project-specific tasks (e.g. creating a database). When
+working on a existing Symfony application for the first time, it may be useful
+to run this command which displays information about the project:
 
 .. code-block:: terminal
 
     $ php bin/console about
+
+.. _symfony-flex:
+
+Installing Packages
+-------------------
+
+A common practice when developing Symfony applications is to install packages
+(Symfony calls them :doc:`bundles </bundles>`) that provide ready-to-use
+features. Packages usually require some setup before using them (editing some
+file to enable the bundle, creating some file to add some initial config, etc.)
+
+Most of the time this setup can be automated and that's why Symfony includes
+`Symfony Flex`_, a tool to simplify the installation/removal of packages in
+Symfony applications. Technically speaking, Symfony Flex is a Composer plugin
+that is installed by default when creating a new Symfony application and which
+**automates the most common tasks of Symfony applications**.
+
+.. tip::
+
+    You can also :doc:`add Symfony Flex to an existing project </setup/flex>`.
+
+Symfony Flex modifies the behavior of the ``require``, ``update``, and
+``remove`` Composer commands to provide advanced features. Consider the
+following example:
+
+.. code-block:: terminal
+
+    $ cd my-project/
+    $ composer require logger
+
+If you execute that command in a Symfony application which doesn't use Flex,
+you'll see a Composer error explaining that ``logger`` is not a valid package
+name. However, if the application has Symfony Flex installed, that command
+installs and enables all the packages needed to use the official Symfony logger.
+
+This is possible because lots of Symfony packages/bundles define **"recipes"**,
+which are a set of automated instructions to install and enable packages into
+Symfony applications. Flex keeps tracks of the recipes it installed in a
+``symfony.lock`` file, which must be committed to your code repository.
+
+Symfony Flex recipes are contributed by the community and they are stored in
+two public repositories:
+
+* `Main recipe repository`_, is a curated list of recipes for high quality and
+  maintained packages. Symfony Flex only looks in this repository by default.
+
+* `Contrib recipe repository`_, contains all the recipes created by the
+  community. All of them are guaranteed to work, but their associated packages
+  could be unmaintained. Symfony Flex will ask your permission before installing
+  any of these recipes.
+
+Read the `Symfony Recipes documentation`_ to learn everything about how to
+create recipes for your own packages.
+
+.. _security-checker:
+
+Checking Security Vulnerabilities
+---------------------------------
+
+The ``symfony`` binary created when you `install Symfony`_ provides a command to
+check whether your project's dependencies contain any known security
+vulnerability:
+
+.. code-block:: terminal
+
+    $ symfony security:check
+
+A good security practice is to execute this command regularly to be able to
+update or replace compromised dependencies as soon as possible. The security
+check is done locally by cloning the public `PHP security advisories database`_,
+so your ``composer.lock`` file is not sent on the network.
+
+.. tip::
+
+    The ``security:check`` command terminates with a non-zero exit code if
+    any of your dependencies is affected by a known security vulnerability.
+    This way you can add it to your project build process and your continuous
+    integration workflows to make them fail when there are vulnerabilities.
+
+Symfony LTS Versions
+--------------------
+
+According to the :doc:`Symfony release process </contributing/community/releases>`,
+"long-term support" (or LTS for short) versions are published every two years.
+Check out the `Symfony roadmap`_ to know which is the latest LTS version.
+
+By default, the command that creates new Symfony applications uses the latest
+stable version. If you want to use an LTS version, add the ``--version`` option:
+
+.. code-block:: terminal
+
+    # find the latest LTS version at https://symfony.com/roadmap
+    $ symfony new --version=3.4 my_project_name_name
+
+    # you can also base your project on development versions
+    $ symfony new --version=4.4.x-dev my_project_name
+    $ symfony new --version=dev-master my_project_name
 
 The Symfony Demo application
 ----------------------------
@@ -134,15 +220,19 @@ The Symfony Demo application
 recommended way to develop Symfony applications. It's a great learning tool for
 Symfony newcomers and its code contains tons of comments and helpful notes.
 
-To check out its code and install it locally, see `symfony/symfony-demo`_.
+Run this command to create a new project based on the Symfony Demo application:
+
+.. code-block:: terminal
+
+    $ symfony new --demo my_project_name
 
 Start Coding!
 -------------
 
 With setup behind you, it's time to :doc:`Create your first page in Symfony </page_creation>`.
 
-Go Deeper with Setup
---------------------
+Learn More
+----------
 
 .. toctree::
     :hidden:
@@ -158,10 +248,13 @@ Go Deeper with Setup
     setup/*
 
 .. _`Stellar Development with Symfony`: http://symfonycasts.com/screencast/symfony
-.. _`Composer`: https://getcomposer.org/
-.. _`installed Composer`: https://getcomposer.org/download/
-.. _`Download the Symfony local web server`: https://symfony.com/download
-.. _`Symfony download page`: https://symfony.com/download
-.. _`the Security Checker`: https://github.com/sensiolabs/security-checker#integration
+.. _`Install Composer`: https://getcomposer.org/download/
+.. _`Install Symfony`: https://symfony.com/download
+.. _`install Symfony`: https://symfony.com/download
 .. _`The Symfony Demo application`: https://github.com/symfony/demo
-.. _`symfony/symfony-demo`: https://github.com/symfony/demo
+.. _`Symfony Flex`: https://github.com/symfony/flex
+.. _`PHP security advisories database`: https://github.com/FriendsOfPHP/security-advisories
+.. _`Symfony roadmap`: https://symfony.com/roadmap
+.. _`Main recipe repository`: https://github.com/symfony/recipes
+.. _`Contrib recipe repository`: https://github.com/symfony/recipes-contrib
+.. _`Symfony Recipes documentation`: https://github.com/symfony/recipes/blob/master/README.rst

--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -1,137 +1,15 @@
 .. index:: Flex
 
-Using Symfony Flex to Manage Symfony Applications
-=================================================
-
-`Symfony Flex`_ is the new way to install and manage Symfony applications. Flex
-is not a new Symfony version, but a tool that replaces and improves the
-`Symfony Installer`_ and the `Symfony Standard Edition`_.
-
-Symfony Flex **automates the most common tasks of Symfony applications**, like
-installing and removing bundles and other Composer dependencies. Symfony
-Flex works for Symfony 3.3 and higher. Starting from Symfony 4.0, Flex
-should be used by default, but it is still optional.
-
-How Does Flex Work
-------------------
-
-Symfony Flex is a Composer plugin that modifies the behavior of the
-``require``, ``update``, and ``remove`` commands. When installing or removing
-dependencies in a Flex-enabled application, Symfony can perform tasks before
-and after the execution of Composer tasks.
-
-Consider the following example:
-
-.. code-block:: terminal
-
-    $ cd my-project/
-    $ composer require mailer
-
-If you execute that command in a Symfony application which doesn't use Flex,
-you'll see a Composer error explaining that ``mailer`` is not a valid package
-name. However, if the application has Symfony Flex installed, that command ends
-up installing and enabling the SwiftmailerBundle, which is the best way to
-integrate Swiftmailer, the official mailer for Symfony applications.
-
-When Symfony Flex is installed in the application and you execute ``composer
-require``, the application makes a request to the Symfony Flex server before
-trying to install the package with Composer.
-
-* If there's no information about that package, the Flex server returns nothing and
-  the package installation follows the usual procedure based on Composer;
-
-* If there's special information about that package, Flex returns it in a file
-  called a "recipe" and the application uses it to decide which package to
-  install and which automated tasks to run after the installation.
-
-In the above example, Symfony Flex asks about the ``mailer`` package and the
-Symfony Flex server detects that ``mailer`` is in fact an alias for
-SwiftmailerBundle and returns the "recipe" for it.
-
-Flex keeps tracks of the recipes it installed in a ``symfony.lock`` file, which
-must be committed to your code repository.
-
-.. _flex-recipe:
-
-Symfony Flex Recipes
-~~~~~~~~~~~~~~~~~~~~
-
-Recipes are defined in a ``manifest.json`` file and can contain any number of
-other files and directories. For example, this is the ``manifest.json`` for
-SwiftmailerBundle:
-
-.. code-block:: javascript
-
-    {
-        "bundles": {
-            "Symfony\\Bundle\\SwiftmailerBundle\\SwiftmailerBundle": ["all"]
-        },
-        "copy-from-recipe": {
-            "config/": "%CONFIG_DIR%/"
-        },
-        "env": {
-            "MAILER_URL": "smtp://localhost:25?encryption=&auth_mode="
-        },
-        "aliases": ["mailer", "mail"]
-    }
-
-The ``aliases`` option allows Flex to install packages using short and easy to
-remember names (``composer require mailer`` vs
-``composer require symfony/swiftmailer-bundle``). The ``bundles`` option tells
-Flex in which environments this bundle should be enabled automatically (``all``
-in this case). The ``env`` option makes Flex add new environment variables to
-the application. Finally, the ``copy-from-recipe`` option allows the recipe to
-copy files and directories into your application.
-
-The instructions defined in this ``manifest.json`` file are also used by
-Symfony Flex when uninstalling dependencies (e.g. ``composer remove mailer``)
-to undo all changes. This means that Flex can remove the SwiftmailerBundle from
-the application, delete the ``MAILER_URL`` environment variable and any other
-file and directory created by this recipe.
-
-Symfony Flex recipes are contributed by the community and they are stored in
-two public repositories:
-
-* `Main recipe repository`_, is a curated list of recipes for high quality and
-  maintained packages. Symfony Flex only looks in this repository by default.
-
-* `Contrib recipe repository`_, contains all the recipes created by the
-  community. All of them are guaranteed to work, but their associated packages
-  could be unmaintained. Symfony Flex will ask your permission before installing
-  any of these recipes.
-
-Read the `Symfony Recipes documentation`_ to learn everything about how to
-create recipes for your own packages.
-
-Using Symfony Flex in New Applications
---------------------------------------
-
-Symfony has published a new "skeleton" project, which is a minimal Symfony
-project recommended to create new applications. This "skeleton" already
-includes Symfony Flex as a dependency. This means you can create a new Flex-enabled
-Symfony application by executing the following command:
-
-.. code-block:: terminal
-
-    $ composer create-project symfony/skeleton my-project
-
-.. note::
-
-    The use of the Symfony Installer to create new applications is no longer
-    recommended since Symfony 3.3. Use the Composer ``create-project`` command
-    instead.
-
-.. _upgrade-to-flex:
-
-Upgrading Existing Applications to Flex
----------------------------------------
+Upgrading Existing Applications to Symfony Flex
+===============================================
 
 Using Symfony Flex is optional, even in Symfony 4, where Flex is used by
 default. However, Flex is so convenient and improves your productivity so much
 that it's strongly recommended to upgrade your existing applications to it.
 
-The only caveat is that Symfony Flex requires that applications use the
-following directory structure, which is the same used by default in Symfony 4:
+Symfony Flex recommends that applications use the following directory structure,
+which is the same used by default in Symfony 4, but you can
+:ref:`customize some directories <flex-customize-paths>`:
 
 .. code-block:: text
 
@@ -283,6 +161,8 @@ manual steps:
 #. Update the ``.gitignore`` file to replace the existing ``var/logs/`` entry
    by ``var/log/``, which is the new name for the log directory.
 
+.. _flex-customize-paths:
+
 Customizing Flex Paths
 ----------------------
 
@@ -316,9 +196,6 @@ manually after a recipe is installed.
 .. _`Symfony Flex`: https://github.com/symfony/flex
 .. _`Symfony Installer`: https://github.com/symfony/symfony-installer
 .. _`Symfony Standard Edition`: https://github.com/symfony/symfony-standard
-.. _`Main recipe repository`: https://github.com/symfony/recipes
-.. _`Contrib recipe repository`: https://github.com/symfony/recipes-contrib
-.. _`Symfony Recipes documentation`: https://github.com/symfony/recipes/blob/master/README.rst
 .. _`default services.yaml file`: https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/config/services.yaml
 .. _`shown in this example`: https://github.com/symfony/skeleton/blob/8e33fe617629f283a12bbe0a6578bd6e6af417af/composer.json#L24-L33
 .. _`shown in this example of the skeleton-project`: https://github.com/symfony/skeleton/blob/8e33fe617629f283a12bbe0a6578bd6e6af417af/composer.json#L44-L46

--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -14,9 +14,8 @@ PHP application and even with HTML/SPA (single page applications).
 Installation
 ------------
 
-The Symfony server is distributed as a free installable binary and has support
-for Linux, macOS and Windows. Go to `symfony.com/download`_ and follow the
-instructions for your operating system.
+The Symfony server is part of the ``symfony`` binary created when you
+`install Symfony`_ and has support for Linux, macOS and Windows.
 
 .. note::
 
@@ -315,68 +314,8 @@ debug any issues.
 
 `Read SymfonyCloud technical docs`_.
 
-Bonus Features
---------------
-
-In addition to being a local web server, the Symfony server provides other
-useful features:
-
-.. _security-checker:
-
-Looking for Security Vulnerabilities
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Run the following command to check whether your project's dependencies contain
-any known security vulnerability:
-
-.. code-block:: terminal
-
-    $ symfony security:check
-
-A good security practice is to execute this command regularly to be able to
-update or replace compromised dependencies as soon as possible. The security
-check is done locally by cloning the public `PHP security advisories database`_,
-so your ``composer.lock`` file is not sent on the network.
-
-.. tip::
-
-    The ``security:check`` command terminates with a non-zero exit code if
-    any of your dependencies is affected by a known security vulnerability.
-    This way you can add it to your project build process and your continuous
-    integration workflows to make them fail when there are vulnerabilities.
-
-Creating Symfony Projects
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In addition to the `different ways of installing Symfony`_, you can use these
-commands from the Symfony server:
-
-.. code-block:: terminal
-
-    # creates a new project based on symfony/skeleton
-    $ symfony new my_project_name
-
-    # creates a new project based on symfony/website-skeleton
-    $ symfony new --full my_project_name
-
-    # creates a new project based on symfony/demo
-    $ symfony new --demo my_project_name
-
-You can create a project depending on a **development** version as well (note
-that Composer will also set the stability to ``dev`` for all root dependencies):
-
-.. code-block:: terminal
-
-    # creates a new project based on Symfony's master branch
-    $ symfony new --version=dev-master my_project_name
-
-    # creates a new project based on Symfony's 4.3 dev branch
-    $ symfony new --version=4.3.x-dev my_project_name
-
-.. _`symfony.com/download`: https://symfony.com/download
+.. _`install Symfony`: https://symfony.com/download
 .. _`symfony/cli`: https://github.com/symfony/cli
-.. _`different ways of installing Symfony`: https://symfony.com/download
 .. _`Docker`: https://en.wikipedia.org/wiki/Docker_(software)
 .. _`SymfonyCloud`: https://symfony.com/cloud/
 .. _`Read SymfonyCloud technical docs`: https://symfony.com/doc/master/cloud/intro.html
-.. _`PHP security advisories database`: https://github.com/FriendsOfPHP/security-advisories

--- a/setup/upgrade_major.rst
+++ b/setup/upgrade_major.rst
@@ -162,6 +162,6 @@ of.
 
 When upgrading to Symfony 4, you will probably also want to upgrade to the new
 Symfony 4 directory structure so that you can take advantage of Symfony Flex.
-This takes some work, but is optional. For details, see :ref:`upgrade-to-flex`.
+This takes some work, but is optional. For details, see :doc:`/setup/flex`.
 
 .. _`Symfony-Upgrade-Fixer`: https://github.com/umpirsky/Symfony-Upgrade-Fixer

--- a/testing.rst
+++ b/testing.rst
@@ -33,7 +33,7 @@ command:
 
 .. note::
 
-    The ``./bin/phpunit`` command is created by :doc:`Symfony Flex </setup/flex>`
+    The ``./bin/phpunit`` command is created by :ref:`Symfony Flex <symfony-flex>`
     when installing the ``phpunit-bridge`` package. If the command is missing, you
     can remove the package (``composer remove symfony/phpunit-bridge``) and install
     it again. Another solution is to remove the project's ``symfony.lock`` file and

--- a/validation.rst
+++ b/validation.rst
@@ -14,7 +14,7 @@ transparent. This component is based on the `JSR303 Bean Validation specificatio
 Installation
 ------------
 
-In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
+In applications using :ref:`Symfony Flex <symfony-flex>`, run this command to
 install the validator before using it:
 
 .. code-block:: terminal

--- a/workflow.rst
+++ b/workflow.rst
@@ -8,7 +8,7 @@ some basic theory and concepts about workflows and state machines.
 Installation
 ------------
 
-In applications using :doc:`Symfony Flex </setup/flex>`, run this command to
+In applications using :ref:`Symfony Flex <symfony-flex>`, run this command to
 install the workflow feature before using it:
 
 .. code-block:: terminal
@@ -318,7 +318,7 @@ workflow leaves a place::
     class WorkflowLogger implements EventSubscriberInterface
     {
         private $logger;
-        
+
         public function __construct(LoggerInterface $logger)
         {
             $this->logger = $logger;


### PR DESCRIPTION
Don't merge this yet ... because it needs some changes in symfony.com/download too.

-----

I think the new docs are better because:

* Symfony Local Server articles only talks about server, not security:check and creating apps.
* Flex is explained in the main setup article ... and /setup/flex is left as the article explaining how to upgrade old apps to Flex
* We now talk about "Install Symfony", to simplify the explanations around "the Symfony binary", which in the past we called it "binary", "CLI", "server", "local server", etc.
* The main setup + installation article shows Composer installation too, to avoid issues for people who can't install Symfony.
* We only have a single place where we show how to create Symfony apps with the Symfony binary and Composer (the main /setup article) instead of showing that in multiple places.
* We remove some internal details about Flex recipes which are already explained in the recipes repository.