### PR TITLE
[PHPUnitBridge] Fix  ClassExistsMock::register issue

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -759,11 +759,25 @@ classes, interfaces and/or traits for the code to run::
 
     class MyClassTest extends TestCase
     {
+        public static function setUpBeforeClass(): void
+        {
+            ClassExistsMock::register(MyClass::class);
+        }
+
+        protected function setUp(): void
+        {
+            ClassExistsMock::withMockedClasses([]);
+        }
+
+        public function tearDown(): void
+        {
+            ClassExistsMock::withMockedClasses([]);
+        }
+        
         // ...
 
         public function testHelloDefault()
         {
-            ClassExistsMock::register(MyClass::class);
             ClassExistsMock::withMockedClasses([DependencyClass::class => false]);
 
             $class = new MyClass();


### PR DESCRIPTION
Hi,

I tried to use the methods [`register` and `withMockedClasses`](https://symfony.com/doc/current/components/phpunit_bridge.html#class-existence-based-tests) from the class `Symfony\Bridge\PhpUnit\ClassExistsMock` without success.
I tried to debug to understand the problem and noted that the mocked functions are correctly created, but not loaded.
I compared the example in the documentation with the tests written for this class and found that the mocked functions are not autoloaded if `register` is called directly in the test.

This PR indicates that the function `register` should be called before the test class is created (`setUpBeforeClass`).
In addition, it proposes to sanitize the mocked classes before and after each test to avoid side effects.

Note: as per [this example](https://github.com/symfony/symfony/blob/494ef421c554a78b38c6779c4b7deb9a20d89923/src/Symfony/Bridge/PhpUnit/Tests/ClassExistsMockTest.php)
