### PR TITLE
[Doctrine][Session] Added doc and defaults for missing 'ttl' option in config

### DIFF
--- a/session/database.rst
+++ b/session/database.rst
@@ -89,9 +89,10 @@ and ``RedisProxy``:
             Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler:
                 arguments:
                     - '@Redis'
-                    # you can optionally pass an array of options. The only option is 'prefix',
-                    # which defines the prefix to use for the keys to avoid collision on the Redis server
-                    # - { prefix: 'my_prefix' }
+                    # you can optionally pass an array of options. The only options are 'prefix' and 'ttl',
+                    # which define the prefix to use for the keys to avoid collision on the Redis server 
+                    # and the expiration time for any given entry (in seconds), defaults are 'sf_s' and null:
+                    # - { 'prefix' => 'my_prefix', 'ttl' => 600 }
 
     .. code-block:: xml
 
@@ -99,8 +100,9 @@ and ``RedisProxy``:
         <services>
             <service id="Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler">
                 <argument type="service" id="Redis"/>
-                <!-- you can optionally pass an array of options. The only option is 'prefix',
-                     which defines the prefix to use for the keys to avoid collision on the Redis server:
+                <!-- you can optionally pass an array of options. The only options are 'prefix' and 'ttl',
+                     which define the prefix to use for the keys to avoid collision on the Redis server 
+                     and the expiration time for any given entry (in seconds), defaults are 'sf_s' and null:
                 <argument type="collection">
                     <argument key="prefix">my_prefix</argument>
                 </argument> -->
@@ -116,9 +118,10 @@ and ``RedisProxy``:
             ->register(RedisSessionHandler::class)
             ->addArgument(
                 new Reference('Redis'),
-                // you can optionally pass an array of options. The only option is 'prefix',
-                // which defines the prefix to use for the keys to avoid collision on the Redis server:
-                // ['prefix' => 'my_prefix'],
+                // you can optionally pass an array of options. The only options are 'prefix' and 'ttl',
+                // which define the prefix to use for the keys to avoid collision on the Redis server 
+                // and the expiration time for any given entry (in seconds), defaults are 'sf_s' and null:
+                // ['prefix' => 'my_prefix', 'ttl' => 600],
             );
 
 Next, use the :ref:`handler_id <config-framework-session-handler-id>`


### PR DESCRIPTION
Hi, this might need validation, but I stumbled upon a difference between what the doc says (4.4+) and what's in https://github.com/symfony/http-foundation/blob/5.x/Session/Storage/Handler/RedisSessionHandler.php.

I think the 'ttl' option is unexplained and undocumented since it was added in 2019: https://github.com/symfony/http-foundation/commit/0c5217a9050712a1e66f851d04962abf8f2c6fc4

Traced it back to 4.4 RC1, so I think it's on all currently maintained branches.