### PR TITLE
Mentioned the mailer debugging options

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -256,6 +256,23 @@ images inside the HTML contents::
         ->html('<img src="cid:logo"> ... <img src="cid:footer-signature"> ...')
     ;
 
+Debugging Emails
+----------------
+
+The :class:`Symfony\\Component\\Mailer\\SentMessage` object returned by the
+``send()`` method of the :class:`Symfony\\Component\\Mailer\\Transport\\TransportInterface`
+provides access to the original message (``getOriginalMessage()``) and to some
+debug information (``getDebug()``) such as the HTTP calls done by the HTTP
+transports, which is useful to debug errors.
+
+The exceptions related to mailer transports (those which implement
+:class:`Symfony\\Component\\Mailer\\Exception\\TransportException`) also provide
+this debug information via the ``getDebug()`` method.
+
+.. versionadded:: 4.4
+
+    The ``getDebug()`` methods were introduced in Symfony 4.4.
+
 .. _mailer-twig:
 
 Twig: HTML & CSS


### PR DESCRIPTION
Fixes #11985 and #12082.

@fabpot I'm having some problems trying to understand this feature. It's related to `SentMessage` class ... but we don't even mention that class in the docs. In the basic mailer example (https://symfony.com/doc/current/mailer.html#creating-sending-messages) the `send()` method doesn't return anything. How can developers access to this `SentMessage` objects? Thanks!