### PR TITLE
[Mailer] fix ses+smtp credentials format

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -146,7 +146,7 @@ party provider:
 ==================== ========================================== =========================================== ========================================
  Provider             SMTP                                       HTTP                                        API
 ==================== ========================================== =========================================== ========================================
- Amazon SES           ses+smtp://ACCESS_KEY:SECRET_KEY@default   ses+https://ACCESS_KEY:SECRET_KEY@default   ses+api://ACCESS_KEY:SECRET_KEY@default
+ Amazon SES           ses+smtp://USERNAME:PASSWORD@default       ses+https://ACCESS_KEY:SECRET_KEY@default   ses+api://ACCESS_KEY:SECRET_KEY@default
  Google Gmail         gmail+smtp://USERNAME:PASSWORD@default     n/a                                         n/a
  Mailchimp Mandrill   mandrill+smtp://USERNAME:PASSWORD@default  mandrill+https://KEY@default                mandrill+api://KEY@default
  Mailgun              mailgun+smtp://USERNAME:PASSWORD@default   mailgun+https://KEY:DOMAIN@default          mailgun+api://KEY:DOMAIN@default


### PR DESCRIPTION
For ses+smtp(s) mailer uses SMTP username and password instead of AWS access key and secret

https://github.com/symfony/amazon-mailer/blob/4.4/Transport/SesTransportFactory.php#L47