### PR TITLE
Changed version for composer create-project

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -65,10 +65,10 @@ Symfony application using Composer:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ composer create-project symfony/website-skeleton:"5.3.x@dev" my_project_name
+    $ composer create-project symfony/website-skeleton:"6.0.x@dev" my_project_name
 
     # run this if you are building a microservice, console application or API
-    $ composer create-project symfony/skeleton:"5.3.x@dev" my_project_name
+    $ composer create-project symfony/skeleton:"6.0.x@dev" my_project_name
 
 No matter which command you run to create the Symfony application. All of them
 will create a new ``my_project_name/`` directory, download some dependencies


### PR DESCRIPTION
In symfony doc composer create-project was at version 5.3 instead of 6.0