### PR TITLE
Remove unnecessary historic configuration: 'sudo: false'

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -181,7 +181,7 @@ of Symfony and the latest beta release:
 .. code-block:: yaml
 
     language: php
-    sudo: false
+
     cache:
         directories:
             - $HOME/.composer/cache/files


### PR DESCRIPTION
I hope I did enough Googling. I really tried to find a reason to keep `sudo :false` in 2020 but it seems that it has no effect anymore.

I even tried to `sudo echo foo` during Travis' `install` phase and that works with and without `sudo: false`.

Docs: https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments

Blog post stating "If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon": https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
