### PR TITLE
Update Symfony browserlists reccomendation to browserlists standard.

### DIFF
--- a/frontend/encore/postcss.rst
+++ b/frontend/encore/postcss.rst
@@ -67,6 +67,16 @@ support. The best-practice is to configure this directly in your ``package.json`
 
     {
     +  "browserslist": [
+    +    "defaults"
+    +  ]
+    }
+
+The ``defaults`` option is reccommended for most users and would be equivilant to the following browserslist.
+
+.. code-block:: diff
+
+    {
+    +  "browserslist": [
     +    "> 0.5%",
     +    "last 2 versions",
     +    "Firefox ESR",


### PR DESCRIPTION
Use the browserlists default browsers as recommended by "browserlists"

The ``defaults`` option of browserlists includes the already mentioned settings on this page and is the recommended value for most users, listing all the including values as a recommendation from Symfony is not helpful. I included the equivalent of defaults below the new recommendation for explanation.

See: [Full List of Browserslist](https://github.com/browserslist/browserslist#full-list)
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
