### PR TITLE
Add note about .env.local being ignored in test environment

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -629,6 +629,11 @@ the only mandatory file and each file content overrides the previous one:
 
 .. note::
 
+    ``.env.local`` is always ignored in test environment. The logic is that
+    tests should always produce the same results for everyone.
+
+.. note::
+
     The real environment variables defined in the server always win over the
     env vars created by the ``.env`` files.
 


### PR DESCRIPTION
This PR add a short note, warning developers that the `.env.local` is always ignored on test environments.

This surprised me, because I am using PHP VCR to isolate my test suite. I set my real API credential in a `.env.local`, however I was suprised to see they were not used when running my test suite against the real API.

I am not sure about which branch I should target, so I aimed at the one when you click on "Edit this page" on the documentation page.