### PR TITLE
Confusing runtime compiler flag

### DIFF
--- a/frontend/encore/vuejs.rst
+++ b/frontend/encore/vuejs.rst
@@ -55,10 +55,10 @@ then you can tell Encore to create a *smaller* and CSP-compliant build:
     Encore
         // ...
 
-        .enableVueLoader(() => {}, { runtimeCompilerBuild: false })
+        .enableVueLoader(() => {}, { runtimeCompilerBuild: true })
     ;
 
-You can also silence the recommendation by passing ``runtimeCompilerBuild: true``.
+You can also silence the recommendation by passing ``runtimeCompilerBuild: false``.
 
 Hot Module Replacement (HMR)
 ----------------------------


### PR DESCRIPTION
The description and example weren't in sync. If the user doesn't need template compilation then the `runtimeCompilerBuild` should be `true`

After the example if you want to disable the command line recommendation you should pass `false`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
