### PR TITLE
Provides a way to override cache and log folders from the ENV

### DIFF
--- a/configuration/override_dir_structure.rst
+++ b/configuration/override_dir_structure.rst
@@ -41,8 +41,8 @@ at your project root directory.
 Override the Cache Directory
 ----------------------------
 
-You can change the default cache directory by overriding the ``getCacheDir()``
-method in the ``Kernel`` class of your application::
+Changing the cache directory can be achieved by overriding the
+``getCacheDir()`` method in the ``Kernel`` class of your application::
 
     // src/Kernel.php
 
@@ -61,6 +61,9 @@ In this code, ``$this->environment`` is the current environment (i.e. ``dev``).
 In this case you have changed the location of the cache directory to
 ``var/{environment}/cache/``.
 
+This can also be achieved using a predefined environment variable named
+``APP_CACHE_DIR``. Its value must be the full path of the cache folder.
+
 .. caution::
 
     You should keep the cache directory different for each environment,
@@ -73,9 +76,11 @@ In this case you have changed the location of the cache directory to
 Override the Log Directory
 --------------------------
 
-Overriding the ``var/log/`` directory is the same as overriding the ``var/cache/``
-directory. The only difference is that you need to override the ``getLogDir()``
-method::
+Overriding the ``var/log/`` directory is almost the same as overriding the
+``var/cache/`` directory.
+
+You can do it overriding the ``getLogDir()`` method in the ``Kernel`` class of
+your application::
 
     // src/Kernel.php
 
@@ -91,6 +96,8 @@ method::
     }
 
 Here you have changed the location of the directory to ``var/{environment}/log/``.
+
+And you can also do it using the predefined ``APP_LOG_DIR`` environment variable.
 
 .. _override-templates-dir:
 


### PR DESCRIPTION
Related to this new feature https://github.com/symfony/symfony/pull/37114.

But I wonder if we have not oversimplified this PR: https://github.com/symfony/symfony/pull/37114

Actually doing the documentation https://github.com/symfony/symfony-docs/issues/13787 I figured that with #37114 we removed the important split per `env`.

In development mode (docker or not) we could definitely have the same project working in N Symfony different environments and this new `APP_CACHE_DIR` will only set the same path for all environments.

That would be manageable in the Virtualhost but in CLI that would be a pain to manage.
Also, we could rely on the DotEnv mechanism, but that could be really easy to forget.

I wonder if we should not change the code to: https://github.com/symfony/symfony/pull/37232

Depending on the decisions I will update the doc here.