### PR TITLE
Add tip about accessing removed services in the testing doc

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -562,12 +562,53 @@ command.
 
 .. tip::
 
-    Keep in mind that, if a private service is never used as a dependency of another service in
-    your application, it is then removed from the container. So, if you try to access a private
-    service in a test through the special test container and that service isn't used elsewhere
-    you'll get a ``ServiceNotFoundException``. The solution, depending on the context, is to
-    define the service as explicitly ``public`` or to inject it where you'll need it so Symfony
-    doesn't remove it.
+    If a private service is *never* used in your application (outside of your test), it
+    is *removed* from the container and cannot be accessed as described above. In that
+    case, you can create a public alias in the ``test`` environment and access it
+    via that alias:
+    
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # config/services_test.yaml
+            services:
+                # access the service in your test via
+                # self::$container->get('test.App\Test\SomeTestHelper')
+                test.App\Test\SomeTestHelper:
+                    # the id of the private service
+                    alias: 'App\Test\SomeTestHelper'
+                    public: true
+
+        .. code-block:: xml
+
+            <!-- config/services_test.xml -->
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <container xmlns="http://symfony.com/schema/dic/services"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://symfony.com/schema/dic/services
+                    https://symfony.com/schema/dic/services/services-1.0.xsd">
+
+                <services>
+                    <!-- ... -->
+
+                    <service id="test.App\Test\SomeTestHelper" alias="App\Test\SomeTestHelper" public="true"/>
+                </services>
+            </container>
+
+        .. code-block:: php
+
+            // config/services_test.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            use App\Service\MessageGenerator;
+            use App\Updates\SiteUpdateManager;
+
+            return function(ContainerConfigurator $configurator) {
+                // ...
+
+                $services->alias('test.App\Test\SomeTestHelper', 'App\Test\SomeTestHelper')->public();
+            };
 
 .. tip::
 

--- a/testing.rst
+++ b/testing.rst
@@ -562,6 +562,15 @@ command.
 
 .. tip::
 
+    Keep in mind that, if a private service is never used as a dependency of another service in
+    your application, it is then removed from the container. So, if you try to access a private
+    service in a test through the special test container and that service isn't used elsewhere
+    you'll get a ``ServiceNotFoundException``. The solution, depending on the context, is to
+    define the service as explicitly ``public`` or to inject it where you'll need it so Symfony
+    doesn't remove it.
+
+.. tip::
+
     The special container that gives access to private services exists only in
     the ``test`` environment and is itself a service that you can get from the
     real container using the ``test.service_container`` id.


### PR DESCRIPTION
As requested [here](https://github.com/symfony/symfony/issues/30104#issuecomment-552948597) this commit will add a tip about accessing removed services through the special test container in the testing docs.
