### PR TITLE
[Browserkit] The Client class has been replaced by the AbstractBrowser since SF 4.3

### DIFF
--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -39,16 +39,16 @@ Creating a Client
 The component only provides an abstract client and does not provide any backend
 ready to use for the HTTP layer.
 
-To create your own client, you must extend the abstract ``Client`` class and
-implement the :method:`Symfony\\Component\\BrowserKit\\Client::doRequest` method.
+To create your own client, you must extend the ``AbstractBrowser`` class and
+implement the :method:`Symfony\\Component\\BrowserKit\\AbstractBrowser::doRequest` method.
 This method accepts a request and should return a response::
 
     namespace Acme;
 
-    use Symfony\Component\BrowserKit\Client as BaseClient;
+    use Symfony\Component\BrowserKit\AbstractBrowser;
     use Symfony\Component\BrowserKit\Response;
 
-    class Client extends BaseClient
+    class Client extends AbstractBrowser
     {
         protected function doRequest($request)
         {
@@ -67,7 +67,7 @@ provided by the :doc:`HttpKernel component </components/http_kernel>`.
 Making Requests
 ~~~~~~~~~~~~~~~
 
-Use the :method:`Symfony\\Component\\BrowserKit\\Client::request` method to
+Use the :method:`Symfony\\Component\\BrowserKit\\AbstractBrowser::request` method to
 make HTTP requests. The first two arguments are the HTTP method and the requested
 URL::
 
@@ -81,7 +81,7 @@ The value returned by the ``request()`` method is an instance of the
 :doc:`DomCrawler component </components/dom_crawler>`, which allows accessing
 and traversing HTML elements programmatically.
 
-The :method:`Symfony\\Component\\BrowserKit\\Client::xmlHttpRequest` method,
+The :method:`Symfony\\Component\\BrowserKit\\AbstractBrowser::xmlHttpRequest` method,
 which defines the same arguments as the ``request()`` method, is a shortcut to
 make AJAX requests::
 

--- a/testing.rst
+++ b/testing.rst
@@ -484,7 +484,7 @@ script::
 AJAX Requests
 ~~~~~~~~~~~~~
 
-The Client provides a :method:`Symfony\\Component\\BrowserKit\\Client::xmlHttpRequest`
+The Client provides a :method:`Symfony\\Component\\BrowserKit\\AbstractBrowser::xmlHttpRequest`
 method, which has the same arguments as the ``request()`` method, and it's a
 shortcut to make AJAX requests::
 


### PR DESCRIPTION
I noticed that in the BrowserKit documentation, there was multiple references to the old ``Symfony\Component\BrowserKit\Client`` class instead of the ``Symfony\Component\BrowserKit\AbstractBrowser`` one.

See [https://github.com/symfony/symfony/pull/30541](https://github.com/symfony/symfony/pull/30541)

There was a previous merge request for SF5 here (#12717), but I don't know if it was possible for me to use it since I'm quite new with Github best practice about contribution.

Don't hesitate to tell me if I'm wrong!

