### PR TITLE
Fixed the use of Session with RequesStack

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -153,10 +153,10 @@ controllers if you type-hint an argument with
             $this->requestStack->getSession()->set('attribute-name', 'attribute-value');
 
             // gets an attribute by name
-            $foo = $this->session->get('foo');
+            $foo = $this->requestStack->getSession()->get('foo');
 
             // the second argument is the value returned when the attribute doesn't exist
-            $filters = $this->session->get('filters', []);
+            $filters = $this->requestStack->getSession()->get('filters', []);
 
             // ...
         }


### PR DESCRIPTION
$this->session is never instanciated. We have to use $this->requestStack->getSession() instead

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
