### PR TITLE
Fix indentation of diff code blocks

### DIFF
--- a/configuration/dot-env-changes.rst
+++ b/configuration/dot-env-changes.rst
@@ -60,16 +60,16 @@ changes can be made to any Symfony 3.4 or higher app:
 
    .. code-block:: diff
 
-       # .gitignore
-       # ...
+         # .gitignore
+         # ...
 
-       ###> symfony/framework-bundle ###
+         ###> symfony/framework-bundle ###
        - /.env
        + /.env.local
        + /.env.local.php
        + /.env.*.local
 
-       # ...
+         # ...
 
 #. Rename ``.env`` to ``.env.local`` and ``.env.dist`` to ``.env``:
 

--- a/controller.rst
+++ b/controller.rst
@@ -98,16 +98,16 @@ Add the ``use`` statement atop your controller class and then modify
 
 .. code-block:: diff
 
-    // src/Controller/LuckyController.php
-    namespace App\Controller;
+      // src/Controller/LuckyController.php
+      namespace App\Controller;
 
     + use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
     - class LuckyController
     + class LuckyController extends AbstractController
-    {
-        // ...
-    }
+      {
+          // ...
+      }
 
 That's it! You now have access to methods like :ref:`$this->render() <controller-rendering-templates>`
 and many others that you'll learn about next.

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -280,20 +280,20 @@ methods:
 
 .. code-block:: diff
 
-    // src/Entity/Product.php
-    // ...
+      // src/Entity/Product.php
+      // ...
 
-    class Product
-    {
-        // ...
+      class Product
+      {
+          // ...
 
     +     /**
     +      * @ORM\Column(type="text")
     +      */
     +     private $description;
 
-        // getDescription() & setDescription() were also added
-    }
+          // getDescription() & setDescription() were also added
+      }
 
 The new property is mapped, but it doesn't exist yet in the ``product`` table. No
 problem! Generate a new migration:

--- a/frontend/encore/cdn.rst
+++ b/frontend/encore/cdn.rst
@@ -6,15 +6,15 @@ built files are uploaded to the CDN, configure it in Encore:
 
 .. code-block:: diff
 
-    // webpack.config.js
-    // ...
+      // webpack.config.js
+      // ...
 
-    Encore
-        .setOutputPath('public/build/')
-        // in dev mode, don't use the CDN
-        .setPublicPath('/build');
-        // ...
-    ;
+      Encore
+          .setOutputPath('public/build/')
+          // in dev mode, don't use the CDN
+          .setPublicPath('/build');
+          // ...
+      ;
 
     + if (Encore.isProduction()) {
     +     Encore.setPublicPath('https://my-cool-app.com.global.prod.fastly.net');

--- a/frontend/encore/copy-files.rst
+++ b/frontend/encore/copy-files.rst
@@ -32,11 +32,11 @@ files into your final output directory.
 
 .. code-block:: diff
 
-    // webpack.config.js
+      // webpack.config.js
 
-    Encore
-        // ...
-        .setOutputPath('public/build/')
+      Encore
+          // ...
+          .setOutputPath('public/build/')
 
     +     .copyFiles({
     +         from: './assets/images',

--- a/frontend/encore/custom-loaders-plugins.rst
+++ b/frontend/encore/custom-loaders-plugins.rst
@@ -50,14 +50,14 @@ to use the `IgnorePlugin`_ (see `moment/moment#2373`_):
 
 .. code-block:: diff
 
-    // webpack.config.js
+      // webpack.config.js
     + var webpack = require('webpack');
 
-    Encore
-        // ...
+      Encore
+          // ...
 
     +     .addPlugin(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/))
-    ;
+      ;
 
 .. _`handlebars-loader`: https://github.com/pcardune/handlebars-loader
 .. _`plugins`: https://webpack.js.org/plugins/

--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -65,14 +65,14 @@ the ``package.json`` file:
 
 .. code-block:: diff
 
-    {
-        ...
-        "scripts": {
+      {
+          ...
+          "scripts": {
     -        "dev-server": "encore dev-server",
     +        "dev-server": "encore dev-server --https --pfx=$HOME/.symfony/certs/default.p12 --allowed-hosts=mydomain.wip",
-            ...
-        }
-    }
+              ...
+          }
+      }
 
 If you experience issues related to CORS (Cross Origin Resource Sharing), add
 the ``--disable-host-check`` and ``--port`` options to the ``dev-server``
@@ -80,14 +80,14 @@ command in the ``package.json`` file:
 
 .. code-block:: diff
 
-    {
-        ...
-        "scripts": {
+      {
+          ...
+          "scripts": {
     -        "dev-server": "encore dev-server",
     +        "dev-server": "encore dev-server --port 8080 --disable-host-check",
-            ...
-        }
-    }
+              ...
+          }
+      }
 
 .. caution::
 

--- a/frontend/encore/faq.rst
+++ b/frontend/encore/faq.rst
@@ -63,11 +63,11 @@ like ``/myAppSubdir``), you will need to configure that when calling ``Encore.se
 
 .. code-block:: diff
 
-    // webpack.config.js
-    Encore
-        // ...
+      // webpack.config.js
+      Encore
+          // ...
 
-        .setOutputPath('public/build/')
+          .setOutputPath('public/build/')
 
     -     .setPublicPath('/build')
     +     // this is your *true* public path
@@ -76,7 +76,7 @@ like ``/myAppSubdir``), you will need to configure that when calling ``Encore.se
     +     // this is now needed so that your manifest.json keys are still `build/foo.js`
     +     // (which is a file that's used by Symfony's `asset()` function)
     +     .setManifestKeyPrefix('build')
-    ;
+      ;
 
 If you're using the ``encore_entry_script_tags()`` and ``encore_entry_link_tags()``
 Twig shortcuts (or are :ref:`processing your assets through entrypoints.json <load-manifest-files>`

--- a/frontend/encore/legacy-applications.rst
+++ b/frontend/encore/legacy-applications.rst
@@ -32,11 +32,11 @@ jQuery plugins often expect that jQuery is already available via the ``$`` or
 
 .. code-block:: diff
 
-    // webpack.config.js
-    Encore
-        // ...
+      // webpack.config.js
+      Encore
+          // ...
     +     .autoProvidejQuery()
-    ;
+      ;
 
 After restarting Encore, Webpack will look for all uninitialized ``$`` and ``jQuery``
 variables and automatically require ``jquery`` and set those variables for you.
@@ -75,10 +75,10 @@ page, add:
 
 .. code-block:: diff
 
-    // webpack.config.js
+      // webpack.config.js
 
-    // require jQuery normally
-    const $ = require('jquery');
+      // require jQuery normally
+      const $ = require('jquery');
 
     + // create global $ and jQuery variables
     + global.$ = global.jQuery = $;

--- a/frontend/encore/legacy-applications.rst
+++ b/frontend/encore/legacy-applications.rst
@@ -32,6 +32,7 @@ jQuery plugins often expect that jQuery is already available via the ``$`` or
 
 .. code-block:: diff
 
+    // webpack.config.js
     Encore
         // ...
     +     .autoProvidejQuery()
@@ -73,6 +74,8 @@ For example, in your ``app.js`` file that's processed by Webpack and loaded on e
 page, add:
 
 .. code-block:: diff
+
+    // webpack.config.js
 
     // require jQuery normally
     const $ = require('jquery');

--- a/frontend/encore/postcss.rst
+++ b/frontend/encore/postcss.rst
@@ -28,12 +28,12 @@ Then, enable the loader in Encore!
 
 .. code-block:: diff
 
-    // webpack.config.js
+      // webpack.config.js
 
-    Encore
-        // ...
+      Encore
+          // ...
     +     .enablePostCssLoader()
-    ;
+      ;
 
 Because you just modified ``webpack.config.js``, stop and restart Encore.
 
@@ -42,17 +42,17 @@ You can also pass options to the `postcss-loader`_ by passing a callback:
 
 .. code-block:: diff
 
-    // webpack.config.js
+      // webpack.config.js
 
-    Encore
-        // ...
+      Encore
+          // ...
     +     .enablePostCssLoader((options) => {
     +         options.config = {
     +             // the directory where the postcss.config.js file is stored
     +             path: 'path/to/config'
     +         };
     +     })
-    ;
+      ;
 
 .. _browserslist_package_config:
 
@@ -65,25 +65,25 @@ support. The best-practice is to configure this directly in your ``package.json`
 
 .. code-block:: diff
 
-    {
+      {
     +  "browserslist": [
     +    "defaults"
     +  ]
-    }
+      }
 
 The ``defaults`` option is recommended for most users and would be equivalent
 to the following browserslist:
 
 .. code-block:: diff
 
-    {
+      {
     +  "browserslist": [
     +    "> 0.5%",
     +    "last 2 versions",
     +    "Firefox ESR",
     +    "not dead"
     +  ]
-    }
+      }
 
 See `browserslist`_ for more details on the syntax.
 

--- a/frontend/encore/reactjs.rst
+++ b/frontend/encore/reactjs.rst
@@ -17,13 +17,13 @@ Enable react in your ``webpack.config.js``:
 
 .. code-block:: diff
 
-    // webpack.config.js
-    // ...
+      // webpack.config.js
+      // ...
 
-    Encore
-        // ...
+      Encore
+          // ...
     +     .enableReactPreset()
-    ;
+      ;
 
 
 Then restart Encore. When you do, it will give you a command you can run to

--- a/frontend/encore/shared-entry.rst
+++ b/frontend/encore/shared-entry.rst
@@ -16,13 +16,13 @@ Update your code to use ``createSharedEntry()``:
 
 .. code-block:: diff
 
-    Encore
-        // ...
+      Encore
+          // ...
     -     .addEntry('app', './assets/js/app.js')
     +     .createSharedEntry('app', './assets/js/app.js')
-        .addEntry('homepage', './assets/js/homepage.js')
-        .addEntry('blog', './assets/js/blog.js')
-        .addEntry('store', './assets/js/store.js')
+          .addEntry('homepage', './assets/js/homepage.js')
+          .addEntry('blog', './assets/js/blog.js')
+          .addEntry('store', './assets/js/store.js')
 
 Before making this change, if both ``app.js`` and ``store.js`` require ``jquery``,
 then ``jquery`` would be packaged into *both* files, which is wasteful. By making

--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -167,8 +167,8 @@ Great! Use ``require()`` to import ``jquery`` and ``greet.js``:
 
 .. code-block:: diff
 
-    // assets/js/app.js
-    // ...
+      // assets/js/app.js
+      // ...
 
     + // loads the jquery package from node_modules
     + var $ = require('jquery');
@@ -196,17 +196,17 @@ To export values using the alternate syntax, use ``export``:
 
 .. code-block:: diff
 
-    // assets/js/greet.js
+      // assets/js/greet.js
     - module.exports = function(name) {
     + export default function(name) {
-        return `Yo yo ${name} - welcome to Encore!`;
-    };
+          return `Yo yo ${name} - welcome to Encore!`;
+      };
 
 To import values, use ``import``:
 
 .. code-block:: diff
 
-    // assets/js/app.js
+      // assets/js/app.js
     - require('../css/app.css');
     + import '../css/app.css';
 
@@ -240,13 +240,13 @@ Next, use ``addEntry()`` to tell Webpack to read these two new files when it bui
 
 .. code-block:: diff
 
-    // webpack.config.js
-    Encore
-        // ...
-        .addEntry('app', './assets/js/app.js')
+      // webpack.config.js
+      Encore
+          // ...
+          .addEntry('app', './assets/js/app.js')
     +     .addEntry('checkout', './assets/js/checkout.js')
     +     .addEntry('account', './assets/js/account.js')
-        // ...
+          // ...
 
 And because you just changed the ``webpack.config.js`` file, make sure to stop
 and restart Encore:
@@ -264,8 +264,8 @@ you need them:
 
 .. code-block:: diff
 
-    {# templates/.../checkout.html.twig #}
-    {% extends 'base.html.twig' %}
+      {# templates/.../checkout.html.twig #}
+      {% extends 'base.html.twig' %}
 
     + {% block stylesheets %}
     +     {{ parent() }}
@@ -294,7 +294,7 @@ file to ``app.scss`` and update the ``import`` statement:
 
 .. code-block:: diff
 
-    // assets/js/app.js
+      // assets/js/app.js
     - import '../css/app.css';
     + import '../css/app.scss';
 
@@ -302,12 +302,12 @@ Then, tell Encore to enable the Sass pre-processor:
 
 .. code-block:: diff
 
-    // webpack.config.js
-    Encore
-        // ...
+      // webpack.config.js
+      Encore
+          // ...
 
     +    .enableSassLoader()
-    ;
+      ;
 
 Because you just changed your ``webpack.config.js`` file, you'll need to restart
 Encore. When you do, you'll see an error!

--- a/frontend/encore/split-chunks.rst
+++ b/frontend/encore/split-chunks.rst
@@ -10,6 +10,7 @@ To enable this, call ``splitEntryChunks()``:
 
 .. code-block:: diff
 
+    // webpack.config.js
     Encore
         // ...
 
@@ -52,6 +53,7 @@ this plugin with the ``configureSplitChunks()`` function:
 
 .. code-block:: diff
 
+    // webpack.config.js
     Encore
         // ...
 

--- a/frontend/encore/split-chunks.rst
+++ b/frontend/encore/split-chunks.rst
@@ -10,15 +10,15 @@ To enable this, call ``splitEntryChunks()``:
 
 .. code-block:: diff
 
-    // webpack.config.js
-    Encore
-        // ...
+      // webpack.config.js
+      Encore
+          // ...
 
-        // multiple entry files, which probably import the same code
-        .addEntry('app', './assets/js/app.js')
-        .addEntry('homepage', './assets/js/homepage.js')
-        .addEntry('blog', './assets/js/blog.js')
-        .addEntry('store', './assets/js/store.js')
+          // multiple entry files, which probably import the same code
+          .addEntry('app', './assets/js/app.js')
+          .addEntry('homepage', './assets/js/homepage.js')
+          .addEntry('blog', './assets/js/blog.js')
+          .addEntry('store', './assets/js/store.js')
 
     +     .splitEntryChunks()
 
@@ -53,11 +53,11 @@ this plugin with the ``configureSplitChunks()`` function:
 
 .. code-block:: diff
 
-    // webpack.config.js
-    Encore
-        // ...
+      // webpack.config.js
+      Encore
+          // ...
 
-        .splitEntryChunks()
+          .splitEntryChunks()
     +     .configureSplitChunks(function(splitChunks) {
     +         // change the configuration
     +         splitChunks.minSize = 0;

--- a/frontend/encore/typescript.rst
+++ b/frontend/encore/typescript.rst
@@ -5,20 +5,20 @@ Want to use `TypeScript`_? No problem! First, enable it:
 
 .. code-block:: diff
 
-    // webpack.config.js
+      // webpack.config.js
 
-    // ...
-    Encore
-        // ...
+      // ...
+      Encore
+          // ...
     +     .addEntry('main', './assets/main.ts')
 
     +     .enableTypeScriptLoader()
 
-        // optionally enable forked type script for faster builds
-        // https://www.npmjs.com/package/fork-ts-checker-webpack-plugin
-        // requires that you have a tsconfig.json file that is setup correctly.
+          // optionally enable forked type script for faster builds
+          // https://www.npmjs.com/package/fork-ts-checker-webpack-plugin
+          // requires that you have a tsconfig.json file that is setup correctly.
     +     //.enableForkedTypeScriptTypesChecking()
-    ;
+      ;
 
 Then restart Encore. When you do, it will give you a command you can run to
 install any missing dependencies. After running that command and restarting
@@ -30,10 +30,10 @@ method.
 
 .. code-block:: diff
 
-    // webpack.config.js
-    Encore
-        // ...
-        .addEntry('main', './assets/main.ts')
+      // webpack.config.js
+      Encore
+          // ...
+          .addEntry('main', './assets/main.ts')
 
     -     .enableTypeScriptLoader()
     +     .enableTypeScriptLoader(function(tsConfig) {
@@ -43,8 +43,8 @@ method.
     +         // tsConfig.silent = false
     +     })
 
-            // ...
-    ;
+              // ...
+      ;
 
 See the `Encore's index.js file`_ for detailed documentation and check
 out the `tsconfig.json reference`_ and the `Webpack guide about Typescript`_.

--- a/frontend/encore/typescript.rst
+++ b/frontend/encore/typescript.rst
@@ -6,8 +6,8 @@ Want to use `TypeScript`_? No problem! First, enable it:
 .. code-block:: diff
 
     // webpack.config.js
-    // ...
 
+    // ...
     Encore
         // ...
     +     .addEntry('main', './assets/main.ts')
@@ -30,6 +30,7 @@ method.
 
 .. code-block:: diff
 
+    // webpack.config.js
     Encore
         // ...
         .addEntry('main', './assets/main.ts')

--- a/frontend/encore/versioning.rst
+++ b/frontend/encore/versioning.rst
@@ -12,12 +12,12 @@ ignoring any existing cache:
 
 .. code-block:: diff
 
-    // webpack.config.js
+      // webpack.config.js
 
-    // ...
-    Encore
-        .setOutputPath('public/build/')
-        // ...
+      // ...
+      Encore
+          .setOutputPath('public/build/')
+          // ...
     +     .enableVersioning()
 
 To link to these assets, Encore creates two files ``entrypoints.json`` and

--- a/frontend/encore/versioning.rst
+++ b/frontend/encore/versioning.rst
@@ -13,8 +13,8 @@ ignoring any existing cache:
 .. code-block:: diff
 
     // webpack.config.js
-    // ...
 
+    // ...
     Encore
         .setOutputPath('public/build/')
         // ...

--- a/frontend/encore/virtual-machine.rst
+++ b/frontend/encore/virtual-machine.rst
@@ -49,14 +49,14 @@ If your Symfony application is running on a custom domain (e.g.
 
 .. code-block:: diff
 
-    {
-        ...
-        "scripts": {
+      {
+          ...
+          "scripts": {
     -        "dev-server": "encore dev-server",
     +        "dev-server": "encore dev-server --public http://app.vm:8080",
-            ...
-        }
-    }
+              ...
+          }
+      }
 
 After restarting Encore and reloading your web page, you will probably see
 different issues in the web console:
@@ -78,14 +78,14 @@ connections:
 
 .. code-block:: diff
 
-    {
-        ...
-        "scripts": {
+      {
+          ...
+          "scripts": {
     -        "dev-server": "encore dev-server --public http://app.vm:8080",
     +        "dev-server": "encore dev-server --public http://app.vm:8080 --host 0.0.0.0",
-            ...
-        }
-    }
+              ...
+          }
+      }
 
 .. caution::
 
@@ -100,14 +100,14 @@ the dev-server. To fix this, add the argument ``--disable-host-check``:
 
 .. code-block:: diff
 
-    {
-        ...
-        "scripts": {
+      {
+          ...
+          "scripts": {
     -        "dev-server": "encore dev-server --public http://app.vm:8080 --host 0.0.0.0",
     +        "dev-server": "encore dev-server --public http://app.vm:8080 --host 0.0.0.0 --disable-host-check",
-            ...
-        }
-    }
+              ...
+          }
+      }
 
 .. caution::
 

--- a/frontend/encore/vuejs.rst
+++ b/frontend/encore/vuejs.rst
@@ -10,15 +10,15 @@ Want to use `Vue.js`_? No problem! First enable it in ``webpack.config.js``:
 
 .. code-block:: diff
 
-    // webpack.config.js
-    // ...
+      // webpack.config.js
+      // ...
 
-    Encore
-        // ...
-        .addEntry('main', './assets/main.js')
+      Encore
+          // ...
+          .addEntry('main', './assets/main.js')
 
     +     .enableVueLoader()
-    ;
+      ;
 
 Then restart Encore. When you do, it will give you a command you can run to
 install any missing dependencies. After running that command and restarting
@@ -53,18 +53,18 @@ You can enable `JSX with Vue.js`_ by configuring the second parameter of the
 
 .. code-block:: diff
 
-    // webpack.config.js
-    // ...
+      // webpack.config.js
+      // ...
 
-    Encore
-        // ...
-        .addEntry('main', './assets/main.js')
+      Encore
+          // ...
+          .addEntry('main', './assets/main.js')
 
     -     .enableVueLoader()
     +     .enableVueLoader(() => {}, {
     +         useJsx: true
     +     })
-    ;
+      ;
 
 Next, run or restart Encore. When you do, you will see an error message helping
 you install any missing dependencies. After running that command and restarting

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -93,20 +93,20 @@ caching kernel:
 
 .. code-block:: diff
 
-    // public/index.php
+      // public/index.php
 
     + use App\CacheKernel;
-    use App\Kernel;
+      use App\Kernel;
 
-    // ...
-    $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+      // ...
+      $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
     + // Wrap the default Kernel with the CacheKernel one in 'prod' environment
     + if ('prod' === $kernel->getEnvironment()) {
     +     $kernel = new CacheKernel($kernel);
     + }
 
-    $request = Request::createFromGlobals();
-    // ...
+      $request = Request::createFromGlobals();
+      // ...
 
 The caching kernel will immediately act as a reverse proxy: caching responses
 from your application and returning them to the client.

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -105,21 +105,21 @@ You can now add your route directly *above* the controller:
 
 .. code-block:: diff
 
-    // src/Controller/LuckyController.php
+      // src/Controller/LuckyController.php
 
-    // ...
+      // ...
     + use Symfony\Component\Routing\Annotation\Route;
 
-    class LuckyController
-    {
+      class LuckyController
+      {
     +     /**
     +      * @Route("/lucky/number")
     +      */
-        public function number()
-        {
-            // this looks exactly the same
-        }
-    }
+          public function number()
+          {
+              // this looks exactly the same
+          }
+      }
 
 That's it! The page - http://localhost:8000/lucky/number will work exactly
 like before! Annotations are the recommended way to configure routes.
@@ -209,16 +209,16 @@ Make sure that ``LuckyController`` extends Symfony's base
 
 .. code-block:: diff
 
-    // src/Controller/LuckyController.php
+      // src/Controller/LuckyController.php
 
-    // ...
+      // ...
     + use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
     - class LuckyController
     + class LuckyController extends AbstractController
-    {
-        // ...
-    }
+      {
+          // ...
+      }
 
 Now, use the handy ``render()`` function to render a template. Pass it a ``number``
 variable so you can use it in Twig::

--- a/quick_tour/flex_recipes.rst
+++ b/quick_tour/flex_recipes.rst
@@ -75,28 +75,28 @@ Thanks to Flex, after one command, you can start using Twig immediately:
 
 .. code-block:: diff
 
-    <?php
-    // src/Controller/DefaultController.php
-    namespace App\Controller;
+      <?php
+      // src/Controller/DefaultController.php
+      namespace App\Controller;
 
-    use Symfony\Component\Routing\Annotation\Route;
+      use Symfony\Component\Routing\Annotation\Route;
     - use Symfony\Component\HttpFoundation\Response;
     + use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
     - class DefaultController
     + class DefaultController extends AbstractController
-    {
-         /**
-          * @Route("/hello/{name}")
-          */
-         public function index($name)
-         {
+      {
+           /**
+            * @Route("/hello/{name}")
+            */
+           public function index($name)
+           {
     -        return new Response("Hello $name!");
     +        return $this->render('default/index.html.twig', [
     +            'name' => $name,
     +        ]);
-         }
-    }
+           }
+      }
 
 By extending ``AbstractController``, you now have access to a number of shortcut
 methods and tools, like ``render()``. Create the new template:

--- a/quick_tour/flex_recipes.rst
+++ b/quick_tour/flex_recipes.rst
@@ -83,9 +83,9 @@ Thanks to Flex, after one command, you can start using Twig immediately:
     - use Symfony\Component\HttpFoundation\Response;
     + use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
-    -class DefaultController
-    +class DefaultController extends AbstractController
-     {
+    - class DefaultController
+    + class DefaultController extends AbstractController
+    {
          /**
           * @Route("/hello/{name}")
           */

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -138,12 +138,12 @@ difference is that it's done in the constructor:
 
 .. code-block:: diff
 
-    <?php
-    // src/GreetingGenerator.php
+      <?php
+      // src/GreetingGenerator.php
     + use Psr\Log\LoggerInterface;
 
-    class GreetingGenerator
-    {
+      class GreetingGenerator
+      {
     +     private $logger;
     +
     +     public function __construct(LoggerInterface $logger)
@@ -151,15 +151,15 @@ difference is that it's done in the constructor:
     +         $this->logger = $logger;
     +     }
 
-        public function getRandomGreeting()
-        {
-            // ...
+          public function getRandomGreeting()
+          {
+              // ...
 
     +        $this->logger->info('Using the greeting: '.$greeting);
 
-             return $greeting;
-        }
-    }
+               return $greeting;
+          }
+      }
 
 Yes! This works too: no configuration, no time wasted. Keep coding!
 
@@ -279,7 +279,7 @@ from ``dev`` to ``prod``:
 
 .. code-block:: diff
 
-    # .env
+      # .env
     - APP_ENV=dev
     + APP_ENV=prod
 
@@ -321,10 +321,10 @@ Thanks to a new recipe installed by Flex, look at the ``.env`` file again:
 
 .. code-block:: diff
 
-    ###> symfony/framework-bundle ###
-    APP_ENV=dev
-    APP_SECRET=cc86c7ca937636d5ddf1b754beb22a10
-    ###< symfony/framework-bundle ###
+      ###> symfony/framework-bundle ###
+      APP_ENV=dev
+      APP_SECRET=cc86c7ca937636d5ddf1b754beb22a10
+      ###< symfony/framework-bundle ###
 
     + ###> doctrine/doctrine-bundle ###
     + # ...

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -105,32 +105,32 @@ But the routing system is *much* more powerful. So let's make the route more int
 
 .. code-block:: diff
 
-    # config/routes.yaml
-    index:
+      # config/routes.yaml
+      index:
     -     path: /
     +     path: /hello/{name}
-        controller: 'App\Controller\DefaultController::index'
+          controller: 'App\Controller\DefaultController::index'
 
 The URL to this page has changed: it is *now* ``/hello/*``: the ``{name}`` acts
 like a wildcard that matches anything. And it gets better! Update the controller too:
 
 .. code-block:: diff
 
-    <?php
-    // src/Controller/DefaultController.php
-    namespace App\Controller;
+      <?php
+      // src/Controller/DefaultController.php
+      namespace App\Controller;
 
-    use Symfony\Component\HttpFoundation\Response;
+      use Symfony\Component\HttpFoundation\Response;
 
-    class DefaultController
-    {
+      class DefaultController
+      {
     -     public function index()
     +     public function index($name)
-        {
+          {
     -         return new Response('Hello!');
     +         return new Response("Hello $name!");
-        }
-    }
+          }
+      }
 
 Try the page out by going to ``http://localhost:8000/hello/Symfony``. You should
 see: Hello Symfony! The value of the ``{name}`` in the URL is available as a ``$name``
@@ -155,22 +155,22 @@ Instead, add the route *right above* the controller method:
 
 .. code-block:: diff
 
-    <?php
-    // src/Controller/DefaultController.php
-    namespace App\Controller;
+      <?php
+      // src/Controller/DefaultController.php
+      namespace App\Controller;
 
-    use Symfony\Component\HttpFoundation\Response;
+      use Symfony\Component\HttpFoundation\Response;
     + use Symfony\Component\Routing\Annotation\Route;
 
-    class DefaultController
-    {
+      class DefaultController
+      {
     +    /**
     +     * @Route("/hello/{name}")
     +     */
-         public function index($name) {
-             // ...
-         }
-    }
+           public function index($name) {
+               // ...
+           }
+      }
 
 This works just like before! But by using annotations, the route and controller
 live right next to each other. Need another page? Add another route and method

--- a/security.rst
+++ b/security.rst
@@ -238,13 +238,13 @@ Use this service to encode the passwords:
 
 .. code-block:: diff
 
-    // src/DataFixtures/UserFixtures.php
+      // src/DataFixtures/UserFixtures.php
 
     + use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
-    // ...
+      // ...
 
-    class UserFixtures extends Fixture
-    {
+      class UserFixtures extends Fixture
+      {
     +     private $passwordEncoder;
 
     +     public function __construct(UserPasswordEncoderInterface $passwordEncoder)
@@ -252,19 +252,19 @@ Use this service to encode the passwords:
     +         $this->passwordEncoder = $passwordEncoder;
     +     }
 
-        public function load(ObjectManager $manager)
-        {
-            $user = new User();
-            // ...
+          public function load(ObjectManager $manager)
+          {
+              $user = new User();
+              // ...
 
     +         $user->setPassword($this->passwordEncoder->encodePassword(
     +             $user,
     +             'the_new_password'
     +         ));
 
-            // ...
-        }
-    }
+              // ...
+          }
+      }
 
 You can manually encode a password by running:
 
@@ -671,8 +671,8 @@ using annotations:
 
 .. code-block:: diff
 
-    // src/Controller/AdminController.php
-    // ...
+      // src/Controller/AdminController.php
+      // ...
 
     + use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 
@@ -681,18 +681,18 @@ using annotations:
     +  *
     +  * @IsGranted("ROLE_ADMIN")
     +  */
-    class AdminController extends AbstractController
-    {
+      class AdminController extends AbstractController
+      {
     +     /**
     +      * Require ROLE_ADMIN for only this controller method.
     +      *
     +      * @IsGranted("ROLE_ADMIN")
     +      */
-        public function adminDashboard()
-        {
-            // ...
-        }
-    }
+          public function adminDashboard()
+          {
+              // ...
+          }
+      }
 
 For more information, see the `FrameworkExtraBundle documentation`_.
 

--- a/security/form_login_setup.rst
+++ b/security/form_login_setup.rst
@@ -377,17 +377,17 @@ be redirected after success:
 
 .. code-block:: diff
 
-    // src/Security/LoginFormAuthenticator.php
+      // src/Security/LoginFormAuthenticator.php
 
-    // ...
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
-    {
-        // ...
+      // ...
+      public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+      {
+          // ...
 
     -     throw new \Exception('TODO: provide a valid redirect inside '.__FILE__);
     +     // redirect to some "app_homepage" route - of wherever you want
     +     return new RedirectResponse($this->urlGenerator->generate('app_homepage'));
-    }
+      }
 
 Unless you have any other TODOs in that file, that's it! If you're loading users
 from the database, make sure you've loaded some :ref:`dummy users <doctrine-fixtures>`.

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -27,22 +27,22 @@ your ``User`` class (the ``make:entity`` command is a good way to do this):
 
 .. code-block:: diff
 
-    // src/Entity/User.php
-    namespace App\Entity;
+      // src/Entity/User.php
+      namespace App\Entity;
 
-    // ...
+      // ...
 
-    class User implements UserInterface
-    {
-        // ...
+      class User implements UserInterface
+      {
+          // ...
 
     +     /**
     +      * @ORM\Column(type="string", unique=true, nullable=true)
     +      */
     +     private $apiToken;
 
-        // the getter and setter methods
-    }
+          // the getter and setter methods
+      }
 
 Don't forget to generate and run the migration:
 
@@ -518,13 +518,13 @@ are two possible fixes:
 
 .. code-block:: diff
 
-    // src/Security/MyIpAuthenticator.php
-    // ...
+      // src/Security/MyIpAuthenticator.php
+      // ...
 
     + use Symfony\Component\Security\Core\Security;
 
-    class MyIpAuthenticator
-    {
+      class MyIpAuthenticator
+      {
     +     private $security;
 
     +     public function __construct(Security $security)
@@ -532,8 +532,8 @@ are two possible fixes:
     +         $this->security = $security;
     +     }
 
-        public function supports(Request $request)
-        {
+          public function supports(Request $request)
+          {
     +         // if there is already an authenticated user (likely due to the session)
     +         // then return false and skip authentication: there is no need.
     +         if ($this->security->getUser()) {
@@ -542,8 +542,8 @@ are two possible fixes:
 
     +         // the user is not logged in, so the authenticator should continue
     +         return true;
-        }
-    }
+          }
+      }
 
 If you use autowiring, the ``Security``  service will automatically be passed to
 your authenticator.

--- a/security/securing_services.rst
+++ b/security/securing_services.rst
@@ -14,14 +14,14 @@ want to include extra details only for users that have a ``ROLE_SALES_ADMIN`` ro
 
 .. code-block:: diff
 
-    // src/Newsletter/NewsletterManager.php
+      // src/Newsletter/NewsletterManager.php
 
-    // ...
-    use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+      // ...
+      use Symfony\Component\Security\Core\Exception\AccessDeniedException;
     + use Symfony\Component\Security\Core\Security;
 
-    class SalesReportManager
-    {
+      class SalesReportManager
+      {
     +     private $security;
 
     +     public function __construct(Security $security)
@@ -29,19 +29,19 @@ want to include extra details only for users that have a ``ROLE_SALES_ADMIN`` ro
     +         $this->security = $security;
     +     }
 
-        public function sendNewsletter()
-        {
-            $salesData = [];
+          public function sendNewsletter()
+          {
+              $salesData = [];
 
     +         if ($this->security->isGranted('ROLE_SALES_ADMIN')) {
     +             $salesData['top_secret_numbers'] = rand();
     +         }
 
-            // ...
-        }
+              // ...
+          }
 
-        // ...
-    }
+          // ...
+      }
 
 If you're using the :ref:`default services.yaml configuration <service-container-services-load-example>`,
 Symfony will automatically pass the ``security.helper`` to your service

--- a/service_container.rst
+++ b/service_container.rst
@@ -369,34 +369,34 @@ example, suppose you want to make the admin email configurable:
 
 .. code-block:: diff
 
-    // src/Service/SiteUpdateManager.php
-    // ...
+      // src/Service/SiteUpdateManager.php
+      // ...
 
-    class SiteUpdateManager
-    {
-        // ...
+      class SiteUpdateManager
+      {
+          // ...
     +    private $adminEmail;
 
     -    public function __construct(MessageGenerator $messageGenerator, MailerInterface $mailer)
     +    public function __construct(MessageGenerator $messageGenerator, MailerInterface $mailer, string $adminEmail)
-        {
-            // ...
+          {
+              // ...
     +        $this->adminEmail = $adminEmail;
-        }
+          }
 
-        public function notifyOfSiteUpdate(): bool
-        {
-            // ...
+          public function notifyOfSiteUpdate(): bool
+          {
+              // ...
 
-            $email = (new Email())
-                // ...
+              $email = (new Email())
+                  // ...
     -            ->to('manager@example.com')
     +            ->to($this->adminEmail)
-                // ...
-            ;
-            // ...
-        }
-    }
+                  // ...
+              ;
+              // ...
+          }
+      }
 
 If you make this change and refresh, you'll see an error:
 

--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -58,14 +58,14 @@ manual steps:
 
    .. code-block:: diff
 
-       {
-           "require": {
-               "symfony/flex": "^1.0",
+         {
+             "require": {
+                 "symfony/flex": "^1.0",
        +   },
        +   "conflict": {
        +       "symfony/symfony": "*"
-           }
-       }
+             }
+         }
 
    Now you must add in ``composer.json`` all the Symfony dependencies required
    by your project. A quick way to do that is to add all the components that

--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -61,9 +61,9 @@ manual steps:
        {
            "require": {
                "symfony/flex": "^1.0",
-       +     },
-       +     "conflict": {
-       +         "symfony/symfony": "*"
+       +   },
+       +   "conflict": {
+       +       "symfony/symfony": "*"
            }
        }
 

--- a/setup/unstable_versions.rst
+++ b/setup/unstable_versions.rst
@@ -33,14 +33,14 @@ new version and change your ``minimum-stability`` to ``beta``:
 
 .. code-block:: diff
 
-    {
-        "require": {
+      {
+          "require": {
     +         "symfony/framework-bundle": "^4.0",
     +         "symfony/finder": "^4.0",
-            "...": "..."
-        },
+              "...": "..."
+          },
     +     "minimum-stability": "beta"
-    }
+      }
 
 You can also use set ``minimum-stability`` to ``dev``, or omit this line
 entirely, and opt into your stability on each package by using constraints

--- a/setup/upgrade_major.rst
+++ b/setup/upgrade_major.rst
@@ -131,26 +131,26 @@ starting with ``symfony/`` to the new major version:
 
 .. code-block:: diff
 
-    {
-        "...": "...",
+      {
+          "...": "...",
 
-        "require": {
+          "require": {
     -         "symfony/cache": "4.4.*",
     +         "symfony/cache": "5.0.*",
     -         "symfony/config": "4.4.*",
     +         "symfony/config": "5.0.*",
     -         "symfony/console": "4.4.*",
     +         "symfony/console": "5.0.*",
-            "...": "...",
+              "...": "...",
 
-            "...": "A few libraries starting with
-                    symfony/ follow their own versioning scheme. You
-                    do not need to update these versions: you can
-                    upgrade them independently whenever you want",
-            "symfony/monolog-bundle": "^3.5",
-        },
-        "...": "...",
-    }
+              "...": "A few libraries starting with
+                      symfony/ follow their own versioning scheme. You
+                      do not need to update these versions: you can
+                      upgrade them independently whenever you want",
+              "symfony/monolog-bundle": "^3.5",
+          },
+          "...": "...",
+      }
 
 At the bottom of your ``composer.json`` file, in the ``extra`` block you can
 find a data setting for the Symfony version. Make sure to also upgrade
@@ -158,13 +158,13 @@ this one. For instance, update it to ``5.0.*`` to upgrade to Symfony 5.0:
 
 .. code-block:: diff
 
-    "extra": {
-        "symfony": {
-            "allow-contrib": false,
+      "extra": {
+          "symfony": {
+              "allow-contrib": false,
     -       "require": "4.4.*"
     +       "require": "5.0.*"
-        }
-    }
+          }
+      }
 
 Next, use Composer to download new versions of the libraries:
 

--- a/setup/upgrade_minor.rst
+++ b/setup/upgrade_minor.rst
@@ -28,39 +28,39 @@ probably need to update the version constraint next to each library starting
 
 .. code-block:: diff
 
-    {
-        "...": "...",
+      {
+          "...": "...",
 
-        "require": {
+          "require": {
     -         "symfony/cache": "4.3.*",
     +         "symfony/cache": "4.4.*",
     -         "symfony/config": "4.3.*",
     +         "symfony/config": "4.4.*",
     -         "symfony/console": "4.3.*",
     +         "symfony/console": "4.4.*",
-            "...": "...",
+              "...": "...",
 
-            "...": "A few libraries starting with
-                    symfony/ follow their versioning scheme. You
-                    do not need to update these versions: you can
-                    upgrade them independently whenever you want",
-            "symfony/monolog-bundle": "^3.5",
-        },
-        "...": "...",
-    }
+              "...": "A few libraries starting with
+                      symfony/ follow their versioning scheme. You
+                      do not need to update these versions: you can
+                      upgrade them independently whenever you want",
+              "symfony/monolog-bundle": "^3.5",
+          },
+          "...": "...",
+      }
 
 Your ``composer.json`` file should also have an ``extra`` block that you will
 *also* need to update:
 
 .. code-block:: diff
 
-    "extra": {
-        "symfony": {
-            "...": "...",
+      "extra": {
+          "symfony": {
+              "...": "...",
     -         "require": "4.3.*"
     +         "require": "4.4.*"
-        }
-    }
+          }
+      }
 
 Next, use Composer to download new versions of the libraries:
 


### PR DESCRIPTION
This continues #14971, the difference:

* The script is run on 4.4 instead
* Keep the starting file line comment at the original indentation (Sphinx takes the first line of the example as the initial indentation)
* If the file is JSON, there is no file line comment, in these cases use the little `:dedent: 0` "hack" (this changes nothing, but makes sure Sphinx knows the indentation).