### PR TITLE
[Bundles] Add part about resolving parameter values to prepend extension

### DIFF
--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -82,6 +82,9 @@ in case a specific other bundle is not registered::
 
         // process the configuration of AcmeHelloExtension
         $configs = $container->getExtensionConfig($this->getAlias());
+        // resolve config parameters e.g. %kernel.debug% to boolean value
+        $resolvingBag = $container->getParameterBag();
+        $configs = $resolvingBag->resolveValue($configs);
         // use the Configuration class to generate a config array with
         // the settings "acme_hello"
         $config = $this->processConfiguration(new Configuration(), $configs);


### PR DESCRIPTION
I did run into the following issue: https://github.com/symfony/symfony/issues/40198

As when the `$configs` arrray did contain something like `%kernel.debug%` it did error with:

> Expected "bool", but got "string". 

I did debug how symfony is handling this and it seems they are resolving the parameter before here:

https://github.com/symfony/symfony/blob/252f85c2c249da7d8f2a490b57cc71199d51fcc9/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php#L54-L62

So I think this should also be part of the Prepend Extension Documentation.