### PR TITLE
Remove hint that redis does not support DelayStamp

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -905,10 +905,6 @@ The Redis transport uses `streams`_ to queue messages.
 To use the Redis transport, you will need the Redis PHP extension (^4.3) and
 a running Redis server (^5.0).
 
-.. caution::
-
-    The Redis transport does not support "delayed" messages.
-
 A number of options can be configured via the DSN or via the ``options`` key
 under the transport in ``messenger.yaml``:
 


### PR DESCRIPTION
The DelayStamp was added in 4.4 https://github.com/symfony/symfony/pull/31977 so the hint can now be removed.

fixes #12595