### PR TITLE
Fix: message must be notInRangeMessage

### DIFF
--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -40,8 +40,7 @@ you might add the following:
              * @Assert\Range(
              *      min = 120,
              *      max = 180,
-             *      minMessage = "You must be at least {{ limit }}cm tall to enter",
-             *      maxMessage = "You cannot be taller than {{ limit }}cm to enter"
+             *      notInRangeMessage = "You must be between {{ min }}cm and {{ max }}cm tall to enter",
              * )
              */
             protected $height;


### PR DESCRIPTION
Example was wrong : when min and max are specified, minMessage and MaxMessage are ignored.
