### PR TITLE
Correct path to action when redirecting from route

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -1319,7 +1319,7 @@ Use the ``RedirectController`` to redirect to other routes and URLs:
         # config/routes.yaml
         doc_shortcut:
             path: /doc
-            controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController
+            controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController:redirectAction
             defaults:
                 route: 'doc_page'
                 # optionally you can define some arguments passed to the route


### PR DESCRIPTION
Correcting an error I got when following documentation: 
Controller class "Symfony\Bundle\FrameworkBundle\Controller\RedirectController" cannot be called without a method name.