### PR TITLE
[Form] Removed sidebar about Stateful data mappers

### DIFF
--- a/form/data_mappers.rst
+++ b/form/data_mappers.rst
@@ -192,30 +192,3 @@ create a new ``Color`` object now.
 
     When a form has the ``inherit_data`` option set to ``true``, it does not use the data mapper and
     lets its parent map inner values.
-
-.. sidebar:: Stateful Data Mappers
-
-    Sometimes, data mappers need to access services or need to maintain their
-    state. In this case, you cannot implement the methods in the form type
-    itself. Create a separate class implementing ``DataMapperInterface`` and
-    initialize it in your form type::
-
-        // src/AppBundle/Form/Type/ColorType.php
-
-        // ...
-        use AppBundle\Form\DataMapper\ColorMapper;
-
-        final class ColorType extends AbstractType
-        {
-            public function buildForm(FormBuilderInterface $builder, array $options)
-            {
-                $builder
-                    // ...
-
-                    // Initialize the data mapper class and e.g. pass some state
-                    ->setDataMapper(new ColorMapper($options['opacity']))
-                ;
-            }
-
-            // ...
-        }


### PR DESCRIPTION
Fixes #11401

As you can see in the referenced comment by @webmozart, having to implement the data mapper in a separate class is a real edge-case: It would have to depend on an option configured on the Form. I would say it's better to just completely remove the sidebar. If a user needs such advanced usage of the form component, they'll probably find out themselves that you can also pass instances of another class to this method.