### PR TITLE
Distinct Bootstrap jQuery requirement

### DIFF
--- a/frontend/encore/bootstrap.rst
+++ b/frontend/encore/bootstrap.rst
@@ -37,7 +37,8 @@ file into ``global.scss``. You can even customize the Bootstrap variables first!
 Importing Bootstrap JavaScript
 ------------------------------
 
-Bootstrap JavaScript requires jQuery and Popper.js, so make sure you have this installed:
+Bootstrap JavaScript requires Popper.js. Prior to Bootstrap 5, jQuery is required too.
+Make sure you have this installed:
 
 .. code-block:: terminal
 


### PR DESCRIPTION
Add distinction to jQuery requirement for Bootstrap version 5, which does not require it to be used:
https://getbootstrap.com/docs/5.0/getting-started/javascript/#still-want-to-use-jquery-its-possible

Text is a suggestion, I feel it could be more elegantly written?