### PR TITLE
Replace deprecated ObjectManager

### DIFF
--- a/doctrine/event_listeners_subscribers.rst
+++ b/doctrine/event_listeners_subscribers.rst
@@ -105,7 +105,7 @@ a ``postPersist()`` method, which will be called when the event is dispatched::
 
     use AppBundle\Entity\Product;
     // for Doctrine < 2.4: use Doctrine\ORM\Event\LifecycleEventArgs;
-    use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+    use Doctrine\Persistence\Event\LifecycleEventArgs;
 
     class SearchIndexer
     {
@@ -151,8 +151,8 @@ interface and have an event method for each event it subscribes to::
     use AppBundle\Entity\Product;
     use Doctrine\Common\EventSubscriber;
     // for Doctrine < 2.4: use Doctrine\ORM\Event\LifecycleEventArgs;
-    use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
     use Doctrine\ORM\Events;
+    use Doctrine\Persistence\Event\LifecycleEventArgs;
 
     class SearchIndexerSubscriber implements EventSubscriber
     {

--- a/doctrine/mapping_model_classes.rst
+++ b/doctrine/mapping_model_classes.rst
@@ -116,8 +116,8 @@ Annotations, XML, Yaml, PHP and StaticPHP. The arguments are:
     instead of the ``SymfonyFileLocator``::
 
         use AppBundle\Model;
-        use Doctrine\Common\Persistence\Mapping\Driver\DefaultFileLocator;
         use Doctrine\ORM\Mapping\Driver\XmlDriver;
+        use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator;
 
         // ...
         private function buildMappingCompilerPass()

--- a/form/data_transformers.rst
+++ b/form/data_transformers.rst
@@ -342,7 +342,6 @@ First, create the custom field type class::
     namespace AppBundle\Form;
 
     use AppBundle\Form\DataTransformer\IssueToNumberTransformer;
-    use Doctrine\Common\Persistence\ObjectManager;
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\Extension\Core\Type\TextType;
     use Symfony\Component\Form\FormBuilderInterface;

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -135,7 +135,7 @@ make sure the ``FormRegistry`` uses the created instance::
     namespace Tests\AppBundle\Form\Type;
 
     use AppBundle\Form\Type\TestedType;
-    use Doctrine\Common\Persistence\ObjectManager;
+    use Doctrine\Persistence\ObjectManager;
     use Symfony\Component\Form\PreloadedExtension;
     use Symfony\Component\Form\Test\TypeTestCase;
     // ...

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -193,7 +193,7 @@ or the short alias name (as shown prior).
 ``em``
 ~~~~~~
 
-**type**: ``string`` | ``Doctrine\Common\Persistence\ObjectManager`` **default**: the default entity manager
+**type**: ``string`` | ``Doctrine\Persistence\ObjectManager`` **default**: the default entity manager
 
 If specified, this entity manager will be used to load the choices
 instead of the ``default`` entity manager.

--- a/service_container/parent_services.rst
+++ b/service_container/parent_services.rst
@@ -12,7 +12,7 @@ you may have multiple repository classes which need the
     // src/AppBundle/Repository/BaseDoctrineRepository.php
     namespace AppBundle\Repository;
 
-    use Doctrine\Common\Persistence\ObjectManager;
+    use Doctrine\Persistence\ObjectManager;
     use Psr\Log\LoggerInterface;
 
     // ...

--- a/testing/database.rst
+++ b/testing/database.rst
@@ -45,7 +45,7 @@ Suppose the class you want to test looks like this::
     namespace AppBundle\Salary;
 
     use AppBundle\Entity\Employee;
-    use Doctrine\Common\Persistence\ObjectManager;
+    use Doctrine\Persistence\ObjectManager;
 
     class SalaryCalculator
     {
@@ -74,8 +74,8 @@ it's easy to pass a mock object within a test::
 
     use AppBundle\Entity\Employee;
     use AppBundle\Salary\SalaryCalculator;
-    use Doctrine\Common\Persistence\ObjectManager;
-    use Doctrine\Common\Persistence\ObjectRepository;
+    use Doctrine\Persistence\ObjectManager;
+    use Doctrine\Persistence\ObjectRepository;
     use PHPUnit\Framework\TestCase;
 
     class SalaryCalculatorTest extends TestCase


### PR DESCRIPTION
```Doctrine\Common\Persistence\ObjectManager``` is deprecated and should be replaced with ```Doctrine\Persistence\ManagerRegistry``` this is supported in symfony/doctrine-bridge now https://github.com/symfony/doctrine-bridge/commit/c94d84f2664f2ea4b049fa0a1c7e68c69fb6ba9e
