### PR TITLE
[Doctrine] Fix wrong event class for entity listener in example

### DIFF
--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -233,13 +233,13 @@ define a listener for the ``postUpdate`` Doctrine event::
     namespace App\EventListener;
 
     use App\Entity\User;
-    use Doctrine\ORM\Event\PreUpdateEventArgs;
+    use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 
     class UserChangedNotifier
     {
         // the entity listener methods receive two arguments:
         // the entity instance and the lifecycle event
-        public function postUpdate(User $user, PreUpdateEventArgs $event)
+        public function postUpdate(User $user, LifecycleEventArgs $event)
         {
             // ... do something to notify the changes
         }


### PR DESCRIPTION
Using class `PreUpdateEventArgs` in code example causes an exception:

>Argument 2 passed to App\EventListener\UserChangedNotifier::postUpdate() must be an instance of Doctrine\ORM\Event\PreUpdateEventArgs, instance of Doctrine\ORM\Event\LifecycleEventArgs given, called in .../vendor/doctrine/orm/lib/Doctrine/ORM/Event/ListenersInvoker.php on line 112

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
