### PR TITLE
Fix load the annotation routes

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -179,7 +179,7 @@ hold the kernel. Now it looks like this::
             }
 
             // load the annotation routes
-            $routes->import(DIR.'/../src/Controller/', 'annotation');
+            $routes->import(__DIR__.'/../src/Controller/', 'annotation');
         }
 
         // optional, to use the standard Symfony cache directory

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -179,7 +179,7 @@ hold the kernel. Now it looks like this::
             }
 
             // load the annotation routes
-            $routes->import(DIR.'/../src/Controller/', 'annotation')
+            $routes->import(DIR.'/../src/Controller/', 'annotation');
         }
 
         // optional, to use the standard Symfony cache directory

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -179,7 +179,7 @@ hold the kernel. Now it looks like this::
             }
 
             // load the annotation routes
-            $routes->import(__DIR__.'/../src/Controller/', '/', 'annotation');
+            $routes->import(DIR.'/../src/Controller/', 'annotation')
         }
 
         // optional, to use the standard Symfony cache directory


### PR DESCRIPTION
**Proposed changes**
MicroKernel documentation - The second parameter is $type, so "annotation" should be given here, not "/".
https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php

**Related issues**
#13827