### PR TITLE
[setup] Friendlier phrasing for people choosing not to use the Symfony CLI

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -51,8 +51,8 @@ The only difference between these two commands is the number of packages
 installed by default. The ``--full`` option installs all the packages that you
 usually need to build web applications, so the installation size will be bigger.
 
-If you can't or don't want to `install Symfony`_ for any reason, run these
-commands to create the new Symfony application using Composer:
+If you're not using the Symfony binary, run these commands to create the new 
+Symfony application using Composer:
 
 .. code-block:: terminal
 


### PR DESCRIPTION
This came up in a discussion on Slack, after the thread on Reddit about the Symfony CLI. This PR changes the phrase "If you can't or don't want to install Symfony for any reason" to wording that sounds less, perhaps, judging. 

Personally I like using the Symfony CLI, but not everybody does. And since it's by no means _required_ to do so, we shouldn't assume the reason why other people might choose not to. ^_^