### PR TITLE
Update : advertize ⮞ advertise

### DIFF
--- a/create_framework/introduction.rst
+++ b/create_framework/introduction.rst
@@ -40,7 +40,7 @@ a fully-featured full-stack web framework.
 
 Each step will be the occasion to learn more about some of the Symfony Components.
 
-Many modern web frameworks advertize themselves as being MVC frameworks. This
+Many modern web frameworks advertise themselves as being MVC frameworks. This
 tutorial won't talk about the MVC pattern, as the Symfony Components are able to
 create any type of frameworks, not just the ones that follow the MVC
 architecture. Anyway, if you have a look at the MVC semantics, this book is


### PR DESCRIPTION
I thought it was a typo, but after some checks it seems that the Z form (advertize) is old british english and quite less used than the S form (advertise).

So let's talk of "update" instead of "typo fix" 😉

- https://trends.google.fr/trends/explore?q=to%20advertize,to%20advertise
- https://grammarist.com/spelling/advertise-vs-advertize/