### PR TITLE
14300 Add support for UUIDv6 in Uuid constraint

### DIFF
--- a/reference/constraints/Uuid.rst
+++ b/reference/constraints/Uuid.rst
@@ -124,9 +124,9 @@ will allow alternate input formats like:
 ``versions``
 ~~~~~~~~~~~~
 
-**type**: ``int[]`` **default**: ``[1,2,3,4,5]``
+**type**: ``int[]`` **default**: ``[1,2,3,4,5,6]``
 
-This option can be used to only allow specific `UUID versions`_.  Valid versions are 1 - 5.
+This option can be used to only allow specific `UUID versions`_.  Valid versions are 1 - 6.
 The following PHP constants can also be used:
 
 * ``Uuid::V1_MAC``
@@ -134,8 +134,9 @@ The following PHP constants can also be used:
 * ``Uuid::V3_MD5``
 * ``Uuid::V4_RANDOM``
 * ``Uuid::V5_SHA1``
+* ``Uuid::V6_SORTABLE``
 
-All five versions are allowed by default.
+All six versions are allowed by default.
 
 .. _`Universally unique identifier (UUID)`: https://en.wikipedia.org/wiki/Universally_unique_identifier
 .. _`RFC 4122`: https://tools.ietf.org/html/rfc4122


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
