### PR TITLE
Removed non working link

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -472,7 +472,7 @@ options can be specified in this way.
 This is purely meant to make the configuration of the most common option of
 a constraint shorter and quicker.
 
-If you're ever unsure of how to specify an option, either check :namespace:`Symfony\\Component\\Validator\\Constraints`
+If you're ever unsure of how to specify an option, either check the namespace `Symfony\\Component\\Validator\\Constraints`
 for the constraint or play it safe by always passing in an array of options
 (the first method shown above).
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
One can't link to a namespace (or so it seems, I'm not that familiar with the docs format so please correct me if I'm wrong). So it seems to me that the non working link should be removed.