### PR TITLE
Typo with backticks.

### DIFF
--- a/http_cache/validation.rst
+++ b/http_cache/validation.rst
@@ -106,7 +106,7 @@ doing so much work.
 
 .. tip::
 
-    Symfony also supports weak ``ETag``s by passing ``true`` as the second
+    Symfony also supports weak ``ETag`` s by passing ``true`` as the second
     argument to the
     :method:`Symfony\\Component\\HttpFoundation\\Response::setEtag` method.
 


### PR DESCRIPTION
Removed extra backticks that are visible.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
