### PR TITLE
Fix invalid yaml

### DIFF
--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -175,7 +175,7 @@ or you decided not to maintain it anymore), you can deprecate its definition:
             deprecated: true
 
             # ...but you can also define a custom deprecation message
-            deprecated: 'The "%alias_id%" alias is deprecated. Don\'t use it anymore.'
+            deprecated: 'The "%alias_id%" alias is deprecated. Do not use it anymore.'
 
     .. code-block:: xml
 


### PR DESCRIPTION
Because `deprecated: 'The "%alias_id%" alias is deprecated. Don\'t use it anymore.'` is not valid Yaml, it leads to this error:

[OK] All 1 YAML files contain valid syntax.
>> Unexpected characters near "t use it anymore.

The yaml specification says: 

> All non-printable characters must be escaped. YAML escape sequences use the “\” notation common to most modern computer languages. Each escape sequence must be parsed into the appropriate Unicode character. The original escape sequence is a presentation detail and must not be used to convey content information.

> Note that escape sequences are only interpreted in double-quoted scalars. In all other scalar styles, the “\” character has no special meaning and non-printable characters are not available.

So I think removing the `'` will help users who copy the configuration from the documentation.