### PR TITLE
[Translation] The 'other' key is mandatory in ICU 'select'

### DIFF
--- a/translation/message_format.rst
+++ b/translation/message_format.rst
@@ -100,6 +100,8 @@ typical usage of this is gender:
     .. code-block:: yaml
 
         # translations/messages+intl-icu.en.yaml
+
+        # the 'other' key is required, and is selected if no other case matches
         invitation_title: >-
             {organizer_gender, select,
                 female {{organizer_name} has invited you for her party!}
@@ -116,6 +118,7 @@ typical usage of this is gender:
                 <body>
                     <trans-unit id="invitation_title">
                         <source>invitation_title</source>
+                        <!-- the 'other' key is required, and is selected if no other case matches -->
                         <target>{organizer_gender, select,
                             female {{organizer_name} has invited you for her party!}
                             male {{organizer_name} has invited you for his party!}
@@ -130,6 +133,7 @@ typical usage of this is gender:
 
         // translations/messages+intl-icu.en.php
         return [
+            // the 'other' key is required, and is selected if no other case matches
             'invitation_title' => '{organizer_gender, select,
                 female {{organizer_name} has invited you for her party!}
                 male   {{organizer_name} has invited you for his party!}


### PR DESCRIPTION
In a new Symfony app I worked on recently, we use ICU intl messages. Symfony makes it super easy to use and everything works perfectly. Thanks to everybody who made it possible!

However, when using `select`, the `other` key is mandatory. In some messages of my app we only have two options, so I didn't add `other` at first ... and I saw this:

![image](https://user-images.githubusercontent.com/73419/90253477-8000d480-de41-11ea-94c0-faa7adb517d4.png)

This option being mandatory is mentioned in http://userguide.icu-project.org/formatparse/messages and https://messageformat.github.io/messageformat/page-guide#toc3__anchor so we may do the same.