### PR TITLE
Update example to use tagged_locator helper function

### DIFF
--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -555,7 +555,7 @@ attribute to the locator service defining the name of this custom method:
         return function(ContainerConfigurator $configurator) {
             $configurator->services()
                 ->set(App\HandlerCollection::class)
-                    ->args([service_locator(tagged('app.handler', null, 'myOwnMethodName'))])
+                    ->args([tagged_locator('app.handler', null, 'myOwnMethodName')])
             ;
         };
 


### PR DESCRIPTION
For some reason all php examples use the `tagged_locator` helper function except one. This has been changed since I don't see any apparent reason why not to use to & it also keeps the examples more consistent.