### PR TITLE
Fix rendering of error code block

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -302,8 +302,10 @@ Then, tell Encore to enable the Sass pre-processor:
 Because you just changed your ``webpack.config.js`` file, you'll need to restart
 Encore. When you do, you'll see an error!
 
->   Error: Install sass-loader & node-sass to use enableSassLoader()
->     yarn add sass-loader@^7.0.1 node-sass --dev
+.. code-block:: terminal
+
+    >   Error: Install sass-loader & node-sass to use enableSassLoader()
+    >     yarn add sass-loader@^7.0.1 node-sass --dev
 
 Encore supports many features. But, instead of forcing all of them on you, when
 you need a feature, Encore will tell you what you need to install. Run:


### PR DESCRIPTION
This is [how it looks](https://symfony.com/doc/3.4/frontend/encore/simple-example.html#using-sass-less-stylus) currently:

![grafik](https://user-images.githubusercontent.com/424602/63836104-36418480-c979-11e9-9ca7-5bf8826adaa6.png)

`sass-loader@^7.0.1` is blue because it is currently rendered as a `mailto:...` link.
