### PR TITLE
[Lock] Fix broken configuration block

### DIFF
--- a/lock.rst
+++ b/lock.rst
@@ -223,7 +223,7 @@ Named Lock
 ----------
 
 If the application needs different kind of Stores alongside each other, Symfony
-provides :ref:`named lock <reference-lock-resources-name>`::
+provides :ref:`named lock <reference-lock-resources-name>`:
 
 .. configuration-block::
 


### PR DESCRIPTION
The formatting is broken: https://symfony.com/doc/4.4/lock.html#named-lock

![image](https://user-images.githubusercontent.com/2445045/99098189-ef20cd00-25d8-11eb-9ad9-458022cdf9c2.png)
