### PR TITLE
[Validator] Options `min` and `max` of Length constraint not required simultaneously  

### DIFF
--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -122,8 +122,10 @@ min
 
 **type**: ``integer``
 
-This required option is the "min" length value. Validation will fail if
+This option is the "min" length value. Validation will fail if
 the given value's length is **less** than this min value.
+
+This option is required when the ``max`` option is not defined.
 
 It is important to notice that NULL values and empty strings are considered
 valid no matter if the constraint required a minimum length. Validators
@@ -134,8 +136,10 @@ max
 
 **type**: ``integer``
 
-This required option is the "max" length value. Validation will fail if
+This option is the "max" length value. Validation will fail if
 the given value's length is **greater** than this max value.
+
+This option is required when the ``min`` option is not defined.
 
 charset
 ~~~~~~~


### PR DESCRIPTION
As for the Count validator constraint (see: #12416]) the options `min` and `max` of the Length constraint are not required simultaneously.
