### PR TITLE
[Mercure] update mercure doc to add clarification in authorization

### DIFF
--- a/mercure.rst
+++ b/mercure.rst
@@ -364,9 +364,16 @@ a JWT containing a topic selector matching by the update's topic.
 
 To provide this JWT, the subscriber can use a cookie,
 or a ``Authorization`` HTTP header.
-Cookies are automatically sent by the browsers when opening an ``EventSource`` connection.
+
+Cookies are automatically sent by the browsers when opening an ``EventSource`` connection if the ``withCredentials`` attribute is set to ``true``.
 Using cookies is the most secure and preferred way when the client is a web browser.
 If the client is not a web browser, then using an authorization header is the way to go.
+
+.. code-block:: javascript
+
+    const eventSource = new EventSource(hub, {
+        withCredentials: true
+    });
 
 .. tip::
 


### PR DESCRIPTION
Hello everyone,

I've added a few words and a code example to clarify the doc about authorization in the Mercure Bundle, to indicate that the `withCredentials` attribute of the `EventSource` must be set to `true` for the authorization cookie to be sent to the Hub. I was missing this info when I installed Mercure for the first time (super protocol, by the way!) and learned about it while reading comments in response to an issue.

By the way, this pull request should fix the closed issue dunglas/mercure#65.

Thanks in advance and have a nice day!

(This is my first pull request ever to an open-source project, all the more so to the Symfony repository, so I hope I did everything right.)