### PR TITLE
Update doctrine fetchAll (deprecated)

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -812,7 +812,7 @@ In addition, you can query directly with SQL if you need to::
         $stmt->execute(['price' => $price]);
 
         // returns an array of arrays (i.e. a raw data set)
-        return $stmt->fetchAll();
+        return $stmt->fetchAllAssociative();
     }
 
 With SQL, you will get back raw data, not objects (unless you use the `NativeQuery`_


### PR DESCRIPTION
Since doctrine/dbal 2.11 [Deprecated FetchMode and the corresponding methods](https://github.com/doctrine/dbal/blob/2.12.x/UPGRADE.md#deprecated-fetchmode-and-the-corresponding-methods)

> The Statement::fetchAll() method is deprecated in favor of Result::fetchAllNumeric(), ::fetchAllAssociative() and ::fetchFirstColumn()