### PR TITLE
Simplifying the code block

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -249,7 +249,6 @@ add the ``allow_add`` option to your collection field::
     // src/Form/TaskType.php
 
     // ...
-    use Symfony\Component\Form\FormBuilderInterface;
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {


### PR DESCRIPTION
Second attempt of https://github.com/symfony/symfony-docs/pull/13446
Still don't know what went wrong with the RST syntax (I did keep the `::` in the first commit last time), so I'm trying it step after step now.
