### PR TITLE
[Validator] Document constraints as php 8 Attributes

### DIFF
--- a/reference/constraints/Bic.rst
+++ b/reference/constraints/Bic.rst
@@ -41,6 +41,19 @@ will contain a Business Identifier Code (BIC).
             protected $businessIdentifierCode;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Transaction.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Transaction
+        {
+            #[Assert\Bic]
+            protected $businessIdentifierCode;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Blank.rst
+++ b/reference/constraints/Blank.rst
@@ -45,6 +45,19 @@ of an ``Author`` class were blank, you could do the following:
             protected $firstName;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Blank]
+            protected $firstName;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -50,6 +50,23 @@ Configuration
             }
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+        use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+        class Author
+        {
+            #[Assert\Callback]
+            public function validate(ExecutionContextInterface $context, $payload)
+            {
+                // ...
+            }
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -174,6 +191,19 @@ You can then use the following configuration to invoke this validator:
         /**
          * @Assert\Callback({"Acme\Validator", "validate"})
          */
+        class Author
+        {
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Acme\Validator;
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        #[Assert\Callback([Validator::class, 'validate'])]
         class Author
         {
         }

--- a/reference/constraints/CardScheme.rst
+++ b/reference/constraints/CardScheme.rst
@@ -41,6 +41,22 @@ on an object that will contain a credit card number.
             protected $cardNumber;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Transaction.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Transaction
+        {
+            #[Assert\CardScheme(
+                schemes: [Assert\CardScheme::VISA],
+                message: 'Your credit card number is invalid.',
+            )]
+            protected $cardNumber;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -58,6 +58,24 @@ If your valid choice list is simple, you can pass them in directly via the
             protected $genre;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            const GENRES = ['fiction', 'non-fiction'];
+
+            #[Assert\Choice(['New York', 'Berlin', 'Tokyo'])]
+            protected $city;
+
+            #[Assert\Choice(choices: Author::GENRES, message: 'Choose a valid genre.')]
+            protected $genre;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -160,6 +178,19 @@ constraint.
             protected $genre;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Choice(callback: 'getGenres')]
+            protected $genre;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -222,6 +253,20 @@ you can pass the class name and the method as an array.
             /**
              * @Assert\Choice(callback={"App\Entity\Genre", "getGenres"})
              */
+            protected $genre;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use App\Entity\Genre
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Choice(callback: [Genre::class, 'getGenres'])]
             protected $genre;
         }
 

--- a/reference/constraints/Count.rst
+++ b/reference/constraints/Count.rst
@@ -47,6 +47,24 @@ you might add the following:
             protected $emails = [];
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Participant.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Participant
+        {
+            #[Assert\Count(
+                min: 1,
+                max: 5,
+                minMessage: 'You must specify at least one email',
+                maxMessage: 'You cannot specify more than {{ limit }} emails',
+            )]
+            protected $emails = [];
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Country.rst
+++ b/reference/constraints/Country.rst
@@ -33,6 +33,19 @@ Basic Usage
             protected $country;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/User.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class User
+        {
+            #[Assert\Country]
+            protected $country;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Currency.rst
+++ b/reference/constraints/Currency.rst
@@ -35,6 +35,19 @@ a valid currency, you could do the following:
             protected $currency;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Order.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Order
+        {
+            #[Assert\Currency]
+            protected $currency;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Date.rst
+++ b/reference/constraints/Date.rst
@@ -34,6 +34,19 @@ Basic Usage
             protected $birthday;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Date]
+            protected $birthday;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/DateTime.rst
+++ b/reference/constraints/DateTime.rst
@@ -35,6 +35,22 @@ Basic Usage
             protected $createdAt;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            /**
+             * @var string A "Y-m-d H:i:s" formatted value
+             */
+            #[Assert\DateTime]
+            protected $createdAt;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/DivisibleBy.rst
+++ b/reference/constraints/DivisibleBy.rst
@@ -53,6 +53,24 @@ The following constraints ensure that:
             protected $quantity;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Item.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Item
+        {
+            #[Assert\DivisibleBy(0.25)]
+            protected $weight;
+
+            #[Assert\DivisibleBy(
+                value: 5,
+            )]
+            protected $quantity;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -37,6 +37,21 @@ Basic Usage
             protected $email;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Email(
+                message: 'The email {{ value }} is not a valid email.',
+            )]
+            protected $email;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/EqualTo.rst
+++ b/reference/constraints/EqualTo.rst
@@ -52,6 +52,24 @@ and that the ``age`` is ``20``, you could do the following:
             protected $age;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\EqualTo("Mary")]
+            protected $firstName;
+
+            #[Assert\EqualTo(
+                value: 20,
+            )]
+            protected $age;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Expression.rst
+++ b/reference/constraints/Expression.rst
@@ -78,6 +78,22 @@ One way to accomplish this is with the Expression constraint:
             // ...
         }
 
+    .. code-block:: php-attributes
+
+        // src/Model/BlogPost.php
+        namespace App\Model;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        #[Assert\Expression(
+            "this.getCategory() in ['php', 'symfony'] or !this.isTechnicalPost()",
+            message: 'If this is a tech post, the category should be either php or symfony!',
+        )]
+        class BlogPost
+        {
+            // ...
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -158,6 +174,26 @@ more about the expression language syntax, see
                  *     message="If this is a tech post, the category should be either php or symfony!"
                  * )
                  */
+                private $isTechnicalPost;
+
+                // ...
+            }
+
+        .. code-block:: php-attributes
+
+            // src/Model/BlogPost.php
+            namespace App\Model;
+
+            use Symfony\Component\Validator\Constraints as Assert;
+
+            class BlogPost
+            {
+                // ...
+
+                #[Assert\Expression(
+                    "this.getCategory() in ['php', 'symfony'] or value == false",
+                    message: 'If this is a tech post, the category should be either php or symfony!',
+                )]
                 private $isTechnicalPost;
 
                 // ...
@@ -294,6 +330,24 @@ type (numeric, boolean, strings, null, etc.)
              *     values = { "error_margin": 0.25, "threshold": 1.5 }
              * )
              */
+            private $metric;
+
+            // ...
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Model/Analysis.php
+        namespace App\Model;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Analysis
+        {
+            #[Assert\Expression(
+                'value + error_margin < threshold',
+                values: ['error_margin' => 0.25, 'threshold' => 1.5],
+            )]
             private $metric;
 
             // ...

--- a/reference/constraints/ExpressionLanguageSyntax.rst
+++ b/reference/constraints/ExpressionLanguageSyntax.rst
@@ -52,6 +52,24 @@ The following constraints ensure that:
             protected $shippingOptions;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Order.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Order
+        {
+            #[Assert\ExpressionLanguageSyntax]
+            protected $promotion;
+
+            #[Assert\ExpressionLanguageSyntax(
+                allowedVariables: ['user', 'shipping_centers'],
+            )]
+            protected $shippingOptions;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -93,6 +93,23 @@ below a certain file size and a valid PDF, add the following:
             protected $bioFile;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\File(
+                maxSize: '1024k',
+                mimeTypes: ['application/pdf', 'application/x-pdf'],
+                mimeTypesMessage: 'Please upload a valid PDF',
+            )]
+            protected $bioFile;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -49,6 +49,24 @@ The following constraints ensure that:
             protected $age;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\GreaterThan(5)]
+            protected $siblings;
+
+            #[Assert\GreaterThan(
+                value: 18,
+            )]
+            protected $age;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -126,6 +144,19 @@ that a date must at least be the next day:
             protected $deliveryDate;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Order.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Order
+        {
+            #[Assert\GreaterThan('today')]
+            protected $deliveryDate;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -182,6 +213,19 @@ dates. If you want to fix the timezone, append it to the date string:
             /**
              * @Assert\GreaterThan("today UTC")
              */
+            protected $deliveryDate;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Order.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Order
+        {
+            #[Assert\GreaterThan('today UTC')]
             protected $deliveryDate;
         }
 
@@ -242,6 +286,19 @@ current time:
             /**
              * @Assert\GreaterThan("+5 hours")
              */
+            protected $deliveryDate;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Order.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Order
+        {
+            #[Assert\GreaterThan('+5 hours')]
             protected $deliveryDate;
         }
 

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -48,6 +48,24 @@ The following constraints ensure that:
             protected $age;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\GreaterThanOrEqual(5)]
+            protected $siblings;
+
+            #[Assert\GreaterThanOrEqual(
+                value: 18,
+            )]
+            protected $age;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -125,6 +143,19 @@ that a date must at least be the current day:
             protected $deliveryDate;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Order.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Order
+        {
+            #[Assert\GreaterThanOrEqual('today')]
+            protected $deliveryDate;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -181,6 +212,19 @@ dates. If you want to fix the timezone, append it to the date string:
             /**
              * @Assert\GreaterThanOrEqual("today UTC")
              */
+            protected $deliveryDate;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Order.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Order
+        {
+            #[Assert\GreaterThanOrEqual('today UTC')]
             protected $deliveryDate;
         }
 
@@ -241,6 +285,19 @@ current time:
             /**
              * @Assert\GreaterThanOrEqual("+5 hours")
              */
+            protected $deliveryDate;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Order.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Order
+        {
+            #[Assert\GreaterThanOrEqual('+5 hours')]
             protected $deliveryDate;
         }
 

--- a/reference/constraints/Hostname.rst
+++ b/reference/constraints/Hostname.rst
@@ -42,6 +42,19 @@ will contain a host name.
             protected $name;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/ServerSettings.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class ServerSettings
+        {
+            #[Assert\Hostname(message: 'The server name must be a valid hostname.')]
+            protected $name;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Iban.rst
+++ b/reference/constraints/Iban.rst
@@ -40,6 +40,21 @@ will contain an International Bank Account Number.
             protected $bankAccountNumber;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Transaction.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Transaction
+        {
+            #[Assert\Iban(
+                message: 'This is not a valid International Bank Account Number (IBAN).',
+            )]
+            protected $bankAccountNumber;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/IdenticalTo.rst
+++ b/reference/constraints/IdenticalTo.rst
@@ -54,6 +54,24 @@ The following constraints ensure that:
             protected $age;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\IdenticalTo("Mary")]
+            protected $firstName;
+
+            #[Assert\IdenticalTo(
+                value: 20,
+            )]
+            protected $age;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -100,6 +100,24 @@ that it is between a certain size, add the following:
             protected $headshot;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Image(
+                minWidth: 200,
+                maxWidth: 400,
+                minHeight: 200,
+                maxHeight: 400,
+            )]
+            protected $headshot;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -177,6 +195,22 @@ following code:
              *     allowPortrait = false
              * )
              */
+            protected $headshot;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Image(
+                allowLandscape: false,
+                allowPortrait: false,
+            )]
             protected $headshot;
         }
 

--- a/reference/constraints/Ip.rst
+++ b/reference/constraints/Ip.rst
@@ -36,6 +36,19 @@ Basic Usage
             protected $ipAddress;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Ip]
+            protected $ipAddress;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/IsFalse.rst
+++ b/reference/constraints/IsFalse.rst
@@ -58,6 +58,24 @@ method returns **false**:
             }
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\IsFalse(
+                message: "You've entered an invalid state."
+            )]
+            public function isStateInvalid()
+            {
+                // ...
+            }
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/IsNull.rst
+++ b/reference/constraints/IsNull.rst
@@ -39,6 +39,19 @@ of an ``Author`` class exactly equal to ``null``, you could do the following:
             protected $firstName;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\IsNull]
+            protected $firstName;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/IsTrue.rst
+++ b/reference/constraints/IsTrue.rst
@@ -60,6 +60,24 @@ Then you can validate this method with ``IsTrue`` as follows:
             }
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            protected $token;
+
+            #[Assert\IsTrue(message: 'The token is invalid.')]
+            public function isTokenValid()
+            {
+                return $this->token == $this->generateToken();
+            }
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -43,6 +43,22 @@ on an object that will contain an ISBN.
             protected $isbn;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Book.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Book
+        {
+            #[Assert\Isbn(
+                type: Assert\Isbn::ISBN_10,
+                message: 'This value is not valid.',
+            )]
+            protected $isbn;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Isin.rst
+++ b/reference/constraints/Isin.rst
@@ -33,6 +33,19 @@ Basic Usage
             protected $isin;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/UnitAccount.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class UnitAccount
+        {
+            #[Assert\Isin]
+            protected $isin;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Issn.rst
+++ b/reference/constraints/Issn.rst
@@ -35,6 +35,19 @@ Basic Usage
             protected $issn;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Journal.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Journal
+        {
+            #[Assert\Issn]
+            protected $issn;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Json.rst
+++ b/reference/constraints/Json.rst
@@ -35,6 +35,21 @@ The ``Json`` constraint can be applied to a property or a "getter" method:
             private $chapters;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Book.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Book
+        {
+            #[Assert\Json(
+                message: "You've entered an invalid Json."
+            )]
+            private $chapters;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Language.rst
+++ b/reference/constraints/Language.rst
@@ -34,6 +34,19 @@ Basic Usage
             protected $preferredLanguage;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/User.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class User
+        {
+            #[Assert\Language]
+            protected $preferredLanguage;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -48,6 +48,25 @@ and "50", you might add the following:
             protected $firstName;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Participant.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Participant
+        {
+            #[Assert\Length(
+                min: 2,
+                max: 50,
+                minMessage: 'Your first name must be at least {{ limit }} characters long',
+                maxMessage: 'Your first name cannot be longer than {{ limit }} characters',
+            )]
+            protected $firstName;
+        }
+
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -49,6 +49,24 @@ The following constraints ensure that:
             protected $age;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\LessThan(5)]
+            protected $siblings;
+
+            #[Assert\LessThan(
+                value: 80,
+            )]
+            protected $age;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -126,6 +144,19 @@ that a date must be in the past like this:
             protected $dateOfBirth;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\LessThan('today')]
+            protected $dateOfBirth;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -185,6 +216,19 @@ dates. If you want to fix the timezone, append it to the date string:
             protected $dateOfBirth;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\LessThan('today UTC')]
+            protected $dateOfBirth;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -241,6 +285,19 @@ can check that a person must be at least 18 years old like this:
             /**
              * @Assert\LessThan("-18 years")
              */
+            protected $dateOfBirth;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\LessThan('-18 years')]
             protected $dateOfBirth;
         }
 

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -48,6 +48,24 @@ The following constraints ensure that:
             protected $age;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\LessThanOrEqual(5)]
+            protected $siblings;
+
+            #[Assert\LessThanOrEqual(
+                value: 80,
+            )]
+            protected $age;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -125,6 +143,19 @@ that a date must be today or in the past like this:
             protected $dateOfBirth;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\LessThanOrEqual('today')]
+            protected $dateOfBirth;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -184,6 +215,19 @@ dates. If you want to fix the timezone, append it to the date string:
             protected $dateOfBirth;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\LessThanOrEqual('today UTC')]
+            protected $dateOfBirth;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -240,6 +284,19 @@ can check that a person must be at least 18 years old like this:
             /**
              * @Assert\LessThanOrEqual("-18 years")
              */
+            protected $dateOfBirth;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\LessThanOrEqual('-18 years')]
             protected $dateOfBirth;
         }
 

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -43,6 +43,21 @@ Basic Usage
             protected $locale;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/User.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class User
+        {
+            #[Assert\Locale(
+                canonicalize: true,
+            )]
+            protected $locale;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Luhn.rst
+++ b/reference/constraints/Luhn.rst
@@ -37,6 +37,19 @@ will contain a credit card number.
             protected $cardNumber;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Transaction.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Transaction
+        {
+            #[Assert\Luhn(message: 'Please check your credit card number.')]
+            protected $cardNumber;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Negative.rst
+++ b/reference/constraints/Negative.rst
@@ -37,6 +37,19 @@ The following constraint ensures that the ``withdraw`` of a  bank account
             protected $withdraw;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/TransferItem.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class TransferItem
+        {
+            #[Assert\Negative]
+            protected $withdraw;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/NegativeOrZero.rst
+++ b/reference/constraints/NegativeOrZero.rst
@@ -36,6 +36,19 @@ is a negative number or equal to zero:
             protected $level;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/TransferItem.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class UnderGroundGarage
+        {
+            #[Assert\NegativeOrZero]
+            protected $level;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/NotBlank.rst
+++ b/reference/constraints/NotBlank.rst
@@ -40,6 +40,19 @@ class were not blank, you could do the following:
             protected $firstName;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\NotBlank]
+            protected $firstName;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/NotCompromisedPassword.rst
+++ b/reference/constraints/NotCompromisedPassword.rst
@@ -38,6 +38,19 @@ The following constraint ensures that the ``rawPassword`` property of the
             protected $rawPassword;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/User.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class User
+        {
+            #[Assert\NotCompromisedPassword]
+            protected $rawPassword;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/NotEqualTo.rst
+++ b/reference/constraints/NotEqualTo.rst
@@ -53,6 +53,24 @@ the following:
             protected $age;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\NotEqualTo('Mary')]
+            protected $firstName;
+
+            #[Assert\NotEqualTo(
+                value: 15,
+            )]
+            protected $age;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/NotIdenticalTo.rst
+++ b/reference/constraints/NotIdenticalTo.rst
@@ -54,6 +54,24 @@ The following constraints ensure that:
             protected $age;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\NotIdenticalTo('Mary')]
+            protected $firstName;
+
+            #[Assert\NotIdenticalTo(
+                value: 15,
+            )]
+            protected $age;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/NotNull.rst
+++ b/reference/constraints/NotNull.rst
@@ -37,6 +37,19 @@ class were not strictly equal to ``null``, you would:
             protected $firstName;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\NotNull]
+            protected $firstName;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Positive.rst
+++ b/reference/constraints/Positive.rst
@@ -37,6 +37,19 @@ positive number (greater than zero):
             protected $income;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Employee.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Employee
+        {
+            #[Assert\Positive]
+            protected $income;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/PositiveOrZero.rst
+++ b/reference/constraints/PositiveOrZero.rst
@@ -36,6 +36,19 @@ is positive or zero:
             protected $siblings;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\PositiveOrZero]
+            protected $siblings;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -47,6 +47,23 @@ you might add the following:
             protected $height;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Participant.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Participant
+        {
+            #[Assert\Range(
+                min: 120,
+                max: 180,
+                notInRangeMessage: 'You must be between {{ min }}cm and {{ max }}cm tall to enter',
+            )]
+            protected $height;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -125,6 +142,22 @@ date must lie within the current year like this:
             protected $startDate;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Event.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Event
+        {
+            #[Assert\Range(
+                min: 'first day of January',
+                max: 'first day of January next year',
+            )]
+            protected $startDate;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -195,6 +228,22 @@ dates. If you want to fix the timezone, append it to the date string:
             protected $startDate;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Event.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Event
+        {
+            #[Assert\Range(
+                min: 'first day of January UTC',
+                max: 'first day of January next year UTC',
+            )]
+            protected $startDate;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -262,6 +311,22 @@ can check that a delivery date starts within the next five hours like this:
              *      max = "+5 hours"
              * )
              */
+            protected $deliveryDate;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Order.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Order
+        {
+            #[Assert\Range(
+                min: 'now',
+                max: '+5 hours',
+            )]
             protected $deliveryDate;
         }
 

--- a/reference/constraints/Regex.rst
+++ b/reference/constraints/Regex.rst
@@ -41,6 +41,19 @@ more word characters at the beginning of your string:
             protected $description;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Regex('/^\w+/')]
+            protected $description;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -107,6 +120,23 @@ it a custom message:
              *     message="Your name cannot contain a number"
              * )
              */
+            protected $firstName;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Regex(
+                pattern: '/\d/',
+                match: false,
+                message: 'Your name cannot contain a number',
+            )]
             protected $firstName;
         }
 
@@ -200,6 +230,22 @@ need to specify the HTML5 compatible pattern in the ``htmlPattern`` option:
              *     htmlPattern = "^[a-zA-Z]+$"
              * )
              */
+            protected $name;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Regex(
+                pattern: '/^[a-z]+$/i',
+                match: '^[a-zA-Z]+$'
+            )]
             protected $name;
         }
 

--- a/reference/constraints/Time.rst
+++ b/reference/constraints/Time.rst
@@ -37,6 +37,22 @@ of the day when the event starts:
             protected $startsAt;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Event.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Event
+        {
+            /**
+             * @var string A "H:i:s" formatted value
+             */
+            #[Assert\Time]
+            protected $startsAt;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Timezone.rst
+++ b/reference/constraints/Timezone.rst
@@ -38,6 +38,19 @@ string which contains any of the `PHP timezone identifiers`_ (e.g. ``America/New
             protected $timezone;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/UserSettings.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class UserSettings
+        {
+            #[Assert\Timezone]
+            protected $timezone;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Traverse.rst
+++ b/reference/constraints/Traverse.rst
@@ -89,6 +89,73 @@ that all have constraints on their properties.
             }
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/BookCollection.php
+        namespace App\Entity;
+
+        use Doctrine\Common\Collections\ArrayCollection;
+        use Doctrine\Common\Collections\Collection
+        use Doctrine\ORM\Mapping as ORM;
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        /**
+         * @ORM\Entity
+         */
+        #[Assert\Traverse]
+        class BookCollection implements \IteratorAggregate
+        {
+            /**
+             * @var string
+             *
+             * @ORM\Column
+             */
+            #[Assert\NotBlank]
+            protected $name = '';
+
+            /**
+             * @var Collection|Book[]
+             *
+             * @ORM\ManyToMany(targetEntity="App\Entity\Book")
+             */
+            protected $books;
+
+            // some other properties
+
+            public function __construct()
+            {
+                $this->books = new ArrayCollection();
+            }
+
+            // ... setter for name, adder and remover for books
+
+            // the name can be validated by calling the getter
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            /**
+             * @return \Generator|Book[] The books for a given author
+             */
+            public function getBooksForAuthor(Author $author): iterable
+            {
+                foreach ($this->books as $book) {
+                    if ($book->isAuthoredBy($author)) {
+                        yield $book;
+                    }
+                }
+            }
+
+            // neither the method above nor any other specific getter
+            // could be used to validated all nested books;
+            // this object needs to be traversed to call the iterator
+            public function getIterator()
+            {
+                return $this->books->getIterator();
+            }
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -163,6 +230,21 @@ disable validating:
          * ...
          * @Assert\Traverse(false)
          */
+         class BookCollection implements \IteratorAggregate
+         {
+             // ...
+         }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/BookCollection.php
+
+        // ... same as above
+
+        /**
+         * ...
+         */
+         #[Assert\Traverse(false)]
          class BookCollection implements \IteratorAggregate
          {
              // ...

--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -59,6 +59,31 @@ This will check if ``id`` is an instance of ``Ramsey\Uuid\UuidInterface``,
             protected $accessCode;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Type('Ramsey\Uuid\UuidInterface')]
+            protected $id;
+
+            #[Assert\Type('string')]
+            protected $firstName;
+
+            #[Assert\Type(
+                type: 'integer',
+                message: 'The value {{ value }} is not a valid {{ type }}.',
+            )]
+            protected $age;
+
+            #[Assert\Type(type: ['alpha', 'digit'])]
+            protected $accessCode;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Ulid.rst
+++ b/reference/constraints/Ulid.rst
@@ -37,6 +37,19 @@ Basic Usage
             protected $identifier;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/File.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class File
+        {
+            #[Assert\Ulid]
+            protected $identifier;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Unique.rst
+++ b/reference/constraints/Unique.rst
@@ -50,6 +50,19 @@ strings:
             protected $contactEmails;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Person.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Person
+        {
+            #[Assert\Unique]
+            protected $contactEmails;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -59,6 +59,31 @@ between all of the rows in your user table:
             protected $email;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/User.php
+        namespace App\Entity;
+
+        use Doctrine\ORM\Mapping as ORM;
+
+        // DON'T forget the following use statement!!!
+        use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        /**
+         * @ORM\Entity
+         */
+        #[UniqueEntity('email')]
+        class User
+        {
+            /**
+             * @ORM\Column(name="email", type="string", length=255, unique=true)
+             */
+            #[Assert\Email]
+            protected $email;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -175,6 +200,35 @@ Consider this example:
          *     message="This port is already in use on that host."
          * )
          */
+        class Service
+        {
+            /**
+             * @ORM\ManyToOne(targetEntity="App\Entity\Host")
+             */
+            public $host;
+
+            /**
+             * @ORM\Column(type="integer")
+             */
+            public $port;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Service.php
+        namespace App\Entity;
+
+        use Doctrine\ORM\Mapping as ORM;
+        use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+
+        /**
+         * @ORM\Entity
+         */
+        #[UniqueEntity(
+            fields: ['host', 'port'],
+            errorPath: 'port',
+            message: 'This port is already in use on that host.',
+        )]
         class Service
         {
             /**

--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -35,6 +35,19 @@ Basic Usage
             protected $bioUrl;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Url]
+            protected $bioUrl;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -124,6 +137,21 @@ Parameter        Description
             protected $bioUrl;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Url(
+                message: 'The url {{ value }} is not a valid url',
+            )]
+            protected $bioUrl;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -200,6 +228,21 @@ the ``ftp://`` type URLs to be valid, redefine the ``protocols`` array, listing
             protected $bioUrl;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Url(
+                protocols: ['http', 'https', 'ftp'],
+            )]
+            protected $bioUrl;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -272,6 +315,21 @@ also relative URLs that contain no protocol (e.g. ``//example.com``).
              *    relativeProtocol = true
              * )
              */
+            protected $bioUrl;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Url(
+                relativeProtocol: true,
+            )]
             protected $bioUrl;
         }
 

--- a/reference/constraints/UserPassword.rst
+++ b/reference/constraints/UserPassword.rst
@@ -51,6 +51,21 @@ the user's current password:
             protected $oldPassword;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Form/Model/ChangePassword.php
+        namespace App\Form\Model;
+
+        use Symfony\Component\Security\Core\Validator\Constraints as SecurityAssert;
+
+        class ChangePassword
+        {
+            #[SecurityAssert\UserPassword(
+                message: 'Wrong value for your current password',
+            )]
+            protected $oldPassword;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Uuid.rst
+++ b/reference/constraints/Uuid.rst
@@ -38,6 +38,19 @@ Basic Usage
             protected $identifier;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/File.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class File
+        {
+            #[Assert\Uuid]
+            protected $identifier;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml

--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -87,6 +87,40 @@ stores an ``Address`` instance in the ``$address`` property::
             protected $address;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Address.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Address
+        {
+            #[Assert\NotBlank]
+            protected $street;
+
+            #[Assert\NotBlank]
+            #[Assert\Length(max: 5)]
+            protected $zipCode;
+        }
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\NotBlank]
+            #[Assert\Length(min: 4)]
+            protected $firstName;
+
+            #[Assert\NotBlank]
+            protected $lastName;
+
+            protected $address;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -193,6 +227,19 @@ an invalid address. To prevent that, add the ``Valid`` constraint to the
             /**
              * @Assert\Valid
              */
+            protected $address;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        class Author
+        {
+            #[Assert\Valid]
             protected $address;
         }
 


### PR DESCRIPTION
We already have [examples](https://github.com/symfony/symfony-docs/pull/14230/files) of code for the PHP attributes.
We also have [Constraints as php 8 Attributes](https://github.com/symfony/symfony/pull/38309) and [2](https://github.com/symfony/symfony-docs/issues/14305).
The rest will be implemented in the [future](https://github.com/symfony/symfony/issues/38503).

