### PR TITLE
Configuration reference: Improve example of http_client::headers

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -873,7 +873,7 @@ headers
 **type**: ``array``
 
 An associative array of the HTTP headers added before making the request. This
-value must use the format ``['header-name' => header-value, ...]``.
+value must use the format ``['header-name' => 'value0, value1, ...']``.
 
 http_version
 ............


### PR DESCRIPTION
This will fix #14326

This can be merged to 4.4