### PR TITLE
[DI] Renamed some PHP-DSL functions

### DIFF
--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -303,10 +303,10 @@ config files:
             ;
 
             $services->set('newsletter_manager', 'NewsletterManager')
-                ->call('setMailer', [ref('mailer')])
+                // In versions earlier to Symfony 5.1 the service() function was called ref()
+                ->call('setMailer', [service('mailer')])
             ;
         };
-
 
 Learn More
 ----------

--- a/security/custom_authentication_provider.rst
+++ b/security/custom_authentication_provider.rst
@@ -433,13 +433,14 @@ to service ids that may not exist yet: ``App\Security\Authentication\Provider\Ws
             $services = $configurator->services();
 
             $services->set(WsseProvider::class)
-                ->arg('$cachePool', ref('cache.app'))
+                ->arg('$cachePool', service('cache.app'))
             ;
 
             $services->set(WsseListener::class)
                 ->args([
-                    ref('security.token_storage'),
-                    ref('security.authentication.manager'),
+                    // In versions earlier to Symfony 5.1 the service() function was called ref()
+                    service('security.token_storage'),
+                    service('security.authentication.manager'),
                 ])
             ;
         };

--- a/service_container.rst
+++ b/service_container.rst
@@ -526,7 +526,8 @@ parameter and in PHP config use the ``Reference`` class:
             $services = $configurator->services();
 
             $services->set(MessageGenerator::class)
-                ->args([ref('logger')])
+                // In versions earlier to Symfony 5.1 the service() function was called ref()
+                ->args([service('logger')])
             ;
         };
 
@@ -633,7 +634,7 @@ But, you can control this and pass in a different logger:
 
             // explicitly configure the service
             $services->set(SiteUpdateManager::class)
-                ->arg('$logger', ref('monolog.logger.request'))
+                ->arg('$logger', service('monolog.logger.request'))
             ;
         };
 
@@ -738,15 +739,15 @@ You can also use the ``bind`` keyword to bind specific arguments by name or type
 
                     // pass this service to any $requestLogger argument for any
                     // service that's defined in this file
-                    ->bind('$requestLogger', ref('monolog.logger.request'))
+                    ->bind('$requestLogger', service('monolog.logger.request'))
 
                     // pass this service for any LoggerInterface type-hint for any
                     // service that's defined in this file
-                    ->bind(LoggerInterface::class, ref('monolog.logger.request'))
+                    ->bind(LoggerInterface::class, service('monolog.logger.request'))
 
                     // optionally you can define both the name and type of the argument to match
                     ->bind('string $adminEmail', 'manager@example.com')
-                    ->bind(LoggerInterface::class.' $requestLogger', ref('monolog.logger.request'))
+                    ->bind(LoggerInterface::class.' $requestLogger', service('monolog.logger.request'))
                     ->bind('iterable $rules', tagged_iterator('app.foo.rule'))
             ;
 
@@ -1113,16 +1114,16 @@ admin email. In this case, each needs to have a unique service id:
                 ->autowire(false)
                 // manually wire all arguments
                 ->args([
-                    ref(MessageGenerator::class),
-                    ref('mailer'),
+                   service(MessageGenerator::class),
+                   service('mailer'),
                     'superadmin@example.com',
                 ]);
 
             $services->set('site_update_manager.normal_users', SiteUpdateManager::class)
                 ->autowire(false)
                 ->args([
-                    ref(MessageGenerator::class),
-                    ref('mailer'),
+                    service(MessageGenerator::class),
+                    service('mailer'),
                     'contact@example.com',
                 ]);
 

--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -267,20 +267,16 @@ The following example shows how to inject an anonymous service into another serv
             $services = $configurator->services();
 
             $services->set(Foo::class)
-                ->args([service(AnonymousBar::class)])
+                // In versions earlier to Symfony 5.1 the inline_service() function was called service()
+                ->args([inline_service(AnonymousBar::class)])
         };
-
-.. versionadded:: 5.1
-
-    The ``service()`` function was introduced in Symfony 5.1. In previous
-    versions it was called ``inline()``.
 
 .. note::
 
     Anonymous services do *NOT* inherit the definitions provided from the
     defaults defined in the configuration. So you'll need to explicitly mark
     service as autowired or autoconfigured when doing an anonymous service
-    e.g.: ``service(Foo::class)->autowire()->autoconfigure()``.
+    e.g.: ``inline_service(Foo::class)->autowire()->autoconfigure()``.
 
 Using an anonymous service as a factory looks like this:
 
@@ -323,7 +319,7 @@ Using an anonymous service as a factory looks like this:
             $services = $configurator->services();
 
             $services->set(Foo::class)
-                ->factory([service(AnonymousBar::class), 'constructFoo'])
+                ->factory([inline_service(AnonymousBar::class), 'constructFoo'])
         };
 
 Deprecating Services

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -507,7 +507,7 @@ the injection::
 
                 // If you wanted to choose the non-default service and do not
                 // want to use a named autowiring alias, wire it manually:
-                //     ->arg('$transformer', ref(UppercaseTransformer::class))
+                //     ->arg('$transformer', service(UppercaseTransformer::class))
                 // ...
         };
 

--- a/service_container/calls.rst
+++ b/service_container/calls.rst
@@ -72,9 +72,9 @@ To configure the container to call the ``setLogger`` method, use the ``calls`` k
             // ...
 
             $services->set(MessageGenerator::class)
-                ->call('setLogger', [ref('logger')]);
+                // In versions earlier to Symfony 5.1 the service() function was called ref()
+                ->call('setLogger', [service('logger')]);
         };
-
 
 To provide immutable services, some classes implement immutable setters.
 Such setters return a new instance of the configured class

--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -179,11 +179,12 @@ all the classes are already loaded as services. All you need to do is specify th
             $services->load('App\\', '../src/*');
 
             // override the services to set the configurator
+            // In versions earlier to Symfony 5.1 the service() function was called ref()
             $services->set(NewsletterManager::class)
-                ->configurator(ref(EmailConfigurator::class), 'configure');
+                ->configurator(service(EmailConfigurator::class), 'configure');
 
             $services->set(GreetingCardManager::class)
-                ->configurator(ref(EmailConfigurator::class), 'configure');
+                ->configurator(service(EmailConfigurator::class), 'configure');
         };
 
 .. _configurators-invokable:
@@ -250,10 +251,10 @@ routes can reference :ref:`invokable controllers <controller-service-invoke>`.
 
             // override the services to set the configurator
             $services->set(NewsletterManager::class)
-                ->configurator(ref(EmailConfigurator::class));
+                ->configurator(service(EmailConfigurator::class));
 
             $services->set(GreetingCardManager::class)
-                ->configurator(ref(EmailConfigurator::class));
+                ->configurator(service(EmailConfigurator::class));
         };
 
 That's it! When requesting the ``App\Mail\NewsletterManager`` or

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -158,7 +158,8 @@ Configuration of the service container then looks like this:
             // second, use the factory service as the first argument of the 'factory'
             // method and the factory method as the second argument
             $services->set(NewsletterManager::class)
-                ->factory([ref(NewsletterManagerFactory::class), 'createNewsletterManager']);
+                // In versions earlier to Symfony 5.1 the service() function was called ref()
+                ->factory([service(NewsletterManagerFactory::class), 'createNewsletterManager']);
         };
 
 .. _factories-invokable:
@@ -228,8 +229,8 @@ method name, just as routes can reference
             $services = $configurator->services();
 
             $services->set(NewsletterManager::class)
-                ->args([ref('templating')])
-                ->factory(ref(NewsletterManagerFactory::class));
+                ->args([service('templating')])
+                ->factory(service(NewsletterManagerFactory::class));
         };
 
 .. _factories-passing-arguments-factory-method:
@@ -289,8 +290,8 @@ previous examples takes the ``templating`` service as an argument:
             $services = $configurator->services();
 
             $services->set(NewsletterManager::class)
-                ->factory([ref(NewsletterManagerFactory::class), 'createNewsletterManager'])
-                ->args([ref('templating')])
+                ->factory([service(NewsletterManagerFactory::class), 'createNewsletterManager'])
+                ->args([service('templating')])
             ;
         };
 

--- a/service_container/injection_types.rst
+++ b/service_container/injection_types.rst
@@ -77,9 +77,9 @@ service container configuration:
             $services = $configurator->services();
 
             $services->set(NewsletterManager::class)
-                ->args(ref('mailer'));
+                // In versions earlier to Symfony 5.1 the service() function was called ref()
+                ->args(service('mailer'));
         };
-
 
 .. tip::
 
@@ -270,7 +270,7 @@ that accepts the dependency::
             $services = $configurator->services();
 
             $services->set(NewsletterManager::class)
-                ->call('setMailer', [ref('mailer')]);
+                ->call('setMailer', [service('mailer')]);
         };
 
 This time the advantages are:
@@ -350,7 +350,7 @@ Another possibility is setting public fields of the class directly::
             $services = $configurator->services();
 
             $services->set('app.newsletter_manager', NewsletterManager::class)
-                ->property('mailer', ref('mailer'));
+                ->property('mailer', service('mailer'));
         };
 
 There are mainly only disadvantages to using property injection, it is similar

--- a/service_container/optional_dependencies.rst
+++ b/service_container/optional_dependencies.rst
@@ -42,9 +42,9 @@ if the service does not exist:
             $services = $configurator->services();
 
             $services->set(NewsletterManager::class)
-                ->args([ref('logger')->nullOnInvalid()]);
+                // In versions earlier to Symfony 5.1 the service() function was called ref()
+                ->args([service('logger')->nullOnInvalid()]);
         };
-
 
 .. note::
 
@@ -99,7 +99,7 @@ call if the service exists and remove the method call if it does not:
             $services = $configurator->services();
 
             $services->set(NewsletterManager::class)
-                ->call('setLogger', [ref('logger')->ignoreOnInvalid()])
+                ->call('setLogger', [service('logger')->ignoreOnInvalid()])
             ;
         };
 

--- a/service_container/parent_services.rst
+++ b/service_container/parent_services.rst
@@ -128,8 +128,9 @@ duplicated service definitions:
 
             $services->set(BaseDoctrineRepository::class)
                 ->abstract()
-                ->args([ref('doctrine.orm.entity_manager')])
-                ->call('setLogger', [ref('logger')])
+                ->args([service('doctrine.orm.entity_manager')])
+                // In versions earlier to Symfony 5.1 the service() function was called ref()
+                ->call('setLogger', [service('logger')])
             ;
 
             $services->set(DoctrineUserRepository::class)
@@ -247,13 +248,13 @@ the child class:
 
                 // appends the '@app.username_checker' argument to the parent
                 // argument list
-                ->args([ref('app.username_checker')])
+                ->args([service('app.username_checker')])
             ;
 
             $services->set(DoctrinePostRepository::class)
                 ->parent(BaseDoctrineRepository::class)
 
                 # overrides the first argument
-                ->arg(0, ref('doctrine.custom_entity_manager'))
+                ->arg(0, service('doctrine.custom_entity_manager'))
             ;
         };

--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -172,7 +172,8 @@ automatically changed to ``'.inner'``):
             $services->set(DecoratingMailer::class)
                 ->decorate(Mailer::class)
                 // pass the old service as an argument
-                ->args([ref('.inner')]);
+                // In versions earlier to Symfony 5.1 the service() function was called ref()
+                ->args([service('.inner')]);
         };
 
 .. versionadded:: 5.1
@@ -242,7 +243,7 @@ automatically changed to ``'.inner'``):
 
                 $services->set(DecoratingMailer::class)
                     ->decorate(Mailer::class, DecoratingMailer::class.'.wooz')
-                    ->args([ref(DecoratingMailer::class.'.wooz')]);
+                    ->args([service(DecoratingMailer::class.'.wooz')]);
             };
 
 Decoration Priority
@@ -303,11 +304,11 @@ the ``decoration_priority`` option. Its value is an integer that defaults to
 
             $services->set(Bar::class)
                 ->decorate(Foo::class, null, 5)
-                ->args([ref('.inner')]);
+                ->args([service('.inner')]);
 
             $services->set(Baz::class)
                 ->decorate(Foo::class, null, 1)
-                ->args([ref('.inner')]);
+                ->args([service('.inner')]);
         };
 
 
@@ -371,7 +372,7 @@ Three different behaviors are available:
 
             $services->set(Bar::class)
                 ->decorate(Foo::class, null, 0, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)
-                ->args([ref('.inner')])
+                ->args([service('.inner')])
             ;
         };
 

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -311,9 +311,10 @@ service definition to pass a collection of services to the service locator:
             $services = $configurator->services();
 
             $services->set('app.command_handler_locator', ServiceLocator::class)
+                // In versions earlier to Symfony 5.1 the service() function was called ref()
                 ->args([[
-                    'App\FooCommand' => ref('app.command_handler.foo'),
-                    'App\BarCommand' => ref('app.command_handler.bar'),
+                    'App\FooCommand' => service('app.command_handler.foo'),
+                    'App\BarCommand' => service('app.command_handler.bar'),
                 ]])
                 // if you are not using the default service autoconfiguration,
                 // add the following tag to the service definition:
@@ -323,7 +324,7 @@ service definition to pass a collection of services to the service locator:
             // if the element has no key, the ID of the original service is used
             $services->set('app.another_command_handler_locator', ServiceLocator::class)
                 ->args([[
-                    ref('app.command_handler.baz'),
+                    service('app.command_handler.baz'),
                 ]])
             ;
         };
@@ -372,7 +373,7 @@ Now you can use the service locator by injecting it in any other service:
             $services = $configurator->services();
 
             $services->set(CommandBus::class)
-                ->args([ref('app.command_handler_locator')]);
+                ->args([service('app.command_handler_locator')]);
         };
 
 In :doc:`compiler passes </service_container/compiler_passes>` it's recommended


### PR DESCRIPTION
Fixes #13673.

I propose to repeat the `deprecated in 5.1` message everywhere because the `ref() -> service()` is an important change and we don't want anybody to miss it. Thanks.