### PR TITLE
Add missing deprecated directive for kernel.log_dir parameter

### DIFF
--- a/reference/configuration/kernel.rst
+++ b/reference/configuration/kernel.rst
@@ -121,6 +121,11 @@ Log Directory
 
 **type**: ``string`` **default**: ``$this->rootDir/log``
 
+.. deprecated:: 4.2
+
+    The ``kernel.log_dir`` parameter was deprecated in Symfony 4.2,
+    use ``kernel.logs_dir`` instead.
+
 This returns the absolute path of the log directory of your Symfony project.
 It's calculated automatically based on the current
 :ref:`environment <configuration-environments>`.


### PR DESCRIPTION
Based on the feedback by @dbrumann in https://github.com/symfony/symfony-docs/pull/12580#issuecomment-549122112
