### PR TITLE
Replace overriding twig.paths by twig.default_path

### DIFF
--- a/configuration/override_dir_structure.rst
+++ b/configuration/override_dir_structure.rst
@@ -94,8 +94,8 @@ Override the Templates Directory
 --------------------------------
 
 If your templates are not stored in the default ``app/Resources/views/``
-directory, use the :ref:`twig.paths <config-twig-paths>` configuration option to
-define your own templates directory (or directories):
+directory, use the :ref:`twig.default_path <config-twig-default-path>` configuration option to
+define your own templates directory (use :ref:`twig.paths <config-twig-paths>` for multiple directories):
 
 .. configuration-block::
 
@@ -104,7 +104,7 @@ define your own templates directory (or directories):
         # app/config/config.yml
         twig:
             # ...
-            paths: ["%kernel.project_dir%/templates"]
+            default_path: "%kernel.project_dir%/templates"
 
     .. code-block:: xml
 
@@ -119,7 +119,7 @@ define your own templates directory (or directories):
                 https://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
             <twig:config>
-                <twig:path>%kernel.project_dir%/templates</twig:path>
+                <twig:default-path>%kernel.project_dir%/templates</twig:default-path>
             </twig:config>
 
         </container>
@@ -128,9 +128,7 @@ define your own templates directory (or directories):
 
         // app/config/config.php
         $container->loadFromExtension('twig', [
-            'paths' => [
-                '%kernel.project_dir%/templates',
-            ],
+            'default_path' => '%kernel.project_dir%/templates',
         ]);
 
 .. _override-web-dir:

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -243,6 +243,8 @@ on. Set it to ``0`` to disable all the optimizations. You can even enable or
 disable these optimizations selectively, as explained in the Twig documentation
 about `the optimizer extension`_.
 
+.. _config-twig-default-path:
+
 ``default_path``
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Since `twig.default_path` has been introduced (3.4), it should be a better idea to override it instead of `twig.paths` for customizing the directory structure (default path is added to paths anyway).
