### PR TITLE
[Translator] Adding more information about default translation domain 'messages'

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -655,9 +655,12 @@ priority message files.
 The filename of the translation files is also important: each message file
 must be named according to the following path: ``domain.locale.loader``:
 
-* **domain**: An optional way to organize messages into groups. Unless
+* **domain**: Domains are a way to organize messages into groups. Unless
   parts of the application are explicitly separated from each other, it is
-  recommended to only use default ``messages`` domain;
+  recommended to only use default ``messages`` domain.
+
+  If no domains are explicitly defined while using the translator, Symfony 
+  will default to the ``messages`` domain (e.g. ``messages.en.yaml``)
 
 * **locale**: The locale that the translations are for (e.g. ``en_GB``, ``en``, etc);
 


### PR DESCRIPTION
Fixes #14390

Not 100% sure about the formulation, but just an idea how to make it more clear