### PR TITLE
[DependencyInjection] Fixing missing `arguments`

### DIFF
--- a/security/user_provider.rst
+++ b/security/user_provider.rst
@@ -534,4 +534,5 @@ user provider:
         # ...
 
         App\Security\LoginFormAuthenticator:
-            $userProvider: '@security.user.provider.concrete.backend_users'
+            arguments:
+                $userProvider: '@security.user.provider.concrete.backend_users'


### PR DESCRIPTION
This PR aim to fix a missing `arguments` key in service configuration example.
