### PR TITLE
Adding opcache.preload_user

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -115,6 +115,9 @@ You can configure PHP to use this preload file:
 
     ; php.ini
     opcache.preload=/path/to/project/config/preload.php
+    
+    ; required for opcache.preload:
+    opcache.preload_user=www-data
 
 .. _performance-configure-opcache:
 


### PR DESCRIPTION
Without this, I can't restart PHP 8 and the service status shows this error:

> Fatal Error "opcache.preload_user" has not been defined

Passing `www-data` is the best guess here, right?
