### PR TITLE
Update DateTime.rst

### DIFF
--- a/reference/constraints/DateTime.rst
+++ b/reference/constraints/DateTime.rst
@@ -29,7 +29,7 @@ Basic Usage
         class Author
         {
             /**
-             * @Assert\DateTime
+             * @Assert\Type("\DateTimeInterface")
              * @var string A "Y-m-d H:i:s" formatted value
              */
             protected $createdAt;


### PR DESCRIPTION
The ability to use Assert\Date to validate DateTime objects was deprecated on Symfony 4.2, and on Symfony 5.0 it was removed altogether.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
