### PR TITLE
Fix count input on form collection

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -328,7 +328,7 @@ will be show next):
 
         // count the current form inputs we have (e.g. 2), use that as the new
         // index when inserting a new item (e.g. 2)
-        $collectionHolder.data('index', $collectionHolder.find(':input').length);
+        $collectionHolder.data('index', $collectionHolder.find('input').length);
 
         $addTagButton.on('click', function(e) {
             // add a new tag form (see next code block)


### PR DESCRIPTION
On documentation, ```:input``` is used to find all input on collection and guess how many items collection contains. But ```:input``` select the button to add item on collection. So it add an item by error.

It cause error for instance with error mapping (Because it generate 1, 2, 3 instead of 0, 1, 2). We know it is our responsibility to check that as dev but it can help new developer to better apprehend Collection Type.
