### PR TITLE
[Translator] Fix select & plural message format

### DIFF
--- a/translation/message_format.rst
+++ b/translation/message_format.rst
@@ -256,27 +256,24 @@ Usage of this string is the same as with variables and select::
     .. code-block:: text
 
         {gender_of_host, select,
-            female {
-                {num_guests, plural, offset:1
+            female {{num_guests, plural, offset:1
                 =0    {{host} does not give a party.}
                 =1    {{host} invites {guest} to her party.}
                 =2    {{host} invites {guest} and one other person to her party.}
-                other {{host} invites {guest} and # other people to her party.}}
-            }
-            male {
-                {num_guests, plural, offset:1
+                other {{host} invites {guest} and # other people to her party.}
+            }}
+            male {{num_guests, plural, offset:1
                 =0    {{host} does not give a party.}
                 =1    {{host} invites {guest} to his party.}
                 =2    {{host} invites {guest} and one other person to his party.}
-                other {{host} invites {guest} and # other people to his party.}}
-            }
-            other {
-                {num_guests, plural, offset:1
+                other {{host} invites {guest} and # other people to his party.}
+            }}
+            other {{num_guests, plural, offset:1
                 =0    {{host} does not give a party.}
                 =1    {{host} invites {guest} to their party.}
                 =2    {{host} invites {guest} and one other person to their party.}
-                other {{host} invites {guest} and # other people to their party.}}
-            }
+                other {{host} invites {guest} and # other people to their party.}
+            }}
         }
 
 .. sidebar:: Using Ranges in Messages


### PR DESCRIPTION
Current version produces spaces around message with both ext-int and symfony version of message formatter. This PR fixes it.

e.g. for parameters `['gender_of_host' => 'male', 'num_guests' => 2, 'host' => 'John', 'guest' => 'Mr. Bean']` output changes from: (select text to see spaces)

```txt

        John invites Mr. Bean and one other person to his party.
    
```
To:

```txt
John invites Mr. Bean and one other person to his party.
```