### PR TITLE
Missing Namespace from event dispatcher

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -289,6 +289,8 @@ This alias mapping can be extended for custom events by registering the
 compiler pass ``AddEventAliasesPass``::
 
     // src/Kernel.php
+    namespace App;
+
     use App\Event\MyCustomEvent;
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
