### PR TITLE
add a warning about Amazon SES signature

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -160,6 +160,11 @@ party provider:
     For example, the DSN ``ses+smtp://ABC1234:abc+12/345@default`` should be
     configured as ``ses+smtp://ABC1234:abc%2B12%2F345@default``
 
+.. caution::
+
+    Symfony 4.4 only suppports Amazon SES Signature Version 3, that has been deprecated.
+    You need to use symfony/amazon-mailer 5.1 or newer.
+
 .. tip::
 
     If you want to override the default host for a provider (to debug an issue using


### PR DESCRIPTION
We need to warn users of Symfony 4.4 that they can't use symfony/amazon-mailer anymore.
They need to upgrade to 5.1 or newer.
See https://github.com/symfony/symfony/issues/36956#issuecomment-785678737
