### PR TITLE
Add isMasterRequest method

### DIFF
--- a/doctrine/pdo_session_storage.rst
+++ b/doctrine/pdo_session_storage.rst
@@ -254,7 +254,7 @@ MySQL
         `sess_id` VARCHAR(128) NOT NULL PRIMARY KEY,
         `sess_data` BLOB NOT NULL,
         `sess_time` INTEGER UNSIGNED NOT NULL,
-        `sess_lifetime` MEDIUMINT NOT NULL
+        `sess_lifetime` INTEGER UNSIGNED NOT NULL
     ) COLLATE utf8mb4_bin, ENGINE = InnoDB;
 
 .. note::

--- a/reference/events.rst
+++ b/reference/events.rst
@@ -23,6 +23,9 @@ following information:
 :method:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent::getRequest`
     Returns the current ``Request`` being handled.
 
+:method:`Symfony\\Component\\HttpKernel\\Event\\KernelEvent::isMasterRequest`
+    Checks if this is a master request.
+
 .. _kernel-core-request:
 
 ``kernel.request``


### PR DESCRIPTION
The isMasterRequest method is available on KernelEvent but not listed in documentation

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
