### PR TITLE
[Mailer] Replace misused EventListener with an EventSubscriber.

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -258,14 +258,14 @@ Global from Address
 Instead of calling ``->from()`` *every* time you create a new email, you can
 create an event subscriber to set it automatically::
 
-    // src/EventListener/MailerFromListener.php
-    namespace App\EventListener;
+    // src/EventSubscriber/MailerFromSubscriber.php
+    namespace App\EventSubscriber;
 
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
     use Symfony\Component\Mailer\Event\MessageEvent;
     use Symfony\Component\Mime\Email;
 
-    class MailerFromListener implements EventSubscriberInterface
+    class MailerFromSubscriber implements EventSubscriberInterface
     {
         public function onMessageSend(MessageEvent $event)
         {


### PR DESCRIPTION
In the new mailer component, the existing code for the "Global from Address" makes use of an EventSubscriber but the namespace & name of the file is wrongly named as an EventListener which could create confusion.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
