### PR TITLE
[Validator] Removing the recommended `Constraints` subdirectory

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -14,8 +14,8 @@ Creating the Constraint Class
 
 First you need to create a Constraint class and extend :class:`Symfony\\Component\\Validator\\Constraint`::
 
-    // src/Validator/Constraints/ContainsAlphanumeric.php
-    namespace App\Validator\Constraints;
+    // src/Validator/ContainsAlphanumeric.php
+    namespace App\Validator;
 
     use Symfony\Component\Validator\Constraint;
 
@@ -54,8 +54,8 @@ when actually performing the validation.
 
 The validator class only has one required method ``validate()``::
 
-    // src/Validator/Constraints/ContainsAlphanumericValidator.php
-    namespace App\Validator\Constraints;
+    // src/Validator/ContainsAlphanumericValidator.php
+    namespace App\Validator;
 
     use Symfony\Component\Validator\Constraint;
     use Symfony\Component\Validator\ConstraintValidator;
@@ -71,7 +71,7 @@ The validator class only has one required method ``validate()``::
             }
 
             // custom constraints should ignore null and empty values to allow
-            // other constraints (NotBlank, NotNull, etc.) take care of that
+            // other constraints (NotBlank, NotNull, etc.) to take care of that
             if (null === $value || '' === $value) {
                 return;
             }
@@ -117,7 +117,7 @@ You can use custom validators like the ones provided by Symfony itself:
         // src/Entity/AcmeEntity.php
         namespace App\Entity;
 
-        use App\Validator\Constraints as AcmeAssert;
+        use App\Validator as AcmeAssert;
         use Symfony\Component\Validator\Constraints as Assert;
 
         class AcmeEntity
@@ -140,7 +140,7 @@ You can use custom validators like the ones provided by Symfony itself:
             properties:
                 name:
                     - NotBlank: ~
-                    - App\Validator\Constraints\ContainsAlphanumeric: ~
+                    - App\Validator\ContainsAlphanumeric: ~
 
     .. code-block:: xml
 
@@ -153,7 +153,7 @@ You can use custom validators like the ones provided by Symfony itself:
             <class name="App\Entity\AcmeEntity">
                 <property name="name">
                     <constraint name="NotBlank"/>
-                    <constraint name="App\Validator\Constraints\ContainsAlphanumeric"/>
+                    <constraint name="App\Validator\ContainsAlphanumeric"/>
                 </property>
             </class>
         </constraint-mapping>
@@ -163,7 +163,7 @@ You can use custom validators like the ones provided by Symfony itself:
         // src/Entity/AcmeEntity.php
         namespace App\Entity;
 
-        use App\Validator\Constraints\ContainsAlphanumeric;
+        use App\Validator\ContainsAlphanumeric;
         use Symfony\Component\Validator\Constraints\NotBlank;
         use Symfony\Component\Validator\Mapping\ClassMetadata;
 
@@ -241,13 +241,13 @@ not to the property:
         # config/validator/validation.yaml
         App\Entity\AcmeEntity:
             constraints:
-                - App\Validator\Constraints\ProtocolClass: ~
+                - App\Validator\ProtocolClass: ~
 
     .. code-block:: xml
 
         <!-- config/validator/validation.xml -->
         <class name="App\Entity\AcmeEntity">
-            <constraint name="App\Validator\Constraints\ProtocolClass"/>
+            <constraint name="App\Validator\ProtocolClass"/>
         </class>
 
     .. code-block:: php
@@ -255,7 +255,7 @@ not to the property:
         // src/Entity/AcmeEntity.php
         namespace App\Entity;
 
-        use App\Validator\Constraints\ProtocolClass;
+        use App\Validator\ProtocolClass;
         use Symfony\Component\Validator\Mapping\ClassMetadata;
 
         class AcmeEntity


### PR DESCRIPTION
Since both the Constraint and the Validator are in the same directory, I can't see any reason for putting them into a *sub*directory called `Constraints`. In other words: When keeping the `Constraints` subdirectory, what would be the recommended contents of the `Validator` directory?
* If you agree in principle, I'll change the other occurrences too.
* If you don't agree (i.e. want to keep the `Constraints` subdirectory), I suggest to rename it to `Constraint`, since all other directory names are singular too.