### PR TITLE
Add a link to the "real" component overview on the component index page

### DIFF
--- a/components/index.rst
+++ b/components/index.rst
@@ -1,9 +1,16 @@
 The Components
 ==============
 
+.. seealso::
+
+    See the dedicated `Symfony Components`_ webpage for a full overview of decoupled
+    and reusable Symfony components.
+
 .. toctree::
     :maxdepth: 1
     :glob:
 
     using_components
     *
+
+.. _`Symfony Components`: https://symfony.com/components


### PR DESCRIPTION
As suggested in https://github.com/symfony/symfony-docs/issues/14194#issuecomment-688520319

@javiereguiluz if I'm correct, the "docs" link on the component overview page is customizable (i.e. Notifier is linking to the guide and not the component docs). Would it be a good idea to do the same for components that are already moved to guide-only mode (e.g. translation and routing) - to avoid weird redirects? Or remove the docs link completely for these components (e.g. all polyfills)?