### PR TITLE
Inform about how to use new DateTime() when Clock Mocking

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -331,8 +331,14 @@ Clock Mocking
 ~~~~~~~~~~~~~
 
 The :class:`Symfony\\Bridge\\PhpUnit\\ClockMock` class provided by this bridge
-allows you to mock the PHP's built-in time functions ``time()``,
-``microtime()``, ``sleep()`` and ``usleep()``.
+allows you to mock the PHP's built-in time functions ``time()``, ``microtime()``,
+``sleep()``, ``usleep()`` and ``gmdate()``. Additionally the function ``date()``
+is mocked so it uses the mocked time if no timestamp is specified.
+
+This means that you don't need to make a single change in your original code, except when using ``new DateTime()``, which must be replaced by ``DateTime::createFromFormat('U', time())`` to use the mocked ``time()`` function.
+
+Other functions with an optional timestamp parameter that defaults to ``time()``
+will still use the system time instead of the mocked time.
 
 To use the ``ClockMock`` class in your test, add the ``@group time-sensitive``
 annotation to its class or methods. This annotation only works when executing


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
