### PR TITLE
[DI] Document param() and abstract_arg()

### DIFF
--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -299,7 +299,8 @@ config files:
             $services = $configurator->services();
 
             $services->set('mailer', 'Mailer')
-                ->args(['%mailer.transport%'])
+                // the param() method was introduced in Symfony 5.2.
+                ->args([param('mailer.transport')])
             ;
 
             $services->set('newsletter_manager', 'NewsletterManager')

--- a/service_container.rst
+++ b/service_container.rst
@@ -1116,7 +1116,7 @@ admin email. In this case, each needs to have a unique service id:
                 ->args([
                    service(MessageGenerator::class),
                    service('mailer'),
-                    'superadmin@example.com',
+                   'superadmin@example.com',
                 ]);
 
             $services->set('site_update_manager.normal_users', SiteUpdateManager::class)

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -273,7 +273,8 @@ For example, you may add the following transports as services:
             $services = $configurator->services();
 
             $services->set(\Swift_SmtpTransport::class)
-                ->args(['%mailer_host%'])
+                // the param() method was introduced in Symfony 5.2.
+                ->args([param('mailer_host')])
                 ->tag('app.mail_transport')
             ;
 
@@ -437,7 +438,8 @@ To answer this, change the service declaration:
             $services = $configurator->services();
 
             $services->set(\Swift_SmtpTransport::class)
-                ->args(['%mailer_host%'])
+                // the param() method was introduced in Symfony 5.2.
+                ->args([param('mailer_host')])
                 ->tag('app.mail_transport', ['alias' => 'smtp'])
             ;
 


### PR DESCRIPTION
This fixes #13794.

I couldn't find any occurrence of "abstract args". It doesn't matter much, because we want to revamp DI docs "soon" and we document them.