### PR TITLE
[Console] Caution about disabling auto exit flag

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -393,6 +393,16 @@ console::
     not dispatched. If you need to test those events, use the
     :class:`Symfony\\Component\\Console\\Tester\\ApplicationTester` instead.
 
+.. caution::
+
+    When testing commands using the :class:`Symfony\\Component\\Console\\Tester\\ApplicationTester`
+    class, don't forget to disable the auto exit flag::
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        
+        $tester = new ApplicationTester($application);
+
 .. note::
 
     When using the Console component in a standalone project, use


### PR DESCRIPTION
Like mentionned in the class comment : https://github.com/symfony/symfony/blob/5.1/src/Symfony/Component/Console/Tester/ApplicationTester.php#L23 : the auto exist flag should be disabled, otherwise the tests won't run

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
