### PR TITLE
Add note on composer update dependency mismatch

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -24,6 +24,11 @@ tests, such as Doctrine, Twig and Monolog. To do so,
 
     $ composer update
 
+.. tip::
+
+    You need to be on ``master`` or version branch (eg. ``5.1``). Otherwise some dependencies
+    might cause ``composer update`` command to fail.
+
 .. _running:
 
 Running the Tests

--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -26,7 +26,7 @@ tests, such as Doctrine, Twig and Monolog. To do so,
 
 .. tip::
 
-    You need to be on ``master`` or version branch (eg. ``5.1``). Otherwise some dependencies
+    You need to be on ``master`` or version branch (e.g. ``5.1``). Otherwise some dependencies
     might cause ``composer update`` command to fail.
 
 .. _running:

--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -26,8 +26,13 @@ tests, such as Doctrine, Twig and Monolog. To do so,
 
 .. tip::
 
-    You need to be on ``master`` or version branch (e.g. ``5.1``). Otherwise some dependencies
-    might cause ``composer update`` command to fail.
+    Dependencies might fail to update and in this case Composer might need you to 
+    tell it what Symfony version you are working on.  
+    To do so set ``COMPOSER_ROOT_VERSION`` variable, e.g.:
+    
+    .. code-block:: terminal
+
+        $ COMPOSER_ROOT_VERSION=5.1.x-dev composer update
 
 .. _running:
 


### PR DESCRIPTION
On branches other that master or version branches (existing in Symfony repository) `composer update` command will fail, since those cannot be installed.

For example, when I've tried to run tests for Redis Messenger message rejection commit, I've got this error output (trimmed a little, and I was on a specific commit, but it happens on branches as well):

```bash
$ composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - doctrine/orm 2.4.x-dev requires symfony/console ~2.0 -> satisfiable by symfony/console[2.0.4
...
    - don't install symfony/console 2.0.4|remove symfony/symfony dev-b40c1abf9ace9411747a9655dabcb560457bf88d
    - don't install symfony/console 2.0.5|remove symfony/symfony dev-b40c1abf9ace9411747a9655dabcb560457bf88d
    - don't install symfony/console 2.0.6|remove symfony/symfony dev-b40c1abf9ace9411747a9655dabcb560457bf88d
    - don't install symfony/console 2.0.7|remove symfony/symfony dev-b40c1abf9ace9411747a9655dabcb560457bf88d
...
```

Figured I have to be on one of existing Symfony branches for the install to proceed, and once I've switched to `master`, I was good to go.

Is the selected doc branch correct in this PR? Is the wording in the tip ok?