### PR TITLE
[Notifier] Update round robin transport explanation

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -256,8 +256,8 @@ transport:
                     # Slack errored
                     main: '%env(SLACK_DSN)% || %env(TELEGRAM_DSN)%'
 
-                    # Always send notifications to both Slack and Telegram
-                    all: '%env(SLACK_DSN)% && %env(TELEGRAM_DSN)%'
+                    # Send notifications to the next scheduled transport calculated by round robin
+                    roundrobin: '%env(SLACK_DSN)% && %env(TELEGRAM_DSN)%'
 
     .. code-block:: xml
 
@@ -279,7 +279,8 @@ transport:
                         %env(SLACK_DSN)% || %env(TELEGRAM_DSN)%
                     </framework:chatter-transport>
 
-                    <!-- Always send notifications to both Slack and Telegram -->
+                    <!-- Send notifications to the next scheduled transport 
+                         calculated by round robin -->
                     <framework:chatter-transport name="slack">
                         %env(SLACK_DSN)% && %env(TELEGRAM_DSN)%
                     </framework:chatter-transport>
@@ -297,8 +298,8 @@ transport:
                     // Slack errored
                     'main' => '%env(SLACK_DSN)% || %env(TELEGRAM_DSN)%',
 
-                    // Always send notifications to both Slack and Telegram
-                    'all' => '%env(SLACK_DSN)% && %env(TELEGRAM_DSN)%',
+                    // Send notifications to the next scheduled transport calculated by round robin
+                    'roundrobin' => '%env(SLACK_DSN)% && %env(TELEGRAM_DSN)%',
                 ],
             ],
         ]);


### PR DESCRIPTION
As you can see in https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Notifier/Transport/RoundRobinTransport.php#L72 only the next scheduled transport is used to send the message and not all transports.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
