### PR TITLE
Remove outdated reference to the difference between mergers and deciders

### DIFF
--- a/contributing/code/core_team.rst
+++ b/contributing/code/core_team.rst
@@ -155,8 +155,7 @@ A pull request **can be merged** if:
 
 * Enough time was given for peer reviews;
 
-* At least two **Merger Team** members voted ``+1`` (only one if the submitter
-  is part of the Merger team) and no Core member voted ``-1`` (via GitHub
+* At least two **Merger Team** members voted ``+1`` and no Core member voted ``-1`` (via GitHub
   reviews or as comments).
 
 Pull Request Merging Process


### PR DESCRIPTION
With the removal of the per-component mergers, all deciders have been promoted to mergers instead, removing the distinction.
The rule about the number of votes was not updated to reflect that. Based on the written rule, it could mean that we can always merge with 1 vote only (as we are all mergers now). But that's not the intent (and the `gh` tool still requires 2 votes). The intent was to removal the `1 vote` special case.

/cc @fabpot 