### PR TITLE
Update service_subscribers_locators.rst

### DIFF
--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -393,7 +393,8 @@ will share identical locators among all the services referencing them::
 
     use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
     use Symfony\Component\DependencyInjection\ContainerBuilder;
-
+    use Symfony\Component\DependencyInjection\Reference;
+    
     public function process(ContainerBuilder $container)
     {
         // ...


### PR DESCRIPTION
Added the missing use statement, even though Symfony is nice enough to give the missing use statement on a silver platter.
I did not check versions going forward in the documentation.
```
  Fatal error: Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "Reference" from namespace "DealExpress\ApiBundle\DependencyInjection\Compiler".                                                                                                                                                                    
  Did you forget a "use" statement for e.g. "Google_Service_Compute_Reference", "phpDocumentor\Reflection\DocBlock\Tags\Reference\Reference", "Symfony\Component\DependencyInjection\Reference" or "Symfony\Component\Validator\Tests\Fixtures\Reference"?
```

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
