### PR TITLE
[Lock] Update table in lock component

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -357,7 +357,7 @@ Store                                         Scope   Blocking  Expiring Sharing
 :ref:`MemcachedStore <lock-store-memcached>`  remote  no        yes      no
 :ref:`MongoDbStore <lock-store-mongodb>`      remote  no        yes      no
 :ref:`PdoStore <lock-store-pdo>`              remote  no        yes      no
-:ref:`PostgreSqlStore <lock-store-pgsql>`     remote  yes       yes      yes
+:ref:`PostgreSqlStore <lock-store-pgsql>`     remote  yes       no       yes
 :ref:`RedisStore <lock-store-redis>`          remote  no        yes      yes
 :ref:`SemaphoreStore <lock-store-semaphore>`  local   yes       no       no
 :ref:`ZookeeperStore <lock-store-zookeeper>`  remote  no        no       no


### PR DESCRIPTION
The table on the locks documentation does not seem to be consistent with the description for `PostgreSqlStore`. The table currently says the locks are expiring, while the textual descriptions further down the page says the opposite:

> the PostgreSqlStore does not need a table to store locks and does not expire.

and

> That means that by using :ref:`PostgreSqlStore <lock-store-pgsql>` the locks will be automatically released at the end of the session in case the client cannot unlock for any reason.

Proposed fix, modify the table so it says `no` under the Expiring column for PostgreSqlStore.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
