### PR TITLE
Update building locally without docker docs

### DIFF
--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -273,7 +273,8 @@ If you don't use Docker, follow these steps to build the docs locally:
 
    .. code-block:: terminal
 
-        $ pip install sphinx~=1.3.0 git+https://github.com/fabpot/sphinx-php.git
+        $ cd _build/
+        $ pip install -r .requirements.txt
 
 #. Run the following command to build the documentation in HTML format:
 


### PR DESCRIPTION
I had trouble generating the docs locally. I think it's related to some dependency changes recently made.

This was the solution for me (I got this from the github workflow).