### PR TITLE
[EventDispatcher] Fix position of `AddEventAliasesPass`

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -235,10 +235,10 @@ determine which instance is passed.
         use Symfony\Component\EventDispatcher\EventDispatcher;
 
         $containerBuilder = new ContainerBuilder(new ParameterBag());
-        $containerBuilder->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $containerBuilder->addCompilerPass(new AddEventAliasesPass([
             \AcmeFooActionEvent::class => 'acme.foo.action',
         ]));
+        $containerBuilder->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING)
 
         $containerBuilder->register('event_dispatcher', EventDispatcher::class);
 


### PR DESCRIPTION
In the note following the change, it's written : Note that ``AddEventAliasesPass`` has to be processed before ``RegisterListenersPass``.
But in the code it was the inverse

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
