### PR TITLE
[HttpClient] Try to make the exception handling more clear

### DIFF
--- a/components/http_client.rst
+++ b/components/http_client.rst
@@ -561,6 +561,13 @@ that network errors can happen when calling e.g. ``getStatusCode()`` too::
 .. note::
 
     Because ``$response->getInfo()`` is non-blocking, it shouldn't throw by design.
+    
+.. note::
+
+    The exceptions are thrown during the response `__destruct()` method. This 
+    means that if you do not store `$client->request(...)` in a variable 
+    (like in the example above), you do not need to call any methods of the 
+    returned responses.
 
 When multiplexing responses, you can deal with errors for individual streams by
 catching ``TransportExceptionInterface`` in the foreach loop::


### PR DESCRIPTION
Not sure that this clarification is worth it, as it is more like the consequence of https://github.com/symfony/symfony-docs/pull/13078
