### PR TITLE
[Validator] Make note that most constaints allow empty values by default

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -303,6 +303,14 @@ In Symfony, constraints are similar: they are assertions that a condition
 is true. Given a value, a constraint will tell you if that value
 adheres to the rules of the constraint.
 
+Most constraints are only validated when the value is non-empty, i.e., it's not
+an empty string and not ``NULL``. This means that a property with a constraint for
+:doc:`Email </reference/constraints/Email>` for example will not be deemed
+invalid if no e-mail address was supplied at all. If an e-mail address is required
+then both the :doc:`Email </reference/constraints/Email>` as well as the
+:doc:`NotBlank </reference/constraints/NotBlank>` constraints must be configured
+for the property in question.
+
 Supported Constraints
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->

I've been bitten by this more than once, thinking that just adding a constraint to a property will also make it required. This is not the case and I think this should be clear to people from the get-go to manage expectations around that. 