### PR TITLE
[HttpClient] Explicits the autowiring behavior

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -326,7 +326,7 @@ Each client has a unique service named after its configuration.
 Each scoped client also defines a corresponding named autowiring alias.
 If you use for example
 ``Symfony\Contracts\HttpClient\HttpClientInterface $myApiClient``
-as the type and name of an argument, autowiring will inject the ``my_api.client``
+as the type and name of an argument and assuming you named your client `my_api.client`` in the ``framework`` section, autowiring will inject the ``my_api.client``
 service into your autowired classes.
 
 Making Requests


### PR DESCRIPTION
Hello :)

This pull request aims to explicit the autowiring behavior when registering new http clients.

At a first glance, I though that registering a `github` client would register a `github.client` service, but it seems not, according to what's implemented in the HttpClientPass https://github.com/symfony/symfony/blob/5.1/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
