### PR TITLE
Move caution plus reword

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -525,7 +525,7 @@ Troubleshooting
 The ``@group time-sensitive`` and ``@group dns-sensitive`` annotations work
 "by convention" and assume that the namespace of the tested class can be
 obtained just by removing the ``Tests\`` part from the test namespace. I.e.
-that if the your test case fully-qualified class name (FQCN) is
+if your test case's fully-qualified class name (FQCN) is
 ``App\Tests\Watch\DummyWatchTest``, it assumes the tested class namespace
 is ``App\Watch``.
 

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -525,7 +525,7 @@ Troubleshooting
 The ``@group time-sensitive`` and ``@group dns-sensitive`` annotations work
 "by convention" and assume that the namespace of the tested class can be
 obtained just by removing the ``Tests\`` part from the test namespace. I.e.
-if your test case's fully-qualified class name (FQCN) is
+if your test cases fully-qualified class name (FQCN) is
 ``App\Tests\Watch\DummyWatchTest``, it assumes the tested class namespace
 is ``App\Watch``.
 

--- a/security.rst
+++ b/security.rst
@@ -449,12 +449,17 @@ To fix this, add an ``encoders`` key:
 User providers load user information and put it into a :class:`Symfony\\Component\\Security\\Core\\User\\UserInterface`
 implementation. If you :doc:`load users from the database </security/entity_provider>`
 or :doc:`some other source </security/custom_provider>`, you'll
-use your own custom User class. But when you use the "in memory" provider type,
+use your own custom User class. But when you use the ``memory`` provider type,
 it gives you a :class:`Symfony\\Component\\Security\\Core\\User\\User` object.
 
 Whatever your User class is, you need to tell Symfony what algorithm was
 used to encode the passwords. In this case, the passwords are just plaintext,
 but in a second, you'll change this to use ``bcrypt``.
+
+.. caution::
+
+    When using a ``memory`` provider and the :class:`Symfony\\Component\\Security\\Core\\User\\User`,
+    you have to choose an encoding without salt (i.e. ``bcrypt``).
 
 If you refresh now, you'll be logged in! The web debug toolbar even tells
 you who you are and what roles you have:

--- a/security/user_provider.rst
+++ b/security/user_provider.rst
@@ -215,6 +215,11 @@ It's not recommended to use this provider in real applications because of its
 limitations and how difficult it is to manage users. It may be useful in application
 prototypes and for limited applications that don't store users in databases.
 
+.. caution::
+
+    When using a ``memory`` provider, the :class:`Symfony\\Component\\Security\\Core\\User\\User`
+    and not the ``auto`` algorithm, you have to choose an encoding without salt (i.e. ``bcrypt``).
+
 This user provider stores all user information in a configuration file,
 including their passwords. That's why the first step is to configure how these
 users will encode their passwords:


### PR DESCRIPTION
Follows #13188

@HeahDude, while up merging #13188, I noticed, that the documents are quite different and the usage of the `memory` provider isn't located in the `security.rst` file anymore.

For now I removed it completely while merging in `4.4` and upper.

This PR is an attempt to move it to the right place. I also take the context (using `auto` algo) into account.

What do you think?