### PR TITLE
Fix some examples

### DIFF
--- a/components/var_dumper/advanced.rst
+++ b/components/var_dumper/advanced.rst
@@ -237,19 +237,22 @@ output produced by the different casters.
 If ``DUMP_STRING_LENGTH`` is set, then the length of a string is displayed
 next to its content::
 
+    use Symfony\Component\VarDumper\Cloner\VarCloner;
     use Symfony\Component\VarDumper\Dumper\AbstractDumper;
     use Symfony\Component\VarDumper\Dumper\CliDumper;
 
+    $varCloner = new VarCloner();
     $var = ['test'];
+    
     $dumper = new CliDumper();
-    echo $dumper->dump($var, true);
+    echo $dumper->dump($varCloner->cloneVar($var), true);
 
     // array:1 [
     //   0 => "test"
     // ]
 
     $dumper = new CliDumper(null, null, AbstractDumper::DUMP_STRING_LENGTH);
-    echo $dumper->dump($var, true);
+    echo $dumper->dump($varCloner->cloneVar($var), true);
 
     // (added string length before the string)
     // array:1 [
@@ -259,19 +262,22 @@ next to its content::
 If ``DUMP_LIGHT_ARRAY`` is set, then arrays are dumped in a shortened format
 similar to PHP's short array notation::
 
+    use Symfony\Component\VarDumper\Cloner\VarCloner;
     use Symfony\Component\VarDumper\Dumper\AbstractDumper;
     use Symfony\Component\VarDumper\Dumper\CliDumper;
 
+    $varCloner = new VarCloner();
     $var = ['test'];
+    
     $dumper = new CliDumper();
-    echo $dumper->dump($var, true);
+    echo $dumper->dump($varCloner->cloneVar($var), true);
 
     // array:1 [
     //   0 => "test"
     // ]
 
     $dumper = new CliDumper(null, null, AbstractDumper::DUMP_LIGHT_ARRAY);
-    echo $dumper->dump($var, true);
+    echo $dumper->dump($varCloner->cloneVar($var), true);
 
     // (no more array:1 prefix)
     // [
@@ -281,12 +287,15 @@ similar to PHP's short array notation::
 If you would like to use both options, then you can just combine them by
 using the logical OR operator ``|``::
 
+    use Symfony\Component\VarDumper\Cloner\VarCloner;
     use Symfony\Component\VarDumper\Dumper\AbstractDumper;
     use Symfony\Component\VarDumper\Dumper\CliDumper;
 
+    $varCloner = new VarCloner();
     $var = ['test'];
+    
     $dumper = new CliDumper(null, null, AbstractDumper::DUMP_STRING_LENGTH | AbstractDumper::DUMP_LIGHT_ARRAY);
-    echo $dumper->dump($var, true);
+    echo $dumper->dump($varCloner->cloneVar($var), true);
 
     // [
     //   0 => (4) "test"


### PR DESCRIPTION
The dumper requires a Cloner\Data object instead of the original variables

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
