### PR TITLE
[Validator] Added {{ min }} and {{ max }} placeholder to Range constraint for minMessage and maxMessage

### DIFF
--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -348,7 +348,7 @@ maxMessage
 The message that will be shown if the underlying value is more than the
 `max`_ option, and **no** `min`_ option has been defined.
 
-If **both** are defined, use `notInRangeMessage`_ or use the parameter ``{{ max }}`` instead.
+If **both** are defined, use `notInRangeMessage`_.
 
 You can use the following parameters in this message:
 
@@ -398,7 +398,7 @@ minMessage
 The message that will be shown if the underlying value is less than the
 `min`_ option, and **no** `max`_ option has been defined.
 
-If **both** are defined, use `notInRangeMessage`_ or use the parameter ``{{ min }}`` instead.
+If **both** are defined, use `notInRangeMessage`_.
 
 You can use the following parameters in this message:
 

--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -346,15 +346,17 @@ maxMessage
 **type**: ``string`` **default**: ``This value should be {{ limit }} or less.``
 
 The message that will be shown if the underlying value is more than the
-`max`_ option, and no `min`_ option has been defined (if both are defined, use
-`notInRangeMessage`_).
+`max`_ option, and **no** `min`_ option has been defined.
+
+If **both** are defined, use `notInRangeMessage`_ or use the parameter ``{{ max }}`` instead.
 
 You can use the following parameters in this message:
 
 ===============  ==============================================================
 Parameter        Description
 ===============  ==============================================================
-``{{ limit }}``  The upper limit
+``{{ limit }}``  The upper limit (if only `max`_ is defined)
+``{{ max }}``    The upper limit (if both `min`_ and `max`_ are defined)
 ``{{ value }}``  The current (invalid) value
 ===============  ==============================================================
 
@@ -394,15 +396,17 @@ minMessage
 **type**: ``string`` **default**: ``This value should be {{ limit }} or more.``
 
 The message that will be shown if the underlying value is less than the
-`min`_ option, and no `max`_ option has been defined (if both are defined, use
-`notInRangeMessage`_).
+`min`_ option, and **no** `max`_ option has been defined.
+
+If **both** are defined, use `notInRangeMessage`_ or use the parameter ``{{ min }}`` instead.
 
 You can use the following parameters in this message:
 
 ===============  ==============================================================
 Parameter        Description
 ===============  ==============================================================
-``{{ limit }}``  The lower limit
+``{{ limit }}``  The lower limit (if only `min`_ is defined)
+``{{ min }}``    The lower limit (if both `min`_ and `max`_ are defined)
 ``{{ value }}``  The current (invalid) value
 ===============  ==============================================================
 


### PR DESCRIPTION
I recognized that `{{ limit }}` can not be used for the [Range constraint](https://symfony.com/doc/current/reference/constraints/Range.html) if both `min` and `max` parameter are given as currently documented. 

The docs say that one should rather use [notInRangeMessage](https://symfony.com/doc/current/reference/constraints/Range.html#notinrangemessage) instead but the information that [minMessage](https://symfony.com/doc/current/reference/constraints/Range.html#minmessage) and [maxMessage](https://symfony.com/doc/current/reference/constraints/Range.html#maxmessage) can *still* be used but with the placeholders `{{ min }}` and `{{ max }}` instead of `{{ limit }}` is missing.

Also, if you don't want to use the `notInRangeMessage` which always includes the upper and lower value but rather just the one that failed, this information is quite useful.