### PR TITLE
[Deployment] Update deployment docs with new .env files logic

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -126,21 +126,29 @@ While developing locally, you'll usually store these in ``.env`` and ``.env.loca
 
 1. Create "real" environment variables. How you set environment variables, depends
    on your setup: they can be set at the command line, in your Nginx configuration,
-   or via other methods provided by your hosting service.
+   or via other methods provided by your hosting service;
 
-2. Or, create a ``.env.local`` file like your local development (see note below)
+2. Or, create a ``.env.local`` file like your local development.
 
 There is no significant advantage to either of the two options: use whatever is
 most natural in your hosting environment.
 
-.. note::
+.. tip::
 
-    If you use the ``.env.*`` files on production, you may need to move your
-    ``symfony/dotenv`` dependency from ``require-dev`` to ``require`` in ``composer.json``:
+    You might not want your application to process the ``.env.*`` files on
+    every request. You can generate an optimized ``.env.local.php`` which
+    overrides all other configuration files:
 
     .. code-block:: terminal
 
-        $ composer require symfony/dotenv
+        $ composer dump-env prod
+
+    The generated file will contain all the configuration stored in ``.env``. If you
+    want to rely only on environment variables, generate one without any values using:
+
+    .. code-block:: terminal
+
+        $ composer dump-env prod --empty
 
 C) Install/Update your Vendors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The [changes from last year regarding how the ``.env`` files are loaded](https://symfony.com/doc/current/configuration/dot-env-changes.html) can affect production deployments. Vendors like [Heroku](https://devcenter.heroku.com/articles/deploying-symfony4#environment-variables) give recommendations based on documentation that no longer applies: "It is recommended that you do not use the symfony/dotenv package in production".

The ``symfony/dotenv`` has been moved from ``require-dev`` to ``require``, so the note I removed in this PR no longer applies: https://github.com/symfony/skeleton/pull/122 , https://github.com/symfony/website-skeleton/pull/132 and https://github.com/symfony/demo/commit/7ead1e4a0bc41cc49595028eb9f508513adef413 . Loading ``.env`` files in production will work without any changes in composer.json.

Putting ``symfony/dotenv`` in ``require-dev`` (or not moving it to ``require`` during an upgrade from older versions of Symfony & recipes) can potentially break your app: if the DotEnv class is missing, the [`config/bootstrap.php` file inside the FrameworkBundle's recipe will throw a RuntimeException](https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/config/bootstrap.php#L14) . Also see https://github.com/symfony/recipes/pull/501

The note now contains the right way to handle these files in production, by using ``$ composer dump-env prod`` in case you do not want the ``.env`` files to be processed on every request, also suggesting the ``--empty`` flag if you want to rely exclusively on "real" environment variables .
