### PR TITLE
[Security] Remove extra argument from call to EntityManager#flush()

### DIFF
--- a/security/password_migration.rst
+++ b/security/password_migration.rst
@@ -190,7 +190,7 @@ storing the newly created password hash::
             $user->setPassword($newEncodedPassword);
 
             // execute the queries on the database
-            $this->getEntityManager()->flush($user);
+            $this->getEntityManager()->flush();
         }
     }
 


### PR DESCRIPTION
See https://github.com/doctrine/orm/blob/master/UPGRADE.md#bc-break-removed-entitymanagerflushentity-and-entitymanagerflushentities