### PR TITLE
Fix test login example for 4.4 - 5.0 applications

### DIFF
--- a/testing/http_authentication.rst
+++ b/testing/http_authentication.rst
@@ -113,6 +113,9 @@ needs::
         {
             $session = self::$container->get('session');
 
+            // somehow fetch the user (e.g. using the user repository)
+            $user = ...;
+
             $firewallName = 'secure_area';
             // if you don't define multiple connected firewalls, the context defaults to the firewall name
             // See https://symfony.com/doc/current/reference/configuration/security.html#firewall-context
@@ -120,7 +123,7 @@ needs::
 
             // you may need to use a different token class depending on your application.
             // for example, when using Guard authentication you must instantiate PostAuthenticationGuardToken
-            $token = new UsernamePasswordToken('admin', null, $firewallName, ['ROLE_ADMIN']);
+            $token = new UsernamePasswordToken($user, null, $firewallName, $user->getRoles());
             $session->set('_security_'.$firewallContext, serialize($token));
             $session->save();
 


### PR DESCRIPTION
Fixes part of #13376 

Since Symfony 4.4, user equality is checked on each request thus the current method (with a non-existent user) is broken. I've updated the example to use something similar to the new `loginUser()` method in Symfony 5.1.

This fixes the docs for 4.4 and 5.0. See #13523 for improvements of this chapter in 5.1.