### PR TITLE
[workflow] corrected argument type

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -620,7 +620,7 @@ place::
             // Block the transition "publish" if it is more than 8 PM
             // with the message for end user
             $explanation = $event->getMetadata('explanation', $eventTransition);
-            $event->addTransitionBlocker(new TransitionBlocker($explanation , 0));
+            $event->addTransitionBlocker(new TransitionBlocker($explanation , '0'));
         }
 
         public static function getSubscribedEvents()


### PR DESCRIPTION
the 2nd argument is required to be a string