### PR TITLE
Update dic_tags.rst

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -927,7 +927,7 @@ file
 When executing the ``translation:update`` command, it uses extractors to
 extract translation messages from a file. By default, the Symfony Framework
 has a :class:`Symfony\\Bridge\\Twig\\Translation\\TwigExtractor` and a
-:class:`Symfony\\Bundle\\FrameworkBundle\\Translation\\PhpExtractor`, which
+:class:`Symfony\\Component\\Translation\\Extractor\\PhpExtractor`, which
 help to find and extract translation keys from Twig templates and PHP files.
 
 You can create your own extractor by creating a class that implements


### PR DESCRIPTION
The `PhpExtractor` in FrameworkBundle is removed in v4, but there is still a link to it.