### PR TITLE
Removed the symfony/security component

### DIFF
--- a/components/security.rst
+++ b/components/security.rst
@@ -14,12 +14,6 @@ The Security Component
 Installation
 ------------
 
-.. code-block:: terminal
-
-    $ composer require symfony/security
-
-.. include:: /components/require_autoload.rst.inc
-
 The Security component is divided into several smaller sub-components which can
 be used separately:
 
@@ -37,6 +31,17 @@ be used separately:
 ``symfony/security-guard``
     It brings many layers of authentication together, allowing the creation
     of complex authentication systems.
+
+You can install each of them separately in your project:
+
+.. code-block:: terminal
+
+    $ composer require symfony/security-core
+    $ composer require symfony/security-http
+    $ composer require symfony/security-csrf
+    $ composer require symfony/security-guard
+
+.. include:: /components/require_autoload.rst.inc
 
 .. seealso::
 


### PR DESCRIPTION
Fixes #11989.

If you are a Symfony developer, don't worry. **We haven't removed the security component**, only the `symfony/security` "meta-package". This won't affect you in any way when using a full Symfony application. It only affects to people using that meta-package as a stand-alone package in a PHP application.