### PR TITLE
Adding warning about depending on concrete implementation of Session

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -536,7 +536,7 @@ you'll use this key to retrieve the message.
 
 .. warning::
 
-    If you want avoid depending on concrete implementation of `Session` and relay on :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionInterface`:
+    If you want avoid depending on concrete implementation of `Session` and rely on :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionInterface`:
     you will find your self in a situation that `getFlashBag` is not declared in an interface.
     In order fix this "problem" you must inject `FlashBagInterface`/`session.flash_bag` and relay on `FlashBagInterface`
     instead of `Session` for access to "Flash Messages"

--- a/controller.rst
+++ b/controller.rst
@@ -534,6 +534,14 @@ After processing the request, the controller sets a flash message in the session
 and then redirects. The message key (``notice`` in this example) can be anything:
 you'll use this key to retrieve the message.
 
+.. warning::
+
+    If you want avoid depending on concrete implementation of `Session` and relay on :class:`Symfony\\Component\\HttpFoundation\\Session\\SessionInterface`:
+    you will find your self in a situation that `getFlashBag` is not declared in an interface.
+    In order fix this "problem" you must inject `FlashBagInterface`/`session.flash_bag` and relay on `FlashBagInterface`
+    instead of `Session` for access to "Flash Messages"
+
+
 In the template of the next page (or even better, in your base layout template),
 read any flash messages from the session using ``app.flashes()``:
 


### PR DESCRIPTION
Relying on the concrete implementation of any class goes against best practices.
So if the application relies on `SessionInterface` user will find themself in a situation when "getFlashBag" is not declared in a `SessionInterface` exactly for this case I've added a **warning** about using `SessionInterface` and `FlashBagInterface` 

Example of an issue when concrete Session class is used https://github.com/sonata-project/SonataUserBundle/issues/1174
Example of an issue when SessionInterface is not enough: https://github.com/sonata-project/SonataUserBundle/pull/1184
