### PR TITLE
Document composer sync recipe force option

### DIFF
--- a/setup/_update_all_packages.rst.inc
+++ b/setup/_update_all_packages.rst.inc
@@ -17,3 +17,16 @@ this safely by running:
     breaking changes.
 
 .. _`version constraints`: https://getcomposer.org/doc/articles/versions.md
+
+If you are in a default Symfony application that uses :ref:`Symfony Flex <symfony-flex>`
+and Symfony Recipes, you may also want to reinstall them to their latest version:
+
+.. code-block:: terminal
+
+    $ composer sync-recipes --force
+
+.. caution::
+
+    By doing this, you reinstall all the recipes again for all packages.
+    It is your job to carefully verify the code changes as it may override
+    your custom code.


### PR DESCRIPTION
Small improvement on the upgrade packages process
It may help the process of upgrading/reinstalling to get latest recipe code

Also fix https://github.com/symfony/symfony-docs/issues/12698 👍 

edit: maybe check also https://github.com/symfony/symfony-docs/pull/13320 as it is very similar :) 