### PR TITLE
[Routing] Remove simple quotes in config/routes/annotations.yaml

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -36,7 +36,7 @@ following configuration file:
 
     # config/routes/annotations.yaml
     controllers:
-        resource: '../../src/Controller/'
+        resource: ../../src/Controller/
         type: annotation
 
     kernel:


### PR DESCRIPTION
I find it weird to have both quoted and un-quoted values for `resource:` key in this code block.
I went to an actual project to double check the content of `config/routes/annotations.yaml` provided by the recipe (https://github.com/symfony/recipes/blob/master/doctrine/annotations/1.0/config/routes/annotations.yaml) and found out that both `resource:` are unquoted.

Versions : 4.4, 5.0, 5.1, 5.2

Have a good day ;)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
