### PR TITLE
Fixed the Quick Tour sample code to work just by copy and paste.

### DIFF
--- a/quick_tour/flex_recipes.rst
+++ b/quick_tour/flex_recipes.rst
@@ -75,6 +75,7 @@ Thanks to Flex, after one command, you can start using Twig immediately:
 
 .. code-block:: diff
 
+    <?php
     // src/Controller/DefaultController.php
     namespace App\Controller;
 
@@ -153,6 +154,7 @@ Rich API Support
 
 Are you building an API? You can already return JSON from any controller::
 
+    <?php
     // src/Controller/DefaultController.php
     namespace App\Controller;
 
@@ -189,6 +191,7 @@ But like usual, we can immediately start using the new library. Want to create a
 rich API for a ``product`` table? Create a ``Product`` entity and give it the
 ``@ApiResource()`` annotation::
 
+    <?php
     // src/Entity/Product.php
     namespace App\Entity;
 

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -21,6 +21,7 @@ Want a logging system? No problem:
 This installs and configures (via a recipe) the powerful `Monolog`_ library. To
 use the logger in a controller, add a new argument type-hinted with ``LoggerInterface``::
 
+    <?php
     // src/Controller/DefaultController.php
     namespace App\Controller;
 
@@ -89,6 +90,7 @@ To keep your code organized, you can even create your own services! Suppose you
 want to generate a random greeting (e.g. "Hello", "Yo", etc). Instead of putting
 this code directly in your controller, create a new class::
 
+    <?php
     // src/GreetingGenerator.php
     namespace App;
 
@@ -105,6 +107,7 @@ this code directly in your controller, create a new class::
 
 Great! You can use this immediately in your controller::
 
+    <?php
     // src/Controller/DefaultController.php
     namespace App\Controller;
 
@@ -135,6 +138,7 @@ difference is that it's done in the constructor:
 
 .. code-block:: diff
 
+    <?php
     // src/GreetingGenerator.php
     + use Psr\Log\LoggerInterface;
 
@@ -167,6 +171,7 @@ by creating an event subscriber or a security voter for complex authorization
 rules. Let's add a new filter to Twig called ``greet``. How? Create a class
 that extends ``AbstractExtension``::
 
+    <?php
     // src/Twig/GreetExtension.php
     namespace App\Twig;
 

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -80,6 +80,7 @@ doesn't exist yet, so let's create it!
 In ``src/Controller``, create a new ``DefaultController`` class and an ``index``
 method inside::
 
+    <?php
     // src/Controller/DefaultController.php
     namespace App\Controller;
 
@@ -115,6 +116,7 @@ like a wildcard that matches anything. And it gets better! Update the controller
 
 .. code-block:: diff
 
+    <?php
     // src/Controller/DefaultController.php
     namespace App\Controller;
 
@@ -153,6 +155,7 @@ Instead, add the route *right above* the controller method:
 
 .. code-block:: diff
 
+    <?php
     // src/Controller/DefaultController.php
     namespace App\Controller;
 
@@ -173,6 +176,7 @@ This works just like before! But by using annotations, the route and controller
 live right next to each other. Need another page? Add another route and method
 in ``DefaultController``::
 
+    <?php
     // src/Controller/DefaultController.php
     namespace App\Controller;
 


### PR DESCRIPTION
Beginners try to imitate the code of the quick tour as it is, but it does not work as it is because there is no `<?php`. Those pages are for beginners, so it's better to work just by copy and paste.