### PR TITLE
replace ExceptionListener by EventListener

### DIFF
--- a/reference/events.rst
+++ b/reference/events.rst
@@ -251,7 +251,7 @@ sent as response::
 
 .. note::
 
-    The TwigBundle registers an :class:`Symfony\\Component\\HttpKernel\\EventListener\\ExceptionListener`
+    The TwigBundle registers an :class:`Symfony\\Component\\HttpKernel\\EventListener\\ErrorListener`
     that forwards the ``Request`` to a given controller defined by the
     ``exception_listener.controller`` parameter.
 


### PR DESCRIPTION
Deprecated  ExceptionListener is replaced by EventListener in Symfony 5.0

