### PR TITLE
[Profiler] Remove unused import

### DIFF
--- a/profiler/data_collector.rst
+++ b/profiler/data_collector.rst
@@ -31,7 +31,6 @@ request::
     use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
-    use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 
     class RequestCollector extends AbstractDataCollector
     {


### PR DESCRIPTION
I removed the DataCollector class import because it has been replaced with the AbstractDataCollector class.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
