### PR TITLE
Mention ISO 639 for languages

### DIFF
--- a/components/intl.rst
+++ b/components/intl.rst
@@ -66,7 +66,8 @@ This component provides the following ICU data:
 Language and Script Names
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``Languages`` class provides access to the name of all languages::
+The ``Languages`` class provides access to the name of all languages
+according to the `ISO 639-1 alpha-2`_ list and the `ISO 639-2 alpha-3`_ list::
 
     use Symfony\Component\Intl\Languages;
 
@@ -356,3 +357,5 @@ Learn more
 .. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 .. _`UTC/GMT time offsets`: https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
 .. _`daylight saving time (DST)`: https://en.wikipedia.org/wiki/Daylight_saving_time
+.. _`ISO 639-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_639-1
+.. _`ISO 639-2 alpha-3`: https://en.wikipedia.org/wiki/ISO_639-2


### PR DESCRIPTION
we've added this in 4.4 (#12105), but languages in 4.3 already had (partial) alpha3 support.

let me know if this is merged in 4.4 :) it needs some cleanup after.

cc @OskarStark 