### PR TITLE
[Uid] Update uid.rst

### DIFF
--- a/components/uid.rst
+++ b/components/uid.rst
@@ -71,7 +71,7 @@ Converting UUIDs
 
 Use these methods to transform the UUID object into different bases::
 
-    $uuid = new Uuid::fromString('d9e7a184-5d5b-11ea-a62a-3499710062d0');
+    $uuid = Uuid::fromString('d9e7a184-5d5b-11ea-a62a-3499710062d0');
 
     $uuid->toBinary();  // string(16) "..." (binary contents can't be printed)
     $uuid->toBase32();  // string(26) "6SWYGR8QAV27NACAHMK5RG0RPG"


### PR DESCRIPTION
Uuid::fromString(); should not be instantiated as "new".
The Ulid section is correct the uuid section contains this error. 
Especially confusing when you are just starting with this newly implemented functionality.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
