### PR TITLE
[Forms] fix displaying `empty_data` option for hidden field

### DIFF
--- a/reference/forms/types/hidden.rst
+++ b/reference/forms/types/hidden.rst
@@ -51,6 +51,12 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/data.rst.inc
 
 .. include:: /reference/forms/types/options/empty_data.rst.inc
+    :end-before: DEFAULT_PLACEHOLDER
+
+The default value is ``''`` (the empty string).
+
+.. include:: /reference/forms/types/options/empty_data.rst.inc
+    :start-after: DEFAULT_PLACEHOLDER
 
 .. include:: /reference/forms/types/options/error_mapping.rst.inc
 


### PR DESCRIPTION
I made a mistake on my previous PR #13458 which cause new issue #13471.

Fixes #13471.