### PR TITLE
[DI] Add missing quotes in expression & escape `\`

### DIFF
--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -67,7 +67,7 @@ to another service: ``App\Mailer``. One way to do this is with an expression:
             $services->set(MailerConfiguration::class);
 
             $services->set(Mailer::class)
-                ->args([expr(sprintf('service(%s).getMailerMethod()', MailerConfiguration::class))]);
+                ->args([expr(sprintf('service("%s").getMailerMethod()', MailerConfiguration::class))]);
         };
 
 

--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -67,7 +67,7 @@ to another service: ``App\Mailer``. One way to do this is with an expression:
             $services->set(MailerConfiguration::class);
 
             $services->set(Mailer::class)
-                ->args([expr(sprintf('service("%s").getMailerMethod()', MailerConfiguration::class))]);
+                ->args([expr(sprintf('service("%s").getMailerMethod()', addcslashes(MailerConfiguration::class, '\\')))]);
         };
 
 


### PR DESCRIPTION
The expression is invalid as it is missing the quotation marks.

Also, the backslashes in the FQCN need to be escaped. I've added a `addcslashes` call but tbh I really don't like this, maybe `sprintf` isn't the way to go here.

**EDIT**: Fixed with https://github.com/symfony/symfony-docs/commit/5bfe888c31e05aff185c643cd4f77bab07a08088