### PR TITLE
[minor] Use correct code block

### DIFF
--- a/reference/forms/types/options/preferred_choices.rst.inc
+++ b/reference/forms/types/options/preferred_choices.rst.inc
@@ -64,7 +64,7 @@ when rendering the field:
 
         {{ form_widget(form.publishAt, { 'separator': '=====' }) }}
 
-    .. code-block:: php
+    .. code-block:: html+php
 
         <?= $view['form']->widget($form['publishAt'], [
             'separator' => '=====',


### PR DESCRIPTION
We use `html+php` on all other places with short open syntax. 