### PR TITLE
remove extra `;` from the code sample

### DIFF
--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -452,7 +452,7 @@ The type would now look like::
                 ->add('sport', EntityType::class, [
                     'class'       => 'App\Entity\Sport',
                     'placeholder' => '',
-                ]);
+                ])
             ;
 
             $formModifier = function (FormInterface $form, Sport $sport = null) {


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->

Just a small fix of a typo
