### PR TITLE
[Messenger] Added Amazon SQS transport

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -118,8 +118,7 @@ is capable of sending messages (e.g. to a queueing system) and then
 .. note::
 
     If you want to use a transport that's not supported, check out the
-    `Enqueue's transport`_, which supports things like Kafka, Amazon SQS and
-    Google Pub/Sub.
+    `Enqueue's transport`_, which supports things like Kafka and Google Pub/Sub.
 
 A transport is registered using a "DSN". Thanks to Messenger's Flex recipe, your
 ``.env`` file already has a few examples.


### PR DESCRIPTION
This fixes #13616.

In fact, it's related but it doesn't fix it. We don't need to document #13616 because transports are not documented in detail yet (and because code will output all the relevant messages needed to make it work). But we can update current docs which imply that we don't support SQS.