### PR TITLE
Fix bad example of lock

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -117,7 +117,9 @@ method, the resource will stay locked until the timeout::
     // create an expiring lock that lasts 30 seconds
     $lock = $factory->createLock('charts-generation', 30);
 
-    $lock->acquire();
+    if (!$lock->acquire()) {
+        return;
+    }
     try {
         // perform a job during less than 30 seconds
     } finally {
@@ -136,7 +138,9 @@ to reset the TTL to its original value::
     // ...
     $lock = $factory->createLock('charts-generation', 30);
 
-    $lock->acquire();
+    if (!$lock->acquire()) {
+        return;
+    }
     try {
         while (!$finished) {
             // perform a small part of the job.
@@ -366,7 +370,9 @@ Using the above methods, a more robust code would be::
     // ...
     $lock = $factory->createLock('invoice-publication', 30);
 
-    $lock->acquire();
+    if (!$lock->acquire()) {
+        return;
+    }
     while (!$finished) {
         if ($lock->getRemainingLifetime() <= 5) {
             if ($lock->isExpired()) {


### PR DESCRIPTION
I just realized that example in lock were BAD. If you don't check the return of `$lock->acquire()`  you don't know if the lock has been acquired

PR against 4.4 because currently maintained, but bug exists since 3.4
