### PR TITLE
Revert "feature #11802 [Process] allow writing "prepared" command line. (Simperfit)"

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -368,27 +368,6 @@ instead::
     );
     $process->run();
 
-Using a Prepared Command Line
------------------------------
-
-You can run the process by using a a prepared command line using the
-double bracket notation. You can use a placeholder in order to have a
-process that can only be changed with the values and without changing
-the PHP code::
-
-    use Symfony\Component\Process\Process;
-
-    $process = Process::fromShellCommandline('echo "$name"');
-    $process->run(null, ['name' => 'Elsa']);
-
-.. caution::
-
-    A prepared command line will not be escaped automatically!
-
-.. versionadded:: 4.4
-
-    Prepared command lines were introduced in Symfony 4.4.
-
 Process Timeout
 ---------------
 


### PR DESCRIPTION
This reverts commit a316cd5e7f37a7b437156c17d5e950adafa91da0, reversing
changes made to cdc0bb70b5410da8c94c96c9ca1000e98d33fd14.

Follows https://github.com/symfony/symfony/pull/34845