### PR TITLE
[Security] remove unused namespace

### DIFF
--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -24,7 +24,6 @@ displayed to the user::
     namespace App\Security;
 
     use App\Entity\User as AppUser;
-    use App\Exception\AccountDeletedException;
     use Symfony\Component\Security\Core\Exception\AccountExpiredException;
     use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
     use Symfony\Component\Security\Core\User\UserCheckerInterface;


### PR DESCRIPTION
when the CustomUserMessageAccountStatusException was introduced in 5.1 version, AccountDeletedException is no longer used in the sample code