### PR TITLE
Update column type for MySQL sessions table

### DIFF
--- a/session/database.rst
+++ b/session/database.rst
@@ -389,7 +389,7 @@ MySQL
     CREATE TABLE `sessions` (
         `sess_id` VARBINARY(128) NOT NULL PRIMARY KEY,
         `sess_data` BLOB NOT NULL,
-        `sess_lifetime` MEDIUMINT NOT NULL,
+        `sess_lifetime` INTEGER UNSIGNED NOT NULL,
         `sess_time` INTEGER UNSIGNED NOT NULL
     ) COLLATE utf8mb4_bin, ENGINE = InnoDB;
 


### PR DESCRIPTION
This page hasnt been updated with this fix #12641 for "Preparing the Database to Store Sessions" on MySQL db, causing error:

SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'sess_lifetime' at row 1

Its fixed by changing MEDIUMINT to INTEGER UNSIGNED for sess_lifetime column.

Its the same miss in 4.4, 5.0 and 5.1