### PR TITLE
[Symfony CLI] Docker integration and MailCatcher prefix

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -352,7 +352,7 @@ RabbitMQ      5672      ``RABBITMQ_`` (set user and pass via Docker ``RABBITMQ_D
 Elasticsearch 9200      ``ELASTICSEARCH_``
 MongoDB       27017     ``MONGODB_`` (set the database via a Docker ``MONGO_DATABASE`` env var)
 Kafka         9092      ``KAFKA_``
-MailCatcher   1025/1080 ``MAILER_``
+MailCatcher   1025/1080 ``MAILCATCHER_``
               or 25/80
 Blackfire     8707      ``BLACKFIRE_``
 ============= ========= ======================


### PR DESCRIPTION
Hi :wave: 

Given my `docker-compose.yaml`: 

```yaml
version: '3.6'

volumes:
    db-data:
    redis-data:

services:

  database:
    image: 'mysql:5.7'
    ports: [3306]
    environment:
      MYSQL_USER: 'app'
      MYSQL_PASSWORD: 'app'
      MYSQL_DATABASE: 'app'
      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
      TZ: Etc/UTC
    volumes:
      - db-data:/var/lib/mysql
      - .manala/init-db:/docker-entrypoint-initdb.d
    healthcheck:
      test: mysqladmin ping --silent
      interval: 10s
      timeout: 5s
      retries: 5

  phpmyadmin:
    image: phpmyadmin
    ports: [80]
    environment:
      PMA_HOST: 'database'
      PMA_USER: 'app'
      PMA_PASSWORD: 'app'

  redis:
    image: 'redis:alpine'
    ports: [6379]
    environment:
      TZ: Etc/UTC
    volumes:
      - redis-data:/data

  phpredisadmin:
    image: erikdubbelboer/phpredisadmin
    ports: [80]
    environment:
      REDIS_1_HOST: 'redis'

  mailcatcher:
    image: 'schickling/mailcatcher'
    ports: [1025, 1080]
    environment:
      TZ: Etc/UTC
```

When running `docker-compose up` and `symfony var:export --multiline`, the env vars for MailCatcher are prefixed (by default) by `MAILCATCHER_` but not by `MAILER_`:
![image](https://user-images.githubusercontent.com/2103975/121185755-b0997b00-c866-11eb-9465-3b1541ab7b81.png)