### PR TITLE
default path of migrations changed in recipe

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -225,7 +225,7 @@ If everything worked, you should see something like this:
 
     SUCCESS!
 
-    Next: Review the new migration "src/Migrations/Version20180207231217.php"
+    Next: Review the new migration "migrations/Version20180207231217.php"
     Then: Run the migration with php bin/console doctrine:migrations:migrate
 
 If you open this file, it contains the SQL needed to update your database! To run


### PR DESCRIPTION
See https://github.com/symfony/recipes/pull/797

Obviously, we can't really know what path the user will have configured. All we can do is have it match the latest config.

Btw, I chose 5.0 as the base branch... but I'm open to other suggestions.

Cheers!