### PR TITLE
Error renderer component is abadoned.

### DIFF
--- a/components/error_handler.rst
+++ b/components/error_handler.rst
@@ -67,11 +67,6 @@ to enable this error handler::
 
     ErrorHandler::register();
 
-.. tip::
-
-    If you want to get even better exception pages, install the
-    :doc:`ErrorRenderer component </components/error_renderer>` too.
-
 Catching PHP Function Errors and Turning Them into Exceptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This error is also in 5.x branch. 

Do I need to send another PR to 5.x?