### PR TITLE
[Yaml] Adds chapters for YAML lint --exclude option

### DIFF
--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -433,6 +433,12 @@ Then, execute the script for validating contents:
     # or contents passed to STDIN
     $ cat path/to/file.yaml | php lint.php
 
+Use the `--exclude` option to exclude one or more specific files from multiple file list:
+
+.. code-block:: terminal
+
+    $ php lint.php path/to/directory --exclude=path/to/directory/foo.yaml --exclude=path/to/directory/bar.yaml
+
 The result is written to STDOUT and uses a plain text format by default.
 Add the ``--format`` option to get the output in JSON format:
 


### PR DESCRIPTION
Adds the new chapters for the yaml lint ``--exclude`` and ``--config`` options.

See the feature pull: https://github.com/symfony/symfony/pull/39641