### PR TITLE
[Form] Added the attr_row option to all form types

### DIFF
--- a/reference/forms/types/birthday.rst
+++ b/reference/forms/types/birthday.rst
@@ -37,6 +37,7 @@ option defaults to 120 years ago to the current year.
 |                      |                                                                               |
 |                      | from the :doc:`FormType </reference/forms/types/form>`:                       |
 |                      |                                                                               |
+|                      | - `attr`_                                                                     |
 |                      | - `data`_                                                                     |
 |                      | - `disabled`_                                                                 |
 |                      | - `help`_                                                                     |
@@ -46,6 +47,7 @@ option defaults to 120 years ago to the current year.
 |                      | - `invalid_message`_                                                          |
 |                      | - `invalid_message_parameters`_                                               |
 |                      | - `mapped`_                                                                   |
+|                      | - `row_attr`_                                                                 |
 +----------------------+-------------------------------------------------------------------------------+
 | Parent type          | :doc:`DateType </reference/forms/types/date>`                                 |
 +----------------------+-------------------------------------------------------------------------------+
@@ -112,6 +114,8 @@ values for the year, month and day fields::
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -129,3 +133,5 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 
 .. include:: /reference/forms/types/options/mapped.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc

--- a/reference/forms/types/button.rst
+++ b/reference/forms/types/button.rst
@@ -14,6 +14,7 @@ A simple, non-responsive button.
 |                      | - `disabled`_                                                        |
 |                      | - `label`_                                                           |
 |                      | - `label_translation_parameters`_                                    |
+|                      | - `row_attr`_                                                        |
 |                      | - `translation_domain`_                                              |
 +----------------------+----------------------------------------------------------------------+
 | Parent type          | none                                                                 |
@@ -91,3 +92,5 @@ option of its parents, so buttons can reuse and/or override any of the parent
 placeholders.
 
 .. include:: /reference/forms/types/options/attr_translation_parameters.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc

--- a/reference/forms/types/checkbox.rst
+++ b/reference/forms/types/checkbox.rst
@@ -20,8 +20,9 @@ if you want to handle submitted values like "0" or "false").
 | Overridden  | - `compound`_                                                          |
 | options     | - `empty_data`_                                                        |
 +-------------+------------------------------------------------------------------------+
-| Inherited   | - `data`_                                                              |
-| options     | - `disabled`_                                                          |
+| Inherited   | - `attr`_                                                              |
+| options     | - `data`_                                                              |
+|             | - `disabled`_                                                          |
 |             | - `error_bubbling`_                                                    |
 |             | - `error_mapping`_                                                     |
 |             | - `help`_                                                              |
@@ -32,6 +33,7 @@ if you want to handle submitted values like "0" or "false").
 |             | - `label_format`_                                                      |
 |             | - `mapped`_                                                            |
 |             | - `required`_                                                          |
+|             | - `row_attr`_                                                          |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                          |
 +-------------+------------------------------------------------------------------------+
@@ -77,6 +79,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -100,6 +104,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 Form Variables
 --------------

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -44,6 +44,7 @@ To use this field, you must specify *either* ``choices`` or ``choice_loader`` op
 |             | - `label_format`_                                                            |
 |             | - `mapped`_                                                                  |
 |             | - `required`_                                                                |
+|             | - `row_attr`_                                                                |
 |             | - `translation_domain`_                                                      |
 |             | - `label_translation_parameters`_                                            |
 |             | - `attr_translation_parameters`_                                             |
@@ -297,6 +298,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. include:: /reference/forms/types/options/choice_type_translation_domain.rst.inc
 

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -23,8 +23,9 @@ photos).
 |             | - `prototype_data`_                                                         |
 |             | - `prototype_name`_                                                         |
 +-------------+-----------------------------------------------------------------------------+
-| Inherited   | - `by_reference`_                                                           |
-| options     | - `empty_data`_                                                             |
+| Inherited   | - `attr`_                                                                   |
+| options     | - `by_reference`_                                                           |
+|             | - `empty_data`_                                                             |
 |             | - `error_bubbling`_                                                         |
 |             | - `error_mapping`_                                                          |
 |             | - `help`_                                                                   |
@@ -35,6 +36,7 @@ photos).
 |             | - `label_format`_                                                           |
 |             | - `mapped`_                                                                 |
 |             | - `required`_                                                               |
+|             | - `row_attr`_                                                               |
 +-------------+-----------------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                               |
 +-------------+-----------------------------------------------------------------------------+
@@ -400,6 +402,8 @@ Inherited Options
 These options inherit from the :doc:`FormType </reference/forms/types/form>`.
 Not all options are listed here - only the most applicable to this type:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. _reference-form-types-by-reference:
 
 .. include:: /reference/forms/types/options/by_reference.rst.inc
@@ -436,6 +440,8 @@ error_bubbling
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 Field Variables
 ---------------

--- a/reference/forms/types/color.rst
+++ b/reference/forms/types/color.rst
@@ -17,8 +17,9 @@ element.
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``color`` field (a text box)                              |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | - `data`_                                                           |
-| options     | - `disabled`_                                                       |
+| Inherited   | - `attr`_                                                           |
+| options     | - `data`_                                                           |
+|             | - `disabled`_                                                       |
 |             | - `empty_data`_                                                     |
 |             | - `error_bubbling`_                                                 |
 |             | - `error_mapping`_                                                  |
@@ -30,6 +31,7 @@ element.
 |             | - `label_format`_                                                   |
 |             | - `mapped`_                                                         |
 |             | - `required`_                                                       |
+|             | - `row_attr`_                                                       |
 |             | - `trim`_                                                           |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                       |
@@ -43,6 +45,8 @@ Inherited Options
 -----------------
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
+
+.. include:: /reference/forms/types/options/attr.rst.inc
 
 .. include:: /reference/forms/types/options/data.rst.inc
 
@@ -75,5 +79,7 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. include:: /reference/forms/types/options/trim.rst.inc

--- a/reference/forms/types/country.rst
+++ b/reference/forms/types/country.rst
@@ -38,6 +38,7 @@ the option manually, but then you should just use the ``ChoiceType`` directly.
 |             |                                                                       |
 |             | from the :doc:`FormType </reference/forms/types/form>`                |
 |             |                                                                       |
+|             | - `attr`_                                                             |
 |             | - `data`_                                                             |
 |             | - `disabled`_                                                         |
 |             | - `empty_data`_                                                       |
@@ -49,6 +50,7 @@ the option manually, but then you should just use the ``ChoiceType`` directly.
 |             | - `label_format`_                                                     |
 |             | - `mapped`_                                                           |
 |             | - `required`_                                                         |
+|             | - `row_attr`_                                                         |
 +-------------+-----------------------------------------------------------------------+
 | Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                     |
 +-------------+-----------------------------------------------------------------------+
@@ -99,6 +101,8 @@ These options inherit from the :doc:`ChoiceType </reference/forms/types/choice>`
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -130,3 +134,5 @@ The actual default value of this option depends on other field options:
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc

--- a/reference/forms/types/currency.rst
+++ b/reference/forms/types/currency.rst
@@ -30,6 +30,7 @@ manually, but then you should just use the ``ChoiceType`` directly.
 |             |                                                                        |
 |             | from the :doc:`FormType </reference/forms/types/form>` type            |
 |             |                                                                        |
+|             | - `attr`_                                                              |
 |             | - `data`_                                                              |
 |             | - `disabled`_                                                          |
 |             | - `empty_data`_                                                        |
@@ -41,6 +42,7 @@ manually, but then you should just use the ``ChoiceType`` directly.
 |             | - `label_format`_                                                      |
 |             | - `mapped`_                                                            |
 |             | - `required`_                                                          |
+|             | - `row_attr`_                                                          |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
 +-------------+------------------------------------------------------------------------+
@@ -88,6 +90,8 @@ These options inherit from the :doc:`ChoiceType </reference/forms/types/choice>`
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -119,5 +123,7 @@ The actual default value of this option depends on other field options:
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. _`3-letter ISO 4217`: https://en.wikipedia.org/wiki/ISO_4217

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -33,8 +33,9 @@ and can understand a number of different input formats via the `input`_ option.
 |                      | - `data_class`_                                                             |
 |                      | - `error_bubbling`_                                                         |
 +----------------------+-----------------------------------------------------------------------------+
-| Inherited            | - `data`_                                                                   |
-| options              | - `disabled`_                                                               |
+| Inherited            | - `attr`_                                                                   |
+| options              | - `data`_                                                                   |
+|                      | - `disabled`_                                                               |
 |                      | - `error_mapping`_                                                          |
 |                      | - `help`_                                                                   |
 |                      | - `help_attr`_                                                              |
@@ -43,6 +44,7 @@ and can understand a number of different input formats via the `input`_ option.
 |                      | - `invalid_message`_                                                        |
 |                      | - `invalid_message_parameters`_                                             |
 |                      | - `mapped`_                                                                 |
+|                      | - `row_attr`_                                                               |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | :doc:`FormType </reference/forms/types/form>`                               |
 +----------------------+-----------------------------------------------------------------------------+
@@ -218,6 +220,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -237,6 +241,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 
 .. include:: /reference/forms/types/options/mapped.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 Field Variables
 ---------------

--- a/reference/forms/types/dateinterval.rst
+++ b/reference/forms/types/dateinterval.rst
@@ -37,8 +37,9 @@ or an array (see `input`_).
 |                      | - `with_years`_                                                                  |
 |                      | - `years`_                                                                       |
 +----------------------+----------------------------------------------------------------------------------+
-| Inherited            | - `data`_                                                                        |
-| options              | - `disabled`_                                                                    |
+| Inherited            | - `attr`_                                                                        |
+| options              | - `data`_                                                                        |
+|                      | - `disabled`_                                                                    |
 |                      | - `help`_                                                                        |
 |                      | - `help_attr`_                                                                   |
 |                      | - `help_html`_                                                                   |
@@ -46,6 +47,7 @@ or an array (see `input`_).
 |                      | - `invalid_message`_                                                             |
 |                      | - `invalid_message_parameters`_                                                  |
 |                      | - `mapped`_                                                                      |
+|                      | - `row_attr`_                                                                    |
 +----------------------+----------------------------------------------------------------------------------+
 | Parent type          | :doc:`FormType </reference/forms/types/form>`                                    |
 +----------------------+----------------------------------------------------------------------------------+
@@ -336,6 +338,8 @@ Inherited Options
 
 These options inherit from the :doc:`form </reference/forms/types/form>` type:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -353,6 +357,8 @@ These options inherit from the :doc:`form </reference/forms/types/form>` type:
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 
 .. include:: /reference/forms/types/options/mapped.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 Field Variables
 ---------------

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -43,8 +43,9 @@ the data can be a ``DateTime`` object, a string, a timestamp or an array.
 |                      | - `data_class`_                                                             |
 |                      | - `error_bubbling`_                                                         |
 +----------------------+-----------------------------------------------------------------------------+
-| Inherited            | - `data`_                                                                   |
-| options              | - `disabled`_                                                               |
+| Inherited            | - `attr`_                                                                   |
+| options              | - `data`_                                                                   |
+|                      | - `disabled`_                                                               |
 |                      | - `help`_                                                                   |
 |                      | - `help_attr`_                                                              |
 |                      | - `help_html`_                                                              |
@@ -52,6 +53,7 @@ the data can be a ``DateTime`` object, a string, a timestamp or an array.
 |                      | - `invalid_message`_                                                        |
 |                      | - `invalid_message_parameters`_                                             |
 |                      | - `mapped`_                                                                 |
+|                      | - `row_attr`_                                                               |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | :doc:`FormType </reference/forms/types/form>`                               |
 +----------------------+-----------------------------------------------------------------------------+
@@ -254,6 +256,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -271,6 +275,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 
 .. include:: /reference/forms/types/options/mapped.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 Field Variables
 ---------------

--- a/reference/forms/types/email.rst
+++ b/reference/forms/types/email.rst
@@ -10,8 +10,9 @@ The ``EmailType`` field is a text field that is rendered using the HTML5
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``email`` field (a text box)                              |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | - `data`_                                                           |
-| options     | - `disabled`_                                                       |
+| Inherited   | - `attr`_                                                           |
+| options     | - `data`_                                                           |
+|             | - `disabled`_                                                       |
 |             | - `empty_data`_                                                     |
 |             | - `error_bubbling`_                                                 |
 |             | - `error_mapping`_                                                  |
@@ -23,6 +24,7 @@ The ``EmailType`` field is a text field that is rendered using the HTML5
 |             | - `label_format`_                                                   |
 |             | - `mapped`_                                                         |
 |             | - `required`_                                                       |
+|             | - `row_attr`_                                                       |
 |             | - `trim`_                                                           |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                       |
@@ -36,6 +38,8 @@ Inherited Options
 -----------------
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
+
+.. include:: /reference/forms/types/options/attr.rst.inc
 
 .. include:: /reference/forms/types/options/data.rst.inc
 
@@ -68,5 +72,7 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. include:: /reference/forms/types/options/trim.rst.inc

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -50,6 +50,7 @@ objects from the database.
 |             | - `label_format`_                                                |
 |             | - `mapped`_                                                      |
 |             | - `required`_                                                    |
+|             | - `row_attr`_                                                    |
 |             | - `label_translation_parameters`_                                |
 |             | - `attr_translation_parameters`_                                 |
 |             | - `help_translation_parameters`_                                 |
@@ -361,6 +362,8 @@ The actual default value of this option depends on other field options:
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. include:: /reference/forms/types/options/label_translation_parameters.rst.inc
 

--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -15,8 +15,9 @@ The ``FileType`` represents a file input in your form.
 | options     | - `data_class`_                                                     |
 |             | - `empty_data`_                                                     |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | - `disabled`_                                                       |
-| options     | - `error_bubbling`_                                                 |
+| Inherited   | - `attr`_                                                           |
+| options     | - `disabled`_                                                       |
+|             | - `error_bubbling`_                                                 |
 |             | - `error_mapping`_                                                  |
 |             | - `help`_                                                           |
 |             | - `help_attr`_                                                      |
@@ -26,6 +27,7 @@ The ``FileType`` represents a file input in your form.
 |             | - `label_format`_                                                   |
 |             | - `mapped`_                                                         |
 |             | - `required`_                                                       |
+|             | - `row_attr`_                                                       |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                       |
 +-------------+---------------------------------------------------------------------+
@@ -123,6 +125,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
@@ -144,6 +148,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 Form Variables
 --------------

--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -42,6 +42,7 @@ on all types for which ``FormType`` is the parent.
 |           | - `block_prefix`_                                                  |
 |           | - `disabled`_                                                      |
 |           | - `label`_                                                         |
+|           | - `row_attr`_                                                      |
 |           | - `translation_domain`_                                            |
 |           | - `label_translation_parameters`_                                  |
 |           | - `attr_translation_parameters`_                                   |
@@ -170,6 +171,8 @@ of the form type tree (i.e. it cannot be used as a form type on its own).
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/label.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. include:: /reference/forms/types/options/translation_domain.rst.inc
 

--- a/reference/forms/types/hidden.rst
+++ b/reference/forms/types/hidden.rst
@@ -13,10 +13,12 @@ The hidden type represents a hidden input field.
 | options     | - `error_bubbling`_                                                  |
 |             | - `required`_                                                        |
 +-------------+----------------------------------------------------------------------+
-| Inherited   | - `data`_                                                            |
-| options     | - `error_mapping`_                                                   |
+| Inherited   | - `attr`_                                                            |
+| options     | - `data`_                                                            |
+|             | - `error_mapping`_                                                   |
 |             | - `mapped`_                                                          |
 |             | - `property_path`_                                                   |
+|             | - `row_attr`_                                                        |
 +-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                        |
 +-------------+----------------------------------------------------------------------+
@@ -49,6 +51,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/error_mapping.rst.inc
@@ -56,3 +60,5 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/property_path.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc

--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -22,8 +22,9 @@ integers. By default, all non-integer values (e.g. 6.78) will round down
 | Overridden  | - `compound`_                                                         |
 | options     | - `scale`_                                                            |
 +-------------+-----------------------------------------------------------------------+
-| Inherited   | - `data`_                                                             |
-| options     | - `disabled`_                                                         |
+| Inherited   | - `attr`_                                                             |
+| options     | - `data`_                                                             |
+|             | - `disabled`_                                                         |
 |             | - `empty_data`_                                                       |
 |             | - `error_bubbling`_                                                   |
 |             | - `error_mapping`_                                                    |
@@ -37,6 +38,7 @@ integers. By default, all non-integer values (e.g. 6.78) will round down
 |             | - `label_format`_                                                     |
 |             | - `mapped`_                                                           |
 |             | - `required`_                                                         |
+|             | - `row_attr`_                                                         |
 +-------------+-----------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                         |
 +-------------+-----------------------------------------------------------------------+
@@ -104,6 +106,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -139,3 +143,5 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -40,6 +40,7 @@ manually, but then you should just use the ``ChoiceType`` directly.
 |             |                                                                        |
 |             | from the :doc:`FormType </reference/forms/types/form>`                 |
 |             |                                                                        |
+|             | - `attr`_                                                              |
 |             | - `data`_                                                              |
 |             | - `disabled`_                                                          |
 |             | - `empty_data`_                                                        |
@@ -51,6 +52,7 @@ manually, but then you should just use the ``ChoiceType`` directly.
 |             | - `label_format`_                                                      |
 |             | - `mapped`_                                                            |
 |             | - `required`_                                                          |
+|             | - `row_attr`_                                                          |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
 +-------------+------------------------------------------------------------------------+
@@ -101,6 +103,8 @@ These options inherit from the :doc:`ChoiceType </reference/forms/types/choice>`
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -132,5 +136,7 @@ The actual default value of this option depends on other field options:
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. _`International Components for Unicode`: http://site.icu-project.org

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -41,6 +41,7 @@ manually, but then you should just use the ``ChoiceType`` directly.
 |             |                                                                        |
 |             | from the :doc:`FormType </reference/forms/types/form>`                 |
 |             |                                                                        |
+|             | - `attr`_                                                              |
 |             | - `data`_                                                              |
 |             | - `disabled`_                                                          |
 |             | - `empty_data`_                                                        |
@@ -52,6 +53,7 @@ manually, but then you should just use the ``ChoiceType`` directly.
 |             | - `label_format`_                                                      |
 |             | - `mapped`_                                                            |
 |             | - `required`_                                                          |
+|             | - `row_attr`_                                                          |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
 +-------------+------------------------------------------------------------------------+
@@ -102,6 +104,8 @@ These options inherit from the :doc:`ChoiceType </reference/forms/types/choice>`
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -133,6 +137,8 @@ The actual default value of this option depends on other field options:
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 .. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -23,8 +23,9 @@ how the input and output of the data is handled.
 | Overridden  | - `compound`_                                                       |
 | options     |                                                                     |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | - `data`_                                                           |
-| options     | - `disabled`_                                                       |
+| Inherited   | - `attr`_                                                           |
+| options     | - `data`_                                                           |
+|             | - `disabled`_                                                       |
 |             | - `empty_data`_                                                     |
 |             | - `error_bubbling`_                                                 |
 |             | - `error_mapping`_                                                  |
@@ -38,6 +39,7 @@ how the input and output of the data is handled.
 |             | - `label_format`_                                                   |
 |             | - `mapped`_                                                         |
 |             | - `required`_                                                       |
+|             | - `row_attr`_                                                       |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                       |
 +-------------+---------------------------------------------------------------------+
@@ -107,6 +109,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -142,6 +146,8 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 Form Variables
 --------------

--- a/reference/forms/types/number.rst
+++ b/reference/forms/types/number.rst
@@ -20,8 +20,9 @@ that you want to use for your number.
 | Overridden  | - `compound`_                                                        |
 | options     |                                                                      |
 +-------------+----------------------------------------------------------------------+
-| Inherited   | - `data`_                                                            |
-| options     | - `disabled`_                                                        |
+| Inherited   | - `attr`_                                                            |
+| options     | - `data`_                                                            |
+|             | - `disabled`_                                                        |
 |             | - `empty_data`_                                                      |
 |             | - `error_bubbling`_                                                  |
 |             | - `error_mapping`_                                                   |
@@ -35,6 +36,7 @@ that you want to use for your number.
 |             | - `label_format`_                                                    |
 |             | - `mapped`_                                                          |
 |             | - `required`_                                                        |
+|             | - `row_attr`_                                                        |
 +-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                        |
 +-------------+----------------------------------------------------------------------+
@@ -97,6 +99,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -132,3 +136,5 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc

--- a/reference/forms/types/options/attr.rst.inc
+++ b/reference/forms/types/options/attr.rst.inc
@@ -10,3 +10,8 @@ as keys. This can be useful when you need to set a custom class for some widget:
     $builder->add('body', TextareaType::class, [
         'attr' => ['class' => 'tinymce'],
     ]);
+
+.. seealso::
+
+    Use the ``row_attr`` option if you want to add these attributes to the
+    the :ref:`form type row <form-rendering-basics>` element.

--- a/reference/forms/types/options/row_attr.rst.inc
+++ b/reference/forms/types/options/row_attr.rst.inc
@@ -1,0 +1,20 @@
+row_attr
+~~~~~~~~
+
+**type**: ``array`` **default**: ``[]``
+
+An associative array of the HTML attributes added to the element which is used
+to render the :ref:`form type row <form-rendering-basics>`::
+
+    $builder->add('body', TextareaType::class, [
+        'row_attr' => ['class' => 'text-editor', 'id' => '...'],
+    ]);
+
+.. seealso::
+
+    Use the ``attr`` option if you want to add these attributes to the
+    the :ref:`form type widget <form-rendering-basics>` element.
+
+.. versionadded:: 4.3
+
+    The ``row_attr`` option was introduced in Symfony 4.3.

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -14,8 +14,9 @@ The ``PasswordType`` field renders an input password text box.
 | Overridden  | - `trim`_                                                              |
 | options     |                                                                        |
 +-------------+------------------------------------------------------------------------+
-| Inherited   | - `disabled`_                                                          |
-| options     | - `empty_data`_                                                        |
+| Inherited   | - `attr`_                                                              |
+| options     | - `disabled`_                                                          |
+|             | - `empty_data`_                                                        |
 |             | - `error_bubbling`_                                                    |
 |             | - `error_mapping`_                                                     |
 |             | - `help`_                                                              |
@@ -26,6 +27,7 @@ The ``PasswordType`` field renders an input password text box.
 |             | - `label_format`_                                                      |
 |             | - `mapped`_                                                            |
 |             | - `required`_                                                          |
+|             | - `row_attr`_                                                          |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                          |
 +-------------+------------------------------------------------------------------------+
@@ -67,6 +69,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/empty_data.rst.inc
@@ -96,3 +100,5 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc

--- a/reference/forms/types/percent.rst
+++ b/reference/forms/types/percent.rst
@@ -22,8 +22,9 @@ the input.
 | Overridden  | - `compound`_                                                         |
 | options     |                                                                       |
 +-------------+-----------------------------------------------------------------------+
-| Inherited   | - `data`_                                                             |
-| options     | - `disabled`_                                                         |
+| Inherited   | - `attr`_                                                             |
+| options     | - `data`_                                                             |
+|             | - `disabled`_                                                         |
 |             | - `empty_data`_                                                       |
 |             | - `error_bubbling`_                                                   |
 |             | - `error_mapping`_                                                    |
@@ -37,6 +38,7 @@ the input.
 |             | - `label_format`_                                                     |
 |             | - `mapped`_                                                           |
 |             | - `required`_                                                         |
+|             | - `row_attr`_                                                         |
 +-------------+-----------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                         |
 +-------------+-----------------------------------------------------------------------+
@@ -100,6 +102,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -135,3 +139,5 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -22,6 +22,7 @@ If you want to have a boolean field, use :doc:`CheckboxType </reference/forms/ty
 |             |                                                                     |
 |             | from the :doc:`FormType </reference/forms/types/form>`:             |
 |             |                                                                     |
+|             | - `attr`_                                                           |
 |             | - `data`_                                                           |
 |             | - `disabled`_                                                       |
 |             | - `empty_data`_                                                     |
@@ -35,6 +36,7 @@ If you want to have a boolean field, use :doc:`CheckboxType </reference/forms/ty
 |             | - `label_format`_                                                   |
 |             | - `mapped`_                                                         |
 |             | - `required`_                                                       |
+|             | - `row_attr`_                                                       |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`CheckboxType </reference/forms/types/checkbox>`               |
 +-------------+---------------------------------------------------------------------+
@@ -51,6 +53,8 @@ These options inherit from the :doc:`CheckboxType </reference/forms/types/checkb
 .. include:: /reference/forms/types/options/value.rst.inc
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
+
+.. include:: /reference/forms/types/options/attr.rst.inc
 
 .. include:: /reference/forms/types/options/data.rst.inc
 
@@ -77,6 +81,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 Form Variables
 --------------

--- a/reference/forms/types/range.rst
+++ b/reference/forms/types/range.rst
@@ -23,6 +23,7 @@ The ``RangeType`` field is a slider that is rendered using the HTML5
 |             | - `label_attr`_                                                     |
 |             | - `mapped`_                                                         |
 |             | - `required`_                                                       |
+|             | - `row_attr`_                                                       |
 |             | - `trim`_                                                           |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                       |
@@ -83,5 +84,7 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. include:: /reference/forms/types/options/trim.rst.inc

--- a/reference/forms/types/repeated.rst
+++ b/reference/forms/types/repeated.rst
@@ -22,14 +22,16 @@ accuracy.
 | Overridden  | - `error_bubbling`_                                                    |
 | options     |                                                                        |
 +-------------+------------------------------------------------------------------------+
-| Inherited   | - `data`_                                                              |
-| options     | - `error_mapping`_                                                     |
+| Inherited   | - `attr`_                                                              |
+| options     | - `data`_                                                              |
+|             | - `error_mapping`_                                                     |
 |             | - `help`_                                                              |
 |             | - `help_attr`_                                                         |
 |             | - `help_html`_                                                         |
 |             | - `invalid_message`_                                                   |
 |             | - `invalid_message_parameters`_                                        |
 |             | - `mapped`_                                                            |
+|             | - `row_attr`_                                                          |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                          |
 +-------------+------------------------------------------------------------------------+
@@ -182,6 +184,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/error_mapping.rst.inc
@@ -197,3 +201,5 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 
 .. include:: /reference/forms/types/options/mapped.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc

--- a/reference/forms/types/reset.rst
+++ b/reference/forms/types/reset.rst
@@ -14,6 +14,7 @@ A button that resets all fields to their original values.
 |                      | - `disabled`_                                                       |
 |                      | - `label`_                                                          |
 |                      | - `label_translation_parameters`_                                   |
+|                      | - `row_attr`_                                                       |
 |                      | - `translation_domain`_                                             |
 +----------------------+---------------------------------------------------------------------+
 | Parent type          | :doc:`ButtonType </reference/forms/types/button>`                   |
@@ -81,3 +82,5 @@ option of its parents, so buttons can reuse and/or override any of the parent
 placeholders.
 
 .. include:: /reference/forms/types/options/attr_translation_parameters.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc

--- a/reference/forms/types/search.rst
+++ b/reference/forms/types/search.rst
@@ -12,8 +12,9 @@ Read about the input search field at `DiveIntoHTML5.info`_
 +-------------+----------------------------------------------------------------------+
 | Rendered as | ``input search`` field                                               |
 +-------------+----------------------------------------------------------------------+
-| Inherited   | - `disabled`_                                                        |
-| options     | - `empty_data`_                                                      |
+| Inherited   | - `attr`_                                                            |
+| options     | - `disabled`_                                                        |
+|             | - `empty_data`_                                                      |
 |             | - `error_bubbling`_                                                  |
 |             | - `error_mapping`_                                                   |
 |             | - `help`_                                                            |
@@ -24,6 +25,7 @@ Read about the input search field at `DiveIntoHTML5.info`_
 |             | - `label_format`_                                                    |
 |             | - `mapped`_                                                          |
 |             | - `required`_                                                        |
+|             | - `row_attr`_                                                        |
 |             | - `trim`_                                                            |
 +-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                        |
@@ -37,6 +39,8 @@ Inherited Options
 -----------------
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
+
+.. include:: /reference/forms/types/options/attr.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
@@ -67,6 +71,8 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. include:: /reference/forms/types/options/trim.rst.inc
 

--- a/reference/forms/types/submit.rst
+++ b/reference/forms/types/submit.rst
@@ -15,6 +15,7 @@ A submit button.
 |                      | - `label`_                                                           |
 |                      | - `label_format`_                                                    |
 |                      | - `label_translation_parameters`_                                    |
+|                      | - `row_attr`_                                                        |
 |                      | - `translation_domain`_                                              |
 |                      | - `validation_groups`_                                               |
 +----------------------+----------------------------------------------------------------------+
@@ -94,6 +95,8 @@ option of its parents, so buttons can reuse and/or override any of the parent
 placeholders.
 
 .. include:: /reference/forms/types/options/attr_translation_parameters.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 validation_groups
 ~~~~~~~~~~~~~~~~~

--- a/reference/forms/types/tel.rst
+++ b/reference/forms/types/tel.rst
@@ -16,8 +16,9 @@ to input phone numbers.
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``tel`` field (a text box)                                |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | - `data`_                                                           |
-| options     | - `disabled`_                                                       |
+| Inherited   | - `attr`_                                                           |
+| options     | - `data`_                                                           |
+|             | - `disabled`_                                                       |
 |             | - `empty_data`_                                                     |
 |             | - `error_bubbling`_                                                 |
 |             | - `error_mapping`_                                                  |
@@ -29,6 +30,7 @@ to input phone numbers.
 |             | - `label_format`_                                                   |
 |             | - `mapped`_                                                         |
 |             | - `required`_                                                       |
+|             | - `row_attr`_                                                       |
 |             | - `trim`_                                                           |
 +-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                       |
@@ -42,6 +44,8 @@ Inherited Options
 -----------------
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
+
+.. include:: /reference/forms/types/options/attr.rst.inc
 
 .. include:: /reference/forms/types/options/data.rst.inc
 
@@ -74,5 +78,7 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. include:: /reference/forms/types/options/trim.rst.inc

--- a/reference/forms/types/text.rst
+++ b/reference/forms/types/text.rst
@@ -23,6 +23,7 @@ The TextType field represents the most basic input text field.
 |             | - `label_format`_                                                  |
 |             | - `mapped`_                                                        |
 |             | - `required`_                                                      |
+|             | - `row_attr`_                                                      |
 |             | - `trim`_                                                          |
 +-------------+--------------------------------------------------------------------+
 | Overridden  | - `compound`_                                                      |
@@ -75,6 +76,8 @@ an empty string, explicitly set the ``empty_data`` option to an empty string.
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. include:: /reference/forms/types/options/trim.rst.inc
 

--- a/reference/forms/types/textarea.rst
+++ b/reference/forms/types/textarea.rst
@@ -23,6 +23,7 @@ Renders a ``textarea`` HTML element.
 |             | - `label_format`_                                                      |
 |             | - `mapped`_                                                            |
 |             | - `required`_                                                          |
+|             | - `row_attr`_                                                          |
 |             | - `trim`_                                                              |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                          |
@@ -76,6 +77,8 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. include:: /reference/forms/types/options/trim.rst.inc
 

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -34,8 +34,9 @@ stored as a ``DateTime`` object, a string, a timestamp or an array.
 |                      | - `data_class`_                                                             |
 |                      | - `error_bubbling`_                                                         |
 +----------------------+-----------------------------------------------------------------------------+
-| Inherited            | - `data`_                                                                   |
-| Options              | - `disabled`_                                                               |
+| Inherited            | - `attr`_                                                                   |
+| options              | - `data`_                                                                   |
+|                      | - `disabled`_                                                               |
 |                      | - `error_mapping`_                                                          |
 |                      | - `help`_                                                                   |
 |                      | - `help_attr`_                                                              |
@@ -44,6 +45,7 @@ stored as a ``DateTime`` object, a string, a timestamp or an array.
 |                      | - `invalid_message`_                                                        |
 |                      | - `invalid_message_parameters`_                                             |
 |                      | - `mapped`_                                                                 |
+|                      | - `row_attr`_                                                               |
 +----------------------+-----------------------------------------------------------------------------+
 | Parent type          | FormType                                                                    |
 +----------------------+-----------------------------------------------------------------------------+
@@ -204,6 +206,8 @@ Inherited Options
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -223,6 +227,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 
 .. include:: /reference/forms/types/options/mapped.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 Form Variables
 --------------

--- a/reference/forms/types/timezone.rst
+++ b/reference/forms/types/timezone.rst
@@ -35,6 +35,7 @@ manually, but then you should just use the ``ChoiceType`` directly.
 |             |                                                                        |
 |             | from the :doc:`FormType </reference/forms/types/form>`                 |
 |             |                                                                        |
+|             | - `attr`_                                                              |
 |             | - `data`_                                                              |
 |             | - `disabled`_                                                          |
 |             | - `empty_data`_                                                        |
@@ -48,6 +49,7 @@ manually, but then you should just use the ``ChoiceType`` directly.
 |             | - `label_format`_                                                      |
 |             | - `mapped`_                                                            |
 |             | - `required`_                                                          |
+|             | - `row_attr`_                                                          |
 +-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
 +-------------+------------------------------------------------------------------------+
@@ -143,6 +145,8 @@ These options inherit from the :doc:`ChoiceType </reference/forms/types/choice>`
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
+.. include:: /reference/forms/types/options/attr.rst.inc
+
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/disabled.rst.inc
@@ -178,5 +182,7 @@ The actual default value of this option depends on other field options:
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. _`ICU Project`: http://site.icu-project.org/

--- a/reference/forms/types/url.rst
+++ b/reference/forms/types/url.rst
@@ -13,8 +13,9 @@ have a protocol.
 +-------------+-------------------------------------------------------------------+
 | Options     | - `default_protocol`_                                             |
 +-------------+-------------------------------------------------------------------+
-| Inherited   | - `data`_                                                         |
-| options     | - `disabled`_                                                     |
+| Inherited   | - `attr`_                                                         |
+| options     | - `data`_                                                         |
+|             | - `disabled`_                                                     |
 |             | - `empty_data`_                                                   |
 |             | - `error_bubbling`_                                               |
 |             | - `error_mapping`_                                                |
@@ -26,6 +27,7 @@ have a protocol.
 |             | - `label_format`_                                                 |
 |             | - `mapped`_                                                       |
 |             | - `required`_                                                     |
+|             | - `row_attr`_                                                     |
 |             | - `trim`_                                                         |
 +-------------+-------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                     |
@@ -51,6 +53,8 @@ Inherited Options
 -----------------
 
 These options inherit from the :doc:`FormType </reference/forms/types/form>`:
+
+.. include:: /reference/forms/types/options/attr.rst.inc
 
 .. include:: /reference/forms/types/options/data.rst.inc
 
@@ -83,5 +87,7 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/mapped.rst.inc
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+.. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. include:: /reference/forms/types/options/trim.rst.inc


### PR DESCRIPTION
Fixes #11560.

I also added the `attr` inherited option in the types which were missing it.