### PR TITLE
Fix typo of HTML5 field type for DateTimeType

### DIFF
--- a/reference/forms/types/options/html5.rst.inc
+++ b/reference/forms/types/options/html5.rst.inc
@@ -4,7 +4,7 @@
 **type**: ``boolean`` **default**: ``true``
 
 If this is set to ``true`` (the default), it'll use the HTML5 type (date, time
-or datetime) to render the field. When set to ``false``, it'll use the text type.
+or datetime-local) to render the field. When set to ``false``, it'll use the text type.
 
 This is useful when you want to use a custom JavaScript datepicker, which
 often requires a text type instead of an HTML5 type.


### PR DESCRIPTION
Changed the html5 input type for DateTimeType to datetime-local (which is the html5 input type) instead of the datetime input type.

- The **datetime** input type field has been removed from WHATWG HTML (https://github.com/whatwg/html/issues/336)
- The **datetime-local** input type is the type used for rendering DateTimeType when html5 option is set to true.
