### PR TITLE
[Messenger] Information about why consumers do not show up in the (rabbitmq) admin panel

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -759,6 +759,17 @@ your Envelope::
         new AmqpStamp('custom-routing-key', AMQP_NOPARAM, $attributes)
     ]);
 
+.. caution::
+
+    The consumers do not show up in an admin panel as this transport does not rely on
+    ``\AmqpQueue::consume()`` which is blocking. Having a blocking receiver makes
+    the ``--time-limit/--memory-limit`` options of the ``messenger:consume`` command as well as
+    the ``messenger:stop-workers`` command inefficient, as they all rely on the fact that
+    the receiver returns immediately no matter if it finds a message or not. The consume
+    worker is responsible for iterating until it receives a message to handle and/or until one
+    of the stop conditions is reached. Thus, the worker's stop logic cannot be reached if it
+    is stuck in a blocking call.
+
 Doctrine Transport
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I wondered why the consumers were not shown up in the rabbitmq admin panel. I found following explanation https://github.com/symfony/symfony/issues/30259#issuecomment-496016792 from @chalasr which should be documented.
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
