### PR TITLE
[Testing] Fix broken link

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -484,7 +484,7 @@ script::
 AJAX Requests
 ~~~~~~~~~~~~~
 
-The Client provides a :method:`Symfony\\Component\\BrowserKit\\Client::xmlHttpRequest`
+The Client provides a :method:`Symfony\\Component\\BrowserKit\\AbstractBrowser::xmlHttpRequest`
 method, which has the same arguments as the ``request()`` method, and it's a
 shortcut to make AJAX requests::
 


### PR DESCRIPTION
Fix a broken link here : https://symfony.com/doc/current/testing.html#ajax-requests

Symfony/Component/BrowserKit/Client has been replaced by Symfony/Component/BrowserKit/AbstractBrowser in 5.0