### PR TITLE
Update http_kernel_controller_resolver.rst

### DIFF
--- a/create_framework/http_kernel_controller_resolver.rst
+++ b/create_framework/http_kernel_controller_resolver.rst
@@ -133,7 +133,7 @@ Let's inject the ``$year`` request attribute for our controller::
     {
         public function index($year)
         {
-            if (is_leap_year($year)) {
+            if (is_leap_year($year[0])) {
                 return new Response('Yep, this is a leap year!');
             }
 


### PR DESCRIPTION
Edited LeapYearController::index

Since $argumentResolver->getArguments($request, $controller) returns an array, we need to call is_leap_year($year[0]) with argument's index to do a boolean comparison.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
