### PR TITLE
Update service id of the MailerInterface

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -93,7 +93,7 @@ Creating & Sending Messages
 ---------------------------
 
 To send an email, autowire the mailer using
-:class:`Symfony\\Component\\Mailer\\MailerInterface` (service id ``mailer``)
+:class:`Symfony\\Component\\Mailer\\MailerInterface` (service id ``mailer.mailer``)
 and create an :class:`Symfony\\Component\\Mime\\Email` object::
 
     // src/Controller/MailerController.php


### PR DESCRIPTION
The service id of the MailerInterface was changed in https://github.com/symfony/symfony/pull/31854 to avoid an conflict with SwiftMailer
