### PR TITLE
Minor change to use DateTimeImmutable instead of DateTime

### DIFF
--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -76,7 +76,7 @@ define a callback for the ``prePersist`` Doctrine event:
              */
             public function setCreatedAtValue(): void
             {
-                $this->createdAt = new \DateTime();
+                $this->createdAt = new \DateTimeImmutable();
             }
         }
 


### PR DESCRIPTION
Using DateTimeImmutable instead of DateTime when no mutation is needed improves performances.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
