### PR TITLE
[DependencyInjection] Replace link to getConfiguration method

### DIFF
--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -334,7 +334,7 @@ As long as your bundle's configuration is located in the standard location
 (``YourBundle\DependencyInjection\Configuration``) and does not have
 a constructor it will work automatically. If you
 have something different, your ``Extension`` class must override the
-:method:`Extension::getConfiguration() <Symfony\\Component\\HttpKernel\\DependencyInjection\\Extension::getConfiguration>`
+:method:`Extension::getConfiguration() <Symfony\\Component\\DependencyInjection\\Extension\\Extension::getConfiguration>`
 method and return an instance of your ``Configuration``.
 
 Supporting XML


### PR DESCRIPTION
In my opinion, the link should redirect to the class where we can preview the method that must be overridden.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
