### PR TITLE
[Lock] Remove tip about  the RetryTillSaveStore

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3090,18 +3090,6 @@ name
 
 Name of the lock you want to create.
 
-.. tip::
-
-    If you want to use the `RetryTillSaveStore` for :ref:`non-blocking locks <lock-blocking-locks>`,
-    you can do it by :doc:`decorating the store </service_container/service_decoration>` service:
-
-    .. code-block:: yaml
-
-        lock.invoice.retry_till_save.store:
-            class: Symfony\Component\Lock\Store\RetryTillSaveStore
-            decorates: lock.invoice.store
-            arguments: ['@.inner', 100, 50]
-
 mailer
 ~~~~~~
 


### PR DESCRIPTION
I'd suggest to remove this tip since it is deprecated since 5.2 (https://github.com/symfony/symfony-docs/pull/14294)