### PR TITLE
feat: add amazon sqs to docs

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1131,6 +1131,35 @@ during a request::
         :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase`
         or :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase`.
 
+Amazon SQS
+~~~~~~~~~~
+
+.. versionadded:: 5.1
+
+    The Amazon SQS transport has been added in Symfony 5.1
+    Install it by running:
+
+    .. code-block:: terminal
+
+        $ composer require symfony/amazon-sqs-messenger
+
+The ``SQS`` transport configuration looks like this:
+
+.. code-block:: bash
+
+    # .env
+    MESSENGER_TRANSPORT_DSN=sqs://guest:guest@sqs.eu-west-3.amazonaws.com/test?region=eu-west-3
+
+
+.. note::
+
+    By default, the transport will automatically create queue that are needed. That can be disabled.
+    
+The transport has a number of other options, including ways to configure
+the exchange, queues binding keys and more. See the documentation on
+:class:`Symfony\\Component\\Messenger\\Transport\\AmazonSqs\\Connection`.
+
+
 Serializing Messages
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->


This fix #13093 and add a begin documentation on how to use the amazon sqs transport.
Tell me if you want more information I guess this is enough and it works properly like this.