### PR TITLE
Renaming "Securing Individual Objects"

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -663,11 +663,11 @@ Securing other Services
 
 See :doc:`/security/securing_services`.
 
-Securing Individual Objects
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setting Individual User Permissions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Most applications require more specific access rules. For instance, a user
-should be able to only edit their own comments on a blog. Voters allow you
+should be able to only edit their *own* comments on a blog. Voters allow you
 to write *whatever* business logic you need to determine access. Using
 these voters is similar to the role-based access checks implemented in the
 previous chapters. Read :doc:`/security/voters` to learn how to implement


### PR DESCRIPTION
Reason: I never understood what "objects" referred to in "Securing Individual Objects". Renaming it to "Individual User Permissions" is another step forward at solving the "discoverability" problem I mentioned in https://github.com/symfony/symfony-docs/issues/11505

However, I would still move it higher up on the page (above Roles), since I see it like this: Having *Individual* users is basic for any security system; grouping those users into something called Roles is advanced.

Second, since Voters are described on a separate page, I would also defer Roles to another page, off the main security page.