### PR TITLE
Recommend using root `controller` attribute in route definition

### DIFF
--- a/controller/service.rst
+++ b/controller/service.rst
@@ -110,7 +110,7 @@ which is a common practice when following the `ADR pattern`_
         # config/routes.yaml
         hello:
             path:     /hello/{name}
-            defaults: { _controller: app.hello_controller }
+            controller: app.hello_controller
 
     .. code-block:: xml
 


### PR DESCRIPTION
Also, it is consistent with the example above:
```
# config/routes.yaml
hello:
    path:     /hello
    controller: App\Controller\HelloController::index
    methods: GET
```

Checked on Symfony 5.2.6