### PR TITLE
RepeatedType overrides `mapped` value for the type to work properly

### DIFF
--- a/reference/forms/types/repeated.rst
+++ b/reference/forms/types/repeated.rst
@@ -98,6 +98,11 @@ shown to the user.
 The ``invalid_message`` is used to customize the error that will
 be displayed when the two fields do not match each other.
 
+.. note::
+
+    The ``mapped`` option is always ``true`` for both fields in order for the type
+    to work properly.
+
 Field Options
 -------------
 


### PR DESCRIPTION
Add a note to the documentation about overridden `mapped` option for inner fields.
