### PR TITLE
Fix build error

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -311,7 +311,7 @@ Deprecation Notices at Autoloading Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, the PHPUnit Bridge uses ``DebugClassLoader`` from the
-:doc:`ErrorHandler component </components/error_handler>`_ to throw deprecation
+:doc:`ErrorHandler component </components/error_handler>` to throw deprecation
 notices at class autoloading time. This can be disabled with the
 ``debug-class-loader`` option.
 


### PR DESCRIPTION
> Warning, treated as error:
> /home/travis/build/symfony/symfony-docs/components/phpunit_bridge.rst:313: WARNING: Mismatch: both interpreted text role prefix and reference suffix.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
