### PR TITLE
Upgrade popper package to v2

### DIFF
--- a/frontend/encore/bootstrap.rst
+++ b/frontend/encore/bootstrap.rst
@@ -43,7 +43,7 @@ used in your application:
 .. code-block:: terminal
 
     // jQuery is only required in versions prior to Bootstrap 5
-    $ yarn add jquery popper.js --dev
+    $ yarn add jquery @popperjs/core --dev
 
 Now, require bootstrap from any of your JavaScript files:
 


### PR DESCRIPTION
Bootstrap 5 is using popper v2

Based on https://popper.js.org/docs/v2/migration-guide/

from `popper.js` to `@popperjs/core`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
