### PR TITLE
[Notifier] Linkedin integration

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -142,6 +142,7 @@ GoogleChat  ``symfony/google-chat-notifier``  ``googlechat://ACCESS_KEY:ACCESS_T
 Mattermost  ``symfony/mattermost-notifier``   ``mattermost://TOKEN@ENDPOINT?channel=CHANNEL``
 RocketChat  ``symfony/rocket-chat-notifier``  ``rocketchat://TOKEN@ENDPOINT?channel=CHANNEL``
 Zulip       ``symfony/zulip-notifier``        ``zulip://EMAIL:APIKEY@ENDPOINT?channel=CHANNEL``
+LinkedIn    ``symfony/linked-in-notifier``    ``linkedin://TOKEN:USER_ID@default``
 ==========  ================================  ===========================================================================
 
 .. versionadded:: 5.1
@@ -152,7 +153,7 @@ Zulip       ``symfony/zulip-notifier``        ``zulip://EMAIL:APIKEY@ENDPOINT?ch
 
 .. versionadded:: 5.2
 
-    The GoogleChat and Zulip integrations were introduced in Symfony 5.2.
+    The GoogleChat, LinkedIn and Zulip integrations were introduced in Symfony 5.2.
 
 Chatters are configured using the ``chatter_transports`` setting:
 


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/14099

I'm wondering if we merge this and then I add an example like it's done [https://symfony.com/doc/master/notifier/chatters.html#adding-interactions-to-a-slack-message](https://symfony.com/doc/master/notifier/chatters.html#adding-interactions-to-a-slack-message) or we wait until I add the example in 1 PR
