### PR TITLE
Fixed syntax errors on 4.4

### DIFF
--- a/components/console/helpers/formatterhelper.rst
+++ b/components/console/helpers/formatterhelper.rst
@@ -78,7 +78,9 @@ you can write::
     $truncatedMessage = $formatter->truncate($message, 7);
     $output->writeln($truncatedMessage);
 
-And the output will be::
+And the output will be:
+
+.. code-block:: text
 
     This is...
 
@@ -93,7 +95,9 @@ from the end of the string::
 
     $truncatedMessage = $formatter->truncate($message, -5);
 
-This will result in::
+This will result in:
+
+.. code-block:: text
 
     This is a very long message, which should be trun...
 

--- a/components/console/helpers/table.rst
+++ b/components/console/helpers/table.rst
@@ -72,8 +72,8 @@ You can add a table separator anywhere in the output by passing an instance of
 You can optionally display titles at the top and the bottom of the table::
 
     // ...
-    $table->setHeaderTitle('Books')
-    $table->setFooterTitle('Page 1/2')
+    $table->setHeaderTitle('Books');
+    $table->setFooterTitle('Page 1/2');
     $table->render();
 
 .. code-block:: terminal

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -555,7 +555,9 @@ You can virtually set and get values on the form::
     // where "registration" is its own array
     $values = $form->getPhpValues();
 
-To work with multi-dimensional fields::
+To work with multi-dimensional fields:
+
+.. code-block:: html
 
     <form>
         <input name="multi[]"/>

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -238,7 +238,7 @@ determine which instance is passed.
         $containerBuilder->addCompilerPass(new AddEventAliasesPass([
             \AcmeFooActionEvent::class => 'acme.foo.action',
         ]));
-        $containerBuilder->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING)
+        $containerBuilder->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING);
 
         $containerBuilder->register('event_dispatcher', EventDispatcher::class);
 

--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -252,7 +252,7 @@ absolute paths and returns the relative path from the second path to the first o
         '/var/lib/symfony/src/Symfony/Component'
     );
     // returns 'videos/'
-    $filesystem->makePathRelative('/tmp/videos', '/tmp')
+    $filesystem->makePathRelative('/tmp/videos', '/tmp');
 
 ``mirror``
 ~~~~~~~~~~

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -547,7 +547,7 @@ represented by a PHP callable instead of a string::
     header in the response::
 
         // disables FastCGI buffering in nginx only for this response
-        $response->headers->set('X-Accel-Buffering', 'no')
+        $response->headers->set('X-Accel-Buffering', 'no');
 
 .. _component-http-foundation-serving-files:
 

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -11,7 +11,7 @@ The Intl Component
 .. caution::
 
     The replacement layer is limited to the ``en`` locale. If you want to use
-    other locales, you should `install the intl extension`_. There is no conflict 
+    other locales, you should `install the intl extension`_. There is no conflict
     between the two because, even if you use the extension, this package can still
     be useful to access the ICU data.
 
@@ -231,9 +231,9 @@ Locales
 ~~~~~~~
 
 A locale is the combination of a language, a region and some parameters that
-define the interface preferences of the user. For example, "Chinese" is the 
-language and ``zh_Hans_MO`` is the locale for "Chinese" (language) + "Simplified" 
-(script) + "Macau SAR China" (region). The ``Locales`` class provides access to 
+define the interface preferences of the user. For example, "Chinese" is the
+language and ``zh_Hans_MO`` is the locale for "Chinese" (language) + "Simplified"
+(script) + "Macau SAR China" (region). The ``Locales`` class provides access to
 the name of all locales::
 
     use Symfony\Component\Intl\Locales;
@@ -351,7 +351,7 @@ translate into any locale with the ``getName()`` method shown earlier::
 The reverse lookup is also possible thanks to the ``getCountryCode()`` method,
 which returns the code of the country where the given timezone ID belongs to::
 
-    $countryCode = Timezones::getCountryCode('America/Vancouver')
+    $countryCode = Timezones::getCountryCode('America/Vancouver');
     // => $countryCode = 'CA' (CA = Canada)
 
 The `UTC/GMT time offsets`_ of all timezones are provided by ``getRawOffset()``

--- a/components/lock.rst
+++ b/components/lock.rst
@@ -63,7 +63,7 @@ method can be safely called repeatedly, even if the lock is already acquired.
 
     Unlike other implementations, the Lock Component distinguishes lock
     instances even when they are created for the same resource. It means that for
-    a given scope and resource one lock instance can be acquired multiple times. 
+    a given scope and resource one lock instance can be acquired multiple times.
     If a lock has to be used by several services, they should share the same ``Lock``
     instance returned by the ``LockFactory::createLock`` method.
 
@@ -223,7 +223,7 @@ Lock will be released automatically as soon as one process finishes::
         sleep(30);
     } else {
         // Child process
-        echo 'The lock will be released now.'
+        echo 'The lock will be released now.';
         exit(0);
     }
     // ...

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -511,7 +511,7 @@ the closure::
 
             $resolver->setDefault('host', function (Options $options, $previousValue) {
                 if ('ssl' === $options['encryption']) {
-                    return 'secure.example.org'
+                    return 'secure.example.org';
                 }
 
                 // Take default value configured in the base class

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -629,7 +629,7 @@ constraint to test the validity of the email domain::
     {
         public function testEmail()
         {
-            $validator = ...
+            $validator = ...;
             $constraint = new Email(['checkMX' => true]);
 
             $result = $validator->validate('foo@example.com', $constraint);
@@ -654,7 +654,7 @@ the data you expect to get for the given hosts::
         {
             DnsMock::withMockedHosts(['example.com' => [['type' => 'MX']]]);
 
-            $validator = ...
+            $validator = ...;
             $constraint = new Email(['checkMX' => true]);
 
             $result = $validator->validate('foo@example.com', $constraint);

--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -188,7 +188,7 @@ expressions have access to a number of
 
     $expression = new Expression(
         '"ROLE_ADMIN" in roles or (not is_anonymous() and user.isSuperAdmin())'
-    )
+    );
 
     $vote = $expressionVoter->vote($token, $object, [$expression]);
 

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -901,7 +901,9 @@ For example, take an object normalized as following::
 
     ['foo' => [1, 2], 'bar' => true];
 
-The ``XmlEncoder`` will encode this object like that::
+The ``XmlEncoder`` will encode this object like that:
+
+.. code-block:: xml
 
     <?xml version="1.0" encoding="UTF-8" ?>
     <response>

--- a/components/validator/resources.rst
+++ b/components/validator/resources.rst
@@ -155,7 +155,7 @@ implement the PSR-6 interface :class:`Psr\\Cache\\CacheItemPoolInterface`)::
 
     $validator = Validation::createValidatorBuilder()
         // ... add loaders
-        ->setMappingCache(new SomePsr6Cache());
+        ->setMappingCache(new SomePsr6Cache())
         ->getValidator();
 
 .. versionadded:: 4.4

--- a/components/workflow.rst
+++ b/components/workflow.rst
@@ -68,8 +68,8 @@ are trying to use it with::
     use Symfony\Component\Workflow\Registry;
     use Symfony\Component\Workflow\SupportStrategy\InstanceOfSupportStrategy;
 
-    $blogPostWorkflow = ...
-    $newsletterWorkflow = ...
+    $blogPostWorkflow = ...;
+    $newsletterWorkflow = ...;
 
     $registry = new Registry();
     $registry->addWorkflow($blogPostWorkflow, new InstanceOfSupportStrategy(BlogPost::class));

--- a/configuration/override_dir_structure.rst
+++ b/configuration/override_dir_structure.rst
@@ -230,7 +230,7 @@ option in your ``composer.json`` file like this:
         "config": {
             "bin-dir": "bin",
             "vendor-dir": "/some/dir/vendor"
-        },
+        }
     }
 
 .. tip::

--- a/configuration/using_parameters_in_dic.rst
+++ b/configuration/using_parameters_in_dic.rst
@@ -85,8 +85,8 @@ Now, examine the results to see this closely:
                 // true/false (depends on 2nd parameter of Kernel),
                 // as expected, because %kernel.debug% inside configuration
                 // gets evaluated before being passed to the extension
-            )
-        ];
+            ]
+        );
 
         $container->loadFromExtension('my_bundle');
         // passes the string "%kernel.debug%".

--- a/contributing/code/conventions.rst
+++ b/contributing/code/conventions.rst
@@ -188,7 +188,9 @@ after the use declarations, like in this example from
 
 .. _`ServiceRouterLoader`: https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Routing/Loader/DependencyInjection/ServiceRouterLoader.php
 
-The deprecation must be added to the ``CHANGELOG.md`` file of the impacted component::
+The deprecation must be added to the ``CHANGELOG.md`` file of the impacted component:
+
+.. code-block:: markdown
 
     4.4
     ---
@@ -196,7 +198,9 @@ The deprecation must be added to the ``CHANGELOG.md`` file of the impacted compo
     * Deprecate the `Deprecated` class, use `Replacement` instead
 
 It must also be added to the ``UPGRADE.md`` file of the targeted minor version
-(``UPGRADE-4.4.md`` in our example)::
+(``UPGRADE-4.4.md`` in our example):
+
+.. code-block:: markdown
 
     DependencyInjection
     -------------------

--- a/controller/soap_web_service.rst
+++ b/controller/soap_web_service.rst
@@ -39,7 +39,7 @@ In this case, the SOAP service will allow the client to call a method called
         public function hello($name)
         {
 
-            $message = new \Swift_Message('Hello Service')
+            $message = (new \Swift_Message('Hello Service'))
                 ->setTo('me@example.com')
                 ->setBody($name.' says hi!');
 

--- a/create_framework/front_controller.rst
+++ b/create_framework/front_controller.rst
@@ -185,7 +185,9 @@ the ``setContent()`` directly from the front controller script::
 
     // ...
 
-And the ``hello.php`` script can now be converted to a template::
+And the ``hello.php`` script can now be converted to a template:
+
+.. code-block:: html+php
 
     <!-- example.com/src/pages/hello.php -->
     <?php $name = $request->get('name', 'World') ?>

--- a/create_framework/routing.rst
+++ b/create_framework/routing.rst
@@ -30,7 +30,9 @@ framework just a little to make templates even more readable::
     $response->send();
 
 As we now extract the request query parameters, simplify the ``hello.php``
-template as follows::
+template as follows:
+
+.. code-block:: html+php
 
     <!-- example.com/src/pages/hello.php -->
     Hello <?= htmlspecialchars(isset($name) ? $name : 'World', ENT_QUOTES, 'UTF-8') ?>
@@ -161,7 +163,9 @@ There are a few new things in the code:
 
 * ``500`` errors are now managed correctly;
 
-* Request attributes are extracted to keep our templates simple::
+* Request attributes are extracted to keep our templates simple:
+
+.. code-block:: html+php
 
     // example.com/src/pages/hello.php
     Hello <?= htmlspecialchars($name, ENT_QUOTES, 'UTF-8') ?>

--- a/doctrine/custom_dql_functions.rst
+++ b/doctrine/custom_dql_functions.rst
@@ -131,16 +131,14 @@ In Symfony, you can register your custom DQL functions as follows:
             use App\DQL\DatetimeFunction;
 
             $container->loadFromExtension('doctrine', [
-                'doctrine' => [
-                    'orm' => [
-                        // ...
-                        'entity_managers' => [
-                            'example_manager' => [
-                                // place your functions here
-                                'dql' => [
-                                    'datetime_functions' => [
-                                        'test_datetime' => DatetimeFunction::class,
-                                    ],
+                'orm' => [
+                    // ...
+                    'entity_managers' => [
+                        'example_manager' => [
+                            // place your functions here
+                            'dql' => [
+                                'datetime_functions' => [
+                                    'test_datetime' => DatetimeFunction::class,
                                 ],
                             ],
                         ],

--- a/form/create_form_type_extension.rst
+++ b/form/create_form_type_extension.rst
@@ -191,14 +191,10 @@ Specifically, you need to override the ``file_widget`` block:
     {% extends 'form_div_layout.html.twig' %}
 
     {% block file_widget %}
-        {% spaceless %}
-
         {{ block('form_widget') }}
         {% if image_url is not null %}
             <img src="{{ asset(image_url) }}"/>
         {% endif %}
-
-        {% endspaceless %}
     {% endblock %}
 
 Be sure to :ref:`configure this form theme template <forms-theming-global>` so that

--- a/form/data_transformers.rst
+++ b/form/data_transformers.rst
@@ -208,7 +208,7 @@ to and from the issue number and the ``Issue`` object::
         {
             // no issue number? It's optional, so that's ok
             if (!$issueNumber) {
-                return;
+                return null;
             }
 
             $issue = $this->entityManager

--- a/form/type_guesser.rst
+++ b/form/type_guesser.rst
@@ -101,7 +101,7 @@ With this knowledge, you can implement the ``guessType()`` method of the
             $annotations = $this->readPhpDocAnnotations($class, $property);
 
             if (!isset($annotations['var'])) {
-                return; // guess nothing if the @var annotation is not available
+                return null; // guess nothing if the @var annotation is not available
             }
 
             // otherwise, base the type on the @var annotation

--- a/form/validation_group_service_resolver.rst
+++ b/form/validation_group_service_resolver.rst
@@ -39,7 +39,7 @@ Then in your form, inject the resolver and set it as the ``validation_groups``::
     namespace App\Form;
 
     use App\Validator\ValidationGroupResolver;
-    use Symfony\Component\Form\AbstractType
+    use Symfony\Component\Form\AbstractType;
     use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class MyClassType extends AbstractType

--- a/forms.rst
+++ b/forms.rst
@@ -592,7 +592,7 @@ argument of ``createForm()``::
         {
             $task = new Task();
             // use some PHP logic to decide if this form field is required or not
-            $dueDateIsRequired = ...
+            $dueDateIsRequired = ...;
 
             $form = $this->createForm(TaskType::class, $task, [
                 'require_due_date' => $dueDateIsRequired,

--- a/http_client.rst
+++ b/http_client.rst
@@ -885,7 +885,7 @@ To abort a request (e.g. because it didn't complete in due time, or you want to
 fetch only the first bytes of the response, etc.), you can either use the
 ``cancel()`` method of ``ResponseInterface``::
 
-    $response->cancel()
+    $response->cancel();
 
 Or throw an exception from a progress callback::
 

--- a/introduction/from_flat_php_to_symfony.rst
+++ b/introduction/from_flat_php_to_symfony.rst
@@ -580,7 +580,7 @@ and uses Twig:
 
 .. code-block:: html+twig
 
-    <!-- templates/blog/list.html.twig -->
+    {# templates/blog/list.html.twig #}
     {% extends 'base.html.twig' %}
 
     {% block title %}List of Posts{% endblock %}

--- a/mercure.rst
+++ b/mercure.rst
@@ -622,7 +622,7 @@ You can instead make use of the `MockHub`::
 
             $controller = new MessageController($hub);
 
-            ...
+            // ...
         }
     }
 
@@ -645,12 +645,13 @@ During functional testing you can instead decorate the Hub::
     }
 
 HubStub decorates the default hub service so no updates are actually
-sent. Here is the HubStub implementation::
+sent. Here is the HubStub implementation:
+
+.. code-block:: yaml
 
     # config/services_test.yaml
     App\Tests\Functional\Fixtures\HubStub:
         decorates: mercure.hub.default
-
 
 Debugging
 ---------

--- a/migration.rst
+++ b/migration.rst
@@ -313,11 +313,11 @@ somewhat like this::
 
     class LegacyBridge
     {
-        public static function prepareLegacyScript(Request $request, Response $response, string $publicDirectory): string
+        public static function prepareLegacyScript(Request $request, Response $response, string $publicDirectory): ?string
         {
             // If Symfony successfully handled the route, you do not have to do anything.
             if (false === $response->isNotFound()) {
-                return;
+                return null;
             }
 
             // Figure out how to map to the needed script file

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -415,7 +415,9 @@ Since every developer uses a different IDE, the recommended way to enable this
 feature is to configure it on a system level. This can be done by setting the
 ``xdebug.file_link_format`` option in your ``php.ini`` configuration file. The
 format to use is the same as for the ``framework.ide`` option, but without the
-need to escape the percent signs (``%``) by doubling them::
+need to escape the percent signs (``%``) by doubling them:
+
+.. code-block:: ini
 
     // example for PhpStorm
     xdebug.file_link_format="phpstorm://open?file=%f&line=%l"
@@ -438,7 +440,9 @@ need to escape the percent signs (``%``) by doubling them::
     When running your app in a container or in a virtual machine, you can tell
     Symfony to map files from the guest to the host by changing their prefix.
     This map should be specified at the end of the URL template, using ``&`` and
-    ``>`` as guest-to-host separators::
+    ``>`` as guest-to-host separators:
+
+    .. code-block:: text
 
         // /path/to/guest/.../file will be opened
         // as /path/to/host/.../file on the host

--- a/reference/constraints/Traverse.rst
+++ b/reference/constraints/Traverse.rst
@@ -27,7 +27,7 @@ that all have constraints on their properties.
         namespace App\Entity;
 
         use Doctrine\Collections\ArrayCollection;
-        use Doctrine\Collections\Collection
+        use Doctrine\Collections\Collection;
         use Doctrine\ORM\Mapping as ORM;
         use Symfony\Component\Validator\Constraints as Assert;
 

--- a/service_container.rst
+++ b/service_container.rst
@@ -341,18 +341,21 @@ you can type-hint the new ``SiteUpdateManager`` class and use it::
     // src/Controller/SiteController.php
     namespace App\Controller;
 
-    // ...
     use App\Service\SiteUpdateManager;
+    // ...
 
-    public function new(SiteUpdateManager $siteUpdateManager)
+    class SiteController extends AbstractController
     {
-        // ...
+        public function new(SiteUpdateManager $siteUpdateManager)
+        {
+            // ...
 
-        if ($siteUpdateManager->notifyOfSiteUpdate()) {
-            $this->addFlash('success', 'Notification mail was sent successfully.');
+            if ($siteUpdateManager->notifyOfSiteUpdate()) {
+                $this->addFlash('success', 'Notification mail was sent successfully.');
+            }
+
+            // ...
         }
-
-        // ...
     }
 
 Thanks to autowiring and your type-hints in ``__construct()``, the container creates
@@ -867,6 +870,7 @@ This is mostly useful when you want to fetch services lazily::
 
             // ...
         }
+    }
 
 As a best practice, you should only create *private* services. This allows for
 safe container optimizations, e.g. removing unused services. You should not use

--- a/setup/homestead.rst
+++ b/setup/homestead.rst
@@ -58,7 +58,9 @@ Homestead now supports a Symfony 2 and 3 web layout with ``app.php`` and
 using type ``symfony4``.
 
 At last, edit the hosts file on your local machine to map ``symfony-demo.test``
-to ``192.168.10.10`` (which is the IP used by Homestead)::
+to ``192.168.10.10`` (which is the IP used by Homestead):
+
+.. code-block:: text
 
     # /etc/hosts (unix) or C:\Windows\System32\drivers\etc\hosts (Windows)
     192.168.10.10 symfony-demo.test

--- a/templating/PHP.rst
+++ b/templating/PHP.rst
@@ -332,7 +332,9 @@ Profiling Templates
 ~~~~~~~~~~~~~~~~~~~
 
 By using the ``stopwatch`` helper, you are able to time parts of your template
-and display it on the timeline of the WebProfilerBundle::
+and display it on the timeline of the WebProfilerBundle:
+
+.. code-block:: html+php
 
     <?php $view['stopwatch']->start('foo') ?>
     ... things that get timed
@@ -347,13 +349,17 @@ Output Escaping
 ---------------
 
 When using PHP templates, escape variables whenever they are displayed to the
-user::
+user:
+
+.. code-block:: html+php
 
     <?= $view->escape($var) ?>
 
 By default, the ``escape()`` method assumes that the variable is outputted
 within an HTML context. The second argument lets you change the context. For
-instance, to output something in a JavaScript script, use the ``js`` context::
+instance, to output something in a JavaScript script, use the ``js`` context:
+
+.. code-block:: html+php
 
     <?= $view->escape($var, 'js') ?>
 

--- a/templating/hinclude.rst
+++ b/templating/hinclude.rst
@@ -94,7 +94,7 @@ Use the ``attributes`` option to define the value of hinclude.js options:
 
     {# by default, cross-site requests don't use credentials such as cookies, authorization
        headers or TLS client certificates; set this option to 'true' to use them #}
-    {{ render_hinclude(controller('...'), {attributes: {data-with-credentials: 'true'}}) }}
+    {{ render_hinclude(controller('...'), {attributes: {'data-with-credentials': 'true'}}) }}
 
     {# by default, the JavaScript code included in the loaded contents is not run;
        set this option to 'true' to run that JavaScript code #}

--- a/testing.rst
+++ b/testing.rst
@@ -1069,7 +1069,7 @@ configuration adds tests from a custom ``lib/tests`` directory:
         <!-- ... -->
         <testsuites>
             <testsuite name="Project Test Suite">
-                <!-- ... --->
+                <!-- ... -->
                 <directory>lib/tests</directory>
             </testsuite>
         </testsuites>

--- a/translation.rst
+++ b/translation.rst
@@ -414,7 +414,9 @@ PHP Templates
 ~~~~~~~~~~~~~
 
 The translator service is accessible in PHP templates through the
-``translator`` helper::
+``translator`` helper:
+
+.. code-block:: html+php
 
     <?= $view['translator']->trans('Symfony is great') ?>
 


### PR DESCRIPTION
I ran the [new parser](https://github.com/symfony/symfony-docs/pull/15257) on 4.4. There are about 130 more syntax errors that I decided not to fix. Some are false positives (ie a code example where we only have a PHP array). Others show some limitations of the parser. Ie, we cannot automatically detect a code block with no language, we currently assume it is PHP but that is not always correct. 

This is the last fixes I'll do for 4.4. 