### PR TITLE
[Mailer][Mime] NamedAddress was removed in 4.4

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -149,7 +149,7 @@ both strings or address objects::
 
         // defining the email address and name as an object
         // (email clients will display the name)
-        ->from(new NamedAddress('fabien@example.com', 'Fabien'))
+        ->from(new Address('fabien@example.com', 'Fabien'))
 
         // defining the email address and name as a string
         // (the format must match: 'Name <email@example.com>')


### PR DESCRIPTION
It was removed in 4.4 (https://github.com/symfony/symfony/pull/33270) in favor of using Address with a second arg.