### PR TITLE
Replace unavailable dependency in Symfony 4

### DIFF
--- a/setup/unstable_versions.rst
+++ b/setup/unstable_versions.rst
@@ -68,7 +68,7 @@ Symfony version has deprecated some of its features.
         $ cd projects/my_project/
         $ git checkout -b testing_new_symfony
         # ... update composer.json configuration
-        $ composer update symfony/symfony
+        $ composer update "symfony/*"
 
         # ... after testing the new Symfony version
         $ git checkout master


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
