### PR TITLE
[Security] Update experimental_authenticators.rst

### DIFF
--- a/security/experimental_authenticators.rst
+++ b/security/experimental_authenticators.rst
@@ -597,8 +597,9 @@ would initialize the passport like this::
 
         // ...
         use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+        use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 
-        class LoginAuthenticator extends AbstractAuthenticator
+        class ApiAuthenticator implements AuthenticatorInterface
         {
             // ...
 

--- a/security/experimental_authenticators.rst
+++ b/security/experimental_authenticators.rst
@@ -596,8 +596,8 @@ would initialize the passport like this::
     ``createAuthenticatedToken()``)::
 
         // ...
-        use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
         use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+        use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
         class ApiAuthenticator implements AuthenticatorInterface
         {


### PR DESCRIPTION
From my POV it makes more sense to rename the authenticator because the example is more related to an Api Authentication than a Login and I replace AbstractAuthenticator with the AuthenticatorInterface, AbstractAuthenticator just have one method `createAuthenticatedToken` that is overwritten in the example

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
