### PR TITLE
[Mailer] Use correct domain

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -173,8 +173,8 @@ party provider:
     .. code-block:: env
 
         # .env
-        MAILER_DSN=mailgun+https://KEY:DOMAIN@example.com
-        MAILER_DSN=mailgun+https://KEY:DOMAIN@example.com:99
+        MAILER_DSN=mailgun+https://KEY:DOMAIN@requestbin.com
+        MAILER_DSN=mailgun+https://KEY:DOMAIN@requestbin.com:99
 
     Note that the protocol is *always* HTTPs and cannot be changed.
 


### PR DESCRIPTION
If we talk about `requestbin.com`, it should be reflected in the corresponding example

![CleanShot 2021-03-17 at 11 37 54](https://user-images.githubusercontent.com/995707/111454729-44025a80-8715-11eb-894c-4ddeeb381149.png)
