### PR TITLE
Adding missing ntlm authentication mode to SwiftmailerBundle config

### DIFF
--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -152,7 +152,11 @@ auth_mode
 **type**: ``string``
 
 The authentication mode to use when using ``smtp`` as the transport. Valid
-values are ``plain``, ``login``, ``cram-md5``, or ``null``.
+values are ``plain``, ``login``, ``cram-md5``,, ``ntlm`` or ``null``.
+
+.. versionadded:: 3.0.4
+
+    The ``ntlm`` authentication mode was introduced in SwiftMailerBundle 3.0.4.
 
 spool
 ~~~~~


### PR DESCRIPTION
Hey guys!

The NTLM auth mode seems to be missing in the config docs for SwiftmailerBundle.

Added with PR [188](https://github.com/symfony/swiftmailer-bundle/pull/188)

Cheers!
