### PR TITLE
Adjust wording at Generating URLs

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -1917,7 +1917,7 @@ Generating URLs in JavaScript
 
 If your JavaScript code is included in a Twig template, you can use the
 ``path()`` and ``url()`` Twig functions to generate the URLs and store them in
-JavaScript variables. The ``escape()`` function is needed to escape any
+JavaScript variables. The ``escape()`` filter is needed to escape any
 non-JavaScript-safe values:
 
 .. code-block:: html+twig


### PR DESCRIPTION
At "Generating URLs in JavaScript" the Twig escape filter is called a escape function. However in context of Twig this is a filter and I guess it should use the right wording also in the Symfony docs.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
