### PR TITLE
Add an opcache preload warning (7.4+)

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -97,6 +97,11 @@ Use the OPcache class preloading
 .. versionadded:: 4.4
 
     The feature that generates the preloading file was introduced in Symfony 4.4.
+    
+.. caution::
+
+    OPcache preloading is a new feature in PHP 7.4, and as of the current version (7.4.3)
+    there are still bugs. This feature may or may not work for your project.
 
 Starting from PHP 7.4, OPcache can compile and load classes at start-up and
 make them available to all requests until the server is restarted, improving


### PR DESCRIPTION
As someone who spent a few hours trying to get preloading working on a large/complex project, I feel like a warning might be helpful to some since the docs currently advertise it as "working out of the box".

Current version is noted as 7.4.3 since that version was tagged 1.5 days ago as of this PR, and I spent time with both 7.4.2 (where I hit the opcache.preload_user bug) and a self-built version of 7.4.3 (where it just segfaulted until I commented specific vendor code, and once it did run it was a lot slower than without preloading since I was forced to use the default vendor and cache folders while on a VM with NFS share to get it working)

Considering the actual release of 7.4.3 should be today, I will test again with those binaries and close this PR if needed.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
