### PR TITLE
Removing notes about doctrine_clear_entity_manager middleware

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1411,11 +1411,6 @@ may want to use:
                             # or pass a different entity manager to any
                             #- doctrine_transaction: ['custom']
 
-                            # After handling, the clear() method is executed in the
-                            # entity manager, which reduces the memory consumption and
-                            # avoids side-effects related to unrefreshed entities
-                            - doctrine_clear_entity_manager
-
     .. code-block:: xml
 
         <!-- config/packages/messenger.xml -->
@@ -1441,8 +1436,6 @@ may want to use:
                             <framework:argument>custom</framework:argument>
                         </framework:middleware>
                         -->
-
-                        <framework:middleware id="doctrine_clear_entity_manager"/>
                     </framework:bus>
                 </framework:messenger>
             </framework:config>
@@ -1461,16 +1454,11 @@ may want to use:
                             'doctrine_close_connection',
                             // Using another entity manager
                             ['id' => 'doctrine_transaction', 'arguments' => ['custom']],
-                            'doctrine_clear_entity_manager',
                         ],
                     ],
                 ],
             ],
         ]);
-
-.. versionadded:: 4.4
-
-    The ``doctrine_clear_entity_manager`` middleware was introduced in Symfony 4.4.
 
 Messenger Events
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
See symfony/symfony#34156

That class was added in 4.4... then removed for 4.4 - so it was never released.

I don't think the new "subscriber" added there needs docs - I'll open a PR in DoctrineBundle so that it's (ideally) enabled by default. I see this more as a bug fix that should... just work without you knowing/caring.