### PR TITLE
Fix construction of SmtpTransport in Mailer docs

### DIFF
--- a/components/mailer.rst
+++ b/components/mailer.rst
@@ -30,9 +30,9 @@ Usage
 The Mailer component has two main classes: a ``Transport`` and the ``Mailer`` itself::
 
     use Symfony\Component\Mailer\Mailer;
-    use Symfony\Component\Mailer\Transport\Smtp\SmtpTransport;
+    use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 
-    $transport = new SmtpTransport('localhost');
+    $transport = new EsmtpTransport('localhost');
     $mailer = new Mailer($transport);
     $mailer->send($email);
 


### PR DESCRIPTION
Changed `SmtpTransport` to `EsmtpTransport` in standalone component docs.
`SmtpTransport::__construct()` requires instance of `AbstractStream` (see https://github.com/symfony/mailer/blob/master/Transport/Smtp/SmtpTransport.php#L41). Construction with host name is available in `EsmtpTransport` (https://github.com/symfony/mailer/blob/master/Transport/Smtp/EsmtpTransport.php#L33)
