### PR TITLE
[Messenger] Add little tip about PHPdoc description in debug:messenger

### DIFF
--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -249,4 +249,9 @@ You can also restrict the list to a specific bus by providing its name as argume
             handled by App\MessageHandler\MultipleBusesMessageHandler
        ---------------------------------------------------------------------------------------
 
+.. tip::
+
+    Since Symfony 5.1, the command will also show the PHPDoc description of
+    the message and handler classes.
+
 .. _article about CQRS: https://martinfowler.com/bliki/CQRS.html


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony-docs/issues/13310