### PR TITLE
Fix supportsNormalization parameters definition

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -47,7 +47,7 @@ to customize the normalized data. To do that, leverage the ``ObjectNormalizer``:
             return $data;
         }
 
-        public function supportsNormalization($data, $format = null)
+        public function supportsNormalization($data, $format = null, array $context = [])
         {
             return $data instanceof Topic;
         }


### PR DESCRIPTION
## Description

Add **$context** parameter in code example which is needed in Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface supportsNormalization definition.

In 3.4 documentation this was not needed because the example code implements NormalizerInterface vs ContextAwareNormalizerInterface since 4.4.

