### PR TITLE
Removing the tests for PHP 7.0

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -198,11 +198,10 @@ of Symfony and the latest beta release:
               # Minimum supported dependencies with the latest and oldest PHP version
             - php: 7.2
               env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
-            - php: 7.0
+            - php: 7.1
               env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
 
               # Test the latest stable release
-            - php: 7.0
             - php: 7.1
             - php: 7.2
               env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"


### PR DESCRIPTION
As Symfony 4 requires minimum PHP 7.1, some builds testing PHP 7.0 will automatically fail.

Also, I want to mention that the builds line 199 and 201 are not running because of the following error: 
```
PHP Warning:  fopen(https://github.com/sebastianbergmann/phpunit/archive/6.3.zip): failed to open stream: HTTP request failed! HTTP/1.0 404 Not Found
``` 
If I remember well, some months ago PHPUnit removed all old available version and I guess that's what's causing the error 
