### PR TITLE
Fix EvolvableLink attribute

### DIFF
--- a/web_link.rst
+++ b/web_link.rst
@@ -166,7 +166,12 @@ You can also add links to the HTTP response directly from controllers and servic
         public function index(Request $request)
         {
             $linkProvider = $request->attributes->get('_links', new GenericLinkProvider());
-            $request->attributes->set('_links', $linkProvider->withLink(new Link('preload', '/app.css', ['as' : 'style'])));
+            $request->attributes->set(
+                '_links',
+                $linkProvider->withLink(
+                    (new Link('preload', '/app.css'))->withAttribute('as', 'style')
+                )
+            );
 
             return $this->render('...');
         }


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->

`Fig\Link\Link` constructor only accepts 2 parameters, `withAttribute` must be used instead of `['as' : 'style']`. (which contains a typo btw :smiley: )