### PR TITLE
Fix sess_time field type

### DIFF
--- a/session/database.rst
+++ b/session/database.rst
@@ -389,7 +389,7 @@ MySQL
     CREATE TABLE `sessions` (
         `sess_id` VARBINARY(128) NOT NULL PRIMARY KEY,
         `sess_data` BLOB NOT NULL,
-        `sess_lifetime` MEDIUMINT NOT NULL,
+        `sess_lifetime` INTEGER UNSIGNED NOT NULL,
         `sess_time` INTEGER UNSIGNED NOT NULL
     ) COLLATE utf8mb4_bin, ENGINE = InnoDB;
 


### PR DESCRIPTION
Current column type throws an error:

> SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'sess_lifetime' at row 1

Fix the column sess_time by using the correct field type

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
