### PR TITLE
Remove usages of transChoice() method for Symfony 5.0

### DIFF
--- a/components/form.rst
+++ b/components/form.rst
@@ -246,13 +246,13 @@ Translation
 ~~~~~~~~~~~
 
 If you're using the Twig integration with one of the default form theme files
-(e.g. ``form_div_layout.html.twig``), there are 2 Twig filters (``trans``
-and ``transChoice``) that are used for translating form labels, errors, option
+(e.g. ``form_div_layout.html.twig``), there is a Twig filter (``trans``)
+that is used for translating form labels, errors, option
 text and other strings.
 
-To add these Twig filters, you can either use the built-in
+To add the ``trans`` Twig filter, you can either use the built-in
 :class:`Symfony\\Bridge\\Twig\\Extension\\TranslationExtension` that integrates
-with Symfony's Translation component, or add the 2 Twig filters yourself,
+with Symfony's Translation component, or add the Twig filter yourself,
 via your own Twig extension.
 
 To use the built-in integration, be sure that your project has Symfony's
@@ -281,7 +281,7 @@ to your ``Twig\Environment`` instance::
         'en'
     );
 
-    // adds the TranslationExtension (gives us trans and transChoice filters)
+    // adds the TranslationExtension (it gives us trans filter)
     $twig->addExtension(new TranslationExtension($translator));
 
     $formFactory = Forms::createFormFactoryBuilder()

--- a/components/translation.rst
+++ b/components/translation.rst
@@ -148,8 +148,7 @@ To actually translate the message, the Translator uses the following process:
   not, the translator returns the original message.
 
 You start this process by calling
-:method:`Symfony\\Component\\Translation\\Translator::trans` or
-:method:`Symfony\\Component\\Translation\\Translator::transChoice`. Then, the
+:method:`Symfony\\Component\\Translation\\Translator::trans`. Then, the
 Translator looks for the exact string inside the appropriate message catalog
 and returns it (if it exists).
 

--- a/components/translation/usage.rst
+++ b/components/translation/usage.rst
@@ -166,28 +166,6 @@ use for translation::
         'fr_FR'
     );
 
-    $translator->transChoice(
-        '{0} There are no apples|{1} There is one apple|]1,Inf[ There are %count% apples',
-        10,
-        [],
-        'messages',
-        'fr_FR'
-    );
-
-.. note::
-
-    Starting from Symfony 3.2, the third argument of ``transChoice()`` is
-    optional when the only placeholder in use is ``%count%``. In previous
-    Symfony versions you needed to always define it::
-
-        $translator->transChoice(
-            '{0} There are no apples|{1} There is one apple|]1,Inf[ There are %count% apples',
-            10,
-            ['%count%' => 10],
-            'messages',
-            'fr_FR'
-        );
-
 .. _retrieving-the-message-catalogue:
 
 Retrieving the Message Catalog


### PR DESCRIPTION
The `transChoice()` method and the `transChoice` Twig filter [were removed in Symfony 5.0](https://github.com/symfony/symfony/blob/master/UPGRADE-5.0.md#frameworkbundle)

**Notes for reviewers:** I'm not too sure about the new `Pluralized Translations` section, I couldn't find any other information about it in the docs so maybe it's relevant? I'm not sure if there's a better place to put it (maybe: `components/translation.rst`), or if it's even needed? 