### PR TITLE
[Validator] Mentioning `$constraints` argument of `validate()`

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -182,6 +182,11 @@ If your constraint contains options, then they should be public properties
 on the custom Constraint class you created earlier. These options can be
 configured like options on core Symfony constraints.
 
+To manually validate an entity, using *just* this single validator, pass an instance
+as second argument to ``validate()``::
+
+    $errors = $validator->validate($author, new ContainsAlphanumeric());
+
 Constraint Validators with Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Reason: How to call `validate()` with a validation group is explained at https://symfony.com/doc/4.4/validation/groups.html (very bottom). But how to pass a constraint isn't explained anywhere.

Question: The option to pass an array is missing. Like this (right?):
```php
$errors = $validator->validate($author, [new ContainsAlphanumeric(), new Foo()]);
```
Should I add this too? If yes, I'd say it should get its own heading.