### PR TITLE
Correct minimum PHP version

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -17,7 +17,7 @@ Technical Requirements
 
 Before creating your first Symfony application you must:
 
-* Install PHP 7.1 or higher and these PHP extensions (which are installed and
+* Install PHP 7.2.9 or higher and these PHP extensions (which are installed and
   enabled by default in most PHP 7 installations): `Ctype`_, `iconv`_, `JSON`_,
   `PCRE`_, `Session`_, `SimpleXML`_, and `Tokenizer`_;
 * `Install Composer`_, which is used to install PHP packages;


### PR DESCRIPTION
The correct minimum version for 5.0 is PHP 7.2.9, as indicated in https://github.com/symfony/symfony/blob/master/composer.json#L19

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
