### PR TITLE
Update http_client.rst 4.4 -> 5.1

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -844,7 +844,7 @@ response sequentially instead of waiting for the entire response::
 
     // get the response content in chunks and save them in a file
     // response chunks implement Symfony\Contracts\HttpClient\ChunkInterface
-    $fileHandler = fopen('/ubuntu.iso', 'w');
+    $fileHandler = fopen('/ubuntu.iso', 'wb');
     foreach ($client->stream($response) as $chunk) {
         fwrite($fileHandler, $chunk->getContent());
     }


### PR DESCRIPTION
`$fileHandler = fopen('/ubuntu.iso', 'w'); -> $fileHandler = fopen('/ubuntu.iso', 'wb');`

[https://www.php.net/manual/ru/function.fopen.php](https://www.php.net/manual/ru/function.fopen.php)
If you do not specify the 'b' flag when working with binary files, you
may experience strange problems with your data, including broken image
files and strange problems with \r\n characters.