### PR TITLE
[Validator] Use constant instead of magic string

### DIFF
--- a/reference/constraints/CardScheme.rst
+++ b/reference/constraints/CardScheme.rst
@@ -101,7 +101,7 @@ on an object that will contain a credit card number.
             {
                 $metadata->addPropertyConstraint('cardNumber', new Assert\CardScheme([
                     'schemes' => [
-                        'VISA',
+                        Assert\CardScheme::VISA,
                     ],
                     'message' => 'Your credit card number is invalid.',
                 ]));

--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -100,7 +100,7 @@ on an object that will contain an ISBN.
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
                 $metadata->addPropertyConstraint('isbn', new Assert\Isbn([
-                    'type' => 'isbn10',
+                    'type' => Assert\Isbn::ISBN_10,
                     'message' => 'This value is not valid.',
                 ]));
             }


### PR DESCRIPTION
Related to the [comment](https://github.com/symfony/symfony-docs/pull/14544#pullrequestreview-546062538).

