### PR TITLE
[Notifier] Fix wrong package name for the RocketChat service

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -134,7 +134,7 @@ Service     Package                          DSN
 Slack       ``symfony/slack-notifier``       ``slack://default/ID``
 Telegram    ``symfony/telegram-notifier``    ``telegram://TOKEN@default?channel=CHAT_ID``
 Mattermost  ``symfony/mattermost-notifier``  ``mattermost://TOKEN@ENDPOINT?channel=CHANNEL``
-RocketChat  ``symfony/rocketchat-notifier``  ``rocketchat://TOKEN@ENDPOINT?channel=CHANNEL``
+RocketChat  ``symfony/rocket-chat-notifier`` ``rocketchat://TOKEN@ENDPOINT?channel=CHANNEL``
 ==========  ===============================  ============================================
 
 .. versionadded:: 5.1


### PR DESCRIPTION
Package name "symfony/rocketchat-notifier" should be "symfony/rocket-chat-notifier" 

Installation of the package using current package name returns InvalidArgumentException

```
[InvalidArgumentException]
Could not find a matching version of package symfony/rocketchat-notifier.
Check the package spelling, your version constraint and that the package is available 
in a stability which matches your minimum-stability (stable).
```

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
