### PR TITLE
Namespace import reference missing

### DIFF
--- a/notifier/texters.rst
+++ b/notifier/texters.rst
@@ -14,6 +14,10 @@ you to send SMS messages::
 
     // src/Controller/SecurityController.php
     namespace App\Controller;
+    
+    use Symfony\Component\Notifier\Message\SmsMessage;
+    use Symfony\Component\Notifier\TexterInterface;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class SecurityController
     {


### PR DESCRIPTION
I forgot to add the Route annotation import

```
use Symfony\Component\Routing\Annotation\Route;
```