### PR TITLE
Add DirectoryIndex to Apache configuration

### DIFF
--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -75,6 +75,8 @@ and increase web server performance:
         ServerAlias www.domain.tld
 
         DocumentRoot /var/www/project/web
+        DirectoryIndex /app.php
+
         <Directory /var/www/project/web>
             AllowOverride None
             Order Allow,Deny


### PR DESCRIPTION
If you have defined "FallbackResource /app.php" without defining
a directory index, then your main page("/") will keep loading
until the request times up.

Replaces https://github.com/symfony/symfony-docs/pull/11941