### PR TITLE
It's needed to change the returned string in testControllerResponse

### DIFF
--- a/create_framework/unit_testing.rst
+++ b/create_framework/unit_testing.rst
@@ -183,7 +183,7 @@ Response::
         $response = $framework->handle(new Request());
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertContains('Hello Fabien', $response->getContent());
+        $this->assertContains('Yep, this is a leap year!', $response->getContent());
     }
 
 In this test, we simulate a route that matches and returns a simple


### PR DESCRIPTION
Following the documentation, we check the Calendar application and get the string "Yep, this is a leap year!" instead of "Hello Fabien".

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
