### PR TITLE
[Notifier] Add FreeMobile SMS entry

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -52,18 +52,19 @@ to send SMS messages to mobile phones. This feature requires subscribing to
 a third-party service that sends SMS messages. Symfony provides integration
 with a couple popular SMS services:
 
-========  =============================  ===========================================
-Service   Package                        DSN
-========  =============================  ===========================================
-Twilio    ``symfony/twilio-notifier``    ``twilio://SID:TOKEN@default?from=FROM``
-Nexmo     ``symfony/nexmo-notifier``     ``nexmo://KEY:SECRET@default?from=FROM``
-OvhCloud  ``symfony/ovhcloud-notifier``  ``ovhcloud://KEY:SECRET@default?from=FROM``
-Sinch     ``symfony/sinch-notifier``     ``sinch://ACCOUNT_ID:AUTH_TOKEN@default?from=FROM``
-========  =============================  ===========================================
+==========  ===============================  ====================================================
+Service     Package                          DSN
+==========  ===============================  ====================================================
+Twilio      ``symfony/twilio-notifier``      ``twilio://SID:TOKEN@default?from=FROM``
+Nexmo       ``symfony/nexmo-notifier``       ``nexmo://KEY:SECRET@default?from=FROM``
+OvhCloud    ``symfony/ovhcloud-notifier``    ``ovhcloud://KEY:SECRET@default?from=FROM``
+Sinch       ``symfony/sinch-notifier``       ``sinch://ACCOUNT_ID:AUTH_TOKEN@default?from=FROM``
+FreeMobile  ``symfony/freemobile-notifier``  ``freemobile://LOGIN:PASS@default?phone=PHONE``
+==========  ===============================  ====================================================
 
 .. versionadded:: 5.1
 
-    The OvhCloud and Sinch integrations were introduced in Symfony 5.1.
+    The OvhCloud, Sinch and FreeMobile integrations were introduced in Symfony 5.1.
 
 To enable a texter, add the correct DSN in your ``.env`` file and
 configure the ``texter_transports``:


### PR DESCRIPTION
Hi, 

I was reading this [blog post](https://symfony.com/blog/new-in-symfony-5-1-new-and-improved-integrations#notifier-component)
and remind I have not yet added it to the doc [this feature](https://github.com/symfony/symfony/pull/35690)

Just a question as I am not sure where and how to document the fact that this sms notifier is a bit special, is it ok like this in the `versionadded code block`?

or maybe it is better in a note afterward?

Thank you