### PR TITLE
Add hint for phpunit

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -26,6 +26,9 @@ tests, such as Doctrine, Twig and Monolog. To do so,
 
 .. _running:
 
+You also have to download the phpunit executable to run tests.
+Follow the instructions of the `phpunit website`_.
+
 Running the Tests
 -----------------
 
@@ -55,6 +58,7 @@ what's going on and if the tests are broken because of the new code.
     to see colored test results.
 
 .. _`install Composer`: https://getcomposer.org/download/
+.. _`phpunit website`: https://phpunit.de/getting-started/phpunit-7.html
 .. _Cmder: http://cmder.net/
 .. _ConEmu: https://conemu.github.io/
 .. _ANSICON: https://github.com/adoxa/ansicon/releases


### PR DESCRIPTION
I wandered through the docs of symfony and found the page https://symfony.com/doc/4.4/contributing/code/tests.html.

The page does not mentioned where the `./phpunit` file comes from. It is confusing for newbies to follow the instruction, when they don't know how to install the phpunit binary, because they may not have this binary.

I added a hint for that. It's obvious to install phpunit for testing purposes, but the docs should be self-explanatory to other people regardless of the knownledge about software. 

I don't know if the 4.4 branch is the right branch, but it should be mentioned in the future docs for the next versions too.