### PR TITLE
Fixes wrong tag for RouteLoaderInterface registration without autoconfiguration

### DIFF
--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -214,7 +214,7 @@ extend or implement any special class, but the called method must return a
 If you're using :ref:`autoconfigure <services-autoconfigure>`, your class should
 implement the :class:`Symfony\\Bundle\\FrameworkBundle\\Routing\\RouteLoaderInterface`
 interface to be tagged automatically. If you're **not using autoconfigure**,
-tag it manually with ``routing.loader``.
+tag it manually with ``routing.route_loader``.
 
 .. note::
 


### PR DESCRIPTION
I had to do a few greps to find the right tag to use, without the tag, it was working seamlessly with 4.4.*, but since 5.0.* I had to add it.

That aside, I'm using this PR to say thank you for this page of documentation, aside this minor typo it helped me a lot. :+1: 
