### PR TITLE
fix: validate signature

### DIFF
--- a/validation/groups.rst
+++ b/validation/groups.rst
@@ -177,7 +177,7 @@ the class name or the string ``Default``.
 To tell the validator to use a specific group, pass one or more group names
 as the third argument to the ``validate()`` method::
 
-    $errors = $validator->validate($author, null, ['registration']);
+    $errors = $validator->validate($author, ['groups' => ['registration']]);
 
 If no groups are specified, all constraints that belong to the group ``Default``
 will be applied.


### PR DESCRIPTION
Fixed a small typo in the documentation. The method validate does not expect a third parameter.

