### PR TITLE
Update performance.rst

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -209,6 +209,8 @@ deployment process too):
   used in your application and prevents Composer from scanning the file system for
   classes that are not found in the class map. (see: `Composer's autoloader optimization`_).
 
+You can also use the ``--classmap-authoritative`` option with the ``composer install`` command.
+
 .. _profiling-applications:
 
 Profiling Symfony Applications


### PR DESCRIPTION
Hi

Small hint as described here https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-2-a-authoritative-class-maps
Sometime it is easier to have oneline command than multiples

❔ I have a question also:

The paragraph above mentioned `Execute this command to generate the class map file for production`
But in fact the file `vendor/composer/autoload_classmap.php` exists even without this, as it seems to be similar with/without.
is it worth a reword or a detail addition? Or a Composer issue?

Thanks