### PR TITLE
[Form] Added documentation for "html5" option of MoneyType and PercentType

### DIFF
--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -17,6 +17,7 @@ how the input and output of the data is handled.
 | Options     | - `currency`_                                                       |
 |             | - `divisor`_                                                        |
 |             | - `grouping`_                                                       |
+|             | - `html5`_                                                          |
 |             | - `rounding_mode`_                                                  |
 |             | - `scale`_                                                          |
 +-------------+---------------------------------------------------------------------+
@@ -89,6 +90,21 @@ be set back on your object.
 .. include:: /reference/forms/types/options/grouping.rst.inc
 
 .. include:: /reference/forms/types/options/rounding_mode.rst.inc
+
+html5
+~~~~~
+
+**type**: ``boolean`` **default**: ``false``
+
+.. versionadded:: 5.2
+
+    This option was introduced in Symfony 5.2.
+
+If set to true, the HTML input will be rendered as a native HTML5 type="number" form.
+
+.. caution::
+
+    As HTML5 number format is normalized, it is incompatible with ``grouping`` option.
 
 scale
 ~~~~~

--- a/reference/forms/types/percent.rst
+++ b/reference/forms/types/percent.rst
@@ -15,7 +15,8 @@ the input.
 +-------------+-----------------------------------------------------------------------+
 | Rendered as | ``input`` ``text`` field                                              |
 +-------------+-----------------------------------------------------------------------+
-| Options     | - `rounding_mode`_                                                    |
+| Options     | - `html5`_                                                            |
+|             | - `rounding_mode`_                                                    |
 |             | - `scale`_                                                            |
 |             | - `symbol`_                                                           |
 |             | - `type`_                                                             |
@@ -56,6 +57,17 @@ Field Options
 .. versionadded:: 5.1
 
     The ``rounding_mode`` option was introduced in Symfony 5.1.
+
+html5
+~~~~~
+
+**type**: ``boolean`` **default**: ``false``
+
+.. versionadded:: 5.2
+
+    This option was introduced in Symfony 5.2.
+
+If set to true, the HTML input will be rendered as a native HTML5 type="number" form.
 
 scale
 ~~~~~


### PR DESCRIPTION
Hello,

Following symfony/symfony/pull/35956, which was merged for 5.2, this PR adds the corresponding documentation.
