### PR TITLE
Update message_format.rst

### DIFF
--- a/translation/message_format.rst
+++ b/translation/message_format.rst
@@ -26,7 +26,7 @@ In order to use the ICU Message Format, the :ref:`message domain
 Normal file name        ICU Message Format filename
 ======================  ===============================
 ``messages.en.yaml``    ``messages+intl-icu.en.yaml``
-``messages.fr_FR.xlf``  ``messages+intl-icu.fr_FR.xlf``
+``messages.fr_FR.xlf``  ``messages+intl-icu.fr.xlf``
 ``admin.en.yaml``       ``admin+intl-icu.en.yaml``
 ======================  ===============================
 


### PR DESCRIPTION
There is a little issue. 
When the suffixe is fr_FR by example, the message formatter does not find the file.

I have to rename `messages.fr_FR.xlf` in `messages+intl-icu.fr.xlf` to make it works.

So for now, i offer you to adapt documentation before fixing the bug. 
Other user could be use easily ICU messages ! 

Thank's for your work !

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
