### PR TITLE
Fix documentation for a controllers with __invoke function in php routing

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -137,7 +137,7 @@ the ``BlogController``:
 
                 // if the action is implemented as the __invoke() method of the
                 // controller class, you can skip the ', method_name]' part:
-                // ->controller([BlogController::class])
+                // ->controller(BlogController::class)
             ;
         };
 


### PR DESCRIPTION
Hi, the current docs tell that proper using controller with ```__invoke``` class should be implemented by:
```
// if the action is implemented as the __invoke() method of the
// controller class, you can skip the ', method_name]' part:
// ->controller([BlogController::class])
```

which is wrong. The implementation should be without ```[]``` brackets:
```
// ->controller(BlogController::class)
```