### PR TITLE
[Configuration] Wrong services path and addition services_environment-name

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -387,7 +387,8 @@ set in the previous ones):
 
 #. ``config/packages/*.yaml`` (and ``*.xml`` and ``*.php`` files too);
 #. ``config/packages/<environment-name>/*.yaml`` (and ``*.xml`` and ``*.php`` files too);
-#. ``config/packages/services.yaml`` (and ``services.xml`` and ``services.php`` files too);
+#. ``config/services.yaml`` (and ``services.xml`` and ``services.php`` files too);
+#. ``config/services_<environment-name>.yaml`` (and ``services_environment-name.xml`` and ``services_environment-name.php`` files too);
 
 Take the ``framework`` package, installed by default, as an example:
 


### PR DESCRIPTION
I saw in Kernel the following:
```
        $loader->load($confDir.'/{packages}/*'.self::CONFIG_EXTS, 'glob');
        $loader->load($confDir.'/{packages}/'.$this->environment.'/*'.self::CONFIG_EXTS, 'glob');
        $loader->load($confDir.'/{services}'.self::CONFIG_EXTS, 'glob');
        $loader->load($confDir.'/{services}_'.$this->environment.self::CONFIG_EXTS, 'glob');`
```
I think that the documentation can be tweaked a little is it make sense?
