### PR TITLE
Fix service contracts import XML example

### DIFF
--- a/service_container/import.rst
+++ b/service_container/import.rst
@@ -103,14 +103,16 @@ a relative or absolute path to the imported file:
 
             <imports>
                 <import resource="services/mailer.xml"/>
+            </imports>
 
+            <services>
                 <defaults autowire="true" autoconfigure="true"/>
 
                 <prototype namespace="App\" resource="../src/*"
                     exclude="../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}"/>
 
                 <!-- ... -->
-            </imports>
+            </services>
         </container>
 
     .. code-block:: php


### PR DESCRIPTION
When the example for imports in service XML was extended in the 4.3 documentation, the defaults and the prototype were put inside the `<imports>` tag instead of a `<services>` tag.