### PR TITLE
Workflow: align Example for property access with implementation of Me…

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -160,14 +160,25 @@ like this:
     If you are creating your first workflows, consider using the ``workflow:dump``
     command to :doc:`debug the workflow contents </workflow/dumping-workflows>`.
 
-As configured, the following property is used by the marking store::
+The configured property will be used via it's implemented getter/setter methods by the marking store::
 
     class BlogPost
     {
-        // This property is used by the marking store
-        public $currentPlace;
-        public $title;
-        public $content;
+        // the configured property must be declared
+        private $currentPlace;
+        private $title;
+        private $content;
+
+        // getter/setter methods must exist for property access by the marking store
+        public function getCurrentPlace()
+        {
+            return $this->currentPlace;
+        }
+
+        public function setCurrentPlace($currentPlace, $context = [])
+        {
+            $this->currentPlace = $currentPlace;
+        }
     }
 
 .. note::


### PR DESCRIPTION
The Implementation in Symfony\Component\Workflow\MarkingStore\MethodMarkingStore does not use symfony/property-access (as the former implementations like e.g. SingleStateMarkingStore did) and requires to have getter/setter implemented in your entity. Therefore the example in docs does not work (any longer). I don't know, why the usage of symfony/property-access was dropped, but it seemed to me not accidentally. That's why I decided to send a PR to update docs. But maybe the implementation is "wrong" and should be changed instead. So please check carefully. Thank you.