### PR TITLE
Minor tweak in a security expression explanation

### DIFF
--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -39,9 +39,9 @@ Inside the expression, you have access to a number of variables:
 ``user``
     The user object (or the string ``anon`` if you're not authenticated).
 ``roles``
-    The array of roles the user has, including from the
-    :ref:`role hierarchy <security-role-hierarchy>` but not including the
-    ``IS_AUTHENTICATED_*`` attributes (see the functions below).
+    The array of roles the user has. This array includes any roles granted
+    indirectly via the :ref:`role hierarchy <security-role-hierarchy>` but it
+    does not include the ``IS_AUTHENTICATED_*`` attributes (see the functions below).
 ``object``
     The object (if any) that's passed as the second argument to ``isGranted()``.
 ``token``


### PR DESCRIPTION
I was checking https://symfony.com/doc/current/security/expressions.html and I was going to submit a PR to fix this -> `"ROLE_ADMIN" in roles ...`

But then I read that `roles` in expressions contains ALL roles (it "flattens" the role hierarchy) which is very different from what happens in other parts of Symfony. So maybe we could tweak the description a bit to make this special behavior more obvious?