### PR TITLE
Escape backslash before string termination

### DIFF
--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -176,7 +176,7 @@ all the classes are already loaded as services. All you need to do is specify th
             $services = $configurator->services();
 
             // Registers all 4 classes as services, including App\Mail\EmailConfigurator
-            $services->load('App\', '../src/*');
+            $services->load('App\\', '../src/*');
 
             // override the services to set the configurator
             $services->set(NewsletterManager::class)
@@ -250,7 +250,7 @@ routes can reference :ref:`invokable controllers <controller-service-invoke>`.
             $services = $configurator->services();
 
             // Registers all 4 classes as services, including App\Mail\EmailConfigurator
-            $services->load('App\', '../src/*');
+            $services->load('App\\', '../src/*');
 
             // override the services to set the configurator
             $services->set(NewsletterManager::class)


### PR DESCRIPTION
To php, `'App\'` looks like a string that contains a quote and is not finished. Using `\\`, the only escape sequence that works within single quotes, should fix the issue.
This was introduced in 2a5b114046e473aa6c82c76b27a97533aa338736 , which is only present on the master branch at the time, that's why I'm targetting master.
