### PR TITLE
update obsolete `PHP callable` docs link

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -532,4 +532,4 @@ Learn More
 .. _Mediator: https://en.wikipedia.org/wiki/Mediator_pattern
 .. _Observer: https://en.wikipedia.org/wiki/Observer_pattern
 .. _Closures: https://www.php.net/manual/en/functions.anonymous.php
-.. _PHP callable: https://www.php.net/manual/en/language.pseudo-types.php#language.types.callback
+.. _PHP callable: https://www.php.net/manual/en/language.types.callable.php


### PR DESCRIPTION
new `PHP callable` link https://www.php.net/manual/en/language.types.callable.php