### PR TITLE
Update dependency_injection.rst

### DIFF
--- a/create_framework/dependency_injection.rst
+++ b/create_framework/dependency_injection.rst
@@ -27,8 +27,12 @@ to it::
             $argumentResolver = new HttpKernel\Controller\ArgumentResolver();
 
             $dispatcher = new EventDispatcher();
+            $dispatcher->addSubscriber(new HttpKernel\EventListener\ExceptionListener(
+                'Calendar\Controller\ErrorController::exception'
+            ));
             $dispatcher->addSubscriber(new HttpKernel\EventListener\RouterListener($matcher, $requestStack));
             $dispatcher->addSubscriber(new HttpKernel\EventListener\ResponseListener('UTF-8'));
+            $dispatcher->addSubscriber(new StringResponseListener());
 
             parent::__construct($dispatcher, $controllerResolver, $requestStack, $argumentResolver);
         }


### PR DESCRIPTION
In previous chapter we changed our controller logic to return string, also we used ExceptionListener, if we won't register them after we move logic into Framework class we will get fatal

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
