### PR TITLE
[Setup] Clarify the Symfony binary and show small PHP built-in command

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -33,6 +33,12 @@ requirements. Open your console terminal and run this command:
 
     $ symfony check:requirements
 
+.. note::
+
+    The Symfony binary is developped internally at Symfony. If you want to
+    report a bug or suggest a new feature, please create an issue on
+    `symfony/cli`_.
+
 .. _creating-symfony-applications:
 
 Creating Symfony Applications
@@ -78,14 +84,16 @@ started. In other words, your new application is ready!
 Running Symfony Applications
 ----------------------------
 
-On production, you should use a web server like Nginx or Apache (see
-:doc:`configuring a web server to run Symfony </setup/web_server_configuration>`).
-But for development, it's more convenient to use the
-:doc:`local web server </setup/symfony_server>` provided by Symfony.
+In production, you should install a webserver like Nginx or Apache and
+:doc:`configure it to run Symfony </setup/web_server_configuration>`. This
+method can also be used if you're not using the Symfony local web server for
+development.
 
-This local server provides support for HTTP/2, TLS/SSL, automatic generation of
-security certificates and many other features. It works with any PHP application,
-not only Symfony projects, so it's a very useful development tool.
+However for local development, the most convenient way of running Symfony is by
+using the :doc:`local web server </setup/symfony_server>` provided by the
+``symfony`` binary. This local server provides among other things support for
+HTTP/2, concurrent requests, TLS/SSL and automatic generation of security
+certificates.
 
 Open your console terminal, move into your new project directory and start the
 local web server as follows:
@@ -98,6 +106,11 @@ local web server as follows:
 Open your browser and navigate to ``http://localhost:8000/``. If everything is
 working, you'll see a welcome page. Later, when you are finished working, stop
 the server by pressing ``Ctrl+C`` from your terminal.
+
+.. tip::
+
+    The web server works with any PHP application, not only Symfony projects,
+    so it's a very useful generic development tool.
 
 .. _install-existing-app:
 
@@ -294,6 +307,7 @@ Learn More
 .. _`Stellar Development with Symfony`: https://symfonycasts.com/screencast/symfony
 .. _`Install Composer`: https://getcomposer.org/download/
 .. _`install Symfony CLI`: https://symfony.com/download
+.. _`symfony/cli`: https://github.com/symfony/cli
 .. _`The Symfony Demo Application`: https://github.com/symfony/demo
 .. _`Symfony Flex`: https://github.com/symfony/flex
 .. _`PHP security advisories database`: https://github.com/FriendsOfPHP/security-advisories

--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -19,8 +19,9 @@ The Symfony server is part of the ``symfony`` binary created when you
 
 .. note::
 
-    If you want to report a bug or suggest a new feature, please create an issue
-    on `symfony/cli`_.
+    The Symfony binary is developped internally at Symfony. If you want to
+    report a bug or suggest a new feature, please create an issue on
+    `symfony/cli`_.
 
 Getting Started
 ---------------


### PR DESCRIPTION
`@MaikB` on Reddit left some very usefull insights in how we documented Symfony CLI ([ref](https://www.reddit.com/r/PHP/comments/foqs7x/symfony_docs_make_it_look_like_you_have_to_use/fm47h1t/?context=8&depth=9)). An excerpt from the comment:

> First there is the docs. [...] They just push very hard towards the symfony-cli. That on its own is no big deal. A big deal is that I had to do some digging to even find out that this CLI is closed source. You have to mention that upfront. [... shows the steps it required to find out the source is closed]
>
> Just give people an page which discusses the usage of the built-in web server (php -S localhost:8000 -t public), with or without a router script. Explain the shortcomings which lead you to develop the now deprecated symfony/web-server-bundle. Then tell the story of how the CLI came about and how it is connected to your cloud business. Tell us that you have to keep the sources closed for now, maybe because it contains details which are important for your business to be keep out of the public. Just give us something.
>
> I sincerely do believe this is an communication issue. [...]
>
> Now that I explained myself in more detail, let me say that I am thankful to Fabien and and everyone who has and still is working on Symfony. This is just a problem, not the end of the world. I hope you have a good day, given the pandemic, and stay safe.

---

I think this is very usefull information. I personally don't think there is anything wrong with the binary being closed source, but obviously there are people that feel uneasy about it. As we're an inclusive community, I think it makes sense to tell people upfront "hey, this is a closed source tool". 
This effectively changes nothing, but would solve part of the problem of these people that now feel excluded. It also opens the possibility to point people to a location to report bugs in the binary (previously, we only mentioned it in the Local web server guide).

I was against documenting the PHP built-in server in the docs, to not make it more complicated. But as it's used by community members and just a very small one-liner, I think it's nice to have a small note about it. Again, it's a small note, but it potentially solves a huge thing for others.

---

@fabpot @nicolas-grekas @javiereguiluz @weaverryan As I'm totally not into all strategy and ideas behind Symfony, I would like your opinions/reviews here. The goal at the very minimal is to not upset people with the changes in this PR.