### PR TITLE
[Validator] Use correct single quotes for a string

### DIFF
--- a/reference/constraints/IsFalse.rst
+++ b/reference/constraints/IsFalse.rst
@@ -3,7 +3,7 @@ IsFalse
 
 Validates that a value is ``false``. Specifically, this checks to see if
 the value is exactly ``false``, exactly the integer ``0``, or exactly the
-string "``0``".
+string ``'0'``.
 
 Also see :doc:`IsTrue <IsTrue>`.
 

--- a/reference/constraints/IsTrue.rst
+++ b/reference/constraints/IsTrue.rst
@@ -2,7 +2,7 @@ IsTrue
 ======
 
 Validates that a value is ``true``. Specifically, this checks if the value is
-exactly ``true``, exactly the integer ``1``, or exactly the string ``"1"``.
+exactly ``true``, exactly the integer ``1``, or exactly the string ``'1'``.
 
 Also see :doc:`IsFalse <IsFalse>`.
 


### PR DESCRIPTION
Like in the [Unique](https://symfony.com/doc/current/reference/constraints/Unique.html).
Currently, it's not consistent with the rest.