### PR TITLE
Add documentation about redis cache configuration

### DIFF
--- a/components/cache/adapters/redis_adapter.rst
+++ b/components/cache/adapters/redis_adapter.rst
@@ -201,6 +201,18 @@ In order to use tag-based invalidation, you can wrap your adapter in :class:`Sym
     $client = RedisAdapter::createConnection('redis://localhost');
     $cache = new RedisTagAwareAdapter($client);
 
+Configuring Redis
+~~~~~~~~~~~~~~~~~
+
+When using Redis as cache, you should configure the `maxmemory` and `maxmemory-policy` settings.
+Read more about this topic in the offical `Redis LRU Cache Documentation`_.
+By setting `maxmemory`, you limit how much memory Redis is allowed to consume. If the amount is too low, Redis will drop entries that would still be useful and you benefit less from your cache. Setting the `maxmemory-policy` to 
+`allkeys-lru` tells Redis that it is ok to drop data when it runs out of memory, and to first drop the oldest entries (least 
+recently used). If you do not allow Redis to drop entries, it will return an error when you try to add data when no 
+memory is available. An example setting could look as follows:
+
+    maxmemory 100mb
+    maxmemory-policy allkeys-lru
 
 .. _`Data Source Name (DSN)`: https://en.wikipedia.org/wiki/Data_source_name
 .. _`Redis server`: https://redis.io/
@@ -211,3 +223,4 @@ In order to use tag-based invalidation, you can wrap your adapter in :class:`Sym
 .. _`Predis Connection Parameters`: https://github.com/nrk/predis/wiki/Connection-Parameters#list-of-connection-parameters
 .. _`TCP-keepalive`: https://redis.io/topics/clients#tcp-keepalive
 .. _`Redis Sentinel`: https://redis.io/topics/sentinel
+.. _`Redis LRU Cache Documentation`: https://redis.io/topics/lru-cache


### PR DESCRIPTION
Add documentation about redis cache configuration.

I personally did run into issue that my cache did explode and I didn't know why. At the end old cache entries where never thrown [away](https://github.com/doctrine/DoctrinePHPCRBundle/issues/349#issuecomment-696671651). This can easily be fixed by configuring redis with a maxmemory and maxmemory-policy. So the server will not run into having to much RAM usage. 