### PR TITLE
The example shortcut was in the wrong location

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -97,10 +97,10 @@ You're ready! To dispatch the message (and call the handler), inject the
         public function index(MessageBusInterface $bus)
         {
             // will cause the SmsNotificationHandler to be called
-            $bus->dispatch(new SmsNotification('Look! I created a message!'));
+            $bus->dispatchMessage(new SmsNotification('Look! I created a message!'));
 
             // or use the shortcut
-            $this->dispatchMessage(new SmsNotification('Look! I created a message!'));
+            $this->dispatch(new SmsNotification('Look! I created a message!'));
 
             // ...
         }


### PR DESCRIPTION
The example code is the same, but the "shortcut" method was in the wrong location.