### PR TITLE
Remove "mocking" to better reflect the subject.

### DIFF
--- a/testing/database.rst
+++ b/testing/database.rst
@@ -200,7 +200,7 @@ the employee which gets returned by the ``Repository``, which itself gets
 returned by the ``EntityManager``. This way, no real class is involved in
 testing.
 
-Mocking a Doctrine Repository in Functional Tests
+Functional Testing of A Doctrine Repository
 -------------------------------------------------
 
 In :ref:`functional tests <functional-tests>` you'll make queries to the


### PR DESCRIPTION
This section is about doing a functional (or perhaps integration?) testing with the real (not mocked) objects, therefore using "mocking" in the title is not correct, especially because it echoes the previous section where actual mock objects are used.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
