### PR TITLE
Fix typo PersistStoreInterface to PersistingStoreInterface

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -215,7 +215,7 @@ Available Stores
 ----------------
 
 Locks are created and managed in ``Stores``, which are classes that implement
-:class:`Symfony\\Component\\Lock\\PersistStoreInterface` and, optionally,
+:class:`Symfony\\Component\\Lock\\PersistingStoreInterface` and, optionally,
 :class:`Symfony\\Component\\Lock\\BlockingStoreInterface`.
 
 The component includes the following built-in store types:
@@ -233,7 +233,7 @@ Store                                         Scope   Blocking  Expiring
 
 .. versionadded:: 4.4
 
-    The ``PersistStoreInterface`` and ``BlockingStoreInterface`` interfaces were
+    The ``PersistingStoreInterface`` and ``BlockingStoreInterface`` interfaces were
     introduced in Symfony 4.4. In previous versions there was only one interface
     called ``Symfony\Component\Lock\StoreInterface``.
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
