### PR TITLE
Add a caution block about using groups with composite constraints

### DIFF
--- a/validation/groups.rst
+++ b/validation/groups.rst
@@ -185,3 +185,13 @@ will be applied.
 You'll usually work with validation indirectly through the form
 library. For information on how to use validation groups inside forms, see
 :doc:`/form/validation_groups`.
+
+.. caution::
+
+    When using groups on a composite constraint (like ``All`` and
+    ``Collection``), the groups will propagate to the nested constraints,
+    unless some groups are explicitely defined on these.
+
+    However, note that using a composite constraint inside another one will
+    *not* propagate the parent groups, you should explicitly redefine them on
+    the nested composite constraint.


### PR DESCRIPTION
I've encountered this behavior recently and had to dig up the code to understand what was happening. I thought it would be interesting to add this to the documentation.