### PR TITLE
use the right method when dealing with promises

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1291,7 +1291,7 @@ Then you're ready to go::
 
     $httpClient = new HttplugClient();
     $request = $httpClient->createRequest('GET', 'https://my.api.com/');
-    $promise = $httpClient->sendRequest($request)
+    $promise = $httpClient->sendAsyncRequest($request)
         ->then(
             function (ResponseInterface $response) {
                 echo 'Got status '.$response->getStatusCode();


### PR DESCRIPTION
sendRequest() returns a response, not a promise, and we can't use then() on a response