### PR TITLE
[HttpClient] Fix specifying http_version in YAML

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -750,7 +750,8 @@ the ``http_version`` option:
         # config/packages/framework.yaml
         framework:
             http_client:
-                http_version: '2.0'
+                default_options:
+                    http_version: '2.0'
 
     .. code-block:: xml
 


### PR DESCRIPTION
With the code from the docs, I get this exception: 

> Unrecognized option "http_version" under "framework.http_client". Available options are "default_options", "enabled", "max_host_connections", "mock_response_factory", "scoped_clients".

Maybe the XML and PHP Annotation also needs a fix, but I don't feel confident doing that.
