### PR TITLE
[DependencyInjection] Minor - add note that file_put_contents is non-atomic

### DIFF
--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -468,6 +468,14 @@ serves at dumping the compiled container::
         file_put_contents($file, $dumper->dump());
     }
 
+
+.. tip::
+
+    Call to `file_put_contents` is not atomic. When generating container in
+    a production  environment with multiple concurrent requests, use `dumpFile`
+    from `component-filesystem` instead. This generates file in tmp and moves it
+    to its destination only once it's fully written to.
+    
 ``ProjectServiceContainer`` is the default name given to the dumped container
 class. However, you can change this with the ``class`` option when you
 dump it::
@@ -559,6 +567,11 @@ for these resources and use them as metadata for the cache::
 
     require_once $file;
     $container = new MyCachedContainer();
+    
+.. note::
+
+    Using `$containerConfigCache->write` also makes sure that
+    the file write operation is atomic.
 
 Now the cached dumped container is used regardless of whether debug mode
 is on or not. The difference is that the ``ConfigCache`` is set to debug


### PR DESCRIPTION
I have minor gripe with article at https://symfony.com/doc/current/components/dependency_injection/compilation.html#dumping-the-configuration-for-performance

While the final snippet is fine, there are some examples along the way that suggest using `file_put_contents` to write cached container, without using `LOCK_EX`. I think that could produce some issues in production environment. With multiple concurrent requests, one might partially write the file, while other could try to require it before it is ready.

Maybe it's worth adding a note as suggested in this MR, to make readers aware of this fact?