### PR TITLE
Mention twig/extensions is not for Twig 3

### DIFF
--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -11,7 +11,8 @@ Before writing your own Twig extension, check if the filter/function that you
 need is already implemented in the `default Twig filters and functions`_ or the
 :doc:`Twig filters and functions added by Symfony </reference/twig_reference>`.
 Check also the `official Twig extensions`_, which add commonly needed filters
-and functions and can be installed in your application as follows:
+and functions and can be installed in your application as follows (only needed
+if you're using Twig 1 or 2):
 
 .. code-block:: terminal
 


### PR DESCRIPTION
As twig/extensions is obsolete according to:
https://github.com/twigphp/Twig-extensions/pull/258

And not compatible with Twig 3, let prevent developers for running a dead end command.