### PR TITLE
dependencies with Login Form Authenticator doc

### DIFF
--- a/security/form_login_setup.rst
+++ b/security/form_login_setup.rst
@@ -139,7 +139,7 @@ a traditional HTML form that submits to ``/login``:
 
         <h1 class="h3 mb-3 font-weight-normal">Please sign in</h1>
         <label for="inputEmail" class="sr-only">Email</label>
-        <input type="email" value="{{ last_username }}" name="email" id="inputEmail" class="form-control" placeholder="Email" required autofocus>
+        <input type="text" value="{{ last_username }}" name="username" id="inputEmail" class="form-control" placeholder="Email" required autofocus>
         <label for="inputPassword" class="sr-only">Password</label>
         <input type="password" name="password" id="inputPassword" class="form-control" placeholder="Password" required>
 


### PR DESCRIPTION
fixed to line  ` if (empty($credentials['username'])) {`
```  /**
     * @param mixed                 $credentials
     * @param UserProviderInterface $userProvider
     *
     * @return User|object|UserInterface|null
     */
    public function getUser($credentials, UserProviderInterface $userProvider)
    {
        $token = new CsrfToken('authenticate', $credentials['csrf_token']);

        if (!$this->csrfTokenManager->isTokenValid($token)) {
            throw new InvalidCsrfTokenException();
        }

        if (empty($credentials['username'])) {
            throw new CustomUserMessageAuthenticationException(self::AUTHENTICATION_ERROR_MESSAGE);
        }
```

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
