### PR TITLE
[Translation] Change translatable example parameter key

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -316,7 +316,7 @@ all the information needed to fully translate its contents when needed::
     $message = new Translatable('Symfony is great!');
     // the optional second argument defines the translation parameters and
     // the optional third argument is the translation domain
-    $status = new Translatable('order.status', ['order' => $order], 'store');
+    $status = new Translatable('order.status', ['%status%' => $order->getStatus()], 'store');
 
 Templates are now much simpler because you can pass translatable objects to the
 ``trans`` filter:


### PR DESCRIPTION
Updated the translatable example to use a key wrapped in `%` as recommended in the docs. Also changed the key to one that I think would be less likely confused with passing the whole order object.