### PR TITLE
Fix logout option in security.yaml

### DIFF
--- a/security/form_login_setup.rst
+++ b/security/form_login_setup.rst
@@ -99,12 +99,13 @@ Edit the ``security.yaml`` file in order to declare the ``/logout`` path:
         security:
             # ...
 
-            providers:
-                # ...
-                logout:
-                    path: app_logout
-                    # where to redirect after logout
-                    # target: app_any_route
+            firewalls:
+                main:
+                    # ...
+                    logout:
+                        path: app_logout
+                        # where to redirect after logout
+                        # target: app_any_route
 
     .. code-block:: xml
 


### PR DESCRIPTION
The logout option should be related to the firewalls section instead of providers

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
