### PR TITLE
[Lock] fix "time to leave" typo ("time to live")

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -478,7 +478,7 @@ Using the above methods, a more robust code would be::
 .. caution::
 
     Choose wisely the lifetime of the ``Lock`` and check whether its remaining
-    time to leave is enough to perform the task.
+    time to live is enough to perform the task.
 
 .. caution::
 


### PR DESCRIPTION
This fixes a typo in one of the warnings about the TTL for expiring stores where TTL was expanded as *time to leave* instead of *time to live*.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
