### PR TITLE
[DependencyInjection] [Service Container] Fix Service parameters typo in services.yml

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -340,7 +340,7 @@ you can type-hint the new ``SiteUpdateManager`` class and use it::
 
     // src/Controller/SiteController.php
     namespace App\Controller;
-    
+
     // ...
     use App\Service\SiteUpdateManager;
 
@@ -500,13 +500,14 @@ parameter and in PHP config use the ``ref`` function:
         # config/services.yaml
         services:
             App\Service\MessageGenerator:
-                # this is not a string, but a reference to a service called 'logger'
-                arguments: ['@logger']
+                arguments:
+                    # this is not a string, but a reference to a service called 'logger'
+                    - '@logger'
 
-                # if the value of a string parameter starts with '@', you need to escape
-                # it by adding another '@' so Symfony doesn't consider it a service
-                # (this will be parsed as the string '@securepassword')
-                mailer_password: '@@securepassword'
+                    # if the value of a string argument starts with '@', you need to escape
+                    # it by adding another '@' so Symfony doesn't consider it a service
+                    # the following example would be parsed as the string '@securepassword'
+                    # - '@@securepassword'
 
     .. code-block:: xml
 


### PR DESCRIPTION
Hi there,

I noticed a strange yml in the service_container doc, affecting >= 4.3 , there was a misplaced parameter under an example service definition.

I thought it would be nice to keep the actual information about escaping using `@` so I just removed the wrong `mailer_password: '@@securepassword'` thing.

I used 4.4 as target, maybe this could be merged to 4.3 as well, I'll let you check this point !

=)