### PR TITLE
Added the way to activate remember me in the new authentication system

### DIFF
--- a/security/remember_me.rst
+++ b/security/remember_me.rst
@@ -167,6 +167,27 @@ this:
 The user will then automatically be logged in on subsequent visits while
 the cookie remains valid.
 
+Beware that in the new Authenitaction System you have to set the RememberMeBadge()
+in the authenticate method of the authenticator, like:
+
+.. code-block:: php
+ 
+     public function authenticate(Request $request): PassportInterface
+        {
+            $email = $request->request->get('email', '');
+
+            $request->getSession()->set(Security::LAST_USERNAME, $email);
+
+            return new Passport(
+                new UserBadge($email),
+                new PasswordCredentials($request->request->get('password', '')),
+                [
+                    new CsrfTokenBadge('authenticate', $request->get('_csrf_token')),
+                    new RememberMeBadge(),
+                ]
+            );
+        }
+
 Forcing the User to Re-Authenticate before Accessing certain Resources
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
I had to search a while for myself not understanding why I did not have a REMEMBERME cookie when I activated the new system. So maybe handy to add it.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
