### PR TITLE
Add DirectoryIndex to fallback for resources

### DIFF
--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -127,6 +127,7 @@ and increase web server performance:
         # which will allow Apache to return a 404 error when files are
         # not found instead of passing the request to Symfony
         <Directory /var/www/project/public/bundles>
+            DirectoryIndex disabled
             FallbackResource disabled
         </Directory>
         ErrorLog /var/log/apache2/project_error.log


### PR DESCRIPTION
When `DirectoryIndex` is set `FallbackResource disabled` will do nothing because apache falls back to `DirectoryIndex`.
