### PR TITLE
SESSION_TOKEN support for Async AWS Mailer Transport

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -158,7 +158,7 @@ party provider:
 ==================== ==================================================== =========================================== ========================================
  Provider             SMTP                                                 HTTP                                        API
 ==================== ==================================================== =========================================== ========================================
- Amazon SES           ses+smtp://ACCESS_KEY:SECRET_KEY@default             ses+https://ACCESS_KEY:SECRET_KEY@default   ses+api://ACCESS_KEY:SECRET_KEY@default
+ Amazon SES           ses+smtp://ACCESS_KEY:SECRET_KEY@default             ses+https://ACCESS_KEY:SECRET_KEY@default?sessionToken=SESSION_TOKEN   ses+api://ACCESS_KEY:SECRET_KEY@default?sessionToken=SESSION_TOKEN
  Google Gmail         gmail+smtp://USERNAME:PASSWORD@default               n/a                                         n/a
  Mailchimp Mandrill   mandrill+smtp://USERNAME:PASSWORD@default            mandrill+https://KEY@default                mandrill+api://KEY@default
  Mailgun              mailgun+smtp://USERNAME:PASSWORD@default             mailgun+https://KEY:DOMAIN@default          mailgun+api://KEY:DOMAIN@default


### PR DESCRIPTION
Documenting support for `SESSION_TOKEN`  for Async AWS Mailer Transport