### PR TITLE
Update dama/doctrine-test-bundle docs

### DIFF
--- a/testing/database.rst
+++ b/testing/database.rst
@@ -48,12 +48,12 @@ Now, enable it as a PHPUnit extension or listener:
     <phpunit>
         <!-- ... -->
 
-        <!-- Add this in PHPUnit 8 or higher -->
+        <!-- Add this for PHPUnit 7.1 or higher -->
         <extensions>
             <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
         </extensions>
 
-        <!-- Add this in PHPUnit 7 or lower -->
+        <!-- Add this for PHPUnit 7.0 -->
         <listeners>
             <listener class="\DAMA\DoctrineTestBundle\PHPUnit\PHPUnitListener"/>
         </listeners>


### PR DESCRIPTION
PHPUnit test hooks can be used starting from PHPUnit version 7.1:
https://phpunit.readthedocs.io/en/7.1/extending-phpunit.html#extending-phpunit-testrunner

This will avoid deprecation notices.

See also https://github.com/dmaicher/doctrine-test-bundle/commit/8f87ad0655bc7b3af935033b095f854c58fa11b9

ping @javiereguiluz 