### PR TITLE
[Cache] Remove `compression` option from Redis and Memcache 

### DIFF
--- a/components/cache/adapters/memcached_adapter.rst
+++ b/components/cache/adapters/memcached_adapter.rst
@@ -124,7 +124,6 @@ option names and their respective values::
 
         // associative array of configuration options
         [
-            'compression' => true,
             'libketama_compatible' => true,
             'serializer' => 'igbinary',
         ]
@@ -142,17 +141,6 @@ Available Options
     commands to buffer instead of being immediately sent to the remote
     server(s). Any action that retrieves data, quits the connection, or closes
     down the connection will cause the buffer to be committed.
-
-``compression`` (type: ``bool``, default: ``true``)
-    Enables or disables payload compression, where item values longer than 100
-    bytes are compressed during storage and decompressed during retrieval.
-
-``compression_type`` (type: ``string``)
-    Specifies the compression method used on value payloads. when the
-    **compression** option is enabled.
-
-    Valid option values include ``fastlz`` and ``zlib``, with a default value
-    that *varies based on flags used at compilation*.
 
 ``connect_timeout`` (type: ``int``, default: ``1000``)
     Specifies the timeout (in milliseconds) of socket connection operations when

--- a/components/cache/adapters/redis_adapter.rst
+++ b/components/cache/adapters/redis_adapter.rst
@@ -131,7 +131,6 @@ array of ``key => value`` pairs representing option names and their respective v
 
         // associative array of configuration options
         [
-            'compression' => true,
             'lazy' => false,
             'persistent' => 0,
             'persistent_id' => null,
@@ -150,10 +149,6 @@ Available Options
     Specifies the connection library to return, either ``\Redis`` or ``\Predis\Client``.
     If none is specified, it will return ``\Redis`` if the ``redis`` extension is
     available, and ``\Predis\Client`` otherwise.
-
-``compression`` (type: ``bool``, default: ``true``)
-    Enables or disables compression of items. This requires phpredis v4 or higher with
-    LZF support enabled.
 
 ``lazy`` (type: ``bool``, default: ``false``)
     Enables or disables lazy connections to the backend. It's ``false`` by


### PR DESCRIPTION
This option was removed in 4.4 because it didn't work. 

See https://github.com/symfony/symfony/pull/34133

This will fix #15050