### PR TITLE
[Console] More explication for return into execute command function

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -45,9 +45,16 @@ want a command to create a user::
 
         protected function execute(InputInterface $input, OutputInterface $output)
         {
-            // ...
+            // ... put here the code to run in your command
 
+            // this method must return an integer number with the "exit status code"
+            // of the command.
+
+            // return this if there was no problem running the command
             return 0;
+
+            // or return this if some error happened during the execution
+            // return 1;
         }
     }
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
Actually, for 5.2 branch, we have got an explication for return into execute function into Command file with new Constant. But for 4.4 we don't have this constant and not explication what is return 1.