### PR TITLE
Fixed typo in the listener that replaces the Symfony Debug Toolbar

### DIFF
--- a/profiler.rst
+++ b/profiler.rst
@@ -195,7 +195,7 @@ event::
 
     public function onKernelResponse(ResponseEvent $event)
     {
-        if (!$this->getKernel()->isDebug()) {
+        if (!$event->getKernel()->isDebug()) {
             return;
         }
 


### PR DESCRIPTION
`$event->getKernel()` should be used instead of `$this->getKernel()`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
