### PR TITLE
[Mailer] Update section setting headers globally

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -605,6 +605,11 @@ and headers.
 .. versionadded:: 5.2
 
     The ``headers`` option was introduced in Symfony 5.2.
+    
+.. caution::
+
+    The usage of keywords like ``from`` in the ``headers`` is not supported for every 3rd party provider (e.g. `Mailjet API V3`_). 
+    Please consult your provider's documentation before setting the ``headers`` globally.
 
 Handling Sending Failures
 -------------------------
@@ -1496,3 +1501,4 @@ you can use the built in assertions::
 .. _`PEM encoded`: https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail
 .. _`default_socket_timeout`: https://www.php.net/manual/en/filesystem.configuration.php#ini.default-socket-timeout
 .. _`RFC 3986`: https://www.ietf.org/rfc/rfc3986.txt
+.. _`Mailjet API V3`: https://dev.mailjet.com/email/guides/send-api-v31/#add-email-headers


### PR DESCRIPTION
**Description**

Added caution to clarify that setting headers globally is not supported for every 3rd party provider / transport with keywords like "from" (e.g. [Mailjet API V3](https://dev.mailjet.com/email/guides/send-api-v31/#add-email-headers)).