### PR TITLE
Update http_client.rst : standalone HttpClient max host connections param

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -197,10 +197,7 @@ The HTTP client also has one configuration option called
 
     .. code-block:: php-standalone
 
-        $client = HttpClient::create([
-            'max_host_connections' => 10,
-            // ...
-        ]);
+        $client = HttpClient::create([], 10);
 
 Scoping Client
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
As the signature of `create` method : `public static function create(array $defaultOptions = [], int $maxHostConnections = 6, int $maxPendingPushes = 50): HttpClientInterface`

The max host connection should be passed as the second param to this method instead of an option.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
