### PR TITLE
Remove old AppBundle code from XML service definition example

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -176,12 +176,12 @@ each time you ask for it.
                     <!-- Default configuration for services in *this* file -->
                     <defaults autowire="true" autoconfigure="true"/>
 
+                    <!-- makes classes in src/ available to be used as services -->
+                    <!-- this creates a service per class whose id is the fully-qualified class name -->
                     <prototype namespace="App\" resource="../src/*" exclude="../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}"/>
 
-                    <!-- makes classes in src/AppBundle available to be used as services -->
-                    <prototype namespace="AppBundle\"
-                        resource="../../src/AppBundle/*"
-                        exclude="../../src/AppBundle/{Entity,Repository}"/>
+                    <!-- ... -->
+
                 </services>
             </container>
 


### PR DESCRIPTION
In the XML example of the default service definition, there still was the AppBundle prototype definition from the 3.4 docs, besides the new App definition. I made the XML example resemble the YAML example.