### PR TITLE
Update input.rst

### DIFF
--- a/console/input.rst
+++ b/console/input.rst
@@ -52,6 +52,8 @@ You now have access to a ``last_name`` argument in your command::
             }
 
             $output->writeln($text.'!');
+            
+            return 0;
         }
     }
 


### PR DESCRIPTION
Starting from SF5.0, the `Command::execute`  should return an int