### PR TITLE
Change the default mapping type to XML

### DIFF
--- a/doctrine/reverse_engineering.rst
+++ b/doctrine/reverse_engineering.rst
@@ -64,7 +64,7 @@ files: ``BlogPost.php`` and ``BlogComment.php``.
 
 .. tip::
 
-    It's also possible to generate the metadata files into XML or YAML:
+    It's also possible to generate the metadata files into XML or eventually into YAML:
 
     .. code-block:: terminal
 
@@ -82,7 +82,7 @@ files: ``BlogPost.php`` and ``BlogComment.php``.
                 mappings:
                     App:
                         is_bundle: false
-                        type: yml # Set to xml in case of XML mapping
+                        type: xml # "yml" is marked as deprecated for doctrine v2.6+ and will be removed in v3
                         dir: '%kernel.project_dir%/config/doctrine'
                         prefix: 'App\Entity'
                         alias: App


### PR DESCRIPTION
YAML mapping are  marked as deprecated for doctrine v2.6+ and will be removed in doctrine v3+ . https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/yaml-mapping.html#yaml-mapping

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
