### PR TITLE
[Security] Remove mention of removed firewall ListenerInterface

### DIFF
--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -17,9 +17,8 @@ The listener should then store the authenticated token using
     use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
     use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
     use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-    use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 
-    class SomeAuthenticationListener implements ListenerInterface
+    class SomeAuthenticationListener
     {
         /**
          * @var TokenStorageInterface
@@ -38,7 +37,7 @@ The listener should then store the authenticated token using
 
         // ...
 
-        public function handle(RequestEvent $event)
+        public function __invoke(RequestEvent $event)
         {
             $request = $event->getRequest();
 

--- a/components/security/firewall.rst
+++ b/components/security/firewall.rst
@@ -60,7 +60,7 @@ the user::
 
     $requestMatcher = new RequestMatcher('^/secured-area/');
 
-    // instances of Symfony\Component\Security\Http\Firewall\ListenerInterface
+    // array of callables
     $listeners = [...];
 
     $exceptionListener = new ExceptionListener(...);
@@ -108,7 +108,7 @@ Firewall Listeners
 When the firewall gets notified of the ``kernel.request`` event, it asks
 the firewall map if the request matches one of the secured areas. The first
 secured area that matches the request will return a set of corresponding
-firewall listeners (which each implement :class:`Symfony\\Component\\Security\\Http\\Firewall\\ListenerInterface`).
+firewall listeners (which each is a callable).
 These listeners will all be asked to handle the current request. This basically
 means: find out if the current request contains any information by which
 the user might be authenticated (for instance the Basic HTTP authentication


### PR DESCRIPTION
Fixes #13069.

The `Symfony\Component\Security\Http\Firewall\ListenerInterface` has been removed in Symfony 5, yet there are still some references to it in the docs. This PR removes any remaining references to the interface.