### PR TITLE
Fix typo on mailer doc

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -841,7 +841,7 @@ key but not a certificate::
     // second and third arguments: the domain name and "selector" used to perform a DNS lookup
     // (the selector is a string used to point to a specific DKIM public key record in your DNS)
     $signer = new DkimSigner('file:///path/to/private-key.key', 'example.com', 'sf');
-    // if the private key has a passphrase, pass it as the fourth argument
+    // if the private key has a passphrase, pass it as the fifth argument
     // new DkimSigner('file:///path/to/private-key.key', 'example.com', 'sf', [], 'the-passphrase');
 
     $signedEmail = $signer->sign($email);


### PR DESCRIPTION
This is the signature of the constructor:
```php
    public function __construct(string $pk, string $domainName, string $selector, array $defaultOptions = [], string $passphrase = '')
```

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
