### PR TITLE
Additional help with Real-Time Output

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -41,7 +41,7 @@ when executing the command.
 
 The ``getOutput()`` method always returns the whole content of the standard
 output of the command and ``getErrorOutput()`` the content of the error
-output. Alternatively, the :method:`Symfony\\Component\\Process\\Process::getIncrementalOutput`
+output.Alternatively, the :method:`Symfony\\Component\\Process\\Process::getIncrementalOutput`
 and :method:`Symfony\\Component\\Process\\Process::getIncrementalErrorOutput`
 methods return the new output since the last call.
 
@@ -151,6 +151,8 @@ anonymous function to the
             echo 'OUT > '.$buffer;
         }
     });
+
+If this is not working, it can be that your server has an output buffer, that means your Server is not giving the information to the browser, so Symfony can't display it. You can use ``ob_flush()`` and ``flush()`` in combination with ``sleep()`` to avoid this in this process. Or change ``output_buffering`` in php.ini to change it globally.
 
 Running Processes Asynchronously
 --------------------------------


### PR DESCRIPTION
I have seen quite some issuse and questions. I think its quite common that php.ini is not allowing real-time output. So the hint helps probably some people

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
