### PR TITLE
Moving mailer transport section

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -658,6 +658,36 @@ and it will select the appropriate certificate depending on the ``To`` option::
     $firstEncryptedEmail = $encrypter->encrypt($firstEmail);
     $secondEncryptedEmail = $encrypter->encrypt($secondEmail);
 
+Multiple Email Transports
+-------------------------
+
+.. versionadded:: 4.4
+
+    The option to define multiple email transports was introduced in Symfony 4.4.
+
+You may want to use more than one mailer transport for delivery of your messages.
+This can be configured by replacing the ``dsn`` configuration entry with a
+``transports`` entry, like:
+
+.. code-block:: yaml
+
+    # config/packages/mailer.yaml
+    framework:
+        mailer:
+            transports:
+                main: '%env(MAILER_DSN)%'
+                alternative: '%env(MAILER_DSN_IMPORTANT)%'
+
+By default the first transport is used. The other transports can be used by
+adding a text header ``X-Transport`` to an email::
+
+    // Send using first "main" transport ...
+    $mailer->send($email);
+
+    // ... or use the "alternative" one
+    $email->getHeaders()->addTextHeader('X-Transport', 'alternative');
+    $mailer->send($email);
+
 Sending Messages Async
 ----------------------
 
@@ -718,36 +748,6 @@ you have a transport called ``async``, you can route the message there:
 
 Thanks to this, instead of being delivered immediately, messages will be sent to
 the transport to be handled later (see :ref:`messenger-worker`).
-
-Multiple Email Transports
--------------------------
-
-.. versionadded:: 4.4
-
-    The option to define multiple email transports was introduced in Symfony 4.4.
-
-You may want to use more than one mailer transport for delivery of your messages.
-This can be configured by replacing the ``dsn`` configuration entry with a
-``transports`` entry, like:
-
-.. code-block:: yaml
-
-    # config/packages/mailer.yaml
-    framework:
-        mailer:
-            transports:
-                main: '%env(MAILER_DSN)%'
-                important: '%env(MAILER_DSN_IMPORTANT)%'
-
-By default the first transport is used. The other transports can be used by
-adding a text header ``X-Transport`` to an email::
-
-    // Send using first "main" transport ...
-    $mailer->send($email);
-
-    // ... or use the "important" one
-    $email->getHeaders()->addTextHeader('X-Transport', 'important');
-    $mailer->send($email);
 
 Development & Debugging
 -----------------------


### PR DESCRIPTION
See https://github.com/symfony/symfony/issues/36348#issuecomment-609393362

I moved this Mailer "transport" section above Messenger so that, if you're reading the Messenger section, you can't accidentally keep reading and think that the "mailer transports" section is talking about Messenger transports.

Also, I changed the transport name from `important` to `alternative` just to add some further differentiation.