### PR TITLE
[Routing] Fix piority parameter listing typo

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -834,7 +834,7 @@ order of your routes, and it is only available when using annotations.
         /**
          * This route could not be matched without defining a higher priority than 0.
          *
-         * @Route("/blog/list", name="blog_list", priority=2)
+         * @Route("/blog/{page}", name="blog_list", priority=2)
          */
         public function list()
         {


### PR DESCRIPTION
Modified the example so that it follows the previous heading and changed the `blog/list` into a dynamic property url.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
