### PR TITLE
Update service_container.rst

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -860,7 +860,7 @@ This is mostly useful when you want to fetch services lazily::
 
 As a best practice, you should only create *private* services, which will happen
 automatically. And also, you should *not* use the ``$container->get()`` method to
-fetch public services.
+fetch private services.
 
 But, if you *do* need to make a service public, override the ``public`` setting:
 


### PR DESCRIPTION
if a public service should *not* be fetched by ``$container->get()``, how should it be fetched? The example shows the use of ``$container->get()``, so I think there was a typo and it should be changed from "public" => "private"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
