### PR TITLE
Some fixes in structure overriding page

### DIFF
--- a/configuration/override_dir_structure.rst
+++ b/configuration/override_dir_structure.rst
@@ -141,8 +141,8 @@ Override the Translations Directory
 -----------------------------------
 
 If your translation files are not stored in the default ``translations/``
-directory, use the :ref:`framework.translator.paths <reference-translator-paths>`
-configuration option to define your own translations directory (or directories):
+directory, use the :ref:`framework.translator.default_path <reference-translator-default_path>`
+configuration option to define your own translations directory (use :ref:`framework.translator.paths <reference-translator-paths>` for multiple directories):
 
 .. configuration-block::
 
@@ -152,7 +152,7 @@ configuration option to define your own translations directory (or directories):
         framework:
             translator:
                 # ...
-                paths: ["%kernel.project_dir%/i18n"]
+                default_path: "%kernel.project_dir%/i18n"
 
     .. code-block:: xml
 
@@ -168,7 +168,7 @@ configuration option to define your own translations directory (or directories):
 
             <framework:config>
                 <framework:translator>
-                    <framework:path>%kernel.project_dir%/i18n</framework:path>
+                    <framework:default-path>%kernel.project_dir%/i18n</framework:default-path>
                 </framework:translator>
             </framework:config>
 
@@ -179,9 +179,7 @@ configuration option to define your own translations directory (or directories):
         // config/packages/translation.php
         $container->loadFromExtension('framework', [
             'translator' => [
-                'paths' => [
-                    '%kernel.project_dir%/i18n',
-                ],
+                'default_path' => '%kernel.project_dir%/i18n',
             ],
         ]);
 
@@ -192,7 +190,7 @@ Override the Public Directory
 -----------------------------
 
 If you need to rename or move your ``public/`` directory, the only thing you
-need to guarantee is that the path to the ``var/`` directory is still correct in
+need to guarantee is that the path to the ``vendor/`` directory is still correct in
 your ``index.php`` front controller. If you renamed the directory, you're fine.
 But if you moved it in some way, you may need to modify these paths inside those
 files::


### PR DESCRIPTION
* Use `default_path` instead of `paths` to change translation directory (default_path is anyway added to paths)
* Replace `var` by `vendor` in the public directory section (I think it's a typo, I don't see why `var` would be involved when public dir is customized)

In the same way, a #14135 targets 3.4 to use `default_path` instead of `paths` for templates.