### PR TITLE
[Process] Document the getLastOutputTime() method.

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -96,6 +96,12 @@ with a non-zero code)::
         echo $exception->getMessage();
     }
 
+.. tip::
+
+    You can get the last output time in seconds by using the
+    :method:`Symfony\\Component\\Process\\Process::getLastOutputTime` method.
+    This method returns ``null`` if the process wasn't started!
+
 Using Features From the OS Shell
 --------------------------------
 


### PR DESCRIPTION
fixes #12194

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
