### PR TITLE
Change function location encore_entry_script_tags

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -107,13 +107,14 @@ can do most of the work for you:
         </head>
         <body>
             <!-- ... -->
+            {{ encore_entry_script_tags('app') }}
 
+            <!-- Renders app.js & a webpack runtime.js file
+                <script src="/build/runtime.js"></script>
+                <script src="/build/app.js"></script> -->
+                    
             {% block javascripts %}
-                {{ encore_entry_script_tags('app') }}
-
-                <!-- Renders app.js & a webpack runtime.js file
-                    <script src="/build/runtime.js"></script>
-                    <script src="/build/app.js"></script> -->
+                
             {% endblock %}
         </body>
     </html>


### PR DESCRIPTION
In my tests the (encore_entry_script_tags) function not working inside "javascripts" block. Tive que incluir a função fora do bloco par que a aplicação cria-se os links.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
