### PR TITLE
default value of csrf_token_id

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -562,7 +562,7 @@ default service whose ID is ``security.csrf.token_manager``.
 csrf_token_id
 ~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``'logout'``
+**type**: ``string`` **default**: ``'authenticate'``
 
 An arbitrary string used to identify the token (and check its validity afterwards).
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
