### PR TITLE
Adding HTTP Certificates

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -712,6 +712,17 @@ called when new data is uploaded or downloaded and at least once per second::
 Any exceptions thrown from the callback will be wrapped in an instance of
 ``TransportExceptionInterface`` and will abort the request.
 
+HTTPS Certificates
+~~~~~~~~~~~~~~~~~~
+
+HttpClient uses the system's certificate store to validate SSL certificates
+(while browsers are using their own stores). If you're using self-signed certificates
+during development, the recommended way is to create your own certificate authority (CA)
+and add it to your system's store.
+Alternatively, you can also disable `verify_host` and `verify_peer` (see
+:ref:`http_client config reference <reference-http-client>`), but this is not
+recommended in production.
+
 Performance
 -----------
 


### PR DESCRIPTION
See https://github.com/symfony/symfony/issues/41255

Questions:
* Should I create an anchor for `verify_host` and `verify_peer` to be able to link directly to these headings?
* Maybe a link on how to actually add it to the system store? For ubuntu I found https://askubuntu.com/a/94861/800003 and https://superuser.com/a/719047