### PR TITLE
[Testing] Change deprecated assertContains to assertStringContainsString

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -356,7 +356,7 @@ console::
 
             // the output of the command in the console
             $output = $commandTester->getDisplay();
-            $this->assertContains('Username: Wouter', $output);
+            $this->assertStringContainsString('Username: Wouter', $output);
 
             // ...
         }

--- a/create_framework/unit_testing.rst
+++ b/create_framework/unit_testing.rst
@@ -49,7 +49,7 @@ resolver. Modify the framework to make use of them::
     namespace Simplex;
 
     // ...
-    
+
     use Calendar\Controller\LeapYearController;
     use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
     use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
@@ -183,7 +183,7 @@ Response::
         $response = $framework->handle(new Request());
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertContains('Yep, this is a leap year!', $response->getContent());
+        $this->assertStringContainsString('Yep, this is a leap year!', $response->getContent());
     }
 
 In this test, we simulate a route that matches and returns a simple

--- a/testing.rst
+++ b/testing.rst
@@ -270,7 +270,7 @@ Or test against the response content directly if you just want to assert that
 the content contains some text or in case that the response is not an XML/HTML
 document::
 
-    $this->assertContains(
+    $this->assertStringContainsString(
         'Hello World',
         $client->getResponse()->getContent()
     );
@@ -316,7 +316,7 @@ document::
         );
 
         // asserts that the response content contains a string
-        $this->assertContains('foo', $client->getResponse()->getContent());
+        $this->assertStringContainsString('foo', $client->getResponse()->getContent());
         // ...or matches a regex
         $this->assertRegExp('/foo(bar)?/', $client->getResponse()->getContent());
 


### PR DESCRIPTION
Symfony 5 requires PHP 7.2. PHPUnit Bridge for this version by default use [PHPUnit 8.3](https://symfony.com/doc/current/components/phpunit_bridge.html#modified-phpunit-script).
The assertContains is [deprecated](https://github.com/sebastianbergmann/phpunit/issues/3425) and in PHPUnit 9 throws an error.


