### PR TITLE
Fix `UnicodeString::fromCodePoints()` example

### DIFF
--- a/components/string.rst
+++ b/components/string.rst
@@ -125,7 +125,7 @@ There are also some specialized constructors::
     $foo = ByteString::fromRandom(12);
 
     // CodePointString and UnicodeString can create a string from code points
-    $foo = UnicodeString::fromCodePoints(0x928, 0x92E, 0x938, 0x94D, 0x924, 0x947);
+    $foo = (string) UnicodeString::fromCodePoints(0x928, 0x92E, 0x938, 0x94D, 0x924, 0x947);
     // $foo = 'नमस्ते'
 
 Methods to Transform String Objects


### PR DESCRIPTION
`UnicodeString::fromCodePoints()` returns a `UnicodeString` so the next line `// $foo = 'नमस्ते'` is not correct as it implies the result to be a `string`.

Thus, the result should be casted to a `string` (or `->toString()` should be called) to match the comment.