### PR TITLE
[Console] Updates method reference for retrieving console helpers

### DIFF
--- a/components/console/helpers/formatterhelper.rst
+++ b/components/console/helpers/formatterhelper.rst
@@ -9,8 +9,8 @@ You can do more advanced things with this helper than you can in
 :doc:`/console/coloring`.
 
 The :class:`Symfony\\Component\\Console\\Helper\\FormatterHelper` is included
-in the default helper set, which you can get by calling
-:method:`Symfony\\Component\\Console\\Command\\Command::getHelperSet`::
+in the default helper set and you can get it by calling
+:method:`Symfony\\Component\\Console\\Command\\Command::getHelper`::
 
     $formatter = $this->getHelper('formatter');
 

--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -6,8 +6,8 @@ Question Helper
 
 The :class:`Symfony\\Component\\Console\\Helper\\QuestionHelper` provides
 functions to ask the user for more information. It is included in the default
-helper set, which you can get by calling
-:method:`Symfony\\Component\\Console\\Command\\Command::getHelperSet`::
+helper set and you can get it by calling
+:method:`Symfony\\Component\\Console\\Command\\Command::getHelper`::
 
     $helper = $this->getHelper('question');
 


### PR DESCRIPTION
While reading the docs, I've found it weird that the documentation was talking about a `getHelperSet()` method when referencing in the following codeblock the method `getHelper`.

This MR harmonizes the wording according to the [Debug Formatter Helper](https://symfony.com/doc/current/components/console/helpers/debug_formatter.html)
