### PR TITLE
[Form] Add note about Intl component

### DIFF
--- a/reference/forms/types/country.rst
+++ b/reference/forms/types/country.rst
@@ -65,6 +65,14 @@ the option manually, but then you should just use the ``ChoiceType`` directly.
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
+.. versionadded:: 5.3
+
+    The Intl component is required to get a list of countries.
+
+    .. code-block:: terminal
+
+        $ composer require symfony/intl
+
 Field Options
 -------------
 

--- a/reference/forms/types/currency.rst
+++ b/reference/forms/types/currency.rst
@@ -56,6 +56,14 @@ manually, but then you should just use the ``ChoiceType`` directly.
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
+.. versionadded:: 5.3
+
+    The Intl component is required to get a list of currencies.
+
+    .. code-block:: terminal
+
+        $ composer require symfony/intl
+
 Field Options
 -------------
 

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -68,6 +68,14 @@ manually, but then you should just use the ``ChoiceType`` directly.
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
+.. versionadded:: 5.3
+
+    The Intl component is required to get a list of languages.
+
+    .. code-block:: terminal
+
+        $ composer require symfony/intl
+
 Field Options
 -------------
 

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -67,6 +67,14 @@ manually, but then you should just use the ``ChoiceType`` directly.
 
 .. include:: /reference/forms/types/options/_debug_form.rst.inc
 
+.. versionadded:: 5.3
+
+    The Intl component is required to get a list of locales.
+
+    .. code-block:: terminal
+
+        $ composer require symfony/intl
+
 Field Options
 -------------
 

--- a/reference/forms/types/timezone.rst
+++ b/reference/forms/types/timezone.rst
@@ -94,6 +94,14 @@ with the ``choice_translation_locale`` option.
     The :doc:`Timezone constraint </reference/constraints/Timezone>` can validate
     both timezone sets and adapts to the selected set automatically.
 
+.. versionadded:: 5.3
+
+    The Intl component needs to be installed when this value is ``true``.
+
+    .. code-block:: terminal
+
+        $ composer require symfony/intl
+
 Overridden Options
 ------------------
 


### PR DESCRIPTION
Documentation for PR https://github.com/symfony/symfony/pull/40298

The Intl component is not a dependency of the form component anymore. 