### PR TITLE
Bus restricting with Interfaces

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -60,6 +60,8 @@ and many tags require additional arguments (beyond the ``name`` parameter).
 **For most users, this is all you need to know**. If you want to go further and
 learn how to create your own custom tags, keep reading.
 
+.. _di-instanceof:
+
 Autoconfiguring Tags
 --------------------
 


### PR DESCRIPTION
Proposed more flexible way to restrict handlers with buses - use interfaces for this.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
