### PR TITLE
Update error_handler.rst

### DIFF
--- a/components/error_handler.rst
+++ b/components/error_handler.rst
@@ -49,7 +49,7 @@ Turning PHP Errors into Exceptions
 The :class:`Symfony\\Component\\ErrorHandler\\ErrorHandler` class catches PHP
 errors and uncaught PHP exceptions and turns them into PHP's
 :phpclass:`ErrorException` objects, except for fatal PHP errors, which are
-turned into Symfony's :class:`Symfony\\Component\\ErrorHandler\\Exception\\FatalErrorException`
+turned into Symfony's :class:`Symfony\\Component\\ErrorHandler\\Error\\FatalError`
 objects.
 
 If the application uses the FrameworkBundle, this error handler is enabled by


### PR DESCRIPTION
There is no more FatalErrorException in SF 5.0