### PR TITLE
Use BaseKernel class alias

### DIFF
--- a/configuration/override_dir_structure.rst
+++ b/configuration/override_dir_structure.rst
@@ -80,7 +80,7 @@ method::
     // src/Kernel.php
 
     // ...
-    class Kernel extends Kernel
+    class Kernel extends BaseKernel
     {
         // ...
 


### PR DESCRIPTION
This PR fixes a namespace conflict.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
