### PR TITLE
Command naming conventions

### DIFF
--- a/contributing/code/conventions.rst
+++ b/contributing/code/conventions.rst
@@ -234,3 +234,11 @@ of the impacted component:
 This task is mandatory and must be done in the same pull request.
 
 .. _`@-silencing operator`: https://www.php.net/manual/en/language.operators.errorcontrol.php
+
+Naming Commands and Options
+---------------------------
+
+Commands and their options should be named and described using the English
+imperative mood (i.e. 'run' instead of 'runs', 'list' instead of 'lists'). Using
+the imperative mood is concise and consistent with similar command-line
+interfaces (such as Unix man pages).


### PR DESCRIPTION
This is a partial fix for https://github.com/symfony/symfony/issues/36973, to be reviewed along with https://github.com/symfony/symfony/pull/40387