### PR TITLE
[Serializer] match example with description above

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1491,7 +1491,7 @@ and ``BitBucketCodeRepository`` classes:
          *    "bitbucket"="App\BitBucketCodeRepository"
          * })
          */
-        interface CodeRepository
+        abstract class CodeRepository
         {
             // ...
         }


### PR DESCRIPTION
Discriminator description mentions abstract class, but example contains interface