### PR TITLE
[Logging] Fix incorrect PHP example to exclude HTTP code with Monolog

### DIFF
--- a/logging/monolog_exclude_http_codes.rst
+++ b/logging/monolog_exclude_http_codes.rst
@@ -52,12 +52,14 @@ logging these HTTP codes based on the MonologBundle configuration:
         use Symfony\Config\MonologConfig;
 
         return static function (MonologConfig $monolog) {
-            $monolog->handler('main')
+            $mainHandler = $monolog->handler('main')
                 // ...
                 ->type('fingers_crossed')
                 ->handler(...)
-                ->excludedHttpCode([403, 404])
             ;
+
+            $mainHandler->excludedHttpCode()->code(403);
+            $mainHandler->excludedHttpCode()->code(404);
         };
 
 .. caution::


### PR DESCRIPTION
With the previous example, when running `composer run-script --no-dev post-install-cmd` we get the following error:

```bash
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!  
!!  In FileLoader.php line 174:
!!                                                                                 
!!    The following keys are not supported by "Symfony\Config\Monolog\HandlerConf  
!!    ig\ExcludedHttpCodeConfig": 0, 1 in /home/ker0x/dev/imdb/config/packages/pr  
!!    od/monolog.php (which is being imported from "/home/ker0x/dev/imdb/src/Kern  
!!    el.php").                                                                    
!!                                                                                 
!!  
!!  In ExcludedHttpCodeConfig.php line 57:
!!                                                                                 
!!    The following keys are not supported by "Symfony\Config\Monolog\HandlerConf  
!!    ig\ExcludedHttpCodeConfig": 0, 1                                             
!!                                                                                 
!!  
!!  
Script @auto-scripts was called via post-install-cmd
```
