### PR TITLE
*Response::create() method is deprecated

### DIFF
--- a/migration.rst
+++ b/migration.rst
@@ -433,7 +433,7 @@ which script to call and wrap the output in a response class::
     {
         public function loadLegacyScript(string $requestPath, string $legacyScript)
         {
-            return StreamedResponse::create(
+            return new StreamedResponse(
                 function () use ($requestPath, $legacyScript) {
                     $_SERVER['PHP_SELF'] = $requestPath;
                     $_SERVER['SCRIPT_NAME'] = $requestPath;


### PR DESCRIPTION
@fabpot deprecated `*Response::create()` methods in https://github.com/symfony/symfony/pull/34771

I think we can use `__construct` from the lowest version on (no occurences in `3.4`, so `4.3`) from now!
No need to mention the deprecation itself in the docs IMHO

Thats why I target `4.3`
