### PR TITLE
Resolve the DATABASE_URL env var in config examples

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -453,7 +453,7 @@ This example shows how you could configure the database connection using an env 
         doctrine:
             dbal:
                 # by convention the env var names are always uppercase
-                url: '%env(DATABASE_URL)%'
+                url: '%env(resolve:DATABASE_URL)%'
             # ...
 
     .. code-block:: xml
@@ -470,7 +470,7 @@ This example shows how you could configure the database connection using an env 
 
             <doctrine:config>
                 <!-- by convention the env var names are always uppercase -->
-                <doctrine:dbal url="%env(DATABASE_URL)%"/>
+                <doctrine:dbal url="%env(resolve:DATABASE_URL)%"/>
             </doctrine:config>
 
         </container>
@@ -481,7 +481,7 @@ This example shows how you could configure the database connection using an env 
         $container->loadFromExtension('doctrine', [
             'dbal' => [
                 // by convention the env var names are always uppercase
-                'url' => '%env(DATABASE_URL)%',
+                'url' => '%env(resolve:DATABASE_URL)%',
             ]
         ]);
 

--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -34,13 +34,13 @@ The following configuration code shows how you can configure two entity managers
                 connections:
                     default:
                         # configure these for your database server
-                        url: '%env(DATABASE_URL)%'
+                        url: '%env(resolve:DATABASE_URL)%'
                         driver: 'pdo_mysql'
                         server_version: '5.7'
                         charset: utf8mb4
                     customer:
                         # configure these for your database server
-                        url: '%env(DATABASE_CUSTOMER_URL)%'
+                        url: '%env(resolve:DATABASE_CUSTOMER_URL)%'
                         driver: 'pdo_mysql'
                         server_version: '5.7'
                         charset: utf8mb4
@@ -83,7 +83,7 @@ The following configuration code shows how you can configure two entity managers
                 <doctrine:dbal default-connection="default">
                     <!-- configure these for your database server -->
                     <doctrine:connection name="default"
-                        url="%env(DATABASE_URL)%"
+                        url="%env(resolve:DATABASE_URL)%"
                         driver="pdo_mysql"
                         server_version="5.7"
                         charset="utf8mb4"
@@ -91,7 +91,7 @@ The following configuration code shows how you can configure two entity managers
 
                     <!-- configure these for your database server -->
                     <doctrine:connection name="customer"
-                        url="%env(DATABASE_CUSTOMER_URL)%"
+                        url="%env(resolve:DATABASE_CUSTOMER_URL)%"
                         driver="pdo_mysql"
                         server_version="5.7"
                         charset="utf8mb4"
@@ -133,14 +133,14 @@ The following configuration code shows how you can configure two entity managers
                 'connections' => [
                     // configure these for your database server
                     'default' => [
-                        'url'            => '%env(DATABASE_URL)%',
+                        'url'            => '%env(resolve:DATABASE_URL)%',
                         'driver'         => 'pdo_mysql',
                         'server_version' => '5.7',
                         'charset'        => 'utf8mb4',
                     ],
                     // configure these for your database server
                     'customer' => [
-                        'url'            => '%env(DATABASE_CUSTOMER_URL)%',
+                        'url'            => '%env(resolve:DATABASE_CUSTOMER_URL)%',
                         'driver'         => 'pdo_mysql',
                         'server_version' => '5.7',
                         'charset'        => 'utf8mb4',

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1255,7 +1255,7 @@ You can also configure the session handler with a DSN. For example:
                 # ...
                 handler_id: 'redis://localhost'
                 handler_id: '%env(REDIS_URL)%'
-                handler_id: '%env(DATABASE_URL)%'
+                handler_id: '%env(resolve:DATABASE_URL)%'
                 handler_id: 'file://%kernel.project_dir%/var/sessions'
 
     .. code-block:: xml
@@ -1273,7 +1273,7 @@ You can also configure the session handler with a DSN. For example:
                 <framework:session enabled="true"
                     handler-id="redis://localhost"
                     handler-id="%env(REDIS_URL)%"
-                    handler-id="%env(DATABASE_URL)%"
+                    handler-id="%env(resolve:DATABASE_URL)%"
                     handler-id="file://%kernel.project_dir%/var/sessions"/>
             </framework:config>
         </container>
@@ -1286,7 +1286,7 @@ You can also configure the session handler with a DSN. For example:
                 // ...
                 'handler_id' => 'redis://localhost',
                 'handler_id' => '%env(REDIS_URL)%',
-                'handler_id' => '%env(DATABASE_URL)%',
+                'handler_id' => '%env(resolve:DATABASE_URL)%',
                 'handler_id' => 'file://%kernel.project_dir%/var/sessions',
             ],
         ]);


### PR DESCRIPTION
This was asked on Symfony's Slack.

The official Symfony recipe uses too by default: https://github.com/symfony/recipes/blob/c7d81ffbff3e2335532b21c0f71289a5489151c8/doctrine/doctrine-bundle/2.0/config/packages/doctrine.yaml#L3

@nicolas-grekas would you agree with this change? Thanks!