### PR TITLE
Set PHP Version requirement to 7.2.5

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -17,7 +17,7 @@ Technical Requirements
 
 Before creating your first Symfony application you must:
 
-* Install PHP 7.2.9 or higher and these PHP extensions (which are installed and
+* Install PHP 7.2.5 or higher and these PHP extensions (which are installed and
   enabled by default in most PHP 7 installations): `Ctype`_, `iconv`_, `JSON`_,
   `PCRE`_, `Session`_, `SimpleXML`_, and `Tokenizer`_;
 * `Install Composer`_, which is used to install PHP packages;


### PR DESCRIPTION
Based on the last pull request for 5.0 the minimum PHP Version is 7.2.5
https://github.com/symfony/symfony/pull/34443

That's also the required version in composer.json
https://github.com/symfony/symfony/blob/5.0/composer.json#L19