### PR TITLE
Add XML schema location for container configuration

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -1949,7 +1949,9 @@ generate URLs. This context can be configured globally for all commands:
         <!-- config/services.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
         <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <parameters>
                 <parameter key="router.request_context.host">example.org</parameter>
@@ -2062,7 +2064,9 @@ method) or globally with these configuration parameters:
         <!-- config/services.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
         <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <parameters>
                 <parameter key="router.request_context.scheme">https</parameter>


### PR DESCRIPTION
At first I assumed this was omitted to keep the code snippet more concise and easier to comprehend. But then again, the `xsi` namespace already in place would be redundant.

If the intention was indeed to keep things more simple, I would suggest removing the `xsi` namespace entirely.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
