### PR TITLE
[CI] Don't use special repository for symfony-tools/docs-builder

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
                 run: make -C _build SPHINXOPTS="-nqW -j auto" html
 
     symfony-docs-builder-build:
-        name: Build (symfony/docs-builder)
+        name: Build (symfony-tools/docs-builder)
 
         runs-on: ubuntu-latest
 

--- a/_build/composer.json
+++ b/_build/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.4",
         "symfony/console": "^5.2",
-        "symfony-tools/docs-builder": "^0.15.0",
-        "symfony/process": "^5.2"
+        "symfony/process": "^5.2",
+        "symfony-tools/docs-builder": "^0.15.0"
     }
 }


### PR DESCRIPTION
When `symfony-tools/docs-builder` is registered on packagist, we can remove the composer.json and composer.lock. But Im not sure we want to do that because we dont want to "live on the edge". 

Blocked by https://github.com/symfony-tools/docs-builder/pull/99
