### PR TITLE
Changed names of Intl classes in form types docs

### DIFF
--- a/reference/forms/types/country.rst
+++ b/reference/forms/types/country.rst
@@ -70,7 +70,7 @@ Overridden Options
 choices
 ~~~~~~~
 
-**default**: ``Symfony\Component\Intl\Intl::getRegionBundle()->getCountryNames()``
+**default**: ``Symfony\Component\Intl\Countries::getNames()``
 
 The country type defaults the ``choices`` option to the whole list of countries.
 The locale is used to translate the countries names.

--- a/reference/forms/types/currency.rst
+++ b/reference/forms/types/currency.rst
@@ -62,7 +62,7 @@ Overridden Options
 choices
 ~~~~~~~
 
-**default**: ``Symfony\Component\Intl\Intl::getCurrencyBundle()->getCurrencyNames()``
+**default**: ``Symfony\Component\Intl\Currencies::getNames()``
 
 The choices option defaults to all currencies.
 

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -72,7 +72,7 @@ Overridden Options
 choices
 ~~~~~~~
 
-**default**: ``Symfony\Component\Intl\Intl::getLanguageBundle()->getLanguageNames()``.
+**default**: ``Symfony\Component\Intl\Languages::getNames()``.
 
 The choices option defaults to all languages.
 The default locale is used to translate the languages names.

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -73,7 +73,7 @@ Overridden Options
 choices
 ~~~~~~~
 
-**default**: ``Symfony\Component\Intl\Intl::getLocaleBundle()->getLocaleNames()``
+**default**: ``Symfony\Component\Intl\Locales::getNames()``
 
 The choices option defaults to all locales. It uses the default locale to
 specify the language.


### PR DESCRIPTION
As per https://github.com/symfony/symfony/pull/28846 we changed Intl classes to be more specific. Looks like some docs left with old naming.