### PR TITLE
[BrowserKit] Tip how to use HttpClient options in BrowserKit requests

### DIFF
--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -317,6 +317,12 @@ dedicated web crawler or scraper such as `Goutte`_::
         '.table-list-header-toggle a:nth-child(1)'
     )->text());
 
+.. tip::
+
+    You can also use HTTP client options like 'ciphers', 'auth_basic' and 'query'.
+    They have to be passed as the default options argument to the client, 
+    which is used by the HTTP browser.
+
 .. versionadded:: 4.3
 
     The feature to make external HTTP requests was introduced in Symfony 4.3.


### PR DESCRIPTION
It's easy to pass options like 'ciphers' and 'query' to requests made by the HttpClient request method. Currently it's not explained in the documentation of the BrowserKit component how to use these options there.

If you know it, it's quite easy: just pass them as default options to the HttpClient that is passed to the Browser on construction.

best regards,
spigandromeda