### PR TITLE
Adding file-loader dependency.

### DIFF
--- a/frontend/encore/copy-files.rst
+++ b/frontend/encore/copy-files.rst
@@ -28,7 +28,7 @@ Referencing Image files from a Template
 
 To reference an image file from outside of a JavaScript file that's processed by
 Webpack - like a template - you can use the ``copyFiles()`` method to copy those
-files into your final output directory.
+files into your final output directory. First enable it in ``webpack.config.js``:
 
 .. code-block:: diff
 
@@ -50,6 +50,10 @@ files into your final output directory.
     +         // only copy files matching this pattern
     +         //pattern: /\.(png|jpg|jpeg)$/
     +     })
+
+Then restart Encore. When you do, it will give you a command you can run to
+install any missing dependencies. After running that command and restarting
+Encore, you're done!
 
 This will copy all files from ``assets/images`` into ``public/build`` (the output
 path). If you have :doc:`versioning enabled <versioning>`, the copied files will

--- a/frontend/encore/postcss.rst
+++ b/frontend/encore/postcss.rst
@@ -4,11 +4,26 @@ PostCSS and autoprefixing (postcss-loader)
 `PostCSS`_ is a CSS post-processing tool that can transform your CSS in a lot
 of cool ways, like `autoprefixing`_, `linting`_ and more!
 
-First, download ``postcss-loader`` and any plugins you want, like ``autoprefixer``:
+First enable it in ``webpack.config.js``:
+
+.. code-block:: diff
+
+      // webpack.config.js
+
+      Encore
+          // ...
+    +     .enablePostCssLoader()
+      ;
+
+Then restart Encore. When you do, it will give you a command you can run to
+install any missing dependencies. After running that command and restarting
+Encore, you're done!
+
+Next, download any plugins you want, like ``autoprefixer``:
 
 .. code-block:: terminal
 
-    $ yarn add postcss-loader autoprefixer --dev
+    $ yarn add autoprefixer --dev
 
 Next, create a ``postcss.config.js`` file at the root of your project:
 
@@ -23,19 +38,6 @@ Next, create a ``postcss.config.js`` file at the root of your project:
             autoprefixer: {}
         }
     }
-
-Then, enable the loader in Encore!
-
-.. code-block:: diff
-
-      // webpack.config.js
-
-      Encore
-          // ...
-    +     .enablePostCssLoader()
-      ;
-
-Because you just modified ``webpack.config.js``, stop and restart Encore.
 
 That's it! The ``postcss-loader`` will now be used for all CSS, Sass, etc files.
 You can also pass options to the `postcss-loader`_ by passing a callback:

--- a/frontend/encore/reactjs.rst
+++ b/frontend/encore/reactjs.rst
@@ -10,7 +10,6 @@ Using React? First add some dependencies with Yarn:
 
 .. code-block:: terminal
 
-    $ yarn add @babel/preset-react --dev
     $ yarn add react react-dom prop-types
 
 Enable react in your ``webpack.config.js``:


### PR DESCRIPTION
When trying to follow the steps described in `frontend/encore/copy-files.html` I'm getting an error related to the missing `file-loader` dependency. Adding it via `yarn` fixes the issue. I've updated this part of the documentation to make this part easier to implement. 