### PR TITLE
Re-adding , '@session.flash_bag'

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -181,7 +181,7 @@ the default ``AttributeBag`` by the ``NamespacedAttributeBag``:
         session:
             public: true
             class: Symfony\Component\HttpFoundation\Session\Session
-            arguments: ['@session.storage', '@session.namespacedattributebag']
+            arguments: ['@session.storage', '@session.namespacedattributebag', '@session.flash_bag']
 
         session.namespacedattributebag:
             class: Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag


### PR DESCRIPTION
It was there in 4.4: https://symfony.com/doc/4.4/session.html#basic-usage
But when I omit it, I'm getting (Symfony 5.2):
> Circular reference detected for service "session", path: "session -> session.flash_bag -> session".

TODO: PHP config is missing for this code block. I'm doing it like this - should I make a PR? (But I don't know the XML way)
```php
use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
use Symfony\Component\HttpFoundation\Session\Session;

$services->set('session', Session::class)->public()->args([service('session.storage'), service('session.namespacedattributebag')]);
$services->set('session.namespacedattributebag', NamespacedAttributeBag::class);
```
