### PR TITLE
[Serializer] add caution for normalize Datetime object with GetSetMethodNormalizer

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -115,6 +115,12 @@ Custom normalizers and/or encoders can also be loaded by tagging them as
 :ref:`serializer.encoder <reference-dic-tags-serializer-encoder>`. It's also
 possible to set the priority of the tag in order to decide the matching order.
 
+.. caution::
+
+    Always make sure to load the ``DateTimeNormalizer`` when serializing the
+    ``DateTime`` or ``DateTimeImmutable`` classes to avoid excessive memory
+    usage and exposing internal details.
+
 Here is an example on how to load the
 :class:`Symfony\\Component\\Serializer\\Normalizer\\GetSetMethodNormalizer`, a
 faster alternative to the `ObjectNormalizer` when data objects always use


### PR DESCRIPTION
I noticed an issue with the GetSetMethodNormalizer, not a real issue, but just a warning about its use.

If we normalize an object which returns a Datetime, without defining the DatetimeNormalizer; on many objects at the same time, we explode the memory of PHP and time of use.

Example :

```php
$serializer = new Serializer([new GetSetMethodNormalizer()]);
$objects = [];
for ($i = 0, $n = 100;$i<$n; $i++) {
  $objects[] = new MyObject(new \DateTime('now'));
}

$serializer->normalize($objects);

dd('memory_get_peak_usage', (memory_get_peak_usage(true) / 1024 / 1024) . ' MiB');
```
"memory_get_peak_usage"
 "46 MiB"

```php
$serializer = new Serializer([new DateTimeNormalizer(), new GetSetMethodNormalizer()]);
$objects = [];
for ($i = 0, $n = 100;$i<$n; $i++) {
  $objects[] = new MyObject(new \DateTime('now'));
}

$serializer->normalize($objects);

dd('memory_get_peak_usage', (memory_get_peak_usage(true) / 1024 / 1024) . ' MiB');
```
"memory_get_peak_usage"
 "14 MiB"

------

For i = 1000 => 334 Mib   :ocean: 

