### PR TITLE
[ExpressionLanguage][Security] Mention the "subject" expression language variable

### DIFF
--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -48,6 +48,8 @@ Inside the expression, you have access to a number of variables:
     does not include the ``IS_AUTHENTICATED_*`` attributes (see the functions below).
 ``object``
     The object (if any) that's passed as the second argument to ``isGranted()``.
+``subject``
+    It stores the same value as ``object``, so they are equivalent.
 ``token``
     The token object.
 ``trust_resolver``


### PR DESCRIPTION
This was requested in https://github.com/symfony/symfony/pull/40089

By the way, in my opinion providing two different ways of doing exactly the same is always confusing.