### PR TITLE
[DOCS] Updated performance page opcache file name

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -119,7 +119,7 @@ The preload file path is the same as the compiled service container but with the
 .. code-block:: ini
 
     ; php.ini
-    opcache.preload=/path/to/project/var/cache/prod/App_KernelProdContainer.preload.php
+    opcache.preload=/path/to/project/var/cache/prod/srcApp_KernelProdContainer.preload.php
 
 .. _performance-configure-opcache:
 


### PR DESCRIPTION
In SF < 5, the app name is included in the file name, so the real name of the opcache preload name should be `srcApp_KernelProdContainer`

Fixes #13330 