### PR TITLE
[Create Framework] Fix namespace from 'HttpKernel' to 'Symfony\Component\HttpKernel'.

### DIFF
--- a/create_framework/dependency_injection.rst
+++ b/create_framework/dependency_injection.rst
@@ -15,7 +15,7 @@ to it::
     use Symfony\Component\HttpKernel;
     use Symfony\Component\Routing;
 
-    class Framework extends HttpKernel\HttpKernel
+    class Framework extends Symfony\Component\HttpKernel\HttpKernel
     {
         public function __construct($routes)
         {
@@ -23,15 +23,15 @@ to it::
             $matcher = new Routing\Matcher\UrlMatcher($routes, $context);
             $requestStack = new RequestStack();
 
-            $controllerResolver = new HttpKernel\Controller\ControllerResolver();
-            $argumentResolver = new HttpKernel\Controller\ArgumentResolver();
+            $controllerResolver = new Symfony\Component\HttpKernel\Controller\ControllerResolver();
+            $argumentResolver = new Symfony\Component\HttpKernel\Controller\ArgumentResolver();
 
             $dispatcher = new EventDispatcher();
-            $dispatcher->addSubscriber(new HttpKernel\EventListener\ErrorListener(
+            $dispatcher->addSubscriber(new Symfony\Component\HttpKernel\EventListener\ErrorListener(
                 'Calendar\Controller\ErrorController::exception'
             ));
-            $dispatcher->addSubscriber(new HttpKernel\EventListener\RouterListener($matcher, $requestStack));
-            $dispatcher->addSubscriber(new HttpKernel\EventListener\ResponseListener('UTF-8'));
+            $dispatcher->addSubscriber(new Symfony\Component\HttpKernel\EventListener\RouterListener($matcher, $requestStack));
+            $dispatcher->addSubscriber(new Symfony\Component\HttpKernel\EventListener\ResponseListener('UTF-8'));
             $dispatcher->addSubscriber(new StringResponseListener());
 
             parent::__construct($dispatcher, $controllerResolver, $requestStack, $argumentResolver);
@@ -114,17 +114,17 @@ Create a new file to host the dependency injection container configuration::
     $containerBuilder->register('matcher', Routing\Matcher\UrlMatcher::class)
         ->setArguments([$routes, new Reference('context')])
     ;
-    $containerBuilder->register('request_stack', HttpFoundation\RequestStack::class);
-    $containerBuilder->register('controller_resolver', HttpKernel\Controller\ControllerResolver::class);
-    $containerBuilder->register('argument_resolver', HttpKernel\Controller\ArgumentResolver::class);
+    $containerBuilder->register('request_stack', Symfony\Component\HttpFoundation\RequestStack::class);
+    $containerBuilder->register('controller_resolver', Symfony\Component\HttpKernel\Controller\ControllerResolver::class);
+    $containerBuilder->register('argument_resolver', Symfony\Component\HttpKernel\Controller\ArgumentResolver::class);
 
-    $containerBuilder->register('listener.router', HttpKernel\EventListener\RouterListener::class)
+    $containerBuilder->register('listener.router', Symfony\Component\HttpKernel\EventListener\RouterListener::class)
         ->setArguments([new Reference('matcher'), new Reference('request_stack')])
     ;
-    $containerBuilder->register('listener.response', HttpKernel\EventListener\ResponseListener::class)
+    $containerBuilder->register('listener.response', Symfony\Component\ttpKernel\EventListener\ResponseListener::class)
         ->setArguments(['UTF-8'])
     ;
-    $containerBuilder->register('listener.exception', HttpKernel\EventListener\ErrorListener::class)
+    $containerBuilder->register('listener.exception', Symfony\Component\HttpKernel\EventListener\ErrorListener::class)
         ->setArguments(['Calendar\Controller\ErrorController::exception'])
     ;
     $containerBuilder->register('dispatcher', EventDispatcher\EventDispatcher::class)
@@ -217,7 +217,7 @@ These parameters can be used when defining object definitions. Let's make the
 charset configurable::
 
     // ...
-    $container->register('listener.response', HttpKernel\EventListener\ResponseListener::class)
+    $container->register('listener.response', Symfony\Component\HttpKernel\EventListener\ResponseListener::class)
         ->setArguments(['%charset%'])
     ;
 

--- a/create_framework/http_kernel_controller_resolver.rst
+++ b/create_framework/http_kernel_controller_resolver.rst
@@ -72,8 +72,8 @@ resolver from HttpKernel::
 
     use Symfony\Component\HttpKernel;
 
-    $controllerResolver = new HttpKernel\Controller\ControllerResolver();
-    $argumentResolver = new HttpKernel\Controller\ArgumentResolver();
+    $controllerResolver = new Symfony\Component\HttpKernel\Controller\ControllerResolver();
+    $argumentResolver = new Symfony\Component\HttpKernel\Controller\ArgumentResolver();
 
     $controller = $controllerResolver->getController($request);
     $arguments = $argumentResolver->getArguments($request, $controller);
@@ -181,8 +181,8 @@ Let's conclude with the new version of our framework::
     $context->fromRequest($request);
     $matcher = new Routing\Matcher\UrlMatcher($routes, $context);
 
-    $controllerResolver = new HttpKernel\Controller\ControllerResolver();
-    $argumentResolver = new HttpKernel\Controller\ArgumentResolver();
+    $controllerResolver = new Symfony\Component\HttpKernel\Controller\ControllerResolver();
+    $argumentResolver = new Symfony\Component\HttpKernel\Controller\ArgumentResolver();
 
     try {
         $request->attributes->add($matcher->match($request->getPathInfo()));

--- a/create_framework/http_kernel_httpkernel_class.rst
+++ b/create_framework/http_kernel_httpkernel_class.rst
@@ -50,11 +50,11 @@ And the new front controller::
     $context = new Routing\RequestContext();
     $matcher = new Routing\Matcher\UrlMatcher($routes, $context);
 
-    $controllerResolver = new HttpKernel\Controller\ControllerResolver();
-    $argumentResolver = new HttpKernel\Controller\ArgumentResolver();
+    $controllerResolver = new Symfony\Component\HttpKernel\Controller\ControllerResolver();
+    $argumentResolver = new Symfony\Component\HttpKernel\Controller\ArgumentResolver();
 
     $dispatcher = new EventDispatcher();
-    $dispatcher->addSubscriber(new HttpKernel\EventListener\RouterListener($matcher, $requestStack));
+    $dispatcher->addSubscriber(new Symfony\Component\HttpKernel\EventListener\RouterListener($matcher, $requestStack));
 
     $framework = new Simplex\Framework($dispatcher, $controllerResolver, $requestStack, $argumentResolver);
 
@@ -74,14 +74,14 @@ make your error management configurable::
 
         return new Response($msg, $exception->getStatusCode());
     };
-    $dispatcher->addSubscriber(new HttpKernel\EventListener\ErrorListener($errorHandler));
+    $dispatcher->addSubscriber(new Symfony\Component\HttpKernel\EventListener\ErrorListener($errorHandler));
 
 ``ErrorListener`` gives you a ``FlattenException`` instance instead of the
 thrown ``Exception`` or ``Error`` instance to ease exception manipulation and
 display. It can take any valid controller as an exception handler, so you can
 create an ErrorController class instead of using a Closure::
 
-    $listener = new HttpKernel\EventListener\ErrorListener(
+    $listener = new Symfony\Component\HttpKernel\EventListener\ErrorListener(
         'Calendar\Controller\ErrorController::exception'
     );
     $dispatcher->addSubscriber($listener);
@@ -112,12 +112,12 @@ ensures that a Response is compliant with the HTTP specification. It is
 probably a good idea to always call it just before sending the Response to the
 client; that's what the ``ResponseListener`` does::
 
-    $dispatcher->addSubscriber(new HttpKernel\EventListener\ResponseListener('UTF-8'));
+    $dispatcher->addSubscriber(new Symfony\Component\HttpKernel\EventListener\ResponseListener('UTF-8'));
 
 If you want out of the box support for streamed responses, subscribe
 to ``StreamedResponseListener``::
 
-    $dispatcher->addSubscriber(new HttpKernel\EventListener\StreamedResponseListener());
+    $dispatcher->addSubscriber(new Symfony\Component\HttpKernel\EventListener\StreamedResponseListener());
 
 And in your controller, return a ``StreamedResponse`` instance instead of a
 ``Response`` instance.

--- a/create_framework/http_kernel_httpkernelinterface.rst
+++ b/create_framework/http_kernel_httpkernelinterface.rst
@@ -59,9 +59,9 @@ PHP; it implements ``HttpKernelInterface`` and wraps another
     use Symfony\Component\HttpKernel;
 
     $framework = new Simplex\Framework($dispatcher, $matcher, $controllerResolver, $argumentResolver);
-    $framework = new HttpKernel\HttpCache\HttpCache(
+    $framework = new Symfony\Component\HttpKernel\HttpCache\HttpCache(
         $framework,
-        new HttpKernel\HttpCache\Store(__DIR__.'/../cache')
+        new Symfony\Component\HttpKernel\HttpCache\Store(__DIR__.'/../cache')
     );
 
     $response = $framework->handle($request);
@@ -173,10 +173,10 @@ For ESI tags to be supported by HttpCache, you need to pass it an instance of
 the ``ESI`` class. The ``ESI`` class automatically parses ESI tags and makes
 sub-requests to convert them to their proper content::
 
-    $framework = new HttpKernel\HttpCache\HttpCache(
+    $framework = new Symfony\Component\HttpKernel\HttpCache\HttpCache(
         $framework,
-        new HttpKernel\HttpCache\Store(__DIR__.'/../cache'),
-        new HttpKernel\HttpCache\Esi()
+        new Symfony\Component\HttpKernel\HttpCache\Store(__DIR__.'/../cache'),
+        new Symfony\Component\HttpKernel\HttpCache\Esi()
     );
 
 .. note::
@@ -189,10 +189,10 @@ When using complex HTTP caching strategies and/or many ESI include tags, it
 can be hard to understand why and when a resource should be cached or not. To
 ease debugging, you can enable the debug mode::
 
-    $framework = new HttpKernel\HttpCache\HttpCache(
+    $framework = new Symfony\Component\HttpKernel\HttpCache\HttpCache(
         $framework,
-        new HttpKernel\HttpCache\Store(__DIR__.'/../cache'),
-        new HttpKernel\HttpCache\Esi(),
+        new Symfony\Component\HttpKernel\HttpCache\Store(__DIR__.'/../cache'),
+        new Symfony\Component\HttpKernel\HttpCache\Esi(),
         ['debug' => true]
     );
 


### PR DESCRIPTION
"Create Framework" documentation shows how to use the HttpKernel component, like below.

```
$controllerResolver = new HttpKernel\Controller\ControllerResolver();
```

I think HttpKernel component's namespace should be 'Symfony\Component\HttpKernel', instead of 'HttpKernel'.
So, I fixed namespace from 'HttpKernel' to 'Symfony\Component\HttpKernel'.
