### PR TITLE
Add missing prefix/xxxer

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -582,11 +582,11 @@ There are several types of normalizers available:
 :class:`Symfony\\Component\\Serializer\\Normalizer\\ObjectNormalizer`
     This normalizer leverages the :doc:`PropertyAccess Component </components/property_access>`
     to read and write in the object. It means that it can access to properties
-    directly and through getters, setters, hassers, adders and removers. It supports
+    directly and through getters, setters, hassers, issers, adders and removers. It supports
     calling the constructor during the denormalization process.
 
     Objects are normalized to a map of property names and values (names are
-    generated removing the ``get``, ``set``, ``has``, ``is`` or ``remove`` prefix from
+    generated removing the ``get``, ``set``, ``has``, ``is``, ``add`` or ``remove`` prefix from
     the method name and transforming the first letter to lowercase; e.g.
     ``getFirstName()`` -> ``firstName``).
 


### PR DESCRIPTION
Add missing prefix/xxxer in ObjectNormalizer description

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
