### PR TITLE
[Validator] Use seealso instead of tip for File

### DIFF
--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -11,7 +11,7 @@ Validates that a value is a valid "file", which can be one of the following:
 This constraint is commonly used in forms with the :doc:`FileType </reference/forms/types/file>`
 form field.
 
-.. tip::
+.. seealso::
 
     If the file you're validating is an image, try the :doc:`Image </reference/constraints/Image>`
     constraint.


### PR DESCRIPTION
In [Unique](https://symfony.com/doc/4.4/reference/constraints/Unique.html), [UniqueEntity](https://symfony.com/doc/4.4/reference/constraints/UniqueEntity.html) and [Collection](https://symfony.com/doc/4.4/reference/constraints/Collection.html) when there is a suggestion to use another constraint, `seealso` is used.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
