### PR TITLE
Adding file-loader dependency to encore copy-files.

### DIFF
--- a/frontend/encore/copy-files.rst
+++ b/frontend/encore/copy-files.rst
@@ -30,7 +30,7 @@ To reference an image file from outside of a JavaScript file that's processed by
 Webpack - like a template - you can use the ``copyFiles()`` method to copy those
 files into your final output directory.
 
-First, install file-loader Webpack extension:
+First, install ``file-loader`` Webpack extension:
 
 .. code-block:: terminal
 

--- a/frontend/encore/copy-files.rst
+++ b/frontend/encore/copy-files.rst
@@ -30,6 +30,14 @@ To reference an image file from outside of a JavaScript file that's processed by
 Webpack - like a template - you can use the ``copyFiles()`` method to copy those
 files into your final output directory.
 
+First, install file-loader Webpack extension:
+
+.. code-block:: terminal
+
+    $ yarn add file-loader --dev
+
+and update your ``webpack.config.js``:
+
 .. code-block:: diff
 
       // webpack.config.js


### PR DESCRIPTION
When trying to follow the steps described in `frontend/encore/copy-files.html` I'm getting an error related to the missing `file-loader` dependency. Adding it via `yarn` fixes the issue. I've updated this part of the documentation to make this part easier to implement. 