### PR TITLE
List CSV encoder's context options

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -810,13 +810,6 @@ The ``CsvEncoder``
 
 The ``CsvEncoder`` encodes to and decodes from CSV.
 
-You can pass the context key ``as_collection`` in order to have the results
-always as a collection.
-
-.. deprecated:: 4.2
-
-    Relying on the default value ``false`` is deprecated since Symfony 4.2.
-
 The ``XmlEncoder``
 ~~~~~~~~~~~~~~~~~~
 
@@ -1254,6 +1247,52 @@ These are the options available:
 ``remove_empty_tags``
     If set to true, removes all empty tags in the generated XML.
 
+The ``CsvEncoder``
+------------------
+
+This encoder transforms arrays into CSV and vice versa.
+
+Context
+~~~~~~~
+
+The ``encode()`` method defines a third optional parameter called ``context``
+which defines the configuration options for the CsvEncoder an associative array::
+
+    $csvEncoder->encode($array, 'csv', $context);
+
+These are the options available:
+
+``csv_delimiter``
+    Sets the field delimiter separating values (one character only, default: ``,``).
+    
+``csv_enclosure``
+    Sets the field enclosure (one character only, default: ``"``).
+    
+``csv_escape_char``
+    Sets the escape character (at most one character, default: empty string).
+    
+``csv_key_separator``
+    Sets the separator for array's keys during its flattening (default: ``.``).
+    
+``csv_headers``
+    Sets the headers for the data (default: ``[]``, inferred from input data's keys).
+    
+``csv_escape_formulas``
+    Escapes fields containg formulas by prepending them with a ``\t`` character (default: ``false``).
+    
+``as_collection``
+    Always returns results as a collection, even if only one line is decoded (default: ``false``).
+    
+.. deprecated:: 4.2
+
+    Relying on the default value ``false`` is deprecated since Symfony 4.2.
+    
+``no_headers``
+    Disables header in the encoded CSV (default: ``false``).
+    
+``output_utf8_bom``
+    Outputs special `UTF-8 BOM`_ along with encoded data (default: ``false``).
+
 Handling Constructor Arguments
 ------------------------------
 
@@ -1506,6 +1545,7 @@ Learn more
 .. _YAML: http://yaml.org/
 .. _CSV: https://tools.ietf.org/html/rfc4180
 .. _`RFC 7807`: https://tools.ietf.org/html/rfc7807
+.. _`UTF-8 BOM`: https://en.wikipedia.org/wiki/Byte_order_mark
 .. _`Value Objects`: https://en.wikipedia.org/wiki/Value_object
 .. _`API Platform`: https://api-platform.com
 .. _`list of PHP timezones`: https://www.php.net/manual/en/timezones.php


### PR DESCRIPTION
I needed to add new option `output_utf8_bom` introduced in https://github.com/symfony/symfony/pull/33896 and since context options weren't documented I figured I'll list them all. Format and text is based on XML's part of the docs.