### PR TITLE
Typo

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -63,7 +63,7 @@ If you want to test an entire feature of your application (e.g. registering as a
 user or generating an invoice), see the section about :ref:`Functional Tests <functional-tests>`.
 
 Writing Symfony unit tests is no different from writing standard PHPUnit
-unit tests. Suppose, for example, that you have an class called ``Calculator``
+unit tests. Suppose, for example, that you have a class called ``Calculator``
 in the ``src/Util/`` directory of the app::
 
     // src/Util/Calculator.php


### PR DESCRIPTION
Replaced "an" by "a" (line 66)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
