### PR TITLE
[Form] Fixed a code example related to CSRF

### DIFF
--- a/components/form.rst
+++ b/components/form.rst
@@ -121,16 +121,17 @@ The following snippet adds CSRF protection to the form factory::
 
     use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
     use Symfony\Component\Form\Forms;
-    use Symfony\Component\HttpFoundation\Session\Session;
+    use Symfony\Component\HttpFoundation\RequestStack;
     use Symfony\Component\Security\Csrf\CsrfTokenManager;
     use Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator;
     use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
 
-    // creates a Session object from the HttpFoundation component
-    $session = new Session();
+    // creates a RequestStack object using the current request
+    $requestStack = new RequestStack();
+    $requestStack->push($request);
 
     $csrfGenerator = new UriSafeTokenGenerator();
-    $csrfStorage = new SessionTokenStorage($session);
+    $csrfStorage = new SessionTokenStorage($requestStack);
     $csrfManager = new CsrfTokenManager($csrfGenerator, $csrfStorage);
 
     $formFactory = Forms::createFormFactoryBuilder()


### PR DESCRIPTION
Fixes #15410 but proposes the fix in 5.3 branch because that's where the deprecation was introduced:

https://github.com/symfony/security-csrf/blob/c7b7006d3ed955da978a002d764cae388bed8d09/TokenStorage/SessionTokenStorage.php#L47-L59