### PR TITLE
Multiple PHP class per file not allowed

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -46,6 +46,10 @@ following configuration file:
 This configuration tells Symfony to look for routes defined as annotations in
 any PHP class stored in the ``src/Controller/`` directory.
 
+.. caution::
+
+    If you define multiple PHP class per file, only the first declared class can be loaded, try to define one PHP class per file instead, visit `PSR-4 <https://www.php-fig.org/psr/psr-4/>`_ for more details.
+
 Suppose you want to define a route for the ``/blog`` URL in your application. To
 do so, create a :doc:`controller class </controller>` like the following::
 


### PR DESCRIPTION
Since `AnnotationFileLoader` from `Routing` component parses and loads only one class per file while ignoring others class if declared in the same file, it is good to let know people about this behaviour to not be surprised.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
