### PR TITLE
Update Key name to match the column name 

### DIFF
--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -115,7 +115,7 @@ This requires you to implement several methods::
 
             // if a User object, checkCredentials() is called
             return $this->em->getRepository(User::class)
-                ->findOneBy(['apiToken' => $apiToken]);
+                ->findOneBy(['api_token' => $apiToken]);
         }
 
         public function checkCredentials($credentials, UserInterface $user)


### PR DESCRIPTION
Update apiToken key name  to => "api_token" in findBy function to  match the default property name for apiToken set by doctrine, 
Reason of edit : 
if the name is not set, Doctrine will set the default name to create the column with "apt_token"
Which will always return not found from the User repository function findBy  using "apiToken" as a key name

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
