### PR TITLE
Update service_container.rst

### DIFF
--- a/frontend/custom_version_strategy.rst
+++ b/frontend/custom_version_strategy.rst
@@ -118,7 +118,6 @@ After creating the strategy PHP class, register it as a Symfony service.
                 arguments:
                     - "%kernel.project_dir%/busters.json"
                     - "%%s?version=%%s"
-                public: false
 
     .. code-block:: xml
 
@@ -130,7 +129,7 @@ After creating the strategy PHP class, register it as a Symfony service.
                 https://symfony.com/schema/dic/services/services-1.0.xsd"
         >
             <services>
-                <service id="App\Asset\VersionStrategy\GulpBusterVersionStrategy" public="false">
+                <service id="App\Asset\VersionStrategy\GulpBusterVersionStrategy">
                     <argument>%kernel.project_dir%/busters.json</argument>
                     <argument>%%s?version=%%s</argument>
                 </service>
@@ -140,16 +139,23 @@ After creating the strategy PHP class, register it as a Symfony service.
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Asset\VersionStrategy\GulpBusterVersionStrategy;
         use Symfony\Component\DependencyInjection\Definition;
 
-        $container->autowire(GulpBusterVersionStrategy::class)
-            ->setArguments(
-                [
-                    '%kernel.project_dir%/busters.json',
-                    '%%s?version=%%s',
-                ]
-        )->setPublic(false);
+        return function(ContainerConfigurator $configurator) {
+            $services = $configurator->services();
+
+            $services->set(GulpBusterVersionStrategy::class)
+                ->args(
+                    [
+                        '%kernel.project_dir%/busters.json',
+                        '%%s?version=%%s',
+                    ]
+                );
+        };
+
 
 Finally, enable the new asset versioning for all the application assets or just
 for some :ref:`asset package <reference-framework-assets-packages>` thanks to

--- a/profiler/data_collector.rst
+++ b/profiler/data_collector.rst
@@ -239,7 +239,6 @@ to specify a tag that contains the template:
                         id:       'app.request_collector'
                         # optional priority
                         # priority: 300
-                public: false
 
     .. code-block:: xml
 
@@ -251,7 +250,7 @@ to specify a tag that contains the template:
                 https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="App\DataCollector\RequestCollector" public="false">
+                <service id="App\DataCollector\RequestCollector">
                     <!-- priority="300" -->
                     <tag name="data_collector"
                         template="data_collector/template.html.twig"
@@ -264,17 +263,21 @@ to specify a tag that contains the template:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\DataCollector\RequestCollector;
 
-        $container
-            ->autowire(RequestCollector::class)
-            ->setPublic(false)
-            ->addTag('data_collector', [
-                'template' => 'data_collector/template.html.twig',
-                'id'       => 'app.request_collector',
-                // 'priority' => 300,
-            ])
-        ;
+        return function(ContainerConfigurator $configurator) {
+            $services = $configurator->services();
+
+            $services->set(RequestCollector::class)
+                ->autowire()
+                ->tag('data_collector', [
+                    'template' => 'data_collector/template.html.twig',
+                    'id'       => 'app.request_collector',
+                    // 'priority' => 300,
+                ]);
+        };
 
 The position of each panel in the toolbar is determined by the collector priority.
 Priorities are defined as positive or negative integers and they default to ``0``.

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -64,13 +64,10 @@ services:
         services:
             app.mysql_lock:
                 class: App\Lock\MysqlLock
-                public: false
             app.postgresql_lock:
                 class: App\Lock\PostgresqlLock
-                public: false
             app.sqlite_lock:
                 class: App\Lock\SqliteLock
-                public: false
 
     .. code-block:: xml
 
@@ -81,24 +78,31 @@ services:
                 https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="app.mysql_lock" public="false"
+                <service id="app.mysql_lock"
                     class="App\Lock\MysqlLock"/>
-                <service id="app.postgresql_lock" public="false"
+                <service id="app.postgresql_lock"
                     class="App\Lock\PostgresqlLock"/>
-                <service id="app.sqlite_lock" public="false"
+                <service id="app.sqlite_lock"
                     class="App\Lock\SqliteLock"/>
             </services>
         </container>
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Lock\MysqlLock;
         use App\Lock\PostgresqlLock;
         use App\Lock\SqliteLock;
 
-        $container->register('app.mysql_lock', MysqlLock::class)->setPublic(false);
-        $container->register('app.postgresql_lock', PostgresqlLock::class)->setPublic(false);
-        $container->register('app.sqlite_lock', SqliteLock::class)->setPublic(false);
+        return function(ContainerConfigurator $configurator) {
+            $services = $configurator->services();
+
+            $services->set('app.mysql_lock', MysqlLock::class);
+            $services->set('app.postgresql_lock', PostgresqlLock::class);
+            $services->set('app.sqlite_lock', SqliteLock::class);
+        };
 
 Instead of dealing with these three services, your application needs a generic
 ``app.lock`` service that will be an alias to one of these services, depending on
@@ -132,11 +136,11 @@ the generic ``app.lock`` service can be defined as follows:
                 https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="app.mysql_lock" public="false"
+                <service id="app.mysql_lock"
                     class="App\Lock\MysqlLock"/>
-                <service id="app.postgresql_lock" public="false"
+                <service id="app.postgresql_lock"
                     class="App\Lock\PostgresqlLock"/>
-                <service id="app.sqlite_lock" public="false"
+                <service id="app.sqlite_lock"
                     class="App\Lock\SqliteLock"/>
 
                 <service id="app.lock">
@@ -147,16 +151,24 @@ the generic ``app.lock`` service can be defined as follows:
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Lock\MysqlLock;
         use App\Lock\PostgresqlLock;
         use App\Lock\SqliteLock;
 
-        $container->register('app.mysql_lock', MysqlLock::class)->setPublic(false);
-        $container->register('app.postgresql_lock', PostgresqlLock::class)->setPublic(false);
-        $container->register('app.sqlite_lock', SqliteLock::class)->setPublic(false);
+        return function(ContainerConfigurator $configurator) {
+            $services = $configurator->services();
 
-        $container->register('app.lock')
-            ->addTag('auto_alias', ['format' => 'app.%database_type%_lock']);
+            $services->set('app.mysql_lock', MysqlLock::class);
+            $services->set('app.postgresql_lock', PostgresqlLock::class);
+            $services->set('app.sqlite_lock', SqliteLock::class);
+
+            $services->set('app.lock')
+                ->tag('auto_alias', ['format' => 'app.%database_type%_lock'])
+            ;
+        };
 
 The ``format`` option defines the expression used to construct the name of the service
 to alias. This expression can use any container parameter (as usual,

--- a/security/custom_authentication_provider.rst
+++ b/security/custom_authentication_provider.rst
@@ -396,11 +396,9 @@ to service ids that may not exist yet: ``App\Security\Authentication\Provider\Ws
             App\Security\Authentication\Provider\WsseProvider:
                 arguments:
                     $cachePool: '@cache.app'
-                public: false
 
             App\Security\Firewall\WsseListener:
                 arguments: ['@security.token_storage', '@security.authentication.manager']
-                public: false
 
     .. code-block:: xml
 
@@ -411,15 +409,11 @@ to service ids that may not exist yet: ``App\Security\Authentication\Provider\Ws
             xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="App\Security\Authentication\Provider\WsseProvider"
-                    public="false"
-                >
+                <service id="App\Security\Authentication\Provider\WsseProvider">
                     <argument key="$cachePool" type="service" id="cache.app"></argument>
                 </service>
 
-                <service id="App\Security\Firewall\WsseListener"
-                    public="false"
-                >
+                <service id="App\Security\Firewall\WsseListener">
                     <argument type="service" id="security.token_storage"/>
                     <argument type="service" id="security.authentication.manager"/>
                 </service>
@@ -428,21 +422,27 @@ to service ids that may not exist yet: ``App\Security\Authentication\Provider\Ws
 
     .. code-block:: php
 
-        // config/services.php
+         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Security\Authentication\Provider\WsseProvider;
         use App\Security\Firewall\WsseListener;
         use Symfony\Component\DependencyInjection\Reference;
 
-        $container->register(WsseProvider::class)
-            ->setArgument('$cachePool', new Reference('cache.app'))
-            ->setPublic(false);
+        return function(ContainerConfigurator $configurator) {
+            $services = $configurator->services();
 
-        $container->register(WsseListener::class)
-            ->setArguments([
-                new Reference('security.token_storage'),
-                new Reference('security.authentication.manager'),
-            ])
-            ->setPublic(false);
+            $services->set(WsseProvider::class)
+                ->arg('$cachePool', ref('cache.app'))
+            ;
+
+            $services->set(WsseListener::class)
+                ->args([
+                    ref('security.token_storage'),
+                    ref('security.authentication.manager'),
+                ])
+            ;
+        };
 
 Now that your services are defined, tell your security context about your
 factory in the kernel::

--- a/serializer.rst
+++ b/serializer.rst
@@ -93,7 +93,6 @@ properties and setters (``setXxx()``) to change properties:
         services:
             get_set_method_normalizer:
                 class: Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer
-                public: false
                 tags: [serializer.normalizer]
 
     .. code-block:: xml
@@ -106,7 +105,7 @@ properties and setters (``setXxx()``) to change properties:
                 https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="get_set_method_normalizer" class="Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer" public="false">
+                <service id="get_set_method_normalizer" class="Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer">
                     <tag name="serializer.normalizer"/>
                 </service>
             </services>
@@ -115,12 +114,17 @@ properties and setters (``setXxx()``) to change properties:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 
-        $container->register('get_set_method_normalizer', GetSetMethodNormalizer::class)
-            ->setPublic(false)
-            ->addTag('serializer.normalizer')
-        ;
+        return function(ContainerConfigurator $configurator) {
+            $services = $configurator->services();
+
+            $services->set('get_set_method_normalizer', GetSetMethodNormalizer::class)
+                ->tag('serializer.normalizer')
+            ;
+        };
 
 .. _serializer-using-serialization-groups-annotations:
 

--- a/service_container.rst
+++ b/service_container.rst
@@ -154,9 +154,6 @@ each time you ask for it.
                 _defaults:
                     autowire: true      # Automatically injects dependencies in your services.
                     autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
-                    public: false       # Allows optimizing the container by removing unused services; this also means
-                                        # fetching services directly from the container via $container->get() won't work.
-                                        # The best practice is to be explicit about your dependencies anyway.
 
                 # makes classes in src/ available to be used as services
                 # this creates a service per class whose id is the fully-qualified class name
@@ -177,7 +174,7 @@ each time you ask for it.
 
                 <services>
                     <!-- Default configuration for services in *this* file -->
-                    <defaults autowire="true" autoconfigure="true" public="false"/>
+                    <defaults autowire="true" autoconfigure="true"/>
 
                     <prototype namespace="App\" resource="../src/*" exclude="../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}"/>
                 </services>
@@ -815,8 +812,7 @@ loss, enable the compiler pass in your application.
 Public Versus Private Services
 ------------------------------
 
-Thanks to the ``_defaults`` section in ``services.yaml``, every service defined in
-this file is ``public: false`` by default.
+From Symfony 4.0, every service defined is private by default.
 
 What does this mean? When a service **is** public, you can access it directly
 from the container object, which is accessible from any controller that extends
@@ -956,9 +952,7 @@ them will not cause the container to be rebuilt.
 .. note::
 
     Wait, does this mean that *every* class in ``src/`` is registered as
-    a service? Even model classes? Actually, no. As long as you have
-    ``public: false`` under your ``_defaults`` key (or you can add it under the
-    specific import), all the imported services are *private*. Thanks to this, all
+    a service? Even model classes? Actually, no. As long as you keep your imported services as :ref:`private <container-public>`, all
     classes in ``src/`` that are *not* explicitly used as services are
     automatically removed from the final container. In reality, the import
     means that all classes are "available to be *used* as services" without needing

--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -23,8 +23,7 @@ And in this case, those services do *not* need to be public.
 
 So unless you *specifically* need to access a service directly from the container
 via ``$container->get()``, the best-practice is to make your services *private*.
-In fact, the :ref:`default services.yaml configuration <container-public>` configures
-all services to be private by default.
+In fact, All services  are :ref:`private <container-public>` by default.
 
 You can also control the ``public`` option on a service-by-service basis:
 
@@ -37,7 +36,7 @@ You can also control the ``public`` option on a service-by-service basis:
             # ...
 
             App\Service\Foo:
-                public: false
+                public: true
 
     .. code-block:: xml
 
@@ -48,7 +47,7 @@ You can also control the ``public`` option on a service-by-service basis:
             xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="App\Service\Foo" public="false"/>
+                <service id="App\Service\Foo" public="true"/>
             </services>
         </container>
 
@@ -63,7 +62,7 @@ You can also control the ``public`` option on a service-by-service basis:
             $services = $configurator->services();
 
             $services->set(Foo::class)
-                ->private();
+                ->public();
         };
 
 .. _services-why-private:

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -73,7 +73,6 @@ both services:
             _defaults:
                 autowire: true
                 autoconfigure: true
-                public: false
             # ...
 
             App\Service\TwitterClient:
@@ -92,7 +91,7 @@ both services:
             xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <defaults autowire="true" autoconfigure="true" public="false"/>
+                <defaults autowire="true" autoconfigure="true"/>
                 <!-- ... -->
 
                 <!-- autowire is redundant thanks to defaults, but value is overridable on each service -->

--- a/service_container/import.rst
+++ b/service_container/import.rst
@@ -85,7 +85,6 @@ a relative or absolute path to the imported file:
             _defaults:
                 autowire: true
                 autoconfigure: true
-                public: false
 
             App\:
                 resource: '../src/*'
@@ -105,7 +104,7 @@ a relative or absolute path to the imported file:
             <imports>
                 <import resource="services/mailer.xml"/>
 
-                <defaults autowire="true" autoconfigure="true" public="false"/>
+                <defaults autowire="true" autoconfigure="true"/>
 
                 <prototype namespace="App\" resource="../src/*"
                     exclude="../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}"/>
@@ -126,7 +125,6 @@ a relative or absolute path to the imported file:
                 ->defaults()
                     ->autowire()
                     ->autoconfigure()
-                    ->private()
             ;
 
             $services->load('App\\', '../src/*')

--- a/service_container/parent_services.rst
+++ b/service_container/parent_services.rst
@@ -181,8 +181,8 @@ the child class:
             App\Repository\DoctrineUserRepository:
                 parent: App\Repository\BaseDoctrineRepository
 
-                # overrides the public setting of the parent service
-                public: false
+                # overrides the private setting of the parent service
+                public: true
 
                 # appends the '@app.username_checker' argument to the parent
                 # argument list
@@ -207,10 +207,10 @@ the child class:
             <services>
                 <!-- ... -->
 
-                <!-- overrides the public setting of the parent service -->
+                <!-- overrides the private setting of the parent service -->
                 <service id="App\Repository\DoctrineUserRepository"
                     parent="App\Repository\BaseDoctrineRepository"
-                    public="false"
+                    public="true"
                 >
                     <!-- appends the '@app.username_checker' argument to the parent
                          argument list -->
@@ -248,8 +248,8 @@ the child class:
             $services->set(DoctrineUserRepository::class)
                 ->parent(BaseDoctrineRepository::class)
 
-                // overrides the public setting of the parent service
-                ->private()
+                // overrides the private setting of the parent service
+                ->public()
 
                 // appends the '@app.username_checker' argument to the parent
                 // argument list

--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -254,13 +254,11 @@ the ``decoration_priority`` option. Its value is an integer that defaults to
         Foo: ~
 
         Bar:
-            public: false
             decorates: Foo
             decoration_priority: 5
             arguments: ['@Bar.inner']
 
         Baz:
-            public: false
             decorates: Foo
             decoration_priority: 1
             arguments: ['@Baz.inner']
@@ -277,11 +275,11 @@ the ``decoration_priority`` option. Its value is an integer that defaults to
             <services>
                 <service id="Foo"/>
 
-                <service id="Bar" decorates="Foo" decoration-priority="5" public="false">
+                <service id="Bar" decorates="Foo" decoration-priority="5">
                     <argument type="service" id="Bar.inner"/>
                 </service>
 
-                <service id="Baz" decorates="Foo" decoration-priority="1" public="false">
+                <service id="Baz" decorates="Foo" decoration-priority="1">
                     <argument type="service" id="Baz.inner"/>
                 </service>
             </services>
@@ -298,12 +296,10 @@ the ``decoration_priority`` option. Its value is an integer that defaults to
             $services->set(Foo::class);
 
             $services->set(Bar::class)
-                ->private()
                 ->decorate(Foo::class, null, 5)
                 ->args([ref(Bar::class.'.inner')]);
 
             $services->set(Baz::class)
-                ->private()
                 ->decorate(Foo::class, null, 1)
                 ->args([ref(Baz::class.'.inner')]);
         };

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -16,7 +16,6 @@ example:
         # config/services.yaml
         services:
             App\Twig\AppExtension:
-                public: false
                 tags: ['twig.extension']
 
     .. code-block:: xml
@@ -29,7 +28,7 @@ example:
                 https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="App\Twig\AppExtension" public="false">
+                <service id="App\Twig\AppExtension">
                     <tag name="twig.extension"/>
                 </service>
             </services>
@@ -46,7 +45,6 @@ example:
             $services = $configurator->services();
 
             $services->set(AppExtension::class)
-                ->private()
                 ->tag('twig.extension');
         };
 


### PR DESCRIPTION
From Symfony 4.0, there is no `public: false` in `_defaults` anymore. As I understand it's the default value (`true`) of the property `private` in [Definition class](https://github.com/symfony/symfony/blob/4.0/src/Symfony/Component/DependencyInjection/Definition.php) + the [ResolvePrivatesPass](
https://github.com/symfony/symfony/blob/4.0/src/Symfony/Component/DependencyInjection/Compiler/ResolvePrivatesPass.php) compiler pass that make services as private by default.