### PR TITLE
Remove wrong colon in input selector

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -332,7 +332,7 @@ will be show next):
 
         // count the current form inputs we have (e.g. 2), use that as the new
         // index when inserting a new item (e.g. 2)
-        $collectionHolder.data('index', $collectionHolder.find(':input').length);
+        $collectionHolder.data('index', $collectionHolder.find('input').length);
 
         $addTagButton.on('click', function(e) {
             // add a new tag form (see next code block)


### PR DESCRIPTION
Fixing a Javascript error in the form documentation.