### PR TITLE
[HttpClient] Import ServerSentEvent class

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1264,7 +1264,8 @@ Symfony's HTTP client provides an EventSource implementation to consume these
 server-sent events. Use the :class:`Symfony\\Component\\HttpClient\\EventSourceHttpClient`
 to wrap your HTTP client, open a connection to a server that responds with a
 ``text/event-stream`` content type and consume the stream as follows::
-
+    
+    use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
     use Symfony\Component\HttpClient\EventSourceHttpClient;
 
     // the second optional argument is the reconnection time in seconds (default = 10)


### PR DESCRIPTION
This PR adds the missing class import in the "Consuming Server-Sent Events" section.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
