### PR TITLE
Make clear when the options are effectively required

### DIFF
--- a/reference/constraints/Count.rst
+++ b/reference/constraints/Count.rst
@@ -119,7 +119,7 @@ max
 
 **type**: ``integer``
 
-This required option is the "max" count value. Validation will fail if the
+This option is the "max" count value and it is required if the **min** option has not been defined. Validation will fail if the
 given collection elements count is **greater** than this max value.
 
 minMessage


### PR DESCRIPTION
In the documentation related to the `Count` constraint is not clear that the parameters `min` and `max` are dependent on each other to determine if they are required.

This is an snipped taken from `\Symfony\Component\Validator\Constraints\Count` in package `symfony/validator` version 4.3.4 that states this dependency:
```
if (null === $this->min && null === $this->max) {
            throw new MissingOptionsException(sprintf('Either option "min" or "max" must be given for constraint %s', __CLASS__), ['min', 'max']);
        }
```