### PR TITLE
From header needs a capital F

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -476,7 +476,7 @@ and headers.
                     sender: 'fabien@example.com'
                     recipients: ['foo@example.com', 'bar@example.com']
                 headers:
-                    from: 'Fabien <fabien@example.com>'
+                    From: 'Fabien <fabien@example.com>'
                     bcc: 'baz@example.com'
                     X-Custom-Header: 'foobar'
 


### PR DESCRIPTION
According to RFC https://www.rfc-editor.org/rfc/rfc2076.txt From message header needs a capital F.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
