### PR TITLE
Update events.rst

### DIFF
--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -122,7 +122,7 @@ Listeners receive a
 
         $output->writeln(sprintf('Oops, exception thrown while running command <info>%s</info>', $command->getName()));
 
-        // gets the current exit code (the exception code or the exit code set by a ConsoleEvents::TERMINATE event)
+        // gets the current exit code (the exception code)
         $exitCode = $event->getExitCode();
 
         // changes the exception to another one


### PR DESCRIPTION
The exit code can't come from the terminate event since terminate is dispatched after the error event.