### PR TITLE
Update normalizers.rst

### DIFF
--- a/serializer/normalizers.rst
+++ b/serializer/normalizers.rst
@@ -36,10 +36,10 @@ Symfony includes the following normalizers but you can also
   transform :phpclass:`SplFileInfo` objects in `Data URIs`_
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\CustomNormalizer` to
   normalize PHP object using an object that implements
+  :class:`Symfony\\Component\\Serializer\\Normalizer\\NormalizableInterface`;
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\FormErrorNormalizer` for
   objects implementing the :class:`Symfony\\Component\\Form\\FormInterface` to
-  normalize form errors.
-  :class:`Symfony\\Component\\Serializer\\Normalizer\\NormalizableInterface`;
+  normalize form errors;
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\GetSetMethodNormalizer` to
   normalize PHP object using the getter and setter methods of the object;
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\PropertyNormalizer` to


### PR DESCRIPTION
It was indicated a wrong class.

The class `Symfony\Component\Serializer\Normalizer\NormalizableInterface` was not mentioned in the part that tells about how to normalize an object that implements the interface.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
