### PR TITLE
Fixed all permanently redirected and broken URLs

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -10,7 +10,8 @@ You can even ignore them completely and continue using your own best practices
 and methodologies. Symfony is flexible enough to adapt to your needs.
 
 This article assumes that you already have experience developing Symfony
-applications. If you don't, read first the rest of the `Symfony documentation`_.
+applications. If you don't, read first the :doc:`Getting Started </setup>`
+section of the documentation.
 
 .. tip::
 
@@ -440,7 +441,6 @@ That's why it's recommended to use raw URLs in tests instead of generating them
 from routes. Whenever a route changes, tests will break and you'll know that
 you must set up a redirection.
 
-.. _`Symfony documentation`: https://symfony.com/doc
 .. _`Symfony Demo`: https://github.com/symfony/demo
 .. _`download Symfony`: https://symfony.com/download
 .. _`Composer`: https://getcomposer.org/

--- a/bundles/override.rst
+++ b/bundles/override.rst
@@ -180,4 +180,4 @@ For example, to override the translations defined in the
 ``Resources/translations/FOSUserBundle.es.yml`` file of the FOSUserBundle,
 create a ``<your-project>/translations/FOSUserBundle.es.yml`` file.
 
-.. _`the Doctrine documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html#overrides
+.. _`the Doctrine documentation`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/inheritance-mapping.html#overrides

--- a/components/cache.rst
+++ b/components/cache.rst
@@ -201,7 +201,7 @@ Advanced Usage
 
     cache/*
 
-.. _`PSR-6`: http://www.php-fig.org/psr/psr-6/
+.. _`PSR-6`: https://www.php-fig.org/psr/psr-6/
 .. _`Cache Contracts`: https://github.com/symfony/contracts/blob/master/Cache/CacheInterface.php
 .. _`Stampede prevention`: https://en.wikipedia.org/wiki/Cache_stampede
 .. _Probabilistic early expiration: https://en.wikipedia.org/wiki/Cache_stampede#Probabilistic_early_expiration

--- a/components/cache/adapters/memcached_adapter.rst
+++ b/components/cache/adapters/memcached_adapter.rst
@@ -296,8 +296,8 @@ Available Options
 .. _`User Datagram Protocol (UDP)`: https://en.wikipedia.org/wiki/User_Datagram_Protocol
 .. _`no-delay`: https://en.wikipedia.org/wiki/TCP_NODELAY
 .. _`keep-alive`: https://en.wikipedia.org/wiki/Keepalive
-.. _`Memcached PHP extension`: http://php.net/manual/en/book.memcached.php
-.. _`predefined constants`: http://php.net/manual/en/memcached.constants.php
+.. _`Memcached PHP extension`: https://www.php.net/manual/en/book.memcached.php
+.. _`predefined constants`: https://www.php.net/manual/en/memcached.constants.php
 .. _`Memcached server`: https://memcached.org/
-.. _`Memcached`: http://php.net/manual/en/class.memcached.php
+.. _`Memcached`: https://www.php.net/manual/en/class.memcached.php
 .. _`Data Source Name (DSN)`: https://en.wikipedia.org/wiki/Data_source_name

--- a/components/cache/adapters/pdo_doctrine_dbal_adapter.rst
+++ b/components/cache/adapters/pdo_doctrine_dbal_adapter.rst
@@ -7,7 +7,7 @@
 PDO & Doctrine DBAL Cache Adapter
 =================================
 
-This adapter stores the cache items in an SQL database. It requires a `PDO`_,
+This adapter stores the cache items in an SQL database. It requires a :phpclass:`PDO`,
 `Doctrine DBAL Connection`_, or `Data Source Name (DSN)`_ as its first parameter, and
 optionally a namespace, default cache lifetime, and options array as its second,
 third, and forth parameters::
@@ -48,6 +48,5 @@ your code.
     allowing for manual :ref:`pruning of expired cache entries <component-cache-cache-pool-prune>` by
     calling its ``prune()`` method.
 
-.. _`PDO`: http://php.net/manual/en/class.pdo.php
 .. _`Doctrine DBAL Connection`: https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Connection.php
 .. _`Data Source Name (DSN)`: https://en.wikipedia.org/wiki/Data_source_name

--- a/components/cache/adapters/php_files_adapter.rst
+++ b/components/cache/adapters/php_files_adapter.rst
@@ -67,4 +67,4 @@ directory path as constructor arguments::
     allowing for manual :ref:`pruning of expired cache entries <component-cache-cache-pool-prune>` by
     calling its ``prune()`` method.
 
-.. _`OPcache`: http://php.net/manual/en/book.opcache.php
+.. _`OPcache`: https://www.php.net/manual/en/book.opcache.php

--- a/components/cache/adapters/proxy_adapter.rst
+++ b/components/cache/adapters/proxy_adapter.rst
@@ -36,5 +36,5 @@ and optionally a namespace and default cache lifetime as its second and third pa
         $defaultLifetime = 0
     );
 
-.. _`PSR-6`: http://www.php-fig.org/psr/psr-6/
-.. _`cache item pool interface`: http://www.php-fig.org/psr/psr-6/#cacheitempoolinterface
+.. _`PSR-6`: https://www.php-fig.org/psr/psr-6/
+.. _`cache item pool interface`: https://www.php-fig.org/psr/psr-6/#cacheitempoolinterface

--- a/components/cache/psr6_psr16_adapters.rst
+++ b/components/cache/psr6_psr16_adapters.rst
@@ -91,4 +91,4 @@ this use-case::
 
     The ``Psr16Cache`` class was introduced in Symfony 4.3.
 
-.. _`PSR-16`: http://www.php-fig.org/psr/psr-16/
+.. _`PSR-16`: https://www.php-fig.org/psr/psr-16/

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -318,4 +318,4 @@ Learn More
     /components/dependency_injection/*
     /service_container/*
 
-.. _`PSR-11`: http://www.php-fig.org/psr/psr-11/
+.. _`PSR-11`: https://www.php-fig.org/psr/psr-11/

--- a/components/dotenv.rst
+++ b/components/dotenv.rst
@@ -170,4 +170,4 @@ Embed commands via ``$()`` (not supported on Windows):
 
     Note that using ``$()`` might not work depending on your shell.
 
-.. _twelve-factor applications: http://www.12factor.net/
+.. _twelve-factor applications: https://12factor.net/

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -531,5 +531,5 @@ Learn More
 
 .. _Mediator: https://en.wikipedia.org/wiki/Mediator_pattern
 .. _Observer: https://en.wikipedia.org/wiki/Observer_pattern
-.. _Closures: https://php.net/manual/en/functions.anonymous.php
-.. _PHP callable: https://php.net/manual/en/language.pseudo-types.php#language.types.callback
+.. _Closures: https://www.php.net/manual/en/functions.anonymous.php
+.. _PHP callable: https://www.php.net/manual/en/language.pseudo-types.php#language.types.callback

--- a/components/finder.rst
+++ b/components/finder.rst
@@ -407,7 +407,7 @@ The contents of returned files can be read with
 .. _`fluent interface`: https://en.wikipedia.org/wiki/Fluent_interface
 .. _`symbolic links`: https://en.wikipedia.org/wiki/Symbolic_link
 .. _`Version Control Systems`: https://en.wikipedia.org/wiki/Version_control
-.. _`PHP wrapper for URL-style protocols`: https://php.net/manual/en/wrappers.php
-.. _`PHP streams`: https://php.net/streams
+.. _`PHP wrapper for URL-style protocols`: https://www.php.net/manual/en/wrappers.php
+.. _`PHP streams`: https://www.php.net/streams
 .. _`IEC standard`: https://physics.nist.gov/cuu/Units/binary.html
 .. _`natural sort order`: https://en.wikipedia.org/wiki/Natural_sort_order

--- a/components/http_client.rst
+++ b/components/http_client.rst
@@ -1032,7 +1032,7 @@ However, using ``MockResponse`` allows simulating chunked responses and timeouts
 
     $mockResponse = new MockResponse($body());
 
-.. _`cURL PHP extension`: https://php.net/curl
+.. _`cURL PHP extension`: https://www.php.net/curl
 .. _`PSR-17`: https://www.php-fig.org/psr/psr-17/
 .. _`PSR-18`: https://www.php-fig.org/psr/psr-18/
 .. _`HTTPlug`: https://github.com/php-http/httplug/#readme

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -725,5 +725,5 @@ Learn More
 
 .. _nginx: https://www.nginx.com/resources/wiki/start/topics/examples/xsendfile/
 .. _Apache: https://tn123.org/mod_xsendfile/
-.. _`JSON Hijacking`: http://haacked.com/archive/2009/06/25/json-hijacking.aspx
+.. _`JSON Hijacking`: https://haacked.com/archive/2009/06/25/json-hijacking.aspx/
 .. _OWASP guidelines: https://cheatsheetseries.owasp.org/cheatsheets/AJAX_Security_Cheat_Sheet.html#always-return-json-with-an-object-on-the-outside

--- a/components/http_foundation/session_configuration.rst
+++ b/components/http_foundation/session_configuration.rst
@@ -29,7 +29,7 @@ All native save handlers are internal to PHP and as such, have no public facing 
 They must be configured by ``php.ini`` directives, usually ``session.save_path`` and
 potentially other driver specific directives. Specific details can be found in
 the docblock of the ``setOptions()`` method of each class. For instance, the one
-provided by the Memcached extension can be found on `php.net/memcached.setoption`_
+provided by the Memcached extension can be found on :phpmethod:`php.net <Memcached::setOption>`.
 
 While native save handlers can be activated by directly using
 ``ini_set('session.save_handler', $name);``, Symfony provides a convenient way to
@@ -286,6 +286,5 @@ particular cookie by reading the ``getLifetime()`` method::
 The expiry time of the cookie can be determined by adding the created
 timestamp and the lifetime.
 
-.. _`php.net/session.customhandler`: https://php.net/session.customhandler
-.. _`php.net/session.configuration`: https://php.net/session.configuration
-.. _`php.net/memcached.setoption`: https://php.net/memcached.setoption
+.. _`php.net/session.customhandler`: https://www.php.net/session.customhandler
+.. _`php.net/session.configuration`: https://www.php.net/session.configuration

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -777,11 +777,11 @@ Learn more
 
    /reference/events
 
-.. _reflection: https://php.net/manual/en/book.reflection.php
+.. _reflection: https://www.php.net/manual/en/book.reflection.php
 .. _FOSRestBundle: https://github.com/friendsofsymfony/FOSRestBundle
-.. _`PHP FPM`: https://php.net/manual/en/install.fpm.php
+.. _`PHP FPM`: https://www.php.net/manual/en/install.fpm.php
 .. _`SensioFrameworkExtraBundle`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html
 .. _`@ParamConverter`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
 .. _`@Template`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/view.html
 .. _`EmailSenderListener`: https://github.com/symfony/swiftmailer-bundle/blob/master/EventListener/EmailSenderListener.php
-.. _variadic: http://php.net/manual/en/functions.arguments.php
+.. _variadic: https://www.php.net/manual/en/functions.arguments.php#functions.variable-arg-list

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -406,8 +406,8 @@ Learn more
     /reference/forms/types/locale
     /reference/forms/types/timezone
 
-.. _intl extension: https://php.net/manual/en/book.intl.php
-.. _install the intl extension: https://php.net/manual/en/intl.setup.php
+.. _intl extension: https://www.php.net/manual/en/book.intl.php
+.. _install the intl extension: https://www.php.net/manual/en/intl.setup.php
 .. _ICU library: http://site.icu-project.org/
 .. _`Unicode ISO 15924 Registry`: https://www.unicode.org/iso15924/iso15924-codes.html
 .. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2

--- a/components/lock.rst
+++ b/components/lock.rst
@@ -685,8 +685,8 @@ are still running.
 
 .. _`ACID`: https://en.wikipedia.org/wiki/ACID
 .. _`locks`: https://en.wikipedia.org/wiki/Lock_(computer_science)
-.. _`PHP semaphore functions`: https://php.net/manual/en/book.sem.php
-.. _`PDO`: https://php.net/pdo
+.. _`PHP semaphore functions`: https://www.php.net/manual/en/book.sem.php
+.. _`PDO`: https://www.php.net/pdo
 .. _`Doctrine DBAL Connection`: https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Connection.php
 .. _`Data Source Name (DSN)`: https://en.wikipedia.org/wiki/Data_source_name
 .. _`ZooKeeper`: https://zookeeper.apache.org/

--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -124,6 +124,8 @@ that will do the required processing for your message::
         }
     }
 
+.. _messenger-envelopes:
+
 Adding Metadata to Messages (Envelopes)
 ---------------------------------------
 

--- a/components/mime.rst
+++ b/components/mime.rst
@@ -302,4 +302,4 @@ You can register your own MIME type guesser by creating a class that implements
 
 .. _`MIME`: https://en.wikipedia.org/wiki/MIME
 .. _`MIME types`: https://en.wikipedia.org/wiki/Media_type
-.. _`fileinfo extension`: https://php.net/fileinfo
+.. _`fileinfo extension`: https://www.php.net/fileinfo

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -223,9 +223,9 @@ message contains the ``"foobar"`` string.
 Making Tests Fail
 ~~~~~~~~~~~~~~~~~
 
-By default, any non-legacy-tagged or any non-`@-silenced`_ deprecation
-notices will make tests fail. Alternatively, you can configure an
-arbitrary threshold by setting ``SYMFONY_DEPRECATIONS_HELPER`` to
+By default, any non-legacy-tagged or any non-`@-silenced <@-silencing operator>`_
+deprecation notices will make tests fail. Alternatively, you can configure
+an arbitrary threshold by setting ``SYMFONY_DEPRECATIONS_HELPER`` to
 ``max[total]=320`` for instance. It will make the tests fails only if a
 higher number of deprecation notices is reached (``0`` is the default
 value).
@@ -971,11 +971,10 @@ not find the SUT:
 .. _`PHPUnit`: https://phpunit.de
 .. _`PHPUnit event listener`: https://phpunit.de/manual/current/en/extending-phpunit.html#extending-phpunit.PHPUnit_Framework_TestListener
 .. _`PHPUnit's assertStringMatchesFormat()`: https://phpunit.de/manual/current/en/appendixes.assertions.html#appendixes.assertions.assertStringMatchesFormat
-.. _`PHP error handler`: https://php.net/manual/en/book.errorfunc.php
+.. _`PHP error handler`: https://www.php.net/manual/en/book.errorfunc.php
 .. _`environment variable`: https://phpunit.de/manual/current/en/appendixes.configuration.html#appendixes.configuration.php-ini-constants-variables
-.. _`@-silencing operator`: https://php.net/manual/en/language.operators.errorcontrol.php
-.. _`@-silenced`: https://php.net/manual/en/language.operators.errorcontrol.php
+.. _`@-silencing operator`: https://www.php.net/manual/en/language.operators.errorcontrol.php
 .. _`Travis CI`: https://travis-ci.org/
 .. _`test listener`: https://phpunit.de/manual/current/en/appendixes.configuration.html#appendixes.configuration.test-listeners
 .. _`@covers`: https://phpunit.de/manual/current/en/appendixes.annotations.html#appendixes.annotations.covers
-.. _`PHP namespace resolutions rules`: https://php.net/manual/en/language.namespaces.rules.php
+.. _`PHP namespace resolutions rules`: https://www.php.net/manual/en/language.namespaces.rules.php

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1507,7 +1507,7 @@ Learn more
 .. _RFC3339: https://tools.ietf.org/html/rfc3339#section-5.8
 .. _JSON: http://www.json.org/
 .. _XML: https://www.w3.org/XML/
-.. _YAML: http://yaml.org/
+.. _YAML: https://yaml.org/
 .. _CSV: https://tools.ietf.org/html/rfc4180
 .. _`RFC 7807`: https://tools.ietf.org/html/rfc7807
 .. _`Value Objects`: https://en.wikipedia.org/wiki/Value_object

--- a/components/validator.rst
+++ b/components/validator.rst
@@ -88,4 +88,4 @@ Learn More
     /validation
     /validation/*
 
-.. _`JSR-303 Bean Validation specification`: http://jcp.org/en/jsr/detail?id=303
+.. _`JSR-303 Bean Validation specification`: https://jcp.org/en/jsr/detail?id=303

--- a/components/var_exporter.rst
+++ b/components/var_exporter.rst
@@ -128,5 +128,5 @@ created by using the special ``"\0"`` property name to define their internal val
         "\0" => [$inputArray]
     ]);
 
-.. _`OPcache`: https://php.net/opcache
+.. _`OPcache`: https://www.php.net/opcache
 .. _`PSR-2`: https://www.php-fig.org/psr/psr-2/

--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -459,6 +459,6 @@ Learn More
 
     yaml/*
 
-.. _`YAML`: http://yaml.org/
-.. _`YAML 1.2 version specification`: http://yaml.org/spec/1.2/spec.html
-.. _`ISO-8601`: http://www.iso.org/iso/iso8601
+.. _`YAML`: https://yaml.org/
+.. _`YAML 1.2 version specification`: https://yaml.org/spec/1.2/spec.html
+.. _`ISO-8601`: https://www.iso.org/iso-8601-date-and-time-format.html

--- a/components/yaml/yaml_format.rst
+++ b/components/yaml/yaml_format.rst
@@ -333,6 +333,6 @@ The following YAML features are not supported by the Symfony Yaml component:
 * Using sequence-like syntax for mapping elements (example: ``{foo, bar}``; use
   ``{foo: ~, bar: ~}`` instead).
 
-.. _`ISO-8601`: http://www.iso.org/iso/iso8601
-.. _`YAML website`: http://yaml.org/
-.. _`YAML specification`: http://www.yaml.org/spec/1.2/spec.html
+.. _`ISO-8601`: https://www.iso.org/iso-8601-date-and-time-format.html
+.. _`YAML website`: https://yaml.org/
+.. _`YAML specification`: https://www.yaml.org/spec/1.2/spec.html

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -80,9 +80,7 @@ That's it! To test it, start the :doc:`Symfony Local Web Server
 
     $ symfony server:start
 
-Then see the JSON response in your browser:
-
-    http://localhost:8000/random/10
+Then see the JSON response in your browser: http://localhost:8000/random/10
 
 The Methods of a "Micro" Kernel
 -------------------------------
@@ -332,6 +330,4 @@ As before you can use the :doc:`Symfony Local Web Server
     cd public/
     $ symfony server:start
 
-Then visit the page in your browser:
-
-    http://localhost:8000/random/10
+Then visit the page in your browser: http://localhost:8000/random/10

--- a/contributing/code/conventions.rst
+++ b/contributing/code/conventions.rst
@@ -125,8 +125,6 @@ notices. Silencing swaps this behavior and allows users to opt-in when they are
 ready to cope with them (by adding a custom error handler like the one used by
 the Web Debug Toolbar or by the PHPUnit bridge).
 
-.. _`@-silencing operator`: https://php.net/manual/en/language.operators.errorcontrol.php
-
 When deprecating a whole class the ``trigger_error()`` call should be placed
 between the namespace and the use declarations, like in this example from
 `ServiceRouterLoader`_::
@@ -184,3 +182,5 @@ of the impacted component::
     * Removed the `Deprecated` class, use `Replacement` instead.
 
 This task is mandatory and must be done in the same pull request.
+
+.. _`@-silencing operator`: https://www.php.net/manual/en/language.operators.errorcontrol.php

--- a/contributing/code/pull_requests.rst
+++ b/contributing/code/pull_requests.rst
@@ -415,7 +415,7 @@ before merging.
 
 .. _ProGit: https://git-scm.com/book
 .. _GitHub: https://github.com/join
-.. _`GitHub's documentation`: https://help.github.com/articles/ignoring-files
+.. _`GitHub's documentation`: https://help.github.com/github/using-git/ignoring-files
 .. _Symfony repository: https://github.com/symfony/symfony
 .. _`documentation repository`: https://github.com/symfony/symfony-docs
 .. _`fabbot`: https://fabbot.io
@@ -424,4 +424,4 @@ before merging.
 .. _`searching on GitHub`: https://github.com/symfony/symfony/issues?q=+is%3Aopen+
 .. _`Symfony Slack`: https://symfony.com/slack-invite
 .. _`Travis-CI`: https://travis-ci.org/symfony/symfony
-.. _`draft status`: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
+.. _`draft status`: https://help.github.com/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -281,7 +281,7 @@ License
 .. _`PSR-1`: https://www.php-fig.org/psr/psr-1/
 .. _`PSR-2`: https://www.php-fig.org/psr/psr-2/
 .. _`PSR-4`: https://www.php-fig.org/psr/psr-4/
-.. _`identical comparison`: https://php.net/manual/en/language.operators.comparison.php
+.. _`identical comparison`: https://www.php.net/manual/en/language.operators.comparison.php
 .. _`Yoda conditions`: https://en.wikipedia.org/wiki/Yoda_conditions
 .. _`camelCase`: https://en.wikipedia.org/wiki/Camel_case
 .. _`UpperCamelCase`: https://en.wikipedia.org/wiki/Camel_case

--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -55,7 +55,7 @@ what's going on and if the tests are broken because of the new code.
     to see colored test results.
 
 .. _`install Composer`: https://getcomposer.org/download/
-.. _Cmder: http://cmder.net/
+.. _Cmder: https://cmder.net/
 .. _ConEmu: https://conemu.github.io/
 .. _ANSICON: https://github.com/adoxa/ansicon/releases
 .. _Mintty: https://mintty.github.io/

--- a/contributing/code_of_conduct/code_of_conduct.rst
+++ b/contributing/code_of_conduct/code_of_conduct.rst
@@ -77,7 +77,7 @@ Attribution
 -----------
 
 This Code of Conduct is adapted from the `Contributor Covenant`_, version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct/
 
 Related Documents
 -----------------

--- a/contributing/community/releases.rst
+++ b/contributing/community/releases.rst
@@ -132,6 +132,6 @@ period to upgrade. Companies wanting more stability use the LTS versions: a new
 version is published every two years and there is a year to upgrade.
 
 .. _`semantic versioning`: https://semver.org/
-.. _`Subscribe to Symfony Roadmap notifications`: https://symfony.com/account
-.. _`Symfony Roadmap`: https://symfony.com/roadmap#checker
+.. _`Subscribe to Symfony Roadmap notifications`: https://symfony.com/account/notifications
+.. _`Symfony Roadmap`: https://symfony.com/releases
 .. _`professional Symfony support`: https://sensiolabs.com/

--- a/contributing/community/reviews.rst
+++ b/contributing/community/reviews.rst
@@ -213,9 +213,9 @@ Pick a pull request from the `PRs in need of review`_ and follow these steps:
 .. _Symfony issue tracker: https://github.com/symfony/symfony/issues
 .. _`Symfony skeleton`: https://github.com/symfony/skeleton
 .. _`Symfony website skeleton`: https://github.com/symfony/website-skeleton
-.. _create a GitHub account: https://help.github.com/articles/signing-up-for-a-new-github-account/
+.. _create a GitHub account: https://help.github.com/github/getting-started-with-github/signing-up-for-a-new-github-account
 .. _bug reports in need of review: https://github.com/symfony/symfony/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Bug%22+label%3A%22Status%3A+Needs+Review%22+
-.. _PRs in need of review: https://github.com/symfony/symfony/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+label%3A%22Status%3A+Needs+Review%22+
-.. _Symfony Roadmap: https://symfony.com/roadmap
+.. _PRs in need of review: https://github.com/symfony/symfony/pulls?q=is%3Aopen+is%3Apr+label%3A%22Status%3A+Needs+Review%22
+.. _Symfony Roadmap: https://symfony.com/releases
 .. _Carson Bot: https://github.com/carsonbot/carsonbot
 .. _`Needs Review`: https://github.com/symfony/symfony/labels/Status%3A%20Needs%20Review

--- a/contributing/documentation/format.rst
+++ b/contributing/documentation/format.rst
@@ -207,10 +207,10 @@ versions that have a lower major version will be removed. For example, if
 Symfony 5.0 were released today, 4.0 to 4.4 ``versionadded`` and ``deprecated``
 tags would be removed from the new ``5.0`` branch.
 
-.. _reStructuredText: http://docutils.sourceforge.net/rst.html
+.. _reStructuredText: https://docutils.sourceforge.net/rst.html
 .. _Sphinx: https://www.sphinx-doc.org/
 .. _`Symfony documentation`: https://github.com/symfony/symfony-docs
 .. _`reStructuredText Primer`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
-.. _`reStructuredText Reference`: http://docutils.sourceforge.net/docs/user/rst/quickref.html
+.. _`reStructuredText Reference`: https://docutils.sourceforge.io/docs/user/rst/quickref.html
 .. _`Sphinx Markup Constructs`: https://www.sphinx-doc.org/en/1.7/markup/index.html
-.. _`supported languages`: http://pygments.org/languages/
+.. _`supported languages`: https://pygments.org/languages/

--- a/contributing/documentation/license.rst
+++ b/contributing/documentation/license.rst
@@ -54,6 +54,6 @@ Other Symfony Licenses
 Check out the :doc:`license of the Symfony code </contributing/code/license>`
 and other `Symfony licenses and trademarks`_.
 
-.. _`CC BY-SA 3.0`: http://creativecommons.org/licenses/by-sa/3.0/
-.. _Legal Code (the full license): http://creativecommons.org/licenses/by-sa/3.0/legalcode
+.. _`CC BY-SA 3.0`: https://creativecommons.org/licenses/by-sa/3.0/
+.. _Legal Code (the full license): https://creativecommons.org/licenses/by-sa/3.0/legalcode
 .. _`Symfony licenses and trademarks`: https://symfony.com/license

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -333,14 +333,14 @@ your proposal after you put all that hard work into making the changes. We
 definitely don't want you to waste your time!
 
 .. _`github.com/symfony/symfony-docs`: https://github.com/symfony/symfony-docs
-.. _`reStructuredText`: http://docutils.sourceforge.net/rst.html
+.. _`reStructuredText`: https://docutils.sourceforge.io/rst.html
 .. _`GitHub`: https://github.com/
-.. _`fork the repository`: https://help.github.com/articles/fork-a-repo
+.. _`fork the repository`: https://help.github.com/github/getting-started-with-github/fork-a-repo
 .. _`Symfony Documentation Contributors`: https://symfony.com/contributors/doc
 .. _`SymfonyConnect`: https://connect.symfony.com/
 .. _`Symfony Documentation Badge`: https://connect.symfony.com/badge/36/symfony-documentation-contributor
 .. _`SymfonyCloud`: https://symfony.com/cloud
-.. _`roadmap`: https://symfony.com/roadmap
+.. _`roadmap`: https://symfony.com/releases
 .. _`pip`: https://pip.pypa.io/en/stable/
 .. _`pip installation`: https://pip.pypa.io/en/stable/installing/
 .. _`Sphinx`: http://sphinx-doc.org/

--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -190,11 +190,11 @@ In addition, documentation follows these rules:
   * simply
   * trivial
 
-.. _`the Sphinx documentation`: http://sphinx-doc.org/rest.html#source-code
+.. _`the Sphinx documentation`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
 .. _`Twig Coding Standards`: https://twig.symfony.com/doc/2.x/coding_standards.html
-.. _`reserved by the IANA`: http://tools.ietf.org/html/rfc2606#section-3
+.. _`reserved by the IANA`: https://tools.ietf.org/html/rfc2606#section-3
 .. _`American English`: https://en.wikipedia.org/wiki/American_English
-.. _`American English Oxford Dictionary`: http://en.oxforddictionaries.com/definition/american_english/
+.. _`American English Oxford Dictionary`: https://www.lexico.com/definition/american_english
 .. _`headings and titles`: https://en.wikipedia.org/wiki/Letter_case#Headings_and_publication_titles
 .. _`Serial (Oxford) Commas`: https://en.wikipedia.org/wiki/Serial_comma
 .. _`nosism`: https://en.wikipedia.org/wiki/Nosism

--- a/controller.rst
+++ b/controller.rst
@@ -76,9 +76,7 @@ In order to *view* the result of this controller, you need to map a URL to it vi
 a route. This was done above with the ``@Route("/lucky/number/{max}")``
 :ref:`route annotation <annotation-routes>`.
 
-To see your page, go to this URL in your browser:
-
-    http://localhost:8000/lucky/number/100
+To see your page, go to this URL in your browser: http://localhost:8000/lucky/number/100
 
 For more information on routing, see :doc:`/routing`.
 
@@ -677,4 +675,4 @@ Learn more about Controllers
     controller/*
 
 .. _`Symfony Maker`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
-.. _`unvalidated redirects security vulnerability`: https://www.owasp.org/index.php/Open_redirect
+.. _`unvalidated redirects security vulnerability`: https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html

--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -263,7 +263,7 @@ sub-requests.
     resolver and will use the default value if no value was already resolved.
 
 .. _`@ParamConverter`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
-.. _`yield`: http://php.net/manual/en/language.generators.syntax.php
+.. _`yield`: https://www.php.net/manual/en/language.generators.syntax.php
 .. _`SecurityBundle`: https://github.com/symfony/security-bundle
 .. _`PSR-7`: https://www.php-fig.org/psr/psr-7/
 .. _`SensioFrameworkExtraBundle`: https://github.com/sensiolabs/SensioFrameworkExtraBundle

--- a/controller/soap_web_service.rst
+++ b/controller/soap_web_service.rst
@@ -14,7 +14,7 @@ create one from scratch or use a 3rd party generator.
 .. note::
 
     There are several SOAP server implementations available for use with
-    PHP. `Zend SOAP`_ and `NuSOAP`_ are two examples. Although the PHP SOAP
+    PHP. `Laminas SOAP`_ and `NuSOAP`_ are two examples. Although the PHP SOAP
     extension is used in these examples, the general idea should still
     be applicable to other implementations.
 
@@ -165,7 +165,7 @@ An example WSDL is below.
         </service>
     </definitions>
 
-.. _`PHP SOAP`: https://php.net/manual/en/book.soap.php
-.. _`NuSOAP`: http://sourceforge.net/projects/nusoap
-.. _`output buffering`: https://php.net/manual/en/book.outcontrol.php
-.. _`Zend SOAP`: http://framework.zend.com/manual/current/en/modules/zend.soap.server.html
+.. _`PHP SOAP`: https://www.php.net/manual/en/book.soap.php
+.. _`NuSOAP`: https://sourceforge.net/projects/nusoap
+.. _`output buffering`: https://www.php.net/manual/en/book.outcontrol.php
+.. _`Laminas SOAP`: https://docs.laminas.dev/laminas-soap/server/

--- a/create_framework/http_foundation.rst
+++ b/create_framework/http_foundation.rst
@@ -292,10 +292,10 @@ and `ezPublish 5`_,  and `more`_).
 .. _`audited`: https://symfony.com/blog/symfony2-security-audit
 .. _`applications using it`: https://symfony.com/components/HttpFoundation
 .. _`Symfony`: https://symfony.com/
-.. _`Drupal 8`: https://drupal.org/
+.. _`Drupal 8`: https://www.drupal.org/
 .. _`phpBB 3`: https://www.phpbb.com/
 .. _`ezPublish 5`: https://ez.no/
 .. _`Laravel`: https://laravel.com/
-.. _`autoloaded`: https://php.net/autoload
+.. _`autoloaded`: https://www.php.net/autoload
 .. _`PSR-4`: https://www.php-fig.org/psr/psr-4/
 .. _`more`: https://symfony.com/components/HttpFoundation

--- a/create_framework/http_kernel_controller_resolver.rst
+++ b/create_framework/http_kernel_controller_resolver.rst
@@ -202,4 +202,4 @@ Let's conclude with the new version of our framework::
 Think about it once more: our framework is more robust and more flexible than
 ever and it still has less than 50 lines of code.
 
-.. _`reflection`: https://php.net/reflection
+.. _`reflection`: https://www.php.net/reflection

--- a/create_framework/http_kernel_httpkernelinterface.rst
+++ b/create_framework/http_kernel_httpkernelinterface.rst
@@ -110,7 +110,7 @@ content and check that the number only changes every 10 seconds::
 Using HTTP cache headers to manage your application cache is very powerful and
 allows you to tune finely your caching strategy as you can use both the
 expiration and the validation models of the HTTP specification. If you are not
-comfortable with these concepts, read the `HTTP caching`_ chapter of the
+comfortable with these concepts, read the :doc:`HTTP caching </http_cache>` chapter of the
 Symfony documentation.
 
 The Response class contains methods that let you configure the HTTP cache. One
@@ -206,6 +206,5 @@ With the addition of a single interface, our framework can now benefit from
 the many features built into the HttpKernel component; HTTP caching being just
 one of them but an important one as it can make your applications fly!
 
-.. _`HTTP caching`: https://symfony.com/doc/current/http_cache.html
 .. _`ESI`: https://en.wikipedia.org/wiki/Edge_Side_Includes
-.. _`Varnish`: https://www.varnish-cache.org/
+.. _`Varnish`: https://varnish-cache.org/

--- a/create_framework/introduction.rst
+++ b/create_framework/introduction.rst
@@ -113,5 +113,5 @@ In the :doc:`next chapter </create_framework/http_foundation>`, we are going to
 introduce the HttpFoundation Component and see what it brings us.
 
 .. _`Symfony`: https://symfony.com/
-.. _`Composer`: http://packagist.org/about-composer
+.. _`Composer`: https//getcomposer.org/
 .. _`download and install Composer`: https://getcomposer.org/download/

--- a/create_framework/templating.rst
+++ b/create_framework/templating.rst
@@ -177,5 +177,5 @@ As always, you can decide to stop here and use the framework as is; it's
 probably all you need to create simple websites like those fancy one-page
 `websites`_ and hopefully a few others.
 
-.. _`callbacks`: https://php.net/callback#language.types.callback
+.. _`callbacks`: https://www.php.net/callback#language.types.callback
 .. _`websites`: https://kottke.org/08/02/single-serving-sites

--- a/deployment.rst
+++ b/deployment.rst
@@ -237,21 +237,21 @@ Learn More
     deployment/proxies
 
 .. _`Capifony`: https://github.com/everzet/capifony
-.. _`Capistrano`: http://capistranorb.com/
+.. _`Capistrano`: https://capistranorb.com/
 .. _`sf2debpkg`: https://github.com/liip/sf2debpkg
 .. _`Fabric`: http://www.fabfile.org/
 .. _`Ansistrano`: https://ansistrano.com/
 .. _`Magallanes`: https://github.com/andres-montanez/Magallanes
-.. _`Ant`: http://blog.sznapka.pl/deploying-symfony2-applications-with-ant
+.. _`Ant`: https://blog.sznapka.pl/deploying-symfony2-applications-with-ant/
 .. _`Memcached`: http://memcached.org/
-.. _`Redis`: http://redis.io/
+.. _`Redis`: https://redis.io/
 .. _`Symfony plugin`: https://github.com/capistrano/symfony/
-.. _`Deployer`: http://deployer.org/
+.. _`Deployer`: https://deployer.org/
 .. _`Git Tagging`: https://git-scm.com/book/en/v2/Git-Basics-Tagging
 .. _`Heroku`: https://devcenter.heroku.com/articles/deploying-symfony4
 .. _`Platform.sh`: https://docs.platform.sh/frameworks/symfony.html
 .. _`Azure`: https://azure.microsoft.com/en-us/develop/php/
-.. _`fortrabbit`: https://help.fortrabbit.com/install-symfony
+.. _`fortrabbit`: https://help.fortrabbit.com/install-symfony-4-uni
 .. _`EasyDeployBundle`: https://github.com/EasyCorp/easy-deploy-bundle
 .. _`Clever Cloud`: https://www.clever-cloud.com/doc/php/tutorial-symfony/
 .. _`Symfony Cloud`: https://symfony.com/doc/master/cloud/intro.html

--- a/deployment/proxies.rst
+++ b/deployment/proxies.rst
@@ -115,6 +115,6 @@ In this case, you'll need to set the header ``X-Forwarded-Proto`` with the value
     // ...
     $response = $kernel->handle($request);
 
-.. _`security groups`: http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-groups.html
+.. _`security groups`: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-groups.html
 .. _`CloudFront`: https://en.wikipedia.org/wiki/Amazon_CloudFront
 .. _`CloudFront IP ranges`: https://ip-ranges.amazonaws.com/ip-ranges.json

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -859,21 +859,21 @@ Learn more
     doctrine/reverse_engineering
     testing/database
 
-.. _`Doctrine`: http://www.doctrine-project.org/
+.. _`Doctrine`: https://www.doctrine-project.org/
 .. _`RFC 3986`: https://www.ietf.org/rfc/rfc3986.txt
-.. _`Doctrine's Mapping Types documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html
-.. _`Query Builder`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/query-builder.html
-.. _`Doctrine Query Language`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/dql-doctrine-query-language.html
-.. _`Reserved SQL keywords documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html#quoting-reserved-words
+.. _`Doctrine's Mapping Types documentation`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/basic-mapping.html
+.. _`Query Builder`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/query-builder.html
+.. _`Doctrine Query Language`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/dql-doctrine-query-language.html
+.. _`Reserved SQL keywords documentation`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/basic-mapping.html#quoting-reserved-words
 .. _`DoctrineMongoDBBundle docs`: https://symfony.com/doc/current/bundles/DoctrineMongoDBBundle/index.html
-.. _`Transactions and Concurrency`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html
+.. _`Transactions and Concurrency`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/transactions-and-concurrency.html
 .. _`DoctrineMigrationsBundle`: https://github.com/doctrine/DoctrineMigrationsBundle
-.. _`NativeQuery`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/native-sql.html
-.. _`SensioFrameworkExtraBundle`: http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html
-.. _`ParamConverter`: http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
+.. _`NativeQuery`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/native-sql.html
+.. _`SensioFrameworkExtraBundle`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html
+.. _`ParamConverter`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
 .. _`limit of 767 bytes for the index key prefix`: https://dev.mysql.com/doc/refman/5.6/en/innodb-restrictions.html
 .. _`Doctrine screencast series`: https://symfonycasts.com/screencast/symfony-doctrine
 .. _`API Platform`: https://api-platform.com/docs/core/validation/
-.. _`PDO`: https://php.net/pdo
+.. _`PDO`: https://www.php.net/pdo
 .. _`available Doctrine extensions`: https://github.com/Atlantic18/DoctrineExtensions
 .. _`StofDoctrineExtensionsBundle`: https://github.com/antishov/StofDoctrineExtensionsBundle

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -595,6 +595,6 @@ Doctrine's `Association Mapping Documentation`_.
     ``@ORM\`` (e.g. ``@ORM\OneToMany``), which is not reflected in Doctrine's
     documentation.
 
-.. _`Association Mapping Documentation`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/association-mapping.html
-.. _`orphanRemoval`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/working-with-associations.html#orphan-removal
+.. _`Association Mapping Documentation`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/association-mapping.html
+.. _`orphanRemoval`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/working-with-associations.html#orphan-removal
 .. _`Mastering Doctrine Relations`: https://symfonycasts.com/screencast/doctrine-relations

--- a/doctrine/custom_dql_functions.rst
+++ b/doctrine/custom_dql_functions.rst
@@ -148,4 +148,4 @@ In Symfony, you can register your custom DQL functions as follows:
                 ],
             ]);
 
-.. _`DQL User Defined Functions`: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/cookbook/dql-user-defined-functions.html
+.. _`DQL User Defined Functions`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/cookbook/dql-user-defined-functions.html

--- a/doctrine/dbal.rst
+++ b/doctrine/dbal.rst
@@ -159,7 +159,7 @@ mapping type:
             ],
         ]);
 
-.. _`PDO`:           https://php.net/pdo
-.. _`Doctrine`:      http://www.doctrine-project.org
-.. _`DBAL Documentation`: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/index.html
-.. _`Custom Mapping Types`: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#custom-mapping-types
+.. _`PDO`: https://www.php.net/pdo
+.. _`Doctrine`: https://www.doctrine-project.org/
+.. _`DBAL Documentation`: https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/index.html
+.. _`Custom Mapping Types`: https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#custom-mapping-types

--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -482,6 +482,6 @@ can do it in the service configuration:
     related event is actually fired, making them more performant.
 
 .. _`Doctrine`: https://www.doctrine-project.org/
-.. _`lifecycle events`: https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/events.html#lifecycle-events
-.. _`official docs about Doctrine events`: https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/events.html
+.. _`lifecycle events`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/events.html#lifecycle-events
+.. _`official docs about Doctrine events`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/events.html
 .. _`DoctrineMongoDBBundle documentation`: https://symfony.com/doc/current/bundles/DoctrineMongoDBBundle/index.html

--- a/doctrine/mongodb_session_storage.rst
+++ b/doctrine/mongodb_session_storage.rst
@@ -28,4 +28,4 @@ may want to add an index to improve garbage collection performance. From the
     use session_db
     db.session.ensureIndex( { "expires_at": 1 }, { expireAfterSeconds: 0 } )
 
-.. _MongoDB shell: http://docs.mongodb.org/v2.2/tutorial/getting-started-with-the-mongo-shell/
+.. _MongoDB shell: https://docs.mongodb.com/manual/mongo/

--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -19,8 +19,7 @@ entity manager that connects to another database might handle the rest.
 .. caution::
 
     Entities cannot define associations across different entity managers. If you
-    need that, there are `several alternatives <https://stackoverflow.com/a/11494543/2804294>`_
-    that require some custom setup.
+    need that, there are `several alternatives`_ that require some custom setup.
 
 The following configuration code shows how you can configure two entity managers:
 
@@ -283,3 +282,5 @@ The same applies to repository calls::
             ;
         }
     }
+
+.. _`several alternatives`: https://stackoverflow.com/a/11494543

--- a/doctrine/reverse_engineering.rst
+++ b/doctrine/reverse_engineering.rst
@@ -111,4 +111,4 @@ run:
 
 The generated entities are now ready to be used. Have fun!
 
-.. _`Doctrine tools documentation`: https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/tools.html#reverse-engineering
+.. _`Doctrine tools documentation`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/tools.html#reverse-engineering

--- a/email.rst
+++ b/email.rst
@@ -657,12 +657,12 @@ redirected page and the email won't be accessible.
 .. _`MailCatcher`: https://github.com/sj26/mailcatcher
 .. _`MailHog`: https://github.com/mailhog/MailHog
 .. _`Mailtrap`: https://mailtrap.io/
-.. _`Swift Mailer`: http://swiftmailer.org/
+.. _`Swift Mailer`: https://swiftmailer.symfony.com/
 .. _`SwiftMailerBundle`: https://github.com/symfony/swiftmailer-bundle
 .. _`Creating Messages`: https://swiftmailer.symfony.com/docs/messages.html
 .. _`Mandrill`: https://mandrill.com/
 .. _`SendGrid`: https://sendgrid.com/
-.. _`Amazon SES`: http://aws.amazon.com/ses/
+.. _`Amazon SES`: https://aws.amazon.com/ses/
 .. _`generate an App password`: https://support.google.com/accounts/answer/185833
 .. _`allow less secure applications to access your Gmail account`: https://support.google.com/accounts/answer/6010255
 .. _`RFC 3986`: https://www.ietf.org/rfc/rfc3986.txt

--- a/form/form_themes.rst
+++ b/form/form_themes.rst
@@ -603,6 +603,6 @@ is a collection of fields (e.g. a whole form), and not just an individual field:
 .. _`Bootstrap 3 CSS framework`: https://getbootstrap.com/docs/3.3/
 .. _`Bootstrap 4 CSS framework`: https://getbootstrap.com/docs/4.1/
 .. _`foundation_5_layout.html.twig`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
-.. _`Foundation CSS framework`: http://foundation.zurb.com/
+.. _`Foundation CSS framework`: https://get.foundation/
 .. _`Twig "use" tag`: https://twig.symfony.com/doc/2.x/tags/use.html
 .. _`Twig parent() function`: https://twig.symfony.com/doc/2.x/functions/parent.html

--- a/frontend/encore/advanced-config.rst
+++ b/frontend/encore/advanced-config.rst
@@ -219,6 +219,6 @@ The following loaders are configurable with ``configureLoaderRule()``:
   - ``handlebars``
 
 .. _`configuration options`: https://webpack.js.org/configuration/
-.. _`array of configurations`: https://github.com/webpack/docs/wiki/configuration#multiple-configurations
+.. _`array of configurations`: https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations
 .. _`Karma`: https://karma-runner.github.io
 .. _`Watching Options`: https://webpack.js.org/configuration/watch/#watchoptions

--- a/frontend/encore/babel.rst
+++ b/frontend/encore/babel.rst
@@ -62,4 +62,4 @@ automatically be added to Babel: you must add it yourself in ``.babelrc``.
 As soon as a ``.babelrc`` file is present, it will take priority over the Babel
 configuration added by Encore.
 
-.. _`Babel`: http://babeljs.io/
+.. _`Babel`: https://babeljs.io/

--- a/frontend/encore/installation.rst
+++ b/frontend/encore/installation.rst
@@ -160,5 +160,5 @@ You'll customize and learn more about these file in :doc:`/frontend/encore/simpl
     :doc:`split chunks </frontend/encore/split-chunks>`.
 
 .. _`install Node.js`: https://nodejs.org/en/download/
-.. _`Yarn package manager`: https://yarnpkg.com/lang/en/docs/install/
+.. _`Yarn package manager`: https://yarnpkg.com/getting-started/install
 .. _`WebpackEncoreBundle`: https://github.com/symfony/webpack-encore-bundle

--- a/frontend/encore/postcss.rst
+++ b/frontend/encore/postcss.rst
@@ -76,7 +76,7 @@ support. The best-practice is to configure this directly in your ``package.json`
 
 See `browserslist`_ for more details on the syntax.
 
-.. _`PostCSS`: http://postcss.org/
+.. _`PostCSS`: https://postcss.org/
 .. _`autoprefixing`: https://github.com/postcss/autoprefixer
 .. _`linting`: https://stylelint.io/
 .. _`browserslist`: https://github.com/browserslist/browserslist

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -414,11 +414,11 @@ Learn more
 
     http_cache/*
 
-.. _`Things Caches Do`: http://2ndscale.com/writings/things-caches-do
-.. _`Cache Tutorial`: http://www.mnot.net/cache_docs/
-.. _`Varnish`: https://www.varnish-cache.org/
-.. _`Squid in reverse proxy mode`: http://wiki.squid-cache.org/SquidFaq/ReverseProxy
+.. _`Things Caches Do`: https://2ndscale.com/writings/things-caches-do
+.. _`Cache Tutorial`: https://www.mnot.net/cache_docs/
+.. _`Varnish`: https://varnish-cache.org/
+.. _`Squid in reverse proxy mode`: https://wiki.squid-cache.org/SquidFaq/ReverseProxy
 .. _`RFC 7234 - Caching`: https://tools.ietf.org/html/rfc7234
 .. _`RFC 7232 - Conditional Requests`: https://tools.ietf.org/html/rfc7232
-.. _`FOSHttpCacheBundle`: http://foshttpcachebundle.readthedocs.org/
+.. _`FOSHttpCacheBundle`: https://foshttpcachebundle.readthedocs.org/
 .. _`they can be cached`: https://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-20#section-2.3.4

--- a/http_cache/cache_invalidation.rst
+++ b/http_cache/cache_invalidation.rst
@@ -104,4 +104,4 @@ different URLs. More flexible concepts exist for those cases:
 * **Cache tagging** lets you add a tag for each content used in a response
   so that you can invalidate all URLs containing a certain content.
 
-.. _`FOSHttpCacheBundle`: http://foshttpcachebundle.readthedocs.org/
+.. _`FOSHttpCacheBundle`: https://foshttpcachebundle.readthedocs.org/

--- a/http_cache/expiration.rst
+++ b/http_cache/expiration.rst
@@ -80,5 +80,5 @@ servers should not send ``Expires`` dates more than one year in the future."
     when the ``s-maxage`` or ``max-age`` directive of the ``Cache-Control``
     header is defined.
 
-.. _`expiration model`: http://tools.ietf.org/html/rfc2616#section-13.2
+.. _`expiration model`: https://tools.ietf.org/html/rfc2616#section-13.2
 .. _`RFC 7234 - Caching`: https://tools.ietf.org/html/rfc7234#section-4.2.1

--- a/http_cache/varnish.rst
+++ b/http_cache/varnish.rst
@@ -233,12 +233,12 @@ proxy before it has expired, it adds complexity to your caching setup.
     The documentation of the `FOSHttpCacheBundle`_ explains how to configure
     Varnish and other reverse proxies for cache invalidation.
 
-.. _`Varnish`: https://www.varnish-cache.org
+.. _`Varnish`: https://varnish-cache.org/
 .. _`Edge Architecture`: http://www.w3.org/TR/edge-arch
-.. _`clean the cookies header`: https://www.varnish-cache.org/trac/wiki/VCLExampleRemovingSomeCookies
+.. _`clean the cookies header`: https://varnish-cache.org/trac/wiki/VCLExampleRemovingSomeCookies
 .. _`Surrogate-Capability Header`: http://www.w3.org/TR/edge-arch
-.. _`cache invalidation`: http://tools.ietf.org/html/rfc2616#section-13.10
-.. _`FOSHttpCacheBundle`: http://foshttpcachebundle.readthedocs.org/
+.. _`cache invalidation`: https://tools.ietf.org/html/rfc2616#section-13.10
+.. _`FOSHttpCacheBundle`: https://foshttpcachebundle.readthedocs.io/en/latest/features/user-context.html
 .. _`default.vcl`: https://github.com/varnishcache/varnish-cache/blob/3.0/bin/varnishd/default.vcl
 .. _`builtin.vcl`: https://github.com/varnishcache/varnish-cache/blob/4.1/bin/varnishd/builtin.vcl
-.. _`User Context`: http://foshttpcachebundle.readthedocs.org/en/latest/features/user-context.html
+.. _`User Context`: https://foshttpcachebundle.readthedocs.org/en/latest/features/user-context.html

--- a/introduction/from_flat_php_to_symfony.rst
+++ b/introduction/from_flat_php_to_symfony.rst
@@ -702,10 +702,10 @@ set of **high-quality open source tools developed by the Symfony community**!
 A good selection of `Symfony community tools`_ can be found on GitHub.
 
 .. _`Model-View-Controller`: https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller
-.. _`Doctrine`: http://www.doctrine-project.org
+.. _`Doctrine`: https://www.doctrine-project.org/
 .. _Translation: https://github.com/symfony/translation
 .. _`Composer`: https://getcomposer.org
 .. _`download Composer`: https://getcomposer.org/download/
 .. _`Validator`: https://github.com/symfony/validator
-.. _`Varnish`: https://www.varnish-cache.org/
+.. _`Varnish`: https://varnish-cache.org/
 .. _`Symfony community tools`: https://github.com/search?q=topic%3Asymfony-bundle&type=Repositories

--- a/introduction/http_fundamentals.rst
+++ b/introduction/http_fundamentals.rst
@@ -385,7 +385,7 @@ Here's what we've learned so far:
 #. Symfony turns your ``Response`` object into the text headers and content
    (i.e. the HTTP response), which are sent back to the client.
 
-.. _`xkcd`: http://xkcd.com/
+.. _`xkcd`: https://xkcd.com/
 .. _`XMLHttpRequest`: https://en.wikipedia.org/wiki/XMLHttpRequest
 .. _`HTTP 1.1 RFC`: http://www.w3.org/Protocols/rfc2616/rfc2616.html
 .. _`HTTP Bis`: http://datatracker.ietf.org/wg/httpbis/

--- a/logging/monolog_console.rst
+++ b/logging/monolog_console.rst
@@ -28,9 +28,10 @@ calls need to be wrapped in conditions. For example::
     }
 
 Instead of using these semantic methods to test for each of the verbosity
-levels, the `MonologBridge`_ provides a `ConsoleHandler`_ that listens to
-console events and writes log messages to the console output depending on the
-current log level and the console verbosity.
+levels, the `MonologBridge`_ provides a
+:class:`Symfony\\Bridge\\Monolog\\Handler\\ConsoleHandler` that listens to
+console events and writes log messages to the console output depending on
+the current log level and the console verbosity.
 
 The example above could then be rewritten as::
 
@@ -122,5 +123,4 @@ Now, log messages will be shown on the console based on the log levels and verbo
 By default (normal verbosity level), warnings and higher will be shown. But in
 :doc:`full verbosity mode </console/verbosity>`, all messages will be shown.
 
-.. _ConsoleHandler: https://github.com/symfony/MonologBridge/blob/master/Handler/ConsoleHandler.php
-.. _MonologBridge: https://github.com/symfony/MonologBridge
+.. _MonologBridge: https://github.com/symfony/monolog-bridge

--- a/mailer.rst
+++ b/mailer.rst
@@ -790,10 +790,10 @@ environment:
                 $sender: null
                 $recipients: ['youremail@example.com']
 
-.. _`download the foundation-emails.css file`: https://github.com/zurb/foundation-emails/blob/develop/dist/foundation-emails.css
+.. _`download the foundation-emails.css file`: https://github.com/foundation/foundation-emails/blob/develop/dist/foundation-emails.css
 .. _`league/html-to-markdown`: https://github.com/thephpleague/html-to-markdown
 .. _`Markdown syntax`: https://commonmark.org/
-.. _`Inky`: https://foundation.zurb.com/emails.html
+.. _`Inky`: https://get.foundation/emails/docs/inky.html
 .. _`S/MIME`: https://en.wikipedia.org/wiki/S/MIME
-.. _`OpenSSL PHP extension`: https://php.net/manual/en/book.openssl.php
+.. _`OpenSSL PHP extension`: https://www.php.net/manual/en/book.openssl.php
 .. _`PEM encoded`: https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail

--- a/mercure.rst
+++ b/mercure.rst
@@ -609,16 +609,16 @@ Enable the panel in your configuration, as follows:
 
 .. image:: /_images/mercure/panel.png
 
-.. _`the Mercure protocol`: https://github.com/dunglas/mercure#protocol-specification
-.. _`Server-Sent Events (SSE)`: https://developer.mozilla.org/docs/Server-sent_events
+.. _`the Mercure protocol`: https://mercure.rocks/spec
+.. _`Server-Sent Events (SSE)`: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events
 .. _`a polyfill`: https://github.com/Yaffle/EventSource
-.. _`high-level implementations`: https://github.com/dunglas/mercure#tools
+.. _`high-level implementations`: https://mercure.rocks/docs/ecosystem/awesome
 .. _`In this recording`: https://www.youtube.com/watch?v=UI1l0JOjLeI
 .. _`Mercure.rocks`: https://mercure.rocks
 .. _`API Platform distribution`: https://api-platform.com/docs/distribution/
 .. _`JSON Web Token`: https://tools.ietf.org/html/rfc7519
 .. _`example JWT`: https://jwt.io/#debugger-io?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdfX0.iHLdpAEjX4BqCsHJEegxRmO-Y6sMxXwNATrQyRNt3GY
 .. _`IRI`: https://tools.ietf.org/html/rfc3987
-.. _`practical UI`: https://twitter.com/chromedevtools/status/562324683194785792
+.. _`practical UI`: https://twitter.com/ChromeDevTools/status/562324683194785792
 .. _`the dedicated API Platform documentation`: https://api-platform.com/docs/core/mercure/
 .. _`the online debugger`: https://uri-template-tester.mercure.rocks

--- a/messenger/message-recorder.rst
+++ b/messenger/message-recorder.rst
@@ -42,8 +42,7 @@ DispatchAfterCurrentBusMiddleware Middleware
 For many applications, the desired behavior is to *only* handle messages that
 are dispatched by a handler once that handler has fully finished. This can be by
 using the ``DispatchAfterCurrentBusMiddleware`` and adding a
-``DispatchAfterCurrentBusStamp`` stamp to
-`the message Envelope </components/messenger#adding-metadata-to-messages-envelopes>`_::
+``DispatchAfterCurrentBusStamp`` stamp to :ref:`the message Envelope <messenger-envelopes>`::
 
     namespace App\Messenger\CommandHandler;
 

--- a/migration.rst
+++ b/migration.rst
@@ -461,7 +461,7 @@ chance to use Symfony's event lifecycle. For instance, this allows you to
 transition the authentication and authorization of the legacy application over
 to the Symfony application using the Security component and its firewalls.
 
-.. _`Strangler Application`: https://www.martinfowler.com/bliki/StranglerApplication.html
+.. _`Strangler Application`: https://martinfowler.com/bliki/StranglerFigApplication.html
 .. _`autoload`: https://getcomposer.org/doc/04-schema.md#autoload
 .. _`Modernizing with Symfony`: https://youtu.be/YzyiZNY9htQ
 .. _`Symfony Panther`: https://github.com/symfony/panther

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -75,9 +75,7 @@ is defined by creating a **route** in the ``config/routes.yaml`` file:
         path: /lucky/number
         controller: App\Controller\LuckyController::number
 
-That's it! If you are using Symfony web server, try it out by going to:
-
-    http://localhost:8000/lucky/number
+That's it! If you are using Symfony web server, try it out by going to: http://localhost:8000/lucky/number
 
 If you see a lucky number being printed back to you, congratulations! But before
 you run off to play the lottery, check out how this works. Remember the two steps
@@ -123,7 +121,7 @@ You can now add your route directly *above* the controller:
         }
     }
 
-That's it! The page - ``http://localhost:8000/lucky/number`` will work exactly
+That's it! The page - http://localhost:8000/lucky/number will work exactly
 like before! Annotations are the recommended way to configure routes.
 
 .. _flex-quick-intro:

--- a/performance.rst
+++ b/performance.rst
@@ -218,10 +218,10 @@ Learn more
 * :doc:`/http_cache/varnish`
 
 .. _`byte code caches`: https://en.wikipedia.org/wiki/List_of_PHP_accelerators
-.. _`OPcache`: https://php.net/manual/en/book.opcache.php
+.. _`OPcache`: https://www.php.net/manual/en/book.opcache.php
 .. _`Composer's autoloader optimization`: https://getcomposer.org/doc/articles/autoloader-optimization.md
-.. _`APC`: https://php.net/manual/en/book.apc.php
+.. _`APC`: https://www.php.net/manual/en/book.apc.php
 .. _`APCu Polyfill component`: https://github.com/symfony/polyfill-apcu
-.. _`APCu PHP functions`: https://php.net/manual/en/ref.apcu.php
+.. _`APCu PHP functions`: https://www.php.net/manual/en/ref.apcu.php
 .. _`cachetool`: https://github.com/gordalina/cachetool
-.. _`open_basedir`: https://php.net/manual/ini.core.php#ini.open-basedir
+.. _`open_basedir`: https://www.php.net/manual/ini.core.php#ini.open-basedir

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -440,4 +440,4 @@ If the ``dir`` configuration is set and the ``is_bundle`` configuration
 is ``true``, the DoctrineBundle will prefix the ``dir`` configuration with
 the path of the bundle.
 
-.. _DBAL documentation: https://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html
+.. _DBAL documentation: https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/configuration.html

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -807,16 +807,16 @@ every request.
 
 Here are some common examples of how ``base_uri`` merging works in practice:
 
-===================  ==============  ======================
-``base_uri``         Relative URI    Actual Requested URI
-===================  ==============  ======================
-http://foo.com       /bar            http://foo.com/bar
-http://foo.com/foo   /bar            http://foo.com/bar
-http://foo.com/foo   bar             http://foo.com/bar
-http://foo.com/foo/  bar             http://foo.com/foo/bar
-http://foo.com       http://baz.com  http://baz.com
-http://foo.com/?bar  bar             http://foo.com/bar
-===================  ==============  ======================
+=======================  ==================  ==========================
+``base_uri``             Relative URI        Actual Requested URI
+=======================  ==================  ==========================
+http://example.org       /bar                http://example.org/bar
+http://example.org/foo   /bar                http://example.org/bar
+http://example.org/foo   bar                 http://example.org/bar
+http://example.org/foo/  bar                 http://example.org/foo/bar
+http://example.org       http://symfony.com  http://symfony.com
+http://example.org/?bar  bar                 http://example.org/bar
+=======================  ==================  ==========================
 
 bindto
 ......
@@ -3087,25 +3087,25 @@ Defines the kind of workflow that is going to be created, which can be either
 a normal workflow or a state machine. Read :doc:`this article </workflow/workflow-and-state-machine>`
 to know their differences.
 
-.. _`HTTP Host header attacks`: http://www.skeletonscribe.net/2013/05/practical-http-host-header-attacks.html
+.. _`HTTP Host header attacks`: https://www.skeletonscribe.net/2013/05/practical-http-host-header-attacks.html
 .. _`Security Advisory Blog post`: https://symfony.com/blog/security-releases-symfony-2-0-24-2-1-12-2-2-5-and-2-3-3-released#cve-2013-4752-request-gethost-poisoning
-.. _`Doctrine Cache`: http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/caching.html
+.. _`Doctrine Cache`: https://www.doctrine-project.org/projects/doctrine-cache/en/current/index.html
 .. _`egulias/email-validator`: https://github.com/egulias/EmailValidator
 .. _`RFC 5322`: https://tools.ietf.org/html/rfc5322
 .. _`PhpStormProtocol`: https://github.com/aik099/PhpStormProtocol
 .. _`phpstorm-url-handler`: https://github.com/sanduhrs/phpstorm-url-handler
-.. _`blue/green deployment`: http://martinfowler.com/bliki/BlueGreenDeployment.html
+.. _`blue/green deployment`: https://martinfowler.com/bliki/BlueGreenDeployment.html
 .. _`gulp-rev`: https://www.npmjs.com/package/gulp-rev
 .. _`webpack-manifest-plugin`: https://www.npmjs.com/package/webpack-manifest-plugin
-.. _`error_reporting PHP option`: https://secure.php.net/manual/en/errorfunc.configuration.php#ini.error-reporting
+.. _`error_reporting PHP option`: https://www.php.net/manual/en/errorfunc.configuration.php#ini.error-reporting
 .. _`CSRF security attacks`: https://en.wikipedia.org/wiki/Cross-site_request_forgery
-.. _`session.sid_length PHP option`: https://php.net/manual/session.configuration.php#ini.session.sid-length
-.. _`session.sid_bits_per_character PHP option`: https://php.net/manual/session.configuration.php#ini.session.sid-bits-per-character
+.. _`session.sid_length PHP option`: https://www.php.net/manual/session.configuration.php#ini.session.sid-length
+.. _`session.sid_bits_per_character PHP option`: https://www.php.net/manual/session.configuration.php#ini.session.sid-bits-per-character
 .. _`X-Robots-Tag HTTP header`: https://developers.google.com/search/reference/robots_meta_tag
 .. _`RFC 3986`: https://www.ietf.org/rfc/rfc3986.txt
-.. _`default_socket_timeout`: https://php.net/manual/en/filesystem.configuration.php#ini.default-socket-timeout
+.. _`default_socket_timeout`: https://www.php.net/manual/en/filesystem.configuration.php#ini.default-socket-timeout
 .. _`PEM formatted`: https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail
 .. _`haveibeenpwned.com`: https://haveibeenpwned.com/
 .. _`session.cache-limiter`: https://www.php.net/manual/en/session.configuration.php#ini.session.cache-limiter
-.. _`Microsoft NTLM authentication protocol`: https://docs.microsoft.com/en-us/windows/desktop/secauthn/microsoft-ntlm
+.. _`Microsoft NTLM authentication protocol`: https://docs.microsoft.com/en-us/windows/win32/secauthn/microsoft-ntlm
 .. _`utf-8 modifier`: https://www.php.net/reference.pcre.pattern.modifiers

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -756,7 +756,7 @@ role inheritance rules by creating a role hierarchy, as explained in
 
 .. _`PBKDF2`: https://en.wikipedia.org/wiki/PBKDF2
 .. _`libsodium`: https://pecl.php.net/package/libsodium
-.. _`Session Fixation`: https://www.owasp.org/index.php/Session_fixation
+.. _`Session Fixation`: https://owasp.org/www-community/attacks/Session_fixation
 .. _`Argon2 key derivation function`: https://en.wikipedia.org/wiki/Argon2
 .. _`bcrypt password hashing function`: https://en.wikipedia.org/wiki/Bcrypt
 .. _`cryptographic salt`: https://en.wikipedia.org/wiki/Salt_(cryptography)

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -173,4 +173,4 @@ This matches the pattern used for the `HTML5 email input element`_.
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _egulias/email-validator: https://packagist.org/packages/egulias/email-validator
-.. _HTML5 email input element: https://www.w3.org/TR/html5/sec-forms.html#email-state-typeemail
+.. _HTML5 email input element: https://www.w3.org/TR/html5/sec-forms.html#valid-e-mail-address

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -395,5 +395,5 @@ The message that is displayed if the uploaded file is only partially uploaded.
 
 This message has no parameters.
 
-.. _`IANA website`: http://www.iana.org/assignments/media-types/index.html
-.. _`Wikipedia: Binary prefix`: http://en.wikipedia.org/wiki/Binary_prefix
+.. _`IANA website`: http://www.iana.org/assignments/media-types/media-types.xhtml
+.. _`Wikipedia: Binary prefix`: https://en.wikipedia.org/wiki/Binary_prefix

--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -313,4 +313,4 @@ Parameter                      Description
 
 .. include:: /reference/constraints/_comparison-value-option.rst.inc
 
-.. _`accepted by the DateTime constructor`: https://php.net/manual/en/datetime.formats.php
+.. _`accepted by the DateTime constructor`: https://www.php.net/manual/en/datetime.formats.php

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -312,4 +312,4 @@ Parameter                      Description
 
 .. include:: /reference/constraints/_comparison-value-option.rst.inc
 
-.. _`accepted by the DateTime constructor`: https://php.net/manual/en/datetime.formats.php
+.. _`accepted by the DateTime constructor`: https://www.php.net/manual/en/datetime.formats.php

--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -552,5 +552,5 @@ options has been set.
 
 This message has no parameters.
 
-.. _`IANA website`: http://www.iana.org/assignments/media-types/image/index.html
-.. _`PHP GD extension`: http://php.net/manual/en/book.image.php
+.. _`IANA website`: http://www.iana.org/assignments/media-types/media-types.xhtml
+.. _`PHP GD extension`: https://www.php.net/manual/en/book.image.php

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -312,4 +312,4 @@ Parameter                      Description
 
 .. include:: /reference/constraints/_comparison-value-option.rst.inc
 
-.. _`accepted by the DateTime constructor`: https://php.net/manual/en/datetime.formats.php
+.. _`accepted by the DateTime constructor`: https://www.php.net/manual/en/datetime.formats.php

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -311,4 +311,4 @@ Parameter                      Description
 
 .. include:: /reference/constraints/_comparison-value-option.rst.inc
 
-.. _`accepted by the DateTime constructor`: https://php.net/manual/en/datetime.formats.php
+.. _`accepted by the DateTime constructor`: https://www.php.net/manual/en/datetime.formats.php

--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -326,7 +326,7 @@ invalidMessage
 **type**: ``string`` **default**: ``This value should be a valid number.``
 
 The message that will be shown if the underlying value is not a number (per
-the `is_numeric`_ PHP function).
+the :phpfunction:`is_numeric` PHP function).
 
 You can use the following parameters in this message:
 
@@ -454,5 +454,4 @@ Parameter        Description
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-.. _`is_numeric`: https://php.net/manual/en/function.is-numeric.php
-.. _`accepted by the DateTime constructor`: https://php.net/manual/en/datetime.formats.php
+.. _`accepted by the DateTime constructor`: https://www.php.net/manual/en/datetime.formats.php

--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -222,5 +222,5 @@ Also, you can use ``ctype_*()`` functions from corresponding
 Make sure that the proper :phpfunction:`locale <setlocale>` is set before
 using one of these.
 
-.. _built-in PHP extension: https://php.net/book.ctype
-.. _a list of ctype functions: https://php.net/ref.ctype
+.. _built-in PHP extension: https://www.php.net/book.ctype
+.. _a list of ctype functions: https://www.php.net/ref.ctype

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -304,7 +304,6 @@ The name of the repository method used to determine the uniqueness. If it's left
 blank, ``findBy()`` will be used. The method receives as its argument a
 ``fieldName => value`` associative array (where ``fieldName`` is each of the
 fields configured in the ``fields`` option). The method should return a
-`countable PHP variable`_.
+:phpfunction:`countable PHP variable <is_countable>`.
 
 .. _`race conditions`: https://en.wikipedia.org/wiki/Race_condition
-.. _`countable PHP variable`: https://php.net/manual/function.is-countable.php

--- a/reference/constraints/Uuid.rst
+++ b/reference/constraints/Uuid.rst
@@ -132,6 +132,6 @@ The following PHP constants can also be used:
 
 All five versions are allowed by default.
 
-.. _`Universally unique identifier (UUID)`: http://en.wikipedia.org/wiki/Universally_unique_identifier
-.. _`RFC 4122`: http://tools.ietf.org/html/rfc4122
-.. _`UUID versions`: http://en.wikipedia.org/wiki/Universally_unique_identifier#Variants_and_versions
+.. _`Universally unique identifier (UUID)`: https://en.wikipedia.org/wiki/Universally_unique_identifier
+.. _`RFC 4122`: https://tools.ietf.org/html/rfc4122
+.. _`UUID versions`: https://en.wikipedia.org/wiki/Universally_unique_identifier#Versions

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -1262,5 +1262,5 @@ For an example, see the ``DoctrineInitializer`` class inside the Doctrine
 Bridge.
 
 .. _`Twig's documentation`: https://twig.symfony.com/doc/2.x/advanced.html#creating-an-extension
-.. _`SwiftMailer's Plugin Documentation`: http://swiftmailer.org/docs/plugins.html
+.. _`SwiftMailer's Plugin Documentation`: https://swiftmailer.symfony.com/docs/plugins.html
 .. _`Twig Loader`: https://twig.symfony.com/doc/2.x/api.html#loaders

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -258,4 +258,4 @@ Field Variables
 | ``date_pattern`` | ``string`` | A string with the date format to use.                                |
 +------------------+------------+----------------------------------------------------------------------+
 
-.. _`Bootstrap Datepicker`: https://github.com/eternicode/bootstrap-datepicker
+.. _`Bootstrap Datepicker`: https://github.com/uxsolutions/bootstrap-datepicker

--- a/reference/forms/types/options/_date_limitation.rst.inc
+++ b/reference/forms/types/options/_date_limitation.rst.inc
@@ -2,4 +2,6 @@
 
     If ``timestamp`` is used, ``DateType`` is limited to dates between
     Fri, 13 Dec 1901 20:45:54 GMT and Tue, 19 Jan 2038 03:14:07 GMT on 32bit
-    systems. This is due to a `limitation in PHP itself <https://php.net/manual/en/function.date.php#refsect1-function.date-changelog>`_.
+    systems. This is due to a `limitation in PHP itself`_.
+
+.. _limitation in PHP itself: https://www.php.net/manual/en/function.date.php#refsect1-function.date-changelog

--- a/reference/forms/types/options/date_format.rst.inc
+++ b/reference/forms/types/options/date_format.rst.inc
@@ -30,5 +30,5 @@ For more information on valid formats, see `Date/Time Format Syntax`_::
     ``single_text`` widget.
 
 .. _`Date/Time Format Syntax`: http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
-.. _`IntlDateFormatter::MEDIUM`: https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants
+.. _`IntlDateFormatter::MEDIUM`: https://www.php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants
 .. _`RFC 3339`: https://tools.ietf.org/html/rfc3339

--- a/reference/forms/types/options/model_timezone.rst.inc
+++ b/reference/forms/types/options/model_timezone.rst.inc
@@ -6,4 +6,4 @@
 Timezone that the input data is stored in. This must be one of the
 `PHP supported timezones`_.
 
-.. _`PHP supported timezones`: https://php.net/manual/en/timezones.php
+.. _`PHP supported timezones`: https://www.php.net/manual/en/timezones.php

--- a/reference/forms/types/options/view_timezone.rst.inc
+++ b/reference/forms/types/options/view_timezone.rst.inc
@@ -7,4 +7,4 @@ Timezone for how the data should be shown to the user (and therefore also
 the data that the user submits). This must be one of the
 `PHP supported timezones`_.
 
-.. _`PHP supported timezones`: https://php.net/manual/en/timezones.php
+.. _`PHP supported timezones`: https://www.php.net/manual/en/timezones.php

--- a/routing.rst
+++ b/routing.rst
@@ -2250,6 +2250,6 @@ Learn more about Routing
     routing/*
 
 .. _`PHP regular expressions`: https://www.php.net/manual/en/book.pcre.php
-.. _`PCRE Unicode properties`: http://php.net/manual/en/regexp.reference.unicode.php
+.. _`PCRE Unicode properties`: https://www.php.net/manual/en/regexp.reference.unicode.php
 .. _`full param converter documentation`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
 .. _`FOSJsRoutingBundle`: https://github.com/FriendsOfSymfony/FOSJsRoutingBundle

--- a/security/csrf.rst
+++ b/security/csrf.rst
@@ -163,4 +163,4 @@ to check its validity::
         }
     }
 
-.. _`Cross-site request forgery`: http://en.wikipedia.org/wiki/Cross-site_request_forgery
+.. _`Cross-site request forgery`: https://en.wikipedia.org/wiki/Cross-site_request_forgery

--- a/security/custom_authentication_provider.rst
+++ b/security/custom_authentication_provider.rst
@@ -636,5 +636,5 @@ The rest is up to you! Any relevant configuration items can be defined
 in the factory and consumed or passed to the other classes in the container.
 
 
-.. _`WSSE`: http://www.xml.com/pub/a/2003/12/17/dive.html
+.. _`WSSE`: https://www.xml.com/pub/a/2003/12/17/dive.html
 .. _`nonce`: https://en.wikipedia.org/wiki/Cryptographic_nonce

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -541,6 +541,6 @@ Configuration example for form login and query_string
     Using the ``query_string`` config option without defining ``search_dn`` and
     ``search_password`` is deprecated since Symfony 4.4.
 
-.. _`LDAP PHP extension`: http://www.php.net/manual/en/intro.ldap.php
+.. _`LDAP PHP extension`: https://www.php.net/manual/en/intro.ldap.php
 .. _`RFC4515`: http://www.faqs.org/rfcs/rfc4515.html
 .. _`LDAP injection`: http://projects.webappsec.org/w/page/13246947/LDAP%20Injection

--- a/serializer.rst
+++ b/serializer.rst
@@ -239,8 +239,8 @@ take a look at how this bundle works.
     serializer/custom_normalizer
 
 .. _`API Platform`: https://api-platform.com
-.. _`JSON-LD`: http://json-ld.org
-.. _`Hydra Core Vocabulary`: http://hydra-cg.com
+.. _`JSON-LD`: https://json-ld.org
+.. _`Hydra Core Vocabulary`: http://www.hydra-cg.com
 .. _`OpenAPI`: https://www.openapis.org
 .. _`GraphQL`: https://graphql.org
 .. _`JSON:API`: https://jsonapi.org

--- a/serializer/normalizers.rst
+++ b/serializer/normalizers.rst
@@ -34,4 +34,4 @@ Symfony includes the following normalizers but you can also
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\PropertyNormalizer` to
   normalize PHP object using `PHP reflection`_.
 
-.. _`PHP reflection`: https://php.net/manual/en/book.reflection.php
+.. _`PHP reflection`: https://www.php.net/manual/en/book.reflection.php

--- a/setup.rst
+++ b/setup.rst
@@ -300,10 +300,10 @@ Learn More
 .. _`Main recipe repository`: https://github.com/symfony/recipes
 .. _`Contrib recipe repository`: https://github.com/symfony/recipes-contrib
 .. _`Symfony Recipes documentation`: https://github.com/symfony/recipes/blob/master/README.rst
-.. _`iconv`: https://php.net/book.iconv
-.. _`JSON`: https://php.net/book.json
-.. _`Session`: https://php.net/book.session
-.. _`Ctype`: https://php.net/book.ctype
-.. _`Tokenizer`: https://php.net/book.tokenizer
-.. _`SimpleXML`: https://php.net/book.simplexml
-.. _`PCRE`: https://php.net/book.pcre
+.. _`iconv`: https://www.php.net/book.iconv
+.. _`JSON`: https://www.php.net/book.json
+.. _`Session`: https://www.php.net/book.session
+.. _`Ctype`: https://www.php.net/book.ctype
+.. _`Tokenizer`: https://www.php.net/book.tokenizer
+.. _`SimpleXML`: https://www.php.net/book.simplexml
+.. _`PCRE`: https://www.php.net/book.pcre

--- a/setup/_update_all_packages.rst.inc
+++ b/setup/_update_all_packages.rst.inc
@@ -16,4 +16,4 @@ this safely by running:
     non-Symfony libraries to new versions that contain backwards-compatibility
     breaking changes.
 
-.. _`version constraints`: https://getcomposer.org/doc/01-basic-usage.md#package-versions
+.. _`version constraints`: https://getcomposer.org/doc/articles/versions.md

--- a/setup/built_in_web_server.rst
+++ b/setup/built_in_web_server.rst
@@ -123,5 +123,5 @@ When you finish your work, you can stop the web server with the following comman
 
     $ php bin/console server:stop
 
-.. _`built-in web server`: https://php.net/manual/en/features.commandline.webserver.php
-.. _`php.net`: https://php.net/manual/en/features.commandline.webserver.php#example-411
+.. _`built-in web server`: https://www.php.net/manual/en/features.commandline.webserver.php
+.. _`php.net`: https://www.php.net/manual/en/features.commandline.webserver.php#example-415

--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -196,6 +196,6 @@ manually after a recipe is installed.
 .. _`default services.yaml file`: https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/config/services.yaml
 .. _`shown in this example`: https://github.com/symfony/skeleton/blob/8e33fe617629f283a12bbe0a6578bd6e6af417af/composer.json#L24-L33
 .. _`shown in this example of the skeleton-project`: https://github.com/symfony/skeleton/blob/8e33fe617629f283a12bbe0a6578bd6e6af417af/composer.json#L44-L46
-.. _`copying Symfony's index.php source`: https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/public/index.php
-.. _`copying Symfony's bin/console source`: https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console
+.. _`copying Symfony's index.php source`: https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.4/public/index.php
+.. _`copying Symfony's bin/console source`: https://github.com/symfony/recipes/blob/master/symfony/console/3.4/bin/console
 .. _`Symfony Requirements Checker`: https://github.com/symfony/requirements-checker

--- a/setup/homestead.rst
+++ b/setup/homestead.rst
@@ -76,4 +76,4 @@ developing your Symfony application!
 .. _`Vagrant`: https://www.vagrantup.com/
 .. _`the Homestead documentation`: https://laravel.com/docs/homestead#installation-and-setup
 .. _`Daily Usage`: https://laravel.com/docs/homestead#daily-usage
-.. _`this blog post`: https://www.whitewashing.de/2013/08/19/speedup_symfony2_on_vagrant_boxes.html
+.. _`this blog post`: https://beberlei.de/2013/08/19/speedup_symfony2_on_vagrant_boxes.html

--- a/testing.rst
+++ b/testing.rst
@@ -1085,5 +1085,5 @@ Learn more
 .. _`PHPUnit`: https://phpunit.de/
 .. _`documentation`: https://phpunit.readthedocs.io/
 .. _`PHPUnit Bridge component`: https://symfony.com/components/PHPUnit%20Bridge
-.. _`$_SERVER`: https://php.net/manual/en/reserved.variables.server.php
+.. _`$_SERVER`: https://www.php.net/manual/en/reserved.variables.server.php
 .. _`data providers`: https://phpunit.de/manual/current/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers

--- a/translation/message_format.rst
+++ b/translation/message_format.rst
@@ -470,6 +470,6 @@ The ``number`` formatter allows you to format numbers using Intl's :phpclass:`Nu
 
 .. _`online editor`: http://format-message.github.io/icu-message-format-for-translators/
 .. _`ICU MessageFormat`: http://userguide.icu-project.org/formatparse/messages
-.. _`switch statement`: https://php.net/control-structures.switch
+.. _`switch statement`: https://www.php.net/control-structures.switch
 .. _`Language Plural Rules`: http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
-.. _`constants defined by the IntlDateFormatter class`: https://php.net/manual/en/class.intldateformatter.php
+.. _`constants defined by the IntlDateFormatter class`: https://www.php.net/manual/en/class.intldateformatter.php

--- a/validation.rst
+++ b/validation.rst
@@ -739,4 +739,4 @@ Learn more
     /validation/*
 
 .. _Validator: https://github.com/symfony/validator
-.. _JSR303 Bean Validation specification: http://jcp.org/en/jsr/detail?id=303
+.. _JSR303 Bean Validation specification: https://jcp.org/en/jsr/detail?id=303

--- a/web_link.rst
+++ b/web_link.rst
@@ -188,9 +188,9 @@ You can also add links to the HTTP response directly from controllers and servic
 .. _`Docker installer and runtime for Symfony`: https://github.com/dunglas/symfony-docker
 .. _`"as" attribute`: https://w3c.github.io/preload/#as-attribute
 .. _`the Priority Hints specification`: https://wicg.github.io/priority-hints/
-.. _`the Preload specification`: https://www.w3.org/TR/preload/#server-push-(http/2)
+.. _`the Preload specification`: https://www.w3.org/TR/preload/#server-push-http-2
 .. _`Cloudflare`: https://blog.cloudflare.com/announcing-support-for-http-2-server-push-2/
-.. _`Fastly`: https://docs.fastly.com/guides/performance-tuning/http2-server-push
+.. _`Fastly`: https://docs.fastly.com/en/guides/http2-server-push
 .. _`Akamai`: https://blogs.akamai.com/2017/03/http2-server-push-the-what-how-and-why.html
 .. _`link defined in the HTML specification`: https://html.spec.whatwg.org/dev/links.html#linkTypes
 .. _`PSR-13`: https://www.php-fig.org/psr/psr-13/

--- a/workflow/dumping-workflows.rst
+++ b/workflow/dumping-workflows.rst
@@ -310,5 +310,5 @@ The PlantUML image will look like this:
 .. image:: /_images/components/workflow/pull_request_puml_styled.png
 
 .. _`Graphviz`: http://www.graphviz.org
-.. _`PlantUML`: http://plantuml.com/
-.. _`PlantUML's color list`: http://plantuml.com/en/color
+.. _`PlantUML`: https://plantuml.com/
+.. _`PlantUML's color list`: https://plantuml.com/color


### PR DESCRIPTION
I ran the linkcheck builder of the 4.4 docs and fixed all broken or permanently redirected links. Most of them are about moving to HTTPS.

We can't run the linkcheck builder automatically:

- Some docs use permanent redirects to redirect `current` to a specific version (seems really bad). We want to keep using "current" here
- In a similair way, some sites allow i18n if you omit the locale from the URL, these are also permanently redirected
- I don't want us to spam all the links every time GitHub actions runs :)

Also note that Doctrine switched the "latest" version to Doctrine ORM 3.0. I've changed all these to "current" (i.e. 2.6 atm) instead.