### PR TITLE
updating config for postcss-loader v4

### DIFF
--- a/frontend/encore/postcss.rst
+++ b/frontend/encore/postcss.rst
@@ -43,13 +43,14 @@ You can also pass options to the `postcss-loader`_ by passing a callback:
 .. code-block:: diff
 
     // webpack.config.js
+    + const path = require('path');
 
     Encore
         // ...
     +     .enablePostCssLoader((options) => {
-    +         options.config = {
+    +         options.postcssOptions = {
     +             // the directory where the postcss.config.js file is stored
-    +             path: 'path/to/config'
+    +             config: path.resolve(__dirname, 'sub-dir', 'custom.config.js'),
     +         };
     +     })
     ;


### PR DESCRIPTION
Encore 1.0 now supports postcss-loader v4, and the options have changed.

This fixes #14935 and https://github.com/symfony/webpack-encore/issues/924

Thanks!