### PR TITLE
[DependencyInjection] [Configuration] Fix PHP configuration sample for setting default parameter bindings

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -881,18 +881,15 @@ whenever a service/controller defines a ``$projectDir`` argument, use this:
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
         use App\Controller\LuckyController;
-        use Psr\Log\LoggerInterface;
-        use Symfony\Component\DependencyInjection\Reference;
 
         return static function (ContainerConfigurator $container) {
-            $container->services()
-                ->set(LuckyController::class)
-                    ->public()
-                    ->args([
-                        // pass this value to any $projectDir argument for any service
-                        // that's created in this file (including controller arguments)
-                        '$projectDir' => '%kernel.project_dir%',
-                    ]);
+            $services = $container->services()
+                ->defaults()
+                    // pass this value to any $projectDir argument for any service
+                    // that's created in this file (including controller arguments)
+                    ->bind('$projectDir', '%kernel.project_dir%');
+            
+            // ...
         };
 
 .. seealso::


### PR DESCRIPTION
This pull request fixes the PHP version of the config for setting default parameter bindings that seems to be irrelevant (whereas the XML and YML versions are ok).