### PR TITLE
[Workflow] Replace has_role by is_granted

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -546,7 +546,7 @@ transition. The value of this option is any valid expression created with the
 
                     <framework:transition name="reject">
                         <!-- or any valid expression language with "subject" referring to the post -->
-                        <framework:guard>has_role("ROLE_ADMIN") and subject.isStatusReviewed()</framework:guard>
+                        <framework:guard>is_granted("ROLE_ADMIN") and subject.isStatusReviewed()</framework:guard>
                         <framework:from>reviewed</framework:from>
                         <framework:to>rejected</framework:to>
                     </framework:transition>
@@ -581,7 +581,7 @@ transition. The value of this option is any valid expression created with the
                         ],
                         'reject' => [
                             // or any valid expression language with "subject" referring to the post
-                            'guard' => 'has_role("ROLE_ADMIN") and subject.isStatusReviewed()',
+                            'guard' => 'is_granted("ROLE_ADMIN") and subject.isStatusReviewed()',
                             'from' => 'reviewed',
                             'to' => 'rejected',
                         ],


### PR DESCRIPTION
As in changelog of security component version 5.0:

```
Removed the `has_role()` function from security expressions, use `is_granted()` instead.
```

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
