### PR TITLE
Removing Note about ArrayCollection

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -54,14 +54,7 @@ by creating a simple ``Task`` class::
         }
     }
 
-.. note::
-
-    The ``ArrayCollection`` is specific to Doctrine and is basically the
-    same as using an ``array`` (but it must be an ``ArrayCollection`` if
-    you're using Doctrine).
-
-Now, create a ``Tag`` class. As you saw above, a ``Task`` can have many ``Tag``
-objects::
+Now, create the corresponding ``Tag`` entity::
 
     // src/AppBundle/Entity/Tag.php
     namespace AppBundle\Entity;


### PR DESCRIPTION
ArrayCollections aren't new anymore, MakerBundle creates them out of the box.
