### PR TITLE
[Validator] Mention doctrine-bridge in the UniqueEntity constraint

### DIFF
--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -10,6 +10,11 @@ using an email address that already exists in the system.
     If you want to validate that all the elements of the collection are unique
     use the :doc:`Unique constraint </reference/constraints/Unique>`.
 
+.. note::
+
+    In order to use this constraint, you should have installed the
+    symfony/doctrine-bridge with Composer.
+
 ==========  ===================================================================
 Applies to  :ref:`class <validation-class-target>`
 Options     - `em`_

--- a/reference/constraints/UserPassword.rst
+++ b/reference/constraints/UserPassword.rst
@@ -12,7 +12,7 @@ password, but needs to enter their old password for security.
 
 .. note::
 
-    In order to use this constraints, you should have installed the
+    In order to use this constraint, you should have installed the
     symfony/security-core component with Composer.
 
 ==========  ===================================================================


### PR DESCRIPTION
Like in the [UserPassword](https://symfony.com/doc/4.4/reference/constraints/UserPassword.html).
Changed also plural to singular because there is only one constraint in those.
