### PR TITLE
Typo with backslashes

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -403,7 +403,7 @@ example, suppose you want to make the admin email configurable:
 
 If you make this change and refresh, you'll see an error:
 
-    Cannot autowire service "App\Service\SiteUpdateManager": argument "$adminEmail"
+    Cannot autowire service "App\\Service\\SiteUpdateManager": argument "$adminEmail"
     of method "__construct()" must have a type-hint or be given a value explicitly.
 
 That makes sense! There is no way that the container knows what value you want to


### PR DESCRIPTION
Added backslahes in SiteUpdateManager path.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
