### PR TITLE
[Twig] Mention that passing an array of roles/attributes is deprecated

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -154,6 +154,10 @@ Returns ``true`` if the current user has the given role. If several roles are
 passed in an array, ``true`` is returned if the user has at least one of
 them.
 
+.. deprecated:: 4.4
+
+    The feature to pass an array of roles to ``is_granted()`` was deprecated in Symfony 4.4.
+
 Optionally, an object can be passed to be used by the voter. More information
 can be found in :ref:`security-template`.
 


### PR DESCRIPTION
Fixes #13773.