### PR TITLE
[Contributing] Fix `trigger_error()` position in deprecated class

### DIFF
--- a/contributing/code/conventions.rst
+++ b/contributing/code/conventions.rst
@@ -129,7 +129,7 @@ the Web Debug Toolbar or by the PHPUnit bridge).
 .. _`@-silencing operator`: https://php.net/manual/en/language.operators.errorcontrol.php
 
 When deprecating a whole class the ``trigger_error()`` call should be placed
-between the namespace and the use declarations, like in this example from
+after the use declarations, like in this example from
 `ServiceRouterLoader`_::
 
     namespace Symfony\Component\Routing\Loader\DependencyInjection;


### PR DESCRIPTION
The code was added in commit: https://github.com/symfony/symfony-docs/commit/a2c04e717d7e70b485ef1a62fb5231e71add3ee2

The change introducing the issue was added in the PR: https://github.com/symfony/symfony-docs/pull/12075

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
