### PR TITLE
[Console] Remove invalid argument

### DIFF
--- a/console/calling_commands.rst
+++ b/console/calling_commands.rst
@@ -20,7 +20,6 @@ Calling a command from another one is straightforward::
         $command = $this->getApplication()->find('demo:greet');
 
         $arguments = [
-            'command' => 'demo:greet',
             'name'    => 'Fabien',
             '--yell'  => true,
         ];


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
Passing in the command is only valid when passing the arguments to the application (https://symfony.com/doc/current/console/command_in_controller.html), not if we directly call the command.

This would currently result in an `InvalidArgumentException: The "command" argument does not exist.`