### PR TITLE
Added indexes to sql commands used to create session tables

### DIFF
--- a/session/database.rst
+++ b/session/database.rst
@@ -393,7 +393,8 @@ MariaDB/MySQL
         `sess_id` VARBINARY(128) NOT NULL PRIMARY KEY,
         `sess_data` BLOB NOT NULL,
         `sess_lifetime` INTEGER UNSIGNED NOT NULL,
-        `sess_time` INTEGER UNSIGNED NOT NULL
+        `sess_time` INTEGER UNSIGNED NOT NULL,
+        INDEX `sessions_sess_lifetime_idx` (`sess_lifetime`)
     ) COLLATE utf8mb4_bin, ENGINE = InnoDB;
 
 .. note::
@@ -414,6 +415,7 @@ PostgreSQL
         sess_lifetime INTEGER NOT NULL,
         sess_time INTEGER NOT NULL
     );
+    CREATE INDEX sessions_sess_time_idx ON sessions (sess_lifetime);
 
 Microsoft SQL Server
 ....................
@@ -424,7 +426,8 @@ Microsoft SQL Server
         sess_id VARCHAR(128) NOT NULL PRIMARY KEY,
         sess_data NVARCHAR(MAX) NOT NULL,
         sess_lifetime INTEGER NOT NULL,
-        sess_time INTEGER NOT NULL
+        sess_time INTEGER NOT NULL,
+        INDEX sessions_sess_lifetime_idx (sess_lifetime)
     );
 
 Store Sessions in a NoSQL Database (MongoDB)


### PR DESCRIPTION
As per https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.4.md#httpfoundation `PdoSessionHandler` now precalculates the expiry timestamp in the lifetime column, so the index will speed up garbage collection

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
