### PR TITLE
Renamed the security:check command as check:security

### DIFF
--- a/contributing/code/security.rst
+++ b/contributing/code/security.rst
@@ -38,7 +38,8 @@ confirmed, the core team works on a solution following these steps:
 #. Publish the post on the official Symfony `blog`_ (it must also be added to
    the "`Security Advisories`_" category);
 #. Update the public `security advisories database`_ maintained by the
-   FriendsOfPHP organization and which is used by the ``security:check`` command.
+   FriendsOfPHP organization and which is used by
+   :doc:`the check:security command </security/security_checker>`.
 
 .. note::
 
@@ -169,7 +170,7 @@ Security Advisories
 .. tip::
 
     You can check your Symfony application for known security vulnerabilities
-    using the ``security:check`` command (see :doc:`/security/security_checker`).
+    using the ``check:security`` command (see :doc:`/security/security_checker`).
 
 Check the `Security Advisories`_ blog category for a list of all security
 vulnerabilities that were fixed in Symfony releases, starting from Symfony

--- a/security/security_checker.rst
+++ b/security/security_checker.rst
@@ -6,12 +6,12 @@ How to Check for Known Security Vulnerabilities in Your Dependencies
 
 When using lots of dependencies in your Symfony projects, some of them may
 contain security vulnerabilities. That's why the :doc:`Symfony local server </setup/symfony_server>`
-includes a command called ``security:check`` that checks your ``composer.lock``
+includes a command called ``check:security`` that checks your ``composer.lock``
 file to find known security vulnerabilities in your installed dependencies:
 
 .. code-block:: terminal
 
-    $ symfony security:check
+    $ symfony check:security
 
 A good security practice is to execute this command regularly to be able to
 update or replace compromised dependencies as soon as possible. The security
@@ -21,7 +21,7 @@ the network.
 
 .. tip::
 
-    The ``security:check`` command terminates with a non-zero exit code if
+    The ``check:security`` command terminates with a non-zero exit code if
     any of your dependencies is affected by a known security vulnerability.
     This way you can add it to your project build process and your continuous
     integration workflows to make them fail when there are vulnerabilities.


### PR DESCRIPTION
This is going to be renamed in the next release of the Symfony binary (release today or tomorrow).