### PR TITLE
[Translator] Recommending real message id for shared bundles

### DIFF
--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -164,7 +164,10 @@ recommended format. These files are parsed by one of the loader classes.
     read "Symfony is really great" in the default locale.
 
     The choice of which method to use is entirely up to you, but the "keyword"
-    format is often recommended.
+    format is often recommended for multi-language applications, whereas for
+    shared bundles that contain translation resources we recommend the real
+    message, so you application can choose to disable the translator layer
+    and you will see a readable message.
 
     Additionally, the ``php`` and ``yaml`` file formats support nested ids to
     avoid repeating yourself if you use keywords instead of real text for your
@@ -351,7 +354,7 @@ effect after removing the explicit rules:
     '{0} There are no apples|[20,Inf[ There are many apples|There is one apple|a_few: There are %count% apples'
 
 For example, for ``1`` apple, the standard rule ``There is one apple`` will
-be used. For ``2-19`` apples, the second standard rule 
+be used. For ``2-19`` apples, the second standard rule
 ``There are %count% apples`` will be selected.
 
 An :class:`Symfony\\Component\\Translation\\Interval` can represent a finite set


### PR DESCRIPTION
Using the "keyword" method to create translation message in public/shared bundles is painful sometimes, because apps with single-lenguage MUST activate the `translator` layer to see the final message, so worse performance. 

DX-wise, the "keyword" method is "practical" (nowaday smart IDEs can replace texts easier), but when we're creating a bundle we should also think that "translation" is optional for apps.