### PR TITLE
corrected tags order

### DIFF
--- a/frontend/encore/split-chunks.rst
+++ b/frontend/encore/split-chunks.rst
@@ -38,8 +38,8 @@ tags as needed:
     {#
         May now render multiple script tags:
             <script src="/build/runtime.js"></script>
-            <script src="/build/homepage.js"></script>
             <script src="/build/vendor~homepage.js"></script>
+            <script src="/build/homepage.js"></script>
     #}
     {{ encore_entry_script_tags('homepage') }}
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->

#### Reference

[`symfony/webpack-encore-bundle` - `README.md`](https://github.com/symfony/webpack-encore-bundle):

> For example, to render all of the script and link tags for a specific "entry" (e.g. entry1), you can:
> [...]
> Assuming that entry1 required two files to be included - `build/vendor~entry1~entry2.js` and `build/entry1.js`, then `encore_entry_script_tags()` is equivalent to:
> 
> `<script src="{{ asset('build/vendor~entry1~entry2.js') }}"></script>`
> `<script src="{{ asset('build/entry1.js') }}"></script>`