### PR TITLE
[Logger] Remove wrong "method" tag

### DIFF
--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -103,7 +103,7 @@ information:
 
         $container
             ->register(SessionRequestProcessor::class)
-            ->addTag('monolog.processor', ['method' => 'processRecord']);
+            ->addTag('monolog.processor');
 
 Finally, set the formatter to be used on whatever handler you want:
 


### PR DESCRIPTION
Method tag is not needed when the processor is invokable, here it would call `processRecord` which doesn't exist

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
