### PR TITLE
add doc for reset-password maker

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1015,6 +1015,7 @@ Authentication (Identifying/Logging in the User)
     :maxdepth: 1
 
     security/form_login_setup
+    security/reset_password
     security/json_login_setup
     security/guard_authentication
     security/password_migration

--- a/security/reset_password.rst
+++ b/security/reset_password.rst
@@ -25,4 +25,4 @@ file. For more information on the configuration, check out the
 `SymfonyCastsResetPasswordBundle`_  guide.
 
 .. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
-.. _`Symfony Cast's Reset Password Bundle`: https://github.com/symfonycasts/reset-password-bundle
+.. _`SymfonyCastsResetPasswordBundle`: https://github.com/symfonycasts/reset-password-bundle

--- a/security/reset_password.rst
+++ b/security/reset_password.rst
@@ -1,17 +1,14 @@
-How to Add Secure Password Reset Functionality
-==============================================
+How to Add a Reset Password Feature
+===================================
 
-Using `MakerBundle`_ & `Symfony Cast's Reset Password Bundle`_ you can create a
+Using `MakerBundle`_ & `SymfonyCastsResetPasswordBundle`_ you can create a
 secure out of the box solution to handle forgotten passwords.
 
-.. caution::
+First, make sure you have a security ``User`` class. Follow
+the :doc:`Security Guide </security>` if you don't have one already.
 
-    Make sure you have created a ``User`` class with a getter method to retrieve
-    the users unique email address. The :doc:`Security Guide </security>` will
-    help you install security and create your user class.
-
-Bootstrap reset password functionality
---------------------------------------
+Generating the Reset Password Code
+----------------------------------
 
 .. code-block:: terminal
 
@@ -19,14 +16,13 @@ Bootstrap reset password functionality
         .....
     $ php bin/console make:reset-password
 
+The `make:reset-password` command will ask you a few questions about your app and
+generate all the files you need! After, you'll see a success message and a list
+of any other steps you need to do.
 
-The reset password maker will then ask you a couple questions about your app and
-generate the required files. Afterword's you should see the success message,
-a list of the files generated, and any other task's that may need to be performed.
-
-You can customize the reset password bundle's behavior by editing ``reset_password.yaml``.
-For more information on the configuration, check out the
-`Symfony Cast's Reset Password Bundle`_  guide.
+You can customize the reset password bundle's behavior by updating the ``reset_password.yaml``
+file. For more information on the configuration, check out the
+`SymfonyCastsResetPasswordBundle`_  guide.
 
 .. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
 .. _`Symfony Cast's Reset Password Bundle`: https://github.com/symfonycasts/reset-password-bundle

--- a/security/reset_password.rst
+++ b/security/reset_password.rst
@@ -21,32 +21,8 @@ Bootstrap reset password functionality
 
 
 The reset password maker will then ask you a couple questions about your app and
-generate the required files. Afterword's you should see a list of the files generated.
-
-.. code-block:: terminal
-
-    created: src/Controller/ResetPasswordController.php
-    created: src/Entity/ResetPasswordRequest.php
-    created: src/Repository/ResetPasswordRequestRepository.php
-    updated: config/packages/reset_password.yaml
-    created: src/Form/ResetPasswordRequestFormType.php
-    created: src/Form/ChangePasswordFormType.php
-    created: templates/reset_password/check_email.html.twig
-    created: templates/reset_password/email.html.twig
-    created: templates/reset_password/request.html.twig
-    created: templates/reset_password/reset.html.twig
-
-
-    Success!
-
-
-    Next:
-    1) Run "php bin/console make:migration" to generate a migration for the new "App\Entity\ResetPasswordRequest" entity.
-    2) Review forms in "src/Form" to customize validation and labels.
-    3) Review and customize the templates in `templates/reset_password`.
-    4) Make sure your MAILER_DSN env var has the correct settings.
-
-    Then open your browser, go to "/reset-password" and enjoy!
+generate the required files. Afterword's you should see the success message,
+a list of the files generated, and any other task's that may need to be performed.
 
 You can customize the reset password bundle's behavior by editing ``reset_password.yaml``.
 For more information on the configuration, check out the

--- a/security/reset_password.rst
+++ b/security/reset_password.rst
@@ -1,0 +1,56 @@
+How to add secure forgotten password functionality
+==================================================
+
+Using `MakerBundle`_ & `Symfony Cast's Reset Password Bundle`_ you can create a
+secure out of the box solution to handle forgotten passwords.
+
+.. caution::
+
+    Make sure you have created a ``User`` class with a getter method to retrieve
+    the users unique email address. The :doc:`Security Guide </security>` will help you
+    install security.
+
+Bootstrap reset password functionality
+---------------------------------------------
+
+.. code-block:: terminal
+
+    $ php composer require symfonycasts/reset-password-bundle
+        .....
+    $ php bin/console make:reset-password
+
+
+The reset password maker will then ask you a couple questions about your app and
+generate the required files. Afterword's you should see a list of the files generated.
+
+.. code-block:: terminal
+
+    created: src/Controller/ResetPasswordController.php
+    created: src/Entity/ResetPasswordRequest.php
+    created: src/Repository/ResetPasswordRequestRepository.php
+    updated: config/packages/reset_password.yaml
+    created: src/Form/ResetPasswordRequestFormType.php
+    created: src/Form/ChangePasswordFormType.php
+    created: templates/reset_password/check_email.html.twig
+    created: templates/reset_password/email.html.twig
+    created: templates/reset_password/request.html.twig
+    created: templates/reset_password/reset.html.twig
+
+
+    Success!
+
+
+    Next:
+    1) Run "php bin/console make:migration" to generate a migration for the new "App\Entity\ResetPasswordRequest" entity.
+    2) Review forms in "src/Form" to customize validation and labels.
+    3) Review and customize the templates in `templates/reset_password`.
+    4) Make sure your MAILER_DSN env var has the correct settings.
+
+    Then open your browser, go to "/reset-password" and enjoy!
+
+You can customize the reset password bundle's behavior by editing ``reset_password.yaml``.
+For more information on the configuration, check out the
+`Symfony Cast's Reset Password Bundle`_  guide.
+
+.. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
+.. _`Symfony Cast's Reset Password Bundle`: https://github.com/symfonycasts/reset-password-bundle

--- a/security/reset_password.rst
+++ b/security/reset_password.rst
@@ -1,4 +1,4 @@
-How to add secure forgotten password functionality
+How To Add Secure Password Reset Functionality
 ==================================================
 
 Using `MakerBundle`_ & `Symfony Cast's Reset Password Bundle`_ you can create a

--- a/security/reset_password.rst
+++ b/security/reset_password.rst
@@ -1,5 +1,5 @@
 How to Add Secure Password Reset Functionality
-==================================================
+==============================================
 
 Using `MakerBundle`_ & `Symfony Cast's Reset Password Bundle`_ you can create a
 secure out of the box solution to handle forgotten passwords.
@@ -7,11 +7,11 @@ secure out of the box solution to handle forgotten passwords.
 .. caution::
 
     Make sure you have created a ``User`` class with a getter method to retrieve
-    the users unique email address. The :doc:`Security Guide </security>` will help you
-    install security.
+    the users unique email address. The :doc:`Security Guide </security>` will
+    help you install security and create your user class.
 
 Bootstrap reset password functionality
----------------------------------------------
+--------------------------------------
 
 .. code-block:: terminal
 

--- a/security/reset_password.rst
+++ b/security/reset_password.rst
@@ -1,4 +1,4 @@
-How To Add Secure Password Reset Functionality
+How to Add Secure Password Reset Functionality
 ==================================================
 
 Using `MakerBundle`_ & `Symfony Cast's Reset Password Bundle`_ you can create a


### PR DESCRIPTION
- Creates a guide to setup reset password functionality
- Security doc links to the new guide

Added to the 4.4 branch as the bundle supports Symfony 4.4+