### PR TITLE
[Security] Fix typo in handler success customization part.

### DIFF
--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -660,8 +660,10 @@ Customizing the Success Handler
 
 Sometimes, the default success handling does not fit your use-case (e.g.
 when you need to generate and return an API key). To customize how the
-success handler behaves, create your own
-:class:`Symfony\\Component\\Security\\Http\\Authentication\\AuthenticationSuccessHandlerInterface`::
+success handler behaves, create your own that must implement
+:class:`Symfony\\Component\\Security\\Http\\Authentication\\AuthenticationSuccessHandlerInterface`.
+
+.. code-block:: php
 
     // src/Security/Authentication/AuthenticationSuccessHandler.php
     namespace App\Security\Authentication;


### PR DESCRIPTION
Backslashes were missing. Reading was difficult, especially at the end of that very complete page 😅 .

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
