### PR TITLE
Documentation correction for symfony security check command

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -228,7 +228,7 @@ vulnerability:
 
 .. code-block:: terminal
 
-    $ symfony check:security
+    $ symfony security:check
 
 A good security practice is to execute this command regularly to be able to
 update or replace compromised dependencies as soon as possible. The security
@@ -237,7 +237,7 @@ so your ``composer.lock`` file is not sent on the network.
 
 .. tip::
 
-    The ``check:security`` command terminates with a non-zero exit code if
+    The ``security:check`` command terminates with a non-zero exit code if
     any of your dependencies is affected by a known security vulnerability.
     This way you can add it to your project build process and your continuous
     integration workflows to make them fail when there are vulnerabilities.


### PR DESCRIPTION
In the latest version of the symfony binary (v4.13.3), the command for security check appears to be `symfony security:check` and not `symfony check:security`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
