### PR TITLE
Update bootstrap5.rst

### DIFF
--- a/form/bootstrap5.rst
+++ b/form/bootstrap5.rst
@@ -187,7 +187,7 @@ class to the ``row_attr`` option.
 
     .. code-block:: php
 
-        $builder->add('email', CheckboxType::class, [
+        $builder->add('email', TextType::class, [
             'label' => '@',
             'row_attr' => [
                 'class' => 'input-group',


### PR DESCRIPTION
Apply input-group class to a TextType field instead of a CheckboxType field

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
