### PR TITLE
Indicate Make Disposition Limitations

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -604,6 +604,8 @@ abstracts the hard work behind a simple API::
     $fileContent = ...; // the generated file content
     $response = new Response($fileContent);
 
+    // Note: this does not handle / or \, use a slugger
+    // like provided in the String component.
     $disposition = HeaderUtils::makeDisposition(
         HeaderUtils::DISPOSITION_ATTACHMENT,
         'foo.pdf'


### PR DESCRIPTION
As discussed in https://github.com/symfony/symfony/issues/34528, the `HeaderUtils::makeDisposition` method does not safely handle all inputs, by design, but is presented in the documentation as a "fool proof" method of handling creation of this header.

I'm not sure how best to indicate this, so open to suggestions...
