### PR TITLE
Fixed broken links to reStructuredText

### DIFF
--- a/contributing/documentation/format.rst
+++ b/contributing/documentation/format.rst
@@ -208,10 +208,10 @@ versions that have a lower major version will be removed. For example, if
 Symfony 4.0 were released today, 3.0 to 3.4 ``versionadded`` and ``deprecated``
 tags would be removed from the new ``4.0`` branch.
 
-.. _reStructuredText: http://docutils.sourceforge.net/rst.html
+.. _reStructuredText: https://docutils.sourceforge.io/rst.html
 .. _Sphinx: https://www.sphinx-doc.org/
 .. _`Symfony documentation`: https://github.com/symfony/symfony-docs
 .. _`reStructuredText Primer`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
-.. _`reStructuredText Reference`: http://docutils.sourceforge.net/docs/user/rst/quickref.html
+.. _`reStructuredText Reference`: https://docutils.sourceforge.io/docs/user/rst/quickref.html
 .. _`Sphinx Markup Constructs`: https://www.sphinx-doc.org/en/1.7/markup/index.html
 .. _`supported languages`: http://pygments.org/languages/

--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -333,7 +333,7 @@ your proposal after you put all that hard work into making the changes. We
 definitely don't want you to waste your time!
 
 .. _`github.com/symfony/symfony-docs`: https://github.com/symfony/symfony-docs
-.. _`reStructuredText`: http://docutils.sourceforge.net/rst.html
+.. _`reStructuredText`: https://docutils.sourceforge.io/rst.html
 .. _`GitHub`: https://github.com/
 .. _`fork the repository`: https://help.github.com/articles/fork-a-repo
 .. _`Symfony Documentation Contributors`: https://symfony.com/contributors/doc
@@ -343,5 +343,5 @@ definitely don't want you to waste your time!
 .. _`roadmap`: https://symfony.com/roadmap
 .. _`pip`: https://pip.pypa.io/en/stable/
 .. _`pip installation`: https://pip.pypa.io/en/stable/installing/
-.. _`Sphinx`: http://sphinx-doc.org/
+.. _`Sphinx`: https://www.sphinx-doc.org/
 .. _`Sphinx Extensions for PHP and Symfony`: https://github.com/fabpot/sphinx-php


### PR DESCRIPTION
On the newer version, one link is actually fixed https://github.com/symfony/symfony-docs/commit/7f8c72ab7f9584f0ff1fc954a4351289cac32d2c#diff-d40e5371f96a5c08e4a8e82bd687f2c5R214 but the first one stays broken.

I also added https to `sphinx-doc.org/` to keep consistency with `format.rst`