### PR TITLE
Update best_practices.rst

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -25,6 +25,7 @@ namespace short name, which must end with ``Bundle``.
 A namespace becomes a bundle as soon as you add a bundle class to it. The
 bundle class name must follow these rules:
 
+* Extend Symfony\Component\HttpKernel\Bundle\Bundle
 * Use only alphanumeric characters and underscores;
 * Use a StudlyCaps name (i.e. camelCase with an uppercase first letter);
 * Use a descriptive and short name (no more than two words);
@@ -40,9 +41,6 @@ Namespace                   Bundle Class Name
 ``Acme\Bundle\BlogBundle``  AcmeBlogBundle
 ``Acme\BlogBundle``         AcmeBlogBundle
 ==========================  ==================
-
-By convention, the ``getName()`` method of the bundle class should return the
-class name.
 
 .. note::
 


### PR DESCRIPTION
It seems that all bundles extend `Symfony\Component\HttpKernel\Bundle\Bundle` which should be included in the requirements.
Also as `Symfony\Component\HttpKernel\Bundle\Bundle` already has `final public function getName()` it makes sense to remove the suggestion that this method should be implemented.
