### PR TITLE
Rework listing of Notifier bridges

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -45,8 +45,8 @@ The notifier component supports the following channels:
 .. _notifier-sms-channel:
 .. _notifier-texter-dsn:
 
-SMS Channel - NEW
-~~~~~~~~~~~~~~~~~
+SMS Channel - NEW - Option 1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The SMS channel uses :class:`Symfony\\Component\\Notifier\\Texter` classes
 to send SMS messages to mobile phones. This feature requires subscribing to
@@ -76,6 +76,42 @@ Clickatell
     .. versionadded:: 5.3
 
         The Clickatell integration was introduced in Symfony 5.3.
+
+SMS Channel - NEW - Option 2
+----------------------------
+
+The SMS channel uses :class:`Symfony\\Component\\Notifier\\Texter` classes
+to send SMS messages to mobile phones. This feature requires subscribing to
+a third-party service that sends SMS messages. Symfony provides integration
+with a couple popular SMS services:
+
+AllMySms
+~~~~~~~~
+
+``symfony/allmysms-notifier``
+
+.. code-block:: bash
+
+    # .env
+    allmysms://LOGIN:APIKEY@default?from=FROM
+
+.. versionadded:: 5.3
+
+    The AllMySms integration was introduced in Symfony 5.3.
+
+Clickatell
+~~~~~~~~~~
+
+``symfony/clickatell-notifier``
+
+.. code-block:: bash
+
+    # .env
+    clickatell://ACCESS_TOKEN@default?from=FROM
+
+.. versionadded:: 5.3
+
+    The Clickatell integration was introduced in Symfony 5.3.
 
 SMS Channel OLD
 ~~~~~~~~~~~~~~~~

--- a/notifier.rst
+++ b/notifier.rst
@@ -45,13 +45,40 @@ The notifier component supports the following channels:
 .. _notifier-sms-channel:
 .. _notifier-texter-dsn:
 
-SMS Channel
-~~~~~~~~~~~
+SMS Channel - NEW
+~~~~~~~~~~~~~~~~~
 
 The SMS channel uses :class:`Symfony\\Component\\Notifier\\Texter` classes
 to send SMS messages to mobile phones. This feature requires subscribing to
 a third-party service that sends SMS messages. Symfony provides integration
 with a couple popular SMS services:
+
+AllMySms
+    ``symfony/allmysms-notifier``
+
+    .. code-block:: bash
+
+        # .env
+        allmysms://LOGIN:APIKEY@default?from=FROM
+
+    .. versionadded:: 5.3
+
+        The AllMySms integration was introduced in Symfony 5.3.
+
+Clickatell
+    ``symfony/clickatell-notifier``
+
+    .. code-block:: bash
+
+        # .env
+        clickatell://ACCESS_TOKEN@default?from=FROM
+
+    .. versionadded:: 5.3
+
+        The Clickatell integration was introduced in Symfony 5.3.
+
+SMS Channel OLD
+~~~~~~~~~~~~~~~~
 
 ==========  ================================  ====================================================
 Service     Package                           DSN


### PR DESCRIPTION
This is a first idea to rearrange the notifier bridges, because its a lot of work to change the table all the time, the diff is unclear and noisy.

Current state:
![CleanShot 2021-04-07 at 09 34 38](https://user-images.githubusercontent.com/995707/113828275-80f5c600-9784-11eb-8543-309729b44e92.png)

If we found a decision, I would propose to create separate files for each notifier which could be included and sorted alphabetically easily.

**Option 1** keeps the same depth and uses a definition list for the bridges.
**Option 2**  changes the depth and uses dedicated sub headings for the name (which is a plus, because you can link to a bridge directly)

My preferred option based on the facts would be **Option 2*, but I would love to see it in action with a SymfonyCloud environment 😃 cc @javiereguiluz can you do this manually?