### PR TITLE
Getting a stack trace follow up

### DIFF
--- a/contributing/code/stack_trace.rst
+++ b/contributing/code/stack_trace.rst
@@ -27,7 +27,7 @@ displayed by default if the exception is not caught. When using Symfony,
 such exceptions go through a custom exception handler, which enhances
 them in various ways before displaying them according to the current
 Server API (CLI or not).
-This means a better way to get a stack trace when you do need the
+This means a better way to get a stack trace when you do not need the
 program to continue is to throw an exception, as follows:
 ``throw new \Exception();``
 
@@ -91,7 +91,7 @@ Several things need to be paid attention to when picking a stack trace
 from your development environment through a web browser:
 
 1. Are there several exceptions? If yes, the most interesting one is
-   often exception 1/n which, is shown _last_ in the example below (it
+   often exception 1/n which, is shown *last* in the example below (it
    is the one marked as exception [1/2]).
 2. Under the "Stack Traces" tab, you will find exceptions in plain
    text, so that you can easily share them in e.g. bug reports. Make


### PR DESCRIPTION
Here are fixes for issues I noticed only now :facepalm:  (sorry)

There is one issue I don't know how to fix: although I put a gif in `_images/contributing/code/stack-trace.gif`, and linked to it with 

https://github.com/symfony/symfony-docs/blob/0f3335f18e1058aa6a68185ff930615c7d827d89/contributing/code/stack_trace.rst#L104, it is served at at least this url: https://symfony.com/doc/4.4/_images/stack-trace.gif (and [the link does not render properly](https://symfony.com/doc/current/contributing/code/stack_trace.html), of course)

What did I do wrong?

![Screenshot_2020-09-21 Getting a Stack Trace (Symfony Docs)](https://user-images.githubusercontent.com/657779/93804337-72abe680-fc46-11ea-92dc-4b6fd612bb80.png)
