### PR TITLE
[Security] Update documentation for stable authenticator security

### DIFF
--- a/_build/redirection_map
+++ b/_build/redirection_map
@@ -515,3 +515,4 @@
 /frontend/encore/shared-entry /frontend/encore/split-chunks
 /testing/functional_tests_assertions /testing#testing-application-assertions
 /security/named_encoders /security/named_hashers
+/security/experimental_authenticators /security/authenticator_manager

--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -335,7 +335,7 @@ or can get everything which partial matches the event name:
 
     The ability to match partial event names was introduced in Symfony 5.3.
 
-The :doc:`new experimental Security </security/experimental_authenticators>`
+The :doc:`new authenticator-based Security </security/authenticator_manager>`
 system adds an event dispatcher per firewall. Use the ``--dispatcher`` option to
 get the registered listeners for a particular event dispatcher:
 

--- a/security.rst
+++ b/security.rst
@@ -40,7 +40,7 @@ install the security feature before using it:
 
 .. tip::
 
-    A :doc:`new experimental Security </security/experimental_authenticators>`
+    A :doc:`new authenticator-based Security </security/authenticator_manager>`
     was introduced in Symfony 5.1, which will eventually replace security in
     Symfony 6.0. This system is almost fully backwards compatible with the
     current Symfony security, add this line to your security configuration to start
@@ -478,7 +478,7 @@ Limiting Login Attempts
     Login throttling was introduced in Symfony 5.2.
 
 Symfony provides basic protection against `brute force login attacks`_ if
-you're using the :doc:`experimental authenticators </security/experimental_authenticators>`.
+you're using the :doc:`authenticator-based authenticators </security/authenticator_manager>`.
 You must enable this using the ``login_throttling`` setting:
 
 .. configuration-block::
@@ -1501,7 +1501,7 @@ Authentication (Identifying/Logging in the User)
 .. toctree::
     :maxdepth: 1
 
-    security/experimental_authenticators
+    security/authenticator_manager
     security/form_login_setup
     security/reset_password
     security/json_login_setup

--- a/security/authenticator_manager.rst
+++ b/security/authenticator_manager.rst
@@ -3,9 +3,7 @@ Using the new Authenticator-based Security
 
 .. versionadded:: 5.1
 
-    Authenticator-based security was introduced as an
-    :doc:`experimental feature </contributing/code/experimental>` in
-    Symfony 5.1.
+    Authenticator-based security was introduced in Symfony 5.1.
 
 In Symfony 5.1, a new authentication system was introduced. This system
 changes the internals of Symfony Security, to make it more extensible

--- a/security/guard_authentication.rst
+++ b/security/guard_authentication.rst
@@ -16,7 +16,7 @@ system, so we can learn more about Guard in detail.
 
 .. tip::
 
-    A :doc:`new experimental authenticator-based system </security/experimental_authenticators>`
+    A :doc:`new authenticator-based system </security/authenticator_manager>`
     was introduced in Symfony 5.1, which will eventually replace Guards in Symfony 6.0.
 
 Step 1) Prepare your User Class


### PR DESCRIPTION
In Symfony 5.3, the new authenticator security was marked as stable (and the legacy authentication is deprecated). We'll update all security docs, but that takes a while. So let's make a first baby-step and remove "experimental" from all mentions of the new system.