### PR TITLE
[Filesystem] fix readlink description

### DIFF
--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -214,10 +214,7 @@ support symbolic links, a third boolean argument is available::
 
 :method:`Symfony\\Component\\Filesystem\\Filesystem::readlink` read links targets.
 
-PHP's :phpfunction:`readlink` function returns the target of a symbolic link. However, its behavior
-is completely different under Windows and Unix. On Windows systems, ``readlink()``
-resolves recursively the children links of a link until a final target is found. On
-Unix-based systems ``readlink()`` only resolves the next link.
+PHP's :phpfunction:`readlink` function returns the target of a symbolic link.
 
 The :method:`Symfony\\Component\\Filesystem\\Filesystem::readlink` method provided
 by the Filesystem component always behaves in the same way::


### PR DESCRIPTION
remove description readlink() for Windows misleading
see https://github.com/symfony/symfony/pull/40866