### PR TITLE
Fixed ambiguous sentence

### DIFF
--- a/setup/upgrade_minor.rst
+++ b/setup/upgrade_minor.rst
@@ -41,7 +41,7 @@ probably need to update the version constraint next to each library starting
               "...": "...",
 
               "...": "A few libraries starting with
-                      symfony/ follow their versioning scheme. You
+                      symfony/ follow their own versioning scheme. You
                       do not need to update these versions: you can
                       upgrade them independently whenever you want",
               "symfony/monolog-bundle": "^3.5",


### PR DESCRIPTION
Fixed sentence that created confusion: "A few libraries starting with symfony/ follow their versioning scheme." should contain "own"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
