### PR TITLE
[Messenger] Update the list of stamp

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -148,21 +148,26 @@ through the transport layer, use the ``SerializerStamp`` stamp::
         ]))
     );
 
-At the moment, the Symfony Messenger has the following built-in envelope stamps:
+Here are some important envelope stamps that are shipped with the Symfony Messenger:
 
-#. :class:`Symfony\\Component\\Messenger\\Stamp\\SerializerStamp`,
-   to configure the serialization groups used by the transport.
-#. :class:`Symfony\\Component\\Messenger\\Stamp\\ValidationStamp`,
-   to configure the validation groups used when the validation middleware is enabled.
+#. :class:`Symfony\\Component\\Messenger\\Stamp\\DelayStamp`,
+   to delay handling of an asynchronous message.
+#. :class:`Symfony\\Component\\Messenger\\Stamp\\DispatchAfterCurrentBusStamp`,
+   to make the message be handled after the current bus has executed. Read more
+   at :doc:`/messenger/dispatch_after_current_bus`.
+#. :class:`Symfony\\Component\\Messenger\\Stamp\\HandledStamp`,
+   a stamp that marks the message as handled by a specific handler.
+   Allows accessing the handler returned value and the handler name.
 #. :class:`Symfony\\Component\\Messenger\\Stamp\\ReceivedStamp`,
    an internal stamp that marks the message as received from a transport.
 #. :class:`Symfony\\Component\\Messenger\\Stamp\\SentStamp`,
    a stamp that marks the message as sent by a specific sender.
    Allows accessing the sender FQCN and the alias if available from the
    :class:`Symfony\\Component\\Messenger\\Transport\\Sender\\SendersLocator`.
-#. :class:`Symfony\\Component\\Messenger\\Stamp\\HandledStamp`,
-   a stamp that marks the message as handled by a specific handler.
-   Allows accessing the handler returned value and the handler name.
+#. :class:`Symfony\\Component\\Messenger\\Stamp\\SerializerStamp`,
+   to configure the serialization groups used by the transport.
+#. :class:`Symfony\\Component\\Messenger\\Stamp\\ValidationStamp`,
+   to configure the validation groups used when the validation middleware is enabled.
 
 Instead of dealing directly with the messages in the middleware you receive the envelope.
 Hence you can inspect the envelope content and its stamps, or add any::


### PR DESCRIPTION
This PR updates the list of stamps. In the current docs it looks like the list of stamps was complete. I think we should just highlight important ones that users will come in contact with. Advanced users will find the rest of the stamps anyways. 

I sorted the list alphabetically. I added DelayStamp and DispatchAfterCurrentBusStamp