### PR TITLE
Update routing.rst

### DIFF
--- a/components/routing.rst
+++ b/components/routing.rst
@@ -40,6 +40,7 @@ A routing system has three parts:
 Here is a quick example::
 
     use App\Controller\BlogController;
+    use Symfony\Component\Routing\Generator\UrlGenerator;
     use Symfony\Component\Routing\Matcher\UrlMatcher;
     use Symfony\Component\Routing\RequestContext;
     use Symfony\Component\Routing\Route;


### PR DESCRIPTION
Missing 'use Symfony\Component\Routing\Generator\UrlGenerator;' in Routing Component documentation

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
