### PR TITLE
[Mailer] Include default_path in twig configuration examples

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -381,6 +381,7 @@ image files as usual. First, to simplify things, define a Twig namespace called
 
     # config/packages/twig.yaml
     twig:
+        default_path: '%kernel.project_dir%/templates' 
         # ...
 
         paths:
@@ -458,6 +459,7 @@ called ``css`` that points to the directory where ``email.css`` lives:
 
     # config/packages/twig.yaml
     twig:
+        default_path: '%kernel.project_dir%/templates' 
         # ...
 
         paths:


### PR DESCRIPTION
Hi there,

I was adding the new Symfony Mailer component to my Symfony app (started from 4.0) and configuring paths was very unclear and confusing to me. My configuration didn't include `twig.default_path` by default.

It may be a good idea to include default_path in the code block so developers don't get confused.

I had to have a look at the SymfonyCasts [tutorial ](https://symfonycasts.com/screencast/mailer/embedded-image#play)"Symfony4 > Symfony Mailer: Love Sending Emails Again > Embedded Images" to understand who to configure twig properly.

_I would definitely understand this DX enhancement should be somewhere else or doesn't suit documentation structure and philosophy. I may miss some points here._