### PR TITLE
Update workflow.rst

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -179,9 +179,6 @@ As configured, the following property is used by the marking store::
     configures the marking store according to the "type" by default, so it's
     preferable to not configure it.
 
-    A single state marking store uses a string to store the data. A multiple
-    state marking store uses an array to store the data.
-
 .. tip::
 
     The ``marking_store.type`` (the default value depends on the ``type`` value)


### PR DESCRIPTION
From what I can tell, this statement is not correct.  `$workFlow->getMarking()` returns the marking with `places` as an array even in a `state_machine` `single_state`  configuration.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
