### PR TITLE
Update index.rst

### DIFF
--- a/components/console/helpers/index.rst
+++ b/components/console/helpers/index.rst
@@ -15,6 +15,6 @@ The Console Helpers
     debug_formatter
 
 The Console component comes with some useful helpers. These helpers contain
-function to ease some common tasks.
+functions to ease some common tasks.
 
 .. include:: map.rst.inc


### PR DESCRIPTION
This is a very small change. I suggest replacing "function" with "functions" because each of these helpers offer more than one function. The word "functions" seems more appropriate.