### PR TITLE
[Console] Update lockable_trait.rst

### DIFF
--- a/console/lockable_trait.rst
+++ b/console/lockable_trait.rst
@@ -38,6 +38,8 @@ that adds two convenient methods to lock and release commands::
             // if not released explicitly, Symfony releases the lock
             // automatically when the execution of the command ends
             $this->release();
+            
+            return 0;
         }
     }
 


### PR DESCRIPTION
While attending to the `SymfonyWorld Online 2020 - Lock & Semaphore: The gatekeepers of your resources`
I remembered this feature and found this missed part
For upper branches v5.1+, the `Command::SUCCESS` is to be used
