### PR TITLE
Kernel constructor (SF v4.4.5) accepts only 2 args

### DIFF
--- a/migration.rst
+++ b/migration.rst
@@ -268,7 +268,7 @@ could look something like this::
         Request::setTrustedHosts([$trustedHosts]);
     }
 
-    $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG'], dirname(__DIR__));
+    $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
     $request = Request::createFromGlobals();
     $response = $kernel->handle($request);
 


### PR DESCRIPTION
In v4.4.5 the Kernel constructor only accepts 2 arguments.
Legacy-Migration documentation updated accordingly