### PR TITLE
ContainerAwareEventDispatcher was removed

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -469,7 +469,6 @@ Other Dispatchers
 Besides the commonly used ``EventDispatcher``, the component comes
 with some other dispatchers:
 
-* :doc:`/components/event_dispatcher/container_aware_dispatcher`
 * :doc:`/components/event_dispatcher/immutable_dispatcher`
 * :doc:`/components/event_dispatcher/traceable_dispatcher`
 


### PR DESCRIPTION
ContainerAwareEventDispatcher was removed in Symfony 4.0

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
