### PR TITLE
Update deployment.rst

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -173,7 +173,7 @@ as you normally do:
     leverage a (feature)[https://symfony.com/doc/4.4/configuration.html#configuring-environment-variables-in-production]
     that dumps your environments variables into a flat file:
 
-.. code-block:: terminal
+    .. code-block:: terminal
 
         $ composer dump-env prod
 

--- a/deployment.rst
+++ b/deployment.rst
@@ -170,7 +170,7 @@ as you normally do:
 .. tip::
 
     To improve performance and if you have Symfony Flex 1.2 or later installed, you may
-    leverage a (feature)[https://symfony.com/doc/4.4/configuration.html#configuring-environment-variables-in-production]
+    leverage this :ref:`feature <configuration-env-var-in-prod>`
     that dumps your environments variables into a flat file:
 
     .. code-block:: terminal

--- a/deployment.rst
+++ b/deployment.rst
@@ -175,7 +175,7 @@ as you normally do:
 
 .. code-block:: terminal
 
-    $ composer dump-env prod
+        $ composer dump-env prod
 
 D) Clear your Symfony Cache
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/deployment.rst
+++ b/deployment.rst
@@ -167,6 +167,16 @@ as you normally do:
     using :ref:`Symfony Flex <symfony-flex>`) before running this command so
     that the ``post-install-cmd`` scripts run in the ``prod`` environment.
 
+.. tip::
+
+    To improve performance and you have Symfony Flex 1.2 or later, you may
+    leverage a (feature)[https://symfony.com/doc/4.4/configuration.html#configuring-environment-variables-in-production]
+    that dumps your environments variables into flat file:
+
+.. code-block:: terminal
+
+    $ composer dump-env prod
+
 D) Clear your Symfony Cache
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/deployment.rst
+++ b/deployment.rst
@@ -169,9 +169,9 @@ as you normally do:
 
 .. tip::
 
-    To improve performance and you have Symfony Flex 1.2 or later, you may
+    To improve performance and if you have Symfony Flex 1.2 or later installed, you may
     leverage a (feature)[https://symfony.com/doc/4.4/configuration.html#configuring-environment-variables-in-production]
-    that dumps your environments variables into flat file:
+    that dumps your environments variables into a flat file:
 
 .. code-block:: terminal
 


### PR DESCRIPTION
Hi,

Small update as i think this tip of `composer dump-env prod` should also be present in the `deployment` part as this page doc talks about production deployment 

the original one is inside `configuration` and i think this command line is more a deploy than config command

If duplicating this information is to much, maybe we can just put the link to the other doc page (or vice versa)

Feel free to edit the PR!