### PR TITLE
You need doctrine/annotations for route annotation support.

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -27,7 +27,7 @@ Run this command once in your application to add support for annotations:
 
 .. code-block:: terminal
 
-    $ composer require annotations
+    $ composer require doctrine/annotations
 
 In addition to installing the needed dependencies, this command creates the
 following configuration file:


### PR DESCRIPTION
For Symfony 4.4

This will correct the mistake in #14387

There is an alternative to this PR here: #14400