### PR TITLE
[Symfony CLI] Document about `APP_ENV=test` behavior

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -322,6 +322,22 @@ prefixed with ``DB_``, but as the ``com.symfony.server.service-prefix`` is set
 to ``DATABASE``, the web server creates environment variables starting with
 ``DATABASE_`` instead as expected by the default Symfony configuration.
 
+You don't need to create two containers for a main database and a test database.
+Using `APP_ENV=test symfony` will automatically adjust `DATABASE_*` environment variables
+for a test environment.
+
+.. code-block:: terminal
+
+    $ symfony var:export --multiline 
+    export DATABASE_DATABASE=app
+    export DATABASE_NAME=app
+    export DATABASE_URL=postgres://app:app@127.0.0.1:49160/app?sslmode=disable&charset=utf8
+
+    $ APP_ENV=test symfony var:export --multiline 
+    export DATABASE_DATABASE=app_test
+    export DATABASE_NAME=app_test
+    export DATABASE_URL=postgres://app:app@127.0.0.1:49160/app_test?sslmode=disable&charset=utf8
+
 Here is the list of supported services with their ports and default Symfony
 prefixes:
 


### PR DESCRIPTION
Hi :wave:

I'm miigrating some projects to the Symfony CLI and Docker and I made a mistake by creating two Docker containers for the main database and a test database (one database per container), but the test database was not used when running `symfony php bin/phpunit` (I have tests which need a database).

This is my `.docker-compose.yaml`:
```yaml
version: '3.6'
services:
  database:
    restart: unless-stopped
    image: 'postgres:12-alpine'
    ports: [5432]
    environment:
      POSTGRES_USER: 'app'
      POSTGRES_PASSWORD: 'app'
      POSTGRES_DB: 'app'
      TZ: Etc/UTC
      PGTZ: Etc/UTC
    volumes:
      - type: bind
        source: .manala/.docker/db-data
        target: /var/lib/postgresql/data:z
    labels:
        com.symfony.server.service-prefix: 'DATABASE_APP'

  database_test:
    restart: unless-stopped
    image: 'postgres:12-alpine'
    ports: [5432]
    environment:
      POSTGRES_USER: 'test'
      POSTGRES_PASSWORD: 'test'
      POSTGRES_DB: 'test'
      TZ: Etc/UTC
      PGTZ: Etc/UTC
    volumes:
      - type: bind
        source: .manala/.docker/db-data-test
        target: /var/lib/postgresql/data:z
    labels:
        com.symfony.server.service-prefix: 'DATABASE_TEST'
```

my `.env` file:
```env
# ...
DATABASE_URL=${DATABASE_APP_URL}
```
and my `.env.test` file:
```env
# ...
DATABASE_URL=${DATABASE_TEST_URL}
```

I had to run PHPunit with `APP_ENV=test` to let Symfony CLI injects `DATABASE_TEST_URL`  but it still didn't work because the database was `test_test`.

It seems by luck I discovered an undocumented behaviour, running the Symfony CLI with `APP_ENV=test` updates `DATABASE_*` environment variables for a test environment, so we just need one database container and no `DATABASE_URL` tricks.

`symfony var:export --multiline` outputs:
```
export DATABASE_DATABASE=app
export DATABASE_DRIVER=postgres
export DATABASE_HOST=127.0.0.1
export DATABASE_NAME=app
export DATABASE_PASSWORD=app
export DATABASE_PORT=49160
export DATABASE_SERVER=postgres://127.0.0.1:49160
export DATABASE_URL=postgres://app:app@127.0.0.1:49160/app?sslmode=disable&charset=utf8
export DATABASE_USER=app
export DATABASE_USERNAME=app
``` 
`APP_ENV=test symfony var:export --multiline` outputs:
```
export DATABASE_DATABASE=app_test
export DATABASE_DRIVER=postgres
export DATABASE_HOST=127.0.0.1
export DATABASE_NAME=app_test
export DATABASE_PASSWORD=app
export DATABASE_PORT=49160
export DATABASE_SERVER=postgres://127.0.0.1:49160
export DATABASE_URL=postgres://app:app@127.0.0.1:49160/app_test?sslmode=disable&charset=utf8
export DATABASE_USER=app
export DATABASE_USERNAME=app
# ...
``` 

I think it can be intersting to document this behaviour, this way: 
- people won't do the same mistake than me
- people won't be surprised by an undocumented behaviour

WDYT? Thanks!