### PR TITLE
[HttpClient] Adding default value for verify_peer

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1046,7 +1046,7 @@ combined with ``verify_peer`` to also verify the certificate authenticity.
 verify_peer
 ...........
 
-**type**: ``boolean``
+**type**: ``boolean`` **default**: ``true``
 
 If ``true``, the certificate sent by other servers when negotiating a TLS or SSL
 connection is verified for authenticity. Authenticating the certificate is not


### PR DESCRIPTION
It's also missing for verify_host - but I don't know the default value there ;-)
