### PR TITLE
[Translation] Fix link to Translatable Extension documentation

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -610,5 +610,5 @@ Learn more
 .. _`ICU MessageFormat`: https://unicode-org.github.io/icu/userguide/format_parse/messages/
 .. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-.. _`Translatable Extension`: http://atlantic18.github.io/DoctrineExtensions/doc/translatable.html
+.. _`Translatable Extension`: https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/translatable.md
 .. _`Translatable Behavior`: https://github.com/KnpLabs/DoctrineBehaviors


### PR DESCRIPTION
The site http://atlantic18.github.io/DoctrineExtensions/ returns 404.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
