### PR TITLE
Update workflow configuration example following Symfony 4.3 deprecations

### DIFF
--- a/workflow/dumping-workflows.rst
+++ b/workflow/dumping-workflows.rst
@@ -84,9 +84,12 @@ Below is the configuration for the pull request state machine with styling added
             workflows:
                 pull_request:
                     type: 'state_machine'
+                    marking_store:
+                        type: 'method'
+                        property: 'currentPlace'
                     supports:
                         - App\Entity\PullRequest
-                    initial_place: start
+                    initial_marking: start
                     places:
                         start: ~
                         coding: ~
@@ -140,9 +143,14 @@ Below is the configuration for the pull request state machine with styling added
 
             <framework:config>
                 <framework:workflow name="pull_request" type="state_machine">
-                    <framework:marking-store type="single_state"/>
+                    <framework:marking-store>
+                        <framework:type>method</framework:type>
+                        <framework:property>currentPlace</framework:property>
+                    </framework:marking-store>
 
                     <framework:support>App\Entity\PullRequest</framework:support>
+
+                    <framework:initial_marking>start</framework:initial_marking>
 
                     <framework:place>start</framework:place>
                     <framework:place>coding</framework:place>
@@ -229,7 +237,12 @@ Below is the configuration for the pull request state machine with styling added
             'workflows' => [
                 'pull_request' => [
                     'type' => 'state_machine',
+                    'marking_store' => [
+                        type: 'method',
+                        property: 'currentPlace',
+                    ],
                     'supports' => ['App\Entity\PullRequest'],
+                    'initial_marking' => 'start',
                     'places' => [
                         'start',
                         'coding',


### PR DESCRIPTION
Changed 'initial_place' to 'initial_marking' and added 'marking_store' with 'type: method' and property name.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
