### PR TITLE
Fixes wrong tag for RouteLoaderInterface registration without autoconfiguration

### DIFF
--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -214,7 +214,7 @@ extend or implement any special class, but the called method must return a
 If you're using :ref:`autoconfigure <services-autoconfigure>`, your class should
 implement the :class:`Symfony\\Bundle\\FrameworkBundle\\Routing\\RouteLoaderInterface`
 interface to be tagged automatically. If you're **not using autoconfigure**,
-tag it manually with ``routing.loader``.
+tag it manually with ``routing.route_loader``.
 
 .. deprecated:: 4.4
 


### PR DESCRIPTION
Following https://github.com/symfony/symfony-docs/pull/13474

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
