### PR TITLE
Tweak doc around proxy manager bridge

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -93,9 +93,9 @@ To check if your proxy works you can check the interface of the received object:
 
 .. note::
 
-    If you don't install the `ProxyManager bridge`_ and the
-    `ocramius/proxy-manager`_, the container will skip over the ``lazy``
-    flag and directly instantiate the service as it would normally do.
+    If you don't install the `ProxyManager bridge`_ , the container will skip
+    over the ``lazy`` flag and directly instantiate the service as it would
+    normally do.
 
 Additional Resources
 --------------------
@@ -106,5 +106,4 @@ in the `documentation of ProxyManager`_.
 .. _`ProxyManager bridge`: https://github.com/symfony/symfony/tree/master/src/Symfony/Bridge/ProxyManager
 .. _`proxy`: https://en.wikipedia.org/wiki/Proxy_pattern
 .. _`documentation of ProxyManager`: https://github.com/Ocramius/ProxyManager/blob/master/docs/lazy-loading-value-holder.md
-.. _`ocramius/proxy-manager`: https://github.com/Ocramius/ProxyManager
 .. _`final`: https://www.php.net/manual/en/language.oop5.final.php


### PR DESCRIPTION
ProxyManager is already a dep of the ProxyManagerBridge, that's why only the bridge needs to be installed.

Relates to https://github.com/symfony/symfony/pull/39610