### PR TITLE
Fix dama/doctrine-test-bundle docs

### DIFF
--- a/testing/database.rst
+++ b/testing/database.rst
@@ -48,12 +48,12 @@ Now, enable it as a PHPUnit extension or listener:
     <phpunit>
         <!-- ... -->
 
-        <!-- Add this for PHPUnit 7.1 or higher -->
+        <!-- Add this for PHPUnit 7.5 or higher -->
         <extensions>
             <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
         </extensions>
 
-        <!-- Add this for PHPUnit 7.0 -->
+        <!-- Add this for PHPUnit 7.0 until 7.4 -->
         <listeners>
             <listener class="\DAMA\DoctrineTestBundle\PHPUnit\PHPUnitListener"/>
         </listeners>


### PR DESCRIPTION
To sync this with the change made here: https://github.com/dmaicher/doctrine-test-bundle/commit/f9abe2c8609352e3989f729031163acf8b7670ef

The PHPUnit extension does not work properly for PHPUnit < 7.5 :confused:

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
