### PR TITLE
Enhancement: Use 'push' only on supported branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,10 @@
 on:
     push:
+        branches:
+            - '3.4'
+            - '4.4'
+            - '5.1'
+            - 'master'
         branches-ignore:
             - 'github-comments'
     pull_request:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,6 @@ on:
         branches-ignore:
             - 'github-comments'
     pull_request:
-        branches-ignore:
-            - 'github-comments'
 
 name: CI
 


### PR DESCRIPTION
This will reduce the number of GithubActions builds.