### PR TITLE
Remove dot which should be escaped on telegram

### DIFF
--- a/notifier/chatters.rst
+++ b/notifier/chatters.rst
@@ -26,7 +26,7 @@ you to send messages to chat services like Slack or Telegram::
          */
         public function thankyou(ChatterInterface $chatter)
         {
-            $message = (new ChatMessage('You got a new invoice for 15 EUR.'))
+            $message = (new ChatMessage('You got a new invoice for 15 EUR'))
                 // if not set explicitly, the message is send to the
                 // default transport (the first one configured)
                 ->transport('slack');


### PR DESCRIPTION
Hello,
Hope I could help a little after I got stuck with an error message telling me to escape the dot, spend a few minutes trying to solve that, really thinking that the trouble was coming from the configuration and not from the example from the doc.

Turns out that telegram wants you to escape the character '.'
Should it be escaped in the documentation ? (But is it compatible with others channels ?)
Or just removed, leaving the doc with a text that works on all channels ?

Cheers

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
