### PR TITLE
Fix typehint of parameter for MicrokernelTrait::configureRoutes()

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -24,12 +24,12 @@ Next, create an ``index.php`` file that defines the kernel class and executes it
 
     // index.php
     use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+    use Symfony\Bundle\FrameworkBundle\Routing\Loader\Configurator\RoutingConfigurator;
     use Symfony\Component\Config\Loader\LoaderInterface;
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\HttpFoundation\JsonResponse;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpKernel\Kernel as BaseKernel;
-    use Symfony\Component\Routing\RouteCollectionBuilder;
 
     require __DIR__.'/vendor/autoload.php';
 
@@ -52,7 +52,7 @@ Next, create an ``index.php`` file that defines the kernel class and executes it
             ]);
         }
 
-        protected function configureRoutes(RouteCollectionBuilder $routes)
+        protected function configureRoutes(RoutingConfigurator $routes)
         {
             // kernel is a service that points to this class
             // optional 3rd argument is the route name
@@ -97,9 +97,9 @@ that define your bundles, your services and your routes:
     of what you see in a normal ``config/packages/*`` file). You can also register
     services directly in PHP or load external configuration files (shown below).
 
-**configureRoutes(RouteCollectionBuilder $routes)**
+**configureRoutes(RoutingConfigurator $routes)**
     Your job in this method is to add routes to the application. The
-    ``RouteCollectionBuilder`` has methods that make adding routes in PHP more
+    ``RoutingConfigurator`` has methods that make adding routes in PHP more
     fun. You can also load external routing files (shown below).
 
 Advanced Example: Twig, Annotations and the Web Debug Toolbar
@@ -134,10 +134,10 @@ hold the kernel. Now it looks like this::
     namespace App;
 
     use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+    use Symfony\Bundle\FrameworkBundle\Routing\Loader\Configurator\RoutingConfigurator;
     use Symfony\Component\Config\Loader\LoaderInterface;
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\HttpKernel\Kernel as BaseKernel;
-    use Symfony\Component\Routing\RouteCollectionBuilder;
 
     class Kernel extends BaseKernel
     {
@@ -170,7 +170,7 @@ hold the kernel. Now it looks like this::
             }
         }
 
-        protected function configureRoutes(RouteCollectionBuilder $routes)
+        protected function configureRoutes(RoutingConfigurator $routes)
         {
             // import the WebProfilerRoutes, only if the bundle is enabled
             if (isset($this->bundles['WebProfilerBundle'])) {


### PR DESCRIPTION
It is now `RoutingConfigurator` instead of `RouteCollectionBuilder` according to https://github.com/symfony/symfony/blob/master/UPGRADE-5.1.md#frameworkbundle

Also... There is a typo on the type on the mentioned file. Should I make  PR to it or is it generated automatically?