### PR TITLE
Use integer type instead of int & boolean instead of bool

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -801,7 +801,7 @@ outgoing network interface.
 buffer
 ......
 
-**type**: ``bool`` | ``Closure``
+**type**: ``boolean`` | ``Closure``
 
 Buffering the response means that you can access its content multiple times
 without performing the request again. Buffering is enabled by default when the
@@ -2851,7 +2851,7 @@ Name of the workflow you want to create.
 audit_trail
 """""""""""
 
-**type**: ``bool``
+**type**: ``boolean``
 
 If set to ``true``, the :class:`Symfony\\Component\\Workflow\\EventListener\\AuditTrailListener`
 will be enabled.

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -294,7 +294,7 @@ no specific character is passed as argument to the ``number_format`` filter.
 optimizations
 ~~~~~~~~~~~~~
 
-**type**: ``int`` **default**: ``-1``
+**type**: ``integer`` **default**: ``-1``
 
 Twig includes an extension called ``optimizer`` which is enabled by default in
 Symfony applications. This extension analyzes the templates to optimize them

--- a/reference/constraints/AtLeastOneOf.rst
+++ b/reference/constraints/AtLeastOneOf.rst
@@ -163,7 +163,7 @@ has to be satisfied in order for the validation to succeed.
 includeInternalMessages
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-**type**: ``bool`` **default**: ``true``
+**type**: ``boolean`` **default**: ``true``
 
 If set to ``true``, the message that is shown if the validation fails,
 will include the list of messages for the internal constraints. See option

--- a/reference/constraints/Hostname.rst
+++ b/reference/constraints/Hostname.rst
@@ -117,7 +117,7 @@ Parameter        Description
 ``requireTld``
 ~~~~~~~~~~~~~~
 
-**type**: ``bool`` **default**: ``true``
+**type**: ``boolean`` **default**: ``true``
 
 By default, hostnames are considered valid only when they are fully qualified
 and include their TLDs (top-level domain names). For instance, ``example.com``

--- a/reference/constraints/NotBlank.rst
+++ b/reference/constraints/NotBlank.rst
@@ -85,7 +85,7 @@ Options
 allowNull
 ~~~~~~~~~
 
-**type**: ``bool`` **default**: ``false``
+**type**: ``boolean`` **default**: ``false``
 
 If set to ``true``, ``null`` values are considered valid and won't trigger a
 constraint violation.

--- a/reference/constraints/Traverse.rst
+++ b/reference/constraints/Traverse.rst
@@ -146,7 +146,7 @@ The ``groups`` option is not available for this constraint.
 ``traverse``
 ~~~~~~~~~~~~
 
-**type**: ``bool`` **default**: ``true``
+**type**: ``boolean`` **default**: ``true``
 
 Instances of ``\Traversable`` are traversed by default, use this option to
 disable validating:

--- a/reference/forms/types/color.rst
+++ b/reference/forms/types/color.rst
@@ -49,7 +49,7 @@ Field Options
 html5
 ~~~~~
 
-**type**: ``bool`` **default**: ``false``
+**type**: ``boolean`` **default**: ``false``
 
 .. versionadded:: 5.1
 

--- a/reference/forms/types/options/help_html.rst.inc
+++ b/reference/forms/types/options/help_html.rst.inc
@@ -1,7 +1,7 @@
 help_html
 ~~~~~~~~~
 
-**type**: ``bool`` **default**: ``false``
+**type**: ``boolean`` **default**: ``false``
 
 By default, the contents of the ``help`` option are escaped before rendering
 them in the template. Set this option to ``true`` to not escape them, which is

--- a/reference/forms/types/options/label_html.rst.inc
+++ b/reference/forms/types/options/label_html.rst.inc
@@ -1,7 +1,7 @@
 ``label_html``
 ~~~~~~~~~~~~~~
 
-**type**: ``bool`` **default**: ``false``
+**type**: ``boolean`` **default**: ``false``
 
 .. versionadded:: 5.1
 


### PR DESCRIPTION
Uses the same type hint `int` already used in the `optimizations` config

# Update
- [x] Replace `int` by `integer`
- [x] Replace `bool` by `boolean`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->


