### PR TITLE
[Messenger] Remove duplicated AMQP transport option

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -971,9 +971,6 @@ The transport has a number of options:
                                               fractional.
 ``connect_timeout``                           Connection timeout. Note: 0 or greater seconds.
                                               May be fractional.
-``confirm_timeout``                           Number of seconds to wait for message sending
-                                              confirmation. If not specified, transport won't
-                                              wait for confirmation. May be fractional.
 ``frame_max``                                 The largest frame size that the server proposes
                                               for the connection, including frame header and
                                               end-byte. 0 means standard extension limit


### PR DESCRIPTION
The confirm_timeout option (introduced in Symfony 5.2) has been documented twice. I left the first version which is closest to the documentation available in the Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection class.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
