### PR TITLE
[Translator] Replace old ICU Formatting Messages url

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -607,7 +607,7 @@ Learn more
     translation/xliff
 
 .. _`i18n`: https://en.wikipedia.org/wiki/Internationalization_and_localization
-.. _`ICU MessageFormat`: http://userguide.icu-project.org/formatparse/messages
+.. _`ICU MessageFormat`: https://unicode-org.github.io/icu/userguide/format_parse/messages/
 .. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 .. _`Translatable Extension`: http://atlantic18.github.io/DoctrineExtensions/doc/translatable.html

--- a/translation/message_format.rst
+++ b/translation/message_format.rst
@@ -474,7 +474,7 @@ The ``number`` formatter allows you to format numbers using Intl's :phpclass:`Nu
     echo $translator->trans('value_of_object', ['value' => 9988776.65]);
 
 .. _`online editor`: http://format-message.github.io/icu-message-format-for-translators/
-.. _`ICU MessageFormat`: http://userguide.icu-project.org/formatparse/messages
+.. _`ICU MessageFormat`: https://unicode-org.github.io/icu/userguide/format_parse/messages/
 .. _`switch statement`: https://www.php.net/control-structures.switch
 .. _`Language Plural Rules`: http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
 .. _`constants defined by the IntlDateFormatter class`: https://www.php.net/manual/en/class.intldateformatter.php


### PR DESCRIPTION
A small update to replace the old documentation url with the new one!