### PR TITLE
Fix small typo by removing semicolon

### DIFF
--- a/security/experimental_authenticators.rst
+++ b/security/experimental_authenticators.rst
@@ -493,7 +493,7 @@ authenticator, you would initialize the passport like this::
             return new Passport($user, new PasswordCredentials($password), [
                 // $this->userRepository must implement PasswordUpgraderInterface
                 new PasswordUpgradeBadge($password, $this->userRepository),
-                new CsrfTokenBadge('login', $csrfToken);
+                new CsrfTokenBadge('login', $csrfToken),
             ]);
         }
     }


### PR DESCRIPTION
Fix small typo by removing semicolon

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
