### PR TITLE
[HttpFoundation] JsonResponse content updated

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -668,9 +668,11 @@ class, which can make this even easier::
     // if you know the data to send when creating the response
     $response = new JsonResponse(['data' => 123]);
 
-    // if you don't know the data to send when creating the response
+    // if you don't know the data to send or if you want to customize the encoding options
     $response = new JsonResponse();
     // ...
+    // configure any custom encoding options (if needed, it must be called before "setData()")
+    //$response->setEncodingOptions(JsonResponse::DEFAULT_ENCODING_OPTIONS | \JSON_PRESERVE_ZERO_FRACTION);
     $response->setData(['data' => 123]);
 
     // if the data to send is already encoded in JSON


### PR DESCRIPTION
When using the `JsonResponse` with customized encoding options, the `JsonResponse` class can modify the given data.
Example:
```php
$response = new JsonResponse(['data' => (float) 3]);
echo $response->getContent(); // {"data": 3}
$response->setEncodingOptions(JsonResponse::DEFAULT_ENCODING_OPTIONS | \JSON_PRESERVE_ZERO_FRACTION);
echo $response->getContent(); // {"data": 3}
```
as you can see we gave float value and it returns integer. Because when we instantiate the `JsonResponse` it serializes the data with default encoding options. The proper way to do this;

```php
$response = new JsonResponse();
$response->setEncodingOptions(JsonResponse::DEFAULT_ENCODING_OPTIONS | \JSON_PRESERVE_ZERO_FRACTION);
$response->setData(['data' => (float) 3]);
echo $response->getContent(); // {"data": 3.0}
```

for details of the \JSON_PRESERVE_ZERO_FRACTION flag see [https://www.php.net/manual/en/function.json-encode.php](https://www.php.net/manual/en/function.json-encode.php)