### PR TITLE
Simplify example of GulpBusterVersionStrategy

### DIFF
--- a/frontend/custom_version_strategy.rst
+++ b/frontend/custom_version_strategy.rst
@@ -94,13 +94,7 @@ version string::
                 return $path;
             }
 
-            $versionized = sprintf($this->format, ltrim($path, '/'), $version);
-
-            if ($path && '/' === $path[0]) {
-                return '/'.$versionized;
-            }
-
-            return $versionized;
+            return sprintf($this->format, $path, $version);
         }
 
         private function loadManifest()


### PR DESCRIPTION
It seems we can simplify the code in `applyVersion()` or am I missing something?

Link to the related docs page:
https://symfony.com/doc/current/frontend/custom_version_strategy.html