### PR TITLE
Corrects description for placement of trigger_deprecation()

### DIFF
--- a/contributing/code/conventions.rst
+++ b/contributing/code/conventions.rst
@@ -122,7 +122,7 @@ A deprecation must also be triggered to help people with the migration
     trigger_deprecation('symfony/package-name', '5.1', 'The "%s" class is deprecated, use "%s" instead.', Deprecated::class, Replacement::class);
 
 When deprecating a whole class the ``trigger_deprecation()`` call should be placed
-between the namespace and the use declarations, like in this example from
+between the use declarations and the class, like in this example from
 `ServiceRouterLoader`_::
 
     namespace Symfony\Component\Routing\Loader\DependencyInjection;


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
