### PR TITLE
Improve doc about log channel and env

### DIFF
--- a/logging/channels_handlers.rst
+++ b/logging/channels_handlers.rst
@@ -25,7 +25,9 @@ Switching a Channel to a different Handler
 
 Now, suppose you want to log the ``security`` channel to a different file.
 To do this, create a new handler and configure it to log only messages
-from the ``security`` channel:
+from the ``security`` channel.
+You might add this in `config/packages/monolog.yaml` to log in all environments,
+or just `config/packages/prod/monolog.yaml` to happen only in prod:
 
 .. configuration-block::
 


### PR DESCRIPTION
Hi

On 3.4 there was such info which is important IMO
ref: https://symfony.com/doc/3.4/logging/channels_handlers.html

but on 4.4+, this info is missing (i do not know if deliberate or mistake)

Maybe related to Slack discussion https://symfony-devs.slack.com/archives/C3EQ7S3MJ/p1597377730129600
