### PR TITLE
Missing format parameter in few serialize calls

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -625,7 +625,7 @@ defines a ``Person`` entity with a ``firstName`` property:
 This custom mapping is used to convert property names when serializing and
 deserializing objects::
 
-    $serialized = $serializer->serialize(new Person("Kévin"));
+    $serialized = $serializer->serialize(new Person("Kévin"), 'json');
     // {"customer_name": "Kévin"}
 
 Serializing Boolean Attributes
@@ -1450,7 +1450,7 @@ and ``BitBucketCodeRepository`` classes:
 
 Once configured, the serializer uses the mapping to pick the correct class::
 
-    $serialized = $serializer->serialize(new GitHubCodeRepository());
+    $serialized = $serializer->serialize(new GitHubCodeRepository(), 'json');
     // {"type": "github"}
 
     $repository = $serializer->deserialize($serialized, CodeRepository::class, 'json');


### PR DESCRIPTION
I noticed the `format` parameter from the [SerializerInterface](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Serializer/SerializerInterface.php#L30) seems missing in a few of the Serializer examples:

- https://symfony.com/doc/current/components/serializer.html#configure-name-conversion-using-metadata
- https://symfony.com/doc/current/components/serializer.html#configure-name-conversion-using-metadata