### PR TITLE
[Validator] Change the example to be consistent with the rest

### DIFF
--- a/reference/constraints/AtLeastOneOf.rst
+++ b/reference/constraints/AtLeastOneOf.rst
@@ -141,7 +141,7 @@ The following constraints ensure that:
                         new Assert\Count(['min' => 3]),
                         new Assert\All([
                             'constraints' => [
-                                new Assert\GreaterThanOrEqual(['value' => 5]),
+                                new Assert\GreaterThanOrEqual(5),
                             ],
                         ]),
                     ],


### PR DESCRIPTION
Other examples do not use key 'value'.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
