### PR TITLE
Adds block about PHP-FPM behaviour

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -60,18 +60,20 @@ run the Symfony server in the background:
 Enabling PHP-FPM
 ----------------
 
-When the server starts it will check the ``public`` folder for an ``index.php``
-file. If this file is found the server will automatically start with PHP-FPM
-enabled. Otherwise the server will start without PHP-FPM and will show a
-``Page not found`` page when trying to access a ``.php`` file in the browser.
+When the server starts it will check for common patterns like ``web/app.php``,
+``web/app_dev.php`` or ``public/index.php``. If a file like this is found the
+server will automatically start with PHP-FPM enabled. Otherwise the server will
+start without PHP-FPM and will show a ``Page not found`` page when trying to 
+access a ``.php`` file in the browser.
 
 .. tip::
 
-    When an index.html and an index.php file are present the server will still
-    start with PHP-FPM enabled but the index.html will take precedence over the
-    index.php file. This means when an index.html file is present in 
-    ``public``, it will be displayed instead of the index.php which would show
-    e.g. the Symfony application.
+    When an ``index.html`` and a front controller like e.g. ``index.php`` are
+    both present the server will still start with PHP-FPM enabled but the 
+    ``index.html`` will take precedence over the front controller. This means
+    when an ``index.html`` file is present in ``public`` or ``web``, it will be
+    displayed instead of the ``index.php`` which would show e.g. the Symfony
+    application.
 
 Enabling TLS
 ------------

--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -68,8 +68,10 @@ enabled. Otherwise the server will start without PHP-FPM and will show a
 .. tip::
 
     When an index.html and an index.php file are present the server will still
-    start with PHP-FPM enabled but browsing the root of your website will serve
-    the index.html file.
+    start with PHP-FPM enabled but the index.html will take precedence over the
+    index.php file. This means when an index.html file is present in 
+    ``public``, it will be displayed instead of the index.php which would show
+    e.g. the Symfony application.
 
 Enabling TLS
 ------------

--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -57,6 +57,20 @@ run the Symfony server in the background:
     # show the latest log messages
     $ symfony server:log
 
+Enabling PHP-FPM
+----------------
+
+When the server starts it will check the ``public`` folder for an ``index.php``
+file. If this file is found the server will automatically start with PHP-FPM
+enabled. Otherwise the server will start without PHP-FPM and will show a
+``Page not found`` page when trying to access a ``.php`` file in the browser.
+
+.. tip::
+
+    When an index.html and an index.php file are present the server will still
+    start with PHP-FPM enabled but browsing the root of your website will serve
+    the index.html file.
+
 Enabling TLS
 ------------
 


### PR DESCRIPTION
Related to the issue https://github.com/symfony/cli/issues/178 I added some documentation on the behaviour of the PHP-FPM in the webserver.
Even though the behaviour is currently "expected" it is not obvious for the user.