### PR TITLE
Fixed package name for ovh cloud.

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -59,7 +59,7 @@ Service     Package                          DSN
 ==========  ===============================  ====================================================
 Twilio      ``symfony/twilio-notifier``      ``twilio://SID:TOKEN@default?from=FROM``
 Nexmo       ``symfony/nexmo-notifier``       ``nexmo://KEY:SECRET@default?from=FROM``
-OvhCloud    ``symfony/ovhcloud-notifier``    ``ovhcloud://KEY:SECRET@default?from=FROM``
+OvhCloud    ``symfony/ovh-cloud-notifier``    ``ovhcloud://KEY:SECRET@default?from=FROM``
 Sinch       ``symfony/sinch-notifier``       ``sinch://ACCOUNT_ID:AUTH_TOKEN@default?from=FROM``
 FreeMobile  ``symfony/freemobile-notifier``  ``freemobile://LOGIN:PASS@default?phone=PHONE``
 ==========  ===============================  ====================================================


### PR DESCRIPTION
Fixed package name for ovh cloud.
See the package: https://packagist.org/packages/symfony/ovh-cloud-notifier

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
