### PR TITLE
Updated the editorconfig configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,8 @@
 root = true
 
-[*.{rst,rst.inc}]
+[*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ python: 2.7
 
 sudo: false
 cache:
-  directories: [$HOME/.cache/pip]
+    directories: [$HOME/.cache/pip]
 
 install: pip install -r _build/.requirements.txt
 
 script: make -C _build SPHINXOPTS=-nW html
 
 branches:
-  except:
-    - github-comments
+    except:
+        - github-comments


### PR DESCRIPTION
First I wanted to fix the indent size of RST files ... but then I realized our YAML files use the same config too, so why not apply this to all files?