### PR TITLE
[Testing] Every custom header in functional testing client must have HTTP_ prefix

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -1029,6 +1029,10 @@ You can also override HTTP headers on a per request basis::
         'HTTP_USER_AGENT' => 'MySuperBrowser/1.0',
     ]);
 
+.. caution::
+
+    Every custom header must have `HTTP_` prefix.
+
 .. tip::
 
     The test client is available as a service in the container in the ``test``


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
Due to https://github.com/symfony/symfony/issues/5074 issue, I would propose to add a simple caution block with information, that the `HTTP_` prefix is mandatory - it will save some hours for others.

