### PR TITLE
[Doctrine] EventSubscriber is not autoconfigured

### DIFF
--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -330,7 +330,7 @@ Doctrine Lifecycle Subscribers
 Lifecycle subscribers are defined as PHP classes that implement the
 ``Doctrine\Common\EventSubscriber`` interface and which listen to one or more
 Doctrine events on all the application entities. For example, suppose that you
-want to log all the database activity. To do so, define a listener for the
+want to log all the database activity. To do so, define a subscriber for the
 ``postPersist``, ``postRemove`` and ``postUpdate`` Doctrine events::
 
     // src/EventListener/DatabaseActivitySubscriber.php
@@ -386,13 +386,9 @@ want to log all the database activity. To do so, define a listener for the
         }
     }
 
-If you're using the :ref:`default services.yaml configuration <service-container-services-load-example>`,
-Symfony will register the Doctrine subscriber automatically thanks to the
-:ref:`autoconfigure <services-autoconfigure>` and
-:doc:`autowiring </service_container/autowiring>` features. However, if you need
-to associate the subscriber with a specific Doctrine connection, you must define
-a service for it and :doc:`tag it </service_container/tags>` with the
-``doctrine.event_subscriber`` tag:
+The next step is to enable the Doctrine subscriber in the Symfony application by
+creating a new service for it and :doc:`tagging it </service_container/tags>`
+with the ``doctrine.event_subscriber`` tag:
 
 .. configuration-block::
 
@@ -401,8 +397,42 @@ a service for it and :doc:`tag it </service_container/tags>` with the
         services:
             # ...
 
-            # in most applications you don't need to define a service for your
-            # subscriber (this is only needed when using a custom Doctrine connection)
+            App\EventListener\DatabaseActivitySubscriber:
+                tags:
+                    - { name: 'doctrine.event_subscriber' }
+
+    .. code-block:: xml
+
+        <?xml version="1.0" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:doctrine="http://symfony.com/schema/dic/doctrine">
+            <services>
+                <!-- ... -->
+
+                <service id="App\EventListener\DatabaseActivitySubscriber">
+                    <tag name="doctrine.event_subscriber"/>
+                </service>
+            </services>
+        </container>
+
+    .. code-block:: php
+
+        use App\EventListener\DatabaseActivitySubscriber;
+
+        $container->autowire(DatabaseActivitySubscriber::class)
+            ->addTag('doctrine.event_subscriber')
+        ;
+
+If you need to associate the subscriber with a specific Doctrine connection, you
+can do it in the service configuration:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        services:
+            # ...
+
             App\EventListener\DatabaseActivitySubscriber:
                 tags:
                     - { name: 'doctrine.event_subscriber', connection: 'default' }
@@ -415,8 +445,6 @@ a service for it and :doc:`tag it </service_container/tags>` with the
             <services>
                 <!-- ... -->
 
-                <!-- in most applications you don't need to define a service for your
-                     subscriber (this is only needed when using a custom Doctrine connection) -->
                 <service id="App\EventListener\DatabaseActivitySubscriber">
                     <tag name="doctrine.event_subscriber" connection="default"/>
                 </service>
@@ -427,8 +455,6 @@ a service for it and :doc:`tag it </service_container/tags>` with the
 
         use App\EventListener\DatabaseActivitySubscriber;
 
-        // in most applications you don't need to define a service for your
-        // subscriber (this is only needed when using a custom Doctrine connection)
         $container->autowire(DatabaseActivitySubscriber::class)
             ->addTag('doctrine.event_subscriber', ['connection' => 'default'])
         ;


### PR DESCRIPTION
Correct me if I'm wrong, but it seems the `Doctrine\Common\EventSubscriber` is not autoconfigured.
This PR removes the wrong affirmation.