### PR TITLE
[RateLimiter] Typo in Rate Limiter Status example

### DIFF
--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -293,7 +293,7 @@ the :class:`Symfony\\Component\\RateLimiter\\Reservation` object returned by the
 
             // ...
 
-            $reponse = new Response('...');
+            $response = new Response('...');
             $response->headers->add($headers);
 
             return $response;


### PR DESCRIPTION
This fixes a typo in the Rate Limiter Status example.