### PR TITLE
[Serializer] Remove duplicate normalizers docs

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -738,7 +738,8 @@ The Serializer component provides several built-in normalizers:
 :class:`Symfony\\Component\\Serializer\\Normalizer\\PropertyNormalizer`
     This normalizer directly reads and writes public properties as well as
     **private and protected** properties (from both the class and all of its
-    parent classes). It supports calling the constructor during the denormalization process.
+    parent classes) by using `PHP reflection`_. It supports calling the constructor
+    during the denormalization process.
 
     Objects are normalized to a map of property names to property values.
 
@@ -769,7 +770,7 @@ The Serializer component provides several built-in normalizers:
         The ``DateTimeZoneNormalizer`` was introduced in Symfony 4.3.
 
 :class:`Symfony\\Component\\Serializer\\Normalizer\\DataUriNormalizer`
-    This normalizer converts :phpclass:`SplFileInfo` objects into a data URI
+    This normalizer converts :phpclass:`SplFileInfo` objects into a `data URI`_
     string (``data:...``) such that files can be embedded into serialized data.
 
 :class:`Symfony\\Component\\Serializer\\Normalizer\\DateIntervalNormalizer`
@@ -781,8 +782,16 @@ The Serializer component provides several built-in normalizers:
     :class:`Symfony\\Component\\Validator\\ConstraintViolationListInterface`
     into a list of errors according to the `RFC 7807`_ standard.
 
+    .. versionadded:: 4.1
+
+        The ``ConstraintViolationListNormalizer`` was introduced in Symfony 4.1.
+
 :class:`Symfony\\Component\\Serializer\\Normalizer\\ProblemNormalizer`
     Normalizes errors according to the API Problem spec `RFC 7807`_.
+
+    .. versionadded:: 4.4
+
+        The ``ProblemNormalizer`` was introduced in Symfony 4.4.
 
 :class:`Symfony\\Component\\Serializer\\Normalizer\\CustomNormalizer`
     Normalizes a PHP object using an object that implements :class:`Symfony\\Component\\Serializer\\Normalizer\\NormalizableInterface`.
@@ -1601,3 +1610,5 @@ Learn more
 .. _`Value Objects`: https://en.wikipedia.org/wiki/Value_object
 .. _`API Platform`: https://api-platform.com
 .. _`list of PHP timezones`: https://www.php.net/manual/en/timezones.php
+.. _`PHP reflection`: https://php.net/manual/en/book.reflection.php
+.. _`data URI`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs

--- a/serializer.rst
+++ b/serializer.rst
@@ -57,36 +57,18 @@ Encoders supporting the following formats are enabled:
 
 As well as the following normalizers:
 
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\ObjectNormalizer` to
-  handle typical data objects
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\DateTimeNormalizer` for
-  objects implementing the :phpclass:`DateTimeInterface` interface
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\DateTimeZoneNormalizer` for
-  :phpclass:`DateTimeZone` objects
+* :class:`Symfony\\Component\\Serializer\\Normalizer\\ObjectNormalizer`
+* :class:`Symfony\\Component\\Serializer\\Normalizer\\DateTimeNormalizer`
+* :class:`Symfony\\Component\\Serializer\\Normalizer\\DateTimeZoneNormalizer`
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\DateIntervalNormalizer`
-  for :phpclass:`DateInterval` objects
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\DataUriNormalizer` to
-  transform :phpclass:`SplFileInfo` objects in `Data URIs`_
+* :class:`Symfony\\Component\\Serializer\\Normalizer\\DataUriNormalizer`
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\JsonSerializableNormalizer`
-  to deal with objects implementing the :phpclass:`JsonSerializable` interface
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\ArrayDenormalizer` to
-  denormalize arrays of objects using a format like `MyObject[]` (note the `[]` suffix)
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\ConstraintViolationListNormalizer` for objects implementing the :class:`Symfony\\Component\\Validator\\ConstraintViolationListInterface` interface
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\ProblemNormalizer` for :class:`Symfony\\Component\\ErrorHandler\\Exception\\FlattenException` objects
+* :class:`Symfony\\Component\\Serializer\\Normalizer\\ArrayDenormalizer`
+* :class:`Symfony\\Component\\Serializer\\Normalizer\\ConstraintViolationListNormalizer`
+* :class:`Symfony\\Component\\Serializer\\Normalizer\\ProblemNormalizer`
 
-.. versionadded:: 4.1
-
-    The ``ConstraintViolationListNormalizer`` was introduced in Symfony 4.1.
-
-.. versionadded:: 4.3
-
-    The ``DateTimeZoneNormalizer`` was introduced in Symfony 4.3.
-
-.. versionadded:: 4.4
-
-    The ``ProblemNormalizer`` was introduced in Symfony 4.4.
-
-Custom normalizers and/or encoders can also be loaded by tagging them as
+Other :ref:`built-in normalizers <component-serializer-normalizers>` and
+custom normalizers and/or encoders can also be loaded by tagging them as
 :ref:`serializer.normalizer <reference-dic-tags-serializer-normalizer>` and
 :ref:`serializer.encoder <reference-dic-tags-serializer-encoder>`. It's also
 possible to set the priority of the tag in order to decide the matching order.
@@ -97,7 +79,7 @@ possible to set the priority of the tag in order to decide the matching order.
     ``DateTime`` or ``DateTimeImmutable`` classes to avoid excessive memory
     usage and exposing internal details.
 
-Here is an example on how to load the
+Here is an example on how to load the built-in
 :class:`Symfony\\Component\\Serializer\\Normalizer\\GetSetMethodNormalizer`, a
 faster alternative to the `ObjectNormalizer` when data objects always use
 getters (``getXxx()``), issers (``isXxx()``) or hassers (``hasXxx()``) to read
@@ -298,4 +280,3 @@ take a look at how this bundle works.
 .. _`GraphQL`: https://graphql.org
 .. _`JSON:API`: https://jsonapi.org
 .. _`HAL`: http://stateless.co/hal_specification.html
-.. _`Data URIs`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs

--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -6,7 +6,7 @@ How to Create your Custom Normalizer
 
 The :doc:`Serializer component </components/serializer>` uses
 normalizers to transform any data into an array. The component provides several
-:doc:`built-in normalizers </serializer/normalizers>` but you may need to create
+:ref:`built-in normalizers <component-serializer-normalizers>` but you may need to create
 your own normalizer to transform an unsupported data structure.
 
 Creating a New Normalizer

--- a/serializer/normalizers.rst
+++ b/serializer/normalizers.rst
@@ -21,30 +21,5 @@ Normalizers are enabled in the serializer passing them as its first argument::
 Built-in Normalizers
 --------------------
 
-Symfony includes the following normalizers but you can also
-:doc:`create your own normalizer </serializer/custom_normalizer>`:
-
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\ObjectNormalizer` to
-  normalize PHP object using the :doc:`PropertyAccess component </components/property_access>`;
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\DateTimeZoneNormalizer`
-  for :phpclass:`DateTimeZone` objects
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\DateTimeNormalizer` for
-  objects implementing the :phpclass:`DateTimeInterface` interface
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\DateIntervalNormalizer`
-  for :phpclass:`DateInterval` objects
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\DataUriNormalizer` to
-  transform :phpclass:`SplFileInfo` objects in `Data URIs`_
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\CustomNormalizer` to
-  normalize PHP object using an object that implements
-  :class:`Symfony\\Component\\Serializer\\Normalizer\\NormalizableInterface`;
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\GetSetMethodNormalizer` to
-  normalize PHP object using the getter and setter methods of the object;
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\PropertyNormalizer` to
-  normalize PHP object using `PHP reflection`_.
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\ConstraintViolationListNormalizer` for objects implementing the :class:`Symfony\\Component\\Validator\\ConstraintViolationListInterface` interface
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\ProblemNormalizer` for :class:`Symfony\\Component\\ErrorHandler\\Exception\\FlattenException` objects
-* :class:`Symfony\\Component\\Serializer\\Normalizer\\JsonSerializableNormalizer`
-  to deal with objects implementing the :phpclass:`JsonSerializable` interface
-
-.. _`Data URIs`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
-.. _`PHP reflection`: https://php.net/manual/en/book.reflection.php
+Symfony includes several types of :ref:`built-in normalizers <component-serializer-normalizers>`
+but you can also :doc:`create your own normalizer </serializer/custom_normalizer>`.


### PR DESCRIPTION
Currently normalizers are documented in three separate places, each of which contains some information the other two don't. This makes browsing the docs difficult and confusing.

With this PR I've consolidated everything to `components/serializer.rst`. I've removed the list from `serializer/normalizers.rst` and added a link to `components/serializer.rst` instead.
Since not all normalizers are enabled by the Framework Bundle by default, `serializer.rst` still contains a list of those that are, but the descriptions have been removed and additional links to `components/serializer.rst` added.