### PR TITLE
[Console] Add explicit note about the type of VALUE_NONE

### DIFF
--- a/console/input.rst
+++ b/console/input.rst
@@ -205,8 +205,8 @@ There are four option variants you can use:
     This option accepts multiple values (e.g. ``--dir=/foo --dir=/bar``);
 
 ``InputOption::VALUE_NONE``
-    Do not accept input for this option (e.g. ``--yell``). This is the default
-    behavior of options;
+    Do not accept input for this option (e.g. ``--yell``). The value returned from this option will be a boolean, ``false`` if the option is not provided.
+    This is the default behavior of options;
 
 ``InputOption::VALUE_REQUIRED``
     This value is required (e.g. ``--iterations=5`` or ``-i5``), the option


### PR DESCRIPTION
It was not clear what the default value nor what the type returned
from InputOption::VALUE_NONE is.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
