### PR TITLE
Add versionadded 4.4 to allowlist

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -95,3 +95,4 @@ whitelist:
         - ".. _`Deploying Symfony 4 Apps on Heroku`: https://devcenter.heroku.com/articles/deploying-symfony4"
         - '.. versionadded:: 0.2' # MercureBundle
         - '.. code-block:: twig'
+        - '.. versionadded:: 4.4' # new bundle directory structure


### PR DESCRIPTION
[PR](https://github.com/symfony/symfony-docs/pull/14993/files) created a bug:
```
Warning: ] Found "1" invalid file!                                              

Error: You are not allowed to use version "4.4". Only major version "5" is allowed.
Error: Please only provide ".. versionadded::" if the version is greater/equal "5.0"
```

I took a fix from @OskarStark [comment](https://github.com/symfony/symfony-docs/pull/14360/files#r500540550).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
