### PR TITLE
[DependencyInjection] Fixed invalid alias definition in "Deprecating Service Aliases" YAML example

### DIFF
--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -166,7 +166,7 @@ or you decided not to maintain it anymore), you can deprecate its definition:
     .. code-block:: yaml
 
         app.mailer:
-            alias: '@App\Mail\PhpMailer'
+            alias: 'App\Mail\PhpMailer'
 
             # this will display a generic deprecation message...
             deprecated: true


### PR DESCRIPTION
Fixed invalid alias definition in "Deprecating Service Aliases" YAML example. Current version is 

```yaml
app.mailer:
    alias: '@App\Mail\PhpMailer'

    # ....
```
Correct version is 

```yaml
app.mailer:
    alias: 'App\Mail\PhpMailer'

    # ....
```

(without `@` prefix in service id)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
