### PR TITLE
Fix user entity import

### DIFF
--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -23,7 +23,7 @@ displayed to the user::
 
     namespace App\Security;
 
-    use App\Security\User as AppUser;
+    use App\Entity\User as AppUser;
     use Symfony\Component\Security\Core\Exception\AccountExpiredException;
     use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
     use Symfony\Component\Security\Core\User\UserCheckerInterface;


### PR DESCRIPTION
The user entity import was incorrectly set to import from the Security namespace instead of Entity.
https://symfony.com/doc/current/security/user_checkers.html

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
