### PR TITLE
Remove caution section about bind scalar controller arguments

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -277,14 +277,6 @@ the argument by its name:
 Like with all services, you can also use regular :ref:`constructor injection <services-constructor-injection>`
 in your controllers.
 
-.. caution::
-
-    You can *only* pass *services* to your controller arguments in this way. It's not
-    possible, for example, to pass a config parameter as a controller argument,
-    even by using ``bind``. If you need a parameter, use the ``$this->getParameter('kernel.debug')``
-    shortcut or pass the value through your controller's ``__construct()`` method
-    and specify its value with ``bind``.
-
 For more information about services, see the :doc:`/service_container` article.
 
 Generating Controllers


### PR DESCRIPTION
This caution section is no longer relevant since 4.1 with https://github.com/symfony/symfony/commit/2c7198cdd03ef4732b0855ffb8bc0efb87701a43 .