### PR TITLE
Update class names as amqp messenger was moved to another package

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -858,10 +858,10 @@ To use Symfony's built-in AMQP transport, you need the AMQP PHP extension.
 
 The transport has a number of other options, including ways to configure
 the exchange, queues binding keys and more. See the documentation on
-:class:`Symfony\\Component\\Messenger\\Transport\\AmqpExt\\Connection`.
+:class:`Symfony\\Component\\Messenger\\Bridge\\Amqp\\Transport\\Connection`.
 
 You can also configure AMQP-specific settings on your message by adding
-:class:`Symfony\\Component\\Messenger\\Transport\\AmqpExt\\AmqpStamp` to
+:class:`Symfony\\Component\\Messenger\\Bridge\\Amqp\\Transport\\AmqpStamp` to
 your Envelope::
 
     use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpStamp;


### PR DESCRIPTION
Doctrine, Redis and Amqp messenger components were moved to external packaged but documentation of classes to be used for Amqp was not updated accordingly.

Source: https://github.com/symfony/symfony/blob/master/UPGRADE-5.1.md#messenger