### PR TITLE
[Encore] Adding documentation for setting Webpack options not supported by Encore

### DIFF
--- a/frontend/encore/advanced-config.rst
+++ b/frontend/encore/advanced-config.rst
@@ -38,6 +38,22 @@ But be careful not to accidentally override any config from Encore:
     // BAD - this replaces any extensions added by Encore
     // config.resolve.extensions = ['json'];
 
+If you absolutely need to overwrite or add to Encore config:
+
+.. code-block:: javascript
+
+    // webpack.config.js
+    // ...
+
+    Object.assign(config, {
+        target: 'web',
+        node: {
+            fs: 'empty'
+        }
+    });
+    
+This should only be used for options not supported by Encore.
+
 Configuring Watching Options and Polling
 ----------------------------------------
 

--- a/frontend/encore/advanced-config.rst
+++ b/frontend/encore/advanced-config.rst
@@ -38,7 +38,7 @@ But be careful not to accidentally override any config from Encore:
     // BAD - this replaces any extensions added by Encore
     // config.resolve.extensions = ['json'];
 
-If you absolutely need to overwrite or add to Encore config:
+If you need to overwrite or add options that are not supported by Encore, use this config:
 
 .. code-block:: javascript
 
@@ -51,8 +51,6 @@ If you absolutely need to overwrite or add to Encore config:
             fs: 'empty'
         }
     });
-    
-This should only be used for options not supported by Encore.
 
 Configuring Watching Options and Polling
 ----------------------------------------


### PR DESCRIPTION
Documentation for adding Webpack options not supported by Encore. Some options such as target, node, etc are not supported by Encore. This adds to the advanced documentation on how to set these options.