### PR TITLE
remove link to the already deleted propel1 bridge

### DIFF
--- a/form/type_guesser.rst
+++ b/form/type_guesser.rst
@@ -13,8 +13,6 @@ type guessers.
 
     Symfony also provides some form type guessers in the bridges:
 
-    * :class:`Symfony\\Bridge\\Propel1\\Form\\PropelTypeGuesser` provided by
-      the Propel1 bridge;
     * :class:`Symfony\\Bridge\\Doctrine\\Form\\DoctrineOrmTypeGuesser`
       provided by the Doctrine bridge.
 


### PR DESCRIPTION
`Symfony\Bridge\Propel1\Form\PropelTypeGuesser` was removed long time ago. Therefore it should be removed from the docs, too.
