### PR TITLE
Move HTTP client docs from components to guides

### DIFF
--- a/_build/redirection_map
+++ b/_build/redirection_map
@@ -482,7 +482,7 @@
 /doctrine/pdo_session_storage /session/database
 /doctrine/mongodb_session_storage /session/database
 /components/dotenv https://github.com/symfony/dotenv
-/components/mercure https://github.com/symfony/mercure
+/components/mercure /mercure
 /components/polyfill_apcu https://github.com/symfony/polyfill-apcu
 /components/polyfill_ctype https://github.com/symfony/polyfill-ctype
 /components/polyfill_iconv https://github.com/symfony/polyfill-iconv
@@ -504,3 +504,4 @@
 /components/error_handler https://github.com/symfony/error-handler
 /components/class_loader https://github.com/symfony/class-loader
 /frontend/encore/versus-assetic /frontend
+/components/http_client /http_client

--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -13,7 +13,7 @@ The BrowserKit Component
     In Symfony versions prior to 4.3, the BrowserKit component could only make
     internal requests to your application. Starting from Symfony 4.3, this
     component can also :ref:`make HTTP requests to any public site <component-browserkit-external-requests>`
-    when using it in combination with the :doc:`HttpClient component </components/http_client>`.
+    when using it in combination with the :doc:`HttpClient component </http_client>`.
 
 Installation
 ------------
@@ -295,7 +295,7 @@ So far, all the examples in this article have assumed that you are making
 internal requests to your own application. However, you can run the exact same
 examples when making HTTP requests to external web sites and applications.
 
-First, install and configure the :doc:`HttpClient component </components/http_client>`.
+First, install and configure the :doc:`HttpClient component </http_client>`.
 Then, use the :class:`Symfony\\Component\\BrowserKit\\HttpBrowser` to create
 the client that will make the external HTTP requests::
 

--- a/index.rst
+++ b/index.rst
@@ -42,6 +42,7 @@ Topics
     forms
     frontend
     http_cache
+    http_client
     logging
     mailer
     mercure


### PR DESCRIPTION
The component docs are actually very similar to the framework guide :). The biggest update is adding framework config examples to all examples showing global configuration and moving the framework integration section more to the start of the article.

We once added `php-standalone` and `php-symfony` tabs to the configuration blocks, which allow showing the same code for standalone and in-framework usage. This currently is used only in the Form component docs: https://symfony.com/doc/current/components/form.html#creating-a-simple-form I heavily used this in the article, so we can show both code examples in a concise matter.

Please let me know what you think! :)