### PR TITLE
Complete documentation about mailer integration

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -73,14 +73,20 @@ over SMTP by configuring the DSN in your ``.env`` file (the ``user``,
 Using Built-in Transports
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-============  ========================================  ==============================
+.. versionadded:: 5.2
+
+    The native protocol was introduced in Symfony 5.2.
+
+============  ========================================  ==============================================================
 DSN protocol  Example                                   Description
-============  ========================================  ==============================
-smtp          ``smtp://user:pass@smtp.example.com:25``  Mailer uses an SMTP server to
-                                                        send emails
-sendmail      ``sendmail://default``                    Mailer uses the local sendmail
-                                                        binary to send emails
-============  ========================================  ==============================
+============  ========================================  ==============================================================
+smtp          ``smtp://user:pass@smtp.example.com:25``  Mailer uses an SMTP server to send emails
+sendmail      ``sendmail://default``                    Mailer uses the local sendmail binary to send emails
+native        ``native://default``                      Mailer uses the sendmail binary and options configured
+                                                        in the ``sendmail_path`` setting of ``php.ini``. On Windows
+                                                        hosts, Mailer fallbacks to ``smtp`` and ``smtp_port``
+                                                        ``php.ini`` settings when ``sendmail_path`` is not configured.
+============  ========================================  ==============================================================
 
 Using a 3rd Party Transport
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -184,6 +184,8 @@ Configuration
     * `sender`_
     * `recipients`_
 
+  * :ref:`headers <mailer-headers>`
+
 * `php_errors`_
 
   * `log`_
@@ -924,8 +926,6 @@ enabled
 
 Whether to enable the support for retry failed HTTP request or not.
 This setting is automatically set to true when one of the child settings is configured.
-
-.. _http-headers:
 
 .. _http-headers:
 
@@ -3090,6 +3090,20 @@ recipients set in the code.
                 ]
             ]);
         };
+
+.. _mailer-headers:
+
+headers
+.......
+
+.. versionadded:: 5.2
+
+    The ``headers`` mailer option was introduced in Symfony 5.2.
+
+**type**: ``array``
+
+Headers to add to emails. The key (``name`` attribute in xml format) is the
+header name and value the header value.
 
 workflows
 ~~~~~~~~~


### PR DESCRIPTION
- Complete framework config reference with `Mailer` (based on #14087 plus `message_bus` and `headers` that was added after 4.4)
- Add documentation about `native` DSN protocol (symfony/symfony#36131)

Close #14066
