### PR TITLE
Documented $response->getInfo('canceled')

### DIFF
--- a/components/http_client.rst
+++ b/components/http_client.rst
@@ -417,6 +417,9 @@ Or throw an exception from a progress callback::
 The exception will be wrapped in an instance of ``TransportExceptionInterface``
 and will abort the request.
 
+In case the response was canceled using ``$response->cancel()``,
+``$response->getInfo('canceled')`` will return ``true``.
+
 Handling Exceptions
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Documented the new `canceled` information introduced in https://github.com/symfony/symfony/pull/34044.

Reading the docs, I wonder if we need to catch any `Throwable` and also set `canceled` to `true` @nicolas-grekas? 
