### PR TITLE
Use updated dependencies

### DIFF
--- a/_build/.requirements.txt
+++ b/_build/.requirements.txt
@@ -1,6 +1,6 @@
 docutils==0.13.1
 Pygments==2.2.0
 sphinx==1.8.5
-git+https://github.com/fabpot/sphinx-php.git@v2.0.0#egg_name=sphinx-php
+git+https://github.com/fabpot/sphinx-php.git@v2.0.2#egg_name=sphinx-php
 jsx-lexer===0.0.8
 sphinx_rtd_theme==0.5.0


### PR DESCRIPTION
Currently I fail to build the docs in 5.x. They complain on php-attributes. 

This PR make sure to use @derrabus PR https://github.com/fabpot/sphinx-php/pull/49 released in 2.0.2. 

This change was missing from https://github.com/symfony/symfony-docs/pull/14230