### PR TITLE
[Validator] Add warning about closure not being cachable

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -251,6 +251,13 @@ constructor of the Callback constraint::
         }
     }
 
+.. warning::
+
+    Using a ``Closure`` together with annotation configuration will disable the
+    annotation cache for that class/property/methods because ``Closure``s cannot
+    be cached. For best performance, it is recommended to use a static callback
+    method.
+
 Options
 -------
 


### PR DESCRIPTION
Follow up from https://github.com/symfony/symfony/pull/40645

The annotation cache will not work with `Closure`. 

If I understand correctly, it is not possible to have external dependencies in your custom validator AND get your annotation cached. You have to chose one or the other. 