### PR TITLE
[Mailer] Improve documentation for mailer failover and round-robin transports

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -186,9 +186,9 @@ A failover transport is configured with two or more transports and the
 
     MAILER_DSN="failover(postmark+api://ID@default sendgrid+smtp://KEY@default)"
 
-The mailer will start using the first transport. If the sending fails, the
-mailer won't retry it with the other transports, but it will switch to the next
-transport automatically for the following deliveries.
+The failover-transport starts using the first transport and if it fails, it
+will retry the same delivery with the next transports until one of them succeeds
+(or until all of them fail).
 
 Load Balancing
 ~~~~~~~~~~~~~~
@@ -203,9 +203,12 @@ A round-robin transport is configured with two or more transports and the
 
     MAILER_DSN="roundrobin(postmark+api://ID@default sendgrid+smtp://KEY@default)"
 
-The mailer will start using the first transport and if it fails, it will retry
-the same delivery with the next transports until one of them succeeds (or until
-all of them fail).
+The round-robin transport starts with a *randomly* selected transport and
+then switches to the next available transport for each subsequent email.
+
+As with the failover transport, round-robin retries deliveries until
+a transport succeeds (or all fail). In contrast to the failover transport,
+it *spreads* the load across all its transports.
 
 Creating & Sending Messages
 ---------------------------


### PR DESCRIPTION
I think the current documentation for the failover transport is not correct.

> If the sending fails, the mailer won’t retry it with the other transports

This isn't what really happens. In my tests (and from studying the code), it seems that the mailer simply retries with the next available transport.

This is also what one would expect from a **failover**. Failing the first time something goes wrong isn't really a failover ;-)

So the only difference between _failover_ and _round-robin_ is that the latter selects a transport at random. My proposed change reflects that more clearly. 