### PR TITLE
Fixed mention of minimum PHP version for v5.x

### DIFF
--- a/contributing/code/pull_requests.rst
+++ b/contributing/code/pull_requests.rst
@@ -25,7 +25,7 @@ Before working on Symfony, setup a friendly environment with the following
 software:
 
 * Git;
-* PHP version 7.1.3 or above.
+* PHP version 7.2.5 or above.
 
 Configure Git
 ~~~~~~~~~~~~~
@@ -193,8 +193,8 @@ want to debug are installed by running ``composer install`` inside it.
 
 .. tip::
 
-    If symlinks to your local Symfony fork cannot be resolved inside your project due to 
-    your dev environment (for instance when using Vagrant where only the current project 
+    If symlinks to your local Symfony fork cannot be resolved inside your project due to
+    your dev environment (for instance when using Vagrant where only the current project
     directory is mounted), you can alternatively use the ``--copy`` option.
 
 .. _work-on-your-patch:

--- a/contributing/code/pull_requests.rst
+++ b/contributing/code/pull_requests.rst
@@ -25,7 +25,7 @@ Before working on Symfony, setup a friendly environment with the following
 software:
 
 * Git;
-* PHP version 5.5.9 or above.
+* PHP version 7.1.3 or above.
 
 Configure Git
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Minimum PHP version for Symfony 5.x is [7.2.5](https://github.com/symfony/symfony/blob/5.0/composer.json#L19), but documentation doesn't reflect this change and keep same PHP version as 3.x.