### PR TITLE
[Mailer] Add missing transports entry in XML and PHP configurations

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -978,6 +978,7 @@ you have a transport called ``async``, you can route the message there:
 
             <framework:config>
                 <framework:messenger>
+                    <framework:transport name="async">%env(MESSENGER_TRANSPORT_DSN)%</framework:transport>
                     <framework:routing message-class="Symfony\Component\Mailer\Messenger\SendEmailMessage">
                         <framework:sender service="async"/>
                     </framework:routing>
@@ -990,6 +991,9 @@ you have a transport called ``async``, you can route the message there:
         // config/packages/messenger.php
         $container->loadFromExtension('framework', [
             'messenger' => [
+                'transports' => [
+                    'async' => '%env(MESSENGER_TRANSPORT_DSN)%',
+                ],
                 'routing' => [
                     'Symfony\Component\Mailer\Messenger\SendEmailMessage' => 'async',
                 ],


### PR DESCRIPTION
The YAML configuration of the Messenger component contains the transports entry that is not defined in the XML and PHP configurations.