### PR TITLE
[Twig] Fix strict_variables default value since Symfony 5

### DIFF
--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -363,7 +363,7 @@ Read more about :ref:`template directories and namespaces <templates-namespaces>
 strict_variables
 ~~~~~~~~~~~~~~~~
 
-**type**: ``boolean`` **default**: ``false``
+**type**: ``boolean`` **default**: ``%kernel.debug%``
 
 If set to ``true``, Symfony shows an exception whenever a Twig variable,
 attribute or method doesn't exist. If set to ``false`` these errors are ignored


### PR DESCRIPTION
The default was changed as of Symfony 5 https://github.com/symfony/symfony/blob/494ef421c554a78b38c6779c4b7deb9a20d89923/UPGRADE-5.0.md#twigbundle
