### PR TITLE
Fix wrong Symfony listeners range

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -131,7 +131,7 @@ listener class:
     and it controls the order in which listeners are executed (the higher the
     number, the earlier a listener is executed). This is useful when you need to
     guarantee that one listener is executed before another. The priorities of the
-    internal Symfony listeners usually range from ``-255`` to ``255`` but your
+    internal Symfony listeners usually range from ``-256`` to ``256`` but your
     own listeners can use any positive or negative integer.
 
 .. _events-subscriber:


### PR DESCRIPTION
It seems to be between -256 and 256.

For example: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/EventListener/ValidateRequestListener.php#L51

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
