### PR TITLE
improve sentence re: `content-disposition` header

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -534,7 +534,7 @@ Serving Files
 
 When sending a file, you must add a ``Content-Disposition`` header to your
 response. While creating this header for basic file downloads is straightforward,
-using non-ASCII filenames is more involving. The
+using non-ASCII filenames is more involved. The
 :method:`Symfony\\Component\\HttpFoundation\\HeaderUtils::makeDisposition`
 abstracts the hard work behind a simple API::
 


### PR DESCRIPTION
The correct English term would be either '...is more involved', or '...involves more effort'.

'involving' would be more appropriately used as a supportive clause in a sentence such as:

"This feature was a biggie; involving contributions from Fabpot, Stof, and Javiereguiluz"