### PR TITLE
[Form] Documented legacy_error_messages

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -553,6 +553,49 @@ To see the second approach - adding constraints to the form - and to
 learn more about the validation constraints, please refer to the
 :doc:`Symfony validation documentation </validation>`.
 
+.. versionadded:: 5.2
+
+    Validation messages for forms have been rewritten to be more user-friendly.
+    These newer messages can be enabled by setting the `legacy_error_messages`
+    option to "false". Details about these messages can be found in the corresponding
+    form type documentation.
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # config/packages/framework.yaml
+            framework:
+                form:
+                    legacy_error_messages: false
+
+        .. code-block:: xml
+
+            <!-- config/packages/framework.xml -->
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <container xmlns="http://symfony.com/schema/dic/services"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:framework="http://symfony.com/schema/dic/symfony"
+                xsi:schemaLocation="http://symfony.com/schema/dic/services
+                    https://symfony.com/schema/dic/services/services-1.0.xsd
+                    http://symfony.com/schema/dic/symfony
+                    https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+                <framework:config>
+                    <framework:form legacy-error-messages="false"/>
+                </framework:config>
+            </container>
+
+        .. code-block:: php
+
+            // config/packages/framework.php
+            $container->loadFromExtension('framework', [
+                'form' => [
+                    'legacy-error-messages' => false,
+                ],
+            ]);
+
+
 Other Common Form Features
 --------------------------
 

--- a/reference/forms/types/birthday.rst
+++ b/reference/forms/types/birthday.rst
@@ -14,50 +14,56 @@ This type is essentially the same as the :doc:`DateType </reference/forms/types/
 type, but with a more appropriate default for the `years`_ option. The `years`_
 option defaults to 120 years ago to the current year.
 
-+----------------------+-------------------------------------------------------------------------------+
-| Underlying Data Type | can be ``DateTime``, ``string``, ``timestamp``, or ``array``                  |
-|                      | (see the :ref:`input option <form-reference-date-input>`)                     |
-+----------------------+-------------------------------------------------------------------------------+
-| Rendered as          | can be three select boxes or 1 or 3 text boxes, based on the `widget`_ option |
-+----------------------+-------------------------------------------------------------------------------+
-| Overridden options   | - `years`_                                                                    |
-+----------------------+-------------------------------------------------------------------------------+
-| Inherited options    | from the :doc:`DateType </reference/forms/types/date>`:                       |
-|                      |                                                                               |
-|                      | - `choice_translation_domain`_                                                |
-|                      | - `days`_                                                                     |
-|                      | - `placeholder`_                                                              |
-|                      | - `format`_                                                                   |
-|                      | - `input`_                                                                    |
-|                      | - `input_format`_                                                             |
-|                      | - `model_timezone`_                                                           |
-|                      | - `months`_                                                                   |
-|                      | - `view_timezone`_                                                            |
-|                      | - `widget`_                                                                   |
-|                      |                                                                               |
-|                      | from the :doc:`FormType </reference/forms/types/form>`:                       |
-|                      |                                                                               |
-|                      | - `attr`_                                                                     |
-|                      | - `data`_                                                                     |
-|                      | - `disabled`_                                                                 |
-|                      | - `help`_                                                                     |
-|                      | - `help_attr`_                                                                |
-|                      | - `help_html`_                                                                |
-|                      | - `inherit_data`_                                                             |
-|                      | - `invalid_message`_                                                          |
-|                      | - `invalid_message_parameters`_                                               |
-|                      | - `mapped`_                                                                   |
-|                      | - `row_attr`_                                                                 |
-+----------------------+-------------------------------------------------------------------------------+
-| Parent type          | :doc:`DateType </reference/forms/types/date>`                                 |
-+----------------------+-------------------------------------------------------------------------------+
-| Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\BirthdayType`        |
-+----------------------+-------------------------------------------------------------------------------+
++---------------------------+-------------------------------------------------------------------------------+
+| Underlying Data Type      | can be ``DateTime``, ``string``, ``timestamp``, or ``array``                  |
+|                           | (see the :ref:`input option <form-reference-date-input>`)                     |
++---------------------------+-------------------------------------------------------------------------------+
+| Rendered as               | can be three select boxes or 1 or 3 text boxes, based on the `widget`_ option |
++---------------------------+-------------------------------------------------------------------------------+
+| Overridden options        | - `invalid_message`_                                                          |
+|                           | - `years`_                                                                    |
++---------------------------+-------------------------------------------------------------------------------+
+| Inherited options         | from the :doc:`DateType </reference/forms/types/date>`:                       |
+|                           |                                                                               |
+|                           | - `choice_translation_domain`_                                                |
+|                           | - `days`_                                                                     |
+|                           | - `placeholder`_                                                              |
+|                           | - `format`_                                                                   |
+|                           | - `input`_                                                                    |
+|                           | - `input_format`_                                                             |
+|                           | - `model_timezone`_                                                           |
+|                           | - `months`_                                                                   |
+|                           | - `view_timezone`_                                                            |
+|                           | - `widget`_                                                                   |
+|                           |                                                                               |
+|                           | from the :doc:`FormType </reference/forms/types/form>`:                       |
+|                           |                                                                               |
+|                           | - `attr`_                                                                     |
+|                           | - `data`_                                                                     |
+|                           | - `disabled`_                                                                 |
+|                           | - `help`_                                                                     |
+|                           | - `help_attr`_                                                                |
+|                           | - `help_html`_                                                                |
+|                           | - `inherit_data`_                                                             |
+|                           | - `invalid_message_parameters`_                                               |
+|                           | - `mapped`_                                                                   |
+|                           | - `row_attr`_                                                                 |
++---------------------------+-------------------------------------------------------------------------------+
+| Default `invalid_message` | Please enter a valid birthdate.                                               |
++---------------------------+-------------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                           |
++---------------------------+-------------------------------------------------------------------------------+
+| Parent type               | :doc:`DateType </reference/forms/types/date>`                                 |
++---------------------------+-------------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\BirthdayType`        |
++---------------------------+-------------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
 Overridden Options
 ------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 ``years``
 ~~~~~~~~~
@@ -127,8 +133,6 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/help_html.rst.inc
 
 .. include:: /reference/forms/types/options/inherit_data.rst.inc
-
-.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 

--- a/reference/forms/types/checkbox.rst
+++ b/reference/forms/types/checkbox.rst
@@ -11,34 +11,39 @@ you can specify an array of values that, if submitted, will be evaluated
 to "false" as well (this differs from what HTTP defines, but can be handy
 if you want to handle submitted values like "0" or "false").
 
-+-------------+------------------------------------------------------------------------+
-| Rendered as | ``input`` ``checkbox`` field                                           |
-+-------------+------------------------------------------------------------------------+
-| Options     | - `false_values`_                                                      |
-|             | - `value`_                                                             |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                          |
-| options     | - `empty_data`_                                                        |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                              |
-| options     | - `data`_                                                              |
-|             | - `disabled`_                                                          |
-|             | - `error_bubbling`_                                                    |
-|             | - `error_mapping`_                                                     |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
-| Parent type | :doc:`FormType </reference/forms/types/form>`                          |
-+-------------+------------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CheckboxType` |
-+-------------+------------------------------------------------------------------------+
++---------------------------+------------------------------------------------------------------------+
+| Rendered as               | ``input`` ``checkbox`` field                                           |
++---------------------------+------------------------------------------------------------------------+
+| Options                   | - `false_values`_                                                      |
+|                           | - `value`_                                                             |
++---------------------------+------------------------------------------------------------------------+
+| Overridden options        | - `compound`_                                                          |
+|                           | - `empty_data`_                                                        |
+|                           | - `invalid_message`_                                                   |
++---------------------------+------------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                              |
+|                           | - `data`_                                                              |
+|                           | - `disabled`_                                                          |
+|                           | - `error_bubbling`_                                                    |
+|                           | - `error_mapping`_                                                     |
+|                           | - `help`_                                                              |
+|                           | - `help_attr`_                                                         |
+|                           | - `help_html`_                                                         |
+|                           | - `label`_                                                             |
+|                           | - `label_attr`_                                                        |
+|                           | - `label_format`_                                                      |
+|                           | - `mapped`_                                                            |
+|                           | - `required`_                                                          |
+|                           | - `row_attr`_                                                          |
++---------------------------+------------------------------------------------------------------------+
+| Default `invalid_message` | The checkbox has an invalid value.                                     |
++---------------------------+------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                    |
++---------------------------+------------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                          |
++---------------------------+------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CheckboxType` |
++---------------------------+------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -73,6 +78,8 @@ Overridden Options
 .. include:: /reference/forms/types/options/checkbox_compound.rst.inc
 
 .. include:: /reference/forms/types/options/checkbox_empty_data.rst.inc
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -9,52 +9,57 @@ It can be rendered as a ``select`` tag, radio buttons, or checkboxes.
 
 To use this field, you must specify *either* ``choices`` or ``choice_loader`` option.
 
-+-------------+------------------------------------------------------------------------------+
-| Rendered as | can be various tags (see below)                                              |
-+-------------+------------------------------------------------------------------------------+
-| Options     | - `choices`_                                                                 |
-|             | - `choice_attr`_                                                             |
-|             | - `choice_filter`_                                                           |
-|             | - `choice_label`_                                                            |
-|             | - `choice_loader`_                                                           |
-|             | - `choice_name`_                                                             |
-|             | - `choice_translation_domain`_                                               |
-|             | - `choice_value`_                                                            |
-|             | - `expanded`_                                                                |
-|             | - `group_by`_                                                                |
-|             | - `multiple`_                                                                |
-|             | - `placeholder`_                                                             |
-|             | - `preferred_choices`_                                                       |
-+-------------+------------------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                                |
-| options     | - `empty_data`_                                                              |
-|             | - `error_bubbling`_                                                          |
-|             | - `trim`_                                                                    |
-+-------------+------------------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                                    |
-| options     | - `by_reference`_                                                            |
-|             | - `data`_                                                                    |
-|             | - `disabled`_                                                                |
-|             | - `error_mapping`_                                                           |
-|             | - `help`_                                                                    |
-|             | - `help_attr`_                                                               |
-|             | - `help_html`_                                                               |
-|             | - `inherit_data`_                                                            |
-|             | - `label`_                                                                   |
-|             | - `label_attr`_                                                              |
-|             | - `label_format`_                                                            |
-|             | - `mapped`_                                                                  |
-|             | - `required`_                                                                |
-|             | - `row_attr`_                                                                |
-|             | - `translation_domain`_                                                      |
-|             | - `label_translation_parameters`_                                            |
-|             | - `attr_translation_parameters`_                                             |
-|             | - `help_translation_parameters`_                                             |
-+-------------+------------------------------------------------------------------------------+
-| Parent type | :doc:`FormType </reference/forms/types/form>`                                |
-+-------------+------------------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\ChoiceType`         |
-+-------------+------------------------------------------------------------------------------+
++---------------------------+----------------------------------------------------------------------+
+| Rendered as               | can be various tags (see below)                                      |
++---------------------------+----------------------------------------------------------------------+
+| Options                   | - `choices`_                                                         |
+|                           | - `choice_attr`_                                                     |
+|                           | - `choice_filter`_                                                   |
+|                           | - `choice_label`_                                                    |
+|                           | - `choice_loader`_                                                   |
+|                           | - `choice_name`_                                                     |
+|                           | - `choice_translation_domain`_                                       |
+|                           | - `choice_value`_                                                    |
+|                           | - `expanded`_                                                        |
+|                           | - `group_by`_                                                        |
+|                           | - `multiple`_                                                        |
+|                           | - `placeholder`_                                                     |
+|                           | - `preferred_choices`_                                               |
++---------------------------+----------------------------------------------------------------------+
+| Overridden options        | - `compound`_                                                        |
+|                           | - `empty_data`_                                                      |
+|                           | - `error_bubbling`_                                                  |
+|                           | - `trim`_                                                            |
+|                           | - `invalid_message`_                                                 |
++---------------------------+----------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                            |
+|                           | - `by_reference`_                                                    |
+|                           | - `data`_                                                            |
+|                           | - `disabled`_                                                        |
+|                           | - `error_mapping`_                                                   |
+|                           | - `help`_                                                            |
+|                           | - `help_attr`_                                                       |
+|                           | - `help_html`_                                                       |
+|                           | - `inherit_data`_                                                    |
+|                           | - `label`_                                                           |
+|                           | - `label_attr`_                                                      |
+|                           | - `label_format`_                                                    |
+|                           | - `mapped`_                                                          |
+|                           | - `required`_                                                        |
+|                           | - `row_attr`_                                                        |
+|                           | - `translation_domain`_                                              |
+|                           | - `label_translation_parameters`_                                    |
+|                           | - `attr_translation_parameters`_                                     |
+|                           | - `help_translation_parameters`_                                     |
++---------------------------+----------------------------------------------------------------------+
+| Default `invalid_message` | The selected choice is invalid.                                      |
++---------------------------+----------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                  |
++---------------------------+----------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                        |
++---------------------------+----------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\ChoiceType` |
++---------------------------+----------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -271,6 +276,8 @@ Set that error on this field must be attached to the field instead of
 the parent field (the form in most cases).
 
 .. include:: /reference/forms/types/options/choice_type_trim.rst.inc
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -11,37 +11,43 @@ forms, which is useful when creating forms that expose one-to-many
 relationships (e.g. a product from where you can manage many related product
 photos).
 
-+-------------+-----------------------------------------------------------------------------+
-| Rendered as | depends on the `entry_type`_ option                                         |
-+-------------+-----------------------------------------------------------------------------+
-| Options     | - `allow_add`_                                                              |
-|             | - `allow_delete`_                                                           |
-|             | - `delete_empty`_                                                           |
-|             | - `entry_options`_                                                          |
-|             | - `entry_type`_                                                             |
-|             | - `prototype`_                                                              |
-|             | - `prototype_data`_                                                         |
-|             | - `prototype_name`_                                                         |
-+-------------+-----------------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                                   |
-| options     | - `by_reference`_                                                           |
-|             | - `empty_data`_                                                             |
-|             | - `error_bubbling`_                                                         |
-|             | - `error_mapping`_                                                          |
-|             | - `help`_                                                                   |
-|             | - `help_attr`_                                                              |
-|             | - `help_html`_                                                              |
-|             | - `label`_                                                                  |
-|             | - `label_attr`_                                                             |
-|             | - `label_format`_                                                           |
-|             | - `mapped`_                                                                 |
-|             | - `required`_                                                               |
-|             | - `row_attr`_                                                               |
-+-------------+-----------------------------------------------------------------------------+
-| Parent type | :doc:`FormType </reference/forms/types/form>`                               |
-+-------------+-----------------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType`    |
-+-------------+-----------------------------------------------------------------------------+
++---------------------------+--------------------------------------------------------------------------+
+| Rendered as               | depends on the `entry_type`_ option                                      |
++---------------------------+--------------------------------------------------------------------------+
+| Options                   | - `allow_add`_                                                           |
+|                           | - `allow_delete`_                                                        |
+|                           | - `delete_empty`_                                                        |
+|                           | - `entry_options`_                                                       |
+|                           | - `entry_type`_                                                          |
+|                           | - `prototype`_                                                           |
+|                           | - `prototype_data`_                                                      |
+|                           | - `prototype_name`_                                                      |
++---------------------------+--------------------------------------------------------------------------+
+| Overridden options        | - `invalid_message`_                                                     |
++---------------------------+--------------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                                |
+|                           | - `by_reference`_                                                        |
+|                           | - `empty_data`_                                                          |
+|                           | - `error_bubbling`_                                                      |
+|                           | - `error_mapping`_                                                       |
+|                           | - `help`_                                                                |
+|                           | - `help_attr`_                                                           |
+|                           | - `help_html`_                                                           |
+|                           | - `label`_                                                               |
+|                           | - `label_attr`_                                                          |
+|                           | - `label_format`_                                                        |
+|                           | - `mapped`_                                                              |
+|                           | - `required`_                                                            |
+|                           | - `row_attr`_                                                            |
++---------------------------+--------------------------------------------------------------------------+
+| Default `invalid_message` | The collection is invalid.                                               |
++---------------------------+--------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                      |
++---------------------------+--------------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                            |
++---------------------------+--------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType` |
++---------------------------+--------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -395,6 +401,11 @@ prototype_name
 If you have several collections in your form, or worse, nested collections
 you may want to change the placeholder so that unrelated placeholders are
 not replaced with the same value.
+
+Overridden Options
+------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/color.rst
+++ b/reference/forms/types/color.rst
@@ -14,32 +14,38 @@ The value of the underlying ``<input type="color">`` field is always a
 That's why it's not possible to select semi-transparent colors with this
 element.
 
-+-------------+---------------------------------------------------------------------+
-| Rendered as | ``input`` ``color`` field (a text box)                              |
-+-------------+---------------------------------------------------------------------+
-| Options     | - `html5`_                                                          |
-+-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-|             | - `trim`_                                                           |
-+-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`TextType </reference/forms/types/text>`                       |
-+-------------+---------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\ColorType` |
-+-------------+---------------------------------------------------------------------+
++---------------------------+---------------------------------------------------------------------+
+| Rendered as               | ``input`` ``color`` field (a text box)                              |
++---------------------------+---------------------------------------------------------------------+
+| Options                   | - `html5`_                                                          |
++---------------------------+---------------------------------------------------------------------+
+| Overridden options        | - `invalid_message`_                                                |
++---------------------------+---------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                           |
+|                           | - `data`_                                                           |
+|                           | - `disabled`_                                                       |
+|                           | - `empty_data`_                                                     |
+|                           | - `error_bubbling`_                                                 |
+|                           | - `error_mapping`_                                                  |
+|                           | - `help`_                                                           |
+|                           | - `help_attr`_                                                      |
+|                           | - `help_html`_                                                      |
+|                           | - `label`_                                                          |
+|                           | - `label_attr`_                                                     |
+|                           | - `label_format`_                                                   |
+|                           | - `mapped`_                                                         |
+|                           | - `required`_                                                       |
+|                           | - `row_attr`_                                                       |
+|                           | - `trim`_                                                           |
++---------------------------+---------------------------------------------------------------------+
+| Default `invalid_message` | Please select a valid color.                                        |
++---------------------------+---------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                 |
++---------------------------+---------------------------------------------------------------------+
+| Parent type               | :doc:`TextType </reference/forms/types/text>`                       |
++---------------------------+---------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\ColorType` |
++---------------------------+---------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -58,6 +64,11 @@ html5
 When this option is set to ``true``, the form type checks that its value matches
 the `HTML5 color format`_ (``/^#[0-9a-f]{6}$/i``). If it doesn't match it,
 you'll see the following error message: *"This value is not a valid HTML5 color"*.
+
+Overridden Options
+------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/country.rst
+++ b/reference/forms/types/country.rst
@@ -18,45 +18,50 @@ Unlike the ``ChoiceType``, you don't need to specify a ``choices`` option as the
 field type automatically uses all of the countries of the world. You *can* specify
 the option manually, but then you should just use the ``ChoiceType`` directly.
 
-+-------------+-----------------------------------------------------------------------+
-| Rendered as | can be various tags (see :ref:`forms-reference-choice-tags`)          |
-+-------------+-----------------------------------------------------------------------+
-| Options     | - `alpha3`_                                                           |
-|             | - `choice_translation_locale`_                                        |
-+-------------+-----------------------------------------------------------------------+
-| Overridden  | - `choices`_                                                          |
-| options     | - `choice_translation_domain`_                                        |
-+-------------+-----------------------------------------------------------------------+
-| Inherited   | from the :doc:`ChoiceType </reference/forms/types/choice>`            |
-| options     |                                                                       |
-|             | - `error_bubbling`_                                                   |
-|             | - `error_mapping`_                                                    |
-|             | - `expanded`_                                                         |
-|             | - `multiple`_                                                         |
-|             | - `placeholder`_                                                      |
-|             | - `preferred_choices`_                                                |
-|             | - `trim`_                                                             |
-|             |                                                                       |
-|             | from the :doc:`FormType </reference/forms/types/form>`                |
-|             |                                                                       |
-|             | - `attr`_                                                             |
-|             | - `data`_                                                             |
-|             | - `disabled`_                                                         |
-|             | - `empty_data`_                                                       |
-|             | - `help`_                                                             |
-|             | - `help_attr`_                                                        |
-|             | - `help_html`_                                                        |
-|             | - `label`_                                                            |
-|             | - `label_attr`_                                                       |
-|             | - `label_format`_                                                     |
-|             | - `mapped`_                                                           |
-|             | - `required`_                                                         |
-|             | - `row_attr`_                                                         |
-+-------------+-----------------------------------------------------------------------+
-| Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                     |
-+-------------+-----------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CountryType` |
-+-------------+-----------------------------------------------------------------------+
++---------------------------+-----------------------------------------------------------------------+
+| Rendered as               | can be various tags (see :ref:`forms-reference-choice-tags`)          |
++---------------------------+-----------------------------------------------------------------------+
+| Options                   | - `alpha3`_                                                           |
+|                           | - `choice_translation_locale`_                                        |
++---------------------------+-----------------------------------------------------------------------+
+| Overridden options        | - `choices`_                                                          |
+|                           | - `choice_translation_domain`_                                        |
+|                           | - `invalid_message`_                                                  |
++---------------------------+-----------------------------------------------------------------------+
+| Inherited options         | from the :doc:`ChoiceType </reference/forms/types/choice>`            |
+|                           |                                                                       |
+|                           | - `error_bubbling`_                                                   |
+|                           | - `error_mapping`_                                                    |
+|                           | - `expanded`_                                                         |
+|                           | - `multiple`_                                                         |
+|                           | - `placeholder`_                                                      |
+|                           | - `preferred_choices`_                                                |
+|                           | - `trim`_                                                             |
+|                           |                                                                       |
+|                           | from the :doc:`FormType </reference/forms/types/form>`                |
+|                           |                                                                       |
+|                           | - `attr`_                                                             |
+|                           | - `data`_                                                             |
+|                           | - `disabled`_                                                         |
+|                           | - `empty_data`_                                                       |
+|                           | - `help`_                                                             |
+|                           | - `help_attr`_                                                        |
+|                           | - `help_html`_                                                        |
+|                           | - `label`_                                                            |
+|                           | - `label_attr`_                                                       |
+|                           | - `label_format`_                                                     |
+|                           | - `mapped`_                                                           |
+|                           | - `required`_                                                         |
+|                           | - `row_attr`_                                                         |
++---------------------------+-----------------------------------------------------------------------+
+| Default `invalid_message` | Please select a valid country.                                        |
++---------------------------+-----------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                   |
++---------------------------+-----------------------------------------------------------------------+
+| Parent type               | :doc:`ChoiceType </reference/forms/types/choice>`                     |
++---------------------------+-----------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CountryType` |
++---------------------------+-----------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -91,6 +96,8 @@ The locale is used to translate the countries names.
     will also have to set the ``choice_loader`` option to ``null``.
 
 .. include:: /reference/forms/types/options/choice_translation_domain_disabled.rst.inc
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/currency.rst
+++ b/reference/forms/types/currency.rst
@@ -11,43 +11,48 @@ Unlike the ``ChoiceType``, you don't need to specify a ``choices`` option as the
 field type automatically uses a large list of currencies. You *can* specify the option
 manually, but then you should just use the ``ChoiceType`` directly.
 
-+-------------+------------------------------------------------------------------------+
-| Rendered as | can be various tags (see :ref:`forms-reference-choice-tags`)           |
-+-------------+------------------------------------------------------------------------+
-| Options     | - `choice_translation_locale`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `choices`_                                                           |
-| options     | - `choice_translation_domain`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | from the :doc:`ChoiceType </reference/forms/types/choice>`             |
-| options     |                                                                        |
-|             | - `error_bubbling`_                                                    |
-|             | - `expanded`_                                                          |
-|             | - `multiple`_                                                          |
-|             | - `placeholder`_                                                       |
-|             | - `preferred_choices`_                                                 |
-|             | - `trim`_                                                              |
-|             |                                                                        |
-|             | from the :doc:`FormType </reference/forms/types/form>` type            |
-|             |                                                                        |
-|             | - `attr`_                                                              |
-|             | - `data`_                                                              |
-|             | - `disabled`_                                                          |
-|             | - `empty_data`_                                                        |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
-| Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
-+-------------+------------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CurrencyType` |
-+-------------+------------------------------------------------------------------------+
++---------------------------+------------------------------------------------------------------------+
+| Rendered as               | can be various tags (see :ref:`forms-reference-choice-tags`)           |
++---------------------------+------------------------------------------------------------------------+
+| Options                   | - `choice_translation_locale`_                                         |
++---------------------------+------------------------------------------------------------------------+
+| Overridden options        | - `choices`_                                                           |
+|                           | - `choice_translation_domain`_                                         |
+|                           | - `invalid_message`_                                                   |
++---------------------------+------------------------------------------------------------------------+
+| Inherited options         | from the :doc:`ChoiceType </reference/forms/types/choice>`             |
+|                           |                                                                        |
+|                           | - `error_bubbling`_                                                    |
+|                           | - `expanded`_                                                          |
+|                           | - `multiple`_                                                          |
+|                           | - `placeholder`_                                                       |
+|                           | - `preferred_choices`_                                                 |
+|                           | - `trim`_                                                              |
+|                           |                                                                        |
+|                           | from the :doc:`FormType </reference/forms/types/form>` type            |
+|                           |                                                                        |
+|                           | - `attr`_                                                              |
+|                           | - `data`_                                                              |
+|                           | - `disabled`_                                                          |
+|                           | - `empty_data`_                                                        |
+|                           | - `help`_                                                              |
+|                           | - `help_attr`_                                                         |
+|                           | - `help_html`_                                                         |
+|                           | - `label`_                                                             |
+|                           | - `label_attr`_                                                        |
+|                           | - `label_format`_                                                      |
+|                           | - `mapped`_                                                            |
+|                           | - `required`_                                                          |
+|                           | - `row_attr`_                                                          |
++---------------------------+------------------------------------------------------------------------+
+| Default `invalid_message` | Please select a valid currency.                                        |
++---------------------------+------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                    |
++---------------------------+------------------------------------------------------------------------+
+| Parent type               | :doc:`ChoiceType </reference/forms/types/choice>`                      |
++---------------------------+------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CurrencyType` |
++---------------------------+------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -72,6 +77,8 @@ The choices option defaults to all currencies.
     will also have to set the ``choice_loader`` option to ``null``.
 
 .. include:: /reference/forms/types/options/choice_translation_domain_disabled.rst.inc
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -10,46 +10,50 @@ different HTML elements.
 This field can be rendered in a variety of different ways via the `widget`_ option
 and can understand a number of different input formats via the `input`_ option.
 
-+----------------------+-----------------------------------------------------------------------------+
-| Underlying Data Type | can be ``DateTime``, string, timestamp, or array (see the ``input`` option) |
-+----------------------+-----------------------------------------------------------------------------+
-| Rendered as          | single text box or three select fields                                      |
-+----------------------+-----------------------------------------------------------------------------+
-| Options              | - `days`_                                                                   |
-|                      | - `placeholder`_                                                            |
-|                      | - `format`_                                                                 |
-|                      | - `html5`_                                                                  |
-|                      | - `input`_                                                                  |
-|                      | - `input_format`_                                                           |
-|                      | - `model_timezone`_                                                         |
-|                      | - `months`_                                                                 |
-|                      | - `view_timezone`_                                                          |
-|                      | - `widget`_                                                                 |
-|                      | - `years`_                                                                  |
-+----------------------+-----------------------------------------------------------------------------+
-| Overridden options   | - `by_reference`_                                                           |
-|                      | - `choice_translation_domain`_                                              |
-|                      | - `compound`_                                                               |
-|                      | - `data_class`_                                                             |
-|                      | - `error_bubbling`_                                                         |
-+----------------------+-----------------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                                   |
-| options              | - `data`_                                                                   |
-|                      | - `disabled`_                                                               |
-|                      | - `error_mapping`_                                                          |
-|                      | - `help`_                                                                   |
-|                      | - `help_attr`_                                                              |
-|                      | - `help_html`_                                                              |
-|                      | - `inherit_data`_                                                           |
-|                      | - `invalid_message`_                                                        |
-|                      | - `invalid_message_parameters`_                                             |
-|                      | - `mapped`_                                                                 |
-|                      | - `row_attr`_                                                               |
-+----------------------+-----------------------------------------------------------------------------+
-| Parent type          | :doc:`FormType </reference/forms/types/form>`                               |
-+----------------------+-----------------------------------------------------------------------------+
-| Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\DateType`          |
-+----------------------+-----------------------------------------------------------------------------+
++---------------------------+-----------------------------------------------------------------------------+
+| Underlying Data Type      | can be ``DateTime``, string, timestamp, or array (see the ``input`` option) |
++---------------------------+-----------------------------------------------------------------------------+
+| Rendered as               | single text box or three select fields                                      |
++---------------------------+-----------------------------------------------------------------------------+
+| Options                   | - `days`_                                                                   |
+|                           | - `placeholder`_                                                            |
+|                           | - `format`_                                                                 |
+|                           | - `html5`_                                                                  |
+|                           | - `input`_                                                                  |
+|                           | - `input_format`_                                                           |
+|                           | - `model_timezone`_                                                         |
+|                           | - `months`_                                                                 |
+|                           | - `view_timezone`_                                                          |
+|                           | - `widget`_                                                                 |
+|                           | - `years`_                                                                  |
++---------------------------+-----------------------------------------------------------------------------+
+| Overridden options        | - `by_reference`_                                                           |
+|                           | - `choice_translation_domain`_                                              |
+|                           | - `compound`_                                                               |
+|                           | - `data_class`_                                                             |
+|                           | - `error_bubbling`_                                                         |
+|                           | - `invalid_message`_                                                        |
++---------------------------+-----------------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                                   |
+|                           | - `data`_                                                                   |
+|                           | - `disabled`_                                                               |
+|                           | - `error_mapping`_                                                          |
+|                           | - `help`_                                                                   |
+|                           | - `help_attr`_                                                              |
+|                           | - `help_html`_                                                              |
+|                           | - `inherit_data`_                                                           |
+|                           | - `invalid_message_parameters`_                                             |
+|                           | - `mapped`_                                                                 |
+|                           | - `row_attr`_                                                               |
++---------------------------+-----------------------------------------------------------------------------+
+| Default `invalid_message` | Please enter a valid date.                                                  |
++---------------------------+-----------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                         |
++---------------------------+-----------------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                               |
++---------------------------+-----------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\DateType`          |
++---------------------------+-----------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -210,6 +214,8 @@ The ``DateTime`` classes are treated as immutable objects.
 
 **default**: ``false``
 
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
+
 Inherited Options
 -----------------
 
@@ -230,8 +236,6 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/help_html.rst.inc
 
 .. include:: /reference/forms/types/options/inherit_data.rst.inc
-
-.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 

--- a/reference/forms/types/dateinterval.rst
+++ b/reference/forms/types/dateinterval.rst
@@ -12,47 +12,52 @@ The field can be rendered in a variety of different ways (see `widget`_) and can
 give you a ``DateInterval`` object, an `ISO 8601`_ duration string (e.g. ``P1DT12H``)
 or an array (see `input`_).
 
-+----------------------+----------------------------------------------------------------------------------+
-| Underlying Data Type | can be ``DateInterval``, string or array (see the ``input`` option)              |
-+----------------------+----------------------------------------------------------------------------------+
-| Rendered as          | single text box, multiple text boxes or select fields - see the `widget`_ option |
-+----------------------+----------------------------------------------------------------------------------+
-| Options              | - `days`_                                                                        |
-|                      | - `hours`_                                                                       |
-|                      | - `minutes`_                                                                     |
-|                      | - `months`_                                                                      |
-|                      | - `seconds`_                                                                     |
-|                      | - `weeks`_                                                                       |
-|                      | - `input`_                                                                       |
-|                      | - `labels`_                                                                      |
-|                      | - `placeholder`_                                                                 |
-|                      | - `widget`_                                                                      |
-|                      | - `with_days`_                                                                   |
-|                      | - `with_hours`_                                                                  |
-|                      | - `with_invert`_                                                                 |
-|                      | - `with_minutes`_                                                                |
-|                      | - `with_months`_                                                                 |
-|                      | - `with_seconds`_                                                                |
-|                      | - `with_weeks`_                                                                  |
-|                      | - `with_years`_                                                                  |
-|                      | - `years`_                                                                       |
-+----------------------+----------------------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                                        |
-| options              | - `data`_                                                                        |
-|                      | - `disabled`_                                                                    |
-|                      | - `help`_                                                                        |
-|                      | - `help_attr`_                                                                   |
-|                      | - `help_html`_                                                                   |
-|                      | - `inherit_data`_                                                                |
-|                      | - `invalid_message`_                                                             |
-|                      | - `invalid_message_parameters`_                                                  |
-|                      | - `mapped`_                                                                      |
-|                      | - `row_attr`_                                                                    |
-+----------------------+----------------------------------------------------------------------------------+
-| Parent type          | :doc:`FormType </reference/forms/types/form>`                                    |
-+----------------------+----------------------------------------------------------------------------------+
-| Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\DateIntervalType`       |
-+----------------------+----------------------------------------------------------------------------------+
++---------------------------+----------------------------------------------------------------------------------+
+| Underlying Data Type      | can be ``DateInterval``, string or array (see the ``input`` option)              |
++---------------------------+----------------------------------------------------------------------------------+
+| Rendered as               | single text box, multiple text boxes or select fields - see the `widget`_ option |
++---------------------------+----------------------------------------------------------------------------------+
+| Options                   | - `days`_                                                                        |
+|                           | - `hours`_                                                                       |
+|                           | - `minutes`_                                                                     |
+|                           | - `months`_                                                                      |
+|                           | - `seconds`_                                                                     |
+|                           | - `weeks`_                                                                       |
+|                           | - `input`_                                                                       |
+|                           | - `labels`_                                                                      |
+|                           | - `placeholder`_                                                                 |
+|                           | - `widget`_                                                                      |
+|                           | - `with_days`_                                                                   |
+|                           | - `with_hours`_                                                                  |
+|                           | - `with_invert`_                                                                 |
+|                           | - `with_minutes`_                                                                |
+|                           | - `with_months`_                                                                 |
+|                           | - `with_seconds`_                                                                |
+|                           | - `with_weeks`_                                                                  |
+|                           | - `with_years`_                                                                  |
+|                           | - `years`_                                                                       |
++---------------------------+----------------------------------------------------------------------------------+
+| Overridden options        | - `invalid_message`_                                                             |
++---------------------------+----------------------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                                        |
+|                           | - `data`_                                                                        |
+|                           | - `disabled`_                                                                    |
+|                           | - `help`_                                                                        |
+|                           | - `help_attr`_                                                                   |
+|                           | - `help_html`_                                                                   |
+|                           | - `inherit_data`_                                                                |
+|                           | - `invalid_message_parameters`_                                                  |
+|                           | - `mapped`_                                                                      |
+|                           | - `row_attr`_                                                                    |
++---------------------------+----------------------------------------------------------------------------------+
+| Default `invalid_message` | Please choose a valid date interval.                                             |
++---------------------------+----------------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                              |
++---------------------------+----------------------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                                    |
++---------------------------+----------------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\DateIntervalType`       |
++---------------------------+----------------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -333,6 +338,11 @@ when the ``widget`` option is set to ``choice``::
     // values displayed to users range from 1 to 100 (both inclusive)
     'years' => array_combine(range(1, 100), range(1, 100)),
 
+Overridden Options
+------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
+
 Inherited Options
 -----------------
 
@@ -351,8 +361,6 @@ These options inherit from the :doc:`form </reference/forms/types/form>` type:
 .. include:: /reference/forms/types/options/help_html.rst.inc
 
 .. include:: /reference/forms/types/options/inherit_data.rst.inc
-
-.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -10,55 +10,59 @@ date and time (e.g. ``1984-06-05 12:15:30``).
 Can be rendered as a text input or select tags. The underlying format of
 the data can be a ``DateTime`` object, a string, a timestamp or an array.
 
-+----------------------+-----------------------------------------------------------------------------+
-| Underlying Data Type | can be ``DateTime``, string, timestamp, or array (see the ``input`` option) |
-+----------------------+-----------------------------------------------------------------------------+
-| Rendered as          | single text box or three select fields                                      |
-+----------------------+-----------------------------------------------------------------------------+
-| Options              | - `choice_translation_domain`_                                              |
-|                      | - `date_format`_                                                            |
-|                      | - `date_label`_                                                             |
-|                      | - `date_widget`_                                                            |
-|                      | - `days`_                                                                   |
-|                      | - `placeholder`_                                                            |
-|                      | - `format`_                                                                 |
-|                      | - `hours`_                                                                  |
-|                      | - `html5`_                                                                  |
-|                      | - `input`_                                                                  |
-|                      | - `input_format`_                                                           |
-|                      | - `minutes`_                                                                |
-|                      | - `model_timezone`_                                                         |
-|                      | - `months`_                                                                 |
-|                      | - `seconds`_                                                                |
-|                      | - `time_label`_                                                             |
-|                      | - `time_widget`_                                                            |
-|                      | - `view_timezone`_                                                          |
-|                      | - `widget`_                                                                 |
-|                      | - `with_minutes`_                                                           |
-|                      | - `with_seconds`_                                                           |
-|                      | - `years`_                                                                  |
-+----------------------+-----------------------------------------------------------------------------+
-| Overridden options   | - `by_reference`_                                                           |
-|                      | - `compound`_                                                               |
-|                      | - `data_class`_                                                             |
-|                      | - `error_bubbling`_                                                         |
-+----------------------+-----------------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                                   |
-| options              | - `data`_                                                                   |
-|                      | - `disabled`_                                                               |
-|                      | - `help`_                                                                   |
-|                      | - `help_attr`_                                                              |
-|                      | - `help_html`_                                                              |
-|                      | - `inherit_data`_                                                           |
-|                      | - `invalid_message`_                                                        |
-|                      | - `invalid_message_parameters`_                                             |
-|                      | - `mapped`_                                                                 |
-|                      | - `row_attr`_                                                               |
-+----------------------+-----------------------------------------------------------------------------+
-| Parent type          | :doc:`FormType </reference/forms/types/form>`                               |
-+----------------------+-----------------------------------------------------------------------------+
-| Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\DateTimeType`      |
-+----------------------+-----------------------------------------------------------------------------+
++---------------------------+-----------------------------------------------------------------------------+
+| Underlying Data Type      | can be ``DateTime``, string, timestamp, or array (see the ``input`` option) |
++---------------------------+-----------------------------------------------------------------------------+
+| Rendered as               | single text box or three select fields                                      |
++---------------------------+-----------------------------------------------------------------------------+
+| Options                   | - `choice_translation_domain`_                                              |
+|                           | - `date_format`_                                                            |
+|                           | - `date_label`_                                                             |
+|                           | - `date_widget`_                                                            |
+|                           | - `days`_                                                                   |
+|                           | - `placeholder`_                                                            |
+|                           | - `format`_                                                                 |
+|                           | - `hours`_                                                                  |
+|                           | - `html5`_                                                                  |
+|                           | - `input`_                                                                  |
+|                           | - `input_format`_                                                           |
+|                           | - `minutes`_                                                                |
+|                           | - `model_timezone`_                                                         |
+|                           | - `months`_                                                                 |
+|                           | - `seconds`_                                                                |
+|                           | - `time_label`_                                                             |
+|                           | - `time_widget`_                                                            |
+|                           | - `view_timezone`_                                                          |
+|                           | - `widget`_                                                                 |
+|                           | - `with_minutes`_                                                           |
+|                           | - `with_seconds`_                                                           |
+|                           | - `years`_                                                                  |
++---------------------------+-----------------------------------------------------------------------------+
+| Overridden options        | - `by_reference`_                                                           |
+|                           | - `compound`_                                                               |
+|                           | - `data_class`_                                                             |
+|                           | - `error_bubbling`_                                                         |
+|                           | - `invalid_message`_                                                        |
++---------------------------+-----------------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                                   |
+|                           | - `data`_                                                                   |
+|                           | - `disabled`_                                                               |
+|                           | - `help`_                                                                   |
+|                           | - `help_attr`_                                                              |
+|                           | - `help_html`_                                                              |
+|                           | - `inherit_data`_                                                           |
+|                           | - `invalid_message_parameters`_                                             |
+|                           | - `mapped`_                                                                 |
+|                           | - `row_attr`_                                                               |
++---------------------------+-----------------------------------------------------------------------------+
+| Default `invalid_message` | Please enter a valid date and time.                                         |
++---------------------------+-----------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                         |
++---------------------------+-----------------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                               |
++---------------------------+-----------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\DateTimeType`      |
++---------------------------+-----------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -231,6 +235,8 @@ error_bubbling
 
 **default**: ``false``
 
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
+
 Inherited Options
 -----------------
 
@@ -249,8 +255,6 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/help_html.rst.inc
 
 .. include:: /reference/forms/types/options/inherit_data.rst.inc
-
-.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 

--- a/reference/forms/types/email.rst
+++ b/reference/forms/types/email.rst
@@ -7,32 +7,43 @@ EmailType Field
 The ``EmailType`` field is a text field that is rendered using the HTML5
 ``<input type="email"/>`` tag.
 
-+-------------+---------------------------------------------------------------------+
-| Rendered as | ``input`` ``email`` field (a text box)                              |
-+-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-|             | - `trim`_                                                           |
-+-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`TextType </reference/forms/types/text>`                       |
-+-------------+---------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\EmailType` |
-+-------------+---------------------------------------------------------------------+
++---------------------------+---------------------------------------------------------------------+
+| Rendered as               | ``input`` ``email`` field (a text box)                              |
++---------------------------+---------------------------------------------------------------------+
+| Overridden options        | - `invalid_message`_                                                |
++---------------------------+---------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                           |
+|                           | - `data`_                                                           |
+|                           | - `disabled`_                                                       |
+|                           | - `empty_data`_                                                     |
+|                           | - `error_bubbling`_                                                 |
+|                           | - `error_mapping`_                                                  |
+|                           | - `help`_                                                           |
+|                           | - `help_attr`_                                                      |
+|                           | - `help_html`_                                                      |
+|                           | - `label`_                                                          |
+|                           | - `label_attr`_                                                     |
+|                           | - `label_format`_                                                   |
+|                           | - `mapped`_                                                         |
+|                           | - `required`_                                                       |
+|                           | - `row_attr`_                                                       |
+|                           | - `trim`_                                                           |
++---------------------------+---------------------------------------------------------------------+
+| Default `invalid_message` | Please enter a valid email address.                                 |
++---------------------------+---------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                 |
++---------------------------+---------------------------------------------------------------------+
+| Parent type               | :doc:`TextType </reference/forms/types/text>`                       |
++---------------------------+---------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\EmailType` |
++---------------------------+---------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
+
+Overridden Options
+------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -6,33 +6,38 @@ FileType Field
 
 The ``FileType`` represents a file input in your form.
 
-+-------------+---------------------------------------------------------------------+
-| Rendered as | ``input`` ``file`` field                                            |
-+-------------+---------------------------------------------------------------------+
-| Options     | - `multiple`_                                                       |
-+-------------+---------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                       |
-| options     | - `data_class`_                                                     |
-|             | - `empty_data`_                                                     |
-+-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `disabled`_                                                       |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-+-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`FormType </reference/forms/types/form>`                       |
-+-------------+---------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\FileType`  |
-+-------------+---------------------------------------------------------------------+
++---------------------------+--------------------------------------------------------------------+
+| Rendered as               | ``input`` ``file`` field                                           |
++---------------------------+--------------------------------------------------------------------+
+| Options                   | - `multiple`_                                                      |
++---------------------------+--------------------------------------------------------------------+
+| Overridden options        | - `compound`_                                                      |
+|                           | - `data_class`_                                                    |
+|                           | - `empty_data`_                                                    |
+|                           | - `invalid_message`_                                               |
++---------------------------+--------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                          |
+|                           | - `disabled`_                                                      |
+|                           | - `error_bubbling`_                                                |
+|                           | - `error_mapping`_                                                 |
+|                           | - `help`_                                                          |
+|                           | - `help_attr`_                                                     |
+|                           | - `help_html`_                                                     |
+|                           | - `label`_                                                         |
+|                           | - `label_attr`_                                                    |
+|                           | - `label_format`_                                                  |
+|                           | - `mapped`_                                                        |
+|                           | - `required`_                                                      |
+|                           | - `row_attr`_                                                      |
++---------------------------+--------------------------------------------------------------------+
+| Default `invalid_message` | Please select a valid file.                                        |
++---------------------------+--------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                |
++---------------------------+--------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                      |
++---------------------------+--------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\FileType` |
++---------------------------+--------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -119,6 +124,11 @@ This option sets the appropriate file-related data mapper to be used by the type
 
 This option determines what value the field will return when the submitted
 value is empty.
+
+Overridden Options
+------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -7,51 +7,55 @@ FormType Field
 The ``FormType`` predefines a couple of options that are then available
 on all types for which ``FormType`` is the parent.
 
-+-----------+--------------------------------------------------------------------+
-| Options   | - `action`_                                                        |
-|           | - `allow_extra_fields`_                                            |
-|           | - `by_reference`_                                                  |
-|           | - `compound`_                                                      |
-|           | - `constraints`_                                                   |
-|           | - `data`_                                                          |
-|           | - `data_class`_                                                    |
-|           | - `empty_data`_                                                    |
-|           | - `error_bubbling`_                                                |
-|           | - `error_mapping`_                                                 |
-|           | - `extra_fields_message`_                                          |
-|           | - `help`_                                                          |
-|           | - `help_attr`_                                                     |
-|           | - `help_html`_                                                     |
-|           | - `help_translation_parameters`_                                   |
-|           | - `inherit_data`_                                                  |
-|           | - `invalid_message`_                                               |
-|           | - `invalid_message_parameters`_                                    |
-|           | - `label_attr`_                                                    |
-|           | - `label_format`_                                                  |
-|           | - `mapped`_                                                        |
-|           | - `method`_                                                        |
-|           | - `post_max_size_message`_                                         |
-|           | - `property_path`_                                                 |
-|           | - `required`_                                                      |
-|           | - `trim`_                                                          |
-|           | - `validation_groups`_                                             |
-+-----------+--------------------------------------------------------------------+
-| Inherited | - `attr`_                                                          |
-| options   | - `auto_initialize`_                                               |
-|           | - `block_name`_                                                    |
-|           | - `block_prefix`_                                                  |
-|           | - `disabled`_                                                      |
-|           | - `label`_                                                         |
-|           | - `label_html`_                                                    |
-|           | - `row_attr`_                                                      |
-|           | - `translation_domain`_                                            |
-|           | - `label_translation_parameters`_                                  |
-|           | - `attr_translation_parameters`_                                   |
-+-----------+--------------------------------------------------------------------+
-| Parent    | none                                                               |
-+-----------+--------------------------------------------------------------------+
-| Class     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType` |
-+-----------+--------------------------------------------------------------------+
++---------------------------+--------------------------------------------------------------------+
+| Options                   | - `action`_                                                        |
+|                           | - `allow_extra_fields`_                                            |
+|                           | - `by_reference`_                                                  |
+|                           | - `compound`_                                                      |
+|                           | - `constraints`_                                                   |
+|                           | - `data`_                                                          |
+|                           | - `data_class`_                                                    |
+|                           | - `empty_data`_                                                    |
+|                           | - `error_bubbling`_                                                |
+|                           | - `error_mapping`_                                                 |
+|                           | - `extra_fields_message`_                                          |
+|                           | - `help`_                                                          |
+|                           | - `help_attr`_                                                     |
+|                           | - `help_html`_                                                     |
+|                           | - `help_translation_parameters`_                                   |
+|                           | - `inherit_data`_                                                  |
+|                           | - `invalid_message`_                                               |
+|                           | - `invalid_message_parameters`_                                    |
+|                           | - `label_attr`_                                                    |
+|                           | - `label_format`_                                                  |
+|                           | - `mapped`_                                                        |
+|                           | - `method`_                                                        |
+|                           | - `post_max_size_message`_                                         |
+|                           | - `property_path`_                                                 |
+|                           | - `required`_                                                      |
+|                           | - `trim`_                                                          |
+|                           | - `validation_groups`_                                             |
++---------------------------+--------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                          |
+|                           | - `auto_initialize`_                                               |
+|                           | - `block_name`_                                                    |
+|                           | - `block_prefix`_                                                  |
+|                           | - `disabled`_                                                      |
+|                           | - `label`_                                                         |
+|                           | - `label_html`_                                                    |
+|                           | - `row_attr`_                                                      |
+|                           | - `translation_domain`_                                            |
+|                           | - `label_translation_parameters`_                                  |
+|                           | - `attr_translation_parameters`_                                   |
++---------------------------+--------------------------------------------------------------------+
+| Default `invalid_message` | This value is not valid.                                           |
++---------------------------+--------------------------------------------------------------------+
+| Legacy `invalid_message`  | This value is not valid.                                           |
++---------------------------+--------------------------------------------------------------------+
+| Parent                    | none                                                               |
++---------------------------+--------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType` |
++---------------------------+--------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 

--- a/reference/forms/types/hidden.rst
+++ b/reference/forms/types/hidden.rst
@@ -6,25 +6,30 @@ HiddenType Field
 
 The hidden type represents a hidden input field.
 
-+-------------+----------------------------------------------------------------------+
-| Rendered as | ``input`` ``hidden`` field                                           |
-+-------------+----------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                        |
-| options     | - `error_bubbling`_                                                  |
-|             | - `required`_                                                        |
-+-------------+----------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                            |
-| options     | - `data`_                                                            |
-|             | - `empty_data`_                                                      |
-|             | - `error_mapping`_                                                   |
-|             | - `mapped`_                                                          |
-|             | - `property_path`_                                                   |
-|             | - `row_attr`_                                                        |
-+-------------+----------------------------------------------------------------------+
-| Parent type | :doc:`FormType </reference/forms/types/form>`                        |
-+-------------+----------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\HiddenType` |
-+-------------+----------------------------------------------------------------------+
++---------------------------+----------------------------------------------------------------------+
+| Rendered as               | ``input`` ``hidden`` field                                           |
++---------------------------+----------------------------------------------------------------------+
+| Overridden options        | - `compound`_                                                        |
+|                           | - `error_bubbling`_                                                  |
+|                           | - `invalid_message`_                                                 |
+|                           | - `required`_                                                        |
++---------------------------+----------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                            |
+|                           | - `data`_                                                            |
+|                           | - `empty_data`_                                                      |
+|                           | - `error_mapping`_                                                   |
+|                           | - `mapped`_                                                          |
+|                           | - `property_path`_                                                   |
+|                           | - `row_attr`_                                                        |
++---------------------------+----------------------------------------------------------------------+
+| Default `invalid_message` | The hidden field is invalid.                                         |
++---------------------------+----------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                  |
++---------------------------+----------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                        |
++---------------------------+----------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\HiddenType` |
++---------------------------+----------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -39,6 +44,8 @@ Overridden Options
 **default**: ``true``
 
 Pass errors to the root form, otherwise they will not be visible.
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 ``required``
 ~~~~~~~~~~~~

--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -13,37 +13,40 @@ This field has different options on how to handle input values that aren't
 integers. By default, all non-integer values (e.g. 6.78) will round down
 (e.g. 6).
 
-+-------------+-----------------------------------------------------------------------+
-| Rendered as | ``input`` ``number`` field                                            |
-+-------------+-----------------------------------------------------------------------+
-| Options     | - `grouping`_                                                         |
-|             | - `rounding_mode`_                                                    |
-+-------------+-----------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                         |
-| options     |                                                                       |
-+-------------+-----------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                             |
-| options     | - `data`_                                                             |
-|             | - `disabled`_                                                         |
-|             | - `empty_data`_                                                       |
-|             | - `error_bubbling`_                                                   |
-|             | - `error_mapping`_                                                    |
-|             | - `help`_                                                             |
-|             | - `help_attr`_                                                        |
-|             | - `help_html`_                                                        |
-|             | - `invalid_message`_                                                  |
-|             | - `invalid_message_parameters`_                                       |
-|             | - `label`_                                                            |
-|             | - `label_attr`_                                                       |
-|             | - `label_format`_                                                     |
-|             | - `mapped`_                                                           |
-|             | - `required`_                                                         |
-|             | - `row_attr`_                                                         |
-+-------------+-----------------------------------------------------------------------+
-| Parent type | :doc:`FormType </reference/forms/types/form>`                         |
-+-------------+-----------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\IntegerType` |
-+-------------+-----------------------------------------------------------------------+
++---------------------------+-----------------------------------------------------------------------+
+| Rendered as               | ``input`` ``number`` field                                            |
++---------------------------+-----------------------------------------------------------------------+
+| Options                   | - `grouping`_                                                         |
+|                           | - `rounding_mode`_                                                    |
++---------------------------+-----------------------------------------------------------------------+
+| Overridden options        | - `compound`_                                                         |
+|                           | - `invalid_message`_                                                  |
++---------------------------+-----------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                             |
+|                           | - `data`_                                                             |
+|                           | - `disabled`_                                                         |
+|                           | - `empty_data`_                                                       |
+|                           | - `error_bubbling`_                                                   |
+|                           | - `error_mapping`_                                                    |
+|                           | - `help`_                                                             |
+|                           | - `help_attr`_                                                        |
+|                           | - `help_html`_                                                        |
+|                           | - `invalid_message_parameters`_                                       |
+|                           | - `label`_                                                            |
+|                           | - `label_attr`_                                                       |
+|                           | - `label_format`_                                                     |
+|                           | - `mapped`_                                                           |
+|                           | - `required`_                                                         |
+|                           | - `row_attr`_                                                         |
++---------------------------+-----------------------------------------------------------------------+
+| Default `invalid_message` | Please enter an integer.                                              |
++---------------------------+-----------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                   |
++---------------------------+-----------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                         |
++---------------------------+-----------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\IntegerType` |
++---------------------------+-----------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -86,6 +89,8 @@ Overridden Options
 
 .. include:: /reference/forms/types/options/compound_type.rst.inc
 
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
+
 Inherited Options
 -----------------
 
@@ -114,8 +119,6 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/help_attr.rst.inc
 
 .. include:: /reference/forms/types/options/help_html.rst.inc
-
-.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -20,46 +20,51 @@ Unlike the ``ChoiceType``, you don't need to specify a ``choices`` option as the
 field type automatically uses a large list of languages. You *can* specify the option
 manually, but then you should just use the ``ChoiceType`` directly.
 
-+-------------+------------------------------------------------------------------------+
-| Rendered as | can be various tags (see :ref:`forms-reference-choice-tags`)           |
-+-------------+------------------------------------------------------------------------+
-| Options     | - `alpha3`_                                                            |
-|             | - `choice_self_translation`_                                           |
-|             | - `choice_translation_locale`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `choices`_                                                           |
-| options     | - `choice_translation_domain`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | from the :doc:`ChoiceType </reference/forms/types/choice>`             |
-| options     |                                                                        |
-|             | - `error_bubbling`_                                                    |
-|             | - `error_mapping`_                                                     |
-|             | - `expanded`_                                                          |
-|             | - `multiple`_                                                          |
-|             | - `placeholder`_                                                       |
-|             | - `preferred_choices`_                                                 |
-|             | - `trim`_                                                              |
-|             |                                                                        |
-|             | from the :doc:`FormType </reference/forms/types/form>`                 |
-|             |                                                                        |
-|             | - `attr`_                                                              |
-|             | - `data`_                                                              |
-|             | - `disabled`_                                                          |
-|             | - `empty_data`_                                                        |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
-| Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
-+-------------+------------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\LanguageType` |
-+-------------+------------------------------------------------------------------------+
++---------------------------+------------------------------------------------------------------------+
+| Rendered as               | can be various tags (see :ref:`forms-reference-choice-tags`)           |
++---------------------------+------------------------------------------------------------------------+
+| Options                   | - `alpha3`_                                                            |
+|                           | - `choice_self_translation`_                                           |
+|                           | - `choice_translation_locale`_                                         |
++---------------------------+------------------------------------------------------------------------+
+| Overridden options        | - `choices`_                                                           |
+|                           | - `choice_translation_domain`_                                         |
+|                           | - `invalid_message`_                                                   |
++---------------------------+------------------------------------------------------------------------+
+| Inherited options         | from the :doc:`ChoiceType </reference/forms/types/choice>`             |
+|                           |                                                                        |
+|                           | - `error_bubbling`_                                                    |
+|                           | - `error_mapping`_                                                     |
+|                           | - `expanded`_                                                          |
+|                           | - `multiple`_                                                          |
+|                           | - `placeholder`_                                                       |
+|                           | - `preferred_choices`_                                                 |
+|                           | - `trim`_                                                              |
+|                           |                                                                        |
+|                           | from the :doc:`FormType </reference/forms/types/form>`                 |
+|                           |                                                                        |
+|                           | - `attr`_                                                              |
+|                           | - `data`_                                                              |
+|                           | - `disabled`_                                                          |
+|                           | - `empty_data`_                                                        |
+|                           | - `help`_                                                              |
+|                           | - `help_attr`_                                                         |
+|                           | - `help_html`_                                                         |
+|                           | - `label`_                                                             |
+|                           | - `label_attr`_                                                        |
+|                           | - `label_format`_                                                      |
+|                           | - `mapped`_                                                            |
+|                           | - `required`_                                                          |
+|                           | - `row_attr`_                                                          |
++---------------------------+------------------------------------------------------------------------+
+| Default `invalid_message` | Please select a valid language.                                        |
++---------------------------+------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                    |
++---------------------------+------------------------------------------------------------------------+
+| Parent type               | :doc:`ChoiceType </reference/forms/types/choice>`                      |
++---------------------------+------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\LanguageType` |
++---------------------------+------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -113,6 +118,8 @@ The default locale is used to translate the languages names.
     will also have to set the ``choice_loader`` option to ``null``.
 
 .. include:: /reference/forms/types/options/choice_translation_domain_disabled.rst.inc
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -21,44 +21,49 @@ Unlike the ``ChoiceType``, you don't need to specify a ``choices`` option as the
 field type automatically uses a large list of locales. You *can* specify these options
 manually, but then you should just use the ``ChoiceType`` directly.
 
-+-------------+------------------------------------------------------------------------+
-| Rendered as | can be various tags (see :ref:`forms-reference-choice-tags`)           |
-+-------------+------------------------------------------------------------------------+
-| Options     | - `choice_translation_locale`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `choices`_                                                           |
-| options     | - `choice_translation_domain`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | from the :doc:`ChoiceType </reference/forms/types/choice>`             |
-| options     |                                                                        |
-|             | - `error_bubbling`_                                                    |
-|             | - `error_mapping`_                                                     |
-|             | - `expanded`_                                                          |
-|             | - `multiple`_                                                          |
-|             | - `placeholder`_                                                       |
-|             | - `preferred_choices`_                                                 |
-|             | - `trim`_                                                              |
-|             |                                                                        |
-|             | from the :doc:`FormType </reference/forms/types/form>`                 |
-|             |                                                                        |
-|             | - `attr`_                                                              |
-|             | - `data`_                                                              |
-|             | - `disabled`_                                                          |
-|             | - `empty_data`_                                                        |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
-| Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
-+-------------+------------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\LocaleType`   |
-+-------------+------------------------------------------------------------------------+
++---------------------------+----------------------------------------------------------------------+
+| Rendered as               | can be various tags (see :ref:`forms-reference-choice-tags`)         |
++---------------------------+----------------------------------------------------------------------+
+| Options                   | - `choice_translation_locale`_                                       |
++---------------------------+----------------------------------------------------------------------+
+| Overridden options        | - `choices`_                                                         |
+|                           | - `choice_translation_domain`_                                       |
+|                           | - `invalid_message`_                                                 |
++---------------------------+----------------------------------------------------------------------+
+| Inherited options         | from the :doc:`ChoiceType </reference/forms/types/choice>`           |
+|                           |                                                                      |
+|                           | - `error_bubbling`_                                                  |
+|                           | - `error_mapping`_                                                   |
+|                           | - `expanded`_                                                        |
+|                           | - `multiple`_                                                        |
+|                           | - `placeholder`_                                                     |
+|                           | - `preferred_choices`_                                               |
+|                           | - `trim`_                                                            |
+|                           |                                                                      |
+|                           | from the :doc:`FormType </reference/forms/types/form>`               |
+|                           |                                                                      |
+|                           | - `attr`_                                                            |
+|                           | - `data`_                                                            |
+|                           | - `disabled`_                                                        |
+|                           | - `empty_data`_                                                      |
+|                           | - `help`_                                                            |
+|                           | - `help_attr`_                                                       |
+|                           | - `help_html`_                                                       |
+|                           | - `label`_                                                           |
+|                           | - `label_attr`_                                                      |
+|                           | - `label_format`_                                                    |
+|                           | - `mapped`_                                                          |
+|                           | - `required`_                                                        |
+|                           | - `row_attr`_                                                        |
++---------------------------+----------------------------------------------------------------------+
+| Default `invalid_message` | Please select a valid locale.                                        |
++---------------------------+----------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                  |
++---------------------------+----------------------------------------------------------------------+
+| Parent type               | :doc:`ChoiceType </reference/forms/types/choice>`                    |
++---------------------------+----------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\LocaleType` |
++---------------------------+----------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -84,6 +89,8 @@ specify the language.
     will also have to set the ``choice_loader`` option to ``null``.
 
 .. include:: /reference/forms/types/options/choice_translation_domain_disabled.rst.inc
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -11,41 +11,44 @@ This field type allows you to specify a currency, whose symbol is rendered
 next to the text field. There are also several other options for customizing
 how the input and output of the data is handled.
 
-+-------------+---------------------------------------------------------------------+
-| Rendered as | ``input`` ``text`` field                                            |
-+-------------+---------------------------------------------------------------------+
-| Options     | - `currency`_                                                       |
-|             | - `divisor`_                                                        |
-|             | - `grouping`_                                                       |
-|             | - `html5`_                                                          |
-|             | - `rounding_mode`_                                                  |
-|             | - `scale`_                                                          |
-+-------------+---------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                       |
-| options     |                                                                     |
-+-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `invalid_message`_                                                |
-|             | - `invalid_message_parameters`_                                     |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-+-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`FormType </reference/forms/types/form>`                       |
-+-------------+---------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\MoneyType` |
-+-------------+---------------------------------------------------------------------+
++---------------------------+---------------------------------------------------------------------+
+| Rendered as               | ``input`` ``text`` field                                            |
++---------------------------+---------------------------------------------------------------------+
+| Options                   | - `currency`_                                                       |
+|                           | - `divisor`_                                                        |
+|                           | - `grouping`_                                                       |
+|                           | - `html5`_                                                          |
+|                           | - `rounding_mode`_                                                  |
+|                           | - `scale`_                                                          |
++---------------------------+---------------------------------------------------------------------+
+| Overridden options        | - `compound`_                                                       |
+|                           | - `invalid_message`_                                                |
++---------------------------+---------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                           |
+|                           | - `data`_                                                           |
+|                           | - `disabled`_                                                       |
+|                           | - `empty_data`_                                                     |
+|                           | - `error_bubbling`_                                                 |
+|                           | - `error_mapping`_                                                  |
+|                           | - `help`_                                                           |
+|                           | - `help_attr`_                                                      |
+|                           | - `help_html`_                                                      |
+|                           | - `invalid_message_parameters`_                                     |
+|                           | - `label`_                                                          |
+|                           | - `label_attr`_                                                     |
+|                           | - `label_format`_                                                   |
+|                           | - `mapped`_                                                         |
+|                           | - `required`_                                                       |
+|                           | - `row_attr`_                                                       |
++---------------------------+---------------------------------------------------------------------+
+| Default `invalid_message` | Please enter a valid money amount.                                  |
++---------------------------+---------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                 |
++---------------------------+---------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                       |
++---------------------------+---------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\MoneyType` |
++---------------------------+---------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -122,6 +125,8 @@ Overridden Options
 
 .. include:: /reference/forms/types/options/compound_type.rst.inc
 
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
+
 Inherited Options
 -----------------
 
@@ -150,8 +155,6 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/help_attr.rst.inc
 
 .. include:: /reference/forms/types/options/help_html.rst.inc
-
-.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 

--- a/reference/forms/types/number.rst
+++ b/reference/forms/types/number.rst
@@ -8,40 +8,43 @@ Renders an input text field and specializes in handling number input. This
 type offers different options for the scale, rounding and grouping
 that you want to use for your number.
 
-+-------------+----------------------------------------------------------------------+
-| Rendered as | ``input`` ``text`` field                                             |
-+-------------+----------------------------------------------------------------------+
-| Options     | - `grouping`_                                                        |
-|             | - `html5`_                                                           |
-|             | - `input`_                                                           |
-|             | - `scale`_                                                           |
-|             | - `rounding_mode`_                                                   |
-+-------------+----------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                        |
-| options     |                                                                      |
-+-------------+----------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                            |
-| options     | - `data`_                                                            |
-|             | - `disabled`_                                                        |
-|             | - `empty_data`_                                                      |
-|             | - `error_bubbling`_                                                  |
-|             | - `error_mapping`_                                                   |
-|             | - `help`_                                                            |
-|             | - `help_attr`_                                                       |
-|             | - `help_html`_                                                       |
-|             | - `invalid_message`_                                                 |
-|             | - `invalid_message_parameters`_                                      |
-|             | - `label`_                                                           |
-|             | - `label_attr`_                                                      |
-|             | - `label_format`_                                                    |
-|             | - `mapped`_                                                          |
-|             | - `required`_                                                        |
-|             | - `row_attr`_                                                        |
-+-------------+----------------------------------------------------------------------+
-| Parent type | :doc:`FormType </reference/forms/types/form>`                        |
-+-------------+----------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\NumberType` |
-+-------------+----------------------------------------------------------------------+
++---------------------------+----------------------------------------------------------------------+
+| Rendered as               | ``input`` ``text`` field                                             |
++---------------------------+----------------------------------------------------------------------+
+| Options                   | - `grouping`_                                                        |
+|                           | - `html5`_                                                           |
+|                           | - `input`_                                                           |
+|                           | - `scale`_                                                           |
+|                           | - `rounding_mode`_                                                   |
++---------------------------+----------------------------------------------------------------------+
+| Overridden options        | - `compound`_                                                        |
+|                           | - `invalid_message`_                                                 |
++---------------------------+----------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                            |
+|                           | - `data`_                                                            |
+|                           | - `disabled`_                                                        |
+|                           | - `empty_data`_                                                      |
+|                           | - `error_bubbling`_                                                  |
+|                           | - `error_mapping`_                                                   |
+|                           | - `help`_                                                            |
+|                           | - `help_attr`_                                                       |
+|                           | - `help_html`_                                                       |
+|                           | - `invalid_message_parameters`_                                      |
+|                           | - `label`_                                                           |
+|                           | - `label_attr`_                                                      |
+|                           | - `label_format`_                                                    |
+|                           | - `mapped`_                                                          |
+|                           | - `required`_                                                        |
+|                           | - `row_attr`_                                                        |
++---------------------------+----------------------------------------------------------------------+
+| Default `invalid_message` | Please enter a number.                                               |
++---------------------------+----------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                  |
++---------------------------+----------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                        |
++---------------------------+----------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\NumberType` |
++---------------------------+----------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -86,6 +89,8 @@ Overridden Options
 
 .. include:: /reference/forms/types/options/compound_type.rst.inc
 
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
+
 Inherited Options
 -----------------
 
@@ -114,8 +119,6 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/help_attr.rst.inc
 
 .. include:: /reference/forms/types/options/help_html.rst.inc
-
-.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -6,33 +6,37 @@ PasswordType Field
 
 The ``PasswordType`` field renders an input password text box.
 
-+-------------+------------------------------------------------------------------------+
-| Rendered as | ``input`` ``password`` field                                           |
-+-------------+------------------------------------------------------------------------+
-| Options     | - `always_empty`_                                                      |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `trim`_                                                              |
-| options     |                                                                        |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                              |
-| options     | - `disabled`_                                                          |
-|             | - `empty_data`_                                                        |
-|             | - `error_bubbling`_                                                    |
-|             | - `error_mapping`_                                                     |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
-| Parent type | :doc:`TextType </reference/forms/types/text>`                          |
-+-------------+------------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\PasswordType` |
-+-------------+------------------------------------------------------------------------+
++---------------------------+------------------------------------------------------------------------+
+| Rendered as               | ``input`` ``password`` field                                           |
++---------------------------+------------------------------------------------------------------------+
+| Options                   | - `always_empty`_                                                      |
++---------------------------+------------------------------------------------------------------------+
+| Overridden options        | - `invalid_message`_                                                   |
+|                           | - `trim`_                                                              |
++---------------------------+------------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                              |
+|                           | - `disabled`_                                                          |
+|                           | - `empty_data`_                                                        |
+|                           | - `error_bubbling`_                                                    |
+|                           | - `error_mapping`_                                                     |
+|                           | - `help`_                                                              |
+|                           | - `help_attr`_                                                         |
+|                           | - `help_html`_                                                         |
+|                           | - `label`_                                                             |
+|                           | - `label_attr`_                                                        |
+|                           | - `label_format`_                                                      |
+|                           | - `mapped`_                                                            |
+|                           | - `required`_                                                          |
+|                           | - `row_attr`_                                                          |
++---------------------------+------------------------------------------------------------------------+
+| Default `invalid_message` | The password is invalid.                                               |
++---------------------------+------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                    |
++---------------------------+------------------------------------------------------------------------+
+| Parent type               | :doc:`TextType </reference/forms/types/text>`                          |
++---------------------------+------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\PasswordType` |
++---------------------------+------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -53,6 +57,8 @@ entered into the box, set this to false and submit the form.
 
 Overridden Options
 ------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 ``trim``
 ~~~~~~~~

--- a/reference/forms/types/percent.rst
+++ b/reference/forms/types/percent.rst
@@ -12,40 +12,43 @@ you can use this field out-of-the-box. If you store your data as a number
 When ``symbol`` is not ``false``, the field will render the given string after
 the input.
 
-+-------------+-----------------------------------------------------------------------+
-| Rendered as | ``input`` ``text`` field                                              |
-+-------------+-----------------------------------------------------------------------+
-| Options     | - `html5`_                                                            |
-|             | - `rounding_mode`_                                                    |
-|             | - `scale`_                                                            |
-|             | - `symbol`_                                                           |
-|             | - `type`_                                                             |
-+-------------+-----------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                         |
-| options     |                                                                       |
-+-------------+-----------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                             |
-| options     | - `data`_                                                             |
-|             | - `disabled`_                                                         |
-|             | - `empty_data`_                                                       |
-|             | - `error_bubbling`_                                                   |
-|             | - `error_mapping`_                                                    |
-|             | - `help`_                                                             |
-|             | - `help_attr`_                                                        |
-|             | - `help_html`_                                                        |
-|             | - `invalid_message`_                                                  |
-|             | - `invalid_message_parameters`_                                       |
-|             | - `label`_                                                            |
-|             | - `label_attr`_                                                       |
-|             | - `label_format`_                                                     |
-|             | - `mapped`_                                                           |
-|             | - `required`_                                                         |
-|             | - `row_attr`_                                                         |
-+-------------+-----------------------------------------------------------------------+
-| Parent type | :doc:`FormType </reference/forms/types/form>`                         |
-+-------------+-----------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\PercentType` |
-+-------------+-----------------------------------------------------------------------+
++---------------------------+-----------------------------------------------------------------------+
+| Rendered as               | ``input`` ``text`` field                                              |
++---------------------------+-----------------------------------------------------------------------+
+| Options                   | - `html5`_                                                            |
+|                           | - `rounding_mode`_                                                    |
+|                           | - `scale`_                                                            |
+|                           | - `symbol`_                                                           |
+|                           | - `type`_                                                             |
++---------------------------+-----------------------------------------------------------------------+
+| Overridden options        | - `compound`_                                                         |
+|                           | - `invalid_message`_                                                  |
++---------------------------+-----------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                             |
+|                           | - `data`_                                                             |
+|                           | - `disabled`_                                                         |
+|                           | - `empty_data`_                                                       |
+|                           | - `error_bubbling`_                                                   |
+|                           | - `error_mapping`_                                                    |
+|                           | - `help`_                                                             |
+|                           | - `help_attr`_                                                        |
+|                           | - `help_html`_                                                        |
+|                           | - `invalid_message_parameters`_                                       |
+|                           | - `label`_                                                            |
+|                           | - `label_attr`_                                                       |
+|                           | - `label_format`_                                                     |
+|                           | - `mapped`_                                                           |
+|                           | - `required`_                                                         |
+|                           | - `row_attr`_                                                         |
++---------------------------+-----------------------------------------------------------------------+
+| Default `invalid_message` | Please enter a percentage value.                                      |
++---------------------------+-----------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                   |
++---------------------------+-----------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                         |
++---------------------------+-----------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\PercentType` |
++---------------------------+-----------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -115,6 +118,8 @@ Overridden Options
 
 .. include:: /reference/forms/types/options/compound_type.rst.inc
 
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
+
 Inherited Options
 -----------------
 
@@ -143,8 +148,6 @@ The default value is ``''`` (the empty string).
 .. include:: /reference/forms/types/options/help_attr.rst.inc
 
 .. include:: /reference/forms/types/options/help_html.rst.inc
-
-.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -13,37 +13,48 @@ The ``RadioType`` isn't usually used directly. More commonly it's used
 internally by other types such as :doc:`ChoiceType </reference/forms/types/choice>`.
 If you want to have a boolean field, use :doc:`CheckboxType </reference/forms/types/checkbox>`.
 
-+-------------+---------------------------------------------------------------------+
-| Rendered as | ``input`` ``radio`` field                                           |
-+-------------+---------------------------------------------------------------------+
-| Inherited   | from the :doc:`CheckboxType </reference/forms/types/checkbox>`:     |
-| options     |                                                                     |
-|             | - `value`_                                                          |
-|             |                                                                     |
-|             | from the :doc:`FormType </reference/forms/types/form>`:             |
-|             |                                                                     |
-|             | - `attr`_                                                           |
-|             | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-+-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`CheckboxType </reference/forms/types/checkbox>`               |
-+-------------+---------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType` |
-+-------------+---------------------------------------------------------------------+
++---------------------------+---------------------------------------------------------------------+
+| Rendered as               | ``input`` ``radio`` field                                           |
++---------------------------+---------------------------------------------------------------------+
+| Overridden options        | - `invalid_message`_                                                |
++---------------------------+---------------------------------------------------------------------+
+| Inherited options         | from the :doc:`CheckboxType </reference/forms/types/checkbox>`:     |
+|                           |                                                                     |
+|                           | - `value`_                                                          |
+|                           |                                                                     |
+|                           | from the :doc:`FormType </reference/forms/types/form>`:             |
+|                           |                                                                     |
+|                           | - `attr`_                                                           |
+|                           | - `data`_                                                           |
+|                           | - `disabled`_                                                       |
+|                           | - `empty_data`_                                                     |
+|                           | - `error_bubbling`_                                                 |
+|                           | - `error_mapping`_                                                  |
+|                           | - `help`_                                                           |
+|                           | - `help_attr`_                                                      |
+|                           | - `help_html`_                                                      |
+|                           | - `label`_                                                          |
+|                           | - `label_attr`_                                                     |
+|                           | - `label_format`_                                                   |
+|                           | - `mapped`_                                                         |
+|                           | - `required`_                                                       |
+|                           | - `row_attr`_                                                       |
++---------------------------+---------------------------------------------------------------------+
+| Default `invalid_message` | Please select a valid option.                                       |
++---------------------------+---------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                 |
++---------------------------+---------------------------------------------------------------------+
+| Parent type               | :doc:`CheckboxType </reference/forms/types/checkbox>`               |
++---------------------------+---------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType` |
++---------------------------+---------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
+
+Overridden Options
+------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/range.rst
+++ b/reference/forms/types/range.rst
@@ -7,29 +7,35 @@ RangeType Field
 The ``RangeType`` field is a slider that is rendered using the HTML5
 ``<input type="range"/>`` tag.
 
-+-------------+---------------------------------------------------------------------+
-| Rendered as | ``input`` ``range`` field (slider in HTML5 supported browser)       |
-+-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-|             | - `trim`_                                                           |
-+-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`TextType </reference/forms/types/text>`                       |
-+-------------+---------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RangeType` |
-+-------------+---------------------------------------------------------------------+
++---------------------------+---------------------------------------------------------------------+
+| Rendered as               | ``input`` ``range`` field (slider in HTML5 supported browser)       |
++---------------------------+---------------------------------------------------------------------+
+| Overridden options        | - `invalid_message`_                                                |
++---------------------------+---------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                           |
+|                           | - `data`_                                                           |
+|                           | - `disabled`_                                                       |
+|                           | - `empty_data`_                                                     |
+|                           | - `error_bubbling`_                                                 |
+|                           | - `error_mapping`_                                                  |
+|                           | - `help`_                                                           |
+|                           | - `help_attr`_                                                      |
+|                           | - `help_html`_                                                      |
+|                           | - `label`_                                                          |
+|                           | - `label_attr`_                                                     |
+|                           | - `mapped`_                                                         |
+|                           | - `required`_                                                       |
+|                           | - `row_attr`_                                                       |
+|                           | - `trim`_                                                           |
++---------------------------+---------------------------------------------------------------------+
+| Default `invalid_message` | Please choose a valid range.                                        |
++---------------------------+---------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                 |
++---------------------------+---------------------------------------------------------------------+
+| Parent type               | :doc:`TextType </reference/forms/types/text>`                       |
++---------------------------+---------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RangeType` |
++---------------------------+---------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -47,6 +53,11 @@ Basic Usage
             'max' => 50
         ]
     ]);
+
+Overridden Options
+------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/repeated.rst
+++ b/reference/forms/types/repeated.rst
@@ -9,34 +9,37 @@ values must match (or a validation error is thrown). The most common use
 is when you need the user to repeat their password or email to verify
 accuracy.
 
-+-------------+------------------------------------------------------------------------+
-| Rendered as | input ``text`` field by default, but see `type`_ option                |
-+-------------+------------------------------------------------------------------------+
-| Options     | - `first_name`_                                                        |
-|             | - `first_options`_                                                     |
-|             | - `options`_                                                           |
-|             | - `second_name`_                                                       |
-|             | - `second_options`_                                                    |
-|             | - `type`_                                                              |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `error_bubbling`_                                                    |
-| options     |                                                                        |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                              |
-| options     | - `data`_                                                              |
-|             | - `error_mapping`_                                                     |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `invalid_message`_                                                   |
-|             | - `invalid_message_parameters`_                                        |
-|             | - `mapped`_                                                            |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
-| Parent type | :doc:`FormType </reference/forms/types/form>`                          |
-+-------------+------------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RepeatedType` |
-+-------------+------------------------------------------------------------------------+
++---------------------------+------------------------------------------------------------------------+
+| Rendered as               | input ``text`` field by default, but see `type`_ option                |
++---------------------------+------------------------------------------------------------------------+
+| Options                   | - `first_name`_                                                        |
+|                           | - `first_options`_                                                     |
+|                           | - `options`_                                                           |
+|                           | - `second_name`_                                                       |
+|                           | - `second_options`_                                                    |
+|                           | - `type`_                                                              |
++---------------------------+------------------------------------------------------------------------+
+| Overridden options        | - `error_bubbling`_                                                    |
+|                           | - `invalid_message`_                                                   |
++---------------------------+------------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                              |
+|                           | - `data`_                                                              |
+|                           | - `error_mapping`_                                                     |
+|                           | - `help`_                                                              |
+|                           | - `help_attr`_                                                         |
+|                           | - `help_html`_                                                         |
+|                           | - `invalid_message_parameters`_                                        |
+|                           | - `mapped`_                                                            |
+|                           | - `row_attr`_                                                          |
++---------------------------+------------------------------------------------------------------------+
+| Default `invalid_message` | The values do not match.                                               |
++---------------------------+------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                    |
++---------------------------+------------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                          |
++---------------------------+------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RepeatedType` |
++---------------------------+------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -184,6 +187,8 @@ Overridden Options
 
 **default**: ``false``
 
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
+
 Inherited Options
 -----------------
 
@@ -200,8 +205,6 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/help_attr.rst.inc
 
 .. include:: /reference/forms/types/options/help_html.rst.inc
-
-.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 

--- a/reference/forms/types/search.rst
+++ b/reference/forms/types/search.rst
@@ -9,31 +9,42 @@ special functionality supported by some browsers.
 
 Read about the input search field at `DiveIntoHTML5.info`_
 
-+-------------+----------------------------------------------------------------------+
-| Rendered as | ``input search`` field                                               |
-+-------------+----------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                            |
-| options     | - `disabled`_                                                        |
-|             | - `empty_data`_                                                      |
-|             | - `error_bubbling`_                                                  |
-|             | - `error_mapping`_                                                   |
-|             | - `help`_                                                            |
-|             | - `help_attr`_                                                       |
-|             | - `help_html`_                                                       |
-|             | - `label`_                                                           |
-|             | - `label_attr`_                                                      |
-|             | - `label_format`_                                                    |
-|             | - `mapped`_                                                          |
-|             | - `required`_                                                        |
-|             | - `row_attr`_                                                        |
-|             | - `trim`_                                                            |
-+-------------+----------------------------------------------------------------------+
-| Parent type | :doc:`TextType </reference/forms/types/text>`                        |
-+-------------+----------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\SearchType` |
-+-------------+----------------------------------------------------------------------+
++---------------------------+----------------------------------------------------------------------+
+| Rendered as               | ``input search`` field                                               |
++---------------------------+----------------------------------------------------------------------+
+| Overridden options        | - `invalid_message`_                                                 |
++---------------------------+----------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                            |
+|                           | - `disabled`_                                                        |
+|                           | - `empty_data`_                                                      |
+|                           | - `error_bubbling`_                                                  |
+|                           | - `error_mapping`_                                                   |
+|                           | - `help`_                                                            |
+|                           | - `help_attr`_                                                       |
+|                           | - `help_html`_                                                       |
+|                           | - `label`_                                                           |
+|                           | - `label_attr`_                                                      |
+|                           | - `label_format`_                                                    |
+|                           | - `mapped`_                                                          |
+|                           | - `required`_                                                        |
+|                           | - `row_attr`_                                                        |
+|                           | - `trim`_                                                            |
++---------------------------+----------------------------------------------------------------------+
+| Default `invalid_message` | Please enter a valid search term.                                    |
++---------------------------+----------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                  |
++---------------------------+----------------------------------------------------------------------+
+| Parent type               | :doc:`TextType </reference/forms/types/text>`                        |
++---------------------------+----------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\SearchType` |
++---------------------------+----------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
+
+Overridden Options
+------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/tel.rst
+++ b/reference/forms/types/tel.rst
@@ -13,32 +13,43 @@ Nevertheless, it may be useful to use this type in web applications because some
 browsers (e.g. smartphone browsers) adapt the input keyboard to make it easier
 to input phone numbers.
 
-+-------------+---------------------------------------------------------------------+
-| Rendered as | ``input`` ``tel`` field (a text box)                                |
-+-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-|             | - `trim`_                                                           |
-+-------------+---------------------------------------------------------------------+
-| Parent type | :doc:`TextType </reference/forms/types/text>`                       |
-+-------------+---------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TelType`   |
-+-------------+---------------------------------------------------------------------+
++---------------------------+-------------------------------------------------------------------+
+| Rendered as               | ``input`` ``tel`` field (a text box)                              |
++---------------------------+-------------------------------------------------------------------+
+| Overridden options        | - `invalid_message`_                                              |
++---------------------------+-------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                         |
+|                           | - `data`_                                                         |
+|                           | - `disabled`_                                                     |
+|                           | - `empty_data`_                                                   |
+|                           | - `error_bubbling`_                                               |
+|                           | - `error_mapping`_                                                |
+|                           | - `help`_                                                         |
+|                           | - `help_attr`_                                                    |
+|                           | - `help_html`_                                                    |
+|                           | - `label`_                                                        |
+|                           | - `label_attr`_                                                   |
+|                           | - `label_format`_                                                 |
+|                           | - `mapped`_                                                       |
+|                           | - `required`_                                                     |
+|                           | - `row_attr`_                                                     |
+|                           | - `trim`_                                                         |
++---------------------------+-------------------------------------------------------------------+
+| Default `invalid_message` | Please provide a valid phone number.                              |
++---------------------------+-------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                               |
++---------------------------+-------------------------------------------------------------------+
+| Parent type               | :doc:`TextType </reference/forms/types/text>`                     |
++---------------------------+-------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TelType` |
++---------------------------+-------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
+
+Overridden Options
+------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -10,48 +10,52 @@ This can be rendered as a text field, a series of text fields (e.g. hour,
 minute, second) or a series of select fields. The underlying data can be
 stored as a ``DateTime`` object, a string, a timestamp or an array.
 
-+----------------------+-----------------------------------------------------------------------------+
-| Underlying Data Type | can be ``DateTime``, string, timestamp, or array (see the ``input`` option) |
-+----------------------+-----------------------------------------------------------------------------+
-| Rendered as          | can be various tags (see below)                                             |
-+----------------------+-----------------------------------------------------------------------------+
-| Options              | - `choice_translation_domain`_                                              |
-|                      | - `placeholder`_                                                            |
-|                      | - `hours`_                                                                  |
-|                      | - `html5`_                                                                  |
-|                      | - `input`_                                                                  |
-|                      | - `input_format`_                                                           |
-|                      | - `minutes`_                                                                |
-|                      | - `model_timezone`_                                                         |
-|                      | - `reference_date`_                                                         |
-|                      | - `seconds`_                                                                |
-|                      | - `view_timezone`_                                                          |
-|                      | - `widget`_                                                                 |
-|                      | - `with_minutes`_                                                           |
-|                      | - `with_seconds`_                                                           |
-+----------------------+-----------------------------------------------------------------------------+
-| Overridden options   | - `by_reference`_                                                           |
-|                      | - `compound`_                                                               |
-|                      | - `data_class`_                                                             |
-|                      | - `error_bubbling`_                                                         |
-+----------------------+-----------------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                                   |
-| options              | - `data`_                                                                   |
-|                      | - `disabled`_                                                               |
-|                      | - `error_mapping`_                                                          |
-|                      | - `help`_                                                                   |
-|                      | - `help_attr`_                                                              |
-|                      | - `help_html`_                                                              |
-|                      | - `inherit_data`_                                                           |
-|                      | - `invalid_message`_                                                        |
-|                      | - `invalid_message_parameters`_                                             |
-|                      | - `mapped`_                                                                 |
-|                      | - `row_attr`_                                                               |
-+----------------------+-----------------------------------------------------------------------------+
-| Parent type          | FormType                                                                    |
-+----------------------+-----------------------------------------------------------------------------+
-| Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TimeType`          |
-+----------------------+-----------------------------------------------------------------------------+
++---------------------------+-----------------------------------------------------------------------------+
+| Underlying Data Type      | can be ``DateTime``, string, timestamp, or array (see the ``input`` option) |
++---------------------------+-----------------------------------------------------------------------------+
+| Rendered as               | can be various tags (see below)                                             |
++---------------------------+-----------------------------------------------------------------------------+
+| Options                   | - `choice_translation_domain`_                                              |
+|                           | - `placeholder`_                                                            |
+|                           | - `hours`_                                                                  |
+|                           | - `html5`_                                                                  |
+|                           | - `input`_                                                                  |
+|                           | - `input_format`_                                                           |
+|                           | - `minutes`_                                                                |
+|                           | - `model_timezone`_                                                         |
+|                           | - `reference_date`_                                                         |
+|                           | - `seconds`_                                                                |
+|                           | - `view_timezone`_                                                          |
+|                           | - `widget`_                                                                 |
+|                           | - `with_minutes`_                                                           |
+|                           | - `with_seconds`_                                                           |
++---------------------------+-----------------------------------------------------------------------------+
+| Overridden options        | - `by_reference`_                                                           |
+|                           | - `compound`_                                                               |
+|                           | - `data_class`_                                                             |
+|                           | - `error_bubbling`_                                                         |
+|                           | - `invalid_message`_                                                        |
++---------------------------+-----------------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                                   |
+|                           | - `data`_                                                                   |
+|                           | - `disabled`_                                                               |
+|                           | - `error_mapping`_                                                          |
+|                           | - `help`_                                                                   |
+|                           | - `help_attr`_                                                              |
+|                           | - `help_html`_                                                              |
+|                           | - `inherit_data`_                                                           |
+|                           | - `invalid_message_parameters`_                                             |
+|                           | - `mapped`_                                                                 |
+|                           | - `row_attr`_                                                               |
++---------------------------+-----------------------------------------------------------------------------+
+| Default `invalid_message` | Please enter a valid time.                                                  |
++---------------------------+-----------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                         |
++---------------------------+-----------------------------------------------------------------------------+
+| Parent type               | FormType                                                                    |
++---------------------------+-----------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TimeType`          |
++---------------------------+-----------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -220,6 +224,8 @@ error_bubbling
 
 **default**: ``false``
 
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
+
 Inherited Options
 -----------------
 
@@ -240,8 +246,6 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/help_html.rst.inc
 
 .. include:: /reference/forms/types/options/inherit_data.rst.inc
-
-.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 

--- a/reference/forms/types/timezone.rst
+++ b/reference/forms/types/timezone.rst
@@ -14,45 +14,50 @@ Unlike the ``ChoiceType``, you don't need to specify a ``choices`` option as the
 field type automatically uses a large list of timezones. You *can* specify the option
 manually, but then you should just use the ``ChoiceType`` directly.
 
-+-------------+------------------------------------------------------------------------+
-| Rendered as | can be various tags (see :ref:`forms-reference-choice-tags`)           |
-+-------------+------------------------------------------------------------------------+
-| Options     | - `input`_                                                             |
-|             | - `intl`_                                                              |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `choices`_                                                           |
-| options     | - `choice_translation_domain`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | from the :doc:`ChoiceType </reference/forms/types/choice>`             |
-| options     |                                                                        |
-|             | - `expanded`_                                                          |
-|             | - `multiple`_                                                          |
-|             | - `placeholder`_                                                       |
-|             | - `preferred_choices`_                                                 |
-|             | - `trim`_                                                              |
-|             |                                                                        |
-|             | from the :doc:`FormType </reference/forms/types/form>`                 |
-|             |                                                                        |
-|             | - `attr`_                                                              |
-|             | - `data`_                                                              |
-|             | - `disabled`_                                                          |
-|             | - `empty_data`_                                                        |
-|             | - `error_bubbling`_                                                    |
-|             | - `error_mapping`_                                                     |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
-| Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
-+-------------+------------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TimezoneType` |
-+-------------+------------------------------------------------------------------------+
++---------------------------+------------------------------------------------------------------------+
+| Rendered as               | can be various tags (see :ref:`forms-reference-choice-tags`)           |
++---------------------------+------------------------------------------------------------------------+
+| Options                   | - `input`_                                                             |
+|                           | - `intl`_                                                              |
++---------------------------+------------------------------------------------------------------------+
+| Overridden options        | - `choices`_                                                           |
+|                           | - `choice_translation_domain`_                                         |
+|                           | - `invalid_message`_                                                   |
++---------------------------+------------------------------------------------------------------------+
+| Inherited options         | from the :doc:`ChoiceType </reference/forms/types/choice>`             |
+|                           |                                                                        |
+|                           | - `expanded`_                                                          |
+|                           | - `multiple`_                                                          |
+|                           | - `placeholder`_                                                       |
+|                           | - `preferred_choices`_                                                 |
+|                           | - `trim`_                                                              |
+|                           |                                                                        |
+|                           | from the :doc:`FormType </reference/forms/types/form>`                 |
+|                           |                                                                        |
+|                           | - `attr`_                                                              |
+|                           | - `data`_                                                              |
+|                           | - `disabled`_                                                          |
+|                           | - `empty_data`_                                                        |
+|                           | - `error_bubbling`_                                                    |
+|                           | - `error_mapping`_                                                     |
+|                           | - `help`_                                                              |
+|                           | - `help_attr`_                                                         |
+|                           | - `help_html`_                                                         |
+|                           | - `label`_                                                             |
+|                           | - `label_attr`_                                                        |
+|                           | - `label_format`_                                                      |
+|                           | - `mapped`_                                                            |
+|                           | - `required`_                                                          |
+|                           | - `row_attr`_                                                          |
++---------------------------+------------------------------------------------------------------------+
+| Default `invalid_message` | Please select a valid timezone.                                        |
++---------------------------+------------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                    |
++---------------------------+------------------------------------------------------------------------+
+| Parent type               | :doc:`ChoiceType </reference/forms/types/choice>`                      |
++---------------------------+------------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TimezoneType` |
++---------------------------+------------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -106,6 +111,8 @@ The Timezone type defaults the choices to all timezones returned by
     will also have to set the ``choice_loader`` option to ``null``.
 
 .. include:: /reference/forms/types/options/choice_translation_domain_disabled.rst.inc
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/url.rst
+++ b/reference/forms/types/url.rst
@@ -8,32 +8,38 @@ The ``UrlType`` field is a text field that prepends the submitted value with
 a given protocol (e.g. ``http://``) if the submitted value doesn't already
 have a protocol.
 
-+-------------+-------------------------------------------------------------------+
-| Rendered as | ``input url`` field                                               |
-+-------------+-------------------------------------------------------------------+
-| Options     | - `default_protocol`_                                             |
-+-------------+-------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                         |
-| options     | - `data`_                                                         |
-|             | - `disabled`_                                                     |
-|             | - `empty_data`_                                                   |
-|             | - `error_bubbling`_                                               |
-|             | - `error_mapping`_                                                |
-|             | - `help`_                                                         |
-|             | - `help_attr`_                                                    |
-|             | - `help_html`_                                                    |
-|             | - `label`_                                                        |
-|             | - `label_attr`_                                                   |
-|             | - `label_format`_                                                 |
-|             | - `mapped`_                                                       |
-|             | - `required`_                                                     |
-|             | - `row_attr`_                                                     |
-|             | - `trim`_                                                         |
-+-------------+-------------------------------------------------------------------+
-| Parent type | :doc:`TextType </reference/forms/types/text>`                     |
-+-------------+-------------------------------------------------------------------+
-| Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\UrlType` |
-+-------------+-------------------------------------------------------------------+
++---------------------------+-------------------------------------------------------------------+
+| Rendered as               | ``input url`` field                                               |
++---------------------------+-------------------------------------------------------------------+
+| Options                   | - `default_protocol`_                                             |
++---------------------------+-------------------------------------------------------------------+
+| Overridden options        | - `invalid_message`_                                              |
++---------------------------+-------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                         |
+|                           | - `data`_                                                         |
+|                           | - `disabled`_                                                     |
+|                           | - `empty_data`_                                                   |
+|                           | - `error_bubbling`_                                               |
+|                           | - `error_mapping`_                                                |
+|                           | - `help`_                                                         |
+|                           | - `help_attr`_                                                    |
+|                           | - `help_html`_                                                    |
+|                           | - `label`_                                                        |
+|                           | - `label_attr`_                                                   |
+|                           | - `label_format`_                                                 |
+|                           | - `mapped`_                                                       |
+|                           | - `required`_                                                     |
+|                           | - `row_attr`_                                                     |
+|                           | - `trim`_                                                         |
++---------------------------+-------------------------------------------------------------------+
+| Default `invalid_message` | Please enter a valid URL.                                         |
++---------------------------+-------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                               |
++---------------------------+-------------------------------------------------------------------+
+| Parent type               | :doc:`TextType </reference/forms/types/text>`                     |
++---------------------------+-------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\UrlType` |
++---------------------------+-------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -48,6 +54,11 @@ Field Options
 If a value is submitted that doesn't begin with some protocol (e.g. ``http://``,
 ``ftp://``, etc), this protocol will be prepended to the string when
 the data is submitted to the form.
+
+Overridden Options
+------------------
+
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 Inherited Options
 -----------------

--- a/reference/forms/types/week.rst
+++ b/reference/forms/types/week.rst
@@ -10,39 +10,43 @@ This field type allows the user to modify data that represents a specific
 Can be rendered as a text input or select tags. The underlying format of
 the data can be a string or an array.
 
-+----------------------+-----------------------------------------------------------------------------+
-| Underlying Data Type | can be a string, or array (see the ``input`` option)                        |
-+----------------------+-----------------------------------------------------------------------------+
-| Rendered as          | single text box, two text boxes or two select fields                        |
-+----------------------+-----------------------------------------------------------------------------+
-| Options              | - `choice_translation_domain`_                                              |
-|                      | - `placeholder`_                                                            |
-|                      | - `html5`_                                                                  |
-|                      | - `input`_                                                                  |
-|                      | - `widget`_                                                                 |
-|                      | - `weeks`_                                                                  |
-|                      | - `years`_                                                                  |
-+----------------------+-----------------------------------------------------------------------------+
-| Overridden options   | - `compound`_                                                               |
-|                      | - `empty_data`_                                                             |
-|                      | - `error_bubbling`_                                                         |
-+----------------------+-----------------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                                   |
-| options              | - `data`_                                                                   |
-|                      | - `disabled`_                                                               |
-|                      | - `help`_                                                                   |
-|                      | - `help_attr`_                                                              |
-|                      | - `help_html`_                                                              |
-|                      | - `inherit_data`_                                                           |
-|                      | - `invalid_message`_                                                        |
-|                      | - `invalid_message_parameters`_                                             |
-|                      | - `mapped`_                                                                 |
-|                      | - `row_attr`_                                                               |
-+----------------------+-----------------------------------------------------------------------------+
-| Parent type          | :doc:`FormType </reference/forms/types/form>`                               |
-+----------------------+-----------------------------------------------------------------------------+
-| Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\WeekType`          |
-+----------------------+-----------------------------------------------------------------------------+
++---------------------------+--------------------------------------------------------------------+
+| Underlying Data Type      | can be a string, or array (see the ``input`` option)               |
++---------------------------+--------------------------------------------------------------------+
+| Rendered as               | single text box, two text boxes or two select fields               |
++---------------------------+--------------------------------------------------------------------+
+| Options                   | - `choice_translation_domain`_                                     |
+|                           | - `placeholder`_                                                   |
+|                           | - `html5`_                                                         |
+|                           | - `input`_                                                         |
+|                           | - `widget`_                                                        |
+|                           | - `weeks`_                                                         |
+|                           | - `years`_                                                         |
++---------------------------+--------------------------------------------------------------------+
+| Overridden options        | - `compound`_                                                      |
+|                           | - `empty_data`_                                                    |
+|                           | - `error_bubbling`_                                                |
+|                           | - `invalid_message`_                                               |
++---------------------------+--------------------------------------------------------------------+
+| Inherited options         | - `attr`_                                                          |
+|                           | - `data`_                                                          |
+|                           | - `disabled`_                                                      |
+|                           | - `help`_                                                          |
+|                           | - `help_attr`_                                                     |
+|                           | - `help_html`_                                                     |
+|                           | - `inherit_data`_                                                  |
+|                           | - `invalid_message_parameters`_                                    |
+|                           | - `mapped`_                                                        |
+|                           | - `row_attr`_                                                      |
++---------------------------+--------------------------------------------------------------------+
+| Default `invalid_message` | Please enter a valid week.                                         |
++---------------------------+--------------------------------------------------------------------+
+| Legacy `invalid_message`  | The value {{ value }} is not valid.                                |
++---------------------------+--------------------------------------------------------------------+
+| Parent type               | :doc:`FormType </reference/forms/types/form>`                      |
++---------------------------+--------------------------------------------------------------------+
+| Class                     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\WeekType` |
++---------------------------+--------------------------------------------------------------------+
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
@@ -138,6 +142,8 @@ error_bubbling
 
 **default**: ``false``
 
+.. include:: /reference/forms/types/options/invalid_message.rst.inc
+
 Inherited Options
 -----------------
 
@@ -156,8 +162,6 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 .. include:: /reference/forms/types/options/help_html.rst.inc
 
 .. include:: /reference/forms/types/options/inherit_data.rst.inc
-
-.. include:: /reference/forms/types/options/invalid_message.rst.inc
 
 .. include:: /reference/forms/types/options/invalid_message_parameters.rst.inc
 


### PR DESCRIPTION
Documented new legacy_error_messages option for forms and documented all new default and legacy `invalid_message` values for each form type.

Also moved/added `invalid_message` as overridden option in all applicable form types.

Fixes #13954