### PR TITLE
Replace ExceptionListener uses with ErrorListener

### DIFF
--- a/create_framework/dependency_injection.rst
+++ b/create_framework/dependency_injection.rst
@@ -27,7 +27,7 @@ to it::
             $argumentResolver = new HttpKernel\Controller\ArgumentResolver();
 
             $dispatcher = new EventDispatcher();
-            $dispatcher->addSubscriber(new HttpKernel\EventListener\ExceptionListener(
+            $dispatcher->addSubscriber(new HttpKernel\EventListener\ErrorListener(
                 'Calendar\Controller\ErrorController::exception'
             ));
             $dispatcher->addSubscriber(new HttpKernel\EventListener\RouterListener($matcher, $requestStack));
@@ -124,7 +124,7 @@ Create a new file to host the dependency injection container configuration::
     $containerBuilder->register('listener.response', HttpKernel\EventListener\ResponseListener::class)
         ->setArguments(['UTF-8'])
     ;
-    $containerBuilder->register('listener.exception', HttpKernel\EventListener\ExceptionListener::class)
+    $containerBuilder->register('listener.exception', HttpKernel\EventListener\ErrorListener::class)
         ->setArguments(['Calendar\Controller\ErrorController::exception'])
     ;
     $containerBuilder->register('dispatcher', EventDispatcher\EventDispatcher::class)

--- a/create_framework/http_kernel_httpkernel_class.rst
+++ b/create_framework/http_kernel_httpkernel_class.rst
@@ -66,7 +66,7 @@ framework: it matches the incoming request and populates the request
 attributes with route parameters.
 
 Our code is now much more concise and surprisingly more robust and more
-powerful than ever. For instance, use the built-in ``ExceptionListener`` to
+powerful than ever. For instance, use the built-in ``ErrorListener`` to
 make your error management configurable::
 
     $errorHandler = function (Symfony\Component\ErrorHandler\Exception\FlattenException $exception) {
@@ -74,14 +74,14 @@ make your error management configurable::
 
         return new Response($msg, $exception->getStatusCode());
     };
-    $dispatcher->addSubscriber(new HttpKernel\EventListener\ExceptionListener($errorHandler));
+    $dispatcher->addSubscriber(new HttpKernel\EventListener\ErrorListener($errorHandler));
 
-``ExceptionListener`` gives you a ``FlattenException`` instance instead of the
+``ErrorListener`` gives you a ``FlattenException`` instance instead of the
 thrown ``Exception`` or ``Error`` instance to ease exception manipulation and
 display. It can take any valid controller as an exception handler, so you can
 create an ErrorController class instead of using a Closure::
 
-    $listener = new HttpKernel\EventListener\ExceptionListener(
+    $listener = new HttpKernel\EventListener\ErrorListener(
         'Calendar\Controller\ErrorController::exception'
     );
     $dispatcher->addSubscriber($listener);


### PR DESCRIPTION
`ExceptionListener` has been deprecated in version 5.0 of `symfony/http-kernel`:
https://github.com/symfony/http-kernel/blob/master/CHANGELOG.md
The changelog recommends using `ErrorListener` instead.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
