### PR TITLE
Update bootstrap4.rst

### DIFF
--- a/form/bootstrap4.rst
+++ b/form/bootstrap4.rst
@@ -77,13 +77,15 @@ If you prefer to apply the Bootstrap styles on a form to form basis, include the
         {{ form(form) }}
     {% endblock %}
 
+.. _reference-forms-bootstrap-error-messages:
+
 Error Messages
 --------------
 
 Form errors are rendered **inside** the ``<label>`` element to make sure there
 is a strong connection between the error and its ``<input>``, as required by the
 `WCAG 2.0 standard`_. To achieve this, ``form_errors()`` is called by
-``form_label()`` internally. If you call to ``form_errors()`` in your template,
+``form_label()`` internally. If you call ``form_errors()`` in your template,
 you'll get the error messages displayed *twice*.
 
 Checkboxes and Radios


### PR DESCRIPTION
Added `.. _reference-forms-bootstrap-error-messages:`. Is this the right way, if I want to add link at https://symfony.com/doc/4.4/form/form_customization.html#form-errors-form-view that leads to here?

