### PR TITLE
[Lock] Default path for FlockStore

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -227,6 +227,10 @@ PHP process is terminated::
     // the argument is the path of the directory where the locks are created
     $store = new FlockStore(sys_get_temp_dir());
 
+.. note::
+
+    If no path is given, ``sys_get_temp_dir`` is used as default value.
+
 .. caution::
 
     Beware that some file systems (such as some types of NFS) do not support


### PR DESCRIPTION
Hi everyone 👋 

As noticed in the source code: 

```php

    /**
     * @param string|null $lockPath the directory to store the lock, defaults to the system's temporary directory
     *
     * @throws LockStorageException If the lock directory doesn’t exist or is not writable
     */
    public function __construct(string $lockPath = null)
    {
        if (null === $lockPath) {
            $lockPath = sys_get_temp_dir();
        }
        if (!is_dir($lockPath) || !is_writable($lockPath)) {
            throw new InvalidArgumentException(sprintf('The directory "%s" is not writable.', $lockPath));
        }

        $this->lockPath = $lockPath;
    }
```

`sys_get_temp_dir` is the default path is null is given in the constructor, could it be a good idea to notice this? 🤔 