### PR TITLE
Removed constructor parameters from AuthenticationTrustResolver

### DIFF
--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -104,10 +104,8 @@ level of authentication, i.e. is the user fully authenticated, or only based
 on a "remember-me" cookie, or even authenticated anonymously?::
 
     use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
-    use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
-    use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 
-    $trustResolver = new AuthenticationTrustResolver(AnonymousToken::class, RememberMeToken::class);
+    $trustResolver = new AuthenticationTrustResolver();
 
     $authenticatedVoter = new AuthenticatedVoter($trustResolver);
 


### PR DESCRIPTION
As per https://github.com/symfony/symfony/pull/26981 there are no constructor arguments in `AuthenticationTrustResolver`.