### PR TITLE
🚑  Fixed: "Could not find package annotations" in composer r…

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -27,7 +27,7 @@ Run this command once in your application to add support for annotations:
 
 .. code-block:: terminal
 
-    $ composer require annotations
+    $ composer require doctrine/annotations
 
 In addition to installing the needed dependencies, this command creates the
 following configuration file:


### PR DESCRIPTION


Apparently, the "annotations" package doesn't exists. I saw in packagist page that the routing component requires a 'doctrine/annotations: ~1.2'.
Packagist symfony/routing url: https://packagist.org/packages/symfony/routing

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
