### PR TITLE
[Workflow] Add workflow documentation link to more detailed doc

### DIFF
--- a/components/workflow.rst
+++ b/components/workflow.rst
@@ -101,6 +101,8 @@ When you have configured a ``Registry`` with your workflows, you may use it as f
 Learn more
 ----------
 
+Read more about the usage of the :doc:`Workflow component </workflow>` inside a Symfony application.
+
 .. toctree::
     :maxdepth: 1
     :glob:


### PR DESCRIPTION
Hi

Here is an attempt to better link the Workflow component bare + component with Symfony documentations

FYI the https://symfony.com/doc/master/workflow.html reference a "read more" page on the first paragraph
But as all components pages looks the same, I put this at the bottom of the page not on top

Related to https://github.com/symfony/symfony-docs/issues/9834#issuecomment-569345215

friendly ping @lyrixx 