### PR TITLE
[Framework] Fix reference to default_path

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2223,7 +2223,7 @@ paths
 This option allows to define an array of paths where the component will look
 for translation files. The later a path is added, the more priority it has
 (translations from later paths overwrite earlier ones). Translations from the
-`default_path <reference-translator-default_path>` have more priority than
+:ref:`default_path <reference-translator-default_path>` have more priority than
 translations from all these paths.
 
 .. _reference-translator-default_path:


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
