### PR TITLE
[String] Update slugger slug() return value

### DIFF
--- a/components/string.rst
+++ b/components/string.rst
@@ -415,13 +415,13 @@ that only includes safe ASCII characters::
     use Symfony\Component\String\Slugger\AsciiSlugger;
 
     $slugger = new AsciiSlugger();
-    $slug = (string) $slugger->slug('Wôrķšƥáçè ~~sèťtïñğš~~');
+    $slug = $slugger->slug('Wôrķšƥáçè ~~sèťtïñğš~~')->toString();
     // $slug = 'Workspace-settings'
 
 The separator between words is a dash (``-``) by default, but you can define
 another separator as the second argument::
 
-    $slug = (string) $slugger->slug('Wôrķšƥáçè ~~sèťtïñğš~~', '/');
+    $slug = $slugger->slug('Wôrķšƥáçè ~~sèťtïñğš~~', '/')->toString();
     // $slug = 'Workspace/settings'
 
 The slugger transliterates the original string into the Latin script before

--- a/components/string.rst
+++ b/components/string.rst
@@ -415,13 +415,13 @@ that only includes safe ASCII characters::
     use Symfony\Component\String\Slugger\AsciiSlugger;
 
     $slugger = new AsciiSlugger();
-    $slug = $slugger->slug('Wôrķšƥáçè ~~sèťtïñğš~~');
+    $slug = (string) $slugger->slug('Wôrķšƥáçè ~~sèťtïñğš~~');
     // $slug = 'Workspace-settings'
 
 The separator between words is a dash (``-``) by default, but you can define
 another separator as the second argument::
 
-    $slug = $slugger->slug('Wôrķšƥáçè ~~sèťtïñğš~~', '/');
+    $slug = (string) $slugger->slug('Wôrķšƥáçè ~~sèťtïñğš~~', '/');
     // $slug = 'Workspace/settings'
 
 The slugger transliterates the original string into the Latin script before


### PR DESCRIPTION
Hi,

It appears that `slug()` returns an `AbstractUnicodeString` and not a `string`
so `$slug` can not be like documented actually, need to cast as `string` first

**PHP 7.4**

```php

// With $a::setSlug(string $slug): void

// KO
$slug = $slugger->slug('123');
$a->setSlug($slug);

// OK
$slug = (string) $slugger->slug('123');
$a->setSlug($slug);
```

Also see https://symfony.com/blog/new-in-symfony-5-0-string-component#string-slugger