### PR TITLE
[Runtime] Composer node `extra.runtime.options` is incorrect

### DIFF
--- a/components/runtime.rst
+++ b/components/runtime.rst
@@ -316,9 +316,7 @@ You can also configure ``extra.runtime.options`` in ``composer.json``:
         },
         "extra": {
             "runtime": {
-                "options": {
-                    "project_dir": "/var/task"
-                }
+                "project_dir": "/var/task"
             }
         }
     }


### PR DESCRIPTION
Wanted to make a change to the `dotenv_path` so set `composer.json` (as per previous docs) to:
```
    "runtime": {
      "options": {
        "dotenv_path": "environments/.env"
      }
    }
```
resulted in `autoload_runtime.php` of:
```
$runtime = new $runtime(($_SERVER['APP_RUNTIME_OPTIONS'] ?? []) + [
  'options' => 
  array (
    'dotenv_path' => 'environments/.env',
  ),
  'project_dir' => dirname(__DIR__, 1),
]);
```
Which obviously didn't work

so I propose the options node is removed from the docs and then `composer.json`:
```
    "runtime": {
      "dotenv_path": "environments/.env"
    }
```
resulted in `autoload_runtime.php`
```
$runtime = new $runtime(($_SERVER['APP_RUNTIME_OPTIONS'] ?? []) + [
  'dotenv_path' => 'environments/.env',
  'project_dir' => dirname(__DIR__, 1),
]);
```

Worked for me.