### PR TITLE
Use non-deprecated options key to configure babel in encore

### DIFF
--- a/frontend/encore/babel.rst
+++ b/frontend/encore/babel.rst
@@ -25,10 +25,10 @@ Need to extend the Babel configuration further? The easiest way is via
         }, {
             // node_modules is not processed through Babel by default
             // but you can whitelist specific modules to process
-            include_node_modules: ['foundation-sites'],
+            includeNodeModules: ['foundation-sites'],
 
             // or completely control the exclude rule (note that you
-            // can't use both "include_node_modules" and "exclude" at
+            // can't use both "includeNodeModules" and "exclude" at
             // the same time)
             exclude: /bower_components/
         })


### PR DESCRIPTION
The options key changed in `v0.24.0` from `include_node_modules` to `includeNodeModules` and the former one is deprecated.

See: https://github.com/symfony/webpack-encore/blob/master/lib/WebpackConfig.js#L412-L415