### PR TITLE
[Messenger] Add a note about `messenger:stop-workers` command

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -493,6 +493,15 @@ On production, there are a few important things to think about:
     new worker processes. The command uses the :ref:`app <cache-configuration-with-frameworkbundle>`
     cache internally - so make sure this is configured to use an adapter you like.
 
+.. note::
+
+    If your deploy strategy involves the creation of new target directories, you
+    should set a value for the :ref:`cache.prefix.seed <reference-cache-prefix-seed>`
+    configuration option in order to let this command use always the same cache namespace
+    between deployments. Otherwise, the ``cache.app`` pool will use the value of the
+    ``kernel.project_dir`` parameter as base for the namespace, which will lead to
+    different namespaces each time a new deployment is made.
+
 Prioritized Transports
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
**TODO**:
- [x] Reword the message to make the description clearer;
- [x] Check if we can provide a recipe to avoid the described problem.

See [`CachePoolPass::process()`](https://github.com/symfony/cache/blob/f133937adf2bb359be0489c40821765e6b7f56b8/DependencyInjection/CachePoolPass.php#L54).