### PR TITLE
Fix 5.0 event get/setThrowable

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -526,7 +526,7 @@ to the exception.
 
 Each listener to this event is passed a :class:`Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent`
 object, which you can use to access the original exception via the
-:method:`Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent::getException`
+:method:`Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent::getThrowable`
 method. A typical listener on this event will check for a certain type of
 exception and create an appropriate error ``Response``.
 

--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -35,7 +35,7 @@ The most common way to listen to an event is to register an **event listener**::
         public function onKernelException(ExceptionEvent $event)
         {
             // You get the exception object from the received event
-            $exception = $event->getException();
+            $exception = $event->getThrowable();
             $message = sprintf(
                 'My Error says: %s with code: %s',
                 $exception->getMessage(),

--- a/reference/events.rst
+++ b/reference/events.rst
@@ -239,14 +239,14 @@ sent as response::
 
     public function onKernelException(ExceptionEvent $event)
     {
-        $exception = $event->getException();
+        $exception = $event->getThrowable();
         $response = new Response();
         // setup the Response object based on the caught exception
         $event->setResponse($response);
 
         // you can alternatively set a new Exception
         // $exception = new \Exception('Some special exception');
-        // $event->setException($exception);
+        // $event->setThrowable($exception);
     }
 
 .. note::


### PR DESCRIPTION
As per https://github.com/symfony/symfony/commit/eba2d8efc9a72ea081938c0bde0b5a8dcb6e6cb9#diff-0039df994b1b952fb5c9bf03294e7535:
 there is right now no `ExceptionEvent::get/setException` but `get/setThrowable` and looks like docs were not updated since then