### PR TITLE
[Messenger] Update version constraint for Redis extension

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -902,7 +902,7 @@ The Redis transport uses `streams`_ to queue messages.
 
     The ``dbindex`` query parameter in Redis DSN was introduced in Symfony 4.4.
 
-To use the Redis transport, you will need the Redis PHP extension (^4.3) and
+To use the Redis transport, you will need the Redis PHP extension (>=4.3) and
 a running Redis server (^5.0).
 
 A number of options can be configured via the DSN or via the ``options`` key
@@ -1088,7 +1088,7 @@ Possible options to configure with tags are:
 * ``priority``
 
 .. versionadded:: 4.4
-    
+
     The ability to specify ``from_transport`` on the tag, was added in Symfony 4.4.
 
 Handler Subscriber & Options


### PR DESCRIPTION
Update version constraint for Redis extension in order to be consistent with the check performed in the component:

https://github.com/symfony/symfony/blob/625a4dbfdafcb8cea8ff90a62b9c24b28694938d/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php#L50-L52.