### PR TITLE
[TwigBridge] Add show-deprecations option to the lint:twig command

### DIFF
--- a/templates.rst
+++ b/templates.rst
@@ -573,6 +573,9 @@ errors. It's useful to run it before deploying your application to production
     $ php bin/console lint:twig templates/email/
     $ php bin/console lint:twig templates/article/recent_list.html.twig
 
+    # you can show deprecations as errors
+    $ php bin/console lint:twig --show-deprecations templates/email/
+
 .. versionadded:: 4.4
 
     The feature that checks all the application templates when not passing any


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->

Hi,

Fixes #12476 (created by @fabpot), I add `--show-deprecations` options in templates documentation.
