### PR TITLE
[Session] Fix handler import

### DIFF
--- a/session/database.rst
+++ b/session/database.rst
@@ -487,7 +487,7 @@ the MongoDB connection as argument:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
+        use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
 
         return static function (ContainerConfigurator $container) {
             $services = $configurator->services();
@@ -596,7 +596,7 @@ configure these values with the second argument passed to the
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
+        use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
 
         return static function (ContainerConfigurator $container) {
             $services = $configurator->services();


### PR DESCRIPTION
I found two examples where PdoSessionHandler is imported instead of MongoDbSessionHandler.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
