### PR TITLE
[Messenger] Add a note about allow_no_handlers option

### DIFF
--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -105,6 +105,11 @@ This will create three new services:
 
 * ``event.bus``: autowireable with ``MessageBusInterface $eventBus``.
 
+.. note::
+
+    The ``allow_no_handlers`` option allows ``event.bus`` to have no handler configured
+    and as a result, it will not end up with error if you define no handler for this bus.
+
 Restrict Handlers per Bus
 -------------------------
 


### PR DESCRIPTION
This option was not documented at this state.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
