### PR TITLE
[HttpClient] Add the buffer option to 4.3 too

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -93,6 +93,7 @@ Configuration
   * :ref:`default_options <reference-http-client-default-options>`
 
     * `bindto`_
+    * `buffer`_
     * `cafile`_
     * `capath`_
     * `ciphers`_
@@ -118,6 +119,7 @@ Configuration
     * `auth_bearer`_
     * `base_uri`_
     * `bindto`_
+    * `buffer`_
     * `cafile`_
     * `capath`_
     * `ciphers`_
@@ -780,6 +782,15 @@ bindto
 
 A network interface name, IP address, a host name or a UNIX socket to use as the
 outgoing network interface.
+
+buffer
+......
+
+**type**: ``bool`` **default**: ``false``
+
+Buffering the response means that you can access its content multiple times
+without performing the request again. Pass ``true`` as the value of this option
+to enable buffering.
 
 cafile
 ......


### PR DESCRIPTION
After merging #12043 I realized we need to document it in 4.3 too.