### PR TITLE
Update testing.rst

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -48,8 +48,13 @@ Symfony application.
 
 .. tip::
 
-    Code coverage can be generated with the ``--coverage-*`` options, see the
-    help information that is shown when using ``--help`` for more information.
+    Code coverage can be generated with the ``--coverage-*`` options, see the help information that is shown when using ``--help`` for more information.
+    To avoid the error "No code coverage driver is available" when you are generating code coverage you must install (xdebug, pcov,    phpdbg)
+    To install x-debug type on Ubuntu:
+
+.. code-block:: terminal
+
+    $ sudo apt-get install php-xdebug
 
 .. index::
    single: Tests; Unit tests


### PR DESCRIPTION
added a comment to a requirement to generate code coverage in html

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
