### PR TITLE
Add Canonicalize option to Locale Constraint

### DIFF
--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -14,10 +14,11 @@ issues with wrong uppercase/lowercase values and to remove unneeded elements
 
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`
-Options     - `groups`_
+Options     _ `canonicalize`_
+            - `groups`_
             - `message`_
             - `payload`_
-            _ `canonicalize`_
+            
 Class       :class:`Symfony\\Component\\Validator\\Constraints\\Locale`
 Validator   :class:`Symfony\\Component\\Validator\\Constraints\\LocaleValidator`
 ==========  ===================================================================

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -114,6 +114,7 @@ Parameter        Description
 
 ``canonicalize``
 ~~~~~~~~~~~~~~~~
+
 **type**: ``boolean`` **default**: ``true``
 
 this method performs Level 1 and Level 2 canonicalization according to ICU standards `ICU format locale IDs`.

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -117,7 +117,7 @@ Parameter        Description
 
 **type**: ``boolean`` **default**: ``true``
 
-this method performs Level 1 and Level 2 canonicalization according to ICU standards `ICU format locale IDs`.
+This method performs level 1 and level 2 canonicalization according to ICU standards `ICU format locale IDs`.
 
 .. _`ICU format locale IDs`: http://userguide.icu-project.org/locale
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -118,7 +118,8 @@ Parameter        Description
 
 **type**: ``boolean`` **default**: ``true``
 
-This method performs level 1 and level 2 canonicalization according to ICU standards `ICU format locale IDs`.
+This method performs level 1 and level 2 canonicalization according to
+ICU standards `ICU format locale IDs`.
 
 .. _`ICU format locale IDs`: http://userguide.icu-project.org/locale
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -113,7 +113,7 @@ Parameter        Description
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 ``canonicalize``
-~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 **type**: ``boolean`` **default**: ``true``
 
 this method performs Level 1 and Level 2 canonicalization according to ICU standards `ICU format locale IDs`.

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -17,6 +17,7 @@ Applies to  :ref:`property or method <validation-property-target>`
 Options     - `groups`_
             - `message`_
             - `payload`_
+            _ `canonicalize`_
 Class       :class:`Symfony\\Component\\Validator\\Constraints\\Locale`
 Validator   :class:`Symfony\\Component\\Validator\\Constraints\\LocaleValidator`
 ==========  ===================================================================
@@ -110,6 +111,12 @@ Parameter        Description
 ===============  ==============================================================
 
 .. include:: /reference/constraints/_payload-option.rst.inc
+
+``canonicalize``
+~~~~~~~~~~~
+**type**: ``boolean`` **default**: ``true``
+
+this method performs Level 1 and Level 2 canonicalization according to ICU standards `ICU format locale IDs`.
 
 .. _`ICU format locale IDs`: http://userguide.icu-project.org/locale
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes


### PR DESCRIPTION
Add Canonicalize option to Locale Constraint (which was added in Symfony 4.1: https://symfony.com/index.php/blog/new-in-symfony-4-1-validator-improvements)