### PR TITLE
[Cache] Custom pool

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -189,13 +189,20 @@ You can also create more customized pools. All you need is an adapter:
                 default_memcached_provider: 'memcached://localhost'
                 pools:
                     my_cache_pool:
-                        adapter: cache.adapter.filesystem
+                        provider: app.my_cache_chain_adapter
                     cache.acme:
                         adapter: cache.adapter.memcached
                     cache.foobar:
                         adapter: cache.adapter.memcached
                         provider: 'memcached://user:password@example.com'
 
+        services:
+            app.my_cache_chain_adapter:
+                class: Symfony\Component\Cache\Adapter\ChainAdapter
+                arguments:
+                    - ['@cache.array', '@cache.apcu', '@cache.my_redis']
+                    - 31536000 # One year
+                    
     .. code-block:: xml
 
         <!-- app/config/config.xml -->


### PR DESCRIPTION
Hi everyone 👋 

It seems that when defining a custom pool, the documenation is talking about an array adapter when the used one is the filesystem, the question is, do we need to reword it as filesystem in the text of change the code? 🤔 

Thanks for the feedback 🙂 