### PR TITLE
Move caution plus reword

### DIFF
--- a/security/user_provider.rst
+++ b/security/user_provider.rst
@@ -215,6 +215,11 @@ It's not recommended to use this provider in real applications because of its
 limitations and how difficult it is to manage users. It may be useful in application
 prototypes and for limited applications that don't store users in databases.
 
+.. caution::
+
+    When using a ``memory`` provider, the :class:`Symfony\\Component\\Security\\Core\\User\\User`
+    and not the ``auto`` algorithm, you have to choose an encoding without salt (i.e. ``bcrypt``).
+
 This user provider stores all user information in a configuration file,
 including their passwords. That's why the first step is to configure how these
 users will encode their passwords:


### PR DESCRIPTION
Follows #13188

@HeahDude, while up merging #13188, I noticed, that the documents are quite different and the usage of the `memory` provider isn't located in the `security.rst` file anymore.

For now I removed it completely while merging in `4.4` and upper.

This PR is an attempt to move it to the right place. I also take the context (using `auto` algo) into account.

What do you think?