### PR TITLE
Replace deprecated configuration key

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -185,7 +185,7 @@ As configured, the following property is used by the marking store::
 .. tip::
 
     The ``marking_store.type`` (the default value depends on the ``type`` value)
-    and ``arguments`` (default value ``['marking']``) attributes of the
+    and ``property`` (default value ``['marking']``) attributes of the
     ``marking_store`` option are optional. If omitted, their default values will
     be used. It's highly recommenced to use the default value.
 


### PR DESCRIPTION
The "framework.workflows.workflows..marking_store.arguments" configuration key has been deprecated in Symfony 4.3. Use "property" instead.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
