### PR TITLE
[RateLimiter] [Rate Limiter] Added missing opening single quotes

### DIFF
--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -410,7 +410,7 @@ Use the ``cache_pool`` option to override the cache used by a specific limiter
 
         // config/packages/rate_limiter.php
         $container->loadFromExtension('framework', [
-            rate_limiter' => [
+            'rate_limiter' => [
                 'anonymous_api' => [
                     // ...
 
@@ -484,7 +484,7 @@ you can use a specific :ref:`named lock <lock-named-locks>` via the
 
         // config/packages/rate_limiter.php
         $container->loadFromExtension('framework', [
-            rate_limiter' => [
+            'rate_limiter' => [
                 'anonymous_api' => [
                     // ...
 


### PR DESCRIPTION
Added the missing opening single quotes in the PHP config example

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
