### PR TITLE
[HttpClient] Clarifying how to autowire scoped HTTP clients

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -215,7 +215,7 @@ autoconfigure the HTTP client based on the requested URL:
             http_client:
                 scoped_clients:
                     # only requests matching scope will use these options
-                    github:
+                    github.client:
                         scope: 'https://api\.github\.com'
                         headers:
                             Accept: 'application/vnd.github.v3+json'
@@ -224,7 +224,7 @@ autoconfigure the HTTP client based on the requested URL:
 
                     # using base_uri, relative URLs (e.g. request("GET", "/repos/symfony/symfony-docs"))
                     # will default to these options
-                    github:
+                    github.client:
                         base_uri: 'https://api.github.com'
                         headers:
                             Accept: 'application/vnd.github.v3+json'
@@ -245,7 +245,7 @@ autoconfigure the HTTP client based on the requested URL:
             <framework:config>
                 <framework:http-client>
                     <!-- only requests matching scope will use these options -->
-                    <framework:scoped-client name="github"
+                    <framework:scoped-client name="github.client"
                         scope="https://api\.github\.com"
                     >
                         <framework:header name="Accept">application/vnd.github.v3+json</framework:header>
@@ -254,7 +254,7 @@ autoconfigure the HTTP client based on the requested URL:
 
                     <!-- using base-uri, relative URLs (e.g. request("GET", "/repos/symfony/symfony-docs"))
                          will default to these options -->
-                    <framework:scoped-client name="github"
+                    <framework:scoped-client name="github.client"
                         base-uri="https://api.github.com"
                     >
                         <framework:header name="Accept">application/vnd.github.v3+json</framework:header>
@@ -271,7 +271,7 @@ autoconfigure the HTTP client based on the requested URL:
             'http_client' => [
                 'scoped_clients' => [
                     // only requests matching scope will use these options
-                    'github' => [
+                    'github.client' => [
                         'scope' => 'https://api\.github\.com',
                         'headers' => [
                             'Accept' => 'application/vnd.github.v3+json',
@@ -282,7 +282,7 @@ autoconfigure the HTTP client based on the requested URL:
 
                     // using base_url, relative URLs (e.g. request("GET", "/repos/symfony/symfony-docs"))
                     // will default to these options
-                    'github' => [
+                    'github.client' => [
                         'base_uri' => 'https://api.github.com',
                         'headers' => [
                             'Accept' => 'application/vnd.github.v3+json',
@@ -329,8 +329,8 @@ Each client has a unique service named after its configuration.
 
 Each scoped client also defines a corresponding named autowiring alias.
 If you use for example
-``Symfony\Contracts\HttpClient\HttpClientInterface $myApiClient``
-as the type and name of an argument, autowiring will inject the ``my_api.client``
+``Symfony\Contracts\HttpClient\HttpClientInterface $githubClient``
+as the type and name of an argument, autowiring will inject the ``github.client``
 service into your autowired classes.
 
 .. note::


### PR DESCRIPTION
The documentation didn't make it very clear that the key of the "scoped_clients" array was the actual service name that could be used to autowire the service. By using the same name in the code example and in the paragraph about autowiring, that should be clearer to the reader.
