### PR TITLE
[Validator] Use constant instead of magic string

### DIFF
--- a/reference/constraints/CardScheme.rst
+++ b/reference/constraints/CardScheme.rst
@@ -34,7 +34,7 @@ on an object that will contain a credit card number.
         {
             /**
              * @Assert\CardScheme(
-             *     schemes={"VISA"},
+             *     schemes={Assert\CardScheme::VISA},
              *     message="Your credit card number is invalid."
              * )
              */
@@ -64,7 +64,7 @@ on an object that will contain a credit card number.
             properties:
                 cardNumber:
                     - CardScheme:
-                        schemes: [VISA]
+                        schemes: [!php/const Symfony\Component\Validator\Constraints\CardScheme::VISA]
                         message: Your credit card number is invalid.
 
     .. code-block:: xml

--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -36,7 +36,7 @@ on an object that will contain an ISBN.
         {
             /**
              * @Assert\Isbn(
-             *     type = "isbn10",
+             *     type = Assert\Isbn::ISBN_10,
              *     message = "This value is not valid."
              * )
              */
@@ -66,7 +66,7 @@ on an object that will contain an ISBN.
             properties:
                 isbn:
                     - Isbn:
-                        type: isbn10
+                        type: !php/const Symfony\Component\Validator\Constraints\Isbn::ISBN_10
                         message: This value is not valid.
 
     .. code-block:: xml


### PR DESCRIPTION
Xml does [not support](https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd) constants in constraints.
The one from the services [does](https://symfony.com/schema/dic/symfony/symfony-1.0.xsd).
PHP constants in YAML files are supported since [Symfony 3.2](https://symfony.com/blog/new-in-symfony-3-2-php-constants-in-yaml-files).