### PR TITLE
remove 'command' from execute argument

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -286,8 +286,6 @@ console::
             $command = $application->find('app:create-user');
             $commandTester = new CommandTester($command);
             $commandTester->execute([
-                'command'  => $command->getName(),
-
                 // pass arguments to the helper
                 'username' => 'Wouter',
 


### PR DESCRIPTION
Including the 'command' argument triggers an exception, "Symfony\Component\Console\Exception\InvalidArgumentException : The "command" argument does not exist.", needs to be removed.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
