### PR TITLE
[Serializer] Fixed typo for YamlEncoder section

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -994,7 +994,7 @@ The ``YamlEncoder`` Context Options
 The ``encode()`` method, like other encoder, uses ``context`` to set
 configuration options for the YamlEncoder an associative array::
 
-    $xmlEncoder->encode($array, 'xml', $context);
+    $yamlEncoder->encode($array, 'yaml', $context);
 
 These are the options available:
 


### PR DESCRIPTION
Minor typo fix for YamlEncoder section

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
