### PR TITLE
Update upgrade_major.rst

### DIFF
--- a/setup/upgrade_major.rst
+++ b/setup/upgrade_major.rst
@@ -170,7 +170,7 @@ Next, use Composer to download new versions of the libraries:
 
 .. code-block:: terminal
 
-    $ composer update symfony/*
+    $ composer update "symfony/*"
 
 .. include:: /setup/_update_dep_errors.rst.inc
 


### PR DESCRIPTION
Mac OS will give error without the quotes.

zsh: no matches found: symfony/*

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
