### PR TITLE
Document the new version option from the Symfony bin

### DIFF
--- a/best_practices/creating-the-project.rst
+++ b/best_practices/creating-the-project.rst
@@ -31,7 +31,7 @@ to create files and execute the following commands:
 .. code-block:: terminal
 
     $ cd projects/
-    $ symfony new blog 3.4
+    $ symfony new --version=3.4 blog
 
 **Windows systems**:
 
@@ -39,7 +39,7 @@ to create files and execute the following commands:
 .. code-block:: terminal
 
     > cd projects/
-    > php symfony new blog 3.4
+    > php symfony new --version=3.4 blog
 
 .. note::
 

--- a/setup.rst
+++ b/setup.rst
@@ -67,7 +67,7 @@ with the ``new`` command:
 
 .. code-block:: terminal
 
-    $ symfony new my_project_name 3.4
+    $ symfony new --version=3.4 my_project_name
 
 This command creates a new directory called ``my_project_name/`` that contains
 an empty project based on the most recent stable Symfony version available. In
@@ -106,24 +106,20 @@ Basing your Project on a Specific Symfony Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In case your project needs to be based on a specific Symfony version, use the
-optional second argument of the ``new`` command:
+``version`` option of the ``new`` command:
 
 .. code-block:: terminal
 
     # use the most recent version in any Symfony branch
-    $ symfony new my_project_name 2.8
-    $ symfony new my_project_name 3.1
+    $ symfony new --version=3.3 my_project_name
+    $ symfony new --version=3.4 my_project_name
 
     # use a specific Symfony version
-    $ symfony new my_project_name 2.8.3
-    $ symfony new my_project_name 3.1.5
-
-    # use a beta or RC version (useful for testing new Symfony versions)
-    $ symfony new my_project 2.7.0-BETA1
-    $ symfony new my_project 2.7.0-RC1
+    $ symfony new --version=3.3.10 my_project_name
+    $ symfony new --version=3.4.5 my_project_name
 
     # use the most recent 'lts' version (Long Term Support version)
-    $ symfony new my_project_name lts
+    $ symfony new --version=lts my_project_name
 
 Each version has its *own* documentation, which you can select on any documentation
 page.

--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -364,13 +364,13 @@ commands from the Symfony server:
 .. code-block:: terminal
 
     # creates a new project based on symfony/skeleton
-    $ symfony new my_project_name
+    $ symfony new --version=3.4 my_project_name
 
     # creates a new project based on symfony/website-skeleton
-    $ symfony new --full my_project_name
+    $ symfony new --version=3.4 --full my_project_name
 
     # creates a new project based on the Symfony Demo application
-    $ symfony new --demo my_project_name
+    $ symfony new --version=3.4 --demo my_project_name
 
 You can create a project depending on a **development** version as well (note
 that Composer will also set the stability to ``dev`` for all root dependencies):


### PR DESCRIPTION
`symfony new blog 3.4` results in `Incorrect usage: Too many arguments`. The version must now be specified with the `version` option.