### PR TITLE
Add a note for preload asset

### DIFF
--- a/web_link.rst
+++ b/web_link.rst
@@ -66,6 +66,17 @@ If you reload the page, the perceived performance will improve because the
 server responded with both the HTML page and the CSS file when the browser only
 requested the HTML page.
 
+.. note::
+
+    You can preload an asset by wrapping it with the ``preload()`` function
+
+    .. code-block:: html+twig
+
+        <head>
+            {# ... #}
+            <link rel="stylesheet" href="{{ preload(asset('build/app.css')) }}">
+        </head>
+
 Additionally, according to `the Priority Hints specification`_, you can signal
 the priority of the resource to download using the ``importance`` attribute:
 


### PR DESCRIPTION
This PR add a note about how to preload asset in Sf 3.4.

Indeed it was not explained. There was just a symfony blog article about it : https://symfony.com/blog/new-in-symfony-3-3-asset-preloading-with-http-2-push

Moreover `preload('build/style.css', { as: 'style' })` generates a good link in Sf4 but not in sf3 (relative instead of absolute). I think is confusing.

I hope it can help other developers.