### PR TITLE
Fix subtype in TextPart constructor calls

### DIFF
--- a/components/mime.rst
+++ b/components/mime.rst
@@ -170,7 +170,7 @@ different parts of the email by hand::
     ;
 
     $textContent = new TextPart('Lorem ipsum...');
-    $htmlContent = new TextPart('<h1>Lorem ipsum</h1> <p>...</p>', 'html');
+    $htmlContent = new TextPart('<h1>Lorem ipsum</h1> <p>...</p>', null, 'html');
     $body = new AlternativePart($textContent, $htmlContent);
 
     $email = new Message($headers, $body);
@@ -192,7 +192,7 @@ email multiparts::
     $textContent = new TextPart('Lorem ipsum...');
     $htmlContent = new TextPart(sprintf(
         '<img src="cid:%s"/> <h1>Lorem ipsum</h1> <p>...</p>', $imageCid
-    ), 'html');
+    ), null, 'html');
     $bodyContent = new AlternativePart($textContent, $htmlContent);
     $body = new RelatedPart($bodyContent, $embeddedImage);
 


### PR DESCRIPTION
In examples, 'html' is given as argument 2, while it has to be argument 3

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
