### PR TITLE
Update logging.rst

### DIFF
--- a/logging.rst
+++ b/logging.rst
@@ -315,7 +315,7 @@ option of your handler to ``rotating_file``:
                 https://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
 
             <monolog:config>
-                <!-- "max_files": max number of log files to keep
+                <!-- "max-files": max number of log files to keep
                      defaults to zero, which means infinite files -->
                 <monolog:handler name="main"
                     type="rotating_file"


### PR DESCRIPTION
In the XML example of [Logging - How to Rotate your Log Files](https://symfony.com/doc/current/logging.html#how-to-rotate-your-log-files) a dash is used for the attribute `max-files`, but in the comment above the `monolog:handler` XML element an underscore was used (`max_files`).

Other XML examples in the Symfony Docs (like the routing doc page) use dashes for XML attributes, so it looks like this XML attribute shares that style, and the comment could be changed instead.