### PR TITLE
[Mailer] Suggest scheme "smtp://null" instead of incorrect "null://null"

### DIFF
--- a/components/mailer.rst
+++ b/components/mailer.rst
@@ -83,7 +83,7 @@ DSN::
 
 Where ``$dsn`` depends on the provider you want to use. For plain SMTP, use
 ``smtp://user:pass@example.com`` or ``sendmail+smtp://default`` to use the
-``sendmail`` binary. To disable the transport, use ``null://null``.
+``sendmail`` binary. To disable the transport, use ``smtp://null``.
 
 For third-party providers, refer to the following table:
 

--- a/mailer.rst
+++ b/mailer.rst
@@ -745,7 +745,7 @@ environment:
     # config/packages/dev/mailer.yaml
     framework:
         mailer:
-            dsn: 'null://null'
+            dsn: 'smtp://null'
 
 .. note::
 


### PR DESCRIPTION
Symfony\Component\Mailer\Transport::createTransport() shows that `smtp://null` is supported while `null://null` is not.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
