### PR TITLE
Update security.rst

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -345,7 +345,6 @@ important section is ``firewalls``:
                     pattern: ^/(_(profiler|wdt)|css|images|js)/
                     security: false
                 main:
-                    anonymous: true
                     lazy: true
 
     .. code-block:: xml


### PR DESCRIPTION
The authenticator manager no longer has "anonymous" security. This appears to be a new change since 5.2