### PR TITLE
Change language about storing .env files in the repo

### DIFF
--- a/components/dotenv.rst
+++ b/components/dotenv.rst
@@ -108,8 +108,8 @@ environments by passing them as additional arguments to ``Dotenv::loadEnv()``
 
     The ``Dotenv::loadEnv()`` method was introduced in Symfony 4.2.
 
-You should never store a ``.env`` file in your code repository as it might
-contain sensitive information; create a ``.env.dist`` file (or multiple
+You should never store a ``.env.local`` file in your code repository as it might
+contain sensitive information; create a ``.env`` file (or multiple
 environment-specific ones as shown above) with sensible defaults instead.
 
 .. note::


### PR DESCRIPTION
I think .env files are now stored in the repo, but this could probably be written better.  

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
