### PR TITLE
Update http_client.rst : HttpClient::Create() standalone

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -138,9 +138,7 @@ You can configure the global options using the ``default_options`` option:
     .. code-block:: php-standalone
 
         $client = HttpClient::create([
-            'default_options' => [
-                'max_redirects' => 7,
-            ],
+             'max_redirects' => 7,
         ]);
 
 Some options are described in this guide:


### PR DESCRIPTION
The method `HttpClient::create(array $defaultOptions, ..)` accepts an array of default options as a parameter (without the `default_options` key)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
