### PR TITLE
[Translation] Added tip about the incompatibility of % character

### DIFF
--- a/translation/message_format.rst
+++ b/translation/message_format.rst
@@ -70,6 +70,11 @@ The basic usage of the MessageFormat allows you to use placeholders (called
             'say_hello' => "Hello {name}!",
         ];
 
+
+.. caution::
+
+    With the previous format, placeholders were often named between ``%``. This character is no longer valid with the ICU MessageFormat syntax. Be careful to rename your parameters.
+
 Everything within the curly braces (``{...}``) is processed by the formatter
 and replaced by its placeholder::
 


### PR DESCRIPTION
With the ICU MessageFormat syntax, the character `%` is not valid anymore in parameter keys. It throws a `U_PATTERN_SYNTAX_ERROR` exception

This fix must be backported on all versions from 4.2 included, since the introduction of IntlMessageFormatter

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
