### PR TITLE
[Workflow] Fixed typo in Workflow documentation

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -305,7 +305,7 @@ order:
 
 .. note::
 
-    The leaving and entering events are triggered even for transitions that stay
+    The leaving and enter events are triggered even for transitions that stay
     in same place.
 
 Here is an example of how to enable logging for every time a "blog_publishing"


### PR DESCRIPTION
Hello,

This is a very small consistency fix.
Workflow documentation (first written for 4.2) states:
 `The leaving and entering events are triggered even for transitions that stay in same place.`

While events are named `leaving` and `enter`, which is a minor confusion. So it fixes that. Maybe I should add quote or code quotes too, so it is understood events names are litterals.