### PR TITLE
Rewrite Intl introduction

### DIFF
--- a/components/intl.rst
+++ b/components/intl.rst
@@ -5,8 +5,8 @@
 The Intl Component
 ==================
 
-    A PHP replacement layer for the C `intl extension`_ that also provides
-    access to the localization data of the `ICU library`_.
+    This component provides access to the localization data of the `ICU library`_.
+    It also provides a PHP replacement layer for the C `intl extension`_.
 
 .. caution::
 


### PR DESCRIPTION
When I first looked at the documentation for the Intl component, I thought I was looking at the wrong place. I got the first impression that this was only about a PHP replacement layer for the C intl extension, and that was not what I was looking for.

This PR is about replacing the introduction paragraph at the top to make it clear that this component may be useful to you even if you do not need the replacement layer and have the PHP intl extension installed.
