### PR TITLE
composer issue for prefer-lowest has been fixed

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -227,8 +227,6 @@ of Symfony and the latest beta release:
         - if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
 
     install:
-        # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
-        - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
         - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
         - ./vendor/bin/simple-phpunit install
 


### PR DESCRIPTION
The issue https://github.com/composer/composer/issues/5355 has been fixed in composer 1.8 and therefore the workaround is no longer needed.

I have tried on a couple of projects that i don't get errors on travis-ci when removing the instruction.

Once this is in 4.4, it should also be merged to the newer versions.