### PR TITLE
[Routing] Rewording Priority Parameter

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -997,11 +997,10 @@ Priority Parameter
 
     The ``priority`` parameter was introduced in Symfony 5.1
 
-When defining a greedy pattern that matches many routes, this may be at the
-beginning of your routing collection and prevents any route defined after to be
-matched.
-A ``priority`` optional parameter is available in order to let you choose the
-order of your routes, and it is only available when using annotations.
+Symfony evaluates routes in the order they are defined. So a routing pattern
+that matches many routes might prevent subsequent routes to be matched. In YAML
+and XML you can control the order by moving the routes up or down inside the file.
+For annotations and attributes, there is an optional ``priority`` parameter:
 
 .. configuration-block::
 


### PR DESCRIPTION
Important part: Explaining how to do it in YAML and XML, to make clear that `priority` is not *limited* to annotations/attributes - but simply not necessary in YAML/XML :-)
Closes https://github.com/symfony/symfony-docs/issues/13367