### PR TITLE
[Mailer] Minor tweaks in the mailer docs

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -121,7 +121,9 @@ and create an :class:`Symfony\\Component\\Mime\\Email` object::
                 ->text('Sending emails is fun again!')
                 ->html('<p>See Twig integration for better HTML integration!</p>');
 
-            $mailer->send($email);
+            /** @var Symfony\Component\Mailer\SentMessage $sentEmail */
+            $sentEmail = $mailer->send($email);
+            // $messageId = $sentEmail->getMessageId();
 
             // ...
         }
@@ -157,7 +159,8 @@ both strings or address objects::
 
     Instead of calling ``->from()`` *every* time you create a new email, you can
     create an :doc:`event subscriber </event_dispatcher>` and listen to the
-    ``MessageEvent::class`` event to set the same ``From`` email to all messages.
+    :class:`Symfony\\Component\\Mailer\\Event\\MessageEvent` event to set the
+    same ``From`` email to all messages.
 
 Multiple addresses are defined with the ``addXXX()`` methods::
 


### PR DESCRIPTION
Maybe you don't like this proposal (it's fine to close without merging) but I'd prefer to make it very obvious that `send()` returns a special class which provides useful methods.