### PR TITLE
Fix double 'is'

### DIFF
--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -184,7 +184,7 @@ type
     in Symfony 4.4.
 
 This required option defines the type or collection of types allowed for the
-given value. Each type is is either the FQCN (fully qualified class name) of some
+given value. Each type is either the FQCN (fully qualified class name) of some
 PHP class/interface or a valid PHP datatype (checked by PHP's ``is_()`` functions):
 
 * :phpfunction:`array <is_array>`


### PR DESCRIPTION
Problem was introduced in 4.4 branch. Linter failed.