### PR TITLE
Fix "ensure the kernel is shut down " error message since SF4.4

### DIFF
--- a/testing/database.rst
+++ b/testing/database.rst
@@ -228,6 +228,8 @@ so, get the entity manager via the service container as follows::
             $this->entityManager = $kernel->getContainer()
                 ->get('doctrine')
                 ->getManager();
+            
+            self::ensureKernelShutdown();
         }
 
         public function testSearchByName()


### PR DESCRIPTION
Fix "ensure the kernel is shut down before calling the method" error message since SF4.4