### PR TITLE
Update serializer.rst

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -27,7 +27,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/serializer
+    $ composer require symfony/serializer symfony/property-access
 
 .. include:: /components/require_autoload.rst.inc
 


### PR DESCRIPTION
 The ObjectNormalizer class requires the "PropertyAccess" component. Install "symfony/property-access" to use it.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
