### PR TITLE
Document usage of Symfony Mailer for error email

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -92,3 +92,4 @@ whitelist:
         - '.. versionadded:: 0.2' # MercureBundle
         - 'provides a ``loginUser()`` method to simulate logging in in your functional'
         - '.. code-block:: twig'
+        - '.. versionadded:: 3.6' # MonologBundle

--- a/logging/monolog_email.rst
+++ b/logging/monolog_email.rst
@@ -4,7 +4,7 @@
 How to Configure Monolog to Email Errors
 ========================================
 
-.. versionadded:: 3.6.0
+.. versionadded:: 3.6
 
     Support for emailing errors using :doc:`Symfony mailer </mailer>` was added in MonologBundle 3.6.0.
 

--- a/logging/monolog_email.rst
+++ b/logging/monolog_email.rst
@@ -4,10 +4,9 @@
 How to Configure Monolog to Email Errors
 ========================================
 
-.. caution::
+.. versionadded:: 3.6.0
 
-    This feature is not compatible yet with the new :doc:`Symfony mailer </mailer>`,
-    so it requires using SwiftMailer.
+    Support for emailing errors using :doc:`Symfony mailer </mailer>` was added in MonologBundle 3.6.0.
 
 `Monolog`_ can be configured to send an email when an error occurs within an
 application. The configuration for this requires a few nested handlers
@@ -33,9 +32,9 @@ it is broken down.
                     handler:      deduplicated
                 deduplicated:
                     type:    deduplication
-                    handler: swift
-                swift:
-                    type:       swift_mailer
+                    handler: symfony_mailer
+                symfony_mailer:
+                    type:       symfony_mailer
                     from_email: 'error@example.com'
                     to_email:   'error@example.com'
                     # or list of recipients
@@ -73,11 +72,11 @@ it is broken down.
                 <monolog:handler
                     name="deduplicated"
                     type="deduplication"
-                    handler="swift"
+                    handler="symfony_mailer"
                 />
                 <monolog:handler
-                    name="swift"
-                    type="swift_mailer"
+                    name="symfony_mailer"
+                    type="symfony_mailer"
                     from-email="error@example.com"
                     subject="An Error Occurred! %%message%%"
                     level="debug"
@@ -114,10 +113,10 @@ it is broken down.
                 ],
                 'deduplicated' => [
                     'type'    => 'deduplication',
-                    'handler' => 'swift',
+                    'handler' => 'symfony_mailer',
                 ],
-                'swift' => [
-                    'type'         => 'swift_mailer',
+                'symfony_mailer' => [
+                    'type'         => 'symfony_mailer',
                     'from_email'   => 'error@example.com',
                     'to_email'     => 'error@example.com',
                     // or a list of recipients
@@ -162,7 +161,7 @@ You can adjust the time period using the ``time`` option:
                     type: deduplication
                     # the time in seconds during which duplicate entries are discarded (default: 60)
                     time: 10
-                    handler: swift
+                    handler: symfony_mailer
 
     .. code-block:: xml
 
@@ -172,7 +171,7 @@ You can adjust the time period using the ``time`` option:
         <monolog:handler name="deduplicated"
             type="deduplication"
             time="10"
-            handler="swift"/>
+            handler="symfony_mailer"/>
 
     .. code-block:: php
 
@@ -184,12 +183,12 @@ You can adjust the time period using the ``time`` option:
                     'type'    => 'deduplication',
                     // the time in seconds during which duplicate entries are discarded (default: 60)
                     'time' => 10,
-                    'handler' => 'swift',
+                    'handler' => 'symfony_mailer',
                 ],
             ],
         ]);
 
-The messages are then passed to the ``swift`` handler. This is the handler that
+The messages are then passed to the ``symfony_mailer`` handler. This is the handler that
 actually deals with emailing you the error. The settings for this are
 straightforward, the to and from addresses, the formatter, the content type
 and the subject.
@@ -217,9 +216,9 @@ get logged on the server as well as the emails being sent:
                     level: debug
                 deduplicated:
                     type:    deduplication
-                    handler: swift
-                swift:
-                    type:         swift_mailer
+                    handler: symfony_mailer
+                symfony_mailer:
+                    type:         symfony_mailer
                     from_email:   'error@example.com'
                     to_email:     'error@example.com'
                     subject:      'An Error Occurred! %%message%%'
@@ -259,11 +258,11 @@ get logged on the server as well as the emails being sent:
                 <monolog:handler
                     name="deduplicated"
                     type="deduplication"
-                    handler="swift"
+                    handler="symfony_mailer"
                 />
                 <monolog:handler
-                    name="swift"
-                    type="swift_mailer"
+                    name="symfony_mailer"
+                    type="symfony_mailer"
                     from-email="error@example.com"
                     subject="An Error Occurred! %%message%%"
                     level="debug"
@@ -303,10 +302,10 @@ get logged on the server as well as the emails being sent:
                 ],
                 'deduplicated' => [
                     'type'     => 'deduplication',
-                    'handler'  => 'swift',
+                    'handler'  => 'symfony_mailer',
                 ],
-                'swift' => [
-                    'type'         => 'swift_mailer',
+                'symfony_mailer' => [
+                    'type'         => 'symfony_mailer',
                     'from_email'   => 'error@example.com',
                     'to_email'     => 'error@example.com',
                     // or a list of recipients

--- a/logging/monolog_email.rst
+++ b/logging/monolog_email.rst
@@ -6,7 +6,7 @@ How to Configure Monolog to Email Errors
 
 .. versionadded:: 3.6
 
-    Support for emailing errors using :doc:`Symfony mailer </mailer>` was added in MonologBundle 3.6.0.
+    Support for emailing errors using :doc:`Symfony mailer </mailer>` was added in MonologBundle 3.6.
 
 `Monolog`_ can be configured to send an email when an error occurs within an
 application. The configuration for this requires a few nested handlers


### PR DESCRIPTION
Related to https://github.com/symfony/monolog-bundle/pull/354
and https://github.com/symfony/monolog-bundle/pull/354#issuecomment-688202777

----------

Should we also document that for the `v4.4` of this page, it will not be possible?
The `Symfony\Bridge\Monolog\Handler\MailerHandler` was added in `v5.1` (https://github.com/symfony/symfony/pull/33456)

Because the wording `compatible yet` implies that it will be compatible in the future

Thank you

edit: I do not understand the `DOCtor-RST` check here :s 