### PR TITLE
Update setup.rst

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -50,10 +50,10 @@ application:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ symfony new my_project_name --version=next --full
+    $ symfony new my_project_name --full
 
     # run this if you are building a microservice, console application or API
-    $ symfony new my_project_name --version=next
+    $ symfony new my_project_name
 
 The only difference between these two commands is the number of packages
 installed by default. The ``--full`` option installs all the packages that you


### PR DESCRIPTION
Using `--version=next` uses a development version of Symfony which right now as of this moment in time doesn't behave the way that the 5.3 documentation (which is "current" on the documentation website) suggests.  I suggest removing this parameter to avoid confusion.

See also https://stackoverflow.com/questions/67874794/symfony5-throws-404-error-in-browser-but-route-is-found-in-cli/67875331#67875331

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
