### PR TITLE
[Notifier] Add Zulip entry

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -125,20 +125,25 @@ The chat channel is used to send chat messages to users by using
 :class:`Symfony\\Component\\Notifier\\Chatter` classes. Symfony provides
 integration with these chat services:
 
-==========  ===============================  ============================================
+==========  ===============================  =================================================
 Service     Package                          DSN
-==========  ===============================  ============================================
+==========  ===============================  =================================================
 Slack       ``symfony/slack-notifier``       ``slack://default/ID``
 Telegram    ``symfony/telegram-notifier``    ``telegram://TOKEN@default?channel=CHAT_ID``
 Mattermost  ``symfony/mattermost-notifier``  ``mattermost://TOKEN@ENDPOINT?channel=CHANNEL``
 RocketChat  ``symfony/rocketchat-notifier``  ``rocketchat://TOKEN@ENDPOINT?channel=CHANNEL``
-==========  ===============================  ============================================
+Zulip       ``symfony/zulip-notifier``       ``zulip://EMAIL:APIKEY@ENDPOINT?channel=CHANNEL``
+==========  ===============================  =================================================
 
 .. versionadded:: 5.1
 
     The Mattermost and RocketChat integrations were introduced in Symfony
     5.1. The Slack DSN changed in Symfony 5.1 to use Slack Incoming
     Webhooks instead of legacy tokens.
+
+.. versionadded:: 5.2
+
+    The Zulip integration was introduced in Symfony 5.2. 
 
 Chatters are configured using the ``chatter_transports`` setting:
 


### PR DESCRIPTION
Added entry for this feature: https://github.com/symfony/symfony/pull/36616

I have question, the integration supports sending notification directly to a person through the recipient parameter. Should that be documented somewhere? 