### PR TITLE
[Encore] Replace "Encore.setPublicPrefix" by "Encore.setPublicPath"

### DIFF
--- a/frontend/encore/faq.rst
+++ b/frontend/encore/faq.rst
@@ -59,7 +59,7 @@ My App Lives under a Subdirectory
 ---------------------------------
 
 If your app does not live at the root of your web server (i.e. it lives under a subdirectory,
-like ``/myAppSubdir``), you just need to configure that when calling ``Encore.setPublicPrefix()``:
+like ``/myAppSubdir``), you will need to configure that when calling ``Encore.setPublicPath()``:
 
 .. code-block:: diff
 


### PR DESCRIPTION
Fixes a small issue in the FAQ page: `Encore.setPublicPrefix()` does not exist, it should be [`Encore.setPublicPath()`](https://github.com/symfony/webpack-encore/blob/314be3277984c8493a5daaae792c05279a9c436b/index.js#L39-L69) instead (the example that follows uses it correctly).

I also removed a "*just*" in the same sentence since, if I recall correctly, it should now be avoided in the docs.