### PR TITLE
messenger: add multiple transports support documentation

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -867,10 +867,10 @@ some messages are more important than others:
                 <!-- after retrying, messages will be sent to the "failed" transport 
                 by default if no "failed-transport" is configured inside a transport -->
                 <framework:messenger failure-transport="failed">
-                    <framework:transport name="async_priority_high" dsn="%env(MESSENGER_TRANSPORT_DSN)%" failure-transport="failed" /> 
+                    <framework:transport name="async_priority_high" dsn="%env(MESSENGER_TRANSPORT_DSN)%" failure-transport="failed"/> 
                     <!-- since no "failed_transport" is configured, the one used will be
                     the global "failed_transport" set -->
-                    <framework:transport name="async_priority_low" dsn="doctrine://default?queue_name=async_priority_low" />
+                    <framework:transport name="async_priority_low" dsn="doctrine://default?queue_name=async_priority_low"/>
                     
                     <framework:transport name="failed" dsn="doctrine://default?queue_name=failed"/>
                     <framework:transport name="failed_other" dsn="doctrine://default?queue_name=failed_other"/>

--- a/messenger.rst
+++ b/messenger.rst
@@ -909,6 +909,28 @@ The transport with a ``failed_transport`` configuration defined, will override t
 If there is no ``failed_transport`` defined globally or on the transport level, the messages
 will be discarded after the number of retries.
 
+The failed commands have an optional argument to specify the ``failed_transport`` configured at the transport level:
+
+.. code-block:: terminal
+
+    # see all messages in the failure transport
+    $ php bin/console messenger:failed:show --failure-transport={failure_transport}
+
+    # see details about a specific failure
+    $ php bin/console messenger:failed:show 20 --failure-transport={failure_transport} -vv
+
+    # view and retry messages one-by-one
+    $ php bin/console messenger:failed:retry -vv
+
+    # retry specific messages
+    $ php bin/console messenger:failed:retry 20 30 --failure-transport={failure_transport} --force
+
+    # remove a message without retrying it
+    $ php bin/console messenger:failed:remove 20 --failure-transport={failure_transport}
+
+    # remove messages without retrying them and show each message before removing it
+    $ php bin/console messenger:failed:remove 20 30 --failure-transport={failure_transport} --show-messages
+
 .. _messenger-transports-config:
 
 Transport Configuration


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).
-->

### New Feature: Messenger: Multiple Failed Transports

This PR adds the documentation related to PR: https://github.com/symfony/symfony/pull/34979

What it needs to be clear in the documentation:
- You can define multiple transports, one per transport (instead of the global one, as it is supported today)
- If you don't define a global failure transport and if the transport does not have the `failed_transport`configured the messages will be discarded
- If you define both a global and at the transport level, the `failure_transport` configuration, the one taken into account is at the transport level configuration.
- The failed commands have an option argument to specify the transport level `failed_transport`. Without arguments is the global failed transport taken into account.

