### PR TITLE
[Testing] add shutdown to KernelTestCase example

### DIFF
--- a/testing/database.rst
+++ b/testing/database.rst
@@ -228,6 +228,8 @@ so, get the entity manager via the service container as follows::
             $this->entityManager = $kernel->getContainer()
                 ->get('doctrine')
                 ->getManager();
+                
+            self::ensureKernelShutdown();
         }
 
         public function testSearchByName()


### PR DESCRIPTION
In Symfony 4.4, a deprecation is raised when a client is created before shutting down the kernel.

> Calling "Symfony\Bundle\FrameworkBundle\Test\WebTestCase::createClient()" while a kernel has been booted is deprecated since Symfony 4.4 and will throw in 5.0, ensure the kernel is shut down before calling the method.

Add method to shutdown the kernel to the example.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
