### PR TITLE
[ExpressionLanguage][Security] role_names instead of roles

### DIFF
--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -42,6 +42,10 @@ Inside the expression, you have access to a number of variables:
     The array of roles the user has. This array includes any roles granted
     indirectly via the :ref:`role hierarchy <security-role-hierarchy>` but it
     does not include the ``IS_AUTHENTICATED_*`` attributes (see the functions below).
+``role_names``
+    A string representation of the roles the user has. This array includes any roles granted
+    indirectly via the :ref:`role hierarchy <security-role-hierarchy>` but it
+    does not include the ``IS_AUTHENTICATED_*`` attributes (see the functions below).
 ``object``
     The object (if any) that's passed as the second argument to ``isGranted()``.
 ``token``


### PR DESCRIPTION
corrected wrong attribute name

relates to symfony/symfony#40087
