### PR TITLE
Add missing `->end()` method call

### DIFF
--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -752,7 +752,7 @@ By changing a string value into an associative array with ``name`` as the key::
                     ->then(function ($v) { return ['name' => $v]; })
                 ->end()
                 ->children()
-                    ->scalarNode('name')->isRequired()
+                    ->scalarNode('name')->isRequired()->end()
                     // ...
                 ->end()
             ->end()


### PR DESCRIPTION
I think for the consistency it might be good to add an `->end()` call here.