### PR TITLE
[Lock] - replace getExpiringDate by getRemainingLifetime

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -196,8 +196,8 @@ to reset the TTL to its original value::
         $lock->refresh(600);
 
 This component also provides two useful methods related to expiring locks:
-``getExpiringDate()`` (which returns ``null`` or a ``\DateTimeImmutable``
-object) and ``isExpired()`` (which returns a boolean).
+``getRemainingLifetime()`` (which returns ``null`` or a ``float``
+as seconds) and ``isExpired()`` (which returns a boolean).
 
 The Owner of The Lock
 ---------------------


### PR DESCRIPTION
As the method `getExpiringDate` doesn't exist, replace it by `getRemainingLifetime` which returns the remaining time to live in seconds

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
