### PR TITLE
[Notifier] Remove SentMessage paragraph

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -380,7 +380,7 @@ To send a notification, autowire the
             );
 
             // Send the notification to the recipient
-            $sentMessage = $notifier->send($notification, $recipient);
+            $notifier->send($notification, $recipient);
 
             // ...
         }
@@ -390,14 +390,6 @@ The ``Notification`` is created by using two arguments: the subject and
 channels. The channels specify which channel (or transport) should be used
 to send the notification. For instance, ``['email', 'sms']`` will send
 both an email and sms notification to the user.
-
-The ``send()`` method used to send the notification returns a variable of type
-:class:`Symfony\\Component\\Notifier\\Message\\SentMessage` which provides
-information such as the message ID and the original message contents.
-
-.. versionadded:: 5.2
-
-    The ``SentMessage`` class was introduced in Symfony 5.2.
 
 The default notification also has a ``content()`` and ``emoji()`` method to
 set the notification content and icon.


### PR DESCRIPTION
The Notifier's `send` method does not return a `SentMessage` object: https://github.com/symfony/symfony/blob/5.2/src/Symfony/Component/Notifier/NotifierInterface.php#L26

Only the Chatter and Texter classes `send` methods return a `SendMessage`.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
