### PR TITLE
[FrameworkBundle] Replace render() with new renderForm() in form documentation

### DIFF
--- a/form/direct_submit.rst
+++ b/form/direct_submit.rst
@@ -29,9 +29,7 @@ control over when exactly your form is submitted and what data is passed to it::
             }
         }
 
-        return $this->render('task/new.html.twig', [
-            'form' => $form->createView(),
-        ]);
+        return $this->renderForm('task/new.html.twig', $form);
     }
 
 .. tip::

--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -534,10 +534,7 @@ your application. Assume that you have a sport meetup creation controller::
                 // ... save the meetup, redirect etc.
             }
 
-            return $this->render(
-                'meetup/create.html.twig',
-                ['form' => $form->createView()]
-            );
+            return $this->renderForm('meetup/create.html.twig', $form);
         }
 
         // ...

--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -164,9 +164,7 @@ In your controller, you'll create a new form from the ``TaskType``::
                 // ... do your form processing, like saving the Task and Tag entities
             }
 
-            return $this->render('task/new.html.twig', [
-                'form' => $form->createView(),
-            ]);
+            return $this->renderForm('task/new.html.twig', $form);
         }
     }
 

--- a/forms.rst
+++ b/forms.rst
@@ -277,11 +277,14 @@ to build another object with the visual representation of the form::
 
             $form = $this->createForm(TaskType::class, $task);
 
-            return $this->render('task/new.html.twig', [
-                'form' => $form->createView(),
-            ]);
+            return $this->renderForm('task/new.html.twig', $form);
         }
     }
+
+.. versionadded:: 5.3
+
+    The ``renderForm`` method was introduced in Symfony 5.3, allowing to
+    return 422 HTTP status code if an invalid form is submitted.
 
 Then, use some :ref:`form helper functions <reference-form-twig-functions>` to
 render the form contents:
@@ -405,9 +408,7 @@ written into the form object::
                 return $this->redirectToRoute('task_success');
             }
 
-            return $this->render('task/new.html.twig', [
-                'form' => $form->createView(),
-            ]);
+            return $this->renderForm('task/new.html.twig', $form);
         }
     }
 


### PR DESCRIPTION
This is the documentation for #14844 