### PR TITLE
Update profiler.rst

### DIFF
--- a/profiler.rst
+++ b/profiler.rst
@@ -206,6 +206,11 @@ event::
         if (!$this->getKernel()->isDebug()) {
             return;
         }
+        
+        $request = $event->getRequest();
+        if (!$request->isXmlHttpRequest()) {
+            return;
+        }
 
         $response = $event->getResponse();
         $response->headers->set('Symfony-Debug-Toolbar-Replace', 1);


### PR DESCRIPTION
No need to add the header `Symfony-Debug-Toolbar-Replace` if the request is not an ajax one