### PR TITLE
Update setup page for Symfony 5.2 - drop dev

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -50,10 +50,10 @@ application:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ symfony new my_project_name --version=next --full
+    $ symfony new my_project_name --full
 
     # run this if you are building a microservice, console application or API
-    $ symfony new my_project_name --version=next
+    $ symfony new my_project_name
 
 The only difference between these two commands is the number of packages
 installed by default. The ``--full`` option installs all the packages that you
@@ -65,10 +65,10 @@ Symfony application using Composer:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ composer create-project symfony/website-skeleton:"5.2.x@dev" my_project_name
+    $ composer create-project symfony/website-skeleton my_project_name
 
     # run this if you are building a microservice, console application or API
-    $ composer create-project symfony/skeleton:"5.2.x@dev" my_project_name
+    $ composer create-project symfony/skeleton my_project_name
 
 No matter which command you run to create the Symfony application. All of them
 will create a new ``my_project_name/`` directory, download some dependencies


### PR DESCRIPTION
Since 5.2 is already released there is no reason to point to `next` version

When merged, fixes #14663
