### PR TITLE
[CI] Fixed composer cache for code blocks job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,6 +127,7 @@ jobs:
 
           - name: Get composer cache directory
             id: composercache
+            working-directory: _build
             run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
           - name: Cache dependencies


### PR DESCRIPTION
I've noticed that since we dont have a composer.json file, we cannot get the path to the cache. This PR will fix that.

<img width="705" alt="Screenshot 2021-05-19 at 11 22 39" src="https://user-images.githubusercontent.com/1275206/118789045-ab16c980-b894-11eb-8422-60a008c967c0.png">
