### PR TITLE
Update Timezone.rst

### DIFF
--- a/reference/constraints/Timezone.rst
+++ b/reference/constraints/Timezone.rst
@@ -112,7 +112,7 @@ This constraint considers valid both the `PHP timezone identifiers`_ and the
 However, the timezones provided by the Intl component can be different from the
 timezones provided by PHP's Intl extension (because they use different ICU
 versions). If this option is set to ``true``, this constraint only considers
-valid the values created with the PHP ``\IntlTimeZone::createTimeZone()`` method.
+valid the values compatible with the PHP ``\IntlTimeZone::createTimeZone()`` method.
 
 message
 ~~~~~~~


### PR DESCRIPTION
we dont "create" anything, the option ensures valid string values that can be used with `IntlTimeZone::createTimeZone` without ever getting `Etc/Unknonwn`

cc @javiereguiluz as we discussed this, i think this is more explicit