### PR TITLE
Edit comment in php block of the admonition note related to escape @ and % 

### DIFF
--- a/service_container/parameters.rst
+++ b/service_container/parameters.rst
@@ -136,7 +136,7 @@ and hidden with the service definition:
 
         .. code-block:: php
 
-            // the @ symbol does NOT need to be escaped in XML
+            // the @ symbol does NOT need to be escaped in PHP
             $container->setParameter('mailer_password', '@securepass');
 
             // But % does need to be escaped


### PR DESCRIPTION
In the php block of the admonition note related to escape **@** and **%**  : 
comments should be related to PHP and not related to XML