### PR TITLE
Update http_foundation.rst to replace withExpiresTime

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -451,7 +451,7 @@ a new object with the modified property::
 
     $cookie = Cookie::create('foo')
         ->withValue('bar')
-        ->withExpiresTime(strtotime('Fri, 20-May-2011 15:25:52 GMT'))
+        ->withExpires(strtotime('Fri, 20-May-2011 15:25:52 GMT'))
         ->withDomain('.example.com')
         ->withSecure(true);
 


### PR DESCRIPTION
The method withExpiresTime does not exist in class https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Cookie.php#L146.
I think it should be withExpires instead.