### PR TITLE
Adding an if condition on a for tag is deprecated in Twig 2.10.

### DIFF
--- a/form/create_custom_field_type.rst
+++ b/form/create_custom_field_type.rst
@@ -405,7 +405,7 @@ libraries are used in your application:
 
     {# templates/form/custom_types.html.twig #}
     {% block postal_address_row %}
-        {% for child in form.children if not child.rendered %}
+        {% for child in form.children|filter(v => not v.rendered) -%}
             <div class="form-group">
                 {{ form_label(child) }}
                 {{ form_widget(child) }}


### PR DESCRIPTION
I've got an error, running example from the docs. Here is the explanation: https://twig.symfony.com/doc/2.x/deprecated.html#tags
I propose to use a filter filter or an “if” condition inside the “for” body instead in this docs.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
