### PR TITLE
[Messenger] Add a description to the AMQP exchange arguments with example

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1023,7 +1023,8 @@ The transport has a number of options:
 ``queues[name][binding_arguments]``           Arguments to be used while binding the queue.
 ``queues[name][binding_keys]``                The binding keys (if any) to bind to this queue
 ``queues[name][flags]``                       Queue flags                                        ``AMQP_DURABLE``
-``exchange[arguments]``
+``exchange[arguments]``                       Extra arguments for the exchange i.e.
+                                              alternate-exchange
 ``exchange[default_publish_routing_key]``     Routing key to use when publishing, if none is
                                               specified on the message
 ``exchange[flags]``                           Exchange flags                                     ``AMQP_DURABLE``


### PR DESCRIPTION
It took me some time to configure an alternate-exchange.

Just figured to append the documentation so others can find it there.