### PR TITLE
Tell user about installing twig

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -197,6 +197,12 @@ If you're returning HTML from your controller, you'll probably want to render
 a template. Fortunately, Symfony comes with `Twig`_: a templating language that's
 easy, powerful and actually quite fun.
 
+Install the twig package with:
+
+.. code-block:: terminal
+
+    $ composer require twig
+
 Make sure that ``LuckyController`` extends Symfony's base
 :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController` class:
 


### PR DESCRIPTION
I tried to follow [this subsection of tutorial](https://symfony.com/doc/current/page_creation.html#rendering-a-template) and I noticed that I'm asked to create a file in a missing **templates** directory. I noticed that I'm missing this directory, because Twig isn't installed, so I simply installed it using composer which fixed the problem. 

I changed the docs so people would know that they need to install Twig before moving on.

