### PR TITLE
[minor] remove usage of Kernel::$rootDir from docs

### DIFF
--- a/reference/configuration/kernel.rst
+++ b/reference/configuration/kernel.rst
@@ -105,7 +105,7 @@ method to return the right project directory::
 Cache Directory
 ~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``$this->rootDir/cache/$this->environment``
+**type**: ``string`` **default**: ``$this->getProjectDir()/var/cache/$this->environment``
 
 This returns the absolute path of the cache directory of your Symfony project.
 It's calculated automatically based on the current
@@ -119,7 +119,7 @@ cache directory.
 Log Directory
 ~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``$this->rootDir/log``
+**type**: ``string`` **default**: ``$this->getProjectDir()/var/log``
 
 .. deprecated:: 4.2
 

--- a/reference/forms/types/country.rst
+++ b/reference/forms/types/country.rst
@@ -70,7 +70,7 @@ Overridden Options
 choices
 ~~~~~~~
 
-**default**: ``Symfony\Component\Intl\Intl::getRegionBundle()->getCountryNames()``
+**default**: ``Symfony\Component\Intl\Countries::getNames()``
 
 The country type defaults the ``choices`` option to the whole list of countries.
 The locale is used to translate the countries names.

--- a/reference/forms/types/currency.rst
+++ b/reference/forms/types/currency.rst
@@ -62,7 +62,7 @@ Overridden Options
 choices
 ~~~~~~~
 
-**default**: ``Symfony\Component\Intl\Intl::getCurrencyBundle()->getCurrencyNames()``
+**default**: ``Symfony\Component\Intl\Currencies::getNames()``
 
 The choices option defaults to all currencies.
 

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -72,7 +72,7 @@ Overridden Options
 choices
 ~~~~~~~
 
-**default**: ``Symfony\Component\Intl\Intl::getLanguageBundle()->getLanguageNames()``.
+**default**: ``Symfony\Component\Intl\Languages::getNames()``.
 
 The choices option defaults to all languages.
 The default locale is used to translate the languages names.

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -73,7 +73,7 @@ Overridden Options
 choices
 ~~~~~~~
 
-**default**: ``Symfony\Component\Intl\Intl::getLocaleBundle()->getLocaleNames()``
+**default**: ``Symfony\Component\Intl\Locales::getNames()``
 
 The choices option defaults to all locales. It uses the default locale to
 specify the language.

--- a/setup.rst
+++ b/setup.rst
@@ -237,7 +237,7 @@ stable version. If you want to use an LTS version, add the ``--version`` option:
 
 .. code-block:: terminal
 
-    # use the most recent 'lts' version
+    # use the most recent LTS version
     $ symfony new my_project_name --version=lts
 
     # use the 'next' Symfony version to be released (still in development)


### PR DESCRIPTION
As per https://github.com/symfony/symfony/pull/28810 $rootDir has been removed in 5.0 - use getProjectDir in docs instead - small change to be consistent