### PR TITLE
[Doctrine] Fix markdown in multiple_entity_managers.rst

### DIFF
--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -313,6 +313,6 @@ The same applies to repository calls::
             // ...
         }
 
-	You should now always fetch this repository using ``ManagerRegistry::getRepository()``.
+You should now always fetch this repository using ``ManagerRegistry::getRepository()``.
 
 .. _`several alternatives`: https://stackoverflow.com/a/11494543


### PR DESCRIPTION
Fix broken markdown at the end of the [multiple entity managers](https://symfony.com/doc/4.4/doctrine/multiple_entity_managers.html) page