### PR TITLE
[Security] Removed some deprecated features related to User::getUsername()

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -75,7 +75,7 @@ with the ``User`` class::
     {
         public function index(User $user)
         {
-            return new Response('Hello '.$user->getUsername().'!');
+            return new Response('Hello '.$user->getUserIdentifier().'!');
         }
     }
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -89,8 +89,8 @@ If ``true``, when a user is not found a generic exception of type
 is thrown with the message "Bad credentials".
 
 If ``false``, the exception thrown is of type
-:class:`Symfony\\Component\\Security\\Core\\Exception\\UsernameNotFoundException`
-and it includes the given not found username.
+:class:`Symfony\\Component\\Security\\Core\\Exception\\UserNotFoundException`
+and it includes the given not found user identifier.
 
 session_fixation_strategy
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/routing.rst
+++ b/routing.rst
@@ -2402,7 +2402,7 @@ use the ``generateUrl()`` helper::
 
             // generate a URL with route arguments
             $userProfilePage = $this->generateUrl('user_profile', [
-                'username' => $user->getUsername(),
+                'username' => $user->getUserIdentifier(),
             ]);
 
             // generated URLs are "absolute paths" by default. Pass a third optional
@@ -2472,7 +2472,7 @@ the :class:`Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface` class
 
             // generate a URL with route arguments
             $userProfilePage = $this->router->generate('user_profile', [
-                'username' => $user->getUsername(),
+                'username' => $user->getUserIdentifier(),
             ]);
 
             // generated URLs are "absolute paths" by default. Pass a third optional
@@ -2595,7 +2595,7 @@ Now you'll get the expected results when generating URLs in your commands::
 
             // generate a URL with route arguments
             $userProfilePage = $this->router->generate('user_profile', [
-                'username' => $user->getUsername(),
+                'username' => $user->getUserIdentifier(),
             ]);
 
             // generated URLs are "absolute paths" by default. Pass a third optional

--- a/security/custom_authentication_provider.rst
+++ b/security/custom_authentication_provider.rst
@@ -218,7 +218,10 @@ the ``PasswordDigest`` header value matches with the user's password::
 
         public function authenticate(TokenInterface $token): WsseUserToken
         {
-            $user = $this->userProvider->loadUserByUsername($token->getUsername());
+            // The loadUserByIdentifier() and getUserIdentifier() methods were
+            // introduced in Symfony 5.3. In previous versions they were called
+            // loadUserByUsername() and getUsername() respectively
+            $user = $this->userProvider->loadUserByIdentifier($token->getUserIdentifier());
 
             if ($user && $this->validateDigest($token->digest, $token->nonce, $token->created, $user->getPassword())) {
                 $authenticatedToken = new WsseUserToken($user->getRoles());

--- a/security/experimental_authenticators.rst
+++ b/security/experimental_authenticators.rst
@@ -456,7 +456,7 @@ using :ref:`the user provider <security-user-providers>`::
     You can optionally pass a user loader as second argument to the
     ``UserBadge``. This callable receives the ``$userIdentifier``
     and must return a ``UserInterface`` object (otherwise a
-    ``UsernameNotFoundException`` is thrown)::
+    ``UserNotFoundException`` is thrown)::
 
         // src/Security/CustomAuthenticator.php
         namespace App\Security;

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -172,10 +172,10 @@ This requires you to implement several methods::
                 return null;
             }
 
-            // The "username" in this case is the apiToken, see the key `property`
+            // The user identifier in this case is the apiToken, see the key `property`
             // of `your_db_provider` in `security.yaml`.
             // If this returns a user, checkCredentials() is called next:
-            return $userProvider->loadUserByUsername($credentials);
+            return $userProvider->loadUserByIdentifier($credentials);
         }
 
         public function checkCredentials($credentials, UserInterface $user): bool

--- a/security/json_login_setup.rst
+++ b/security/json_login_setup.rst
@@ -85,7 +85,9 @@ The next step is to configure a route in your app matching this path:
                 $user = $this->getUser();
 
                 return $this->json([
-                    'username' => $user->getUsername(),
+                    // The getUserIdentifier() method was introduced in Symfony 5.3.
+                    // In previous versions it was called getUsername()
+                    'username' => $user->getUserIdentifier(),
                     'roles' => $user->getRoles(),
                 ]);
             }

--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -401,7 +401,7 @@ The signed URL contains 3 parameters:
     The UNIX timestamp when the link expires.
 
 ``user``
-    The value returned from ``$user->getUsername()`` for this user.
+    The value returned from ``$user->getUserIdentifier()`` for this user.
 
 ``hash``
     A hash of ``expires``, ``user`` and any configured signature


### PR DESCRIPTION
Fixes #15164.

The only occurrence of `getUsername()` left in the docs is in this file: https://github.com/symfony/symfony-docs/blob/5.x/components/messenger.rst

Please help me to know how should I proceed to remove it. Thanks!