### PR TITLE
[PropertyInfo] Document setting serializer_groups to null in the SerializerExtractor

### DIFF
--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -435,7 +435,18 @@ with the ``property_info`` service in the Symfony Framework::
     $serializerExtractor = new SerializerExtractor($serializerClassMetadataFactory);
 
     // List information.
-    $serializerExtractor->getProperties($class);
+    $serializerExtractor->getProperties($class, ['serializer_groups' => ['mygroup']]);
+    
+.. note::
+
+    The ``serializer_groups`` option must be provided in order to have a value different than ``null`` returned.
+   
+    If ``serializer_groups`` is set to ``null``, serializer groups metadata won't be checked but you will get only the properties 
+    considered by the Serializer Component (notably the ``@Ignore`` annotation is taken into account).
+
+.. versionadded:: 5.2
+
+    Support for the ``null`` value in ``serializer_groups`` was introduced in Symfony 5.2. 
 
 DoctrineExtractor
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR fixes https://github.com/symfony/symfony-docs/issues/13793 :)

If you'd like I can backport the part about `serializer_groups` begin mandatory in order to use the `SerializerExtractor`.