### PR TITLE
Update prepared process documentation

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -377,10 +377,9 @@ instead::
 Using a Prepared Command Line
 -----------------------------
 
-You can run the process by using a a prepared command line using the
-double bracket notation. You can use a placeholder in order to have a
-process that can only be changed with the values and without changing
-the PHP code::
+You can run a process by using a prepared command line with double quote variable
+notation. This allows you to use placeholders so that only the parameterized
+values can be changed, but not the rest of the script::
 
     use Symfony\Component\Process\Process;
 


### PR DESCRIPTION
The docs say that the prepared command line feature of the Process component uses a "double bracket" syntax; however, in looking at the code example and actually using it, @faxblaster think this should instead say "double quotes".

> If your pull request documents a NEW FEATURE, use the same Symfony branch where the feature was introduced (and `master` for features of unreleased versions).

Apologies, I'm not actually sure in which version this was introduced; I'd be happy to re-pull it against a different branch if necessary. Thanks for understanding my ignorance!