### PR TITLE
Fix documentation for PhpUnitBridge regex configuration

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -209,7 +209,7 @@ message, enclosed with ``/``. For example, with:
 
         <php>
             <server name="KERNEL_CLASS" value="App\Kernel"/>
-            <env name="SYMFONY_DEPRECATIONS_HELPER" value="regex=/foobar/"/>
+            <env name="SYMFONY_DEPRECATIONS_HELPER" value="/foobar/"/>
         </php>
     </phpunit>
 


### PR DESCRIPTION
Fixes #12726 

According to comments in https://github.com/symfony/symfony/pull/34693, documentation appears to have diverged between 4.2 and 4.3.
Restoring the correct syntax in 4.3 documentation. 