### PR TITLE
[Messenger] Note about serializer

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1023,6 +1023,13 @@ If you *do* choose to use the Symfony serializer, you can control the context
 on a case-by-case basis via the :class:`Symfony\\Component\\Messenger\\Stamp\\SerializerStamp`
 (see `Envelopes & Stamps`_).
 
+.. tip::
+
+    When sending/receiving messages to/from another application, it could be a good
+    idea to have more control over the serialization process. Using a custom serializer
+    provides that control. See `Symfony Casts' message serializer tutorial`_ for
+    details.
+
 Customizing Handlers
 --------------------
 
@@ -1514,3 +1521,4 @@ Learn more
 .. _`Enqueue's transport`: https://github.com/sroze/messenger-enqueue-transport
 .. _`streams`: https://redis.io/topics/streams-intro
 .. _`Supervisor docs`: http://supervisord.org/
+.. _`Symfony Casts' message serializer tutorial`: https://symfonycasts.com/screencast/messenger/transport-serializer


### PR DESCRIPTION
The issue is that I've multiple times heard people saying: 

> I like Messenger component, but it does not work if you send messages from one app to another. 

First I wanted to solve this issue by adding a new page just saying "YES YOU CAN". 

But for now, I settle with a small note and a link to Symfony Cast explaining this. 

There is also a great over engineered package that I believe everybody should use... but I dont feel link symfony docs is a place to promote a package like this, or is it? https://github.com/Happyr/message-serializer


I think this will fix https://github.com/symfony/symfony/issues/35439