### PR TITLE
Update experimental_authenticators.rst

### DIFF
--- a/security/experimental_authenticators.rst
+++ b/security/experimental_authenticators.rst
@@ -464,7 +464,7 @@ the following badges are supported:
     authentication. The constructor requires a token ID (unique per form)
     and CSRF token (unique per request). See :doc:`/security/csrf`.
 
-:class:`Symfony\\Component\\Security\\Http\\Authenticator\\Passport\\Badge\\PreAuthenticatedBadge`
+:class:`Symfony\\Component\\Security\\Http\\Authenticator\\Passport\\Badge\\PreAuthenticatedUserBadge`
     Indicates that this user was pre-authenticated (i.e. before Symfony was
     initiated). This skips the
     :doc:`pre-authentication user checker </security/user_checkers>`.


### PR DESCRIPTION
Fix the link for `PreAuthenticatedUserBadge` class

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
