### PR TITLE
fix TraceableEventDispatcherInterface removed in 5.0

### DIFF
--- a/components/event_dispatcher/traceable_dispatcher.rst
+++ b/components/event_dispatcher/traceable_dispatcher.rst
@@ -41,10 +41,10 @@ to register event listeners and dispatch events::
     $traceableEventDispatcher->dispatch($event, 'event.the_name');
 
 After your application has been processed, you can use the
-:method:`Symfony\\Component\\EventDispatcher\\Debug\\TraceableEventDispatcherInterface::getCalledListeners`
+:method:`Symfony\\Component\\EventDispatcher\\Debug\\TraceableEventDispatcher::getCalledListeners`
 method to retrieve an array of event listeners that have been called in
 your application. Similarly, the
-:method:`Symfony\\Component\\EventDispatcher\\Debug\\TraceableEventDispatcherInterface::getNotCalledListeners`
+:method:`Symfony\\Component\\EventDispatcher\\Debug\\TraceableEventDispatcher::getNotCalledListeners`
 method returns an array of event listeners that have not been called::
 
     // ...


### PR DESCRIPTION
As per https://github.com/symfony/symfony/pull/24392/files in 5.0 `TraceableEventDispatcherInterface` is no more.