### PR TITLE
Fixed mention of minimum PHP version for v4.x

### DIFF
--- a/contributing/code/pull_requests.rst
+++ b/contributing/code/pull_requests.rst
@@ -25,7 +25,7 @@ Before working on Symfony, setup a friendly environment with the following
 software:
 
 * Git;
-* PHP version 5.5.9 or above.
+* PHP version 7.1.3 or above.
 
 Configure Git
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Minimum PHP version for Symfony 4.x is [7.1.3](https://github.com/symfony/symfony/blob/4.4/composer.json#L19), but documentation doesn't reflect this change and keep same PHP version as 3.x.