### PR TITLE
[Mailer][Mime] Address::fromString() is not available in 4.3

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -150,10 +150,6 @@ both strings or address objects::
         // (email clients will display the name)
         ->from(new NamedAddress('fabien@example.com', 'Fabien'))
 
-        // defining the email address and name as a string
-        // (the format must match: 'Name <email@example.com>')
-        ->from(Address::fromString('Fabien Potencier <fabien@example.com>'))
-
         // ...
     ;
 


### PR DESCRIPTION
It was added in https://github.com/symfony/symfony-docs/pull/12128 (4.4)

So beware this change should not be merged up. Only merged to 4.3.