### PR TITLE
[RateLimiter] Closes #15034 adds information about the lock being nullable

### DIFF
--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -442,9 +442,9 @@ simultaneous requests (e.g. three servers of a company hitting your API at the
 same time). Rate limiters use :doc:`locks </lock>` to protect their operations
 against these race conditions.
 
-By default, Symfony uses the global lock configured by ``framework.lock``), but
+By default, Symfony uses the global lock configured by ``framework.lock``, but
 you can use a specific :ref:`named lock <lock-named-locks>` via the
-``lock_factory`` option:
+``lock_factory`` option (or none at all):
 
 .. configuration-block::
 
@@ -458,6 +458,9 @@ you can use a specific :ref:`named lock <lock-named-locks>` via the
 
                     # use the "lock.rate_limiter.factory" for this limiter
                     lock_factory: 'lock.rate_limiter.factory'
+
+                    # or don't use any lock mechanism
+                    lock_factory: null
 
     .. code-block:: xml
 
@@ -481,6 +484,14 @@ you can use a specific :ref:`named lock <lock-named-locks>` via the
                         lock-factory="lock.rate_limiter.factory"
                     />
 
+                    <!-- limiter-factory: or don't use any lock mechanism -->
+                    <framework:limiter name="anonymous_api"
+                        policy="fixed_window"
+                        limit="100"
+                        interval="60 minutes"
+                        lock-factory="null"
+                    />
+
                     <!-- ... -->
                 </framework:rate-limiter>
             </framework:config>
@@ -498,8 +509,15 @@ you can use a specific :ref:`named lock <lock-named-locks>` via the
 
                     // use the "lock.rate_limiter.factory" for this limiter
                     ->lockFactory('lock.rate_limiter.factory')
+
+                    // or don't use any lock mechanism
+                    ->lockFactory(null)
                 ;
         };
+
+.. versionadded:: 5.3
+
+    The login throttling doesn't use any lock since Symfony 5.3 to avoid extra load.
 
 .. _`DoS attacks`: https://cheatsheetseries.owasp.org/cheatsheets/Denial_of_Service_Cheat_Sheet.html
 .. _`Apache mod_ratelimit`: https://httpd.apache.org/docs/current/mod/mod_ratelimit.html


### PR DESCRIPTION
Closes #15034 by adding documentation about the ability to make the lock factory null to disable this behavior.
It also adds a "new in sf 5.3" text about the login throttling that has it disabled by default.
