### PR TITLE
[Validator] Use null coalescing operator instead of ternary operator

### DIFF
--- a/validation/severity.rst
+++ b/validation/severity.rst
@@ -137,7 +137,7 @@ method. Each constraint exposes the attached payload as a public property::
     // Symfony\Component\Validator\ConstraintViolation
     $constraintViolation = ...;
     $constraint = $constraintViolation->getConstraint();
-    $severity = isset($constraint->payload['severity']) ? $constraint->payload['severity'] : null;
+    $severity = $constraint->payload['severity'] ?? null;
 
 For example, you can leverage this to customize the ``form_errors`` block
 so that the severity is added as an additional HTML class:


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
