### PR TITLE
Fix PHP example on ExpressionLanguage Injection

### DIFF
--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -67,7 +67,7 @@ to another service: ``App\Mailer``. One way to do this is with an expression:
             $services->set(MailerConfiguration::class);
 
             $services->set(Mailer::class)
-                ->args([expr(sprintf('service(%s).getMailerMethod()', MailerConfiguration::class))]);
+                ->args([expr(sprintf('service(%s).getMailerMethod()', var_export(MailerConfiguration::class, true)))]);
         };
 
 


### PR DESCRIPTION
Current example does not work. generate `service(App\Service)` instead of `service('App\\Service')`
Missing quotes and `\` escape