### PR TITLE
Minor clarification

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -947,10 +947,10 @@ This can be configured by replacing the ``dsn`` configuration entry with a
 By default the first transport is used. The other transports can be used by
 adding a text header ``X-Transport`` to an email::
 
-    // Send using first "main" transport ...
+    // Send using first transport ("main"):
     $mailer->send($email);
 
-    // ... or use the "alternative" one
+    // ... or use the transport "alternative":
     $email->getHeaders()->addTextHeader('X-Transport', 'alternative');
     $mailer->send($email);
 


### PR DESCRIPTION
The text above says:
> By default the first transport is used

The wording I changed suggested that the first transport called "main" is used (not the very first one in total).
