### PR TITLE
[Lock] Use .inner instead of decorating_service_id + '.inner'

### DIFF
--- a/lock.rst
+++ b/lock.rst
@@ -293,4 +293,4 @@ you can do it by :doc:`decorating the store </service_container/service_decorati
     lock.default.retry_till_save.store:
         class: Symfony\Component\Lock\Store\RetryTillSaveStore
         decorates: lock.default.store
-        arguments: ['@lock.default.retry_till_save.store.inner', 100, 50]
+        arguments: ['@.inner', 100, 50]


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
