### PR TITLE
RedisTagAwareAdapter integration

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -102,6 +102,11 @@ The Cache component comes with a series of adapters pre-configured:
 * :doc:`cache.adapter.pdo </components/cache/adapters/pdo_doctrine_dbal_adapter>`
 * :doc:`cache.adapter.psr6 </components/cache/adapters/proxy_adapter>`
 * :doc:`cache.adapter.redis </components/cache/adapters/redis_adapter>`
+* :ref:`cache.adapter.redis_tag_aware <redis-tag-aware-adapter>` (Redis adapter optimized to work with tags)
+
+.. versionadded:: 5.2
+
+    ``cache.adapter.redis_tag_aware`` has been introduced in Symfony 5.2.
 
 Some of these adapters could be configured via shortcuts. Using these shortcuts
 will create pools with service IDs that follow the pattern ``cache.[type]``.


### PR DESCRIPTION
Documentation about symfony/symfony#36596

This PR contains documentation on `RedisTagAwareAdapter` (introduced in 4.3) **and** its integration in the fullstack framework (introduced in 5.2).

I created another PR (#14081) with only the documentation about `RedisTagAwareAdapter` that targets 4.4.

Close #14065


