### PR TITLE
[Validator] PHP 7.4 uninitialized typed property handling

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -611,6 +611,13 @@ class to have at least 3 characters.
             }
         }
 
+.. caution::
+
+    With PHP 7.4, typed properties were introduced. If a property is accessed
+    before a value is assigned (explicitly or as a default value), PHP will
+    throw an exception. To avoid that, the Validator will use ``null`` as the
+    properties value if it's uninitialized.
+
 .. index::
    single: Validation; Getter constraints
 


### PR DESCRIPTION
The Validator component is able to handle uninitialized properties since this [PR](https://github.com/symfony/symfony/pull/35532/commits/1edecf77c115fc1a5e7163ad1a829ed271d1ca9c) was merged.

However, the behavior (null usage) is not documented in the symfony docs.

P.S. PR [14375](https://github.com/symfony/symfony-docs/pull/14375) was closed due to wrong source branch.