### PR TITLE
Throw Exception if twig variable is not found

### DIFF
--- a/templates.rst
+++ b/templates.rst
@@ -164,7 +164,7 @@ in the following order:
 #. ``$foo->getBar()`` (object and *getter* method);
 #. ``$foo->isBar()`` (object and *isser* method);
 #. ``$foo->hasBar()`` (object and *hasser* method);
-#. If none of the above exists, use ``null``.
+#. If none of the above exists, use ``null`` or throw a ``Twig\Error\RuntimeError`` exception if ``strict_variables`` config is enabled.
 
 This allows to evolve your application code without having to change the
 template code (you can start with array variables for the application proof of


### PR DESCRIPTION
An exception of type `Twig\Error\RuntimeError` is thrown when a variable is not found while `strict_variables` is enabled

![image](https://user-images.githubusercontent.com/7301643/98787347-aeba2700-23ff-11eb-9957-4ac56ff4e6ca.png)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
