### PR TITLE
[Monolog] Do not autowire the ElasticsearchLogstashHandler service

### DIFF
--- a/logging/handlers.rst
+++ b/logging/handlers.rst
@@ -28,7 +28,8 @@ To use it, declare it as a service:
 
         # config/services.yaml
         services:
-            Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler: ~
+            Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler:
+                autowire: false
 
     .. code-block:: xml
 


### PR DESCRIPTION
If so, Symfony will inject an HttpClient, and this one has a logger in it. So for each log, another log for the HTTP Client will be emitted => infinite loop => :boom:

ref: https://github.com/symfony/symfony/pull/32360#issuecomment-554511075

