### PR TITLE
Update routing.rst

### DIFF
--- a/components/routing.rst
+++ b/components/routing.rst
@@ -45,7 +45,7 @@ Here is a quick example::
     use Symfony\Component\Routing\Route;
     use Symfony\Component\Routing\RouteCollection;
 
-    $route = new Route('/blog/{slug}', ['_controller' => BlogController::class])
+    $route = new Route('/blog/{slug}', ['_controller' => BlogController::class]);
     $routes = new RouteCollection();
     $routes->add('blog_show', $route);
 


### PR DESCRIPTION
Missing ';' in Routing Component documentation

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
