### PR TITLE
Update link for (No|Admin)Recipient

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -354,16 +354,16 @@ set the notification content and icon.
 
 Symfony provides three types of recipients:
 
-:class:`Symfony\\Component\\Notifier\\Recipient\\NoRecipient``
+:class:`Symfony\\Component\\Notifier\\Recipient\\NoRecipient`
     This is the default and is useful when there is no need to have
     information about the receiver. For example, the browser channel uses
     the current requests's :ref:`session flashbag <flash-messages>`;
 
-:class:`Symfony\\Component\\Notifier\\Recipient\\Recipient``
+:class:`Symfony\\Component\\Notifier\\Recipient\\Recipient`
     This contains only the email address of the user and can be used for
     messages on the email and browser channel;
 
-:class:`Symfony\\Component\\Notifier\\Recipient\\AdminRecipient``.
+:class:`Symfony\\Component\\Notifier\\Recipient\\AdminRecipient`
     This can contain both email address and phonenumber of the user. This
     recipient can be used for all channels (depending on whether they are
     actually set).


### PR DESCRIPTION
Looks like there is ` to much hence breaking the link.

![image](https://user-images.githubusercontent.com/3902676/74105011-6c0aac00-4b5a-11ea-92b0-b2df8c877a12.png)

https://symfony.com/doc/current/notifier#creating-sending-notifications


<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
