### PR TITLE
[Security] Add a note about Access Decision Strategy with access_control

### DIFF
--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -160,6 +160,13 @@ options:
     can learn how to use your custom attributes by reading
     :ref:`security/custom-voter`.
 
+.. caution::
+
+    If you define both ``roles`` and ``allow_if``, and your Access Decision
+    Strategy is the default one (``affirmative``), then the user will be granted
+    access if there's at least one valid condition. See :doc:`/security/voters`
+    to change your strategy to something more suited to your needs.
+
 .. tip::
 
     If access is denied, the system will try to authenticate the user if not


### PR DESCRIPTION
It took me so much time to understand why my `access_control` wasn't working properly, this was due to my Access Decision Strategy being `affirmative` instead of `unanimous`.