### PR TITLE
Tweak the IsTrue validation docs

### DIFF
--- a/reference/constraints/IsTrue.rst
+++ b/reference/constraints/IsTrue.rst
@@ -1,9 +1,8 @@
 IsTrue
 ======
 
-Validates that a value is ``true``. Specifically, this checks to see if
-the value is exactly ``true``, exactly the integer ``1``, or exactly the
-string "``1``".
+Validates that a value is ``true``. Specifically, this checks if the value is
+exactly ``true``, exactly the integer ``1``, or exactly the string ``"1"``.
 
 Also see :doc:`IsFalse <IsFalse>`.
 
@@ -23,9 +22,9 @@ Basic Usage
 -----------
 
 This constraint can be applied to properties (e.g. a ``termsAccepted`` property
-on a registration model) or to a "getter" method. It's most powerful in
-the latter case, where you can assert that a method returns a true value.
-For example, suppose you have the following method::
+on a registration model) and methods. It's most powerful in the latter case,
+where you can assert that a method returns a true value. For example, suppose
+you have the following method::
 
     // src/AppBundle/Entity/Author.php
     namespace AppBundle\Entity;
@@ -40,7 +39,7 @@ For example, suppose you have the following method::
         }
     }
 
-Then you can constrain this method with ``IsTrue``.
+Then you can validate this method with ``IsTrue`` as follows:
 
 .. configuration-block::
 


### PR DESCRIPTION
Please review that this is correct: *IsTrue requires that method names start with "is" or "get"* Thanks!