### PR TITLE
Possible suggestions to getData() returned use.

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -147,7 +147,7 @@ Finally, you need to update the code of the controller that handles the form::
 
                 // this condition is needed because the 'brochure' field is not required
                 // so the PDF file must be processed only when a file is uploaded
-                if ($brochureFile !== null) {
+                if (null !== $brochureFile) {
                     $originalFilename = pathinfo($brochureFile->getClientOriginalName(), PATHINFO_FILENAME);
                     // this is needed to safely include the file name as part of the URL
                     $safeFilename = transliterator_transliterate('Any-Latin; Latin-ASCII; [^A-Za-z0-9_] remove; Lower()', $originalFilename);

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -142,12 +142,12 @@ Finally, you need to update the code of the controller that handles the form::
             $form->handleRequest($request);
 
             if ($form->isSubmitted() && $form->isValid()) {
-                /** @var UploadedFile $brochureFile */
+                /** @var UploadedFile|null $brochureFile */
                 $brochureFile = $form['brochure']->getData();
 
                 // this condition is needed because the 'brochure' field is not required
                 // so the PDF file must be processed only when a file is uploaded
-                if ($brochureFile) {
+                if ($brochureFile !== null) {
                     $originalFilename = pathinfo($brochureFile->getClientOriginalName(), PATHINFO_FILENAME);
                     // this is needed to safely include the file name as part of the URL
                     $safeFilename = transliterator_transliterate('Any-Latin; Latin-ASCII; [^A-Za-z0-9_] remove; Lower()', $originalFilename);


### PR DESCRIPTION
This might be controversial, just proposing.
- Adding the correct returned values on PHPDoc, letting this as is is a misleading code hint in PHPDoc (most IDEs won't detect that it can be `null`).
- Adding a strong typing check to the code. The current example is simpler, though, which might be better for a documentation. Also feel free to Yoda condition it if like Yoda you like to speech, young padawan. ;)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
