### PR TITLE
Add link to symfony form's github repo

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -10,7 +10,7 @@ Forms
     Do you prefer video tutorials? Check out the `Symfony Forms screencast series`_.
 
 Dealing with HTML forms is one of the most common - and challenging - tasks for
-a web developer. Symfony integrates a Form component that helps you dealing
+a web developer. Symfony integrates a [Form](https://github.com/symfony/form) component that helps you dealing
 with forms. In this article, you'll build a complex form from the ground up,
 learning the most important features of the form library along the way.
 


### PR DESCRIPTION
At the beginning of [Validation Doc page](https://symfony.com/doc/current/validation.html) page there is the link to symfony validator's github. It seemed to be convenient, so I decided to add the link to symfony form's github repo at [Forms Doc page](https://symfony.com/doc/current/forms.html#installation).
