### PR TITLE
Add reference from CHANGELOG conventions to commit message conventions

### DIFF
--- a/contributing/code/conventions.rst
+++ b/contributing/code/conventions.rst
@@ -99,9 +99,9 @@ conventions:
 
 * No third level sections are allowed;
 
-* Messages should follow the commit message conventions: should be short,
-  capitalize the line, do not end with a period, use an imperative verb to
-  start the line;
+* Messages should follow the :ref:`commit message conventions <commit-messages>`:
+  should be short, capitalize the line, do not end with a period, use an
+  imperative verb to start the line;
 
 * New entries must be added on top of the list.
 

--- a/contributing/code/pull_requests.rst
+++ b/contributing/code/pull_requests.rst
@@ -224,6 +224,8 @@ in mind the following:
 * Never fix coding standards in some existing code as it makes the code review
   more difficult;
 
+.. _commit-messages:
+
 * Write good commit messages: Start by a short subject line (the first line),
   followed by a blank line and a more detailed description.
 


### PR DESCRIPTION
As they are in different documents, I think adding a reference is a good idea.