### PR TITLE
Make sure we install FrameworkExtra bundle and not just doctrine/annotations

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -27,7 +27,7 @@ Run this command once in your application to add support for annotations:
 
 .. code-block:: terminal
 
-    $ composer require doctrine/annotations
+    $ composer require annotations
 
 In addition to installing the needed dependencies, this command creates the
 following configuration file:


### PR DESCRIPTION
This PR will fix #14203 and revert #14198

@javiereguiluz wrote: 

> There was a package called annotations-pack (see https://packagist.org/packages/symfony/annotations-pack) which allowed to run composer require annotations (when using Symfony Flex)

This is true. The pack was removed. Currently there is a flex alias to install SensioFrameworkExtraBundle when one run `composer require annotations`. That will make sure to install SensioFrameworkExtraBundle and doctrine/annotations. 

One will always need SensioFrameworkExtraBundle to be able to use route config with annotations, only doctrine/annotations is not good enough. 

------

People that is not using Flex will see the `Could not find package annotations` as @albuquerque53 saw. 