### PR TITLE
[FrameworkBundle] Document assertResponseFormatSame()

### DIFF
--- a/testing/functional_tests_assertions.rst
+++ b/testing/functional_tests_assertions.rst
@@ -39,6 +39,12 @@ Response
 - ``assertResponseHasCookie()``
 - ``assertResponseNotHasCookie()``
 - ``assertResponseCookieValueSame()``
+- ``assertResponseFormatSame()`` (the response format is the value returned by
+  the :method:`Symfony\Component\HttpFoundation\Response::getFormat` method).
+
+.. versionadded:: 5.3
+
+    The ``assertResponseFormatSame()`` method was introduced in Symfony 5.3.
 
 Request
 ~~~~~~~


### PR DESCRIPTION
Fixes #14772.

Given that "format" is something not as standard as Content-Type, MIME type, etc. I decided to add some short description of the value that you'll get. But we can remove it if you prefer. Thanks.