### PR TITLE
Correct defintion of Range validation messages

### DIFF
--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -56,8 +56,7 @@ you might add the following:
                     - Range:
                         min: 120
                         max: 180
-                        minMessage: You must be at least {{ limit }}cm tall to enter
-                        maxMessage: You cannot be taller than {{ limit }}cm to enter
+                        notInRangeMessage: You must be between {{ min }}cm and {{ max }}cm tall to enter
 
     .. code-block:: xml
 
@@ -72,8 +71,7 @@ you might add the following:
                     <constraint name="Range">
                         <option name="min">120</option>
                         <option name="max">180</option>
-                        <option name="minMessage">You must be at least {{ limit }}cm tall to enter</option>
-                        <option name="maxMessage">You cannot be taller than {{ limit }}cm to enter</option>
+                        <option name="notInRangeMessage">You must be between {{ min }}cm and {{ max }}cm tall to enter</option>
                     </constraint>
                 </property>
             </class>
@@ -94,8 +92,7 @@ you might add the following:
                 $metadata->addPropertyConstraint('height', new Assert\Range([
                     'min' => 120,
                     'max' => 180,
-                    'minMessage' => 'You must be at least {{ limit }}cm tall to enter',
-                    'maxMessage' => 'You cannot be taller than {{ limit }}cm to enter',
+                    'notInRangeMessage' => 'You must be between {{ min }}cm and {{ max }}cm tall to enter',
                 ]));
             }
         }
@@ -350,7 +347,8 @@ maxMessage
 **type**: ``string`` **default**: ``This value should be {{ limit }} or less.``
 
 The message that will be shown if the underlying value is more than the
-`max`_ option.
+`max`_ option, and no `min`_ option has been defined (if both are defined, use
+`notInRangeMessage`_).
 
 You can use the following parameters in this message:
 
@@ -397,7 +395,8 @@ minMessage
 **type**: ``string`` **default**: ``This value should be {{ limit }} or more.``
 
 The message that will be shown if the underlying value is less than the
-`min`_ option.
+`min`_ option, and no `max`_ option has been defined (if both are defined, use
+`notInRangeMessage`_).
 
 You can use the following parameters in this message:
 


### PR DESCRIPTION
The example given in the docs doesn't work since this change in 4.4: https://github.com/symfony/symfony/commit/c5488bcec1f42d896e33d3c67a5117fb96186896

Even if you've written a nice min `minMessage` and `maxMessage`, users will just get the default "This value should be between X and Y." message, because the `notInRange` check gets carried out first, and returns before the individual min/max checks get performed.