### PR TITLE
Update references to 4.4 version

### DIFF
--- a/setup/upgrade_minor.rst
+++ b/setup/upgrade_minor.rst
@@ -45,14 +45,15 @@ are like this:
 
 At the bottom of your ``composer.json`` file, in the ``extra`` block you can
 find a data setting for the symfony version. Make sure to also upgrade
-this one. For instance, update it to ``4.3.*`` to upgrade to Symfony 4.3:
+this one. For instance, update it to ``
+.*`` to upgrade to Symfony 4.4:
 
 .. code-block:: json
 
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "4.3.*"
+            "require": "4.4.*"
         }
     }
 


### PR DESCRIPTION
As version `4.4` is an LTS, would be useful for the docs to reference the `4.4` version specifically when updating to this version.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
