### PR TITLE
[Notifier] Update SlackOptions code example

### DIFF
--- a/notifier/chatters.rst
+++ b/notifier/chatters.rst
@@ -77,7 +77,7 @@ some interactive options called `Block elements`_::
             ->text('The Symfony Community')
             ->accessory(
                 new SlackImageBlockElement(
-                    'https://example.com/symfony-logo.png',
+                    'https://symfony.com/favicons/apple-touch-icon.png',
                     'Symfony'
                 )
             )


### PR DESCRIPTION
If you copy and paste the SlackOptions as it was, Slack gives back the error `invalid blocks`.

When I was trying to use the Slack notifier component, I couldn't understand why and I found out is because Slack needs a working URL to an image, so I suggest to this change to help other developers when they will reach the same issue.

Apparently Slack does not support SVG and the logo from here https://symfony.com/logo are cropped in the Slack message. For this reason, I took the apple-touch icon URL, because it fits well in the Slack message.