### PR TITLE
[Testing] Fix typo in assertEmailAttachmentCount

### DIFF
--- a/testing/functional_tests_assertions.rst
+++ b/testing/functional_tests_assertions.rst
@@ -84,7 +84,7 @@ Mailer
 - ``assertQueuedEmailCount()``
 - ``assertEmailIsQueued()``
 - ``assertEmailIsNotQueued()``
-- ``assertEmailAttachementCount()``
+- ``assertEmailAttachmentCount()``
 - ``assertEmailTextBodyContains()``
 - ``assertEmailTextBodyNotContains()``
 - ``assertEmailHtmlBodyContains()``


### PR DESCRIPTION
The initial typo has been fixed in https://github.com/symfony/symfony/commit/327a13cac0f57bf2d4b728a63beddd2a52f2d352. 