### PR TITLE
Add new core team members

### DIFF
--- a/contributing/code/core_team.rst
+++ b/contributing/code/core_team.rst
@@ -67,12 +67,17 @@ Active Core Members
   * **Robin Chalas** (`chalasr`_);
   * **Maxime Steinhausser** (`ogizanagi`_);
   * **Samuel Rozé** (`sroze`_);
-  * **Yonel Ceruto** (`yceruto`_).
+  * **Yonel Ceruto** (`yceruto`_);
+  * **Tobias Nyholm** (`Nyholm`_);
+  * **Wouter De Jong** (`wouterj`_);
+  * **Alexander M. Turek** (`derrabus`_);
+  * **Jérémy Derussé** (`jderusse`_).
 
 * **Security Team** (``@symfony/security`` on GitHub):
 
   * **Fabien Potencier** (`fabpot`_);
-  * **Michael Cullum** (`michaelcullum`_).
+  * **Michael Cullum** (`michaelcullum`_);
+  * **Jérémy Derussé** (`jderusse`_).
 
 * **Recipes Team**:
 
@@ -200,3 +205,5 @@ discretion of the **Project Leader**.
 .. _`OskarStark`: https://github.com/OskarStark
 .. _`romainneutron`: https://github.com/romainneutron
 .. _`lsmith77`: https://github.com/lsmith77/
+.. _`derrabus`: https://github.com/derrabus/
+.. _`jderusse`: https://github.com/jderusse/


### PR DESCRIPTION
As announced here: https://symfony.com/blog/new-core-team-members
