### PR TITLE
[Validator] Unique validator: Better description for the value placeholder

### DIFF
--- a/reference/constraints/Unique.rst
+++ b/reference/constraints/Unique.rst
@@ -107,7 +107,7 @@ You can use the following parameters in this message:
 =============================  ================================================
 Parameter                      Description
 =============================  ================================================
-``{{ value }}``                The repeated value
+``{{ value }}``                The current (invalid) value
 =============================  ================================================
 
 .. include:: /reference/constraints/_payload-option.rst.inc


### PR DESCRIPTION
The current description does not match the actual behavior of the validator, as spotted in symfony/symfony#40305 by @UFTimmy.