### PR TITLE
Fix code indentation

### DIFF
--- a/translation/message_format.rst
+++ b/translation/message_format.rst
@@ -239,7 +239,7 @@ Usage of this string is the same as with variables and select::
 
     .. code-block:: text
 
-		{gender_of_host, select,
+        {gender_of_host, select,
             female {
                 {num_guests, plural, offset:1
                 =0    {{host} does not give a party.}


### PR DESCRIPTION
Fix code indentation for `MessageFormat` documentation.

The code snipped used tabs instead of spaces which broke the indentation.