### PR TITLE
[DependencyInjection] Require preprocessor env name fix used in PHP snippet

### DIFF
--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -394,7 +394,7 @@ Symfony provides the following env var processors:
             // config/packages/framework.php
             $container->setParameter('env(PHP_FILE)', '../config/.runtime-evaluated.php');
             $container->loadFromExtension('app', [
-                'auth' => '%env(require:AUTH_FILE)%',
+                'auth' => '%env(require:PHP_FILE)%',
             ]);
 
     .. versionadded:: 4.3


### PR DESCRIPTION
A PHP code snippet for `require` preprocessor defines default environment variable with a different name than used in parameter resolution.
