### PR TITLE
[DI] Use improved Yaml syntax for defining method calls

### DIFF
--- a/service_container/calls.rst
+++ b/service_container/calls.rst
@@ -40,9 +40,7 @@ To configure the container to call the ``setLogger`` method, use the ``calls`` k
             App\Service\MessageGenerator:
                 # ...
                 calls:
-                    - method: setLogger
-                      arguments:
-                          - '@logger'
+                    - setLogger: ['@logger']
 
     .. code-block:: xml
 
@@ -121,10 +119,7 @@ The configuration to tell the container it should do so would be like:
             App\Service\MessageGenerator:
                 # ...
                 calls:
-                    - method: withLogger
-                      arguments:
-                          - '@logger'
-                      returns_clone: true
+                    - withLogger: !returns_clone ['@logger']
 
     .. code-block:: xml
 


### PR DESCRIPTION
Examples were desribed in the blog: https://symfony.com/blog/new-in-symfony-4-4-dependency-injection-improvements-part-2#improved-yaml-syntax-for-method-calls

Fixes #12443 
