### PR TITLE
[Notifier] Added a placeholder article for the component docs

### DIFF
--- a/components/notifier.rst
+++ b/components/notifier.rst
@@ -1,0 +1,33 @@
+.. index::
+   single: Notifier
+   single: Notifications
+   single: Components; Notifier
+
+The Notifier Component
+======================
+
+    The Notifier component sends notifications via one or more channels
+    (email, SMS, Slack, ...).
+
+.. versionadded:: 5.0
+
+    The String component was introduced in Symfony 5.0 as an
+    :doc:`experimental feature </contributing/code/experimental>`.
+
+Installation
+------------
+
+.. code-block:: terminal
+
+    $ composer require symfony/notifier
+
+.. include:: /components/require_autoload.rst.inc
+
+
+Usage
+-----
+
+.. caution::
+
+	We're still working on the docs of this component. Check this page again
+	in a few days.


### PR DESCRIPTION
Notifier doesn't have docs yet. We don't link to them from symfony.com ... but we link to them from the README of the code repo. So, let's add a placeholder article to avoid 404 errors.