### PR TITLE
[Messenger] Fix a typo on Messenger handler results example

### DIFF
--- a/messenger/handler_results.rst
+++ b/messenger/handler_results.rst
@@ -40,7 +40,7 @@ handler is registered. The ``HandleTrait`` can be used in any class that has a
     namespace App\Action;
 
     use App\Message\ListItemsQuery;
-    use App\MessageHandler\ListItemsQueryResult;
+    use App\MessageHandler\ListItemsResult;
     use Symfony\Component\Messenger\HandleTrait;
     use Symfony\Component\Messenger\MessageBusInterface;
 


### PR DESCRIPTION
This fixes typo on the Messenger handler results sample snippet by renaming `Result` object since the definition in the import and the name used in the return type of the function did not match.

I fixed with `ListItemsResult` instead of `ListItemsQueryResult` but tell me which one is better.