### PR TITLE
Add reapply proxy settings on chrome tooltip

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -201,7 +201,7 @@ Now run this command to start the proxy:
 
 .. note::
 
-    Some browsers (e.g. Chrome) require a full restart after starting the proxy.
+    Some browsers (e.g. Chrome) require to re-apply proxy settings (clicking on ``Re-apply settings`` button on the ``chrome://net-internals/#proxy`` page) or a full restart after starting the proxy.
     Otherwise, you'll see a *"This webpage is not available"* error (``ERR_NAME_NOT_RESOLVED``).
 
 Defining the Local Domain


### PR DESCRIPTION
Hi,

Just a very small tooltip : you don't need to fully restart chrome on proxy start, just to re-apply proxy settings.
