### PR TITLE
[Console] A method call is reversed

### DIFF
--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -362,8 +362,8 @@ placeholder before displaying the progress bar::
     $progressBar->start();
     // 0/100 -- Start
 
-    $progressBar->advance();
     $progressBar->setMessage('Task is in progress...');
+    $progressBar->advance();    
     // 1/100 -- Task is in progress...
 
 Messages can be combined with custom placeholders too. In this example, the


### PR DESCRIPTION
The order of the methods is reversed. The method "advance()" must be called after the "setMessage()".