### PR TITLE
Use a instead of an before consonant sounds

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -228,7 +228,7 @@ value).
 
 You can have even finer-grained control by using other keys of the ``max``
 array, which are ``self``, ``direct``, and ``indirect``. The
-``SYMFONY_DEPRECATIONS_HELPER`` environment variable accepts an URL-encoded
+``SYMFONY_DEPRECATIONS_HELPER`` environment variable accepts a URL-encoded
 string, meaning you can combine thresholds and any other configuration setting,
 like this: ``SYMFONY_DEPRECATIONS_HELPER=max[total]=42&max[self]=0&verbose=0``
 

--- a/http_cache/cache_invalidation.rst
+++ b/http_cache/cache_invalidation.rst
@@ -9,7 +9,7 @@ Cache Invalidation
     "There are only two hard things in Computer Science: cache invalidation
     and naming things." -- Phil Karlton
 
-Once an URL is cached by a gateway cache, the cache will not ask the
+Once a URL is cached by a gateway cache, the cache will not ask the
 application for that content anymore. This allows the cache to provide fast
 responses and reduces the load on your application. However, you risk
 delivering outdated content. A way out of this dilemma is to use long

--- a/mercure.rst
+++ b/mercure.rst
@@ -7,7 +7,7 @@ Pushing Data to Clients Using the Mercure Protocol
 Being able to broadcast data in real-time from servers to clients is a
 requirement for many modern web and mobile applications.
 
-Creating an UI reacting in live to changes made by other users
+Creating a UI reacting in live to changes made by other users
 (e.g. a user changes the data currently browsed by several other users,
 all UIs are instantly updated),
 notifying the user when :doc:`an asynchronous job </messenger>` has been
@@ -175,7 +175,7 @@ of the resource being dispatched.
 
 Usually, this parameter contains the original URL of the resource
 transmitted to the client, but it can be any valid `IRI`_, it doesn't
-have to be an URL that exists (similarly to XML namespaces).
+have to be a URL that exists (similarly to XML namespaces).
 
 The second parameter of the constructor is the content of the update.
 It can be anything, stored in any format.
@@ -229,7 +229,7 @@ and to use URI Templates as patterns:
 
 .. tip::
 
-    Test if a URI Template match an URL using `the online debugger`_
+    Test if a URI Template match a URL using `the online debugger`_
 
 Async dispatching
 -----------------


### PR DESCRIPTION
u is a vowel, but will sometime produce a consonant sound, as in user
(`[ˈjuːzər]`) or URL (`[ˌjuːɑːrˈɛl]`).
See https://www.grammar.com/a-vs-an-when-to-use/
