### PR TITLE
[DependencyInjection] Minor modification about the .meta file contents

### DIFF
--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -564,8 +564,8 @@ Now the cached dumped container is used regardless of whether debug mode
 is on or not. The difference is that the ``ConfigCache`` is set to debug
 mode with its second constructor argument. When the cache is not in debug
 mode the cached container will always be used if it exists. In debug mode,
-an additional metadata file is written with the timestamps of all the resource
-files. These are then checked to see if the files have changed, if they
+an additional metadata file is written with all the involved resource
+files. These are then checked to see if their timestamps have changed, if they
 have the cache will be considered stale.
 
 .. note::


### PR DESCRIPTION
The explanation about the `.meta` file contents is not totally true. Only `ComposerResource` stores timestamps (for `installed.json` files). For project source and configuration files involved in the generation of a file in the cache, the `filemtime` is directly used to retrieve the resource timestamp and to compare it with the `filemtime` of the generated file.

Source: https://github.com/symfony/symfony/blob/21ef411cc96459d0d87ac3e1d565aca4bba1cb21/src/Symfony/Component/Config/Resource/FileResource.php#L65

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
