### PR TITLE
Clarified the two main types of exceptions thrown in HttpClient

### DIFF
--- a/components/http_client.rst
+++ b/components/http_client.rst
@@ -436,7 +436,8 @@ Handling Exceptions
 
 When the HTTP status code of the response is in the 300-599 range (i.e. 3xx,
 4xx or 5xx) your code is expected to handle it. If you don't do that, the
-``getHeaders()`` and ``getContent()`` methods throw an appropriate exception::
+``getHeaders()`` and ``getContent()`` methods throw an appropriate exception, all of
+which implement the :class:`Symfony\\Contracts\\HttpClient\\Exception\\HttpExceptionInterface`::
 
     // the response of this request will be a 403 HTTP error
     $response = $client->request('GET', 'https://httpbin.org/status/403');
@@ -476,6 +477,17 @@ component. No errors will be unnoticed: if you don't write the code to handle
 errors, exceptions will notify you when needed. On the other hand, if you write
 the error-handling code, you will opt-out from these fallback mechanisms as the
 destructor won't have anything remaining to do.
+
+There are three types of exceptions:
+
+* Exceptions implementing the :class:`Symfony\\Contracts\\HttpClient\\Exception\\HttpExceptionInterface` are thrown when
+  your code does not handle the status codes in the 300-599 range.
+
+* Exceptions implementing the :class:`Symfony\\Contracts\\HttpClient\\Exception\\TransportExceptionInterface` are thrown
+  when a lower level issue occurs.
+
+* Exceptions implementing the :class:`Symfony\\Contracts\\HttpClient\\Exception\\DecodingExceptionInterface` are thrown
+  when a content-type cannot be decoded to the expected representation.
 
 Concurrent Requests
 -------------------


### PR DESCRIPTION
As learned from @nicolas-grekas in https://github.com/symfony/symfony/issues/34837.
I guess it's worth clarifying it a little bit :)