### PR TITLE
[Migration guide] Change Strangler App to Strangler Fig App

### DIFF
--- a/migration.rst
+++ b/migration.rst
@@ -7,7 +7,7 @@ Migrating an Existing Application to Symfony
 When you have an existing application that was not built with Symfony,
 you might want to move over parts of that application without rewriting
 the existing logic completely. For those cases there is a pattern called
-`Strangler Application`_. The basic idea of this pattern is to create a
+`Strangler Fig Application`_. The basic idea of this pattern is to create a
 new application that gradually takes over functionality from an existing
 application. This migration approach can be implemented with Symfony in
 various ways and has some benefits over a rewrite such as being able
@@ -461,7 +461,7 @@ chance to use Symfony's event lifecycle. For instance, this allows you to
 transition the authentication and authorization of the legacy application over
 to the Symfony application using the Security component and its firewalls.
 
-.. _`Strangler Application`: https://martinfowler.com/bliki/StranglerFigApplication.html
+.. _`Strangler Fig Application`: https://martinfowler.com/bliki/StranglerFigApplication.html
 .. _`autoload`: https://getcomposer.org/doc/04-schema.md#autoload
 .. _`Modernizing with Symfony`: https://youtu.be/YzyiZNY9htQ
 .. _`Symfony Panther`: https://github.com/symfony/panther


### PR DESCRIPTION
Martin Fowler, the author of the article, update its post to rename the pattern because it has a violent feeling to it.

I'm making this PR to stick to the intention of the author and make this doc a bit more welcoming

You can find at the bottom of the linked article
> The original post was entitled “Strangler Application”, and when used, the pattern is often referred to as a “strangler”. But its usage often gets separated from its metaphorical root, and takes on a unpleasantly violent connotation.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
