### PR TITLE
Typo

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -458,7 +458,7 @@ This means that each event has access to the following information:
     Returns a metadata.
 
 For Guard Events, there is an extended :class:`Symfony\\Component\\Workflow\\Event\\GuardEvent` class.
-This class has two more methods:
+This class has the additonal methods:
 
 :method:`Symfony\\Component\\Workflow\\Event\\GuardEvent::isBlocked`
     Returns if transition is blocked.

--- a/workflow.rst
+++ b/workflow.rst
@@ -458,7 +458,7 @@ This means that each event has access to the following information:
     Returns a metadata.
 
 For Guard Events, there is an extended :class:`Symfony\\Component\\Workflow\\Event\\GuardEvent` class.
-This class has the additonal methods:
+This class has these additonal methods:
 
 :method:`Symfony\\Component\\Workflow\\Event\\GuardEvent::isBlocked`
     Returns if transition is blocked.


### PR DESCRIPTION
Since 4.4 we have 4 methods

I am wondering why there is no `versionadded::` directive 

EDIT: ah it is below the examples:
<img width="721" alt="Screenshot 2020-03-04 08 55 54" src="https://user-images.githubusercontent.com/995707/75857174-024a8e80-5df6-11ea-9c1d-c718d3d75561.png">
