### PR TITLE
[Monolog] Add a caution note about Symfony Mailer and Monolog

### DIFF
--- a/logging/monolog_email.rst
+++ b/logging/monolog_email.rst
@@ -4,6 +4,11 @@
 How to Configure Monolog to Email Errors
 ========================================
 
+.. caution::
+
+    This feature is not compatible yet with the new :doc:`Symfony mailer </mailer>`,
+    so it requires using SwiftMailer.
+
 `Monolog`_ can be configured to send an email when an error occurs with an
 application. The configuration for this requires a few nested handlers
 in order to avoid receiving too many emails. This configuration looks


### PR DESCRIPTION
We can't fix #12758 properly until this is fixed in https://github.com/symfony/symfony/pull/33456  but meanwhile we can display a caution message to avoid confusion.