### PR TITLE
Typo in allow_if condition in access_control security

### DIFF
--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -291,7 +291,7 @@ key:
                     # the 'role' and 'allow-if' options work like an OR expression, so
                     # access is granted if the expression is TRUE or the user has ROLE_ADMIN
                     roles: 'ROLE_ADMIN'
-                    allow_if: "'127.0.0.1' == request.getClientIp() or request.header.has('X-Secure-Access')"
+                    allow_if: "'127.0.0.1' == request.getClientIp() or request.headers.has('X-Secure-Access')"
 
     .. code-block:: xml
 
@@ -308,7 +308,7 @@ key:
                      access is granted if the expression is TRUE or the user has ROLE_ADMIN -->
                 <rule path="^/_internal/secure"
                     role="ROLE_ADMIN"
-                    allow-if="'127.0.0.1' == request.getClientIp() or request.header.has('X-Secure-Access')"/>
+                    allow-if="'127.0.0.1' == request.getClientIp() or request.headers.has('X-Secure-Access')"/>
             </config>
         </srv:container>
 
@@ -320,7 +320,7 @@ key:
                     // the 'role' and 'allow-if' options work like an OR expression, so
                     // access is granted if the expression is TRUE or the user has ROLE_ADMIN
                     'roles' => 'ROLE_ADMIN',
-                    'allow_if' => '"127.0.0.1" == request.getClientIp() or request.header.has('X-Secure-Access')',
+                    'allow_if' => '"127.0.0.1" == request.getClientIp() or request.headers.has('X-Secure-Access')',
                 ],
             ],
 


### PR DESCRIPTION
Fix typo in allow_if condition when trying to access headers. With old `request.header.has('X-Secure-Access')` there is a notice "Undefined property".