### PR TITLE
Fix broken link for multiple messenger buses

### DIFF
--- a/messenger/message-recorder.rst
+++ b/messenger/message-recorder.rst
@@ -6,7 +6,7 @@ Transactional Messages: Handle New Messages After Handling is Done
 
 A message handler can ``dispatch`` new messages during execution, to either the
 same or a different bus (if the application has
-`multiple buses </messenger/multiple_buses>`_). Any errors or exceptions that
+:doc:`/messenger/multiple_buses`). Any errors or exceptions that
 occur during this process can have unintended consequences, such as:
 
 - If using the ``DoctrineTransactionMiddleware`` and a dispatched message throws


### PR DESCRIPTION
There is an incorrect link in the documentation of the messenger component for multiple buses. The broken link is visible [here](https://symfony.com/doc/current/messenger/message-recorder.html) and the bug is present for 4.3, 4.4 and current documentation.

I don't know if I use the correct syntax. I just copy/past a different declaration that works in https://symfony.com/doc/current/messenger.html#multiple-buses-command-event-buses.
