### PR TITLE
[Validator] Mention IsNull in Basic Constraints

### DIFF
--- a/reference/constraints/IsFalse.rst
+++ b/reference/constraints/IsFalse.rst
@@ -107,6 +107,8 @@ method returns **false**:
             // ...
         }
 
+.. include:: /reference/constraints/_null-values-are-valid.rst.inc
+
 Options
 -------
 

--- a/reference/constraints/IsTrue.rst
+++ b/reference/constraints/IsTrue.rst
@@ -111,6 +111,8 @@ Then you can validate this method with ``IsTrue`` as follows:
 
 If the ``isTokenValid()`` returns false, the validation will fail.
 
+.. include:: /reference/constraints/_null-values-are-valid.rst.inc
+
 Options
 -------
 

--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -148,6 +148,8 @@ This will check if ``emailAddress`` is an instance of ``Symfony\Component\Mime\A
     The feature to define multiple types in the ``type`` option was introduced
     in Symfony 4.4.
 
+.. include:: /reference/constraints/_null-values-are-valid.rst.inc
+
 Options
 -------
 

--- a/reference/constraints/_null-values-are-valid.rst.inc
+++ b/reference/constraints/_null-values-are-valid.rst.inc
@@ -1,0 +1,6 @@
+.. note::
+
+    As with most of the other constraints, ``null`` is
+    considered a valid value. This is to allow the use of optional values.
+    If the value is mandatory, a common solution is to combine this constraint
+    with :doc:`NotNull </reference/constraints/NotNull>`.


### PR DESCRIPTION

[Email](https://symfony.com/doc/4.4/reference/constraints/Email.html), [Date](https://symfony.com/doc/4.4/reference/constraints/Date.html), [File](https://symfony.com/doc/4.4/reference/constraints/File.html) and other string constraints have note:

> As with most of the other constraints, null and empty strings are considered valid values. This is to allow them to be optional values. If the value is mandatory, a common solution is to combine this constraint with NotBlank.

This pull request adds a note about `null`  to Basic Constraints. Empty/Blank string is an invalid value for them. That's why I added a new note.