### PR TITLE
Fixing code sample

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -80,7 +80,7 @@ container into a single file, which could improve performance when using
         // config/services.php
 
         // ...
-        $container->setParameter('container.dumper.inline_factories', true);
+        $container->parameters()->set('container.dumper.inline_factories', true);
 
 .. _performance-use-opcache:
 


### PR DESCRIPTION
This is now the usual way to do it, right? https://symfony.com/doc/current/configuration.html#configuration-parameters

In any case, `->setParameter()` results in:
> Call to undefined method "Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator::setParameter()".
