### PR TITLE
Update to twig/cssinliner-extra

### DIFF
--- a/components/mime.rst
+++ b/components/mime.rst
@@ -103,12 +103,12 @@ extension:
 
 .. code-block:: terminal
 
-    $ composer require twig/cssinliner-extension
+    $ composer require twig/cssinliner-extra
 
 Now, enable the extension::
 
     // ...
-    use Twig\CssInliner\CssInlinerExtension;
+    use Twig\Extra\CssInliner\CssInlinerExtension;
 
     $loader = new FilesystemLoader(__DIR__.'/templates');
     $twig = new Environment($loader);


### PR DESCRIPTION
The package twig/cssinliner-extension has been abandoned. 