### PR TITLE
Update deployment.rst

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -184,7 +184,6 @@ E) Other Things!
 There may be lots of other things that you need to do, depending on your
 setup:
 
-* Running any database migrations
 * Clearing your APC cache
 * Add/edit CRON jobs
 * :ref:`Building and minifying your assets <how-do-i-deploy-my-encore-assets>` with Webpack Encore


### PR DESCRIPTION
Hi,

According to the `Symfony Deployment Basics` part of this page,
the `Running database migrations` part must be done before the `Clearing / warming cache` part.

- As I did not want to reorder all steps, I only removed the migration part of the step E

- Also, is it usefull to write as well a line on this hint? https://symfony.com/doc/current/configuration.html#configuring-environment-variables-in-production (`composer dump-env prod`)

Spotted as well on 4.X doc

edit:


**small question:**
migrating with the doctrine migration bundle command (the cache is empty as a new code deploy)
then the cache before executing the migration command will be built,
So is reclearing the cache usefull after the migration finished?


Thank you