### PR TITLE
Add warning about removed services

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -590,6 +590,12 @@ container is a service that can be get via the normal container::
         // ...
     }
 
+.. caution::
+
+    The special container ``test.service_container`` doesn't give access
+    to the services that have been removed. In this case, you'll have
+    to declare the services you need as public.
+
 .. tip::
 
     If the information you need to check is available from the profiler, use


### PR DESCRIPTION
I was confused by the fact that the documentation explains:

> Finally, for the most rare edge-cases, Symfony includes a special container which provides access to all services, public and private. This special container is a service that can be get via the normal container

and the fact that the special container doesn't give access to the removed service.

So I added a tip in the documentation, taking inspiration from a Symfony article:

> Keep in mind that, because of how Symfony's service container work, unused services are removed from the container. This means that if you have a private service not used by any other service, Symfony will remove it and you won't be able to get it as explained in this article. The solution is to define the service as public explicitly so Symfony doesn't remove it.

Source: https://symfony.com/blog/new-in-symfony-4-1-simpler-service-testing

This is also consistent with the error message from Symfony: https://github.com/symfony/symfony/blob/3ffe5573e9dd045e157c6f17358c700fceae3feb/src/Symfony/Component/DependencyInjection/Container.php#L275

See also https://github.com/symfony/symfony-docs/pull/12647 and https://github.com/symfony/symfony/issues/30104