### PR TITLE
[Messenger] Adds a note InMemoryTransports will be reset in tests

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -960,6 +960,13 @@ during a request::
         }
     }
 
+.. note::
+
+        All ``in-memory`` transports will be reset automatically after each test **in**
+        test classes extending
+        :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase`
+        or :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase`.
+
 Serializing Messages
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The `InMemoryTransport` implements the `Symfony\Contracts\Service\ResetInterface`.