### PR TITLE
[Routing] Fixing some typos

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -1125,11 +1125,11 @@ A possible solution is to change the parameter requirements to be more permissiv
 
 .. note::
 
-    If the route defines several parameter and you apply this permissive
+    If the route defines several parameters and you apply this permissive
     regular expression to all of them, you might get unexpected results. For
     example, if the route definition is ``/share/{path}/{token}`` and both
-    ``path`` and ``token`` accept ``/``. The ``token`` only get the last path
-    and the rest of the match is matched by the first argument (``path``).
+    ``path`` and ``token`` accept ``/``, then ``token`` will only get the last part
+    and the rest is matched by ``path``.
 
 .. note::
 


### PR DESCRIPTION
Question: Is this rule always true?:
> then ``token`` will only get the last part and the rest is matched by ``path``.

Cause if Yes, the introduction doesn't make sense:

> you might get unexpected results

since if there's a *rule*, it's not unexpected ;-)

So it would be better to explain that the *first* parameter is always greedy.
