### PR TITLE
Unifying to "configuration parameters"

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -328,7 +328,7 @@ arbitrary matching logic:
              *     condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'"
              * )
              *
-             * expressions can also include config parameters:
+             * expressions can also include configuration parameters:
              * condition: "request.headers.get('User-Agent') matches '%app.allowed_browsers%'"
              */
             public function contact(): Response


### PR DESCRIPTION
Currently, there are multiple words for the same thing:
* configuration parameter
* config parameter
* container parameter

An on https://symfony.com/doc/current/best_practices.html#use-constants-to-define-options-that-rarely-change:
* service container parameter

Since the dedicated chapter at https://symfony.com/doc/current/configuration.html#configuration-parameters calls it "configuration parameter", I'd say all of them should be changed to that. Do you agree? Then I'll commit the rest.
