### PR TITLE
[Tests] added a note about installing PHPUnit dependencies

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -22,14 +22,19 @@ wraps the original PHPUnit binary to provide additional features:
 
     $ composer require --dev symfony/phpunit-bridge
 
-Each test - whether it's a unit test or a functional test - is a PHP class
-that should live in the ``tests/`` directory of your application. If you follow
-this rule, then you can run all of your application's tests with the following
-command:
+After the library downloads, try executing PHPUnit by running:
 
 .. code-block:: terminal
 
     $ ./vendor/bin/simple-phpunit
+
+The first time you run this, it will download PHPUnit itself and make its
+classes available in your app.
+
+Each test - whether it's a unit test or a functional test - is a PHP class
+that should live in the ``tests/`` directory of your application. If you follow
+this rule, then you can run all of your application's tests with the same
+command as before.
 
 PHPUnit is configured by the ``phpunit.xml.dist`` file in the root of your
 Symfony application.


### PR DESCRIPTION
When first installing the bridge, one cannot start working by extending the `TestCase` since the bridge has no requirements.
It is not obvious that they are installed the first time we run the test suite, neither that we should run it without tests to get started.
Let's make all that explicit with a short note.