### PR TITLE
[HttpClient] Update http_client.rst

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -904,8 +904,7 @@ You can prevent the exception from being thrown by either:
         $response->getContent();
     }
 
-* Or passing ``false`` as the optional argument to the methods, e.g.
-``$response->getHeaders(false);``
+* Or passing ``false`` as the optional argument to the methods, e.g. ``$response->getHeaders(false);``
 
 While responses are lazy, their destructor will always wait for headers to come
 back. This means that the following request *will* complete; and if e.g. a 404

--- a/http_client.rst
+++ b/http_client.rst
@@ -895,12 +895,14 @@ When the HTTP status code of the response is in the 300-599 range (i.e. 3xx,
 throw an appropriate exception, all of which implement the
 :class:`Symfony\\Contracts\\HttpClient\\Exception\\HttpExceptionInterface`.
 
-To prevent the exception from being thrown, you need to pass ``false`` as the optional argument
-to every call of those methods, e.g. ``$response->getHeaders(false);``.
+To opt-out from this exception and deal with 300-599 status codes on your own,
+pass ``false`` as the optional argument to every call of those methods,
+e.g. ``$response->getHeaders(false);``.
 
 If you do not call any of these 3 methods at all, the exception will still be thrown
-when the Symfony kernel delivers the final response.
-You can prevent this by calling ``$response->getStatusCode()``.
+when the ``$response`` object is destructed (i.e. when the Symfony kernel delivers the final response).
+Calling ``$response->getStatusCode()`` is enough to disable this behavior
+(but then don't miss checking the status code yourself).
 
 While responses are lazy, their destructor will always wait for headers to come
 back. This means that the following request *will* complete; and if e.g. a 404

--- a/http_client.rst
+++ b/http_client.rst
@@ -895,16 +895,12 @@ When the HTTP status code of the response is in the 300-599 range (i.e. 3xx,
 throw an appropriate exception, all of which implement the
 :class:`Symfony\\Contracts\\HttpClient\\Exception\\HttpExceptionInterface`.
 
-You can prevent the exception from being thrown by either:
+To prevent the exception from being thrown, you need to pass ``false`` as the optional argument
+to every call of those methods, e.g. ``$response->getHeaders(false);``.
 
-* Checking for the exact status code::
-    
-    $response = $client->request('GET', 'https://httpbin.org/status/403');
-    if (403 === $response->getStatusCode()) {
-        $response->getContent();
-    }
-
-* Or passing ``false`` as the optional argument to the methods, e.g. ``$response->getHeaders(false);``
+If you do not call any of these 3 methods at all, the exception will still be thrown
+when the Symfony kernel delivers the final response.
+You can prevent this by calling ``$response->getStatusCode()``.
 
 While responses are lazy, their destructor will always wait for headers to come
 back. This means that the following request *will* complete; and if e.g. a 404

--- a/http_client.rst
+++ b/http_client.rst
@@ -900,7 +900,7 @@ You can prevent the exception from being thrown by either:
 * Checking for the exact status code::
     
     $response = $client->request('GET', 'https://httpbin.org/status/403');
-    if ('403' === $response->getStatusCode()) {
+    if (403 === $response->getStatusCode()) {
         $response->getContent();
     }
 

--- a/http_client.rst
+++ b/http_client.rst
@@ -891,20 +891,21 @@ Handling Exceptions
 ~~~~~~~~~~~~~~~~~~~
 
 When the HTTP status code of the response is in the 300-599 range (i.e. 3xx,
-4xx or 5xx) your code is expected to handle it. If you don't do that, the
-``getHeaders()``, ``getContent()`` and ``toArray()`` methods throw an appropriate exception, all of
-which implement the :class:`Symfony\\Contracts\\HttpClient\\Exception\\HttpExceptionInterface`::
+4xx or 5xx), the ``getHeaders()``, ``getContent()`` and ``toArray()`` methods
+throw an appropriate exception, all of which implement the
+:class:`Symfony\\Contracts\\HttpClient\\Exception\\HttpExceptionInterface`.
 
-    // the response of this request will be a 403 HTTP error
+You can prevent the exception from being thrown by either:
+
+* Checking for the exact status code::
+    
     $response = $client->request('GET', 'https://httpbin.org/status/403');
+    if ('403' === $response->getStatusCode()) {
+        $response->getContent();
+    }
 
-    // this code results in a Symfony\Component\HttpClient\Exception\ClientException
-    // because it doesn't check the status code of the response
-    $content = $response->getContent();
-
-    // pass FALSE as the optional argument to not throw an exception and return
-    // instead the original response content (even if it's an error message)
-    $content = $response->getContent(false);
+* Or passing ``false`` as the optional argument to the methods, e.g.
+``$response->getHeaders(false);``
 
 While responses are lazy, their destructor will always wait for headers to come
 back. This means that the following request *will* complete; and if e.g. a 404


### PR DESCRIPTION
I started from scratch after https://github.com/symfony/symfony-docs/pull/14174

* The most important change is that the old text "your code is expected to handle it" didn't make it clear *how* people are supposed to handle it.
* I omitted the note that a `Symfony\Component\HttpClient\Exception\ClientException` is thrown. Is this important? Or is the existing `Symfony\\Contracts\\HttpClient\\Exception\\HttpExceptionInterface` enough?
