### PR TITLE
Update the Nginx example

### DIFF
--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -333,6 +333,9 @@ The **minimum configuration** to get your application running under Nginx is:
             # Otherwise, PHP's OPcache may not properly detect changes to
             # your PHP files (see https://github.com/zendtech/ZendOptimizerPlus/issues/126
             # for more information).
+            # Caveat: When PHP-FPM is hosted on a different machine from nginx
+            #         $realpath_root may not resolve as you expect! In this case try using
+            #         $document_root instead.
             fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
             fastcgi_param DOCUMENT_ROOT $realpath_root;
             # Prevents URIs that include the front controller. This will 404:


### PR DESCRIPTION
When I was looking through the Nginx configuration recipe for Symfony 4.x I discovered an important comment that isn’t included in the example in the Nginx section. I think this tip may be useful for those who create their environment using docker containers. In this PR I added the missing comment, which is taken from the recipe on this page: https://www.nginx.com/resources/wiki/start/topics/recipes/symfony/#secure-symfony-4-x.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
