### PR TITLE
Adjusts description of the csrf_token extension

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -131,7 +131,7 @@ csrf_token
     {{ csrf_token(intention) }}
 
 ``intention``
-    **type**: ``string`` - an arbitrary string used to generate the token value.
+    **type**: ``string`` - an arbitrary string used to identify the token value.
 
 Renders a CSRF token. Use this function if you want :doc:`CSRF protection </security/csrf>`
 in a regular HTML form not managed by the Symfony Form component.


### PR DESCRIPTION
I think using `...used to generate the token...` here leads to misunderstanding. 

The `intention` argument is not used to generate the csrf token. It is used to create a namespace string used to store and identify the token in the storage implementation.
