### PR TITLE
Update UniqueEntity->message description

### DIFF
--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -147,7 +147,7 @@ each with a single field.
 
 The message that's displayed when this constraint fails. This message is by default
 mapped to the first field causing the violation. When using multiple fields
-in the constraint, the mapping can be specified in the `errorPath`_ property.
+in the constraint, the mapping can be specified via the `errorPath`_ property.
 
 Messages can include the ``{{ value }}`` placeholder to display a string
 representation of the invalid entity. If the entity doesn't define the

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -145,9 +145,9 @@ each with a single field.
 
 **type**: ``string`` **default**: ``This value is already used.``
 
-The message that's displayed when this constraint fails. This message is always
-mapped to the first field causing the violation, even when using multiple fields
-in the constraint.
+The message that's displayed when this constraint fails. This message is by default
+mapped to the first field causing the violation. When using multiple fields
+in the constraint, the mapping can be specified in the `errorPath`_ property.
 
 Messages can include the ``{{ value }}`` placeholder to display a string
 representation of the invalid entity. If the entity doesn't define the


### PR DESCRIPTION
The description of the message property implies that it is not possible to change the mapping of the error message.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
