### PR TITLE
Hint for generating container preload file

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -113,6 +113,10 @@ with the ``preload`` suffix:
 
 .. _performance-configure-opcache:
 
+You need to set both parameters ``container.dumper.inline_factories`` and 
+``container.dumper.inline_class_loader`` to ``true`` to enable generating 
+the ``preload`` file during container compilation.
+
 Configure OPcache for Maximum Performance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The container preload file will only be generated when both factories and class_loader are inline, so you need to set both parameters to `true` explicitly.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
