### PR TITLE
[EventDispatcher] Document dispatch() with one argument as a FQCN

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -348,6 +348,7 @@ of the event to dispatch::
     // creates the OrderPlacedEvent and dispatches it
     $event = new OrderPlacedEvent($order);
     $dispatcher->dispatch($event, OrderPlacedEvent::NAME);
+    // note that ``OrderPlacedEvent::NAME`` is optional, read below
 
 Notice that the special ``OrderPlacedEvent`` object is created and passed to
 the ``dispatch()`` method. Now, any listener to the ``order.placed``
@@ -391,6 +392,9 @@ Take the following example of a subscriber that subscribes to the
                     ['onKernelResponsePost', -10],
                 ],
                 OrderPlacedEvent::NAME => 'onStoreOrder',
+                // note that you can also subscribe like this
+                // when passing only the event
+                OrderPlacedEvent::class => 'onStoreOrder',
             ];
         }
 

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -353,8 +353,8 @@ of the event to dispatch::
 
 .. versionadded:: 4.3
 
-    The event name is now optional since Symfony 4.3 in
-    the :method:`Symfony\\Component\\EventDispatcher\\EventDispatcher::dispatch`.
+    The event name in :method:`Symfony\\Component\\EventDispatcher\\EventDispatcher::dispatch`
+    is optional since Symfony 4.3.
 
 Notice that the special ``OrderPlacedEvent`` object is created and passed to
 the ``dispatch()`` method. Now, any listener to the ``order.placed`` or the

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -348,7 +348,7 @@ of the event to dispatch::
     // creates the OrderPlacedEvent and dispatches it
     $event = new OrderPlacedEvent($order);
     $dispatcher->dispatch($event, OrderPlacedEvent::NAME);
-    // or since Symfony 4.3+
+    // you can also omit the second argument
     $dispatcher->dispatch($event);
 
 .. versionadded:: 4.3

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -348,11 +348,17 @@ of the event to dispatch::
     // creates the OrderPlacedEvent and dispatches it
     $event = new OrderPlacedEvent($order);
     $dispatcher->dispatch($event, OrderPlacedEvent::NAME);
-    // note that the second argument ``OrderPlacedEvent::NAME`` is optional,
-    // read more below in the subscriber code part
+    // or since Symfony 4.3+
+    $dispatcher->dispatch($event);
+
+.. versionadded:: 4.3
+
+    The event name is now optional since Symfony 4.3 in
+    the :method:`Symfony\\Component\\EventDispatcher\\EventDispatcher::dispatch`.
 
 Notice that the special ``OrderPlacedEvent`` object is created and passed to
-the ``dispatch()`` method. Now, any listener to the ``order.placed``
+the ``dispatch()`` method. Now, any listener to the ``order.placed`` or the
+``Acme\Store\Event\OrderPlacedEvent`` (FQCN)
 event will receive the ``OrderPlacedEvent``.
 
 .. index::
@@ -392,10 +398,9 @@ Take the following example of a subscriber that subscribes to the
                     ['onKernelResponsePre', 10],
                     ['onKernelResponsePost', -10],
                 ],
+                // when using two arguments, the event and the event name
                 OrderPlacedEvent::NAME => 'onStoreOrder',
-                // you can also subscribe this way if you pass only
-                // the event object as first argument and omit the second
-                // of the $dispatcher->dispatch method
+                // when using only one argument, the event (since Symfony 4.3+)
                 OrderPlacedEvent::class => 'onStoreOrder',
             ];
         }

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -348,7 +348,8 @@ of the event to dispatch::
     // creates the OrderPlacedEvent and dispatches it
     $event = new OrderPlacedEvent($order);
     $dispatcher->dispatch($event, OrderPlacedEvent::NAME);
-    // note that ``OrderPlacedEvent::NAME`` is optional, read more below
+    // note that the second argument ``OrderPlacedEvent::NAME`` is optional,
+    // read more below in the subscriber code part
 
 Notice that the special ``OrderPlacedEvent`` object is created and passed to
 the ``dispatch()`` method. Now, any listener to the ``order.placed``
@@ -393,7 +394,8 @@ Take the following example of a subscriber that subscribes to the
                 ],
                 OrderPlacedEvent::NAME => 'onStoreOrder',
                 // you can also subscribe this way if you pass only
-                // the event object
+                // the event object as first argument and omit the second
+                // of the $dispatcher->dispatch method
                 OrderPlacedEvent::class => 'onStoreOrder',
             ];
         }

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -348,7 +348,7 @@ of the event to dispatch::
     // creates the OrderPlacedEvent and dispatches it
     $event = new OrderPlacedEvent($order);
     $dispatcher->dispatch($event, OrderPlacedEvent::NAME);
-    // note that ``OrderPlacedEvent::NAME`` is optional, read below
+    // note that ``OrderPlacedEvent::NAME`` is optional, read more below
 
 Notice that the special ``OrderPlacedEvent`` object is created and passed to
 the ``dispatch()`` method. Now, any listener to the ``order.placed``
@@ -392,8 +392,8 @@ Take the following example of a subscriber that subscribes to the
                     ['onKernelResponsePost', -10],
                 ],
                 OrderPlacedEvent::NAME => 'onStoreOrder',
-                // note that you can also subscribe like this
-                // when passing only the event
+                // you can also subscribe this way if you pass only
+                // the event object
                 OrderPlacedEvent::class => 'onStoreOrder',
             ];
         }


### PR DESCRIPTION
Related to https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching
Feature introduced in https://github.com/symfony/symfony/pull/28920

Maybe it is useful/helpful to document this here as well as the blog post