### PR TITLE
[Routing] added missing "version-added" for i18n routes

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -38,7 +38,7 @@ following configuration file:
     controllers:
         resource: '../../src/Controller/'
         type: annotation
-        
+
     kernel:
         resource: ../../src/Kernel.php
         type: annotation
@@ -1654,6 +1654,10 @@ these routes.
 
 Localized Routes (i18n)
 -----------------------
+
+..version-added:: 4.1
+
+    The i18n routing has been introduced in Symfony 4.1.
 
 If your application is translated into multiple languages, each route can define
 a different URL per each :doc:`translation locale </translation/locale>`. This


### PR DESCRIPTION
To revert in 5.0.
