### PR TITLE
[Monolog] Add documentation about how to autowire monolog channels

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -461,6 +461,11 @@ to the service id. For example, in MonologBundle, an alias is created from
 ``Psr\Log\LoggerInterface`` to ``logger`` so that the ``LoggerInterface`` type-hint
 can be used for autowiring.
 
+.. versionadded:: 4.2
+
+    Since Monolog Bundle 3.5 each channel bind into container by type-hinted alias.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
+
 Services should not use autowiring or autoconfiguration. Instead, all services should
 be defined explicitly.
 

--- a/console/commands_as_services.rst
+++ b/console/commands_as_services.rst
@@ -53,6 +53,11 @@ the command class will automatically be registered as a service and passed the `
 argument (thanks to autowiring). In other words, *just* by creating this class, everything
 works! You can call the ``app:sunshine`` command and start logging.
 
+.. versionadded:: 4.2
+
+    Since Monolog Bundle 3.5 each channel bind into container by type-hinted alias.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
+
 .. caution::
 
     You *do* have access to services in ``configure()``. However, if your command is

--- a/controller.rst
+++ b/controller.rst
@@ -275,6 +275,11 @@ the argument by its name:
             ])
         ;
 
+.. versionadded:: 4.2
+
+    Since Monolog Bundle 3.5 each channel bind into container by type-hinted alias.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
+
 Like with all services, you can also use regular :ref:`constructor injection <services-constructor-injection>`
 in your controllers.
 

--- a/logging.rst
+++ b/logging.rst
@@ -353,6 +353,11 @@ specific channel (``app`` by default), use the ``monolog.logger`` tag  with the
 ``channel`` property as explained in the
 :ref:`Dependency Injection reference <dic_tags-monolog>`.
 
+.. versionadded:: 4.2
+
+    Since Monolog Bundle 3.5 each channel bind into container by type-hinted alias.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
+
 Adding extra Data to each Log (e.g. a unique request token)
 -----------------------------------------------------------
 

--- a/logging/channels_handlers.rst
+++ b/logging/channels_handlers.rst
@@ -18,6 +18,11 @@ the channel).
     in the container (use the ``php bin/console debug:container monolog`` command
     to see a full list) and those are injected into different services.
 
+.. versionadded:: 4.2
+
+    Since Monolog Bundle 3.5 each channel bind into container by type-hinted alias.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
+
 .. _logging-channel-handler:
 
 Switching a Channel to a different Handler
@@ -172,3 +177,26 @@ Symfony automatically registers one service per channel (in this example, the
 channel ``foo`` creates a service called ``monolog.logger.foo``). In order to
 inject this service into others, you must update the service configuration to
 :ref:`choose the specific service to inject <services-wire-specific-service>`.
+
+.. _monolog-autowire-channels:
+
+How to autowire logger channels
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 4.2
+
+    This feature available since MonologBundle 3.5
+
+Each channel already bind into container by type-hinted alias.
+Just use method variables, which follows next naming template ``Psr\Log\LoggerInterface $<channel>Logger``.
+For example, you have ``App\Log\CustomLogger`` service which tagged by ``app`` logger channel
+as described in part :ref:`Logging with a custom logging channel <dic_tags-monolog>`.
+Now you can remove service configuration at all and change constructor signature:
+
+.. code-block:: diff
+
+    -     public function __construct(LoggerInterface $logger)
+    +     public function __construct(LoggerInterface $appLogger)
+        {
+            $this->logger = $appLogger;
+        }

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -52,6 +52,11 @@ But wait! Something *very* cool just happened. Symfony read the ``LoggerInterfac
 type-hint and automatically figured out that it should pass us the Logger object!
 This is called *autowiring*.
 
+.. versionadded:: 4.2
+
+    Furthermore, since Monolog Bundle 3.5 each channel bind into container by type-hinted alias.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
+
 Every bit of work that's done in a Symfony app is done by an *object*: the Logger
 object logs things and the Twig object renders templates. These objects are called
 *services* and they are *tools* that help you build rich features.

--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -8,6 +8,11 @@ The MonologBundle integrates the Monolog :doc:`logging </logging>` library in
 Symfony applications. All these options are configured under the ``monolog`` key
 in your application configuration.
 
+.. versionadded:: 4.2
+
+    Since Monolog Bundle 3.5 each channel bind into container by type-hinted alias.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
+
 .. code-block:: terminal
 
     # displays the default config values defined by Symfony

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -534,6 +534,11 @@ channel when injecting the logger in a service.
     the corresponding logger service from the service container directly (see
     :ref:`monolog-channels-config`).
 
+.. versionadded:: 4.2
+
+    Since Monolog Bundle 3.5 each channel bind into container by type-hinted alias.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
+
 .. _dic_tags-monolog-processor:
 
 monolog.processor

--- a/service_container.rst
+++ b/service_container.rst
@@ -616,6 +616,13 @@ But, you can control this and pass in a different logger:
 This tells the container that the ``$logger`` argument to ``__construct`` should use
 service whose id is ``monolog.logger.request``.
 
+.. versionadded:: 4.2
+
+    Since Monolog Bundle 3.5 each channel already into container by type-hinted alias.
+    Instead of explicit declare configuration ``$logger: '@monolog.logger.request'``
+    just use variable in the constructor signature: ``Psr\Log\LoggerInterface $requestLogger``.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
+
 .. _container-debug-container:
 
 For a full list of *all* possible services in the container, run:
@@ -713,6 +720,11 @@ By putting the ``bind`` key under ``_defaults``, you can specify the value of *a
 argument for *any* service defined in this file! You can bind arguments by name
 (e.g. ``$adminEmail``), by type (e.g. ``Psr\Log\LoggerInterface``) or both
 (e.g. ``Psr\Log\LoggerInterface $requestLogger``).
+
+.. versionadded:: 4.2
+
+    Since Monolog Bundle 3.5 each channel already bind into container by type-hinted alias.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
 
 The ``bind`` config can also be applied to specific services or when loading many
 services at once (i.e. :ref:`service-psr4-loader`).

--- a/service_container/3.3-di-changes.rst
+++ b/service_container/3.3-di-changes.rst
@@ -392,8 +392,15 @@ create the class::
     }
 
 Great! In Symfony 3.2 or lower, you would now need to register this as a service
-in ``services.yaml`` and tag it with ``kernel.event_subscriber``. In Symfony 3.3,
-you're already done! The service is :ref:`automatically registered <service-33-changes-automatic-registration>`.
+in ``services.yaml`` and tag it with ``kernel.event_subscriber``.
+In Symfony 3.3, you're already done!
+
+.. versionadded:: 4.2
+
+    Furthermore, since Monolog Bundle 3.5 each channel bind into container by type-hinted alias.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
+
+The service is :ref:`automatically registered <service-33-changes-automatic-registration>`.
 And thanks to ``autoconfigure``, Symfony automatically tags the service because
 it implements ``EventSubscriberInterface``.
 

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -248,6 +248,11 @@ class is type-hinted.
     adds an alias: ``Psr\Log\LoggerInterface`` that points to the ``logger`` service.
     This is why arguments type-hinted with ``Psr\Log\LoggerInterface`` can be autowired.
 
+.. versionadded:: 4.2
+
+    Since Monolog Bundle 3.5 each channel bind into container by type-hinted alias.
+    More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
+
 .. _autowiring-interface-alias:
 
 Working with Interfaces


### PR DESCRIPTION
resolved: #12195 
- Added documentation about how to autowire monolog channels.

Relates to [Symfony autowiring monolog channels](https://github.com/symfony/monolog-bundle/pull/315)