### PR TITLE
[Mailer] doc(mailer): add Sendinblue to transports supporting tags and metadata

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1209,6 +1209,7 @@ The following transports currently support tags and metadata:
 * Postmark
 * Mailgun
 * MailChimp
+* Sendinblue
 
 Development & Debugging
 -----------------------


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
