### PR TITLE
Move doctrine/annotations instructions

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -189,6 +189,8 @@ when constructing the normalizer::
         'allow_extra_attributes' => false,
     ]);
 
+.. include:: /_includes/_annotation_loader_tip.rst.inc
+
 Deserializing in an Existing Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -367,8 +369,6 @@ You are now able to serialize only attributes in the groups you want::
         ['groups' => ['group1', 'group3']]
     );
     // $obj2 = MyObj(foo: 'foo', bar: 'bar')
-
-.. include:: /_includes/_annotation_loader_tip.rst.inc
 
 .. _ignoring-attributes-when-serializing:
 


### PR DESCRIPTION
Move doctrine/annotation instructions to first example using annotation loader

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
