### PR TITLE
typo fix for the Signing Messages chapter

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -798,7 +798,7 @@ S/MIME Signer
 .............
 
 `S/MIME`_ is a standard for public key encryption and signing of MIME data. It
-requires using both a certificate and a private key:
+requires using both a certificate and a private key::
 
     use Symfony\Component\Mime\Crypto\SMimeSigner;
     use Symfony\Component\Mime\Email;
@@ -1168,7 +1168,7 @@ a specific address, instead of the *real* address:
 .. _`Markdown syntax`: https://commonmark.org/
 .. _`Inky`: https://get.foundation/emails/docs/inky.html
 .. _`S/MIME`: https://en.wikipedia.org/wiki/S/MIME
-.. _`DKIM`: `https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
+.. _`DKIM`: https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
 .. _`OpenSSL PHP extension`: https://www.php.net/manual/en/book.openssl.php
 .. _`PEM encoded`: https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail
 .. _`default_socket_timeout`: https://www.php.net/manual/en/filesystem.configuration.php#ini.default-socket-timeout


### PR DESCRIPTION
While reading the docs at https://symfony.com/doc/master/mailer.html#signing-messages i have noticed that the syntax highlighting for the SMimeSigner code examle is not correct.

![image](https://user-images.githubusercontent.com/72142966/94695663-791d1b00-0336-11eb-9285-177e464e62dc.png)

Also the wikipedia link for DKIM is not working.