### PR TITLE
Fix option double dashes

### DIFF
--- a/console/input.rst
+++ b/console/input.rst
@@ -247,7 +247,7 @@ optionally accepts a value, but it's a bit tricky. Consider this example::
         )
     ;
 
-This option can be used in 3 ways: ``greet --yell``, ``greet yell=louder``,
+This option can be used in 3 ways: ``greet --yell``, ``greet --yell=louder``,
 and ``greet``. However, it's hard to distinguish between passing the option
 without a value (``greet --yell``) and not passing the option (``greet``).
 


### PR DESCRIPTION
The option `yell` should have double dashes instead none
