### PR TITLE
Note doctrine bundle version for middlewares

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1363,6 +1363,10 @@ middleware and *only* include your own:
 Middleware for Doctrine
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. note::
+
+    Doctrine middlewares mentioned below require `doctrine/doctrine-bundle@^1.11`.
+
 If you use Doctrine in your app, a number of optional middleware exist that you
 may want to use:
 


### PR DESCRIPTION
Adds note regarding Doctrine middlewares being available since version 1.11 of the bundle

See: https://github.com/doctrine/DoctrineBundle/pull/956