### PR TITLE
[Translation] Update translation.rst

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -352,7 +352,7 @@ The ``translation:update`` command looks for missing translations in:
   defined in the :ref:`twig.default_path <config-twig-default-path>` and
   :ref:`twig.paths <config-twig-paths>` config options);
 * Any PHP file/class that injects or :doc:`autowires </service_container/autowiring>`
-  the ``translator`` service and makes calls to the ``trans()`` function.
+  the ``translator`` service and makes calls to the ``trans()`` method.
 
 .. versionadded:: 4.3
 


### PR DESCRIPTION
The `trans()` in the `translator` service is a method, not a function.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
