### PR TITLE
[Notifier] Add better example for Slack DSN

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -149,6 +149,8 @@ Chatters are configured using the ``chatter_transports`` setting:
 
     # .env
     SLACK_DSN=slack://default/ID
+    # If your slack webhook looks like "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX" then use:
+    SLACK_DSN=slack://default/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX
 
 .. configuration-block::
 


### PR DESCRIPTION
Slacks API documentation is a mess!

This small change would make it more clear that one should use their webhook URL's parameters. 