### PR TITLE
Update testing.rst

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -261,8 +261,8 @@ the container is stored in ``self::$container``::
             // (1) boot the Symfony kernel
             self::bootKernel();
 
-            // (2) use self::$container to access the service container
-            $container = self::$container;
+            // (2) use static::getContainer() to access the service container
+            $container = static::getContainer();
 
             // (3) run some service & test the result
             $newsletterGenerator = $container->get(NewsletterGenerator::class);


### PR DESCRIPTION
Deprecated self::$container since Symfony 5.3, use static::getContainer() instead
