### PR TITLE
Adding notes

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -309,6 +309,12 @@ Notice that the special ``OrderPlacedEvent`` object is created and passed to
 the ``dispatch()`` method. Now, any listener to the ``order.placed``
 event will receive the ``OrderPlacedEvent``.
 
+.. note::
+
+    For BC with Symfony 4, the $eventName argument is not declared explicitly on the
+    signature of the method. Implementations that are not bound by this BC constraint
+    MUST declare it explicitly, as allowed by PHP.
+
 .. index::
    single: EventDispatcher; Event subscribers
 


### PR DESCRIPTION
I propose to add this note so people does not get lost since the clarification does only exists [here](https://github.com/symfony/symfony/blob/4.3/src/Symfony/Contracts/EventDispatcher/EventDispatcherInterface.php#L25-L27) and [here](https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching). Once the second argument gets completely deprecated this can be removed

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
