### PR TITLE
Change in table creation SQL for SQL Server

### DIFF
--- a/session/database.rst
+++ b/session/database.rst
@@ -417,7 +417,7 @@ Microsoft SQL Server
 
     CREATE TABLE sessions (
         sess_id VARCHAR(128) NOT NULL PRIMARY KEY,
-        sess_data VARBINARY(MAX) NOT NULL,
+        sess_data NVARCHAR(MAX) NOT NULL,
         sess_lifetime INTEGER NOT NULL,
         sess_time INTEGER NOT NULL
     );


### PR DESCRIPTION
I propose to change VARBINARY to NVARCHAR, because for the newest version of drivers and SQL Server 17 or newer this script creates a table which is not valid: PdoSessionHandler actually tries to insert string in sess_data not binary data. 
What's more: VARBINARY(max) is about 8kB long at most whereas NVARCHAR can contain up to 2GB of data. 
There is of course another way, suggested by ODBC error while trying to insert data to sessions created like shown: use convert during inserting, however I would not consider it a way.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
