### PR TITLE
[Console] Update table.rst

### DIFF
--- a/components/console/helpers/table.rst
+++ b/components/console/helpers/table.rst
@@ -233,7 +233,7 @@ If the built-in styles do not fit your need, define your own::
 
     // customizes the style
     $tableStyle
-        ->setDefaultCrossingChars('<fg=magenta>|</>')
+        ->setHorizontalBorderChars('<fg=magenta>|</>')
         ->setVerticalBorderChars('<fg=magenta>-</>')
         ->setDefaultCrossingChar(' ')
     ;
@@ -244,7 +244,7 @@ If the built-in styles do not fit your need, define your own::
 Here is a full list of things you can customize:
 
 *  :method:`Symfony\\Component\\Console\\Helper\\TableStyle::setPaddingChar`
-*  :method:`Symfony\\Component\\Console\\Helper\\TableStyle::setDefaultCrossingChars`
+*  :method:`Symfony\\Component\\Console\\Helper\\TableStyle::setHorizontalBorderChars`
 *  :method:`Symfony\\Component\\Console\\Helper\\TableStyle::setVerticalBorderChars`
 *  :method:`Symfony\\Component\\Console\\Helper\\TableStyle::setCrossingChars`
 *  :method:`Symfony\\Component\\Console\\Helper\\TableStyle::setDefaultCrossingChar`


### PR DESCRIPTION
The Symfony\Component\Console\Helper\TableStyle class doesn't have the setDefaultCrossingChars method. I removed all references to this method.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
