### PR TITLE
[Encore] Deploying to a CDN subdirectory

### DIFF
--- a/frontend/encore/cdn.rst
+++ b/frontend/encore/cdn.rst
@@ -39,6 +39,10 @@ pages also use the CDN. Fortunately, the
 :ref:`entrypoints.json <encore-entrypointsjson-simple-description>` paths are updated
 to include the full URL to the CDN.
 
+When deploying to a subdirectory of your CDN, you must add the path at the end of your URL -
+e.g. ``Encore.setPublicPath('https://my-cool-app.com.global.prod.fastly.net/awesome-website')``
+will generate assets URLs like ``https://my-cool-app.com.global.prod.fastly.net/awesome-website/dashboard.js``
+
 If you are using ``Encore.enableIntegrityHashes()`` and your CDN and your domain
 are not the `same-origin`_, you may need to set the ``crossorigin`` option in
 your webpack_encore.yaml configuration to ``anonymous`` or ``use-credentials``


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
When deploying to a CDN, you might want to deploy your whole public directory to also include bundles assets for example.

This would result in the CDN containing two folders `bundles` and `build` when using Encore.

This may also be the case if using a shared CDN for multiple applications where each project lives in a given folder.

This PR tries to document this and it seems the only solution is to add the path of the subdirectory at the end of the URL.

It's even showcased in the code comments [here](https://github.com/symfony/webpack-encore/blob/main/index.js#L84).