### PR TITLE
Fixed some explanations in the mailer component

### DIFF
--- a/components/mailer.rst
+++ b/components/mailer.rst
@@ -100,15 +100,11 @@ binary. For third-party providers, refers to the following table:
  Sendgrid             smtp://apikey:KEY@sendgrid         n/a                                api://KEY@sendgrid
 ==================== ================================== ================================== ================================
 
-Load Balancing
---------------
+High Availability
+-----------------
 
-Symfony's mailer supports `load balancing`_ so you can distribute the mailing
-workload across multiple transports. There are two main techniques to balance
-the load: failover and round-robin.
-
-Failover Load Balancing
-~~~~~~~~~~~~~~~~~~~~~~~
+Symfony's mailer supports `high availability`_ via a technique called "failover"
+to ensure that emails are sent even if one mailer server fails .
 
 A failover transport is configured with two or more transports joined by the
 ``||`` operator::
@@ -119,8 +115,11 @@ The mailer will start using the first transport. If the sending fails, the
 mailer won't retry it with the other transports, but it will switch to the next
 transport automatically for the following deliveries.
 
-Round-Robin Load Balancing
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Load Balancing
+--------------
+
+Symfony's mailer supports `load balancing`_ via a technique called "round-robin"
+to distribute the mailing workload across multiple transports .
 
 A round-robin transport is configured with two or more transports joined by the
 ``&&`` operator::
@@ -181,4 +180,5 @@ Learn More
 To learn more about how to use the mailer component, refer to the
 :doc:`Symfony Framework Mailer documentation </mailer>`.
 
+.. _`high availability`: https://en.wikipedia.org/wiki/High_availability
 .. _`load balancing`: https://en.wikipedia.org/wiki/Load_balancing_(computing)


### PR DESCRIPTION
This fixes some mistakes introduced in #12301 because "failover" is not a "load balancing" technique but a "high availability" one.