### PR TITLE
[Security] changed interface name to the correct one

### DIFF
--- a/security/named_hashers.rst
+++ b/security/named_hashers.rst
@@ -139,7 +139,7 @@ the name of the hasher to use::
     }
 
 If you created your own password hasher implementing the
-:class:`Symfony\\Component\\PasswordHasher\\Hasher\\UserPasswordHasherInterface`,
+:class:`Symfony\\Component\\PasswordHasher\\PasswordHasherInterface`,
 you must register a service for it in order to use it as a named hasher:
 
 .. configuration-block::


### PR DESCRIPTION
changed interface name to the correct one, otherwise it will result in a configuration error, see https://github.com/symfony/symfony/issues/41702