### PR TITLE
Showing new -extra Twig extension repos

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -395,9 +395,9 @@ it with:
 
 .. code-block:: terminal
 
-    $ composer require twig/cssinliner-extension
+    $ composer require twig/extra-bundle twig/cssinliner-extra
 
-The extension is enabled automatically. To use this, wrap the entire template
+The extension is enabled automatically. To use it, wrap the entire template
 with the ``inline_css`` filter:
 
 .. code-block:: html+twig
@@ -497,14 +497,14 @@ the extension in your application:
 
 .. code-block:: terminal
 
-    $ composer require twig/inky-extension
+    $ composer require twig/extra-bundle twig/inky-extra
 
-The extension adds an ``inky`` filter, which can be used to convert parts or the
-entire email contents from Inky to HTML:
+The extension adds an ``inky_to_html`` filter, which can be used to convert parts
+or the entire email contents from Inky to HTML:
 
 .. code-block:: html+twig
 
-    {% apply inky %}
+    {% apply inky_to_html %}
         <container>
             <row class="header">
                 <columns>
@@ -521,7 +521,7 @@ You can combine all filters to create complex email messages:
 
 .. code-block:: twig
 
-    {% apply inky|inline_css(source('@css/foundation-emails.css')) %}
+    {% apply inky_to_html|inline_css(source('@css/foundation-emails.css')) %}
         {# ... #}
     {% endapply %}
 


### PR DESCRIPTION
Recently, the old Twig extension repositories were deprecated and new (and mostly identical) `-extra` repos were added. So, mostly people just need to use the new library name. However, to get the new extensions to be loaded automatically, the user must also have the new `twig/extra-bundle` installed (this detects the `-extra` libraries and registers the extensions).

Knowing this, the diff is self-explanatory. However, the workflow for *new* users will be simpler. Starting yesterday, when you run `composer require twig`, you get a `twig-pack` which contains TwigBundle AND `twig/extra-bundle`. That means that new users will *only* need to `composer require twig/cssinliner-extra`, they will not also need to install `twig/extra-bundle`. But, to be safe, I've added it here so that it works for everyone. Maybe someday we'll remove that part.

Also, For Inky, when the repository was moved, the filter was also changed from `inky` to `inky_to_html`: https://twig.symfony.com/doc/2.x/filters/inky_to_html.html

Finally, all of this requires Twig 2.12. I did not mention that. We *could*, but if you try to install `twig/extra-bundle` on a lower version, you'll get a composer error about the version problem.

Now that my PR description is longer than my patch... I'll stop ;) 