### PR TITLE
Be more specific about flock releasing locks automatically

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -220,7 +220,7 @@ FlockStore
 
 The FlockStore uses the file system on the local computer to create the locks.
 It does not support expiration, but the lock is automatically released when the
-PHP process is terminated::
+lock object goes out of scope and is freed by the garbage collector::
 
     use Symfony\Component\Lock\Store\FlockStore;
 


### PR DESCRIPTION
While working on some Unit-Tests for my application I found out about a problem regarding the `Flock` store. Unfortunately it is a problem coming from the way PHP works internally. Resource handles/file locks are released as soon as the variable holding the handle is going out of scope. This makes it easy for developers when directly working with files, but in this case, it was stopping me.

To make this restriction more clear, I just changed that line in the documentation.