### PR TITLE
Fixed syntax errors in 5.x

### DIFF
--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -454,8 +454,6 @@ with the ``doctrine.event_subscriber`` tag:
                 <service id="App\EventListener\DatabaseActivitySubscriber">
                     <tag name="doctrine.event_subscriber" priority="500" connection="default"/>
                 </service>
-
-                </service>
             </services>
         </container>
 
@@ -475,7 +473,7 @@ with the ``doctrine.event_subscriber`` tag:
                     // to the same event (default priority = 0; higher numbers = listener is run earlier)
                     'priority' => 500,
 
-                    # you can also restrict listeners to a specific Doctrine connection
+                    // you can also restrict listeners to a specific Doctrine connection
                     'connection' => 'default',
                 ])
             ;

--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -178,7 +178,7 @@ enforce different levels of service (free or paid):
 
         // config/packages/rate_limiter.php
         $container->loadFromExtension('framework', [
-            rate_limiter' => [
+            'rate_limiter' => [
                 'anonymous_api' => [
                     // use 'sliding_window' if you prefer that policy
                     'policy' => 'fixed_window',
@@ -401,7 +401,7 @@ Use the ``cache_pool`` option to override the cache used by a specific limiter
                         cache-pool="cache.anonymous_rate_limiter"
                     />
 
-                    <!-- ... ->
+                    <!-- ... -->
                 </framework:rate-limiter>
             </framework:config>
         </container>
@@ -410,7 +410,7 @@ Use the ``cache_pool`` option to override the cache used by a specific limiter
 
         // config/packages/rate_limiter.php
         $container->loadFromExtension('framework', [
-            rate_limiter' => [
+            'rate_limiter' => [
                 'anonymous_api' => [
                     // ...
 
@@ -484,7 +484,7 @@ you can use a specific :ref:`named lock <lock-named-locks>` via the
 
         // config/packages/rate_limiter.php
         $container->loadFromExtension('framework', [
-            rate_limiter' => [
+            'rate_limiter' => [
                 'anonymous_api' => [
                     // ...
 

--- a/security.rst
+++ b/security.rst
@@ -712,7 +712,7 @@ and set the ``limiter`` option to its service ID:
             'firewalls' => [
                 'main' => [
                     // use a custom rate limiter via its service ID
-                    'login_throttling' =>
+                    'login_throttling' => [
                         'limiter' => 'app.login_rate_limiter',
                     ],
                 ],


### PR DESCRIPTION
These errors does not exist in 5.2