### PR TITLE
[5.0] [security] formatting

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -361,8 +361,8 @@ authentication process. There are many different ways to build an authenticator;
 here are a few common use-cases:
 
 * :doc:`/security/form_login_setup`
-* :doc:`/security/guard_authentication` – see this for the most detailed description of
-   authenticators and how they work
+* :doc:`/security/guard_authentication` – see this for the most detailed
+  description of authenticators and how they work
 
 .. _`security-authorization`:
 .. _denying-access-roles-and-other-authorization:


### PR DESCRIPTION
This is to fix the following output in the 5.0 version:

<img width="710" alt="Capture d’écran 2020-08-28 à 19 32 04" src="https://user-images.githubusercontent.com/177844/91596785-3518ae00-e965-11ea-9b87-bc05618921ae.png">
