### PR TITLE
[4.4+] Updated links to Bootstrap docs

### DIFF
--- a/form/bootstrap4.rst
+++ b/form/bootstrap4.rst
@@ -121,6 +121,6 @@ is a strong connection between the error and its ``<input>``, as required by the
 
 .. _`WCAG 2.0 standard`: https://www.w3.org/TR/WCAG20/
 .. _`custom forms`: https://getbootstrap.com/docs/4.4/components/forms/#custom-forms
-.. _`custom radio`: https://getbootstrap.com/docs/4.3/components/forms/#radios
-.. _`custom checkbox`: https://getbootstrap.com/docs/4.3/components/forms/#checkboxes
-.. _`switch instead of a checkbox`: https://getbootstrap.com/docs/4.3/components/forms/#switches
+.. _`custom radio`: https://getbootstrap.com/docs/4.4/components/forms/#radios
+.. _`custom checkbox`: https://getbootstrap.com/docs/4.4/components/forms/#checkboxes
+.. _`switch instead of a checkbox`: https://getbootstrap.com/docs/4.4/components/forms/#switches

--- a/form/form_themes.rst
+++ b/form/form_themes.rst
@@ -600,8 +600,8 @@ is a collection of fields (e.g. a whole form), and not just an individual field:
 .. _`bootstrap_3_horizontal_layout.html.twig`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_horizontal_layout.html.twig
 .. _`bootstrap_4_layout.html.twig`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
 .. _`bootstrap_4_horizontal_layout.html.twig`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
-.. _`Bootstrap 3 CSS framework`: https://getbootstrap.com/docs/3.3/
-.. _`Bootstrap 4 CSS framework`: https://getbootstrap.com/docs/4.1/
+.. _`Bootstrap 3 CSS framework`: https://getbootstrap.com/docs/3.4/
+.. _`Bootstrap 4 CSS framework`: https://getbootstrap.com/docs/4.4/
 .. _`foundation_5_layout.html.twig`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
 .. _`Foundation CSS framework`: https://get.foundation/
 .. _`Twig "use" tag`: https://twig.symfony.com/doc/2.x/tags/use.html


### PR DESCRIPTION
Like in the title. I didn't target this PR to 3.4 as docs there are very different and links to custom components are missing. I can do a separate PR for 3.4 if needed. (My guess is yes as 3.4 is still supported)