### PR TITLE
Minor change at email_validation_mode

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2398,7 +2398,7 @@ email_validation_mode
 
 **type**: ``string`` **default**: ``loose``
 
-It controls the way email addresses are validated by the
+Sets the default value for 
 :doc:`/reference/constraints/Email` validator. The possible values are:
 
 * ``loose``, it uses a simple regular expression to validate the address (it


### PR DESCRIPTION
Info is taken from https://github.com/symfony/symfony/issues/41855#issuecomment-868670803

Maybe you should create an include to use the same wording for here and https://symfony.com/doc/4.4/reference/constraints/Email.html#mode
(But please merge https://github.com/symfony/symfony-docs/pull/15467 first)