### PR TITLE
[Testing] Corrected link to 'Integration Tests' section

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -101,8 +101,6 @@ You can run tests using the ``./vendor/bin/phpunit`` command:
     In large test suites, it can make sense to create subdirectories for
     each type of tests (e.g. ``tests/Unit/`` and ``test/Functional/``).
 
-.. _integration-tests:
-
 Integration Tests
 -----------------
 


### PR DESCRIPTION
Currently the url displayed when clicking on 'Integration Tests' section is : https://symfony.com/doc/current/testing.html#id1. I think it should be like that one: https://symfony.com/doc/current/testing.html#integration-tests.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
