### PR TITLE
Custom User Checker, AuthenticationException is allowed

### DIFF
--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -16,7 +16,7 @@ User checkers are classes that must implement the
 defines two methods called ``checkPreAuth()`` and ``checkPostAuth()`` to
 perform checks before and after user authentication. If one or more conditions
 are not met, an exception should be thrown which extends the
-:class:`Symfony\\Component\\Security\\Core\\Exception\\AccountStatusException`::
+:class:`Symfony\\Component\\Security\\Core\\Exception\\AccountStatusException`: or :class:`Symfony\\Component\\Security\\Core\\Exception\\AuthenticationException`::
 
     namespace App\Security;
 


### PR DESCRIPTION
According to https://github.com/symfony/security-core/blob/master/Authentication/AuthenticationProviderManager.php#L80-L93, and my local tests, both works.

