### PR TITLE
[CARE] Update section about blog posts

### DIFF
--- a/contributing/code_of_conduct/care_team.rst
+++ b/contributing/code_of_conduct/care_team.rst
@@ -42,3 +42,16 @@ The :doc:`Symfony project leader </contributing/code/core_team>` appoints the CA
 team with candidates they see fit. The CARE team will consist of at least
 3 people. The team should be representing as many demographics as possible,
 ideally from different employers.
+
+CARE Team Related Posts
+-----------------------
+
+Blog posts related to the Symfony CARE team.
+
+* `Symfony CARE Team Training 2018`_.
+* `The first CARE Team`_.
+* `Symfony Code of Conduct Transparency Report 2018`_.
+
+.. _`Symfony CARE Team Training 2018`: https://symfony.com/blog/care-team-training
+.. _`The first CARE Team`: https://symfony.com/blog/diversity-initiative-the-care-team
+.. _`Symfony Code of Conduct Transparency Report 2018`: https://symfony.com/blog/symfony-code-of-conduct-transparency-report-2018

--- a/contributing/code_of_conduct/care_team.rst
+++ b/contributing/code_of_conduct/care_team.rst
@@ -42,12 +42,3 @@ The :doc:`Symfony project leader </contributing/code/core_team>` appoints the CA
 team with candidates they see fit. The CARE team will consist of at least
 3 people. The team should be representing as many demographics as possible,
 ideally from different employers.
-
-CARE Team Transparency Reports
-------------------------------
-
-The CARE team publishes a transparency report at the end of each year:
-
-* `Symfony Code of Conduct Transparency Report 2018`_.
-
-.. _`Symfony Code of Conduct Transparency Report 2018`: https://symfony.com/blog/symfony-code-of-conduct-transparency-report-2018


### PR DESCRIPTION
I don't like this section. It should must rather be "CARE related updates". But that is borderlining a "CARE" category on the blog. 

I am all for transparency reports. I also know that @javiereguiluz has asked me for "last years data" more than once... Maybe it is time for a "past 3 years transparency report".

This is a draft PR because I dont want to remove this section without replacing it with something else. Please give me opinions and suggestions. 
