### PR TITLE
[Validator] Add missing backticks for constraint option names

### DIFF
--- a/reference/constraints/Bic.rst
+++ b/reference/constraints/Bic.rst
@@ -87,8 +87,8 @@ Available Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-iban
-~~~~
+``iban``
+~~~~~~~~
 
 **type**: ``string`` **default**: ``null``
 
@@ -98,8 +98,8 @@ iban
 
 An IBAN value to validate that its country code is the same as the BIC's one.
 
-ibanMessage
-~~~~~~~~~~~
+``ibanMessage``
+~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.``
 
@@ -109,8 +109,8 @@ ibanMessage
 
 The default message supplied when the value does not pass the combined BIC/IBAN check.
 
-ibanPropertyPath
-~~~~~~~~~~~~~~~~
+``ibanPropertyPath``
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``null``
 
@@ -124,8 +124,8 @@ For example, if you want to compare the ``$bic`` property of some object
 with regard to the ``$iban`` property of the same object, use
 ``ibanPropertyPath="iban"`` in the comparison constraint of ``$bic``.
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This is not a valid Business Identifier Code (BIC).``
 

--- a/reference/constraints/CardScheme.rst
+++ b/reference/constraints/CardScheme.rst
@@ -99,8 +99,8 @@ Available Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``Unsupported card type or invalid card number.``
 
@@ -116,8 +116,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-schemes
-~~~~~~~
+``schemes``
+~~~~~~~~~~~
 
 **type**: ``mixed`` [:ref:`default option <validation-default-option>`]
 

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -275,8 +275,8 @@ you can pass the class name and the method as an array.
 Available Options
 -----------------
 
-callback
-~~~~~~~~
+``callback``
+~~~~~~~~~~~~
 
 **type**: ``string|array|Closure``
 
@@ -284,8 +284,8 @@ This is a callback method that can be used instead of the `choices`_ option
 to return the choices array. See
 `Supplying the Choices with a Callback Function`_ for details on its usage.
 
-choices
-~~~~~~~
+``choices``
+~~~~~~~~~~~
 
 **type**: ``array`` [:ref:`default option <validation-default-option>`]
 
@@ -295,8 +295,8 @@ will be matched against this array.
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-max
-~~~
+``max``
+~~~~~~~
 
 **type**: ``integer``
 
@@ -305,8 +305,8 @@ to force no more than XX number of values to be selected. For example, if
 ``max`` is 3, but the input array contains 4 valid items, the validation
 will fail.
 
-maxMessage
-~~~~~~~~~~
+``maxMessage``
+~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``You must select at most {{ limit }} choices.``
 
@@ -326,8 +326,8 @@ Parameter          Description
 
     The ``{{ choices }}`` parameter was introduced in Symfony 4.3.
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The value you selected is not a valid choice.``
 
@@ -344,8 +344,8 @@ Parameter          Description
 ``{{ value }}``    The current (invalid) value
 =================  ============================================================
 
-min
-~~~
+``min``
+~~~~~~~
 
 **type**: ``integer``
 
@@ -354,8 +354,8 @@ to force at least XX number of values to be selected. For example, if
 ``min`` is 3, but the input array only contains 2 valid items, the validation
 will fail.
 
-minMessage
-~~~~~~~~~~
+``minMessage``
+~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``You must select at least {{ limit }} choices.``
 
@@ -375,8 +375,8 @@ Parameter          Description
 
     The ``{{ choices }}`` parameter was introduced in Symfony 4.3.
 
-multiple
-~~~~~~~~
+``multiple``
+~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``false``
 
@@ -385,8 +385,8 @@ of a single, scalar value. The constraint will check that each value of
 the input array can be found in the array of valid choices. If even one
 of the input values cannot be found, the validation will fail.
 
-multipleMessage
-~~~~~~~~~~~~~~~
+``multipleMessage``
+~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``One or more of the given values is invalid.``
 

--- a/reference/constraints/Count.rst
+++ b/reference/constraints/Count.rst
@@ -101,8 +101,8 @@ you might add the following:
 Options
 -------
 
-exactMessage
-~~~~~~~~~~~~
+``exactMessage``
+~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This collection should contain exactly {{ limit }} elements.``
 
@@ -120,8 +120,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-max
-~~~
+``max``
+~~~~~~~
 
 **type**: ``integer``
 
@@ -130,8 +130,8 @@ collection elements count is **greater** than this max value.
 
 This option is required when the ``min`` option is not defined.
 
-maxMessage
-~~~~~~~~~~
+``maxMessage``
+~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This collection should contain {{ limit }} elements or less.``
 
@@ -147,8 +147,8 @@ Parameter        Description
 ``{{ limit }}``  The upper limit
 ===============  ==============================================================
 
-min
-~~~
+``min``
+~~~~~~~
 
 **type**: ``integer``
 
@@ -157,8 +157,8 @@ collection elements count is **less** than this min value.
 
 This option is required when the ``max`` option is not defined.
 
-minMessage
-~~~~~~~~~~
+``minMessage``
+~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This collection should contain {{ limit }} elements or more.``
 

--- a/reference/constraints/DateTime.rst
+++ b/reference/constraints/DateTime.rst
@@ -84,8 +84,8 @@ Basic Usage
 Options
 -------
 
-format
-~~~~~~
+``format``
+~~~~~~~~~~
 
 **type**: ``string`` **default**: ``Y-m-d H:i:s``
 

--- a/reference/constraints/DivisibleBy.rst
+++ b/reference/constraints/DivisibleBy.rst
@@ -104,8 +104,8 @@ Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value should be a multiple of {{ compared_value }}.``
 

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -92,8 +92,8 @@ Basic Usage
 Options
 -------
 
-checkHost
-~~~~~~~~~
+``checkHost``
+~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``false``
 
@@ -105,8 +105,8 @@ If true, then the :phpfunction:`checkdnsrr` PHP function will be used to
 check the validity of the MX *or* the A *or* the AAAA record of the host
 of the given email.
 
-checkMX
-~~~~~~~
+``checkMX``
+~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``false``
 
@@ -124,8 +124,8 @@ check the validity of the MX record of the host of the given email.
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value is not a valid email address.``
 
@@ -139,8 +139,8 @@ Parameter        Description
 ``{{ value }}``  The current (invalid) value
 ===============  ==============================================================
 
-mode
-~~~~
+``mode``
+~~~~~~~~
 
 **type**: ``string`` **default**: ``loose``
 

--- a/reference/constraints/Expression.rst
+++ b/reference/constraints/Expression.rst
@@ -264,8 +264,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-values
-~~~~~~
+``values``
+~~~~~~~~~~
 
 **type**: ``array`` **default**: ``[]``
 

--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -158,8 +158,8 @@ have been specified.
 Options
 -------
 
-binaryFormat
-~~~~~~~~~~~~
+``binaryFormat``
+~~~~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``null``
 
@@ -171,8 +171,8 @@ the value defined in the ``maxSize`` option.
 For more information about the difference between binary and SI prefixes,
 see `Wikipedia: Binary prefix`_.
 
-disallowEmptyMessage
-~~~~~~~~~~~~~~~~~~~~
+``disallowEmptyMessage``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``An empty file is not allowed.``
 
@@ -190,8 +190,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-maxSize
-~~~~~~~
+``maxSize``
+~~~~~~~~~~~
 
 **type**: ``mixed``
 
@@ -212,8 +212,8 @@ Suffix  Unit Name  Value            Example
 For more information about the difference between binary and SI prefixes,
 see `Wikipedia: Binary prefix`_.
 
-maxSizeMessage
-~~~~~~~~~~~~~~
+``maxSizeMessage``
+~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.``
 
@@ -231,8 +231,8 @@ Parameter         Description
 ``{{ suffix }}``  Suffix for the used file size unit (see above)
 ================  =============================================================
 
-mimeTypes
-~~~~~~~~~
+``mimeTypes``
+~~~~~~~~~~~~~
 
 **type**: ``array`` or ``string``
 
@@ -256,8 +256,8 @@ You can find a list of existing mime types on the `IANA website`_.
 
         This feature was introduced in Symfony 4.4.
 
-mimeTypesMessage
-~~~~~~~~~~~~~~~~
+``mimeTypesMessage``
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.``
 
@@ -275,8 +275,8 @@ Parameter        Description
 ``{{ types }}``  The list of allowed MIME types
 ===============  ==============================================================
 
-notFoundMessage
-~~~~~~~~~~~~~~~
+``notFoundMessage``
+~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The file could not be found.``
 
@@ -292,8 +292,8 @@ Parameter        Description
 ``{{ file }}``   Absolute file path
 ===============  ==============================================================
 
-notReadableMessage
-~~~~~~~~~~~~~~~~~~
+``notReadableMessage``
+~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The file is not readable.``
 
@@ -310,8 +310,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-uploadCantWriteErrorMessage
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``uploadCantWriteErrorMessage``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``Cannot write temporary file to disk.``
 
@@ -320,8 +320,8 @@ temporary folder.
 
 This message has no parameters.
 
-uploadErrorMessage
-~~~~~~~~~~~~~~~~~~
+``uploadErrorMessage``
+~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The file could not be uploaded.``
 
@@ -330,8 +330,8 @@ for some unknown reason.
 
 This message has no parameters.
 
-uploadExtensionErrorMessage
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``uploadExtensionErrorMessage``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``A PHP extension caused the upload to fail.``
 
@@ -340,8 +340,8 @@ fail.
 
 This message has no parameters.
 
-uploadFormSizeErrorMessage
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+``uploadFormSizeErrorMessage``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The file is too large.``
 
@@ -350,8 +350,8 @@ by the HTML file input field.
 
 This message has no parameters.
 
-uploadIniSizeErrorMessage
-~~~~~~~~~~~~~~~~~~~~~~~~~
+``uploadIniSizeErrorMessage``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.``
 
@@ -367,8 +367,8 @@ Parameter         Description
 ``{{ suffix }}``  Suffix for the used file size unit (see above)
 ================  =============================================================
 
-uploadNoFileErrorMessage
-~~~~~~~~~~~~~~~~~~~~~~~~
+``uploadNoFileErrorMessage``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``No file was uploaded.``
 
@@ -376,8 +376,8 @@ The message that is displayed if no file was uploaded.
 
 This message has no parameters.
 
-uploadNoTmpDirErrorMessage
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+``uploadNoTmpDirErrorMessage``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``No temporary folder was configured in php.ini.``
 
@@ -386,8 +386,8 @@ missing.
 
 This message has no parameters.
 
-uploadPartialErrorMessage
-~~~~~~~~~~~~~~~~~~~~~~~~~
+``uploadPartialErrorMessage``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The file was only partially uploaded.``
 

--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -230,15 +230,15 @@ This constraint shares all of its options with the :doc:`File </reference/constr
 constraint. It does, however, modify two of the default option values and
 add several other options.
 
-allowLandscape
-~~~~~~~~~~~~~~
+``allowLandscape``
+~~~~~~~~~~~~~~~~~~
 
 **type**: ``Boolean`` **default**: ``true``
 
 If this option is false, the image cannot be landscape oriented.
 
-allowLandscapeMessage
-~~~~~~~~~~~~~~~~~~~~~
+``allowLandscapeMessage``
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image is landscape oriented ({{ width }}x{{ height }}px).
 Landscape oriented images are not allowed``
@@ -254,15 +254,15 @@ Parameter         Description
 ``{{ width }}``   The current width
 ================  =============================================================
 
-allowPortrait
-~~~~~~~~~~~~~
+``allowPortrait``
+~~~~~~~~~~~~~~~~~
 
 **type**: ``Boolean`` **default**: ``true``
 
 If this option is false, the image cannot be portrait oriented.
 
-allowPortraitMessage
-~~~~~~~~~~~~~~~~~~~~
+``allowPortraitMessage``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image is portrait oriented ({{ width }}x{{ height }}px).
 Portrait oriented images are not allowed``
@@ -278,8 +278,8 @@ Parameter         Description
 ``{{ width }}``   The current width
 ================  =============================================================
 
-allowSquare
-~~~~~~~~~~~
+``allowSquare``
+~~~~~~~~~~~~~~~
 
 **type**: ``Boolean`` **default**: ``true``
 
@@ -287,8 +287,8 @@ If this option is false, the image cannot be a square. If you want to force
 a square image, then leave this option as its default ``true`` value
 and set `allowLandscape`_ and `allowPortrait`_ both to ``false``.
 
-allowSquareMessage
-~~~~~~~~~~~~~~~~~~
+``allowSquareMessage``
+~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image is square ({{ width }}x{{ height }}px).
 Square images are not allowed``
@@ -304,8 +304,8 @@ Parameter         Description
 ``{{ width }}``   The current width
 ================  =============================================================
 
-corruptedMessage
-~~~~~~~~~~~~~~~~
+``corruptedMessage``
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image file is corrupted.``
 
@@ -314,8 +314,8 @@ is corrupted.
 
 This message has no parameters.
 
-detectCorrupted
-~~~~~~~~~~~~~~~
+``detectCorrupted``
+~~~~~~~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``false``
 
@@ -325,16 +325,16 @@ function, which requires the `PHP GD extension`_ to be enabled.
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-maxHeight
-~~~~~~~~~
+``maxHeight``
+~~~~~~~~~~~~~
 
 **type**: ``integer``
 
 If set, the height of the image file must be less than or equal to this
 value in pixels.
 
-maxHeightMessage
-~~~~~~~~~~~~~~~~
+``maxHeightMessage``
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image height is too big ({{ height }}px).
 Allowed maximum height is {{ max_height }}px.``
@@ -350,16 +350,16 @@ Parameter             Description
 ``{{ max_height }}``  The maximum allowed height
 ====================  =========================================================
 
-maxPixels
-~~~~~~~~~
+``maxPixels``
+~~~~~~~~~~~~~
 
 **type**: ``integer``
 
 If set, the amount of pixels of the image file must be less than or equal to this
 value.
 
-maxPixelsMessage
-~~~~~~~~~~~~~~~~
+``maxPixelsMessage``
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image has to many pixels ({{ pixels }} pixels).
 Maximum amount expected is {{ max_pixels }} pixels.``
@@ -377,16 +377,16 @@ Parameter             Description
 ``{{ width }}``       The current image width
 ====================  =========================================================
 
-maxRatio
-~~~~~~~~
+``maxRatio``
+~~~~~~~~~~~~
 
 **type**: ``float``
 
 If set, the aspect ratio (``width / height``) of the image file must be less
 than or equal to this value.
 
-maxRatioMessage
-~~~~~~~~~~~~~~~
+``maxRatioMessage``
+~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image ratio is too big ({{ ratio }}).
 Allowed maximum ratio is {{ max_ratio }}``
@@ -402,16 +402,16 @@ Parameter            Description
 ``{{ ratio }}``      The current (invalid) ratio
 ===================  ==========================================================
 
-maxWidth
-~~~~~~~~
+``maxWidth``
+~~~~~~~~~~~~
 
 **type**: ``integer``
 
 If set, the width of the image file must be less than or equal to this
 value in pixels.
 
-maxWidthMessage
-~~~~~~~~~~~~~~~
+``maxWidthMessage``
+~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image width is too big ({{ width }}px).
 Allowed maximum width is {{ max_width }}px.``
@@ -427,28 +427,28 @@ Parameter            Description
 ``{{ width }}``      The current (invalid) width
 ===================  ==========================================================
 
-mimeTypes
-~~~~~~~~~
+``mimeTypes``
+~~~~~~~~~~~~~
 
 **type**: ``array`` or ``string`` **default**: ``image/*``
 
 You can find a list of existing image mime types on the `IANA website`_.
 
-mimeTypesMessage
-~~~~~~~~~~~~~~~~
+``mimeTypesMessage``
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This file is not a valid image.``
 
-minHeight
-~~~~~~~~~
+``minHeight``
+~~~~~~~~~~~~~
 
 **type**: ``integer``
 
 If set, the height of the image file must be greater than or equal to this
 value in pixels.
 
-minHeightMessage
-~~~~~~~~~~~~~~~~
+``minHeightMessage``
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image height is too small ({{ height }}px).
 Minimum height expected is {{ min_height }}px.``
@@ -464,16 +464,16 @@ Parameter             Description
 ``{{ min_height }}``  The minimum required height
 ====================  =========================================================
 
-minPixels
-~~~~~~~~~
+``minPixels``
+~~~~~~~~~~~~~
 
 **type**: ``integer``
 
 If set, the amount of pixels of the image file must be greater than or equal to this
 value.
 
-minPixelsMessage
-~~~~~~~~~~~~~~~~
+``minPixelsMessage``
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image has too few pixels ({{ pixels }} pixels).
 Minimum amount expected is {{ min_pixels }} pixels.``
@@ -491,16 +491,16 @@ Parameter             Description
 ``{{ width }}``       The current image width
 ====================  =========================================================
 
-minRatio
-~~~~~~~~
+``minRatio``
+~~~~~~~~~~~~
 
 **type**: ``float``
 
 If set, the aspect ratio (``width / height``) of the image file must be greater
 than or equal to this value.
 
-minRatioMessage
-~~~~~~~~~~~~~~~
+``minRatioMessage``
+~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image ratio is too small ({{ ratio }}).
 Minimum ratio expected is {{ min_ratio }}``
@@ -516,16 +516,16 @@ Parameter            Description
 ``{{ ratio }}``      The current (invalid) ratio
 ===================  ==========================================================
 
-minWidth
-~~~~~~~~
+``minWidth``
+~~~~~~~~~~~~
 
 **type**: ``integer``
 
 If set, the width of the image file must be greater than or equal to this
 value in pixels.
 
-minWidthMessage
-~~~~~~~~~~~~~~~
+``minWidthMessage``
+~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The image width is too small ({{ width }}px).
 Minimum width expected is {{ min_width }}px.``
@@ -541,8 +541,8 @@ Parameter            Description
 ``{{ width }}``      The current (invalid) width
 ===================  ==========================================================
 
-sizeNotDetectedMessage
-~~~~~~~~~~~~~~~~~~~~~~
+``sizeNotDetectedMessage``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The size of the image could not be detected.``
 

--- a/reference/constraints/Ip.rst
+++ b/reference/constraints/Ip.rst
@@ -82,8 +82,8 @@ Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This is not a valid IP address.``
 
@@ -101,8 +101,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-version
-~~~~~~~
+``version``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``4``
 

--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -95,8 +95,8 @@ on an object that will contain an ISBN.
 Available Options
 -----------------
 
-bothIsbnMessage
-~~~~~~~~~~~~~~~
+``bothIsbnMessage``
+~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value is neither a valid ISBN-10 nor a valid ISBN-13.``
 
@@ -113,8 +113,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-isbn10Message
-~~~~~~~~~~~~~
+``isbn10Message``
+~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value is not a valid ISBN-10.``
 
@@ -129,8 +129,8 @@ Parameter        Description
 ``{{ value }}``  The current (invalid) value
 ===============  ==============================================================
 
-isbn13Message
-~~~~~~~~~~~~~
+``isbn13Message``
+~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value is not a valid ISBN-13.``
 
@@ -145,8 +145,8 @@ Parameter        Description
 ``{{ value }}``  The current (invalid) value
 ===============  ==============================================================
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``null``
 
@@ -163,8 +163,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-type
-~~~~
+``type``
+~~~~~~~~
 
 **type**: ``string`` **default**: ``null``
 

--- a/reference/constraints/Issn.rst
+++ b/reference/constraints/Issn.rst
@@ -79,8 +79,8 @@ Basic Usage
 Options
 -------
 
-caseSensitive
-~~~~~~~~~~~~~
+``caseSensitive``
+~~~~~~~~~~~~~~~~~
 
 **type**: ``boolean`` default: ``false``
 
@@ -89,8 +89,8 @@ When switching this to ``true``, the validator requires an upper case 'X'.
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` default: ``This value is not a valid ISSN.``
 
@@ -106,8 +106,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-requireHyphen
-~~~~~~~~~~~~~
+``requireHyphen``
+~~~~~~~~~~~~~~~~~
 
 **type**: ``boolean`` default: ``false``
 

--- a/reference/constraints/Json.rst
+++ b/reference/constraints/Json.rst
@@ -82,8 +82,8 @@ The ``Json`` constraint can be applied to a property or a "getter" method:
 Options
 -------
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value should be valid JSON.``
 

--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -114,8 +114,8 @@ and ``50``, you might add the following:
 Options
 -------
 
-allowEmptyString
-~~~~~~~~~~~~~~~~
+``allowEmptyString``
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``boolean``  **default**: ``true``
 
@@ -132,8 +132,8 @@ valid.
 
     This option does not have any effect when no minimum length is given.
 
-charset
-~~~~~~~
+``charset``
+~~~~~~~~~~~
 
 **type**: ``string``  **default**: ``UTF-8``
 
@@ -141,8 +141,8 @@ The charset to be used when computing value's length with the
 :phpfunction:`mb_check_encoding` and :phpfunction:`mb_strlen`
 PHP functions.
 
-charsetMessage
-~~~~~~~~~~~~~~
+``charsetMessage``
+~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value does not match the expected {{ charset }} charset.``
 
@@ -176,8 +176,8 @@ Parameter          Description
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-max
-~~~
+``max``
+~~~~~~~
 
 **type**: ``integer``
 
@@ -186,8 +186,8 @@ the given value's length is **greater** than this max value.
 
 This option is required when the ``min`` option is not defined.
 
-maxMessage
-~~~~~~~~~~
+``maxMessage``
+~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value is too long. It should have {{ limit }} characters or less.``
 
@@ -203,8 +203,8 @@ Parameter          Description
 ``{{ value }}``    The current (invalid) value
 =================  ============================================================
 
-min
-~~~
+``min``
+~~~~~~~
 
 **type**: ``integer``
 
@@ -217,8 +217,8 @@ It is important to notice that NULL values and empty strings are considered
 valid no matter if the constraint required a minimum length. Validators
 are triggered only if the value is not blank.
 
-minMessage
-~~~~~~~~~~
+``minMessage``
+~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value is too short. It should have {{ limit }} characters or more.``
 

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -89,8 +89,8 @@ Basic Usage
 Options
 -------
 
-canonicalize
-~~~~~~~~~~~~
+``canonicalize``
+~~~~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``false``
 

--- a/reference/constraints/Negative.rst
+++ b/reference/constraints/Negative.rst
@@ -85,8 +85,8 @@ Available Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value should be negative.``
 

--- a/reference/constraints/NegativeOrZero.rst
+++ b/reference/constraints/NegativeOrZero.rst
@@ -84,8 +84,8 @@ Available Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value should be either negative or zero.``
 

--- a/reference/constraints/NotBlank.rst
+++ b/reference/constraints/NotBlank.rst
@@ -82,8 +82,8 @@ class were not blank, you could do the following:
 Options
 -------
 
-allowNull
-~~~~~~~~~
+``allowNull``
+~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``false``
 

--- a/reference/constraints/NotCompromisedPassword.rst
+++ b/reference/constraints/NotCompromisedPassword.rst
@@ -106,8 +106,8 @@ Available Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This password has been leaked in a data breach, it must not be used. Please use another password.``
 
@@ -115,8 +115,8 @@ The default message supplied when the password has been compromised.
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-skipOnError
-~~~~~~~~~~~
+``skipOnError``
+~~~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``false``
 
@@ -124,8 +124,8 @@ When the HTTP request made to the ``haveibeenpwned.com`` API fails for any
 reason, an exception is thrown (no validation error is displayed). Set this
 option to ``true`` to not throw the exception and consider the password valid.
 
-threshold
-~~~~~~~~~
+``threshold``
+~~~~~~~~~~~~~
 
 **type**: ``integer`` **default**: ``1``
 

--- a/reference/constraints/Positive.rst
+++ b/reference/constraints/Positive.rst
@@ -86,8 +86,8 @@ Available Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value should be positive.``
 

--- a/reference/constraints/PositiveOrZero.rst
+++ b/reference/constraints/PositiveOrZero.rst
@@ -84,8 +84,8 @@ Available Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value should be either positive or zero.``
 

--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -316,8 +316,8 @@ Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-invalidMessage
-~~~~~~~~~~~~~~
+``invalidMessage``
+~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value should be a valid number.``
 
@@ -332,16 +332,16 @@ Parameter        Description
 ``{{ value }}``  The current (invalid) value
 ===============  ==============================================================
 
-max
-~~~
+``max``
+~~~~~~~
 
 **type**: ``number`` or ``string`` (date format)
 
 This required option is the "max" value. Validation will fail if the given
 value is **greater** than this max value.
 
-maxMessage
-~~~~~~~~~~
+``maxMessage``
+~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value should be {{ limit }} or less.``
 
@@ -358,8 +358,8 @@ Parameter        Description
 ``{{ value }}``  The current (invalid) value
 ===============  ==============================================================
 
-maxPropertyPath
-~~~~~~~~~~~~~~~
+``maxPropertyPath``
+~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string``
 
@@ -380,16 +380,16 @@ with regard to the ``$deadline`` property of the same object, use
     include it in the error messages displayed to end users, it's useful when
     using APIs for doing any mapping logic on client-side.
 
-min
-~~~
+``min``
+~~~~~~~
 
 **type**: ``number`` or ``string`` (date format)
 
 This required option is the "min" value. Validation will fail if the given
 value is **less** than this min value.
 
-minMessage
-~~~~~~~~~~
+``minMessage``
+~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value should be {{ limit }} or more.``
 
@@ -406,8 +406,8 @@ Parameter        Description
 ``{{ value }}``  The current (invalid) value
 ===============  ==============================================================
 
-minPropertyPath
-~~~~~~~~~~~~~~~
+``minPropertyPath``
+~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string``
 
@@ -428,8 +428,8 @@ with regard to the ``$startDate`` property of the same object, use
     include it in the error messages displayed to end users, it's useful when
     using APIs for doing any mapping logic on client-side.
 
-notInRangeMessage
-~~~~~~~~~~~~~~~~~
+``notInRangeMessage``
+~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value should be between {{ min }} and {{ max }}.``
 

--- a/reference/constraints/Regex.rst
+++ b/reference/constraints/Regex.rst
@@ -167,8 +167,8 @@ Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-htmlPattern
-~~~~~~~~~~~
+``htmlPattern``
+~~~~~~~~~~~~~~~
 
 **type**: ``string|boolean`` **default**: null
 
@@ -252,8 +252,8 @@ need to specify the HTML5 compatible pattern in the ``htmlPattern`` option:
 
 Setting ``htmlPattern`` to false will disable client side validation.
 
-match
-~~~~~
+``match``
+~~~~~~~~~
 
 **type**: ``boolean`` default: ``true``
 
@@ -262,8 +262,8 @@ the given `pattern`_ regular expression. However, when this option is set
 to ``false``, the opposite will occur: validation will pass only if the
 given string does **not** match the `pattern`_ regular expression.
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value is not valid.``
 
@@ -277,8 +277,8 @@ Parameter        Description
 ``{{ value }}``  The current (invalid) value
 ===============  ==============================================================
 
-pattern
-~~~~~~~
+``pattern``
+~~~~~~~~~~~
 
 **type**: ``string`` [:ref:`default option <validation-default-option>`]
 

--- a/reference/constraints/Timezone.rst
+++ b/reference/constraints/Timezone.rst
@@ -86,8 +86,8 @@ string which contains any of the `PHP timezone identifiers`_ (e.g. ``America/New
 Options
 -------
 
-countryCode
-~~~~~~~~~~~
+``countryCode``
+~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``null``
 
@@ -100,8 +100,8 @@ The value of this option must be a valid `ISO 3166-1 alpha-2`_ country code
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-intlCompatible
-~~~~~~~~~~~~~~
+``intlCompatible``
+~~~~~~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``false``
 
@@ -114,8 +114,8 @@ timezones provided by PHP's Intl extension (because they use different ICU
 versions). If this option is set to ``true``, this constraint only considers
 valid the values compatible with the PHP ``\IntlTimeZone::createTimeZone()`` method.
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value is not a valid timezone.``
 
@@ -131,8 +131,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-zone
-~~~~
+``zone``
+~~~~~~~~
 
 **type**: ``string`` **default**: ``\DateTimeZone::ALL``
 

--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -155,8 +155,8 @@ Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value should be of type {{ type }}.``
 
@@ -175,8 +175,8 @@ Parameter        Description
 
 .. _reference-constraint-type-type:
 
-type
-~~~~
+``type``
+~~~~~~~~
 
 **type**: ``string`` or ``array`` [:ref:`default option <validation-default-option>`]
 

--- a/reference/constraints/Unique.rst
+++ b/reference/constraints/Unique.rst
@@ -94,8 +94,8 @@ Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This collection should contain only unique elements.``
 

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -140,8 +140,8 @@ the uniqueness. If it's left blank, the correct entity manager will be
 determined for this class. For that reason, this option should probably
 not need to be used.
 
-entityClass
-~~~~~~~~~~~
+``entityClass``
+~~~~~~~~~~~~~~~
 
 **type**: ``string``
 
@@ -151,8 +151,8 @@ inheritance mapping, you need to execute the query in a different repository.
 Use this option to define the fully-qualified class name (FQCN) of the Doctrine
 entity associated with the repository you want to use.
 
-errorPath
-~~~~~~~~~
+``errorPath``
+~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: The name of the first field in `fields`_
 
@@ -249,8 +249,8 @@ Consider this example:
 
 Now, the message would be bound to the ``port`` field with this configuration.
 
-fields
-~~~~~~
+``fields``
+~~~~~~~~~~
 
 **type**: ``array`` | ``string`` [:ref:`default option <validation-default-option>`]
 
@@ -266,8 +266,8 @@ each with a single field.
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-ignoreNull
-~~~~~~~~~~
+``ignoreNull``
+~~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``true``
 
@@ -276,8 +276,8 @@ entities to have a ``null`` value for a field without failing validation.
 If set to ``false``, only one ``null`` value is allowed - if a second entity
 also has a ``null`` value, validation would fail.
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value is already used.``
 
@@ -300,8 +300,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-repositoryMethod
-~~~~~~~~~~~~~~~~
+``repositoryMethod``
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``findBy``
 

--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -81,8 +81,8 @@ Basic Usage
 Options
 -------
 
-checkDNS
-~~~~~~~~
+``checkDNS``
+~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``false``
 
@@ -163,8 +163,8 @@ option to the value of any of the ``CHECK_DNS_TYPE_*`` constants in the
 This option uses the :phpfunction:`checkdnsrr` PHP function to check the validity
 of the DNS record corresponding to the host associated with the given URL.
 
-dnsMessage
-~~~~~~~~~~
+``dnsMessage``
+~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The host could not be resolved.``
 
@@ -242,8 +242,8 @@ DNS check failed.
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
-message
-~~~~~~~
+``message``
+~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``This value is not a valid URL.``
 
@@ -324,8 +324,8 @@ Parameter        Description
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-protocols
-~~~~~~~~~
+``protocols``
+~~~~~~~~~~~~~
 
 **type**: ``array`` **default**: ``['http', 'https']``
 
@@ -399,8 +399,8 @@ the ``ftp://`` type URLs to be valid, redefine the ``protocols`` array, listing
             }
         }
 
-relativeProtocol
-~~~~~~~~~~~~~~~~
+``relativeProtocol``
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``false``
 

--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -250,8 +250,8 @@ Options
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-traverse
-~~~~~~~~
+``traverse``
+~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``true``
 

--- a/reference/constraints/_normalizer-option.rst.inc
+++ b/reference/constraints/_normalizer-option.rst.inc
@@ -1,5 +1,5 @@
-normalizer
-~~~~~~~~~~
+``normalizer``
+~~~~~~~~~~~~~~
 
 **type**: a `PHP callable`_ **default**: ``null``
 


### PR DESCRIPTION
Adding some missing backticks for constraint option names. Thanks! :)
Issue: https://github.com/symfony/symfony-docs/issues/15134
