### PR TITLE
another fix to make amqp messages go to a separate queue

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -503,9 +503,11 @@ different messages to them. For example:
                             # queue_name is specific to the doctrine transport
                             queue_name: high
 
-                            # for amqp
+                            # for amqp send to a separate exchange then queue
                             #exchange:
                             #    name: high
+                            #queues:
+                            #    messages_high
                             # or redis try "group"
                     async_priority_low:
                         dsn: '%env(MESSENGER_TRANSPORT_DSN)%'

--- a/messenger.rst
+++ b/messenger.rst
@@ -507,7 +507,7 @@ different messages to them. For example:
                             #exchange:
                             #    name: high
                             #queues:
-                            #    messages_high
+                            #    messages_high: ~
                             # or redis try "group"
                     async_priority_low:
                         dsn: '%env(MESSENGER_TRANSPORT_DSN)%'


### PR DESCRIPTION
Sorry! Missed this detail from my PR yesterday. Because the default queue is always named "messages", you need to send to a separate exchange (because exchanges are "fan out" by default... so you need a different exchange per queue if you keep this setting... which is the easiest) and also configure that exchange to bind to a queue of a different name. The end result is that the 2 transports will send messages to 2 separate queues.

