### PR TITLE
Fix example with iterable

### DIFF
--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -110,9 +110,15 @@ which starts, advances and finishes the progress bar automatically::
 
     $progressBar = new ProgressBar($output);
 
-    // $iterable can be for example an array ([1, 2, 3, ...]) or a generator
-    // $iterable = function () { yield 1; yield 2; ... };
+    // $iterable can be for example an array ([1, 2, 3, ...])
+    $iterable = [1, 2];
     foreach ($progressBar->iterate($iterable) as $value) {
+        // ... do some work
+    }
+    
+    // or a generator
+    function iterable() { yield 1; yield 2; ... };
+    foreach ($progressBar->iterate(iterable()) as $value) {
         // ... do some work
     }
 


### PR DESCRIPTION
The old example throws this error; `PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Symfony\Component\Console\Helper\ProgressBar::iterate() must be iterable, object given`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
