### PR TITLE
Fix typo PersistStoreInterface to PersistingStoreInterface

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -210,7 +210,7 @@ Available Stores
 ----------------
 
 Locks are created and managed in ``Stores``, which are classes that implement
-:class:`Symfony\\Component\\Lock\\PersistStoreInterface` and, optionally,
+:class:`Symfony\\Component\\Lock\\PersistingStoreInterface` and, optionally,
 :class:`Symfony\\Component\\Lock\\BlockingStoreInterface`.
 
 The component includes the following built-in store types:


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
