### PR TITLE
[Validator] Calling enableAnnotationMapping without argument is deprecated

### DIFF
--- a/components/validator/resources.rst
+++ b/components/validator/resources.rst
@@ -106,14 +106,14 @@ prefixed classes included in doc block comments (``/** ... */``). For example::
     }
 
 To enable the annotation loader, call the
-:method:`Symfony\\Component\\Validator\\ValidatorBuilder::enableAnnotationMapping`
-method. It takes an optional annotation reader instance, which defaults to
-``Doctrine\Common\Annotations\AnnotationReader``::
+:method:`Symfony\\Component\\Validator\\ValidatorBuilder::enableAnnotationMapping` method.
+``addDefaultDoctrineAnnotationReader`` must also be called to use ``Doctrine\Common\Annotations\AnnotationReader``::
 
     use Symfony\Component\Validator\Validation;
 
     $validator = Validation::createValidatorBuilder()
-        ->enableAnnotationMapping()
+        ->enableAnnotationMapping(true)
+        ->addDefaultDoctrineAnnotationReader()
         ->getValidator();
 
 To disable the annotation loader after it was enabled, call
@@ -134,7 +134,8 @@ multiple mappings::
     use Symfony\Component\Validator\Validation;
 
     $validator = Validation::createValidatorBuilder()
-        ->enableAnnotationMapping()
+        ->enableAnnotationMapping(true)
+        ->addDefaultDoctrineAnnotationReader()
         ->addMethodMapping('loadValidatorMetadata')
         ->addXmlMapping('validator/validation.xml')
         ->getValidator();

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -219,7 +219,8 @@ allows you to return a list of extensions to register::
 
             // or if you also need to read constraints from annotations
             $validator = Validation::createValidatorBuilder()
-                ->enableAnnotationMapping()
+                ->enableAnnotationMapping(true)
+                ->addDefaultDoctrineAnnotationReader()
                 ->getValidator();
 
             return [


### PR DESCRIPTION
Since 5.2, first argument of `enableAnnotationMapping` must be set to true (https://github.com/symfony/symfony/blob/v5.2.0/src/Symfony/Component/Validator/ValidatorBuilder.php#L227)

Closes #14522 (I guess).

