### PR TITLE
Fix OPcache class preload requirement

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -109,9 +109,7 @@ During container compilation (e.g. when running the ``cache:clear`` command),
 Symfony generates a file called ``preload.php`` in the ``config/`` directory
 with the list of classes to preload.
 
-The only requirement is that you need to set both ``container.dumper.inline_factories``
-and ``container.dumper.inline_class_loader`` parameters to ``true``. Then, you
-can configure PHP to use this preload file:
+You can configure PHP to use this preload file:
 
 .. code-block:: ini
 


### PR DESCRIPTION
`container.dumper.inline_factories` 
As stated by @nicolas-grekas in https://github.com/symfony/symfony/pull/32581#issuecomment-513134244
> With preloading, a single big file can, in theory, be similarly fast or faster.

`container.dumper.inline_class_loader`
With this parameter set to `true`, we'll do extra `include_once` for classes already preloaded by OPcache.
Additionally, it can lead to warnings (cannot redeclare class) in classes that use `class_alias`, like https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/blob/master/src/EventListener/InvalidationListener.php#L33
It's because this class already declared in preload, and PHP tries to declare it again after `include_once` in service getter.
