### PR TITLE
[WIP][Console] Fix missing return in console documentation on execute function

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -146,6 +146,8 @@ the console::
         // outputs a message without adding a "\n" at the end of the line
         $output->write('You are about to ');
         $output->write('create a user.');
+        
+        return 0;
     }
 
 Now, try executing the command:
@@ -195,6 +197,8 @@ which returns an instance of
             // (this example deletes the last two lines of the section)
             $section1->clear(2);
             // Output is now completely empty!
+            
+            return 0;
         }
     }
 
@@ -235,6 +239,8 @@ Use input options or arguments to pass information to the command::
 
         // retrieve the argument value using getArgument()
         $output->writeln('Username: '.$input->getArgument('username'));
+        
+        return 0;
     }
 
 Now, you can pass the username to the command:
@@ -284,6 +290,8 @@ as a service, you can use normal dependency injection. Imagine you have a
             $this->userManager->create($input->getArgument('username'));
 
             $output->writeln('User successfully generated!');
+            
+            return 0;
         }
     }
 


### PR DESCRIPTION
Since Symfony 5.0, we have an error if we don't return an int on the `execute` function, I added it in the doc so there will not be an `TypeError` when trying this.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
