### PR TITLE
Use right option in composer update

### DIFF
--- a/setup/_update_dep_errors.rst.inc
+++ b/setup/_update_dep_errors.rst.inc
@@ -6,7 +6,7 @@ other Symfony dependencies too. In that case, try the following command:
 
 .. code-block:: terminal
 
-    $ composer update "symfony/*" --with-all-dependencies
+    $ composer update "symfony/*" --with-dependencies
 
 This updates ``symfony/symfony`` and *all* packages that it depends on, which will
 include several other packages. By using tight version constraints in


### PR DESCRIPTION
Update documentation for composer option

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
