### PR TITLE
Section method only in ConsoleOutputInterface

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -181,8 +181,18 @@ which returns an instance of
     {
         protected function execute(InputInterface $input, OutputInterface $output)
         {
+            // The section() method is only available in classes that implement ConsoleOutputInterface
+            if (!$output instanceof ConsoleOutputInterface) {
+                throw new LogicException(sprintf(
+                    'This command accepts only an instance of "%s", an instance of "%s" is given',
+                    ConsoleOutputInterface::class,
+                    \get_class($output)
+                ));
+            }
+
             $section1 = $output->section();
             $section2 = $output->section();
+
             $section1->writeln('Hello');
             $section2->writeln('World!');
             // Output displays "Hello\nWorld!\n"


### PR DESCRIPTION
Since `excecute()` accepts an instanceof `OutputInterface` which doesn't contain the method [`section`](https://github.com/symfony/symfony/blob/5.1/src/Symfony/Component/Console/Output/ConsoleOutputInterface.php#L31) we have to add a check on `ConsoleOutputInterface`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
