### PR TITLE
Replace tagged with tagged_iterator for service tagging PHP example

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -553,7 +553,7 @@ first  constructor argument to the ``App\HandlerCollection`` service:
 
             $services->set(App\HandlerCollection::class)
                 // inject all services tagged with app.handler as first argument
-                ->args([tagged('app.handler')])
+                ->args([tagged_iterator('app.handler')])
             ;
         };
 


### PR DESCRIPTION
Replace tagged with tagged_iterator for service tagging PHP example. Since 'tagged' will be eventually deprecated it would be better to show an example using tagged_iterator instead

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
