### PR TITLE
Fix user entity import

### DIFF
--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -21,7 +21,7 @@ are not met, an exception should be thrown which extends the
     namespace AppBundle\Security;
 
     use AppBundle\Exception\AccountDeletedException;
-    use AppBundle\Security\User as AppUser;
+    use AppBundle\Entity\User as AppUser;
     use Symfony\Component\Security\Core\Exception\AccountExpiredException;
     use Symfony\Component\Security\Core\User\UserCheckerInterface;
     use Symfony\Component\Security\Core\User\UserInterface;

--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -20,8 +20,8 @@ are not met, an exception should be thrown which extends the
 
     namespace AppBundle\Security;
 
-    use AppBundle\Exception\AccountDeletedException;
     use AppBundle\Entity\User as AppUser;
+    use AppBundle\Exception\AccountDeletedException;
     use Symfony\Component\Security\Core\Exception\AccountExpiredException;
     use Symfony\Component\Security\Core\User\UserCheckerInterface;
     use Symfony\Component\Security\Core\User\UserInterface;


### PR DESCRIPTION
The user entity import was incorrectly set to import from the Security namespace instead of Entity.
https://symfony.com/doc/3.4/security/user_checkers.html

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
