### PR TITLE
[Security] bcrypt is the new default hasher for native/auto

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -368,7 +368,7 @@ Use the ``auto`` Password Hasher
 
 The :ref:`auto password hasher <reference-security-encoder-auto>` automatically
 selects the best possible encoder/hasher depending on your PHP installation.
-Currently, it tries to use ``sodium`` by default and falls back to ``bcrypt``.
+Starting from Symfony 5.3, the default auto hasher is ``bcrypt``.
 
 Use Voters to Implement Fine-grained Security Restrictions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/security.rst
+++ b/security.rst
@@ -219,9 +219,8 @@ command will pre-configure this for you:
             encoders:
                 # use your user class name here
                 App\Entity\User:
-                    # Use native password encoder
-                    # This value auto-selects the best possible hashing algorithm
-                    # (i.e. Sodium when available).
+                    # Use native password encoder, which auto-selects the best
+                    # possible hashing algorithm (starting from Symfony 5.3 this is "bcrypt")
                     algorithm: auto
 
     .. code-block:: xml


### PR DESCRIPTION
Fixes #14980.