### PR TITLE
[Messenger] Fix NewOrdersFromCsvFileReceiver::get() return type

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -282,7 +282,7 @@ do is to write your own CSV receiver::
             $this->filePath = $filePath;
         }
 
-        public function get(): void
+        public function get(): iterable
         {
             $ordersFromCsv = $this->serializer->deserialize(file_get_contents($this->filePath), 'csv');
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
