### PR TITLE
add html extension to snake_case recommendation examples

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -586,7 +586,7 @@ arguments to the filter:
 
 .. code-block:: html+twig
 
-    {% apply inline_css(source('@styles/email.css')) %}
+    {% apply inline_css(source('@css/email.css')) %}
         <h1>Welcome {{ username }}!</h1>
         {# ... #}
     {% endapply %}

--- a/templates.rst
+++ b/templates.rst
@@ -118,8 +118,8 @@ Template Naming
 
 Symfony recommends the following for template names:
 
-* Use `snake case`_ for filenames and directories (e.g. ``blog_posts.twig``,
-  ``admin/default_theme/blog/index.twig``, etc.);
+* Use `snake case`_ for filenames and directories (e.g. ``blog_posts.html.twig``,
+  ``admin/default_theme/blog/index.html.twig``, etc.);
 * Define two extensions for filenames (e.g. ``index.html.twig`` or
   ``blog_posts.xml.twig``) being the first extension (``html``, ``xml``, etc.)
   the final format that the template will generate.


### PR DESCRIPTION
Some readers may inconsciently memorize the syntax `file_name.twig` and ignores the second `recommendation` (declaring two extension `html.twig`), it can happen if someone looks only for `snak_case` keyword without reading the whole page (at least the second recommentdation).

I suggest to add `html` extension on the first examples to make sure the second recommendation cannot escape reader's eyes.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
