### PR TITLE
Update http_authentication.rst

### DIFF
--- a/testing/http_authentication.rst
+++ b/testing/http_authentication.rst
@@ -111,7 +111,7 @@ needs::
 
         private function logIn()
         {
-            $session = $this->client->getContainer()->get('session');
+            $session = self::$container->get('session');
 
             $firewallName = 'secure_area';
             // if you don't define multiple connected firewalls, the context defaults to the firewall name


### PR DESCRIPTION
The preferred way to get the container in functional tests is `self::$container` (see https://symfony.com/doc/current/testing.html#accessing-the-container).

The issue with `$this->client->getContainer()` is that `Symfony\Bundle\FrameworkBundle\KernelBrowser::getContainer()` can return `null`. This can lead to a NullPointerException when calling `get()` on it.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
