### PR TITLE
fix build error: inline literal start-string without end-string

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -279,7 +279,7 @@ impersonation_exit_path
 
 .. versionadded:: 5.2
 
-    The ``impersonation_exit_path()` function was introduced in Symfony 5.2.
+    The ``impersonation_exit_path()`` function was introduced in Symfony 5.2.
 
 Generates a URL that you can visit to exit :doc:`user impersonation </security/impersonating_user>`.
 After exiting impersonation, the user is redirected to the current URI. If you
@@ -299,7 +299,7 @@ impersonation_exit_url
 
 .. versionadded:: 5.2
 
-    The ``impersonation_exit_url()` function was introduced in Symfony 5.2.
+    The ``impersonation_exit_url()`` function was introduced in Symfony 5.2.
 
 It's similar to the `impersonation_exit_path`_ function, but it generates
 absolute URLs instead of relative URLs.


### PR DESCRIPTION
This PR fixes the current build error:

> sphinx-build -b html -c . -d ./doctrees  -nqW -j auto ../ ./html
> Warning, treated as error:
> /home/runner/work/symfony-docs/symfony-docs/reference/twig_reference.rst:282:Inline literal start-string without end-string.
> make: *** [html] Error 2

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
