### PR TITLE
Update micro_kernel_trait.rst

### DIFF
--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -109,9 +109,9 @@ level of verbosity of the ``OutputInterface`` instance:
      3/3 [============================] 100%  1 sec
 
     # OutputInterface::VERBOSITY_VERY_VERBOSE (-vv)
-     0/3 [>---------------------------]   0%  1 sec
-     1/3 [=========>------------------]  33%  1 sec
-     3/3 [============================] 100%  1 sec
+     0/3 [>---------------------------]   0%  1 sec/1 sec
+     1/3 [=========>------------------]  33%  1 sec/1 sec
+     3/3 [============================] 100%  1 sec/1 sec
 
     # OutputInterface::VERBOSITY_DEBUG (-vvv)
      0/3 [>---------------------------]   0%  1 sec/1 sec  1.0 MB

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -341,7 +341,7 @@ methods described in :doc:`/service_container/definitions`.
 .. note::
 
     Please note that the ``process()`` method in the extension class is
-    called during the optimization step. You can read
+    called during the ``PassConfig::TYPE_BEFORE_OPTIMIZATION`` step. You can read
     :ref:`the next section <components-di-separate-compiler-passes>` if you
     need to edit the container during another step.
 

--- a/components/lock.rst
+++ b/components/lock.rst
@@ -530,6 +530,14 @@ can be two running containers in parallel.
     concurrent process on a new machine, check that other process are stopped
     on the old one.
 
+.. caution::
+
+    When runing on systemd with non-system user with option ``RemoveIPC=yes``
+    (default value), locks are deleted by systemd when that user logs out.
+    Check that process is ran with a system user (UID <= SYS_UID_MAX) with
+    ``SYS_UID_MAX`` defined in ``/etc/login.defs``, or set the option
+    ``RemoveIPC=off`` in ``/etc/systemd/logind.conf``.
+
 Overall
 ~~~~~~~
 

--- a/components/lock.rst
+++ b/components/lock.rst
@@ -532,9 +532,9 @@ can be two running containers in parallel.
 
 .. caution::
 
-    When runing on systemd with non-system user with option ``RemoveIPC=yes``
+    When runing on systemd with non-system user and option ``RemoveIPC=yes``
     (default value), locks are deleted by systemd when that user logs out.
-    Check that process is ran with a system user (UID <= SYS_UID_MAX) with
+    Check that process is run with a system user (UID <= SYS_UID_MAX) with
     ``SYS_UID_MAX`` defined in ``/etc/login.defs``, or set the option
     ``RemoveIPC=off`` in ``/etc/systemd/logind.conf``.
 

--- a/components/lock.rst
+++ b/components/lock.rst
@@ -227,6 +227,10 @@ PHP process is terminated::
     // the argument is the path of the directory where the locks are created
     $store = new FlockStore(sys_get_temp_dir());
 
+.. note::
+
+    If no path is given, ``sys_get_temp_dir`` is used as default value.
+
 .. caution::
 
     Beware that some file systems (such as some types of NFS) do not support

--- a/components/lock.rst
+++ b/components/lock.rst
@@ -225,11 +225,8 @@ PHP process is terminated::
     use Symfony\Component\Lock\Store\FlockStore;
 
     // the argument is the path of the directory where the locks are created
-    $store = new FlockStore(sys_get_temp_dir());
-
-.. note::
-
-    If no path is given, ``sys_get_temp_dir`` is used as default value.
+    // if none is given, sys_get_temp_dir() is used internally.
+    $store = new FlockStore('/var/stores');
 
 .. caution::
 

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -32,7 +32,7 @@ Next, create an ``index.php`` file that creates a kernel class and executes it::
     use Symfony\Component\Routing\RouteCollectionBuilder;
 
     // require Composer's autoloader
-    require __DIR__.'/vendor/autoload.php';
+    require dirname(__DIR__).'/vendor/autoload.php';
 
     class AppKernel extends Kernel
     {

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -506,6 +506,10 @@ Public and Reusable Bundles
 ---------------------------
 
 Public bundles should explicitly configure their services and not rely on autowiring.
+Autowiring depends on the services that are available in the container and bundles have
+no control over the service container of applications they are included in. You can use
+autowiring when building reusable bundles within your company, as you have full control
+over all code.
 
 .. _ROT13: https://en.wikipedia.org/wiki/ROT13
 .. _service definition prototype: https://symfony.com/blog/new-in-symfony-3-3-psr-4-based-service-discovery


### PR DESCRIPTION
**__DIR__**  returns  **home/aminebetari/Projects/Symfony/my-project/src**

**dirname(__DIR__)** returns **/home/aminebetari/Projects/Symfony/my-project**

So if we keep in this example : 
require `__DIR__.'/vendor/autoload.php';`  we will have an error because the path is not correct 

But if we change by require `dirname(__DIR__).'/vendor/autoload.php';`  we will not have the error because we put the correct path 