### PR TITLE
Update performance.rst

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -106,8 +106,16 @@ make them available to all requests until the server is restarted, improving
 performance significantly.
 
 During container compilation (e.g. when running the ``cache:clear`` command),
-Symfony generates a file called ``preload.php`` in the ``config/`` directory
-with the list of classes to preload.
+Symfony generates a file with the list of classes to preload in the
+``var/cache`` directory.
+
+Rather than use this file directly, when installing with Flex the Framework
+Bundle recipe will create a file called ``preload.php`` in the ``config/``
+directory, which you can use safely, since it includes safeguards in case the
+cache has not been warmed beforehand.
+
+If this file is missing, you can reinstall the recipe by executing
+``composer recipes:install symfony/framework-bundle --force -v``.
 
 The only requirement is that you need to set both ``container.dumper.inline_factories``
 and ``container.dumper.inline_class_loader`` parameters to ``true``. Then, you


### PR DESCRIPTION
The explanation for when the `preload.php` file was generated was wrong, since that file is not created during container compilation. The actual list of classes is generated then, but that one is placed on `var/cache`. The `preload.php` file depends on the `symfony/framework-bundle` [recipe](https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/5.1/config/preload.php).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
