### PR TITLE
scope singly-implemented interfaces detection by file

### DIFF
--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -339,7 +339,7 @@ dealing with the ``TransformerInterface``.
 
     When using a `service definition prototype`_, if only one service is
     discovered that implements an interface, and that interface is also
-    discovered at the same time, configuring the alias is not mandatory
+    discovered in the same file, configuring the alias is not mandatory
     and Symfony will automatically create one.
 
 Dealing with Multiple Implementations of the Same Type


### PR DESCRIPTION
Documentation change for https://github.com/symfony/symfony/pull/33350

This is probably the only place where automatically registering singly implemented interfaces is referenced.