### PR TITLE
Update best_practices.rst

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -234,8 +234,7 @@ the fact that a controller should always return a ``Response`` object.
 Use Dependency Injection to Get Services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you extend the base ``AbstractController``, you can't access services
-directly from the container via ``$this->container->get()`` or ``$this->get()``.
+If you extend the base ``AbstractController``, you can only access to the most common services (e.g ``twig``, ``router``, ``doctrine``, etc.), directly from the container via ``$this->container->get()`` or ``$this->get()``.
 Instead, you must use dependency injection to fetch services by
 :ref:`type-hinting action method arguments <controller-accessing-services>` or
 constructor arguments.


### PR DESCRIPTION
// there is a public "router" service in the container
       $router = $this->container->get('router');

// this will not Work: MailLogger is a private service
     $mailLogger = $this->container->get(MailLogger::class);

