### PR TITLE
Remove paragraph about doctrine mapping override

### DIFF
--- a/bundles/override.rst
+++ b/bundles/override.rst
@@ -53,13 +53,8 @@ inside a :doc:`compiler pass </service_container/compiler_passes>`.
 Entities & Entity Mapping
 -------------------------
 
-If a bundle defines its entity mapping in configuration files instead of
-annotations, you can override them as any other regular bundle configuration
-file. The only caveat is that you must override all those mapping configuration
-files and not just the ones you actually want to override.
-
-If a bundle provides a mapped superclass (such as the ``User`` entity in the
-FOSUserBundle) you can override its attributes and associations. Learn more
+Entity mapping can only be overridden if a bundle provides a mapped superclass (such as the ``User`` entity in the
+FOSUserBundle). It's possible to override attributes and associations in this way. Learn more
 about this feature and its limitations in `the Doctrine documentation`_.
 
 Forms


### PR DESCRIPTION
Hello,

I would suggest to remove the paragraph about mapping override because it doesn't work in all cases.

I read the related PR (#10053) and the issue (#7076) which motivated it. The example in the issue works only because `auto_mapping` is set to `true` (`auto_mapping: true` allows to find definitions in `Resources/config/doctrine/*.orm.{xml, yml, php} of all the bundles even if nothing is declared in the bundles).

From the POV of the bundle , it's IMHO not a good practice to rely on app `auto_mapping` configuration (the trend for sf4 and sf5 is to rely on configurations over conventions).

So when bundle mapping rely on the dedicated compiler pass (example [here](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/cf7fe27b2f4e1f298ee6eadf537267f8c9f9b85c/FOSUserBundle.php#L50)) and not on `auto_mapping` app configuration , the mapping definition file in the compiler pass (from the bundle) overrides the mapping definition file defined in the application.