### PR TITLE
[FrameworkBundle] Fix lock.invoice.retry_till_save.store decoration

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2366,7 +2366,7 @@ Name of the lock you want to create.
         lock.invoice.retry_till_save.store:
             class: Symfony\Component\Lock\Store\RetryTillSaveStore
             decorates: lock.invoice.store
-            arguments: ['@lock.invoice.retry.till.save.store.inner', 100, 50]
+            arguments: ['@lock.invoice.retry_till_save.store.inner', 100, 50]
 
 ``workflows``
 ~~~~~~~~~~~~~


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
