### PR TITLE
Fixed syntax error in 5.2

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -247,7 +247,7 @@ configurable with the ``verify_peer`` option. Although it's not recommended to
 disable this verification for security reasons, it can be useful while developing
 the application or when using a self-signed certificate::
 
-    $dsn = 'smtp://user:pass@smtp.example.com?verify_peer=0'
+    $dsn = 'smtp://user:pass@smtp.example.com?verify_peer=0';
 
 .. versionadded:: 5.1
 

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -316,8 +316,8 @@ is restarted):
 
         $container
             ->register(SomeService::class)
-            ->addTag('container.preload', ['class' => SomeClass::class)
-            ->addTag('container.preload', ['class' => OtherClass::class)
+            ->addTag('container.preload', ['class' => SomeClass::class])
+            ->addTag('container.preload', ['class' => OtherClass::class])
             // ...
         ;
 

--- a/security.rst
+++ b/security.rst
@@ -368,7 +368,6 @@ important section is ``firewalls``:
                 <firewall name="main"
                     anonymous="true"
                     lazy="true"/>
-                </firewall>
             </config>
         </srv:container>
 

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -65,7 +65,7 @@ Take the following ``access_control`` entries as an example:
                 https://symfony.com/schema/dic/security/security-1.0.xsd">
 
             <srv:parameters>
-                <srv:parameter key="env(TRUSTED_IPS)">10.0.0.1, 10.0.0.2</parameter>
+                <srv:parameter key="env(TRUSTED_IPS)">10.0.0.1, 10.0.0.2</srv:parameter>
             </srv:parameters>
 
             <config>

--- a/security/experimental_authenticators.rst
+++ b/security/experimental_authenticators.rst
@@ -226,6 +226,7 @@ You can configure this using the ``entry_point`` setting:
                     <!-- allow authentication using a form or HTTP basic -->
                     <form-login/>
                     <http-basic/>
+                </firewall>
             </config>
         </srv:container>
 

--- a/session/database.rst
+++ b/session/database.rst
@@ -90,7 +90,7 @@ and ``RedisProxy``:
                 arguments:
                     - '@Redis'
                     # you can optionally pass an array of options. The only options are 'prefix' and 'ttl',
-                    # which define the prefix to use for the keys to avoid collision on the Redis server 
+                    # which define the prefix to use for the keys to avoid collision on the Redis server
                     # and the expiration time for any given entry (in seconds), defaults are 'sf_s' and null:
                     # - { 'prefix' => 'my_prefix', 'ttl' => 600 }
 
@@ -101,7 +101,7 @@ and ``RedisProxy``:
             <service id="Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler">
                 <argument type="service" id="Redis"/>
                 <!-- you can optionally pass an array of options. The only options are 'prefix' and 'ttl',
-                     which define the prefix to use for the keys to avoid collision on the Redis server 
+                     which define the prefix to use for the keys to avoid collision on the Redis server
                      and the expiration time for any given entry (in seconds), defaults are 'sf_s' and null:
                 <argument type="collection">
                     <argument key="prefix">my_prefix</argument>
@@ -119,7 +119,7 @@ and ``RedisProxy``:
             ->addArgument(
                 new Reference('Redis'),
                 // you can optionally pass an array of options. The only options are 'prefix' and 'ttl',
-                // which define the prefix to use for the keys to avoid collision on the Redis server 
+                // which define the prefix to use for the keys to avoid collision on the Redis server
                 // and the expiration time for any given entry (in seconds), defaults are 'sf_s' and null:
                 // ['prefix' => 'my_prefix', 'ttl' => 600],
             );
@@ -601,7 +601,7 @@ configure these values with the second argument passed to the
             $services->set(MongoDbSessionHandler::class)
                 ->args([
                     service('doctrine_mongodb.odm.default_connection'),
-                    ['id_field' => '_guid', 'expiry_field' => 'eol'],,
+                    ['id_field' => '_guid', 'expiry_field' => 'eol'],
                 ])
             ;
         };


### PR DESCRIPTION
Here are the syntax errors I found when running the parser (#15257) on 5.2. 