### PR TITLE
[Mailer] Document how to set headers

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -186,6 +186,23 @@ Alternatively, you can pass multiple addresses to each method::
         // ...
     ;
 
+Message Headers
+~~~~~~~~~~~~~~~
+
+Messages include a number of header fields to describe their contents. Symfony
+sets all the required headers automatically, but you can set your own headers
+too. There are different types of headers (Id header, Mailbox header, Date
+header, etc.) but most of the times you'll set text headers::
+
+    $email = (new Email())
+        ->getHeaders()
+            // this header tells auto-repliers ("email holiday mode") to not
+            // reply to this message because it's an automated email
+            ->addTextHeader('X-Auto-Response-Suppress', 'OOF, DR, RN, NRN, AutoReply');
+
+        // ...
+    ;
+
 Message Contents
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This fixes #13399 partially. We document headers in 4.4 version ... and after this is merged, we can document the tags/metadata introduced in 5.1 version.