### PR TITLE
Expected scalar type, got array

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -55,8 +55,7 @@ like this:
                         enabled: true
                     marking_store:
                         type: 'method'
-                        property:
-                            - 'currentPlace'
+                        property: 'currentPlace'
                     supports:
                         - App\Entity\BlogPost
                     initial_marking: draft


### PR DESCRIPTION
The example is returning an error because of `currentPlace`. The error is:

```
invalid type for path 'famework.workflows.workflows.blog_publishing.marking_store.property'.
expected scalar, but got array.
```

once changed, the error is fixed
