### PR TITLE
[DependencyInjection] Fix possible error in example code

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -798,7 +798,7 @@ array element. For example, to retrieve the ``handler_two`` handler::
     {
         public function __construct(iterable $handlers)
         {
-            $handlers = iterator_to_array($handlers);
+            $handlers = $handlers instanceof \Traversable ? iterator_to_array($handlers) : $handlers;
 
             $handlerTwo = $handlers['handler_two'];
         }


### PR DESCRIPTION
Pseudo-type `iterable` accepts any `array` or `object` implementing the `Traversable` interface.  Constructor will be crashed when we try to pass array instead of `Traversable` and use `iterator_to_array`.
`iterator_to_array` dont work with arrays.
Then if always passing `Traversable` we could write like this:
```php
public function __construct(Traversable $handlers)
```
or check instance of `Traversable`.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
