### PR TITLE
No longer list the Symfony binary as a requirement

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -20,11 +20,13 @@ Before creating your first Symfony application you must:
 * Install PHP 7.1 or higher and these PHP extensions (which are installed and
   enabled by default in most PHP 7 installations): `Ctype`_, `iconv`_, `JSON`_,
   `PCRE`_, `Session`_, `SimpleXML`_, and `Tokenizer`_;
-* `Install Composer`_, which is used to install PHP packages;
-* `Install Symfony`_, which creates in your computer a binary called ``symfony``
-  that provides all the tools you need to develop your application locally.
+* `Install Composer`_, which is used to install PHP packages.
 
-The ``symfony`` binary provides a tool to check if your computer meets these
+Optionally, you can also `install Symfony`_. This creates a binary called
+``symfony`` that provides all the tools you need to develop and run your
+Symfony application locally.
+
+The ``symfony`` binary provides a tool to check if your computer meets all
 requirements. Open your console terminal and run this command:
 
 .. code-block:: terminal


### PR DESCRIPTION
Based on the same Slack discussion as #13461, I think we should also change this section a little bit. 

Instead of listing it as a requirement (and then in the next sections, mention ways to do things without Symfony CLI), I think it's more fair to mention it as a highly recommended tool instead.