### PR TITLE
Mentioning "array" explicitly

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -281,19 +281,15 @@ Use ``addTo()``, ``addCc()``, or ``addBcc()`` methods to add more addresses::
         ->addTo('bar@example.com')
         ->cc('cc@example.com')
         ->addCc('cc2@example.com')
-
-        // ...
     ;
 
 Alternatively, you can pass multiple addresses to each method::
 
-    $toAddresses = ['foo@example.com', new Address('bar@example.com')];
+    $addressesArray = ['foo@example.com', new Address('bar@example.com')];
 
     $email = (new Email())
-        ->to(...$toAddresses)
+        ->to(...$addressesArray)
         ->cc('cc1@example.com', 'cc2@example.com')
-
-        // ...
     ;
 
 Message Headers


### PR DESCRIPTION
See https://github.com/symfony/symfony-docs/pull/13996#issuecomment-663622246 - I opened that other PR to get the word **array** on the page ;-)

Also, I'm deleting two comments `// ...` from code blocks, since they're present in some, and absent in some. I think it's better to always omit them, if the given example is (sort of) complete in itself. IMO, these 2 deleted comments didn't add any value, and just made the page longer.

General question: How often are the pages rebuilt? Or what's the process of getting stuff online at https://symfony.com/doc/4.4/mailer.html#email-addresses after a PR has been merged?