### PR TITLE
Remove StofDoctrineExtensionBundle

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -884,8 +884,7 @@ Doctrine Extensions (Timestampable, Translatable, etc.)
 
 Doctrine community has created some extensions to implement common needs such as
 *"set the value of the createdAt property automatically when creating an entity"*.
-Read more about the `available Doctrine extensions`_ and use the
-`StofDoctrineExtensionsBundle`_ to integrate them in your application.
+Read more about the `available Doctrine extensions`_ .
 
 Learn more
 ----------
@@ -921,4 +920,3 @@ Learn more
 .. _`API Platform`: https://api-platform.com/docs/core/validation/
 .. _`PDO`: https://www.php.net/pdo
 .. _`available Doctrine extensions`: https://github.com/Atlantic18/DoctrineExtensions
-.. _`StofDoctrineExtensionsBundle`: https://github.com/stof/StofDoctrineExtensionsBundle


### PR DESCRIPTION
Unfortunately, StofDoctrineExtensionBundle isn't actively maintained anymore. A PR that added PHP 8 support was merged after more than a month and now we're waiting for a tag release, but the maintainer doesn't reply at all. The maintainer seems to have other priorities (no hard feelings, he's still working on open source projects), but since he doesn't respond to our questions, we have to guess about the reason it takes so long to get a response.

Fortunately, Doctrine Extensions can be configured without a third party bundle: https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/symfony4.md.

I think Symfony shouldn't recommend third party bundles that aren't actively maintained anymore.