### PR TITLE
[DependencyInjection] Typo in class name

### DIFF
--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -204,7 +204,7 @@ method name:
 
             App\Email\NewsletterManager:
                 class:   App\Email\NewsletterManager
-                factory: '@App\Email\NewsletterManagerFactory'
+                factory: '@App\Email\InvokableNewsletterManagerFactory'
 
     .. code-block:: xml
 
@@ -220,7 +220,7 @@ method name:
 
                 <service id="App\Email\NewsletterManager"
                          class="App\Email\NewsletterManager">
-                    <factory service="App\Email\NewsletterManagerFactory"/>
+                    <factory service="App\Email\InvokableNewsletterManagerFactory"/>
                 </service>
             </services>
         </container>
@@ -237,7 +237,7 @@ method name:
             $services = $configurator->services();
 
             $services->set(NewsletterManager::class)
-                ->factory(service(NewsletterManagerFactory::class));
+                ->factory(service(InvokableNewsletterManagerFactory::class));
         };
 
 .. _factories-passing-arguments-factory-method:


### PR DESCRIPTION
Set right name for the name of factory class

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
