### PR TITLE
Update optional_dependencies.rst

### DIFF
--- a/service_container/optional_dependencies.rst
+++ b/service_container/optional_dependencies.rst
@@ -113,7 +113,7 @@ In YAML, the special ``@?`` syntax tells the service container that the
 dependency is optional. The ``NewsletterManager`` must also be rewritten by
 adding a ``setLogger()`` method::
 
-        public function setLogger(LoggerInterface $logger): void
+        public function setLogger(?LoggerInterface $logger): void
         {
             // ...
         }


### PR DESCRIPTION
May the dependency LoggerInterface is null if we declare that the argument is optional (with @? in YAML for instance)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
