### PR TITLE
Adding details about Encore dev-server and https

### DIFF
--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -17,6 +17,24 @@ Twig shortcuts (or are :ref:`processing your assets through entrypoints.json <lo
 in some other way), you're done: the paths in your templates will automatically point
 to the dev server.
 
+Enabling https & the Symfony Web Server
+---------------------------------------
+
+If you're using the `Symfony web server`_ locally with https, you'll need to also
+tell the dev-server to use https. To do this, you can reuse the Symfony web
+server SSL certificate:
+
+.. code-block:: terminal
+
+    # Unix-based systems
+    $ yarn dev-server --https --pfx=$HOME/.symfony/certs/default.p12
+
+    # Windows
+    $ encore dev-server --https --pfx=%UserProfile%\.symfony\certs\default.p12
+
+dev-server Options
+------------------
+
 The ``dev-server`` command supports all the options defined by `webpack-dev-server`_.
 You can set these options via command line options:
 

--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -20,7 +20,7 @@ to the dev server.
 Enabling https & the Symfony Web Server
 ---------------------------------------
 
-If you're using the `Symfony web server`_ locally with https, you'll need to also
+If you're using the :doc:`Symfony web server </setup/symfony_server>` locally with https, you'll need to also
 tell the dev-server to use https. To do this, you can reuse the Symfony web
 server SSL certificate:
 

--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -17,8 +17,8 @@ Twig shortcuts (or are :ref:`processing your assets through entrypoints.json <lo
 in some other way), you're done: the paths in your templates will automatically point
 to the dev server.
 
-Enabling HTTPS & the Symfony Web Server
----------------------------------------
+Enabling HTTPS using the Symfony Web Server
+-------------------------------------------
 
 If you're using the :doc:`Symfony web server </setup/symfony_server>` locally with HTTPS,
 you'll need to also tell the dev-server to use HTTPS. To do this, you can reuse the Symfony web

--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -17,11 +17,11 @@ Twig shortcuts (or are :ref:`processing your assets through entrypoints.json <lo
 in some other way), you're done: the paths in your templates will automatically point
 to the dev server.
 
-Enabling https & the Symfony Web Server
+Enabling HTTPS & the Symfony Web Server
 ---------------------------------------
 
-If you're using the :doc:`Symfony web server </setup/symfony_server>` locally with https, you'll need to also
-tell the dev-server to use https. To do this, you can reuse the Symfony web
+If you're using the :doc:`Symfony web server </setup/symfony_server>` locally with HTTPS,
+you'll need to also tell the dev-server to use HTTPS. To do this, you can reuse the Symfony web
 server SSL certificate:
 
 .. code-block:: terminal


### PR DESCRIPTION
Hi!

See: https://github.com/symfony/cli/issues/93

Just some missing docs on use the `dev-server` with the Symfony binary.