### PR TITLE
List which values are true for %env(bool:xxx)%

### DIFF
--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -96,7 +96,7 @@ Symfony provides the following env var processors:
             ]);
 
 ``env(bool:FOO)``
-    Casts ``FOO`` to a bool:
+    Casts ``FOO`` to a bool (true values are `'true'`, `'on'`, `'yes'` and all numers unequal to `0`, everything else is false):
 
     .. configuration-block::
 


### PR DESCRIPTION
This is the behaviour since [4.2](https://github.com/symfony/symfony/commit/ce532613239fbb0dc7fbd870e96560f4df456fc4).
Before all strings except `''`, `'false'`, `'off'` and `'no'` were true as well.