### PR TITLE
[Messenger] [CS] Add missing commas

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -859,7 +859,7 @@ your Envelope::
 
     $attributes = [];
     $bus->dispatch(new SmsNotification(), [
-        new AmqpStamp('custom-routing-key', AMQP_NOPARAM, $attributes)
+        new AmqpStamp('custom-routing-key', AMQP_NOPARAM, $attributes),
     ]);
 
 .. caution::
@@ -1483,12 +1483,12 @@ to your message::
     {
         $bus->dispatch(new SmsNotification('...'), [
             // wait 5 seconds before processing
-            new DelayStamp(5000)
+            new DelayStamp(5000),
         ]);
 
         // or explicitly create an Envelope
         $bus->dispatch(new Envelope(new SmsNotification('...'), [
-            new DelayStamp(5000)
+            new DelayStamp(5000),
         ]));
 
         // ...


### PR DESCRIPTION
I discovered two more examples where a comma is missing after the last array item in a multi-line array.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
