### PR TITLE
Update the default `cookie_secure` value in framework.rst

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1589,10 +1589,10 @@ The possible values for this option are:
 cookie_secure
 .............
 
-**type**: ``boolean`` or ``null`` **default**: ``null``
+**type**: ``boolean`` or ``'auto'`` **default**: ``'auto'``
 
 This determines whether cookies should only be sent over secure connections. In
-addition to ``true`` and ``false``, there's a special ``null`` value that
+addition to ``true`` and ``false``, there's a special ``'auto'`` value that
 means ``true`` for HTTPS requests and ``false`` for HTTP requests.
 
 cookie_httponly


### PR DESCRIPTION

Auto-secure cookies was introduced in Symfony 4.2. In Symfony 4.4, according to the Framework Configuration Reference, [the default value for `cookie_secure` is 'auto'](https://symfony.com/doc/4.4/reference/configuration/framework.html#cookie-secure). "Auto" means that the framework will set the `cookie_secure` flag to `true` when the traffic is sent through HTTPS, or `false` otherwise.

Since 5.0, [the value for this "auto" behavior is changed to `null`](https://symfony.com/doc/5.0/reference/configuration/framework.html#cookie-secure) according to the Framework Configuration Reference documentation (the doc change happened somewhere in Jan 2020, I could not pinpoint the exact commit that caused this though). That said, I can still find "auto" being mentioned in [the session documentation](https://symfony.com/doc/current/session.html). It is still the default configuration value of a new Symfony 5.2 project. Also, in the [Symfony\Bundle\FrameworkBundle\DependencyInjection\Configuration class](https://github.com/symfony/symfony/blob/f50e6afd7dd90e5a09e3e2ef81a2b10a8185e812/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php#L626), I can see that "auto" (but not null) being one of the allowed values.

So, I believe the behavior in the framework hasn't been changed, and the documentation change in `framework.rst` was not an intentional one. This PR updates the current `framework.rst` with the correct value.