### PR TITLE
Avoid Supervisord to go in fatal error

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -619,6 +619,7 @@ times:
     command=php /path/to/your/app/bin/console messenger:consume async --time-limit=3600
     user=ubuntu
     numprocs=2
+    startsecs=0
     autostart=true
     autorestart=true
     process_name=%(program_name)s_%(process_num)02d


### PR DESCRIPTION
`startsecs`: The total number of seconds which the program needs to stay running after a startup to consider the start successful (moving the process from the `STARTING` state to the `RUNNING` state).
Set to 0 to indicate that the program needn’t stay running for any particular amount of time.

Default : 1

It means that if you have for instance a `--limit=1` and your program has finished before 1 second, Supervisord will consider it failed.
After 3 times (cf `startretries` value), your process won't run anymore, considering that too many occured quickly.

Apparently it's a good pratice to set this value to `0`, specially with php.

Doc : http://supervisord.org/configuration.html?highlight=startsecs

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
