### PR TITLE
Fix typo in lock.rst

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -164,7 +164,7 @@ object) and ``isExpired()`` (which returns a boolean).
 The Owner of The Lock
 ---------------------
 
-Locks that are acquired for the first time are owned[1]_ by the ``Lock`` instance that acquired
+Locks that are acquired for the first time are owned by the ``Lock`` instance that acquired
 it. If you need to check whether the current ``Lock`` instance is (still) the owner of
 a lock, you can use the ``isAcquired()`` method::
 


### PR DESCRIPTION
`owned[1]_` => `owned`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
