### PR TITLE
Remove references to the secret env processors

### DIFF
--- a/configuration/secrets.rst
+++ b/configuration/secrets.rst
@@ -115,7 +115,7 @@ If you stored a ``DATABASE_PASSWORD`` secret, you can reference by:
         # config/packages/doctrine.yaml
         doctrine:
             dbal:
-                password: '%env(secret:DATABASE_PASSWORD)%'
+                password: '%env(DATABASE_PASSWORD)%'
                 # ...
             # ...
 
@@ -133,7 +133,7 @@ If you stored a ``DATABASE_PASSWORD`` secret, you can reference by:
 
             <doctrine:config>
                 <doctrine:dbal
-                    password="%env(secret:DATABASE_PASSWORD)%"
+                    password="%env(DATABASE_PASSWORD)%"
                 />
             </doctrine:config>
 
@@ -144,7 +144,7 @@ If you stored a ``DATABASE_PASSWORD`` secret, you can reference by:
         // config/packages/doctrine.php
         $container->loadFromExtension('doctrine', [
             'dbal' => [
-                'password' => '%env(secret:DATABASE_PASSWORD)%',
+                'password' => '%env(DATABASE_PASSWORD)%',
             ]
         ]);
 


### PR DESCRIPTION
The `secret` environment variable processor was removed in https://github.com/symfony/symfony/pull/34295, yet the examples in the docs still use it. The text in the docs seems to have been updated in https://github.com/symfony/symfony-docs/commit/75e5ae65e9d75c78a7de931c71101f81a4a3ad5f & is ok, it's just these examples that are still wrong.