### PR TITLE
[Messenger] Remove duplicated Redis transport requirements

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1164,9 +1164,6 @@ The Redis transport DSN may looks like this:
 
     The Unix socket DSN was introduced in Symfony 5.1.
 
-To use the Redis transport, you will need the Redis PHP extension (>=4.3) and
-a running Redis server (^5.0).
-
 A number of options can be configured via the DSN or via the ``options`` key
 under the transport in ``messenger.yaml``:
 


### PR DESCRIPTION
The Redis transport requirements has been presented twice. I mean the following sentences: 

> This transport requires the Redis PHP extension (>=4.3) and a running Redis server (^5.0).

> To use the Redis transport, you will need the Redis PHP extension (>=4.3) and a running Redis server (^5.0).
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
