### PR TITLE
Update information in flex about added files for twig

### DIFF
--- a/quick_tour/flex_recipes.rst
+++ b/quick_tour/flex_recipes.rst
@@ -61,8 +61,8 @@ What did this recipe do? In addition to automatically enabling the feature in
 ``config/packages/twig.yaml``
     A configuration file that sets up Twig with sensible defaults.
 
-``config/routes/dev/twig.yaml``
-    A route that helps you debug your error pages.
+``config/packages/test/twig.yaml``
+    A configuration file to override some of the settings previously configured in ``config/packages/twig.yaml``.
 
 ``templates/``
     This is the directory where template files will live. The recipe also added


### PR DESCRIPTION
The information about the recipe files of the twig-bundle are outdated for symfony 4.4 and 5.

* The route configuration file for the dev environment in the recipe of the twig-bundle was removed last year
  * https://github.com/symfony/recipes/pull/675
* A package configuration file was added for the test environment
  * https://github.com/symfony/recipes/pull/666
  * Maybe this change must be also documented in 3.4 or what do you think?