### PR TITLE
Update http_client.rst

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -843,7 +843,7 @@ response sequentially instead of waiting for the entire response::
 
     // get the response content in chunks and save them in a file
     // response chunks implement Symfony\Contracts\HttpClient\ChunkInterface
-    $fileHandler = fopen('/ubuntu.iso', 'w');
+    $fileHandler = fopen('/ubuntu.iso', 'b');
     foreach ($client->stream($response) as $chunk) {
         fwrite($fileHandler, $chunk->getContent());
     }


### PR DESCRIPTION
$fileHandler = fopen('/ubuntu.iso', 'b');

If you do not specify the 'b' flag when working with binary files, you
may experience strange problems with your data, including broken image
files and strange problems with \r\n characters.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
