### PR TITLE
[Workflow] Removed note about flushing in `entered` event

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -260,8 +260,7 @@ order:
     * ``workflow.[workflow name].enter.[place name]``
 
 ``workflow.entered``
-    The subject has entered in the places and the marking is updated (making it a good
-    place to flush data in Doctrine).
+    The subject has entered in the places and the marking is updated.
 
     The three events being dispatched are:
 


### PR DESCRIPTION
This sentence is confusing and lead to bad practices:

* It's not a good idea to flush in the model layer
* It can lead to many calls to `flush()` method if the user uses a workflow (with many `to` places after a transition)
* It's not possible to "preview" what a transition do, because everything is flushed in the DB
