### PR TITLE
Added PHP type declarations to getting started guides

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -765,12 +765,13 @@ use the ``getParameter()`` helper::
     namespace App\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\Response;
 
     class UserController extends AbstractController
     {
         // ...
 
-        public function index()
+        public function index(): Response
         {
             $projectDir = $this->getParameter('kernel.project_dir');
             $adminEmail = $this->getParameter('app.admin_email');

--- a/controller.rst
+++ b/controller.rst
@@ -36,7 +36,7 @@ class::
         /**
          * @Route("/lucky/number/{max}", name="app_lucky_number")
          */
-        public function number($max)
+        public function number(int $max): Response
         {
             $number = random_int(0, $max);
 
@@ -134,7 +134,7 @@ and ``redirect()`` methods::
     use Symfony\Component\HttpFoundation\RedirectResponse;
 
     // ...
-    public function index()
+    public function index(): RedirectResponse
     {
         // redirects to the "homepage" route
         return $this->redirectToRoute('homepage');
@@ -196,12 +196,13 @@ If you need a service in a controller, type-hint an argument with its class
 (or interface) name. Symfony will automatically pass you the service you need::
 
     use Psr\Log\LoggerInterface;
+    use Symfony\Component\HttpFoundation\Response;
     // ...
 
     /**
      * @Route("/lucky/number/{max}")
      */
-    public function number($max, LoggerInterface $logger)
+    public function number(int $max, LoggerInterface $logger): Response
     {
         $logger->info('We are logging!');
         // ...
@@ -322,10 +323,11 @@ Managing Errors and 404 Pages
 When things are not found, you should return a 404 response. To do this, throw a
 special type of exception::
 
+    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
     // ...
-    public function index()
+    public function index(): Response
     {
         // retrieve the object from database
         $product = ...;
@@ -370,8 +372,10 @@ object. To access it in your controller, add it as an argument and
 **type-hint it with the Request class**::
 
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HttpFoundation\Response;
+    // ...
 
-    public function index(Request $request, $firstName, $lastName)
+    public function index(Request $request, string $firstName, string $lastName): Response
     {
         $page = $request->query->get('page', 1);
 
@@ -401,9 +405,11 @@ Session storage and other configuration can be controlled under the
 To get the session, add an argument and type-hint it with
 :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionInterface`::
 
+    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpFoundation\Session\SessionInterface;
+    // ...
 
-    public function index(SessionInterface $session)
+    public function index(SessionInterface $session): Response
     {
         // stores an attribute for reuse during a later user request
         $session->set('foo', 'bar');
@@ -413,6 +419,8 @@ To get the session, add an argument and type-hint it with
 
         // uses a default value if the attribute doesn't exist
         $filters = $session->get('filters', []);
+
+        // ...
     }
 
 Stored attributes remain in the session for the remainder of that user's session.
@@ -435,8 +443,10 @@ from the session automatically as soon as you retrieve them. This feature makes
 For example, imagine you're processing a :doc:`form </forms>` submission::
 
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HttpFoundation\Response;
+    // ...
 
-    public function update(Request $request)
+    public function update(Request $request): Response
     {
         // ...
 
@@ -515,8 +525,9 @@ pass the ``Request`` object to any controller argument that is type-hinted with
 the ``Request`` class::
 
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HttpFoundation\Response;
 
-    public function index(Request $request)
+    public function index(Request $request): Response
     {
         $request->isXmlHttpRequest(); // is it an Ajax request?
 
@@ -572,7 +583,7 @@ To get the value of any :ref:`configuration parameter <configuration-parameters>
 from a controller, use the ``getParameter()`` helper method::
 
     // ...
-    public function index()
+    public function index(): Response
     {
         $contentsDir = $this->getParameter('kernel.project_dir').'/contents';
         // ...
@@ -584,8 +595,10 @@ Returning JSON Response
 To return JSON from a controller, use the ``json()`` helper method. This returns a
 ``JsonResponse`` object that encodes the data automatically::
 
+    use Symfony\Component\HttpFoundation\Response;
     // ...
-    public function index()
+
+    public function index(): Response
     {
         // returns '{"username":"jane.doe"}' and sets the proper Content-Type header
         return $this->json(['username' => 'jane.doe']);
@@ -604,7 +617,10 @@ Streaming File Responses
 You can use the :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController::file`
 helper to serve a file from inside a controller::
 
-    public function download()
+    use Symfony\Component\HttpFoundation\Response;
+    // ...
+
+    public function download(): Response
     {
         // send the file contents and force the browser to download it
         return $this->file('/path/to/some_file.pdf');
@@ -614,8 +630,9 @@ The ``file()`` helper provides some arguments to configure its behavior::
 
     use Symfony\Component\HttpFoundation\File\File;
     use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+    // ...
 
-    public function download()
+    public function download(): Response
     {
         // load the file from the filesystem
         $file = new File('/path/to/some_file.pdf');

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -226,13 +226,15 @@ variable so you can use it in Twig::
     // src/Controller/LuckyController.php
     namespace App\Controller;
 
+    use Symfony\Component\HttpFoundation\Response;
     // ...
+
     class LuckyController extends AbstractController
     {
         /**
          * @Route("/lucky/number")
          */
-        public function number()
+        public function number(): Response
         {
             $number = random_int(0, 100);
 

--- a/routing.rst
+++ b/routing.rst
@@ -53,6 +53,7 @@ do so, create a :doc:`controller class </controller>` like the following::
     namespace App\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Routing\Annotation\Route;
 
     class BlogController extends AbstractController
@@ -60,7 +61,7 @@ do so, create a :doc:`controller class </controller>` like the following::
         /**
          * @Route("/blog", name="blog_list")
          */
-        public function list()
+        public function list(): Response
         {
             // ...
         }
@@ -161,14 +162,16 @@ Use the ``methods`` option to restrict the verbs each route should respond to:
         // src/Controller/BlogApiController.php
         namespace App\Controller;
 
-        // ...
+        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class BlogApiController extends AbstractController
         {
             /**
              * @Route("/api/posts/{id}", methods={"GET","HEAD"})
              */
-            public function show(int $id)
+            public function show(int $id): Response
             {
                 // ... return a JSON response with the post
             }
@@ -176,7 +179,7 @@ Use the ``methods`` option to restrict the verbs each route should respond to:
             /**
              * @Route("/api/posts/{id}", methods={"PUT"})
              */
-            public function edit(int $id)
+            public function edit(int $id): Response
             {
                 // ... edit a post
             }
@@ -254,6 +257,7 @@ arbitrary matching logic:
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class DefaultController extends AbstractController
@@ -268,7 +272,7 @@ arbitrary matching logic:
              * expressions can also include config parameters:
              * condition: "request.headers.get('User-Agent') matches '%app.allowed_browsers%'"
              */
-            public function contact()
+            public function contact(): Response
             {
                 // ...
             }
@@ -406,6 +410,7 @@ defined as ``/blog/{slug}``:
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends AbstractController
@@ -415,7 +420,7 @@ defined as ``/blog/{slug}``:
             /**
              * @Route("/blog/{slug}", name="blog_show")
              */
-            public function show(string $slug)
+            public function show(string $slug): Response
             {
                 // $slug will equal the dynamic part of the URL
                 // e.g. at /blog/yay-routing, then $slug='yay-routing'
@@ -486,6 +491,7 @@ the ``{page}`` parameter using the ``requirements`` option:
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends AbstractController
@@ -493,7 +499,7 @@ the ``{page}`` parameter using the ``requirements`` option:
             /**
              * @Route("/blog/{page}", name="blog_list", requirements={"page"="\d+"})
              */
-            public function list(int $page)
+            public function list(int $page): Response
             {
                 // ...
             }
@@ -501,7 +507,7 @@ the ``{page}`` parameter using the ``requirements`` option:
             /**
              * @Route("/blog/{slug}", name="blog_show")
              */
-            public function show($slug)
+            public function show(string $slug): Response
             {
                 // ...
             }
@@ -597,6 +603,7 @@ concise, but it can decrease route readability when requirements are complex:
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends AbstractController
@@ -604,7 +611,7 @@ concise, but it can decrease route readability when requirements are complex:
             /**
              * @Route("/blog/{page<\d+>}", name="blog_list")
              */
-            public function list(int $page)
+            public function list(int $page): Response
             {
                 // ...
             }
@@ -665,6 +672,7 @@ other configuration formats they are defined with the ``defaults`` option:
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends AbstractController
@@ -672,7 +680,7 @@ other configuration formats they are defined with the ``defaults`` option:
             /**
              * @Route("/blog/{page}", name="blog_list", requirements={"page"="\d+"})
              */
-            public function list(int $page = 1)
+            public function list(int $page = 1): Response
             {
                 // ...
             }
@@ -756,6 +764,7 @@ parameter:
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends AbstractController
@@ -763,7 +772,7 @@ parameter:
             /**
              * @Route("/blog/{page<\d+>?1}", name="blog_list")
              */
-            public function list(int $page)
+            public function list(int $page): Response
             {
                 // ...
             }
@@ -831,6 +840,7 @@ controller action. Instead of ``string $slug``, add ``BlogPost $post``::
 
     use App\Entity\BlogPost;
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Routing\Annotation\Route;
 
     class BlogController extends AbstractController
@@ -840,7 +850,7 @@ controller action. Instead of ``string $slug``, add ``BlogPost $post``::
         /**
          * @Route("/blog/{slug}", name="blog_show")
          */
-        public function show(BlogPost $post)
+        public function show(BlogPost $post): Response
         {
             // $post is the object whose slug matches the routing parameter
 
@@ -893,7 +903,10 @@ and in route imports. Symfony defines some special attributes with the same name
         // src/Controller/ArticleController.php
         namespace App\Controller;
 
-        // ...
+        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
+        use Symfony\Component\Routing\Annotation\Route;
+
         class ArticleController extends AbstractController
         {
             /**
@@ -907,7 +920,7 @@ and in route imports. Symfony defines some special attributes with the same name
              *     }
              * )
              */
-            public function search()
+            public function search(): Response
             {
             }
         }
@@ -982,14 +995,16 @@ the controllers of the routes:
         // src/Controller/BlogController.php
         namespace App\Controller;
 
+        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
-        class BlogController
+        class BlogController extends AbstractController
         {
             /**
              * @Route("/blog/{page}", name="blog_index", defaults={"page": 1, "title": "Hello world!"})
              */
-            public function index(int $page, string $title)
+            public function index(int $page, string $title): Response
             {
                 // ...
             }
@@ -1055,14 +1070,16 @@ A possible solution is to change the parameter requirements to be more permissiv
         // src/Controller/DefaultController.php
         namespace App\Controller;
 
+        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
-        class DefaultController
+        class DefaultController extends AbstractController
         {
             /**
              * @Route("/share/{token}", name="share", requirements={"token"=".+"})
              */
-            public function share($token)
+            public function share($token): Response
             {
                 // ...
             }
@@ -1143,17 +1160,19 @@ the common configuration using options when importing the routes.
         // src/Controller/BlogController.php
         namespace App\Controller;
 
+        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         /**
          * @Route("/blog", requirements={"_locale": "en|es|fr"}, name="blog_")
          */
-        class BlogController
+        class BlogController extends AbstractController
         {
             /**
              * @Route("/{_locale}", name="index")
              */
-            public function index()
+            public function index(): Response
             {
                 // ...
             }
@@ -1161,7 +1180,7 @@ the common configuration using options when importing the routes.
             /**
              * @Route("/{_locale}/posts/{slug}", name="show")
              */
-            public function show(Post $post)
+            public function show(Post $post): Response
             {
                 // ...
             }
@@ -1267,6 +1286,7 @@ information in a controller via the ``Request`` object::
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Routing\Annotation\Route;
 
     class BlogController extends AbstractController
@@ -1274,15 +1294,15 @@ information in a controller via the ``Request`` object::
         /**
          * @Route("/blog", name="blog_list")
          */
-        public function list(Request $request)
+        public function list(Request $request): Response
         {
-            // ...
-
             $routeName = $request->attributes->get('_route');
             $routeParameters = $request->attributes->get('_route_params');
 
             // use this to get all the available attributes (not only routing ones):
             $allAttributes = $request->attributes->all();
+
+            // ...
         }
     }
 
@@ -1467,6 +1487,7 @@ host name:
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class MainController extends AbstractController
@@ -1474,7 +1495,7 @@ host name:
             /**
              * @Route("/", name="mobile_homepage", host="m.example.com")
              */
-            public function mobileHomepage()
+            public function mobileHomepage(): Response
             {
                 // ...
             }
@@ -1482,7 +1503,7 @@ host name:
             /**
              * @Route("/", name="homepage")
              */
-            public function homepage()
+            public function homepage(): Response
             {
                 // ...
             }
@@ -1546,6 +1567,7 @@ multi-tenant applications) and these parameters can be validated too with
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class MainController extends AbstractController
@@ -1559,7 +1581,7 @@ multi-tenant applications) and these parameters can be validated too with
              *     requirements={"subdomain"="m|mobile"}
              * )
              */
-            public function mobileHomepage()
+            public function mobileHomepage(): Response
             {
                 // ...
             }
@@ -1567,7 +1589,7 @@ multi-tenant applications) and these parameters can be validated too with
             /**
              * @Route("/", name="homepage")
              */
-            public function homepage()
+            public function homepage(): Response
             {
                 // ...
             }
@@ -1676,6 +1698,7 @@ avoids the need for duplicating routes, which also reduces the potential bugs:
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class CompanyController extends AbstractController
@@ -1686,7 +1709,7 @@ avoids the need for duplicating routes, which also reduces the potential bugs:
              *     "nl": "/over-ons"
              * }, name="about_us")
              */
-            public function about()
+            public function about(): Response
             {
                 // ...
             }
@@ -1816,6 +1839,7 @@ use the ``generateUrl()`` helper::
     namespace App\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Routing\Annotation\Route;
     use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -1824,10 +1848,8 @@ use the ``generateUrl()`` helper::
         /**
          * @Route("/blog", name="blog_list")
          */
-        public function list()
+        public function list(): Response
         {
-            // ...
-
             // generate a URL with no route arguments
             $signUpPage = $this->generateUrl('sign_up');
 
@@ -1843,6 +1865,8 @@ use the ``generateUrl()`` helper::
             // when a route is localized, Symfony uses by default the current request locale
             // pass a different '_locale' value if you want to set the locale explicitly
             $signUpPageInDutch = $this->generateUrl('sign_up', ['_locale' => 'nl']);
+
+            // ...
         }
     }
 
@@ -2000,7 +2024,7 @@ This information can be configured per command too::
             $this->router = $router;
         }
 
-        protected function execute(InputInterface $input, OutputInterface $output)
+        protected function execute(InputInterface $input, OutputInterface $output): int
         {
             // these values override any global configuration
             $context = $this->router->getContext();
@@ -2101,6 +2125,7 @@ each route explicitly:
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class SecurityController extends AbstractController
@@ -2108,7 +2133,7 @@ each route explicitly:
             /**
              * @Route("/login", name="login", schemes={"https"})
              */
-            public function login()
+            public function login(): Response
             {
                 // ...
             }
@@ -2222,7 +2247,7 @@ Here are some common errors you might see while working with routing:
 
 This happens when your controller method has an argument (e.g. ``$slug``)::
 
-    public function show($slug)
+    public function show(string $slug): Response
     {
         // ...
     }

--- a/templates.rst
+++ b/templates.rst
@@ -90,12 +90,13 @@ passes to it the needed variables::
     namespace App\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\Response;
 
     class UserController extends AbstractController
     {
         // ...
 
-        public function notifications()
+        public function notifications(): Response
         {
             // get the user information and notifications somehow
             $userFirstName = '...';
@@ -191,6 +192,7 @@ Consider the following routing configuration:
         namespace App\Controller;
 
         // ...
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends AbstractController
@@ -198,7 +200,7 @@ Consider the following routing configuration:
             /**
              * @Route("/", name="blog_index")
              */
-            public function index()
+            public function index(): Response
             {
                 // ...
             }
@@ -206,7 +208,7 @@ Consider the following routing configuration:
             /**
              * @Route("/article/{slug}", name="blog_post")
              */
-            public function show(string $slug)
+            public function show(string $slug): Response
             {
                 // ...
             }
@@ -399,7 +401,7 @@ use the ``render()`` helper::
 
     class ProductController extends AbstractController
     {
-        public function index()
+        public function index(): Response
         {
             // ...
 
@@ -723,11 +725,12 @@ First, create the controller that renders a certain number of recent articles::
     // src/Controller/BlogController.php
     namespace App\Controller;
 
+    use Symfony\Component\HttpFoundation\Response;
     // ...
 
     class BlogController extends AbstractController
     {
-        public function recentArticles($max = 3)
+        public function recentArticles(int $max = 3): Response
         {
             // get the recent articles somehow (e.g. making a database query)
             $articles = ['...', '...', '...'];


### PR DESCRIPTION
Relates to #12235 

I've scanned all PHP examples in the getting started guides and updated them to use PHP typing consistently (most already used typing in some way or another).

Practical things:
* Once approved, I'll take care of merging this into 5.0 and master and open new PRs for new code blocks in those branches;
* I suggest not touching 3.4 at all, we should not update that version anymore unless there is a major bug (which is unlikely, as it's around for years already);
* Method declarations almost never change (because of the BC promise), and as we're fixing these in all active branches (except 3.4), this change will not lead to persistent merge conflicts in the future.
* I don't think we can add a DOCbot rule for this one, as we cannot introduce typing in all PHP examples everywhere (see the mentioned issue).