### PR TITLE
Fixed: tagged services YAML example can be misleading

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -466,7 +466,8 @@ first  constructor argument to the ``App\HandlerCollection`` service:
 
             AppBundle\HandlerCollection:
                 # inject all services tagged with app.handler as first argument
-                arguments: [!tagged app.handler]
+                arguments:
+                    - !tagged app.handler
 
     .. code-block:: xml
 


### PR DESCRIPTION
Hello,

At the moment, I find [tagged services example](https://symfony.com/doc/current/service_container/tags.html#reference-tagged-services) in YAML to be misleading:

```yaml
# config/services.yaml
services:
    App\HandlerCollection:
        # inject all services tagged with app.handler as first argument
        arguments: [!tagged app.handler]
```

`[!tagged app.handler]` means all tagged services, which is a `RewindableGenerator`, to be injected **as the array of** arguments. It combines both a syntax specific _to injecting the array of arguments_, and the `!tagged app.handler` syntax, to get _an array of tagged services_ (moreover, which is a non-standard and uncommon syntax).

Having both syntax, both arrays, shown at the same time makes the snippet hard to grasp for newcomers. 
We had the issue with a coworker a few minutes ago, he did this naively:
```yaml
services:
    App\HandlerCollection:
        arguments: 
             - @router
             - @my_other_service
             - [!tagged app.handler]
```
And we lost some time to debug why we where getting an array of `RewindableGenerator`.

This PR simplifies YAML example to use a more common, more readable, and less risky to modify syntax:
```yaml
services:
    App\HandlerCollection:
        arguments: 
            - !tagged app.handler
```

I think it will be clearer to newcomers. 
I believe it also makes YAML example closer to XML example, since XML does not have a syntax for "array of all arguments passed to that service".
