### PR TITLE
[Form] Fix incorrect class name for Twig configurations

### DIFF
--- a/form/bootstrap5.rst
+++ b/form/bootstrap5.rst
@@ -61,7 +61,7 @@ configuration:
         // config/packages/twig.php
         use Symfony\Config\TwigConfig;
 
-        return static function(FrameworkConfig $twig) {
+        return static function(TwigConfig $twig) {
             $twig->formThemes(['bootstrap_5_layout.html.twig']);
 
             // ...


### PR DESCRIPTION
I made a mistake while writing the Bootstrap 5 configuration documentation.
