### PR TITLE
Wrong syntax in documentation

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -67,7 +67,7 @@ with the ``new`` command:
 
 .. code-block:: terminal
 
-    $ symfony new my_project_name --version=3.4
+    $ symfony new my_project_name 3.4
 
 This command creates a new directory called ``my_project_name/`` that contains
 an empty project based on the most recent stable Symfony version available. In
@@ -111,8 +111,8 @@ In case your project needs to be based on a specific Symfony version, use the
 .. code-block:: terminal
 
     # use the most recent version in any Symfony branch
-    $ symfony new my_project_name --version=3.3
-    $ symfony new my_project_name --version=3.4
+    $ symfony new my_project_name 3.3
+    $ symfony new my_project_name 3.4
 
     # use the most recent 'lts' version (Long Term Support version)
     $ symfony new my_project_name --version=lts


### PR DESCRIPTION
New one symfony new blog 3.4

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
