### PR TITLE
Update access_denied_handler.rst

### DIFF
--- a/security/access_denied_handler.rst
+++ b/security/access_denied_handler.rst
@@ -210,7 +210,7 @@ configure a :ref:`kernel.exception listener <use-kernel-exception-event>`::
 
         public function onKernelException(ExceptionEvent $event): void
         {
-            $exception = $event->getException();
+            $exception = $event->getThrowable();
             if (!$exception instanceof AccessDeniedException) {
                 return;
             }


### PR DESCRIPTION
getException is deprecated from symfony 4.4,  as per event listerner docs we have to use getThrowable()

