### PR TITLE
[Mailer] Update mailer.rst

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -526,7 +526,7 @@ several popular libraries):
 .. code-block:: terminal
 
     # instead of league/commonmark, you can also use erusev/parsedown or michelf/php-markdown
-    $ composer require twig/markdown-extra league/commonmark
+    $ composer require twig/extra-bundle twig/markdown-extra league/commonmark
 
 The extension adds a ``markdown_to_html`` filter, which you can use to convert parts or
 the entire email contents from Markdown to HTML:


### PR DESCRIPTION
Brings consistency with the CSS Inliner & Inky Extension Installation Instructions. 

Furthermore, without the `twig/extra-bundle` installed one needs to manually register the extension & the filter by itself will not work automatically.