### PR TITLE
[secrets] Use APP_RUNTIME_ENV to define secrets

### DIFF
--- a/configuration/secrets.rst
+++ b/configuration/secrets.rst
@@ -48,7 +48,7 @@ running:
 
 .. code-block:: terminal
 
-    $ php bin/console secrets:generate-keys --env=prod
+    $ APP_RUNTIME_ENV=prod php bin/console secrets:generate-keys
 
 This will generate ``config/secrets/prod/prod.encrypt.public.php`` and
 ``config/secrets/prod/prod.decrypt.private.php``.
@@ -78,7 +78,7 @@ Suppose you want to store your database password as a secret. By using the
     $ php bin/console secrets:set DATABASE_PASSWORD
 
     # set your production value
-    $ php bin/console secrets:set DATABASE_PASSWORD --env=prod
+    $ APP_RUNTIME_ENV=prod php bin/console secrets:set DATABASE_PASSWORD
 
 This will create a new file for the secret in ``config/secrets/dev`` and another
 in ``config/secrets/prod``. You can also set the secret in a few other ways:
@@ -253,7 +253,7 @@ your secrets during deployment to the "local" vault:
 
 .. code-block:: terminal
 
-    $ php bin/console secrets:decrypt-to-local --force --env=prod
+    $ APP_RUNTIME_ENV=prod php bin/console secrets:decrypt-to-local --force
 
 This will write all the decrypted secrets into the ``.env.prod.local`` file.
 After doing this, the decryption key does *not* need to remain on the server(s).


### PR DESCRIPTION
Use new env variable introduced in https://github.com/symfony/symfony/pull/38543 to define secrets.

/cc @nicolas-grekas 