### PR TITLE
Mention region parameter for Mailgun mailer too

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -76,7 +76,7 @@ The *only* part you need to change is to replace ``KEY`` in the ``MAILER_DSN`` (
 Each provider has different environment variables that the Mailer uses to
 configure the *actual* protocol, address and authentication for delivery. Some
 also have options that can be configured with query parameters at the end of the
-``MAILER_DSN`` - like ``?region=`` for Amazon SES. Some providers support
+``MAILER_DSN`` - like ``?region=`` for Amazon SES or Mailgun. Some providers support
 sending via ``http``, ``api`` or ``smtp``. Symfony chooses the best available
 transport, but you can force to use one:
 


### PR DESCRIPTION
Just got a hard time to get SMTP working with european servers from Mailgun. It was unclear how to configure the EU host (ie. should I change the `@default` host? Should I add another config?). I think `region` parameter deserves at least a small mention in the mailer documentation.

I also proposed to add this parameter by default in mailgun mailer's recipe: https://github.com/symfony/recipes/pull/742