### PR TITLE
Fix inconsistent security docs

### DIFF
--- a/security/form_login.rst
+++ b/security/form_login.rst
@@ -28,7 +28,8 @@ First, enable ``form_login`` under your firewall:
 
             firewalls:
                 main:
-                    anonymous: lazy
+                    anonymous: true
+                    lazy: true
                     form_login:
                         login_path: login
                         check_path: login
@@ -46,8 +47,7 @@ First, enable ``form_login`` under your firewall:
                 https://symfony.com/schema/dic/security/security-1.0.xsd">
 
             <config>
-                <firewall name="main">
-                    <anonymous lazy="true"/>
+                <firewall name="main" anonymous="true" lazy="true">
                     <form-login login-path="login" check-path="login"/>
                 </firewall>
             </config>
@@ -59,7 +59,8 @@ First, enable ``form_login`` under your firewall:
         $container->loadFromExtension('security', [
             'firewalls' => [
                 'main' => [
-                    'anonymous'  => 'lazy',
+                    'anonymous' => true,
+                    'lazy' => true,
                     'form_login' => [
                         'login_path' => 'login',
                         'check_path' => 'login',

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -189,7 +189,8 @@ Finally, configure your ``firewalls`` key in ``security.yaml`` to use this authe
                 # ...
 
                 main:
-                    anonymous: lazy
+                    anonymous: true
+                    lazy: true
                     logout: ~
 
                     guard:
@@ -217,8 +218,7 @@ Finally, configure your ``firewalls`` key in ``security.yaml`` to use this authe
 
                 <!-- if you want, disable storing the user in the session
                     add 'stateless="true"' to the firewall -->
-                <firewall name="main" pattern="^/">
-                    <anonymous lazy="true"/>
+                <firewall name="main" pattern="^/" anonymous="true" lazy="true">
                     <logout/>
 
                     <guard>
@@ -241,7 +241,8 @@ Finally, configure your ``firewalls`` key in ``security.yaml`` to use this authe
             'firewalls' => [
                 'main'       => [
                     'pattern'        => '^/',
-                    'anonymous'      => 'lazy',
+                    'anonymous'      => true,
+                    'lazy'           => true,
                     'logout'         => true,
                     'guard'          => [
                         'authenticators'  => [

--- a/security/json_login_setup.rst
+++ b/security/json_login_setup.rst
@@ -17,7 +17,8 @@ First, enable the JSON login under your firewall:
 
             firewalls:
                 main:
-                    anonymous: lazy
+                    anonymous: true
+                    lazy: true
                     json_login:
                         check_path: /login
 
@@ -34,8 +35,7 @@ First, enable the JSON login under your firewall:
                 https://symfony.com/schema/dic/security/security-1.0.xsd">
 
             <config>
-                <firewall name="main">
-                    <anonymous lazy="true"/>
+                <firewall name="main" anonymous="true" lazy="true">
                     <json-login check-path="/login"/>
                 </firewall>
             </config>
@@ -47,7 +47,8 @@ First, enable the JSON login under your firewall:
         $container->loadFromExtension('security', [
             'firewalls' => [
                 'main' => [
-                    'anonymous'  => 'lazy',
+                    'anonymous' => true,
+                    'lazy' => true,
                     'json_login' => [
                         'check_path' => '/login',
                     ],
@@ -165,7 +166,8 @@ The security configuration should be:
 
             firewalls:
                 main:
-                    anonymous: lazy
+                    anonymous: true
+                    lazy: true
                     json_login:
                         check_path:    login
                         username_path: security.credentials.login
@@ -184,8 +186,7 @@ The security configuration should be:
                 https://symfony.com/schema/dic/security/security-1.0.xsd">
 
             <config>
-                <firewall name="main">
-                    <anonymous lazy="true"/>
+                <firewall name="main" anonymous="true" lazy="true">
                     <json-login check-path="login"
                         username-path="security.credentials.login"
                         password-path="security.credentials.password"/>
@@ -199,7 +200,8 @@ The security configuration should be:
         $container->loadFromExtension('security', [
             'firewalls' => [
                 'main' => [
-                    'anonymous'  => 'lazy',
+                    'anonymous' => true,
+                    'lazy' => true,
                     'json_login' => [
                         'check_path' => 'login',
                         'username_path' => 'security.credentials.login',

--- a/security/multiple_guard_authenticators.rst
+++ b/security/multiple_guard_authenticators.rst
@@ -27,7 +27,8 @@ This is how your security configuration can look in action:
             # ...
             firewalls:
                 default:
-                    anonymous: lazy
+                    anonymous: true
+                    lazy: true
                     guard:
                         authenticators:
                             - App\Security\LoginFormAuthenticator
@@ -48,8 +49,7 @@ This is how your security configuration can look in action:
 
             <config>
                 <!-- ... -->
-                <firewall name="default">
-                    <anonymous lazy="true"/>
+                <firewall name="default" anonymous="true" lazy="true">
                     <guard entry-point="App\Security\LoginFormAuthenticator">
                         <authenticator>App\Security\LoginFormAuthenticator</authenticator>
                         <authenticator>App\Security\FacebookConnectAuthenticator</authenticator>
@@ -68,7 +68,8 @@ This is how your security configuration can look in action:
             // ...
             'firewalls' => [
                 'default' => [
-                    'anonymous' => 'lazy',
+                    'anonymous' => true,
+                    'lazy' => true,
                     'guard' => [
                         'entry_point' => LoginFormAuthenticator::class,
                         'authenticators' => [
@@ -105,7 +106,8 @@ the solution is to split the configuration into two separate firewalls:
                         authenticators:
                             - App\Security\ApiTokenAuthenticator
                 default:
-                    anonymous: lazy
+                    anonymous: true
+                    lazy: true
                     guard:
                         authenticators:
                             - App\Security\LoginFormAuthenticator
@@ -133,8 +135,7 @@ the solution is to split the configuration into two separate firewalls:
                         <authenticator>App\Security\ApiTokenAuthenticator</authenticator>
                     </guard>
                 </firewall>
-                <firewall name="default">
-                    <anonymous lazy="true"/>
+                <firewall name="default" anonymous="true" lazy="true">
                     <guard>
                         <authenticator>App\Security\LoginFormAuthenticator</authenticator>
                     </guard>
@@ -163,7 +164,8 @@ the solution is to split the configuration into two separate firewalls:
                     ],
                 ],
                 'default' => [
-                    'anonymous' => 'lazy',
+                    'anonymous' => true,
+                    'lazy' => true,
                     'guard' => [
                         'authenticators' => [
                             LoginFormAuthenticator::class,


### PR DESCRIPTION
According to the https://symfony.com/doc/current/security.html#a-authentication-firewalls since version 5.1
`anonymous: lazy` configuration was replaced with `anonymous: true; lazy: true`.
I've replaced those old occurences to the new format.