### PR TITLE
Make it more obvious what the $handler is on Messenger docs

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -89,9 +89,12 @@ are configured for you:
 Example::
 
     use App\Message\MyMessage;
+    use App\MessageHandler\MyMessageHandler;
     use Symfony\Component\Messenger\Handler\HandlersLocator;
     use Symfony\Component\Messenger\MessageBus;
     use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+
+    $handler = new MyMessageHandler();
 
     $bus = new MessageBus([
         new HandleMessageMiddleware(new HandlersLocator([


### PR DESCRIPTION
fixes #13148

As mentioned in the issue `$handler` was not obvious. I referenced the next item in the docs in the hope that this makes things more clear.

This issue is present on other versions of the documentation but the behaviour of the function also changed (parameter now can be an array). I am unsure of how to proceed in such a case.