### PR TITLE
Encore Versus Assetic: Suggest to use a fork

### DIFF
--- a/frontend/encore/versus-assetic.rst
+++ b/frontend/encore/versus-assetic.rst
@@ -52,5 +52,9 @@ Should I Upgrade from Assetic to Encore
 
 If you already have Assetic working in an application, and haven't needed any of
 the features that Encore offers over Assetic, continuing to use Assetic is fine.
+The bundle `symfony/assetic-bundle` has been forked as `sanpi/assetic-bundle`_
+to allow compatibility with Symfony 4.
 If you *do* start to need more features, then you might have a business case for
 changing to Encore.
+
+.. _`sanpi/assetic-bundle`: https://packagist.org/packages/sanpi/assetic-bundle


### PR DESCRIPTION
The documentation suggest to keep using [`symfony/assetic-bundle`](https://packagist.org/packages/symfony/assetic-bundle) but this bundle doesn't work with Symfony 4. This PR add a link to a fork that will solve this issue.