### PR TITLE
Add \ in Yaml syntax

### DIFF
--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -203,7 +203,7 @@ automatically changed to ``'.inner'``):
                 App\DecoratingMailer:
                     # ...
                     decoration_inner_name: App\DecoratingMailer.wooz
-                    arguments: ['@App\DecoratingMailer.wooz']
+                    arguments: ['@App\\DecoratingMailer.wooz']
 
         .. code-block:: xml
 


### PR DESCRIPTION
Error without escapping`\` : `The file does not contain valid YAML: Found unknown escape character "\D"`