### PR TITLE
Add priority order explanation for tagged services

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -596,8 +596,9 @@ Tagged Services with Priority
 
     The ability to prioritize tagged services was introduced in Symfony 4.4.
 
-The tagged services can be prioritized using the ``priority`` attribute,
-thus providing a way to inject a sorted collection of services:
+The tagged services can be prioritized using the ``priority`` attribute.
+The priority is a positive or negative integer. The higher the number,
+the earlier the tagged service will be located in the collection:
 
 .. configuration-block::
 
@@ -655,7 +656,7 @@ service itself::
         }
     }
 
-If you want to have another method defining the priority 
+If you want to have another method defining the priority
 (e.g. ``getPriority()`` rather than ``getDefaultPriority()``),
 you can define it in the configuration of the collecting service:
 


### PR DESCRIPTION
Hi,

In this page, the priority order is not explained for tagged services. Since I needed to know this, I guess it is a good addition.
The text is mostly inspired by the paragraph about priority in the event dispatcher documentation : https://symfony.com/doc/current/event_dispatcher.html#creating-an-event-listener 

Fell free to edit it or to provide me some advices to do it.

Regards

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
