### PR TITLE
[Doctrine] add missing mapping type (PHP Attributes)

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -265,7 +265,7 @@ you can control. The following configuration options exist for a mapping:
 ``type``
 ........
 
-One of ``annotation`` (the default value), ``xml``, ``yml``, ``php`` or
+One of ``annotation`` (the default value), ``attribute``, ``xml``, ``yml``, ``php`` or
 ``staticphp``. This specifies which type of metadata type your mapping uses.
 
 ``dir``


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
Support for [Doctrine ORM 2.9 AttributeDrive was added a time ago](https://github.com/doctrine/DoctrineBundle/pull/1322), but the docs does not mention that possibility yet.

```yaml
doctrine:
    orm:
        mappings:
            Your\Namespace:
                type: attribute # <-- HERE
                dir: '%kernel.project_dir%/src/Your/Namespace'
                prefix: 'Your\Namespace'
                alias: YN
```