### PR TITLE
Fix link syntax in hinclude.rst

### DIFF
--- a/templating/hinclude.rst
+++ b/templating/hinclude.rst
@@ -10,7 +10,7 @@ performance you can use the `hinclude.js`_ JavaScript library to embed
 controllers asynchronously.
 
 First, include the `hinclude.js`_ library in your page
-ref:`linking to it <templates-link-to-assets>` from the template or adding it
+:ref:`linking to it <templates-link-to-assets>` from the template or adding it
 to your application JavaScript :doc:`using Webpack Encore </frontend>`.
 
 As the embedded content comes from another page (or controller for that matter),


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
