### PR TITLE
Do not promote deprecated message_bus service use

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -83,7 +83,7 @@ Dispatching the Message
 -----------------------
 
 You're ready! To dispatch the message (and call the handler), inject the
-``message_bus`` service (via the ``MessageBusInterface``), like in a controller::
+``messenger.default_bus`` service (via the ``MessageBusInterface``), like in a controller::
 
     // src/Controller/DefaultController.php
     namespace App\Controller;


### PR DESCRIPTION
The message_bus service is deprecated and messenger.default_bus should be used instead.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
