### PR TITLE
[Routing] add a warning about object as extra parameter in route

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -1880,6 +1880,14 @@ use the ``generateUrl()`` helper::
         // the 'blog' route only defines the 'page' parameter; the generated URL is:
         // /blog/2?category=Symfony
 
+.. caution::
+
+    While objects are converted to string when used as placeholders, they are not
+    converted when used as extra parameters. So, if you're passing an object (e.g. an Uuid)
+    as value of an extra parameter, you need to explictly convert it to a string::
+
+        $this->generateUrl('blog', ['uuid' => (string) $entity->getUuid())]
+
 If your controller does not extend from ``AbstractController``, you'll need to
 :ref:`fetch services in your controller <controller-accessing-services>` and
 follow the instructions of the next section.


### PR DESCRIPTION
As explained in [this issue](https://github.com/symfony/symfony/issues/26992), objects are not converted to string when used as extra parameter.
I think that user should be warned about such behaviour, because failing to casting object is resulting in an empty query string, without any notice/warning/error.
