### PR TITLE
Update configuration.rst

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -833,7 +833,7 @@ part of Symfony individually by following the guides. Check out:
 * :doc:`/doctrine`
 * :doc:`/service_container`
 * :doc:`/security`
-* :doc:`/email`
+* :doc:`/mailer`
 * :doc:`/logging`
 
 And all the other topics related to configuration:


### PR DESCRIPTION
Small improvement, as I see the doc tend to push `Mailer` instead of `SwiftMailer`

uses:
- https://symfony.com/doc/4.4/mailer.html

instead of:
- https://symfony.com/doc/4.4/email.html