### PR TITLE
[Serializer] Remove note about CsvEncoder as_collection flag

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -786,9 +786,6 @@ The ``CsvEncoder``
 
 The ``CsvEncoder`` encodes to and decodes from CSV.
 
-You can pass the context key ``as_collection`` in order to have the results
-always as a collection.
-
 The ``XmlEncoder``
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This is the default since 5.0 

https://github.com/symfony/symfony/blob/ad7d24109c5d9d9bce66ae57c509eb9baa3cc21b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php#L47
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
