### PR TITLE
Consider option "allowEmptyString" in examples

### DIFF
--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -42,7 +42,8 @@ and "50", you might add the following:
              *      min = 2,
              *      max = 50,
              *      minMessage = "Your first name must be at least {{ limit }} characters long",
-             *      maxMessage = "Your first name cannot be longer than {{ limit }} characters"
+             *      maxMessage = "Your first name cannot be longer than {{ limit }} characters",
+             *      allowEmptyString = false
              * )
              */
             protected $firstName;
@@ -59,6 +60,7 @@ and "50", you might add the following:
                         max: 50
                         minMessage: 'Your first name must be at least {{ limit }} characters long'
                         maxMessage: 'Your first name cannot be longer than {{ limit }} characters'
+                        allowEmptyString: false
 
     .. code-block:: xml
 
@@ -79,6 +81,7 @@ and "50", you might add the following:
                         <option name="maxMessage">
                             Your first name cannot be longer than {{ limit }} characters
                         </option>
+                        <option name="allowEmptyString">false</option>
                     </constraint>
                 </property>
             </class>
@@ -101,6 +104,7 @@ and "50", you might add the following:
                     'max' => 50,
                     'minMessage' => 'Your first name must be at least {{ limit }} characters long',
                     'maxMessage' => 'Your first name cannot be longer than {{ limit }} characters',
+                    'allowEmptyString' => false,
                 ]));
             }
         }


### PR DESCRIPTION
According to https://symfony.com/doc/4.4/reference/constraints/Length.html#allowemptystring the option "allowEmptyString" is mandatory if "min" is set (only for symfony 4.4). Therefore I'd like to consider this in the examples.
