### PR TITLE
[Mailer] Added link to https://symfony.com/doc/current/mailer.html#configuring…

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3207,6 +3207,10 @@ headers
 Headers to add to emails. The key (``name`` attribute in xml format) is the
 header name and value the header value.
 
+.. seealso::
+
+    For more information, see :ref:`Configuring Emails Globally <mailer-configure-email-globally>`
+
 web_link
 ~~~~~~~~
 


### PR DESCRIPTION
…-emails-globally

https://symfony.com/doc/current/mailer.html#configuring-emails-globally

Question: If I add a From-header here, and then use a different `$email->from(...)` in the code, which will win? Since "envelope" has an unusual behavior in this regard, it might be better to explain this here too.