### PR TITLE
Remove 5.x versionadded directives

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -368,7 +368,7 @@ Use the ``auto`` Password Hasher
 
 The :ref:`auto password hasher <reference-security-encoder-auto>` automatically
 selects the best possible encoder/hasher depending on your PHP installation.
-Starting from Symfony 5.3, the default auto hasher is ``bcrypt``.
+Currently, the default auto hasher is ``bcrypt``.
 
 Use Voters to Implement Fine-grained Security Restrictions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cache.rst
+++ b/cache.rst
@@ -107,10 +107,6 @@ The Cache component comes with a series of adapters pre-configured:
 * :doc:`cache.adapter.redis </components/cache/adapters/redis_adapter>`
 * :ref:`cache.adapter.redis_tag_aware <redis-tag-aware-adapter>` (Redis adapter optimized to work with tags)
 
-.. versionadded:: 5.2
-
-    ``cache.adapter.redis_tag_aware`` has been introduced in Symfony 5.2.
-
 Some of these adapters could be configured via shortcuts. Using these shortcuts
 will create pools with service IDs that follow the pattern ``cache.[type]``.
 
@@ -724,11 +720,6 @@ Clear all caches everywhere:
 
 Encrypting the Cache
 --------------------
-
-.. versionadded:: 5.1
-
-    The :class:`Symfony\\Component\\Cache\\Marshaller\\SodiumMarshaller`
-    class was introduced in Symfony 5.1.
 
 To encrypt the cache using ``libsodium``, you can use the
 :class:`Symfony\\Component\\Cache\\Marshaller\\SodiumMarshaller`.

--- a/components/asset.rst
+++ b/components/asset.rst
@@ -179,10 +179,6 @@ with the :doc:`HttpClient component </http_client>`::
     $manifestUrl = 'https://cdn.example.com/rev-manifest.json';
     $package = new Package(new RemoteJsonManifestVersionStrategy($manifestUrl, $httpClient));
 
-.. versionadded:: 5.1
-
-    The ``RemoteJsonManifestVersionStrategy`` was introduced in Symfony 5.1.
-
 Custom Version Strategies
 .........................
 

--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -90,10 +90,6 @@ convert the request parameters into a JSON string and set the needed HTTP header
     // this encodes parameters as JSON and sets the required CONTENT_TYPE and HTTP_ACCEPT headers
     $crawler = $client->jsonRequest('GET', '/', ['some_parameter' => 'some_value']);
 
-.. versionadded:: 5.3
-
-    The ``jsonRequest()`` method was introduced in Symfony 5.3.
-
 The :method:`Symfony\\Component\\BrowserKit\\AbstractBrowser::xmlHttpRequest` method,
 which defines the same arguments as the ``request()`` method, is a shortcut to
 make AJAX requests::
@@ -177,10 +173,6 @@ provides access to the form properties (e.g. ``$form->getUri()``,
 
 Custom Header Handling
 ~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.2
-
-    The ``getHeaders()`` method was introduced in Symfony 5.2.
 
 The optional HTTP headers passed to the ``request()`` method follows the FastCGI
 request format (uppercase, underscores instead of dashes and prefixed with ``HTTP_``).

--- a/components/cache/adapters/array_cache_adapter.rst
+++ b/components/cache/adapters/array_cache_adapter.rst
@@ -30,7 +30,3 @@ method::
         // is reached, cache follows the LRU model (least recently used items are deleted)
         $maxItems = 0
     );
-
-.. versionadded:: 5.1
-
-    The ``maxLifetime`` and ``maxItems`` options were introduced in Symfony 5.1.

--- a/components/cache/adapters/couchbasebucket_adapter.rst
+++ b/components/cache/adapters/couchbasebucket_adapter.rst
@@ -7,10 +7,6 @@
 Couchbase Cache Adapter
 =======================
 
-.. versionadded:: 5.1
-
-    The CouchbaseBucketAdapter was introduced in Symfony 5.1.
-
 This adapter stores the values in-memory using one (or more) `Couchbase server`_
 instances. Unlike the :ref:`APCu adapter <apcu-adapter>`, and similarly to the
 :ref:`Memcached adapter <memcached-adapter>`, it is not limited to the current server's

--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -435,13 +435,6 @@ The following example shows these methods in practice::
 Deprecating the Option
 ----------------------
 
-.. versionadded:: 5.1
-
-    The signature of the ``setDeprecated()`` method changed from
-    ``setDeprecated(?string $message)`` to
-    ``setDeprecated(string $package, string $version, ?string $message)``
-    in Symfony 5.1.
-
 You can deprecate options using the
 :method:`Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::setDeprecated`
 method::

--- a/components/console/helpers/cursor.rst
+++ b/components/console/helpers/cursor.rst
@@ -4,11 +4,6 @@
 Cursor Helper
 =============
 
-.. versionadded:: 5.1
-
-    The :class:`Symfony\\Component\\Console\\Cursor` class was introduced
-    in Symfony 5.1.
-
 The :class:`Symfony\\Component\\Console\\Cursor` allows you to change the
 cursor position in a console command. This allows you to write on any position
 of the output:

--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -117,10 +117,6 @@ from a predefined list::
         // ... do something with the color
     }
 
-.. versionadded:: 5.2
-
-    Support for using PHP objects as choice values was introduced in Symfony 5.2.
-
 The option which should be selected by default is provided with the third
 argument of the constructor. The default is ``null``, which means that no
 option is the default one.
@@ -241,11 +237,6 @@ You can also specify if you want to not trim the answer by setting it directly w
 
 Accept Multiline Answers
 ~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.2
-
-    The ``setMultiline()`` and ``isMultiline()`` methods were introduced in
-    Symfony 5.2.
 
 By default, the question helper stops reading user input when it receives a newline
 character (i.e., when the user hits ``ENTER`` once). However, you may specify that

--- a/components/console/helpers/table.rst
+++ b/components/console/helpers/table.rst
@@ -265,10 +265,6 @@ Here is a full list of things you can customize:
 
     This method can also be used to override a built-in style.
 
-.. versionadded:: 5.2
-
-    The option to style table cells was introduced in Symfony 5.2.
-
 In addition to the built-in table styles, you can also apply different styles
 to each table cell via :class:`Symfony\\Component\\Console\\Helper\\TableCellStyle`::
 

--- a/components/console/single_command_tool.rst
+++ b/components/console/single_command_tool.rst
@@ -7,11 +7,6 @@ Building a single Command Application
 When building a command line tool, you may not need to provide several commands.
 In such case, having to pass the command name each time is tedious.
 
-.. versionadded:: 5.1
-
-    The :class:`Symfony\\Component\\Console\\SingleCommandApplication` class was
-    introduced in Symfony 5.1.
-
 Fortunately, it is possible to remove this need by declaring a single command
 application::
 

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -299,12 +299,10 @@ config files:
             $services = $configurator->services();
 
             $services->set('mailer', 'Mailer')
-                // the param() method was introduced in Symfony 5.2.
                 ->args([param('mailer.transport')])
             ;
 
             $services->set('newsletter_manager', 'NewsletterManager')
-                // In versions earlier to Symfony 5.1 the service() function was called ref()
                 ->call('setMailer', [service('mailer')])
             ;
         };

--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -192,10 +192,6 @@ Get all the child or ancestor nodes::
     $crawler->filter('body')->children();
     $crawler->filter('body > p')->ancestors();
 
-.. versionadded:: 5.3
-
-    The ``ancestors()`` method was introduced in Symfony 5.3.
-
 Get all the direct child nodes matching a CSS selector::
 
     $crawler->filter('body')->children('p.lorem');
@@ -632,10 +628,6 @@ the whole form or specific field(s)::
 
 Resolving a URI
 ~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.1
-
-    The :class:`Symfony\\Component\\DomCrawler\\UriResolver` helper class was added in Symfony 5.1.
 
 The :class:`Symfony\\Component\\DomCrawler\\UriResolver` class takes an URI
 (relative, absolute, fragment, etc.) and turns it into an absolute URI against

--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -287,10 +287,6 @@ exception on failure::
     // returns a path like : /tmp/prefix_wyjgtF.png
     $filesystem->tempnam('/tmp', 'prefix_', '.png');
 
-.. versionadded:: 5.1
-
-    The option to set a suffix in  ``tempnam()`` was introduced in Symfony 5.1.
-
 ``dumpFile``
 ~~~~~~~~~~~~
 

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -198,10 +198,6 @@ If the request body is a JSON string, it can be accessed using
 
     $data = $request->toArray();
 
-.. versionadded:: 5.2
-
-    The ``toArray()`` method was introduced in Symfony 5.2.
-
 Identifying a Request
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -287,10 +283,6 @@ this complexity and defines some methods for the most common tasks::
     // Parses a query string but maintains dots (PHP parse_str() replaces '.' by '_')
     HeaderUtils::parseQuery('foo[bar.baz]=qux');
     // => ['foo' => ['bar.baz' => 'qux']]
-
-.. versionadded:: 5.2
-
-    The ``parseQuery()`` method was introduced in Symfony 5.2.
 
 Accessing ``Accept-*`` Headers Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -475,10 +467,6 @@ a new object with the modified property::
         ->withDomain('.example.com')
         ->withSecure(true);
 
-.. versionadded:: 5.1
-
-    The ``with*()`` methods were introduced in Symfony 5.1.
-
 Managing the HTTP Cache
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -522,11 +510,6 @@ call::
         'last_modified'    => new \DateTime(),
         'etag'             => 'abcdef',
     ]);
-
-.. versionadded:: 5.1
-
-    The ``must_revalidate``, ``no_cache``, ``no_store``, ``no_transform`` and
-    ``proxy_revalidate`` directives were introduced in Symfony 5.1.
 
 To check if the Response validators (``ETag``, ``Last-Modified``) match a
 conditional value specified in the client Request, use the
@@ -765,11 +748,6 @@ Symfony offers two methods to interact with this preference:
 
 * :method:`Symfony\\Component\\HttpFoundation\\Request::preferSafeContent`;
 * :method:`Symfony\\Component\\HttpFoundation\\Response::setContentSafe`;
-
-.. versionadded:: 5.1
-
-    The ``preferSafeContent()`` and ``setContentSafe()`` methods were introduced
-    in Symfony 5.1.
 
 The following example shows how to detect if the user agent prefers "safe" content::
 

--- a/components/http_foundation/sessions.rst
+++ b/components/http_foundation/sessions.rst
@@ -166,14 +166,6 @@ and "Remember Me" login settings or other user based state information.
 :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBag`
     This is the standard default implementation.
 
-:class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\NamespacedAttributeBag`
-    This implementation allows for attributes to be stored in a structured namespace.
-
-    .. deprecated:: 5.3
-
-        The ``NamespacedAttributeBag`` class is deprecated since Symfony 5.3.
-        If you need this feature, you will have to implement the class yourself.
-
 :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBagInterface`
 has the API
 
@@ -241,20 +233,6 @@ So any processing of this might quickly get ugly, even adding a token to the arr
     $tokens = $session->get('tokens');
     $tokens['c'] = $value;
     $session->set('tokens', $tokens);
-
-.. deprecated:: 5.3
-
-    The ``NamespacedAttributeBag`` class is deprecated since Symfony 5.3.
-    If you need this feature, you will have to implement the class yourself.
-
-With structured namespacing, the key can be translated to the array
-structure like this using a namespace character (which defaults to ``/``)::
-
-    // ...
-    use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
-
-    $session = new Session(new NativeSessionStorage(), new NamespacedAttributeBag());
-    $session->set('tokens/c', $value);
 
 Flash Messages
 ~~~~~~~~~~~~~~

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -250,10 +250,6 @@ can change if the number is used in cash transactions or in other scenarios
     $fractionDigits = Currencies::getFractionDigits('SEK');         // returns: 2
     $cashFractionDigits = Currencies::getCashFractionDigits('SEK'); // returns: 0
 
-.. versionadded:: 5.3
-
-    The ``getCashFractionDigits()`` method was introduced in Symfony 5.3.
-
 Some currencies require to round numbers to the nearest increment of some value
 (e.g. 5 cents). This increment might be different if numbers are formatted for
 cash transactions or other scenarios (e.g. accounting)::
@@ -267,10 +263,6 @@ cash transactions or other scenarios (e.g. accounting)::
     // 5 cents (e.g. if price is 7.42 you pay 7.40; if price is 7.48 you pay 7.50)
     $roundingIncrement = Currencies::getRoundingIncrement('CAD');         // returns: 0
     $cashRoundingIncrement = Currencies::getCashRoundingIncrement('CAD'); // returns: 5
-
-.. versionadded:: 5.3
-
-    The ``getCashRoundingIncrement()`` method was introduced in Symfony 5.3.
 
 All methods (except for ``getFractionDigits()``, ``getCashFractionDigits()``,
 ``getRoundingIncrement()`` and ``getCashRoundingIncrement()``) accept the

--- a/components/ldap.rst
+++ b/components/ldap.rst
@@ -160,11 +160,6 @@ delete existing ones::
     // Removing an existing entry
     $entryManager->remove(new Entry('cn=Test User,dc=symfony,dc=com'));
 
-.. versionadded:: 5.3
-
-    The option to make attribute names case-insensitive in ``getAttribute()``
-    and ``hasAttribute()`` was introduced in Symfony 5.3.
-
 Batch Updating
 ______________
 

--- a/components/lock.rst
+++ b/components/lock.rst
@@ -123,14 +123,9 @@ they can be decorated with the ``RetryTillSaveStore`` class::
 When the provided store does not implement the
 :class:`Symfony\\Component\\Lock\\BlockingStoreInterface` interface, the
 ``Lock`` class will retry to acquire the lock in a non-blocking way until the
-lock is acquired.
-
-.. deprecated:: 5.2
-
-    As of Symfony 5.2, you don't need to use the ``RetryTillSaveStore`` class
-    anymore. The ``Lock`` class now provides the default logic to acquire locks
-    in blocking mode when the store does not implement the
-    ``BlockingStoreInterface`` interface.
+lock is acquired. However, the ``Lock`` class also provides the default logic to
+acquire locks in blocking mode when the store does not implement the
+``BlockingStoreInterface`` interface.
 
 Expiring Locks
 --------------
@@ -241,11 +236,6 @@ or until ``Lock::release()`` is called.
 
 Shared Locks
 ------------
-
-.. versionadded:: 5.2
-
-    Shared locks (and the associated ``acquireRead()`` method and
-    ``SharedLockStoreInterface``) were introduced in Symfony 5.2.
 
 A shared or `readers–writer lock`_ is a synchronization primitive that allows
 concurrent access for read-only operations, while write operations require
@@ -410,10 +400,6 @@ support blocking, and expects a TTL to avoid stalled locks::
 MongoDbStore
 ~~~~~~~~~~~~
 
-.. versionadded:: 5.1
-
-    The ``MongoDbStore`` was introduced in Symfony 5.1.
-
 The MongoDbStore saves locks on a MongoDB server ``>=2.2``, it requires a
 ``\MongoDB\Collection`` or ``\MongoDB\Client`` from `mongodb/mongodb`_ or a
 `MongoDB Connection String`_.
@@ -509,10 +495,6 @@ locks::
 
 In opposite to the ``PdoStore``, the ``PostgreSqlStore`` does not need a table to
 store locks and does not expire.
-
-.. versionadded:: 5.2
-
-    The ``PostgreSqlStore`` was introduced in Symfony 5.2.
 
 .. _lock-store-redis:
 

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -720,10 +720,6 @@ In same way, parent options can access to the nested options as normal arrays::
 Prototype Options
 ~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.3
-
-    Prototype options were introduced in Symfony 5.3.
-
 There are situations where you will have to resolve and validate a set of
 options that may repeat many times within another option. Let's imagine a
 ``connections`` option that will accept an array of database connections
@@ -768,13 +764,6 @@ connections.
 
 Deprecating the Option
 ~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.1
-
-    The signature of the ``setDeprecated()`` method changed from
-    ``setDeprecated(string $option, ?string $message)`` to
-    ``setDeprecated(string $option, string $package, string $version, $message)``
-    in Symfony 5.1.
 
 Once an option is outdated or you decided not to maintain it anymore, you can
 deprecate it using the :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::setDeprecated`
@@ -869,10 +858,6 @@ method::
                 ->allowedValues(['sendmail', 'mail', 'smtp']);
         }
     }
-
-.. versionadded:: 5.1
-
-    The ``define()`` and ``info()`` methods were introduced in Symfony 5.1.
 
 Performance Tweaks
 ~~~~~~~~~~~~~~~~~~

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -313,11 +313,6 @@ Then, you can run the following command to use that file and ignore those deprec
 
     $ SYMFONY_DEPRECATIONS_HELPER='baselineFile=./tests/allowed.json' ./vendor/bin/simple-phpunit
 
-.. versionadded:: 5.2
-
-    The ``baselineFile`` and ``generateBaseline`` options were introduced in
-    Symfony 5.2.
-
 Disabling the Verbose Output
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -328,10 +323,6 @@ deprecations and where they arise. If this is too much for you, you can use
 It's also possible to change verbosity per deprecation type. For example, using
 ``quiet[]=indirect&quiet[]=other`` will hide details for deprecations of types
 "indirect" and "other".
-
-.. versionadded:: 5.1
-
-    The ``quiet`` option was introduced in Symfony 5.1.
 
 Disabling the Deprecation Helper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -375,19 +366,11 @@ the compiling and warming up of the container:
 
     $ php bin/console debug:container --deprecations
 
-.. versionadded:: 5.1
-
-    The ``--deprecations`` option was introduced in Symfony 5.1.
-
 Log Deprecations
 ~~~~~~~~~~~~~~~~
 
 For turning the verbose output off and write it to a log file instead you can use
 ``SYMFONY_DEPRECATIONS_HELPER='logFile=/path/deprecations.log'``.
-
-.. versionadded:: 5.3
-
-    The ``logFile`` option was introduced in Symfony 5.3.
 
 Write Assertions about Deprecations
 -----------------------------------
@@ -423,11 +406,6 @@ times (order matters)::
             $this->expectDeprecation('Since vendor-name/package-name 4.4: The second argument of the "%s" method is deprecated.');
         }
     }
-
-.. deprecated:: 5.1
-
-    Symfony versions previous to 5.1 also included a ``@expectedDeprecation``
-    annotation to test deprecations, but it was deprecated in favor of the method.
 
 Display the Full Stack Trace
 ----------------------------
@@ -935,11 +913,6 @@ If you have installed the bridge through Composer, you can run it by calling e.g
     of PHPUnit to be considered. This is useful when testing a framework that does
     not support the latest version(s) of PHPUnit.
 
-.. versionadded:: 5.2
-
-    The ``SYMFONY_MAX_PHPUNIT_VERSION`` env variable was introduced in
-    Symfony 5.2.
-
 .. tip::
 
     If you still need to use ``prophecy`` (but not ``symfony/yaml``),
@@ -953,11 +926,6 @@ If you have installed the bridge through Composer, you can run it by calling e.g
     the rest of the needed PHPUnit packages using the ``SYMFONY_PHPUNIT_REQUIRE``
     env variable. This is specially useful for installing PHPUnit plugins without
     having to add them to your main ``composer.json`` file.
-
-.. versionadded:: 5.3
-
-    The ``SYMFONY_PHPUNIT_REQUIRE`` env variable was introduced in
-    Symfony 5.3.
 
 Code Coverage Listener
 ----------------------

--- a/components/process.rst
+++ b/components/process.rst
@@ -105,10 +105,6 @@ with a non-zero code)::
 Configuring Process Options
 ---------------------------
 
-.. versionadded:: 5.2
-
-    The feature to configure process options was introduced in Symfony 5.2.
-
 Symfony uses the PHP :phpfunction:`proc_open` function to run the processes.
 You can configure the options passed to the ``other_options`` argument of
 ``proc_open()`` using the ``setOptions()`` method::
@@ -451,10 +447,6 @@ check regularly::
 .. tip::
 
     You can get the process start time using the ``getStartTime()`` method.
-
-    .. versionadded:: 5.1
-
-        The ``getStartTime()`` method was introduced in Symfony 5.1.
 
 .. _reference-process-signal:
 

--- a/components/property_access.rst
+++ b/components/property_access.rst
@@ -215,10 +215,10 @@ The ``getValue()`` method can also use the magic ``__get()`` method::
 
     var_dump($propertyAccessor->getValue($person, 'Wouter')); // [...]
 
-.. versionadded:: 5.2
+.. note::
 
-    The magic ``__get()`` method can be disabled since in Symfony 5.2.
-    see `Enable other Features`_.
+    The ``__get()`` method support is enabled by default.
+    See `Enable other Features`_ if you want to disable it.
 
 .. _components-property-access-magic-call:
 
@@ -356,10 +356,10 @@ see `Enable other Features`_::
 
     var_dump($person->getWouter()); // [...]
 
-.. versionadded:: 5.2
+.. note::
 
-    The magic ``__set()`` method can be disabled since in Symfony 5.2.
-    see `Enable other Features`_.
+    The ``__set()`` method support is enabled by default.
+    See `Enable other Features`_ if you want to disable it.
 
 Writing to Array Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -441,10 +441,6 @@ If ``serializer_groups`` is set to ``null``, serializer groups metadata won't be
 checked but you will get only the properties considered by the Serializer
 Component (notably the ``@Ignore`` annotation is taken into account).
 
-.. versionadded:: 5.2
-
-    Support for the ``null`` value in ``serializer_groups`` was introduced in Symfony 5.2. 
-
 DoctrineExtractor
 ~~~~~~~~~~~~~~~~~
 

--- a/components/runtime.rst
+++ b/components/runtime.rst
@@ -9,10 +9,6 @@ The Runtime Component
     to make sure the application can run with runtimes like PHP-FPM, ReactPHP,
     Swoole, etc. without any changes.
 
-.. versionadded:: 5.3
-
-    The Runtime component was introduced in Symfony 5.3.
-
 Installation
 ------------
 
@@ -361,12 +357,6 @@ Using the Runtime component will benefit maintainers because the bootstrap
 logic could be versioned as a part of a normal package. If the application
 author decides to use this component, the package maintainer of the Runtime
 class will have more control and can fix bugs and add features.
-
-.. note::
-
-    Before Symfony 5.3, the Symfony bootstrap logic was part of a Flex recipe.
-    Since recipes are rarely updated by users, bug patches would rarely be
-    installed.
 
 The Runtime component is designed to be totally generic and able to run any
 application outside of the global state in 6 steps:

--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -130,8 +130,6 @@ password was valid::
     use Symfony\Component\Security\Core\User\InMemoryUserProvider;
     use Symfony\Component\Security\Core\User\UserChecker;
 
-    // The 'InMemoryUser' class was introduced in Symfony 5.3.
-    // In previous versions it was called 'User'
     $userProvider = new InMemoryUserProvider(
         [
             'admin' => [

--- a/components/security/authorization.rst
+++ b/components/security/authorization.rst
@@ -54,10 +54,6 @@ recognizes several strategies:
 ``priority``
     grants or denies access by the first voter that does not abstain;
 
-    .. versionadded:: 5.1
-
-        The ``priority`` version strategy was introduced in Symfony 5.1.
-
 Usage of the available options in detail::
 
     use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
@@ -116,11 +112,6 @@ authenticated anonymously?
 It also supports the attributes ``IS_ANONYMOUS``, ``IS_REMEMBERED``,
 ``IS_IMPERSONATOR`` to grant access based on a specific state of
 authentication.
-
-.. versionadded:: 5.1
-
-    The ``IS_ANONYMOUS``, ``IS_REMEMBERED`` and ``IS_IMPERSONATOR``
-    attributes were introduced in Symfony 5.1.
 
 ::
 

--- a/components/security/secure_tools.rst
+++ b/components/security/secure_tools.rst
@@ -7,9 +7,9 @@ also use them if you want to solve the problem they address.
 
 .. note::
 
-    The functions described in this article were introduced in PHP 5.6 or 7.
-    For older PHP versions, a polyfill is provided by the
-    `Symfony Polyfill Component`_.
+    The functions described in this article are available in modern PHP versions.
+    If your project uses a legacy PHP version, you can use them thanks to some
+    of the polyfills provided by the `Symfony Polyfill Component`_.
 
 Comparing Strings
 ~~~~~~~~~~~~~~~~~

--- a/components/semaphore.rst
+++ b/components/semaphore.rst
@@ -8,10 +8,6 @@ The Semaphore Component
     The Semaphore Component manages `semaphores`_, a mechanism to provide
     exclusive access to a shared resource.
 
-.. versionadded:: 5.2
-
-    The Semaphore Component was introduced in Symfony 5.2.
-
 Installation
 ------------
 

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -899,14 +899,6 @@ The Serializer component provides several built-in normalizers:
     Also it can denormalize ``uuid`` or ``ulid`` strings to :class:`Symfony\\Component\\Uid\\Uuid`
     or :class:`Symfony\\Component\\Uid\\Ulid`. The format does not matter.
 
-.. versionadded:: 5.2
-
-    The ``UidNormalizer`` was introduced in Symfony 5.2.
-
-.. versionadded:: 5.3
-
-    The ``UidNormalizer`` normalization formats were introduced in Symfony 5.3.
-
 .. _component-serializer-encoders:
 
 Encoders
@@ -1003,10 +995,6 @@ Option                  Description                                            D
 ``no_headers``          Disables header in the encoded CSV                     ``false``
 ``output_utf8_bom``     Outputs special `UTF-8 BOM`_ along with encoded data   ``false``
 ======================= =====================================================  ==========================
-
-.. versionadded:: 5.3
-
-    The ``csv_end_of_line`` option was introduced in Symfony 5.3.
 
 The ``XmlEncoder``
 ~~~~~~~~~~~~~~~~~~

--- a/components/string.rst
+++ b/components/string.rst
@@ -8,10 +8,6 @@ The String Component
     The String component provides a single object-oriented API to work with
     three "unit systems" of strings: bytes, code points and grapheme clusters.
 
-.. versionadded:: 5.0
-
-    The String component was introduced in Symfony 5.0.
-
 Installation
 ------------
 
@@ -129,10 +125,6 @@ to make your code more concise::
     // creates a UnicodeString object
     $foo = s('अनुच्छेद');
 
-.. versionadded:: 5.1
-
-    The ``s()`` function was introduced in Symfony 5.1.
-
 There are also some specialized constructors::
 
     // ByteString can create a random string of the given length
@@ -145,10 +137,6 @@ There are also some specialized constructors::
     // CodePointString and UnicodeString can create a string from code points
     $foo = UnicodeString::fromCodePoints(0x928, 0x92E, 0x938, 0x94D, 0x924, 0x947);
     // equivalent to: $foo = new UnicodeString('नमस्ते');
-
-.. versionadded:: 5.1
-
-    The second argument of ``ByteString::fromRandom()`` was introduced in Symfony 5.1.
 
 Methods to Transform String Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -354,10 +342,6 @@ Methods to Search and Replace
         return '['.$match[0].']';
     }); // result = '[1][2][3]'
 
-.. versionadded:: 5.1
-
-    The ``containsAny()`` method was introduced in Symfony 5.1.
-
 Methods to Join, Split, Truncate and Reverse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -388,10 +372,6 @@ Methods to Join, Split, Truncate and Reverse
     // even if that generates a string longer than the desired length
     u('Lorem Ipsum')->truncate(8, '…', false); // 'Lorem Ipsum'
 
-.. versionadded:: 5.1
-
-    The third argument of ``truncate()`` was introduced in Symfony 5.1.
-
 ::
 
     // breaks the string into lines of the given length
@@ -413,10 +393,6 @@ Methods to Join, Split, Truncate and Reverse
     // reverses the order of the string contents
     u('foo bar')->reverse(); // 'rab oof'
     u('さよなら')->reverse(); // 'らなよさ'
-
-.. versionadded:: 5.1
-
-    The ``reverse()`` method was introduced in Symfony 5.1.
 
 Methods Added by ByteString
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -488,18 +464,6 @@ that only includes safe ASCII characters::
         return str_replace('❤️', 'love', $string);
     });
 
-.. versionadded:: 5.1
-
-    The feature to define additional substitutions was introduced in Symfony 5.1.
-
-.. versionadded:: 5.2
-
-    The feature to use a PHP closure to define substitutions was introduced in Symfony 5.2.
-
-.. versionadded:: 5.3
-
-    The feature to fallback to the parent locale's symbols map was introduced in Symfony 5.3.
-
 The separator between words is a dash (``-``) by default, but you can define
 another separator as the second argument::
 
@@ -543,10 +507,6 @@ the injected slugger is the same as the request locale::
 
 Inflector
 ---------
-
-.. versionadded:: 5.1
-
-    The inflector feature was introduced in Symfony 5.1.
 
 In some scenarios such as code generation and code introspection, you need to
 convert words from/to singular/plural. For example, to know the property

--- a/components/uid.rst
+++ b/components/uid.rst
@@ -8,10 +8,6 @@ The UID Component
     The UID component provides utilities to work with `unique identifiers`_ (UIDs)
     such as UUIDs and ULIDs.
 
-.. versionadded:: 5.1
-
-    The UID component was introduced in Symfony 5.1.
-
 Installation
 ------------
 
@@ -67,11 +63,6 @@ to create each type of UUID::
     // It's defined in http://gh.peabody.io/uuidv6/
     $uuid = Uuid::v6(); // $uuid is an instance of Symfony\Component\Uid\UuidV6
 
-.. versionadded:: 5.3
-
-    The ``Uuid::NAMESPACE_*`` constants and the namespace string values (``'dns'``,
-    ``'url'``, etc.) were introduced in Symfony 5.3.
-
 If your UUID value is already generated in another format, use any of the
 following methods to create a ``Uuid`` object from it::
 
@@ -81,11 +72,6 @@ following methods to create a ``Uuid`` object from it::
     $uuid = Uuid::fromBase32('6SWYGR8QAV27NACAHMK5RG0RPG');
     $uuid = Uuid::fromBase58('TuetYWNHhmuSQ3xPoVLv9M');
     $uuid = Uuid::fromRfc4122('d9e7a184-5d5b-11ea-a62a-3499710062d0');
-
-.. versionadded:: 5.3
-
-    The ``fromBinary()``, ``fromBase32()``, ``fromBase58()`` and ``fromRfc4122()``
-    methods were introduced in Symfony 5.3.
 
 Converting UUIDs
 ~~~~~~~~~~~~~~~~
@@ -133,11 +119,6 @@ UUID objects created with the ``Uuid`` class can use the following methods
     //   * int < 0 if $uuid1 is less than $uuid4
     $uuid1->compare($uuid4); // e.g. int(4)
 
-.. versionadded:: 5.3
-
-    The ``getDateTime()`` method was introduced in Symfony 5.3. In previous
-    versions it was called ``getTime()``.
-
 Storing UUIDs in Databases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -161,10 +142,6 @@ type, which converts to/from UUID objects automatically::
 
         // ...
     }
-
-.. versionadded:: 5.2
-
-    The UUID type was introduced in Symfony 5.2.
 
 There is no generator to assign UUIDs automatically as the value of your entity
 primary keys, but you can use the following::
@@ -264,11 +241,6 @@ following methods to create a ``Ulid`` object from it::
     $ulid = Ulid::fromBase58('1BKocMc5BnrVcuq2ti4Eqm');
     $ulid = Ulid::fromRfc4122('0171069d-593d-97d3-8b3e-23d06de5b308');
 
-.. versionadded:: 5.3
-
-    The ``fromBinary()``, ``fromBase32()``, ``fromBase58()`` and ``fromRfc4122()``
-    methods were introduced in Symfony 5.3.
-
 Converting ULIDs
 ~~~~~~~~~~~~~~~~
 
@@ -301,11 +273,6 @@ ULID objects created with the ``Ulid`` class can use the following methods::
     $ulid1->equals($ulid2); // false
     // this method returns $ulid1 <=> $ulid2
     $ulid1->compare($ulid2); // e.g. int(-1)
-
-.. versionadded:: 5.3
-
-    The ``getDateTime()`` method was introduced in Symfony 5.3. In previous
-    versions it was called ``getTime()``.
 
 Storing ULIDs in Databases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -361,10 +328,6 @@ entity primary keys::
 
     }
 
-.. versionadded:: 5.2
-
-    The ULID type and generator were introduced in Symfony 5.2.
-
 When using built-in Doctrine repository methods (e.g. ``findOneBy()``), Doctrine
 knows how to convert these ULID types to build the SQL query
 (e.g. ``->findOneBy(['user' => $user->getUlid()])``). However, when using DQL
@@ -396,10 +359,6 @@ of the ULID parameters::
 
 Generating and Inspecting UUIDs/ULIDs in the Console
 ----------------------------------------------------
-
-.. versionadded:: 5.3
-
-    The commands to inspect and generate UUIDs/ULIDs were introduced in Symfony 5.3.
 
 This component provides several commands to generate and inspect UUIDs/ULIDs in
 the console. They are not enabled by default, so you must add the following

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -191,10 +191,6 @@ Then you can use the following command to start a server out-of-the-box:
 Configuring the Dump Server with Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.2
-
-    The ``VAR_DUMPER_FORMAT=server`` feature was introduced in Symfony 5.2.
-
 If you prefer to not modify the application configuration (e.g. to quickly debug
 a project given to you) use the ``VAR_DUMPER_FORMAT`` env var.
 

--- a/components/yaml/yaml_format.rst
+++ b/components/yaml/yaml_format.rst
@@ -124,12 +124,6 @@ Numbers
     # an octal
     0o14
 
-.. deprecated:: 5.1
-
-    In YAML 1.1, octal numbers use the notation ``0...``, whereas in YAML 1.2
-    the notation changes to ``0o...``. Symfony 5.1 added support for YAML 1.2
-    notation and deprecated support for YAML 1.1 notation.
-
 .. code-block:: yaml
 
     # an hexadecimal

--- a/configuration.rst
+++ b/configuration.rst
@@ -919,11 +919,6 @@ parameters at once by type-hinting any of its constructor arguments with the
 Using PHP ConfigBuilders
 ------------------------
 
-.. versionadded:: 5.3
-
-    The "ConfigBuilders" feature was introduced in Symfony 5.3 as an
-    :doc:`experimental feature </contributing/code/experimental>`.
-
 Writing PHP config is sometimes difficult because you end up with large nested
 arrays and you have no autocompletion help from your favorite IDE. A way to
 address this is to use "ConfigBuilders". They are objects that will help you

--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -151,11 +151,6 @@ Symfony provides the following env var processors:
             };
 
 ``env(not:FOO)``
-
-    .. versionadded:: 5.3
-
-        The ``not:`` env var processor was introduced in Symfony 5.3.
-
     Casts ``FOO`` to a bool (just as ``env(bool:...)`` does) except it returns the inverted value
     (falsy values are returned as ``true``, truthy values are returned as ``false``):
 

--- a/console.rst
+++ b/console.rst
@@ -64,15 +64,6 @@ want a command to create a user::
         }
     }
 
-.. versionadded:: 5.1
-
-    The ``Command::SUCCESS`` and ``Command::FAILURE`` constants were introduced
-    in Symfony 5.1.
-
-.. versionadded:: 5.3
-
-    The ``Command::INVALID`` constant was introduced in Symfony 5.3
-
 Configuring the Command
 -----------------------
 
@@ -396,15 +387,6 @@ console::
 
 If you are using a :doc:`single-command application </components/console/single_command_tool>`,
 call ``setAutoExit(false)`` on it to get the command result in ``CommandTester``.
-
-.. versionadded:: 5.2
-
-    The ``setAutoExit()`` method for single-command applications was introduced
-    in Symfony 5.2.
-
-.. versionadded:: 5.4
-
-    The ``assertCommandIsSuccessful()`` method was introduced in Symfony 5.4.
 
 .. tip::
 

--- a/console/coloring.rst
+++ b/console/coloring.rst
@@ -50,14 +50,6 @@ Any hex color is supported for foreground and background colors. Besides that, t
 ``gray``, ``bright-red``, ``bright-green``, ``bright-yellow``, ``bright-blue``,
 ``bright-magenta``, ``bright-cyan`` and ``bright-white``.
 
-.. versionadded:: 5.2
-
-    True (hex) color support was introduced in Symfony 5.2
-
-.. versionadded:: 5.3
-
-    Support for bright colors was introduced in Symfony 5.3.
-
 .. note::
 
     If the terminal doesn't support true colors, the nearest named color is used.

--- a/console/input.rst
+++ b/console/input.rst
@@ -221,10 +221,6 @@ There are five option variants you can use:
     Accept either the flag (e.g. ``--yell``) or its negation (e.g.
     ``--no-yell``).
 
-.. versionadded:: 5.3
-
-    The ``InputOption::VALUE_NEGATABLE`` constant was introduced in Symfony 5.3.
-
 You can combine ``VALUE_IS_ARRAY`` with ``VALUE_REQUIRED`` or
 ``VALUE_OPTIONAL`` like this::
 

--- a/console/lockable_trait.rst
+++ b/console/lockable_trait.rst
@@ -43,8 +43,4 @@ that adds two convenient methods to lock and release commands::
         }
     }
 
-.. versionadded:: 5.1
-
-    The ``Command::SUCCESS`` constant was introduced in Symfony 5.1.
-
 .. _`locks`: https://en.wikipedia.org/wiki/Lock_(computer_science)

--- a/console/style.rst
+++ b/console/style.rst
@@ -342,10 +342,6 @@ Result Methods
             'Consectetur adipiscing elit',
         ]);
 
-.. versionadded:: 5.2
-
-    The ``info()`` method was introduced in Symfony 5.2.
-
 :method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::warning`
     It displays the given string or array of strings highlighted as a warning
     message (with a red background and the ``[WARNING]`` label). It's meant to be

--- a/contributing/documentation/format.rst
+++ b/contributing/documentation/format.rst
@@ -174,32 +174,32 @@ If you are documenting a brand new feature, a change or a deprecation that's
 been made in Symfony, you should precede your description of the change with
 the corresponding directive and a short description:
 
-For a new feature or a behavior change use the ``.. versionadded:: 5.x``
+For a new feature or a behavior change use the ``.. versionadded:: 6.x``
 directive:
 
 .. code-block:: rst
 
-    .. versionadded:: 5.2
+    .. versionadded:: 6.2
 
-        ... ... ... was introduced in Symfony 5.2.
+        ... ... ... was introduced in Symfony 6.2.
 
 If you are documenting a behavior change, it may be helpful to *briefly*
 describe how the behavior has changed:
 
 .. code-block:: rst
 
-    .. versionadded:: 5.2
+    .. versionadded:: 6.2
 
-       ... ... ... was introduced in Symfony 5.2. Prior to this,
+       ... ... ... was introduced in Symfony 6.2. Prior to this,
        ... ... ... ... ... ... ... ... .
 
-For a deprecation use the ``.. deprecated:: 5.x`` directive:
+For a deprecation use the ``.. deprecated:: 6.x`` directive:
 
 .. code-block:: rst
 
-    .. deprecated:: 5.2
+    .. deprecated:: 6.2
 
-        ... ... ... was deprecated in Symfony 5.2.
+        ... ... ... was deprecated in Symfony 6.2.
 
 Whenever a new major version of Symfony is released (e.g. 6.0, 7.0, etc),
 a new branch of the documentation is created from the ``master`` branch.

--- a/deployment/proxies.rst
+++ b/deployment/proxies.rst
@@ -81,12 +81,6 @@ and what headers your reverse proxy uses to send information:
             ;
         };
 
-.. deprecated:: 5.2
-
-    In previous Symfony versions, the above example used ``HEADER_X_FORWARDED_ALL``
-    to trust all "X-Forwarded-" headers, but that constant is deprecated since
-    Symfony 5.2 in favor of the individual ``HEADER_X_FORWARDED_*`` constants.
-
 .. caution::
 
     Enabling the ``Request::HEADER_X_FORWARDED_HOST`` option exposes the
@@ -96,13 +90,6 @@ and what headers your reverse proxy uses to send information:
 The Request object has several ``Request::HEADER_*`` constants that control exactly
 *which* headers from your reverse proxy are trusted. The argument is a bit field,
 so you can also pass your own value (e.g. ``0b00110``).
-
-.. versionadded:: 5.2
-
-    The feature to configure trusted proxies and headers with ``trusted_proxies``
-    and ``trusted_headers`` options was introduced in Symfony 5.2. In earlier
-    Symfony versions you needed to use the ``Request::setTrustedProxies()``
-    method in the ``public/index.php`` file.
 
 .. caution::
 

--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -524,10 +524,6 @@ can do it in the service configuration:
             ;
         };
 
-.. versionadded:: 5.3
-
-    Subscriber priority was introduced in Symfony 5.3.
-
 .. tip::
 
     Symfony loads (and instantiates) Doctrine subscribers whenever the

--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -220,8 +220,6 @@ a "main" request or a "sub request"::
     {
         public function onKernelRequest(RequestEvent $event)
         {
-            // The isMainRequest() method was introduced in Symfony 5.3.
-            // In previous versions it was called isMasterRequest()
             if (!$event->isMainRequest()) {
                 // don't do anything if it's not the main request
                 return;
@@ -331,10 +329,6 @@ or can get everything which partial matches the event name:
     $ php bin/console debug:event-dispatcher kernel // matches "kernel.exception", "kernel.response" etc.
     $ php bin/console debug:event-dispatcher Security // matches "Symfony\Component\Security\Http\Event\CheckPassportEvent"
 
-.. versionadded:: 5.3
-
-    The ability to match partial event names was introduced in Symfony 5.3.
-
 The :doc:`new authenticator-based Security </security/authenticator_manager>`
 system adds an event dispatcher per firewall. Use the ``--dispatcher`` option to
 get the registered listeners for a particular event dispatcher:
@@ -342,10 +336,6 @@ get the registered listeners for a particular event dispatcher:
 .. code-block:: terminal
 
     $ php bin/console debug:event-dispatcher --dispatcher=security.event_dispatcher.main
-
-.. versionadded:: 5.3
-
-    The ``dispatcher`` option was introduced in Symfony 5.3.
 
 Learn more
 ----------

--- a/form/bootstrap5.rst
+++ b/form/bootstrap5.rst
@@ -1,10 +1,6 @@
 Bootstrap 5 Form Theme
 ======================
 
-.. versionadded:: 5.3
-
-    The Bootstrap 5 Form Theme was introduced in Symfony 5.3.
-
 Symfony provides several ways of integrating Bootstrap into your application.
 The most straightforward way is to add the required ``<link>`` and ``<script>``
 elements in your templates (usually you only include them in the main layout

--- a/form/data_mappers.rst
+++ b/form/data_mappers.rst
@@ -224,10 +224,6 @@ If available, these options have priority over the property path accessor and
 the default data mapper will still use the :doc:`PropertyAccess component </components/property_access>`
 for the other form fields.
 
-.. versionadded:: 5.2
-
-    The ``getter`` and ``setter`` options were introduced in Symfony 5.2.
-
 .. caution::
 
     When a form has the ``inherit_data`` option set to ``true``, it does not use the data mapper and

--- a/form/form_themes.rst
+++ b/form/form_themes.rst
@@ -47,14 +47,6 @@ in a single Twig template and they are enabled in the
   element with the absolute minimum styles to make them usable. It is based on the
   `Tailwind CSS form plugin`_.
 
-.. versionadded:: 5.1
-
-    The ``foundation_6_layout.html.twig`` was introduced in Symfony 5.1.
-
-.. versionadded:: 5.3
-
-    The ``bootstrap_5_layout.html.twig``, ``bootstrap_5_horizontal_layout.html.twig`` and ``tailwind_2_layout.html.twig`` were introduced in Symfony 5.3.
-
 .. tip::
 
     Read the articles about :doc:`Bootstrap 4 Symfony form theme </form/bootstrap4>` and :doc:`Bootstrap 5 Symfony form theme </form/bootstrap5>`
@@ -347,10 +339,6 @@ You can also customize each entry of all collections with the following blocks:
     {% block collection_entry_widget %} ... {% endblock %}
     {% block collection_entry_help %} ... {% endblock %}
     {% block collection_entry_errors %} ... {% endblock %}
-
-.. versionadded:: 5.1
-
-    The ``collection_entry_*`` blocks were introduced in Symfony 5.1.
 
 Finally, you can customize specific form collections instead of all of them.
 For example, consider the following complex example where a ``TaskManagerType``

--- a/forms.rst
+++ b/forms.rst
@@ -590,10 +590,6 @@ learn more about the validation constraints, please refer to the
 Form Validation Messages
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.2
-
-    The ``legacy_error_messages`` option was introduced in Symfony 5.2
-
 The form types have default error messages that are more clear and
 user-friendly than the ones provided by the validation constraints. To enable
 these new messages set the ``legacy_error_messages`` option to ``false``:

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -360,11 +360,6 @@ Additionally, most cache-related HTTP headers can be set via the single
         'etag'             => 'abcdef'
     ]);
 
-.. versionadded:: 5.1
-
-    The ``must_revalidate``, ``no_cache``, ``no_store``, ``no_transform`` and
-    ``proxy_revalidate`` directives were introduced in Symfony 5.1.
-
 Cache Invalidation
 ------------------
 

--- a/http_client.rst
+++ b/http_client.rst
@@ -146,10 +146,6 @@ method to retrieve a new instance of the client with new default options::
         'headers' => ['header-name' => 'header-value']
     ]);
 
-.. versionadded:: 5.3
-
-    The ``withOptions()`` method was introduced in Symfony 5.3.
-
 Some options are described in this guide:
 
 * `Authentication`_
@@ -659,10 +655,6 @@ according to the ``multipart/form-data`` content-type. The
         $formData->getParts(); // Returns two instances of TextPart both
                                // with the name "array_field"
 
-    .. versionadded:: 5.2
-
-        The alternative array structure was introduced in Symfony 5.2.
-
 By default, HttpClient streams the body contents when uploading them. This might
 not work with all servers, resulting in HTTP status code 411 ("Length Required")
 because there is no ``Content-Length`` header. The solution is to turn the body
@@ -706,10 +698,6 @@ making a request. Use the ``max_redirects`` setting to configure this behavior
 
 Retry Failed Requests
 ~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.2
-
-    The feature to retry failed HTTP requests was introduced in Symfony 5.2.
 
 Sometimes, requests fail because of network issues or temporary server errors.
 Symfony's HttpClient allows to retry failed requests automatically using the
@@ -821,10 +809,6 @@ is installed and enabled. Otherwise, the native PHP streams will be used.
 Configuring CurlHttpClient Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.2
-
-    The feature to configure extra cURL options was introduced in Symfony 5.2.
-
 PHP allows to configure lots of `cURL options`_ via the :phpfunction:`curl_setopt`
 function. In order to make the component more portable when not using cURL, the
 ``CurlHttpClient`` only uses some of those options (and they are ignored in the
@@ -858,12 +842,6 @@ following tools is installed:
 
 * The `libcurl`_ package version 7.36 or higher;
 * The `amphp/http-client`_ Packagist package version 4.2 or higher.
-
-.. versionadded:: 5.1
-
-    Integration with ``amphp/http-client`` was introduced in Symfony 5.1.
-    Prior to this version, HTTP/2 was only supported when ``libcurl`` was
-    installed.
 
 To force HTTP/2 for ``http`` URLs, you need to enable it explicitly via the
 ``http_version`` option:
@@ -1257,10 +1235,6 @@ installed in your application::
 Consuming Server-Sent Events
 ----------------------------
 
-.. versionadded:: 5.2
-
-    The feature to consume server-sent events was introduced in Symfony 5.2.
-
 `Server-sent events`_ is an Internet standard used to push data to web pages.
 Its JavaScript API is built around an `EventSource`_ object, which listens to
 the events sent from some URL. The events are a stream of data (served with the
@@ -1566,10 +1540,6 @@ The solution is to also decorate the response object itself.
 :class:`Symfony\\Component\\HttpClient\\Response\\TraceableResponse` are good
 examples as a starting point.
 
-.. versionadded:: 5.2
-
-    ``AsyncDecoratorTrait`` was introduced in Symfony 5.2.
-
 In order to help writing more advanced response processors, the component provides
 an :class:`Symfony\\Component\\HttpClient\\AsyncDecoratorTrait`. This trait allows
 processing the stream of chunks as they come back from the network::
@@ -1690,10 +1660,6 @@ However, using ``MockResponse`` allows simulating chunked responses and timeouts
     };
 
     $mockResponse = new MockResponse($body());
-
-.. versionadded:: 5.2
-
-    The feature explained below was introduced in Symfony 5.2.
 
 Finally, you can also create an invokable or iterable class that generates the
 responses and use it as a callback in functional tests::

--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -178,10 +178,6 @@ Symfony's MonologBridge provides processors that can be registered inside your a
     Adds information about the user who is impersonating the logged in user,
     namely username, roles and whether the user is authenticated.
 
-    .. versionadded:: 5.2
-
-        The ``SwitchUserTokenProcessor`` was introduced in Symfony 5.2.
-
 :class:`Symfony\\Bridge\\Monolog\\Processor\\WebProcessor`
     Overrides data from the request using the data inside Symfony's request
     object.

--- a/mailer.rst
+++ b/mailer.rst
@@ -80,10 +80,6 @@ over SMTP by configuring the DSN in your ``.env`` file (the ``user``,
 Using Built-in Transports
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.2
-
-    The native protocol was introduced in Symfony 5.2.
-
 ============  ========================================  ==============================================================
 DSN protocol  Example                                   Description
 ============  ========================================  ==============================================================
@@ -113,10 +109,6 @@ Postmark            ``composer require symfony/postmark-mailer``
 SendGrid            ``composer require symfony/sendgrid-mailer``
 Sendinblue          ``composer require symfony/sendinblue-mailer``
 ==================  ==============================================
-
-.. versionadded:: 5.2
-
-    The Sendinblue integration was introduced in Symfony 5.2.
 
 Each library includes a :ref:`Symfony Flex recipe <symfony-flex>` that will add
 a configuration example to your ``.env`` file. For example, suppose you want to
@@ -179,11 +171,6 @@ party provider:
     When using SMTP, the default timeout for sending a message before throwing an
     exception is the value defined in the `default_socket_timeout`_ PHP.ini option.
 
-    .. versionadded:: 5.1
-
-        The usage of ``default_socket_timeout`` as the default timeout was
-        introduced in Symfony 5.1.
-
 .. tip::
 
     If you want to override the default host for a provider (to debug an issue using
@@ -234,11 +221,6 @@ As with the failover transport, round-robin retries deliveries until
 a transport succeeds (or all fail). In contrast to the failover transport,
 it *spreads* the load across all its transports.
 
-.. versionadded:: 5.1
-
-    The random selection of the first transport was introduced in Symfony 5.1.
-    In previous Symfony versions the first transport was always selected first.
-
 TLS Peer Verification
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -248,10 +230,6 @@ disable this verification for security reasons, it can be useful while developin
 the application or when using a self-signed certificate::
 
     $dsn = 'smtp://user:pass@smtp.example.com?verify_peer=0';
-
-.. versionadded:: 5.1
-
-    The ``verify_peer`` option was introduced in Symfony 5.1.
 
 Creating & Sending Messages
 ---------------------------
@@ -332,10 +310,6 @@ both strings or address objects::
     The local part of the address (what goes before the ``@``) can include UTF-8
     characters, except for the sender address (to avoid issues with bounced emails).
     For example: ``föóbàr@example.com``, ``用户@example.com``, ``θσερ@example.com``, etc.
-
-    .. versionadded:: 5.2
-
-        Support for UTF-8 characters in email addresses was introduced in Symfony 5.2.
 
 Use ``addTo()``, ``addCc()``, or ``addBcc()`` methods to add more addresses::
 
@@ -524,10 +498,6 @@ and headers.
             $mailer->header('bcc')->value('baz@example.com');
             $mailer->header('X-Custom-Header')->value('foobar');
         };
-
-.. versionadded:: 5.2
-
-    The ``headers`` option was introduced in Symfony 5.2.
 
 Handling Sending Failures
 -------------------------
@@ -1004,10 +974,6 @@ key but not a certificate::
         ->toArray()
     );
 
-.. versionadded:: 5.2
-
-    The DKIM signer was introduced in Symfony 5.2.
-
 Encrypting Messages
 ~~~~~~~~~~~~~~~~~~~
 
@@ -1221,18 +1187,8 @@ disable asynchronous delivery.
                 ->messageBus('app.another_bus');
         };
 
-.. versionadded:: 5.1
-
-    The ``message_bus`` option was introduced in Symfony 5.1.
-
 Adding Tags and Metadata to Emails
 ----------------------------------
-
-.. versionadded:: 5.1
-
-    The :class:`Symfony\\Component\\Mailer\\Header\\TagHeader` and
-    :class:`Symfony\\Component\\Mailer\\Header\\MetadataHeader` classes were
-    introduced in Symfony 5.1.
 
 Certain 3rd party transports support email *tags* and *metadata*, which can be used
 for grouping, tracking and workflows. You can add those by using the

--- a/messenger.rst
+++ b/messenger.rst
@@ -613,10 +613,6 @@ You can limit the worker to only process messages from specific queues:
 To allow using the ``queues`` option, the receiver must implement the
 :class:`Symfony\\Component\\Messenger\\Transport\\Receiver\\QueueReceiverInterface`.
 
-.. versionadded:: 5.3
-
-    Limiting the worker to specific queues was introduced in Symfony 5.3.
-
 .. _messenger-supervisor:
 
 Supervisor Configuration
@@ -759,10 +755,6 @@ this is configurable for each transport:
     Symfony triggers a :class:`Symfony\\Component\\Messenger\\Event\\WorkerMessageRetriedEvent`
     when a message is retried so you can run your own logic.
 
-    .. versionadded:: 5.2
-
-        The ``WorkerMessageRetriedEvent`` class was introduced in Symfony 5.2.
-
 Avoiding Retrying
 ~~~~~~~~~~~~~~~~~
 
@@ -773,10 +765,6 @@ the message will not be retried.
 
 Forcing Retrying
 ~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.1
-
-    The ``RecoverableMessageHandlingException`` was introduced in Symfony 5.1.
 
 Sometimes handling a message must fail in a way that you *know* is temporary
 and must be retried. If you throw
@@ -871,20 +859,12 @@ to retry them:
     # remove messages without retrying them and show each message before removing it
     $ php bin/console messenger:failed:remove 20 30 --show-messages
 
-.. versionadded:: 5.1
-
-    The ``--show-messages`` option was introduced in Symfony 5.1.
-
 If the message fails again, it will be re-sent back to the failure transport
 due to the normal :ref:`retry rules <messenger-retries-failures>`. Once the max
 retry has been hit, the message will be discarded permanently.
 
 Multiple Failed Transports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.3
-
-    The possibility to use multiple failed transports was introduced in Symfony 5.3.
 
 Sometimes it is not enough to have a single, global ``failed transport`` configured
 because some messages are more important than others. In those cases, you can
@@ -1052,16 +1032,11 @@ AMQP Transport
 ~~~~~~~~~~~~~~
 
 The AMQP transport uses the AMQP PHP extension to send messages to queues like
-RabbitMQ.
+RabbitMQ. Install it by running:
 
-.. versionadded:: 5.1
+.. code-block:: terminal
 
-    Starting from Symfony 5.1, the AMQP transport has moved to a separate package.
-    Install it by running:
-
-    .. code-block:: terminal
-
-        $ composer require symfony/amqp-messenger
+    $ composer require symfony/amqp-messenger
 
 The AMQP transport DSN may looks like this:
 
@@ -1072,10 +1047,6 @@ The AMQP transport DSN may looks like this:
 
     # or use the AMQPS protocol
     MESSENGER_TRANSPORT_DSN=amqps://guest:guest@localhost/%2f/messages
-
-.. versionadded:: 5.2
-
-    The AMQPS protocol support was introduced in Symfony 5.2.
 
 If you want to use TLS/SSL encrypted AMQP, you must also provide a CA certificate.
 Define the certificate path in the ``amqp.cacert`` PHP.ini setting
@@ -1093,8 +1064,8 @@ it in the ``port`` parameter of the DSN (e.g. ``amqps://localhost?cacert=/etc/ss
 
 .. note::
 
-    With Symfony 5.3 or newer, you can limit the consumer of an AMQP transport to only
-    process messages from some queues of an exchange. See :ref:`messenger-limit-queues`.
+    You can limit the consumer of an AMQP transport to only process messages
+    from some queues of an exchange. See :ref:`messenger-limit-queues`.
 
 The transport has a number of other options, including ways to configure
 the exchange, queues binding keys and more. See the documentation on
@@ -1161,15 +1132,6 @@ The transport has a number of options:
 ``exchange[type]``                            Type of exchange                                   ``fanout``
 ============================================  =================================================  ===================================
 
-.. versionadded:: 5.2
-
-    The ``confirm_timeout`` option was introduced in Symfony 5.2.
-
-.. deprecated:: 5.3
-
-    The ``prefetch_count`` option was deprecated in Symfony 5.3 because it has
-    no effect on the AMQP Messenger transport.
-
 You can also configure AMQP-specific settings on your message by adding
 :class:`Symfony\\Component\\Messenger\\Bridge\\Amqp\\Transport\\AmqpStamp` to
 your Envelope::
@@ -1197,15 +1159,11 @@ Doctrine Transport
 ~~~~~~~~~~~~~~~~~~
 
 The Doctrine transport can be used to store messages in a database table.
+Install it by running:
 
-.. versionadded:: 5.1
+.. code-block:: terminal
 
-    Starting from Symfony 5.1, the Doctrine transport has moved to a separate package.
-    Install it by running:
-
-    .. code-block:: terminal
-
-        $ composer require symfony/doctrine-messenger
+    $ composer require symfony/doctrine-messenger
 
 The Doctrine transport DSN may looks like this:
 
@@ -1217,11 +1175,6 @@ The Doctrine transport DSN may looks like this:
 The format is ``doctrine://<connection_name>``, in case you have multiple connections
 and want to use one other than the "default". The transport will automatically create
 a table named ``messenger_messages``.
-
-.. versionadded:: 5.1
-
-    The ability to automatically generate a migration for the ``messenger_messages``
-    table was introduced in Symfony 5.1 and DoctrineBundle 2.1.
 
 Or, to create the table yourself, set the ``auto_setup`` option to ``false`` and
 :ref:`generate a migration <doctrine-creating-the-database-tables-schema>`.
@@ -1251,11 +1204,6 @@ auto_setup          Whether the table should be created
                     automatically during send / get.       true
 ==================  =====================================  ======================
 
-.. versionadded:: 5.1
-
-    The ability to leverage PostgreSQL's LISTEN/NOTIFY was introduced
-    in Symfony 5.1.
-
 When using PostgreSQL, you have access to the following options to leverage
 the `LISTEN/NOTIFY`_ feature. This allow for a more performant approach
 than the default polling behavior of the Doctrine transport because
@@ -1276,10 +1224,6 @@ get_notify_timeout       The length of time to wait for a            0
 
 Beanstalkd Transport
 ~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.2
-
-    The Beanstalkd transport was introduced in Symfony 5.2.
 
 The Beanstalkd transport sends messages directly to a Beanstalkd work queue. Install
 it by running:
@@ -1319,16 +1263,12 @@ Redis Transport
 ~~~~~~~~~~~~~~~
 
 The Redis transport uses `streams`_ to queue messages. This transport requires
-the Redis PHP extension (>=4.3) and a running Redis server (^5.0).
+the Redis PHP extension (>=4.3) and a running Redis server (^5.0). Install it by
+running:
 
-.. versionadded:: 5.1
+.. code-block:: terminal
 
-    Starting from Symfony 5.1, the Redis transport has moved to a separate package.
-    Install it by running:
-
-    .. code-block:: terminal
-
-        $ composer require symfony/redis-messenger
+    $ composer require symfony/redis-messenger
 
 The Redis transport DSN may looks like this:
 
@@ -1342,10 +1282,6 @@ The Redis transport DSN may looks like this:
     MESSENGER_TRANSPORT_DSN=redis://host-01:6379,redis://host-02:6379,redis://host-03:6379,redis://host-04:6379
     # Unix Socket Example
     MESSENGER_TRANSPORT_DSN=redis:///var/run/redis.sock
-
-.. versionadded:: 5.1
-
-    The Unix socket DSN was introduced in Symfony 5.1.
 
 A number of options can be configured via the DSN or via the ``options`` key
 under the transport in ``messenger.yaml``:
@@ -1400,15 +1336,6 @@ claim_interval       Interval on which pending/abandoned    ``60000`` (1 Minute)
     ``stream_max_entries`` (if you can estimate how many max entries is acceptable
     in your case) to avoid memory leaks. Otherwise, all messages will remain
     forever in Redis.
-
-.. versionadded:: 5.1
-
-    The ``delete_after_ack``, ``redeliver_timeout`` and ``claim_interval``
-    options were introduced in Symfony 5.1.
-
-.. versionadded:: 5.2
-
-    The ``delete_after_reject`` and ``lazy`` options were introduced in Symfony 5.2.
 
 In Memory Transport
 ~~~~~~~~~~~~~~~~~~~
@@ -1490,23 +1417,15 @@ The transport has a number of options:
     Whether to serialize messages or not. This is useful to test an additional
     layer, especially when you use your own message serializer.
 
-.. versionadded:: 5.3
-
-    The ``serialize`` option was introduced in Symfony 5.3.
-
 .. note::
 
-        All ``in-memory`` transports will be reset automatically after each test **in**
-        test classes extending
-        :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase`
-        or :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase`.
+    All ``in-memory`` transports will be reset automatically after each test **in**
+    test classes extending
+    :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase`
+    or :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase`.
 
 Amazon SQS
 ~~~~~~~~~~
-
-.. versionadded:: 5.1
-
-    The Amazon SQS transport was introduced in Symfony 5.1.
 
 The Amazon SQS transport is perfect for application hosted on AWS. Install it by
 running:
@@ -1534,10 +1453,6 @@ The SQS transport DSN may looks like this:
     name into an AWS queue URL by calling the ``GetQueueUrl`` API in AWS. This
     extra API call can be avoided by providing a DSN which is the queue URL.
 
-    .. versionadded:: 5.2
-
-        The feature to provide the queue URL in the DSN was introduced in Symfony 5.2.
-
 The transport has a number of options:
 
 ======================  ======================================  ===================================
@@ -1560,10 +1475,6 @@ The transport has a number of options:
                         not be visible (`Visibility Timeout`_)
 ``wait_time``           `Long polling`_ duration in seconds     20
 ======================  ======================================  ===================================
-
-.. versionadded:: 5.3
-
-    The ``debug`` option was introduced in Symfony 5.3.
 
 .. note::
 
@@ -2121,10 +2032,6 @@ may want to use:
 
 Other Middlewares
 ~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.3
-
-    The ``router_context`` middleware was introduced in Symfony 5.3.
 
 Add the ``router_context`` middleware if you need to generate absolute URLs in
 the consumer (e.g. render a template with links). This middleware stores the

--- a/notifier.rst
+++ b/notifier.rst
@@ -4,10 +4,6 @@
 Creating and Sending Notifications
 ==================================
 
-.. versionadded:: 5.0
-
-    The Notifier component was introduced in Symfony 5.0.
-
 Installation
 ------------
 
@@ -78,23 +74,6 @@ SmsBiuras       ``symfony/sms-biuras-notifier``       ``smsbiuras://UID:API_KEY@
 SpotHit         ``symfony/spothit-notifier``          ``spothit://TOKEN@default?from=FROM``
 Twilio          ``symfony/twilio-notifier``           ``twilio://SID:TOKEN@default?from=FROM``
 ==============  ====================================  ===========================================================================
-
-.. versionadded:: 5.1
-
-    The OvhCloud, Sinch and FreeMobile integrations were introduced in Symfony 5.1.
-
-.. versionadded:: 5.2
-
-    The Smsapi, Infobip, Mobyt, Esendex and Sendinblue integrations were introduced in Symfony 5.2.
-
-.. versionadded:: 5.3
-
-    The Iqsms, GatewayApi, Octopush, AllMySms, Clickatell, SpotHit, FakeSms, LightSms, SmsBiuras
-    and MessageBird integrations were introduced in Symfony 5.3.
-
-.. versionadded:: 5.4
-
-    The MessageMedia integration was introduced in Symfony 5.4.
 
 To enable a texter, add the correct DSN in your ``.env`` file and
 configure the ``texter_transports``:
@@ -173,21 +152,6 @@ Slack           ``symfony/slack-notifier``            ``slack://TOKEN@default?ch
 Telegram        ``symfony/telegram-notifier``         ``telegram://TOKEN@default?channel=CHAT_ID``
 Zulip           ``symfony/zulip-notifier``            ``zulip://EMAIL:TOKEN@HOST?channel=CHANNEL``
 ==============  ====================================  ===========================================================================
-
-.. versionadded:: 5.1
-
-    The Firebase, Mattermost and RocketChat integrations were introduced in Symfony
-    5.1. The Slack DSN changed in Symfony 5.1 to use Slack Incoming
-    Webhooks instead of legacy tokens.
-
-.. versionadded:: 5.2
-
-    The GoogleChat, LinkedIn, Zulip and Discord integrations were introduced in Symfony 5.2.
-    The Slack DSN changed in Symfony 5.2 to use Slack Web API again same as in 5.0.
-
-.. versionadded:: 5.3
-
-    The Gitter, Mercure, FakeChat and Microsoft Teams integrations were introduced in Symfony 5.3.
 
 Chatters are configured using the ``chatter_transports`` setting:
 
@@ -433,11 +397,6 @@ Symfony provides the following recipients:
     This can contain both email address and phonenumber of the user. This
     recipient can be used for all channels (depending on whether they are
     actually set).
-
-.. versionadded:: 5.2
-
-    The ``AdminRecipient`` class was removed in Symfony 5.2, you should use
-    ``Recipient`` instead.
 
 Configuring Channel Policies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/notifier/chatters.rst
+++ b/notifier/chatters.rst
@@ -4,10 +4,6 @@
 How to send Chat Messages
 =========================
 
-.. versionadded:: 5.0
-
-    The Notifier component was introduced in Symfony 5.0.
-
 The :class:`Symfony\\Component\\Notifier\\ChatterInterface` class allows
 you to send messages to chat services like Slack or Telegram::
 
@@ -40,10 +36,6 @@ you to send messages to chat services like Slack or Telegram::
 The ``send()`` method returns a variable of type
 :class:`Symfony\\Component\\Notifier\\Message\\SentMessage` which provides
 information such as the message ID and the original message contents.
-
-.. versionadded:: 5.2
-
-    The ``SentMessage`` class was introduced in Symfony 5.2.
 
 .. seealso::
 
@@ -131,10 +123,6 @@ The result will be something like:
 .. image:: /_images/notifier/slack/field-method.png
    :align: center
 
-.. versionadded:: 5.1
-
-    The `field()` method was introduced in Symfony 5.1.
-
 Adding a Header to a Slack Message
 ----------------------------------
 
@@ -170,10 +158,6 @@ The result will be something like:
 
 .. image:: /_images/notifier/slack/slack-header.png
    :align: center
-
-.. versionadded:: 5.3
-
-    The ``SlackHeaderBlock`` class was introduced in Symfony 5.3.
 
 Adding a Footer to a Slack Message
 ----------------------------------
@@ -214,10 +198,6 @@ The result will be something like:
 .. image:: /_images/notifier/slack/slack-footer.png
    :align: center
 
-.. versionadded:: 5.3
-
-    The ``SlackContextBlock`` class was introduced in Symfony 5.3.
-
 Sending a Slack Message as a Reply
 ----------------------------------
 
@@ -244,10 +224,6 @@ The result will be something like:
 
 .. image:: /_images/notifier/slack/message-reply.png
    :align: center
-
-.. versionadded:: 5.3
-
-    The ``threadTs()`` method was introduced in Symfony 5.3.
 
 Adding Interactions to a Discord Message
 ----------------------------------------

--- a/notifier/texters.rst
+++ b/notifier/texters.rst
@@ -4,10 +4,6 @@
 How to send SMS Messages
 ========================
 
-.. versionadded:: 5.0
-
-    The Notifier component was introduced in Symfony 5.0.
-
 The :class:`Symfony\\Component\\Notifier\\TexterInterface` class allows
 you to send SMS messages::
 
@@ -41,10 +37,6 @@ you to send SMS messages::
 The ``send()`` method returns a variable of type
 :class:`Symfony\\Component\\Notifier\\Message\\SentMessage` which provides
 information such as the message ID and the original message contents.
-
-.. versionadded:: 5.2
-
-    The ``SentMessage`` class was introduced in Symfony 5.2.
 
 .. seealso::
 

--- a/profiler/data_collector.rst
+++ b/profiler/data_collector.rst
@@ -18,10 +18,6 @@ For convenience, your data collectors can also extend from the
 class, which implements the interface and provides some utilities and the
 ``$this->data`` property to store the collected information.
 
-.. versionadded:: 5.2
-
-    The ``AbstractDataCollector`` class was introduced in Symfony 5.2.
-
 The following example shows a custom collector that stores information about the
 request::
 

--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -1,11 +1,6 @@
 Rate Limiter
 ============
 
-.. versionadded:: 5.2
-
-    The RateLimiter component was introduced in Symfony 5.2 as an
-    :doc:`experimental feature </contributing/code/experimental>`.
-
 A "rate limiter" controls how frequently some event (e.g. an HTTP request or a
 login attempt) is allowed to happen. Rate limiting is commonly used as a
 defensive measure to protect services from excessive use (intended or not) and
@@ -514,10 +509,6 @@ you can use a specific :ref:`named lock <lock-named-locks>` via the
                     ->lockFactory(null)
                 ;
         };
-
-.. versionadded:: 5.3
-
-    The login throttling doesn't use any lock since Symfony 5.3 to avoid extra load.
 
 .. _`DoS attacks`: https://cheatsheetseries.owasp.org/cheatsheets/Denial_of_Service_Cheat_Sheet.html
 .. _`Apache mod_ratelimit`: https://httpd.apache.org/docs/current/mod/mod_ratelimit.html

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -387,10 +387,6 @@ named ``kernel.http_method_override``.
 trusted_headers
 ~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.2
-
-    The ``trusted_headers`` option was introduced in Symfony 5.2.
-
 The ``trusted_headers`` option is needed to configure which client information
 should be trusted (e.g. their host) when running Symfony behind a load balancer
 or a reverse proxy. See :doc:`/deployment/proxies`.
@@ -399,11 +395,6 @@ or a reverse proxy. See :doc:`/deployment/proxies`.
 
 trusted_proxies
 ~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.2
-
-    The ``trusted_proxies`` option was reintroduced in Symfony 5.2 (it had been
-    removed in Symfony 3.3).
 
 The ``trusted_proxies`` option is needed to get precise information about the
 client (e.g. their IP address) when running Symfony behind a load balancer or a
@@ -498,11 +489,6 @@ some environment variable that stores the name of the IDE/editor:
             // the env var stores the IDE/editor name (e.g. 'phpstorm', 'vscode', etc.)
             $framework->ide('%env(resolve:CODE_EDITOR)%');
         };
-
-.. versionadded:: 5.3
-
-    The option to use env vars in the ``framework.ide`` option was introduced
-    in Symfony 5.3.
 
 Another alternative is to set the ``xdebug.file_link_format`` option in your
 ``php.ini`` configuration file. The format to use is the same as for the
@@ -990,10 +976,6 @@ will automatically retry failed HTTP requests.
                     retry_failed:
                         max_retries: 4
 
-.. versionadded:: 5.2
-
-    The ``retry_failed`` option was introduced in Symfony 5.2.
-
 auth_basic
 ..........
 
@@ -1096,10 +1078,6 @@ delay
 
 **type**: ``integer`` **default**: ``1000``
 
-.. versionadded:: 5.2
-
-    The ``delay`` option was introduced in Symfony 5.2.
-
 The initial delay in milliseconds used to compute the waiting time between retries.
 
 .. _reference-http-client-retry-enabled:
@@ -1127,10 +1105,6 @@ http_codes
 
 **type**: ``array`` **default**: :method:`Symfony\\Component\\HttpClient\\Retry\\GenericRetryStrategy::DEFAULT_RETRY_STATUS_CODES`
 
-.. versionadded:: 5.2
-
-    The ``http_codes`` option was introduced in Symfony 5.2.
-
 The list of HTTP status codes that triggers a retry of the request.
 
 http_version
@@ -1145,10 +1119,6 @@ jitter
 ......
 
 **type**: ``float`` **default**: ``0.1`` (must be between 0.0 and 1.0)
-
-.. versionadded:: 5.2
-
-    The ``jitter`` option was introduced in Symfony 5.2.
 
 This option adds some randomness to the delay. It's useful to avoid sending
 multiple requests to the server at the exact same time. The randomness is
@@ -1176,10 +1146,6 @@ max_delay
 .........
 
 **type**: ``integer`` **default**: ``0``
-
-.. versionadded:: 5.2
-
-    The ``max_delay`` option was introduced in Symfony 5.2.
 
 The maximum amount of milliseconds initial to wait between retries.
 Use ``0`` to not limit the duration.
@@ -1215,10 +1181,6 @@ max_retries
 
 **type**: ``integer`` **default**: ``3``
 
-.. versionadded:: 5.2
-
-    The ``max_retries`` option was introduced in Symfony 5.2.
-
 The maximum number of retries for failing requests. When the maximum is reached,
 the client returns the last received response.
 
@@ -1226,10 +1188,6 @@ multiplier
 ..........
 
 **type**: ``float`` **default**: ``2``
-
-.. versionadded:: 5.2
-
-    The ``multiplier`` option was introduced in Symfony 5.2.
 
 This value is multiplied to the delay each time a retry occurs, to distribute
 retries in time instead of making all of them sequentially.
@@ -1297,10 +1255,6 @@ retry_strategy
 ...............
 
 **type**: ``string``
-
-.. versionadded:: 5.2
-
-    The ``retry_strategy`` option was introduced in Symfony 5.2.
 
 The service is used to decide if a request should be retried and to compute the
 time to wait between retries. By default, it uses an instance of
@@ -1393,11 +1347,6 @@ only_main_requests
 ..................
 
 **type**: ``boolean`` **default**: ``false``
-
-.. versionadded:: 5.3
-
-    The ``only_main_requests`` option was introduced in Symfony 5.3. In previous
-    versions it was called ``only_master_requests``.
 
 When this is set to ``true``, the profiler will only be enabled on the main
 requests (and not on the subrequests).
@@ -1529,10 +1478,6 @@ default_uri
 
 **type**: ``string``
 
-.. versionadded:: 5.1
-
-    The ``default_uri`` option was introduced in Symfony 5.1.
-
 The default URI used to generate URLs in a non-HTTP context (see
 :ref:`Generating URLs in Commands <router-generate-urls-commands>`).
 
@@ -1576,12 +1521,7 @@ or ``null`` might be preferred in production.
 utf8
 ....
 
-**type**: ``boolean`` **default**: ``false``
-
-.. deprecated:: 5.1
-
-    Not setting this option is deprecated since Symfony 5.1. Moreover, the
-    default value of this option will change to ``true`` in Symfony 6.0.
+**type**: ``boolean`` **default**: ``true``
 
 When this option is set to ``true``, the regular expressions used in the
 :ref:`requirements of route parameters <routing-requirements>` will be run
@@ -1614,10 +1554,6 @@ To see a list of all available storages, run:
 .. code-block:: terminal
 
     $ php bin/console debug:container session.storage.factory.
-
-.. versionadded:: 5.3
-
-    The ``storage_factory_id`` option was introduced in Symfony 5.3.
 
 .. _config-framework-session-handler-id:
 
@@ -2381,11 +2317,6 @@ package:
                 ->basePath('/images');
         };
 
-.. versionadded:: 5.1
-
-    The option to use an absolute URL in  ``json_manifest_path`` was introduced
-    in Symfony 5.1.
-
 .. note::
 
     This parameter cannot be set at the same time as ``version`` or ``version_strategy``.
@@ -2427,10 +2358,6 @@ enabled_locales
 ...............
 
 **type**: ``array`` **default**: ``[]`` (empty array = enable all locales)
-
-.. versionadded:: 5.1
-
-    The ``enabled_locales`` option was introduced in Symfony 5.1.
 
 Symfony applications generate by default the translation files for validation
 and security messages in all locales. If your application only uses some
@@ -2545,10 +2472,6 @@ providers
 
 **type**: ``array`` **default**: ``[]``
 
-.. versionadded:: 5.3
-
-    The ``providers`` option was introduced in Symfony 5.3.
-
 This option enables and configures :ref:`translation providers <translation-providers>`
 to push and pull your translations to/from third party translation services.
 
@@ -2573,10 +2496,6 @@ When enabled, the ``property_accessor`` service uses PHP's
 :ref:`magic __get() method <components-property-access-magic-get>` when
 its ``getValue()`` method is called.
 
-.. versionadded:: 5.2
-
-    The ``magic_get`` option was introduced in Symfony 5.2.
-
 magic_set
 .........
 
@@ -2585,10 +2504,6 @@ magic_set
 When enabled, the ``property_accessor`` service uses PHP's
 :ref:`magic __set() method <components-property-access-writing-to-objects>` when
 its ``setValue()`` method is called.
-
-.. versionadded:: 5.2
-
-    The ``magic_set`` option was introduced in Symfony 5.2.
 
 throw_exception_on_invalid_index
 ................................
@@ -2992,10 +2907,6 @@ This option also accepts a map of PHP errors to log levels:
             // ...
         };
 
-.. versionadded:: 5.3
-
-    The option to map PHP errors to log levels was introduced in Symfony 5.3.
-
 throw
 .....
 
@@ -3243,12 +3154,6 @@ It's also useful when using `blue/green deployment`_ strategies and more
 generally, when you need to abstract out the actual deployment directory (for
 example, when warming caches offline).
 
-.. versionadded:: 5.2
-
-    Starting from Symfony 5.2, the ``%kernel.container_class%`` parameter is no
-    longer appended automatically to the value of this option. This allows
-    sharing caches between applications or different environments.
-
 .. _reference-lock:
 
 lock
@@ -3351,10 +3256,6 @@ mailer. A transport name is the key and the dsn is the value.
 message_bus
 ...........
 
-.. versionadded:: 5.1
-
-    The ``message_bus`` option was introduced in Symfony 5.1.
-
 **type**: ``string`` **default**: ``null`` or default bus if Messenger component is installed
 
 Service identifier of the message bus to use when using the
@@ -3433,10 +3334,6 @@ recipients set in the code.
 
 headers
 .......
-
-.. versionadded:: 5.2
-
-    The ``headers`` mailer option was introduced in Symfony 5.2.
 
 **type**: ``array``
 

--- a/reference/configuration/kernel.rst
+++ b/reference/configuration/kernel.rst
@@ -110,10 +110,6 @@ Build Directory
 
 **type**: ``string`` **default**: ``$this->getCacheDir()``
 
-.. versionadded:: 5.2
-
-    The build directory feature was introduced in Symfony 5.2.
-
 This returns the absolute path of a build directory of your Symfony project. This
 directory can be used to separate read-only cache (i.e. the compiled container)
 from read-write cache (i.e. :doc:`cache pools </cache>`). Specify a non-default

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -125,9 +125,7 @@ This option is explained in detail in :doc:`/security/access_control`.
 hashers
 -------
 
-This option defines the algorithm used to *hash* the password of the users
-(which in previous Symfony versions was wrongly called *"password encoding"*).
-
+This option defines the algorithm used to *hash* the password of the users.
 If your app defines more than one user class, each of them can define its own
 hashing algorithm. Also, each algorithm defines different config options:
 
@@ -244,11 +242,6 @@ hashing algorithm. Also, each algorithm defines different config options:
                 ->algorithm('sha512');
         };
 
-.. versionadded:: 5.3
-
-    The ``password_hashers`` option was introduced in Symfony 5.3. In previous
-    versions it was called ``encoders``.
-
 .. tip::
 
     You can also create your own password hashers as services and you can even
@@ -325,9 +318,9 @@ hashing algorithm. Also, each algorithm defines different config options:
 Using the "auto" Password Hasher
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It automatically selects the best available hasher. Starting from Symfony 5.3,
-it uses the Bcrypt hasher. If PHP or Symfony adds new password hashers in the
-future, it might select a different hasher.
+It automatically selects the best available hasher, which currently is the
+Bcrypt hasher. If PHP or Symfony adds new password hashers in the future, it
+might select a different hasher.
 
 Because of this, the length of the hashed passwords may change in the future, so
 make sure to allocate enough space for them to be persisted (``varchar(255)``
@@ -367,8 +360,8 @@ used back when they were hashed.
 Using the Sodium Password Hasher
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It uses the `Argon2 key derivation function`_. Argon2 support was introduced
-in PHP 7.2 by bundeling the `libsodium`_ extension.
+It uses the `Argon2 key derivation function`_, which PHP supports natively since
+PHP 7.2 version.
 
 The hashed passwords are ``96`` characters long, but due to the hashing
 requirements saved in the resulting hash this may change in the future, so make
@@ -500,11 +493,6 @@ the ``debug:firewall`` command:
     # displays the details of a specific firewall, including detailed information
     # about the event listeners for the firewall
     $ php bin/console debug:firewall main --include-listeners
-
-.. versionadded:: 5.3
-
-    The ``debug:firewall`` command was introduced in Symfony 5.3.
-
 
 .. _reference-security-firewall-form-login:
 
@@ -638,8 +626,6 @@ The ``invalidate_session`` option allows to redefine this behavior. Set this
 option to ``false`` in every firewall and the user will only be logged out from
 the current firewall and not the other ones.
 
-.. _reference-security-logout-success-handler:
-
 ``path``
 ~~~~~~~~
 
@@ -656,23 +642,6 @@ target
 The relative path (if the value starts with ``/``), or absolute URL (if it
 starts with ``http://`` or ``https://``) or the route name (otherwise) to
 redirect after logout.
-
-success_handler
-~~~~~~~~~~~~~~~
-
-.. deprecated:: 5.1
-
-    This option is deprecated since Symfony 5.1. Register an
-    :doc:`event listener </event_dispatcher>` on the
-    :class:`Symfony\\Component\\Security\\Http\\Event\\LogoutEvent`
-    instead.
-
-**type**: ``string`` **default**: ``'security.logout.success_handler'``
-
-The service ID used for handling a successful logout. The service must implement
-:class:`Symfony\\Component\\Security\\Http\\Logout\\LogoutSuccessHandlerInterface`.
-
-If it is set, the logout ``target`` option will be ignored.
 
 .. _reference-security-logout-csrf:
 

--- a/reference/configuration/swiftmailer.rst
+++ b/reference/configuration/swiftmailer.rst
@@ -211,10 +211,6 @@ delivery_addresses
 
 **type**: ``array``
 
-.. note::
-
-    In previous versions, this option was called ``delivery_address``.
-
 If set, all email messages will be sent to these addresses instead of being sent
 to their actual recipients. This is often useful when developing. For example,
 by setting this in the ``config/packages/dev/swiftmailer.yaml`` file, you can

--- a/reference/constraints/AtLeastOneOf.rst
+++ b/reference/constraints/AtLeastOneOf.rst
@@ -4,10 +4,6 @@ AtLeastOneOf
 This constraint checks that the value satisfies at least one of the given
 constraints. The validation stops as soon as one constraint is satisfied.
 
-.. versionadded:: 5.1
-
-    The ``AtLeastOneOf`` constraint was introduced in Symfony 5.1.
-
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`
 Options     - `constraints`_

--- a/reference/constraints/Blank.rst
+++ b/reference/constraints/Blank.rst
@@ -118,8 +118,4 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/CardScheme.rst
+++ b/reference/constraints/CardScheme.rst
@@ -131,10 +131,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 ``schemes``

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -440,8 +440,4 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Compound.rst
+++ b/reference/constraints/Compound.rst
@@ -5,10 +5,6 @@ To the contrary to the other constraints, this constraint cannot be used on its 
 Instead, it allows you to create your own set of reusable constraints, representing
 rules to use consistently across your application, by extending the constraint.
 
-.. versionadded:: 5.1
-
-    The ``Compound`` constraint was introduced in Symfony 5.1.
-
 ==========  ===================================================================
 Applies to  :ref:`class <validation-class-target>` or :ref:`property or method <validation-property-target>`
 Options     - `groups`_
@@ -74,12 +70,6 @@ you can create your own named set or requirements to be reused consistently ever
 Add ``@Annotation`` or ``#[\Attribute]`` to the constraint class if you want to
 use it as an annotation/attribute in other classes. If the constraint has
 configuration options, define them as public properties on the constraint class.
-
-.. versionadded:: 5.2
-
-    The ability to use PHP attributes to configure constraints was introduced in
-    Symfony 5.2. Prior to this, Doctrine Annotations were the only way to
-    annotate constraints.
 
 You can now use it anywhere you need it:
 

--- a/reference/constraints/Count.rst
+++ b/reference/constraints/Count.rst
@@ -126,10 +126,6 @@ Options
 
 **type**: ``integer`` **default**: null
 
-.. versionadded:: 5.1
-
-    The ``divisibleBy`` option was introduced in Symfony 5.1.
-
 Validates that the number of elements of the given collection is divisible by
 a certain number.
 
@@ -143,10 +139,6 @@ a certain number.
 ~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``The number of elements in this collection should be a multiple of {{ compared_value }}.``
-
-.. versionadded:: 5.1
-
-    The ``divisibleByMessage`` option was introduced in Symfony 5.1.
 
 The message that will be shown if the number of elements of the given collection
 is not divisible by the number defined in the ``divisibleBy`` option.

--- a/reference/constraints/Country.rst
+++ b/reference/constraints/Country.rst
@@ -93,10 +93,6 @@ Options
 alpha3
 ~~~~~~
 
-.. versionadded:: 5.1
-
-    The ``alpha3`` option was introduced in Symfony 5.1.
-
 **type**: ``boolean`` **default**: ``false``
 
 If this option is ``true``, the constraint checks that the value is a

--- a/reference/constraints/Currency.rst
+++ b/reference/constraints/Currency.rst
@@ -110,10 +110,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`3-letter ISO 4217`: https://en.wikipedia.org/wiki/ISO_4217

--- a/reference/constraints/Date.rst
+++ b/reference/constraints/Date.rst
@@ -114,8 +114,4 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/DateTime.rst
+++ b/reference/constraints/DateTime.rst
@@ -126,8 +126,4 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Email.rst
+++ b/reference/constraints/Email.rst
@@ -119,10 +119,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 ``mode``
 ~~~~~~~~
 

--- a/reference/constraints/Expression.rst
+++ b/reference/constraints/Expression.rst
@@ -299,10 +299,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 ``values``

--- a/reference/constraints/ExpressionLanguageSyntax.rst
+++ b/reference/constraints/ExpressionLanguageSyntax.rst
@@ -4,10 +4,6 @@ ExpressionLanguageSyntax
 This constraint checks that the value is valid as an `ExpressionLanguage`_
 expression.
 
-.. versionadded:: 5.1
-
-    The ``ExpressionLanguageSyntax`` constraint was introduced in Symfony 5.1.
-
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`
 Options     - `allowedVariables`_

--- a/reference/constraints/Hostname.rst
+++ b/reference/constraints/Hostname.rst
@@ -5,10 +5,6 @@ This constraint ensures that the given value is a valid host name (internally it
 uses the ``FILTER_VALIDATE_DOMAIN`` option of the :phpfunction:`filter_var` PHP
 function).
 
-.. versionadded:: 5.1
-
-    The ``Hostname`` constraint was introduced in Symfony 5.1.
-
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`
 Options     - `groups`_
@@ -125,10 +121,6 @@ Parameter        Description
 ``{{ value }}``  The current (invalid) value
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
-
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 

--- a/reference/constraints/Iban.rst
+++ b/reference/constraints/Iban.rst
@@ -126,10 +126,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`International Bank Account Number (IBAN)`: https://en.wikipedia.org/wiki/International_Bank_Account_Number

--- a/reference/constraints/Ip.rst
+++ b/reference/constraints/Ip.rst
@@ -111,10 +111,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_normalizer-option.rst.inc
 
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/IsFalse.rst
+++ b/reference/constraints/IsFalse.rst
@@ -148,8 +148,4 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/IsNull.rst
+++ b/reference/constraints/IsNull.rst
@@ -112,8 +112,4 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/IsTrue.rst
+++ b/reference/constraints/IsTrue.rst
@@ -152,8 +152,4 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Isbn.rst
+++ b/reference/constraints/Isbn.rst
@@ -128,10 +128,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_groups-option.rst.inc
 
 ``isbn10Message``
@@ -151,10 +147,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 ``isbn13Message``
 ~~~~~~~~~~~~~~~~~
 
@@ -172,10 +164,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 ``message``
 ~~~~~~~~~~~
 
@@ -192,10 +180,6 @@ Parameter        Description
 ``{{ value }}``  The current (invalid) value
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
-
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 

--- a/reference/constraints/Isin.rst
+++ b/reference/constraints/Isin.rst
@@ -108,10 +108,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`International Securities Identification Number (ISIN)`: https://en.wikipedia.org/wiki/International_Securities_Identification_Number

--- a/reference/constraints/Issn.rst
+++ b/reference/constraints/Issn.rst
@@ -118,10 +118,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 ``requireHyphen``

--- a/reference/constraints/Language.rst
+++ b/reference/constraints/Language.rst
@@ -94,10 +94,6 @@ Options
 alpha3
 ~~~~~~
 
-.. versionadded:: 5.1
-
-    The ``alpha3`` option was introduced in Symfony 5.1.
-
 **type**: ``boolean`` **default**: ``false``
 
 If this option is ``true``, the constraint checks that the value is a
@@ -121,10 +117,6 @@ Parameter        Description
 ``{{ value }}``  The current (invalid) value
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
-
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 

--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -5,8 +5,7 @@ Validates that a given string length is *between* some minimum and maximum value
 
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`
-Options     - `allowEmptyString`_
-            - `charset`_
+Options     - `charset`_
             - `charsetMessage`_
             - `exactMessage`_
             - `groups`_
@@ -128,26 +127,6 @@ and ``50``, you might add the following:
 
 Options
 -------
-
-``allowEmptyString``
-~~~~~~~~~~~~~~~~~~~~
-
-**type**: ``boolean``  **default**: ``false``
-
-.. deprecated:: 5.2
-
-    The ``allowEmptyString`` option is deprecated since Symfony 5.2. If you
-    want to allow empty strings too, combine the ``Length`` constraint with
-    the :doc:`Blank constraint </reference/constraints/Blank>` inside the
-    :doc:`AtLeastOneOf constraint </reference/constraints/AtLeastOneOf>`.
-
-If set to ``true``, empty strings are considered valid (which is the same
-behavior as previous Symfony versions). The default ``false`` value considers
-empty strings not valid.
-
-.. caution::
-
-    This option does not have any effect when no minimum length is given.
 
 ``charset``
 ~~~~~~~~~~~

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -125,10 +125,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`ICU format locale IDs`: http://userguide.icu-project.org/locale

--- a/reference/constraints/Luhn.rst
+++ b/reference/constraints/Luhn.rst
@@ -117,10 +117,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`Luhn algorithm`: https://en.wikipedia.org/wiki/Luhn_algorithm

--- a/reference/constraints/NotBlank.rst
+++ b/reference/constraints/NotBlank.rst
@@ -121,10 +121,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_normalizer-option.rst.inc
 
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/NotNull.rst
+++ b/reference/constraints/NotNull.rst
@@ -110,8 +110,4 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -387,10 +387,6 @@ Options
 
 **type**: ``string`` **default**: ``This value should be a valid number.``
 
-.. versionadded:: 5.2
-
-    The ``invalidDateTimeMessage`` option was introduced in Symfony 5.2.
-
 The message displayed when the ``min`` and ``max`` values are PHP datetimes but
 the given value is not.
 
@@ -418,10 +414,6 @@ Parameter        Description
 ``{{ value }}``  The current (invalid) value
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
-
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
 
 ``max``
 ~~~~~~~

--- a/reference/constraints/Regex.rst
+++ b/reference/constraints/Regex.rst
@@ -324,10 +324,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 ``pattern``
 ~~~~~~~~~~~
 

--- a/reference/constraints/Sequentially.rst
+++ b/reference/constraints/Sequentially.rst
@@ -7,10 +7,6 @@ step-by-step, allowing to interrupt the validation once the first violation is r
 As an alternative in situations ``Sequentially`` cannot solve, you may consider
 using :doc:`GroupSequence </validation/sequence_provider>` which allows more control.
 
-.. versionadded:: 5.1
-
-    The ``Sequentially`` constraint was introduced in Symfony 5.1.
-
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`
 Options     - `constraints`_

--- a/reference/constraints/Time.rst
+++ b/reference/constraints/Time.rst
@@ -120,8 +120,4 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc

--- a/reference/constraints/Timezone.rst
+++ b/reference/constraints/Timezone.rst
@@ -139,10 +139,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 ``zone``

--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -193,10 +193,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _reference-constraint-type-type:

--- a/reference/constraints/Ulid.rst
+++ b/reference/constraints/Ulid.rst
@@ -1,10 +1,6 @@
 ULID
 ====
 
-.. versionadded:: 5.2
-
-    The ULID validator was introduced in Symfony 5.2.
-
 Validates that a value is a valid `Universally Unique Lexicographically Sortable Identifier (ULID)`_.
 
 ==========  ===================================================================

--- a/reference/constraints/Unique.rst
+++ b/reference/constraints/Unique.rst
@@ -130,10 +130,6 @@ Parameter                      Description
 
 **type**: a `PHP callable`_ **default**: ``null``
 
-.. versionadded:: 5.3
-
-    The ``normalizer`` option was introduced in Symfony 5.3.
-
 This option defined the PHP callable applied to each element of the given
 collection before checking if the collection is valid.
 

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -353,10 +353,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 ``repositoryMethod``

--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -114,10 +114,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. configuration-block::
 
     .. code-block:: php-annotations

--- a/reference/constraints/Uuid.rst
+++ b/reference/constraints/Uuid.rst
@@ -113,10 +113,6 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
-.. versionadded:: 5.2
-
-    The ``{{ label }}`` parameter was introduced in Symfony 5.2.
-
 .. include:: /reference/constraints/_normalizer-option.rst.inc
 
 .. include:: /reference/constraints/_payload-option.rst.inc
@@ -150,10 +146,6 @@ The following PHP constants can also be used:
 * ``Uuid::V6_SORTABLE``
 
 All six versions are allowed by default.
-
-.. versionadded:: 5.2
-
-    The UUID 6 version support was introduced in Symfony 5.2.
 
 .. _`Universally unique identifier (UUID)`: https://en.wikipedia.org/wiki/Universally_unique_identifier
 .. _`RFC 4122`: https://tools.ietf.org/html/rfc4122

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -13,10 +13,6 @@ assets.package
 
 **Purpose**: Add an asset package to the application
 
-.. versionadded:: 5.3
-
-    The ``assets.package`` tag was introduced in Symfony 5.3.
-
 This is an alternative way to declare an :ref:`asset package <asset-packages>`.
 The name of the package is set in this order:
 
@@ -195,13 +191,6 @@ wrapping their names with ``%`` characters).
     sense most of the times to prevent accessing those services directly instead
     of using the generic service alias.
 
-.. versionadded:: 5.1
-
-    In Symfony versions prior to 5.1, you needed to manually add the
-    ``Symfony\Component\DependencyInjection\Compiler\AutoAliasServicePass``
-    compiler pass to the container for this feature to work. This compiler pass
-    is now added automatically.
-
 console.command
 ---------------
 
@@ -233,10 +222,6 @@ container.no_preload
 --------------------
 
 **Purpose**: Remove a class from the list of classes preloaded by PHP
-
-.. versionadded:: 5.1
-
-    The ``container.no_preload`` tag was introduced in Symfony 5.1.
 
 Add this tag to a service and its class won't be preloaded when using
 `PHP class preloading`_:
@@ -283,10 +268,6 @@ container.preload
 -----------------
 
 **Purpose**: Add some class to the list of classes preloaded by PHP
-
-.. versionadded:: 5.1
-
-    The ``container.preload`` tag was introduced in Symfony 5.1.
 
 When using `PHP class preloading`_, this tag allows you to define which PHP
 classes should be preloaded. This can improve performance by making some of the
@@ -515,12 +496,7 @@ the :class:`Symfony\\Component\\HttpKernel\\CacheWarmer\\CacheWarmerInterface` i
 The ``warmUp()`` method must return an array with the files and classes to
 preload. Files must be absolute paths and classes must be fully-qualified class
 names. The only restriction is that files must be stored in the cache directory.
-If you don't need to preload anything, return an empty array
-
-.. deprecated:: 5.1
-
-    Not returning an array from the ``warmUp()`` method with the files to
-    preload is deprecated since Symfony 5.1.
+If you don't need to preload anything, return an empty array.
 
 The ``isOptional()`` method should return true if it's possible to use the
 application without calling this cache warmer. In Symfony, optional warmers

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -188,11 +188,6 @@ To get fancier, use the `group_by`_ option instead.
 Field Options
 -------------
 
-.. versionadded:: 5.1
-
-    The :class:`Symfony\\Component\\Form\\ChoiceList\\ChoiceList` class was
-    introduced in Symfony 5.1, to help configuring choices options.
-
 choices
 ~~~~~~~
 

--- a/reference/forms/types/color.rst
+++ b/reference/forms/types/color.rst
@@ -57,10 +57,6 @@ html5
 
 **type**: ``boolean`` **default**: ``false``
 
-.. versionadded:: 5.1
-
-    This option was introduced in Symfony 5.1.
-
 When this option is set to ``true``, the form type checks that its value matches
 the `HTML5 color format`_ (``/^#[0-9a-f]{6}$/i``). If it doesn't match it,
 you'll see the following error message: *"This value is not a valid HTML5 color"*.

--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -88,12 +88,6 @@ is a constant on the :phpclass:`NumberFormatter` class:
   "nearest neighbor". If both neighbors are equidistant, round up. It rounds
   ``2.5`` to ``3``, ``1.6`` and ``1.5`` to ``2`` and ``1.4`` to ``1``.
 
-.. deprecated:: 5.1
-
-    In Symfony versions prior to 5.1, these constants were also defined as aliases
-    in the :class:`Symfony\\Component\\Form\\Extension\\Core\\DataTransformer\\NumberToLocalizedStringTransformer`
-    class, but they are now deprecated in favor of the :phpclass:`NumberFormatter` constants.
-
 Overridden Options
 ------------------
 

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -85,10 +85,6 @@ choice_self_translation
 
 **type**: ``boolean`` **default**: ``false``
 
-.. versionadded:: 5.1
-
-    The ``choice_self_translation`` option was introduced in Symfony 5.1.
-
 By default, language names are translated into the current locale of the
 application. For example, when browsing the application in English, you'll get
 an array like ``[..., 'cs' => 'Czech', ..., 'es' => 'Spanish', ..., 'zh' => 'Chinese']``

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -99,10 +99,6 @@ html5
 
 **type**: ``boolean`` **default**: ``false``
 
-.. versionadded:: 5.2
-
-    This option was introduced in Symfony 5.2.
-
 If set to ``true``, the HTML input will be rendered as a native HTML5
 ``<input type="number">`` element.
 

--- a/reference/forms/types/options/choice_filter.rst.inc
+++ b/reference/forms/types/options/choice_filter.rst.inc
@@ -3,10 +3,6 @@
 
 **type**: ``callable``, ``string`` or :class:`Symfony\\Component\\PropertyAccess\\PropertyPath` **default**: ``null``
 
-.. versionadded:: 5.1
-
-    The ``choice_filter`` option has been introduced in Symfony 5.1.
-
 When using predefined choice types from Symfony core or vendor libraries (i.e.
 :doc:`CountryType </reference/forms/types/country>`) this option lets you
 define a callable that takes each choice as the only argument and must return

--- a/reference/forms/types/options/extra_fields_message.rst.inc
+++ b/reference/forms/types/options/extra_fields_message.rst.inc
@@ -1,10 +1,6 @@
 ``extra_fields_message``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.1
-
-    Pluralization support was introduced in Symfony 5.1.
-
 **type**: ``string`` **default**: ``This form should not contain extra fields.``
 
 This is the validation error message that's used if the submitted form data

--- a/reference/forms/types/options/label_html.rst.inc
+++ b/reference/forms/types/options/label_html.rst.inc
@@ -3,10 +3,6 @@
 
 **type**: ``boolean`` **default**: ``false``
 
-.. versionadded:: 5.1
-
-	The ``label_html`` option was introduced in Symfony 5.1.
-
 By default, the contents of the ``label`` option are escaped before rendering
 them in the template. Set this option to ``true`` to not escape them, which is
 useful when the label contains HTML elements.

--- a/reference/forms/types/options/priority.rst.inc
+++ b/reference/forms/types/options/priority.rst.inc
@@ -3,10 +3,6 @@ priority
 
 **type**: ``integer`` **default**: ``0``
 
-.. versionadded:: 5.3
-
-    The ``priority`` option was introduced in Symfony 5.3.
-
 Fields are rendered in the same order as they are included in the form. This
 option changes the field rendering priority, allowing you to display fields
 earlier or later than their original order.

--- a/reference/forms/types/options/rounding_mode.rst.inc
+++ b/reference/forms/types/options/rounding_mode.rst.inc
@@ -30,9 +30,3 @@ on the :phpclass:`NumberFormatter` class:
 * ``\NumberFormatter::ROUND_HALFUP`` Round towards the
   "nearest neighbor". If both neighbors are equidistant, round up. It rounds
   ``2.5`` to ``3``, ``1.6`` and ``1.5`` to ``2`` and ``1.4`` to ``1``.
-
-.. deprecated:: 5.1
-
-    In Symfony versions prior to 5.1, these constants were also defined as aliases
-    in the :class:`Symfony\\Component\\Form\\Extension\\Core\\DataTransformer\\NumberToLocalizedStringTransformer`
-    class, but they are now deprecated in favor of the :phpclass:`NumberFormatter` constants.

--- a/reference/forms/types/percent.rst
+++ b/reference/forms/types/percent.rst
@@ -57,18 +57,10 @@ Field Options
 
 .. include:: /reference/forms/types/options/rounding_mode.rst.inc
 
-.. versionadded:: 5.1
-
-    The ``rounding_mode`` option was introduced in Symfony 5.1.
-
 html5
 ~~~~~
 
 **type**: ``boolean`` **default**: ``false``
-
-.. versionadded:: 5.2
-
-    This option was introduced in Symfony 5.2.
 
 If set to ``true``, the HTML input will be rendered as a native HTML5
 ``<input type="number">`` element.

--- a/reference/forms/types/ulid.rst
+++ b/reference/forms/types/ulid.rst
@@ -4,10 +4,6 @@
 UlidType Field
 ==============
 
-.. versionadded:: 5.3
-
-    The ``UlidType`` field was introduced in Symfony 5.3.
-
 Renders an input text field with the ULID string value and transforms it back to
 a proper :ref:`Ulid object <ulid>` when submitting the form.
 

--- a/reference/forms/types/uuid.rst
+++ b/reference/forms/types/uuid.rst
@@ -4,10 +4,6 @@
 UuidType Field
 ==============
 
-.. versionadded:: 5.3
-
-    The ``UuidType`` field was introduced in Symfony 5.3.
-
 Renders an input text field with the UUID string value and transforms it back to
 a proper :ref:`Uuid object <uuid>` when submitting the form.
 

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -277,10 +277,6 @@ impersonation_exit_path
 ``exitTo`` *(optional)*
     **type**: ``string``
 
-.. versionadded:: 5.2
-
-    The ``impersonation_exit_path()`` function was introduced in Symfony 5.2.
-
 Generates a URL that you can visit to exit :doc:`user impersonation </security/impersonating_user>`.
 After exiting impersonation, the user is redirected to the current URI. If you
 prefer to redirect to a different URI, define its value in the ``exitTo`` argument.
@@ -296,10 +292,6 @@ impersonation_exit_url
 
 ``exitTo`` *(optional)*
     **type**: ``string``
-
-.. versionadded:: 5.2
-
-    The ``impersonation_exit_url()`` function was introduced in Symfony 5.2.
 
 It's similar to the `impersonation_exit_path`_ function, but it generates
 absolute URLs instead of relative URLs.
@@ -319,10 +311,6 @@ t
     **type**: ``array`` **default**: ``[]``
 ``domain`` *(optional)*
     **type**: ``string`` **default**: ``messages``
-
-.. versionadded:: 5.2
-
-    The ``t()`` function was introduced in Symfony 5.2.
 
 Creates a ``Translatable`` object that can be passed to the
 :ref:`trans filter <reference-twig-filter-trans>`.
@@ -381,10 +369,6 @@ trans
     **type**: ``string`` **default**: ``null``
 ``locale`` *(optional)*
     **type**: ``string`` **default**: ``null``
-
-.. versionadded:: 5.2
-
-    ``message`` accepting ``Translatable`` as a valid type was introduced in Symfony 5.2.
 
 Translates the text into the current language. More information in
 :ref:`Translation Filters <translation-filters>`.
@@ -573,10 +557,6 @@ serialize
 
 ``context`` *(optional)*
     **type**: ``array``
-
-.. versionadded:: 5.3
-
-    The ``serialize`` filter was introduced in Symfony 5.3.
 
 Accepts any data that can be serialized by the :doc:`Serializer component </serializer>`
 and returns a serialized string in the specified ``format``.

--- a/routing.rst
+++ b/routing.rst
@@ -35,12 +35,6 @@ once in your application to enable them:
 
     $ composer require doctrine/annotations
 
-.. versionadded:: 5.2
-
-    The ability to use PHP attributes to configure routes was introduced in
-    Symfony 5.2. Prior to this, Doctrine Annotations were the only way to
-    annotate controller actions with routing configuration.
-
 This command also creates the following configuration file:
 
 .. code-block:: yaml
@@ -178,11 +172,11 @@ the ``BlogController``:
             ;
         };
 
-.. versionadded:: 5.1
+.. note::
 
-    Starting from Symfony 5.1, by default Symfony only loads the routes defined
-    in YAML format. If you define routes in XML and/or PHP formats, update the
-    ``src/Kernel.php`` file to add support for the ``.xml`` and ``.php`` file extensions.
+    By default Symfony only loads the routes defined in YAML format. If you
+    define routes in XML and/or PHP formats, update the ``src/Kernel.php`` file
+    to add support for the ``.xml`` and ``.php`` file extensions.
 
 .. _routing-matching-http-methods:
 
@@ -998,10 +992,6 @@ parameter:
 
 Priority Parameter
 ~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.1
-
-    The ``priority`` parameter was introduced in Symfony 5.1
 
 Symfony evaluates routes in the order they are defined. If the path of a route
 matches many different patterns, it might prevent other routes from being
@@ -2070,11 +2060,6 @@ these routes.
     You can also use the inline defaults and requirements format in the
     ``host`` option: ``{subdomain<m|mobile>?m}.example.com``
 
-.. versionadded:: 5.2
-
-    Inline parameter default values support in hosts were introduced in
-    Symfony 5.2. Prior to Symfony 5.2, they were supported in the path only.
-
 .. _i18n-routing:
 
 Localized Routes (i18n)
@@ -2234,10 +2219,6 @@ Another common requirement is to host the website on a different domain
 according to the locale. This can be done by defining a different host for each
 locale.
 
-.. versionadded:: 5.1
-
-    The ability to define an array of hosts was introduced in Symfony 5.1.
-
 .. configuration-block::
 
     .. code-block:: yaml
@@ -2281,10 +2262,6 @@ locale.
 
 Stateless Routes
 ----------------
-
-.. versionadded:: 5.1
-
-    The ``stateless`` option was introduced in Symfony 5.1.
 
 Sometimes, when an HTTP response should be cached, it is important to ensure
 that can happen. However, whenever a session is started during a request,
@@ -2575,10 +2552,6 @@ The solution is to configure the ``default_uri`` option to define the
         return static function (FrameworkConfig $framework) {
             $framework->router()->defaultUri('https://example.org/my/path/');
         };
-
-.. versionadded:: 5.1
-
-    The ``default_uri`` option was introduced in Symfony 5.1.
 
 Now you'll get the expected results when generating URLs in your commands::
 

--- a/security.rst
+++ b/security.rst
@@ -221,7 +221,7 @@ command will pre-configure this for you:
                 # use your user class name here
                 App\Entity\User:
                     # Use native password hasher, which auto-selects the best
-                    # possible hashing algorithm (starting from Symfony 5.3 this is "bcrypt")
+                    # possible hashing algorithm (which currently is "bcrypt")
                     algorithm: auto
 
     .. code-block:: xml
@@ -262,11 +262,6 @@ command will pre-configure this for you:
 
             // ...
         };
-
-.. versionadded:: 5.3
-
-    The ``password_hashers`` option was introduced in Symfony 5.3. In previous
-    versions it was called ``encoders``.
 
 Now that Symfony knows *how* you want to hash the passwords, you can use the
 ``UserPasswordHasherInterface`` service to do this before saving your users to
@@ -328,11 +323,6 @@ You can manually hash a password by running:
 
 3a) Authentication & Firewalls
 ------------------------------
-
-.. versionadded:: 5.1
-
-    The ``lazy: true`` option was introduced in Symfony 5.1. Prior to version 5.1,
-    it was enabled using ``anonymous: lazy``
 
 The security system is configured in ``config/packages/security.yaml``. The *most*
 important section is ``firewalls``:
@@ -478,10 +468,6 @@ here are a few common use-cases:
 Limiting Login Attempts
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.2
-
-    Login throttling was introduced in Symfony 5.2.
-
 Symfony provides basic protection against `brute force login attacks`_ if
 you're using the :doc:`authenticator-based authenticators </security/authenticator_manager>`.
 You must enable this using the ``login_throttling`` setting:
@@ -573,10 +559,6 @@ You must enable this using the ``login_throttling`` setting:
                 ->loginThrottling()
                     ->maxAttempts(3);
         };
-
-.. versionadded:: 5.3
-
-    The ``login_throttling.interval`` option was introduced in Symfony 5.3.
 
 By default, login attempts are limited on ``max_attempts`` (default: 5)
 failed requests for ``IP address + username`` and ``5 * max_attempts``
@@ -1094,11 +1076,6 @@ like this:
   :doc:`impersonating </security/impersonating_user>` another user in this
   session, this attribute will match.
 
-.. versionadded:: 5.1
-
-    The ``IS_ANONYMOUS``, ``IS_REMEMBERED`` and ``IS_IMPERSONATOR``
-    attributes were introduced in Symfony 5.1.
-
 .. _retrieving-the-user-object:
 
 5a) Fetching the User Object
@@ -1303,13 +1280,6 @@ Symfony will un-authenticate the current user and redirect them.
 Customizing Logout
 ~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.1
-
-    The ``LogoutEvent`` was introduced in Symfony 5.1. Prior to this
-    version, you had to use a
-    :ref:`logout success handler <reference-security-logout-success-handler>`
-    to customize the logout.
-
 In some cases you need to execute extra logic upon logout (e.g. invalidate
 some tokens) or want to customize what happens after a logout. During
 logout, a :class:`Symfony\\Component\\Security\\Http\\Event\\LogoutEvent`
@@ -1325,7 +1295,6 @@ event class:
 ``getResponse()``
     Returns a response, if it is already set by a custom listener. Use
     ``setResponse()`` to configure a custom logout response.
-
 
 .. tip::
 

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -129,10 +129,6 @@ Take the following ``access_control`` entries as an example:
             ;
         };
 
-.. versionadded:: 5.2
-
-    Support for comma-separated IP addresses was introduced in Symfony 5.2.
-
 For each incoming request, Symfony will decide which ``access_control``
 to use based on the URI, the client's IP address, the incoming host name,
 and the request method. Remember, the first rule that matches is used, and

--- a/security/authenticator_manager.rst
+++ b/security/authenticator_manager.rst
@@ -139,10 +139,6 @@ unauthenticated access (e.g. the login page):
 Granting Anonymous Users Access in a Custom Voter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.2
-
-    The ``NullToken`` class was introduced in Symfony 5.2.
-
 If you're using a :doc:`custom voter </security/voters>`, you can allow
 anonymous users access by checking for a special
 :class:`Symfony\\Component\\Security\\Core\\Authentication\\Token\\NullToken`. This token is used
@@ -424,11 +420,6 @@ into a security
 Security Passports
 ~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.2
-
-    The ``UserBadge`` was introduced in Symfony 5.2. Prior to 5.2, the user
-    instance was provided directly to the passport.
-
 A passport is an object that contains the user that will be authenticated as
 well as other pieces of information, like whether a password should be checked
 or if "remember me" functionality should be enabled.
@@ -550,10 +541,10 @@ the following badges are supported:
     initiated). This skips the
     :doc:`pre-authentication user checker </security/user_checkers>`.
 
-.. versionadded:: 5.2
+.. note::
 
-    Since 5.2, the ``PasswordUpgradeBadge`` is automatically added to
-    the passport if the passport has ``PasswordCredentials``.
+    The ``PasswordUpgradeBadge`` is automatically added to the passport if the
+    passport has ``PasswordCredentials``.
 
 For instance, if you want to add CSRF to your custom authenticator, you
 would initialize the passport like this::
@@ -618,7 +609,3 @@ would initialize the passport like this::
                 return new CustomOauthToken($passport->getUser(), $passport->getAttribute('scope'));
             }
         }
-
-.. versionadded:: 5.2
-
-    Passport attributes were introduced in Symfony 5.2.

--- a/security/csrf.rst
+++ b/security/csrf.rst
@@ -176,10 +176,6 @@ targeted parts of the plaintext. To mitigate these attacks, and prevent an
 attacker from guessing the CSRF tokens, a random mask is prepended to the token
 and used to scramble it.
 
-.. versionadded:: 5.3
-
-    The randomization of tokens was introduced in Symfony 5.3
-
 .. _`Cross-site request forgery`: https://en.wikipedia.org/wiki/Cross-site_request_forgery
 .. _`BREACH`: https://en.wikipedia.org/wiki/BREACH
 .. _`CRIME`: https://en.wikipedia.org/wiki/CRIME

--- a/security/custom_authentication_provider.rst
+++ b/security/custom_authentication_provider.rst
@@ -216,9 +216,6 @@ the ``PasswordDigest`` header value matches with the user's password::
 
         public function authenticate(TokenInterface $token): WsseUserToken
         {
-            // The loadUserByIdentifier() and getUserIdentifier() methods were
-            // introduced in Symfony 5.3. In previous versions they were called
-            // loadUserByUsername() and getUsername() respectively
             $user = $this->userProvider->loadUserByIdentifier($token->getUserIdentifier());
 
             if ($user && $this->validateDigest($token->digest, $token->nonce, $token->created, $user->getPassword())) {
@@ -439,7 +436,6 @@ to service ids that may not exist yet: ``App\Security\Authentication\Provider\Ws
 
             $services->set(WsseListener::class)
                 ->args([
-                    // In versions earlier to Symfony 5.1 the service() function was called ref()
                     service('security.token_storage'),
                     service('security.authentication.manager'),
                 ])

--- a/security/impersonating_user.rst
+++ b/security/impersonating_user.rst
@@ -101,11 +101,6 @@ instance, to show a link to exit impersonation in a template:
         <a href="{{ impersonation_exit_path(path('homepage') ) }}">Exit impersonation</a>
     {% endif %}
 
-.. versionadded:: 5.1
-
-    The ``IS_IMPERSONATOR`` was introduced in Symfony 5.1. Use
-    ``ROLE_PREVIOUS_ADMIN`` prior to Symfony 5.1.
-
 Finding the Original User
 -------------------------
 

--- a/security/json_login_setup.rst
+++ b/security/json_login_setup.rst
@@ -84,8 +84,6 @@ The next step is to configure a route in your app matching this path:
                 $user = $this->getUser();
 
                 return $this->json([
-                    // The getUserIdentifier() method was introduced in Symfony 5.3.
-                    // In previous versions it was called getUsername()
                     'username' => $user->getUserIdentifier(),
                     'roles' => $user->getRoles(),
                 ]);

--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -743,10 +743,6 @@ Then, configure this service ID as the ``success_handler``:
 Customizing the Login Link
 --------------------------
 
-.. versionadded:: 5.3
-
-    The possibility to customize the login link was introduced in Symfony 5.3.
-
 The ``createLoginLink()`` method accepts a second optional argument to pass the
 ``Request`` object used when generating the login link. This allows to customize
 features such as the locale used to generate the link::

--- a/security/remember_me.rst
+++ b/security/remember_me.rst
@@ -137,10 +137,6 @@ The ``remember_me`` firewall defines the following configuration options:
     Defines the ID of the service used to handle the Remember Me feature. It's
     useful if you need to overwrite the current behavior entirely.
 
-    .. versionadded:: 5.1
-
-        The ``service`` option was introduced in Symfony 5.1.
-
 Forcing the User to Opt-Out of the Remember Me Feature
 ------------------------------------------------------
 
@@ -206,10 +202,6 @@ users to change their password. You can do this by leveraging a few special
 
     There is also a ``IS_REMEMBERED`` attribute that grants *only* when the
     user is authenticated via the remember me mechanism.
-
-.. versionadded:: 5.1
-
-    The ``IS_REMEMBERED`` attribute was introduced in Symfony 5.1.
 
 .. _remember-me-token-in-database:
 

--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -56,10 +56,6 @@ displayed to the user::
         }
     }
 
-.. versionadded:: 5.1
-
-    The ``CustomUserMessageAccountStatusException`` class was introduced in Symfony 5.1.
-
 Enabling the Custom User Checker
 --------------------------------
 

--- a/security/user_provider.rst
+++ b/security/user_provider.rst
@@ -135,8 +135,6 @@ interface only requires one method: ``loadUserByIdentifier($identifier)``::
     {
         // ...
 
-        // The loadUserByIdentifier() method was introduced in Symfony 5.3.
-        // In previous versions it was called loadUserByUsername()
         public function loadUserByIdentifier(string $usernameOrEmail): ?User
         {
             $entityManager = $this->getEntityManager();
@@ -231,8 +229,6 @@ users will hash their passwords:
             # ...
             password_hashers:
                 # this internal class is used by Symfony to represent in-memory users
-                # (the 'InMemoryUser' class was introduced in Symfony 5.3.
-                # In previous versions it was called 'User')
                 Symfony\Component\Security\Core\User\InMemoryUser: 'auto'
 
     .. code-block:: xml
@@ -251,8 +247,6 @@ users will hash their passwords:
                 <!-- ... -->
 
                 <!-- this internal class is used by Symfony to represent in-memory users -->
-                <!-- (the 'InMemoryUser' class was introduced in Symfony 5.3.
-                     In previous versions it was called 'User') -->
                 <security:password-hasher class="Symfony\Component\Security\Core\User\InMemoryUser"
                     algorithm="auto"
                 />
@@ -264,8 +258,6 @@ users will hash their passwords:
         // config/packages/security.php
 
         // this internal class is used by Symfony to represent in-memory users
-        // (the 'InMemoryUser' class was introduced in Symfony 5.3.
-        // In previous versions it was called 'User')
         use Symfony\Component\Security\Core\User\InMemoryUser;
         use Symfony\Config\SecurityConfig;
 
@@ -373,9 +365,6 @@ command will generate a nice skeleton to get you started::
     class UserProvider implements UserProviderInterface, PasswordUpgraderInterface
     {
         /**
-         * The loadUserByIdentifier() method was introduced in Symfony 5.3.
-         * In previous versions it was called loadUserByUsername()
-         *
          * Symfony calls this method if you use features like switch_user
          * or remember_me. If you're not using these features, you do not
          * need to implement this method.

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -289,10 +289,6 @@ There are three strategies available:
     This grants or denies access by the first voter that does not abstain,
     based on their service priority;
 
-    .. versionadded:: 5.1
-
-        The ``priority`` version strategy was introduced in Symfony 5.1.
-
 Regardless the chosen strategy, if all voters abstained from voting, the
 decision is based on the ``allow_if_all_abstain`` config option (which
 defaults to ``false``).

--- a/serializer.rst
+++ b/serializer.rst
@@ -50,10 +50,6 @@ Or you can use the ``serialize`` Twig filter in a template:
 See the :doc:`twig reference </reference/twig_reference>` for
 more information.
 
-.. versionadded:: 5.3
-
-    A ``serialize`` filter was introduced in Symfony 5.3 that uses the Serializer component.
-
 Adding Normalizers and Encoders
 -------------------------------
 

--- a/service_container.rst
+++ b/service_container.rst
@@ -533,7 +533,6 @@ parameter and in PHP config use the ``service()`` function:
             $services = $configurator->services();
 
             $services->set(MessageGenerator::class)
-                // In versions earlier to Symfony 5.1 the service() function was called ref()
                 ->args([service('logger')])
             ;
         };
@@ -880,11 +879,6 @@ setting:
                 ->public()
             ;
         };
-
-.. deprecated:: 5.1
-
-    As of Symfony 5.1, it is no longer possible to autowire the service
-    container by type-hinting ``Psr\Container\ContainerInterface``.
 
 .. _service-psr4-loader:
 

--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -158,12 +158,6 @@ This means that when using the container directly, you can access the
 Deprecating Service Aliases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.1
-
-    The ``package`` and ``version`` options were introduced in Symfony 5.1.
-    Prior to 5.1, you had to use ``deprecated: true`` or
-    ``deprecated: 'Custom message'``.
-
 If you decide to deprecate the use of a service alias (because it is outdated
 or you decided not to maintain it anymore), you can deprecate its definition:
 
@@ -282,7 +276,6 @@ The following example shows how to inject an anonymous service into another serv
             $services = $configurator->services();
 
             $services->set(Foo::class)
-                // In versions earlier to Symfony 5.1 the inline_service() function was called inline()
                 ->args([inline_service(AnonymousBar::class)]);
         };
 

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -607,10 +607,6 @@ to a method, you can always explicitly :doc:`configure the method call </service
 If your PHP version doesn't support attributes (they were introduced in PHP 8),
 you can use the ``@required`` annotation instead.
 
-.. versionadded:: 5.2
-
-    The ``#[Required]`` attribute was introduced in Symfony 5.2.
-
 Despite property injection has some :ref:`drawbacks <property-injection>`,
 autowiring with ``#[Required]`` or ``@required`` can also be applied to public
 typed properties:
@@ -650,10 +646,6 @@ typed properties:
                 // ...
             }
         }
-
-.. versionadded:: 5.1
-
-    Public typed properties autowiring was introduced in Symfony 5.1.
 
 Autowiring Controller Action Methods
 ------------------------------------

--- a/service_container/calls.rst
+++ b/service_container/calls.rst
@@ -73,7 +73,6 @@ To configure the container to call the ``setLogger`` method, use the ``calls`` k
             // ...
 
             $services->set(MessageGenerator::class)
-                // In versions earlier to Symfony 5.1 the service() function was called ref()
                 ->call('setLogger', [service('logger')]);
         };
 
@@ -166,8 +165,3 @@ The configuration to tell the container it should do so would be like:
     PHP 8 ``static`` return type and a ``@required`` annotation to behave as
     a wither, you can add a ``@return $this`` annotation to disable the
     *returns clone* feature.
-
-    .. versionadded:: 5.1
-
-        Support for the PHP 8 ``static`` return type was introduced in
-        Symfony 5.1.

--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -179,7 +179,6 @@ all the classes are already loaded as services. All you need to do is specify th
             $services->load('App\\', '../src/*');
 
             // override the services to set the configurator
-            // In versions earlier to Symfony 5.1 the service() function was called ref()
             $services->set(NewsletterManager::class)
                 ->configurator(service(EmailConfigurator::class), 'configure');
 

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -163,7 +163,6 @@ Configuration of the service container then looks like this:
             // second, use the factory service as the first argument of the 'factory'
             // method and the factory method as the second argument
             $services->set(NewsletterManager::class)
-                // In versions earlier to Symfony 5.1 the service() function was called ref()
                 ->factory([service(NewsletterManagerFactory::class), 'createNewsletterManager']);
         };
 

--- a/service_container/injection_types.rst
+++ b/service_container/injection_types.rst
@@ -78,7 +78,6 @@ service container configuration:
             $services = $configurator->services();
 
             $services->set(NewsletterManager::class)
-                // In versions earlier to Symfony 5.1 the service() function was called ref()
                 ->args(service('mailer'));
         };
 

--- a/service_container/optional_dependencies.rst
+++ b/service_container/optional_dependencies.rst
@@ -42,7 +42,6 @@ if the service does not exist:
             $services = $configurator->services();
 
             $services->set(NewsletterManager::class)
-                // In versions earlier to Symfony 5.1 the service() function was called ref()
                 ->args([service('logger')->nullOnInvalid()]);
         };
 

--- a/service_container/parent_services.rst
+++ b/service_container/parent_services.rst
@@ -128,7 +128,6 @@ avoid duplicated service definitions:
             $services->set(BaseDoctrineRepository::class)
                 ->abstract()
                 ->args([service('doctrine.orm.entity_manager')])
-                // In versions earlier to Symfony 5.1 the service() function was called ref()
                 ->call('setLogger', [service('logger')])
             ;
 

--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -172,14 +172,8 @@ automatically changed to ``'.inner'``):
             $services->set(DecoratingMailer::class)
                 ->decorate(Mailer::class)
                 // pass the old service as an argument
-                // In versions earlier to Symfony 5.1 the service() function was called ref()
                 ->args([service('.inner')]);
         };
-
-.. versionadded:: 5.1
-
-    The special ``.inner`` value was introduced in Symfony 5.1. In previous
-    versions you needed to use: ``decorating_service_id + '.inner'``.
 
 .. tip::
 

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -372,7 +372,6 @@ other services. To do so, create a new service definition using the
             $services = $configurator->services();
 
             $services->set('app.command_handler_locator', ServiceLocator::class)
-                // In versions earlier to Symfony 5.1 the service() function was called ref()
                 ->args([[
                     'App\FooCommand' => service('app.command_handler.foo'),
                     'App\BarCommand' => service('app.command_handler.bar'),

--- a/session.rst
+++ b/session.rst
@@ -164,88 +164,10 @@ controllers if you type-hint an argument with
         }
     }
 
-.. deprecated:: 5.3
-
-    The ``SessionInterface`` and ``session`` service were deprecated in
-    Symfony 5.3. Instead, inject the ``RequestStack`` service to get the session
-    object of the current request.
-
 Stored attributes remain in the session for the remainder of that user's session.
 By default, session attributes are key-value pairs managed with the
 :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBag`
 class.
-
-.. deprecated:: 5.3
-
-    The ``NamespacedAttributeBag`` class is deprecated since Symfony 5.3.
-    If you need this feature, you will have to implement the class yourself.
-
-If your application needs are complex, you may prefer to use
-:ref:`namespaced session attributes <namespaced-attributes>` which are managed with the
-:class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\NamespacedAttributeBag`
-class. Before using them, override the ``session_listener`` service definition to build
-your ``Session`` object with the default ``AttributeBag`` by the ``NamespacedAttributeBag``:
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # config/services.yaml
-        session.factory:
-            autoconfigure: true
-            class: App\Session\SessionFactory
-            arguments:
-            - '@request_stack'
-            - '@session.storage.factory'
-            - ['@session_listener', 'onSessionUsage']
-            - '@session.namespacedattributebag'
-
-        session.namespacedattributebag:
-            class: Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag
-
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
-
-            <services>
-                <service id="session" class="Symfony\Component\HttpFoundation\Session\Session" public="true">
-                    <argument type="service" id="session.storage"/>
-                    <argument type="service" id="session.namespacedattributebag"/>
-                    <argument type="service" id="session.flash_bag"/>
-                </service>
-
-                <service id="session.namespacedattributebag"
-                    class="Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag"
-                />
-            </services>
-        </container>
-
-    .. code-block:: php
-
-        // config/services.php
-        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
-
-        use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
-        use Symfony\Component\HttpFoundation\Session\Session;
-
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
-
-            $services->set('session', Session::class)
-                ->public()
-                ->args([
-                    ref('session.storage'),
-                    ref('session.namespacedattributebag'),
-                    ref('session.flash_bag'),
-                ])
-            ;
-
-            $services->set('session.namespacedattributebag', NamespacedAttributeBag::class);
-        };
 
 .. _session-avoid-start:
 

--- a/session/database.rst
+++ b/session/database.rst
@@ -242,11 +242,6 @@ first register a new handler service with your database credentials:
     When using MySQL as the database, the DSN defined in ``DATABASE_URL`` can
     contain the ``charset`` and ``unix_socket`` options as query string parameters.
 
-    .. versionadded:: 5.3
-
-        The support for ``charset`` and ``unix_socket`` options was introduced
-        in Symfony 5.3.
-
 Next, use the :ref:`handler_id <config-framework-session-handler-id>`
 configuration option to tell Symfony to use this service as the session handler:
 

--- a/templates.rst
+++ b/templates.rst
@@ -559,10 +559,6 @@ provided by Symfony:
             ;
         };
 
-.. versionadded:: 5.1
-
-    The ``context`` option was introduced in Symfony 5.1.
-
 Checking if a Template Exists
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/testing.rst
+++ b/testing.rst
@@ -577,10 +577,6 @@ will no longer be followed::
 Logging in Users (Authentication)
 .................................
 
-.. versionadded:: 5.1
-
-    The ``loginUser()`` method was introduced in Symfony 5.1.
-
 When you want to add application tests for protected pages, you have to
 first "login" as a user. Reproducing the actual steps - such as
 submitting a login form - make a test very slow. For this reason, Symfony
@@ -900,10 +896,6 @@ Response Assertions
     :method:`Symfony\\Component\\HttpFoundation\\Response::getFormat` method
     is the same as the expected value.
 
-.. versionadded:: 5.3
-
-    The ``assertResponseFormatSame()`` method was introduced in Symfony 5.3.
-
 Request Assertions
 ..................
 
@@ -948,19 +940,8 @@ Crawler Assertions
     Asserts that value of the field of the first form matching the given
     selector does (not) equal the expected value.
 
-.. versionadded:: 5.2
-
-    The ``assertCheckboxChecked()``, ``assertCheckboxNotChecked()``,
-    ``assertFormValue()`` and ``assertNoFormValue()`` methods were introduced
-    in Symfony 5.2.
-
 Mailer Assertions
 .................
-
-.. versionadded:: 5.1
-
-    Starting from Symfony 5.1, the following assertions no longer require to make
-    a request with the ``Client`` in a test case extending the ``WebTestCase`` class.
 
 ``assertEmailCount(int $count, string $transport = null, string $message = '')``
     Asserts that the expected number of emails was sent.

--- a/translation.rst
+++ b/translation.rst
@@ -302,10 +302,6 @@ using PHP's :phpclass:`MessageFormatter` class. Read more about this in
 Translatable Objects
 --------------------
 
-.. versionadded:: 5.2
-
-    Translatable objects were introduced in Symfony 5.2.
-
 Sometimes translating contents in templates is cumbersome because you need the
 original message, the translation parameters and the translation domain for
 each content. Making the translation in the controller or services simplifies
@@ -475,11 +471,6 @@ The ``translation:update`` command looks for missing translations in:
   :ref:`translatable-objects` using the constructor or the ``t()`` method or calls
   the ``trans()`` method.
 
-.. versionadded:: 5.3
-
-    Support for extracting Translatable objects has been introduced in
-    Symfony 5.3.
-
 .. _translation-resource-locations:
 
 Translation Resource/File Names and Locations
@@ -595,11 +586,6 @@ if you're generating translations with specialized programs or teams.
 
 Translation Providers
 ---------------------
-
-.. versionadded:: 5.3
-
-    Translation providers were introduced in Symfony 5.3 as an
-    :doc:`experimental feature </contributing/code/experimental>`.
 
 When using external translators to translate your application, you must send
 them the new contents to translate frequently and merge the results back in the

--- a/translation/debug.rst
+++ b/translation/debug.rst
@@ -21,9 +21,8 @@ command helps you to find these missing or unused translation messages templates
 
     The extractors can't find messages translated outside templates (like form
     labels or controllers) unless using :ref:`translatable-objects` or calling
-    the ``trans()`` method on a translator (since Symfony 5.3). Dynamic
-    translations using variables or expressions in templates are not
-    detected either:
+    the ``trans()`` method on a translator. Dynamic translations using variables
+    or expressions in templates are not detected either:
 
     .. code-block:: twig
 
@@ -208,7 +207,3 @@ These constants are defined as "bit masks", so you can combine them as follows::
     if (TranslationDebugCommand::EXIT_CODE_MISSING | TranslationDebugCommand::EXIT_CODE_UNUSED) {
         // ... there are missing and/or unused translations
     }
-
-.. versionadded:: 5.1
-
-    The exit codes were introduced in Symfony 5.1

--- a/translation/lint.rst
+++ b/translation/lint.rst
@@ -40,10 +40,6 @@ adapted to the format required by GitHub, but you can force that format too:
 
     $ php bin/console lint:yaml translations/ --format=github
 
-.. versionadded:: 5.3
-
-    The ``github`` output format was introduced in Symfony 5.3.
-
 .. tip::
 
     The Yaml component provides a stand-alone ``yaml-lint`` binary allowing
@@ -52,9 +48,5 @@ adapted to the format required by GitHub, but you can force that format too:
     .. code-block:: terminal
 
         $ php vendor/bin/yaml-lint translations/
-
-    .. versionadded:: 5.1
-
-        The ``yaml-lint`` binary was introduced in Symfony 5.1.
 
 .. _`GitHub Actions`: https://docs.github.com/en/free-pro-team@latest/actions

--- a/validation.rst
+++ b/validation.rst
@@ -817,10 +817,6 @@ provide more custom validation.
 Debugging the Constraints
 -------------------------
 
-.. versionadded:: 5.2
-
-    The ``debug:validator`` command was introduced in Symfony 5.2.
-
 Use the ``debug:validator`` command to list the validation constraints of a
 given class:
 

--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -48,12 +48,6 @@ Add ``@Annotation`` or ``#[\Attribute]`` to the constraint class if you want to
 use it as an annotation/attribute in other classes. If the constraint has
 configuration options, define them as public properties on the constraint class.
 
-.. versionadded:: 5.2
-
-    The ability to use PHP attributes to configure constraints was introduced in
-    Symfony 5.2. Prior to this, Doctrine Annotations were the only way to
-    annotate constraints.
-
 Creating the Validator itself
 -----------------------------
 
@@ -229,10 +223,6 @@ Create a Reusable Set of Constraints
 
 In case you need to apply some common set of constraints in different places
 consistently across your application, you can extend the :doc:`Compound constraint </reference/constraints/Compound>`.
-
-.. versionadded:: 5.1
-
-    The ``Compound`` constraint was introduced in Symfony 5.1.
 
 Class Constraint Validator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/validation/sequence_provider.rst
+++ b/validation/sequence_provider.rst
@@ -426,7 +426,3 @@ How to Sequentially Apply Constraints on a Single Property
 Sometimes, you may want to apply constraints sequentially on a single
 property. The :doc:`Sequentially constraint </reference/constraints/Sequentially>`
 can solve this for you in a more straightforward way than using a ``GroupSequence``.
-
-.. versionadded:: 5.1
-
-    The ``Sequentially`` constraint was introduced in Symfony 5.1.

--- a/workflow.rst
+++ b/workflow.rst
@@ -382,20 +382,14 @@ order:
 
         $workflow->apply($subject, $transitionName, [Workflow::DISABLE_ANNOUNCE_EVENT => true]);
 
-    .. versionadded:: 5.1
+    The context is accessible in all events::
 
-        The ``Workflow::DISABLE_ANNOUNCE_EVENT`` constant was introduced in Symfony 5.1.
+        // $context must be an array
+        $context = ['context_key' => 'context_value'];
+        $workflow->apply($subject, $transitionName, $context);
 
-    .. versionadded:: 5.2
-
-        In Symfony 5.2, the context is accessible in all events::
-
-            // $context must be an array
-            $context = ['context_key' => 'context_value'];
-            $workflow->apply($subject, $transitionName, $context);
-
-            // in an event listener
-            $context = $event->getContext(); // returns ['context']
+        // in an event listener
+        $context = $event->getContext(); // returns ['context']
 
 .. note::
 
@@ -492,16 +486,8 @@ missing a title::
         }
     }
 
-.. versionadded:: 5.1
-
-    The optional second argument of ``setBlocked()`` was introduced in Symfony 5.1.
-
 Choosing which Events to Dispatch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.2
-
-    Ability to choose which events to dispatch was introduced in Symfony 5.2.
 
 If you prefer to control which events are fired when performing each transition,
 use the ``events_to_dispatch`` configuration option. This option does not apply
@@ -593,13 +579,7 @@ events specified in the workflow configuration. In the above example the
 ``workflow.leave`` event will not be fired, even if it has been specified as an
 event to be dispatched for all transitions in the workflow configuration.
 
-.. versionadded:: 5.1
-
-    The ``Workflow::DISABLE_ANNOUNCE_EVENT`` constant was introduced in Symfony 5.1.
-
-.. versionadded:: 5.2
-
-    The constants for other events (as seen below) were introduced in Symfony 5.2.
+Thees are all the available constants:
 
     * ``Workflow::DISABLE_LEAVE_EVENT``
     * ``Workflow::DISABLE_TRANSITION_EVENT``

--- a/workflow/dumping-workflows.rst
+++ b/workflow/dumping-workflows.rst
@@ -12,10 +12,6 @@ applications needed to generate the images:
 * `Mermaid CLI`_, provides the ``mmdc`` command;
 * `PlantUML`_, provides the ``plantuml.jar`` file (which requires Java).
 
-.. versionadded:: 5.3
-
-    The ``mermaid`` dump format was introduced in Symfony 5.3.
-
 If you are defining the workflow inside a Symfony application, run this command
 to dump it as an image:
 


### PR DESCRIPTION
This process had to be manual because some `versionadded` directives contained information that had to be moved to notes or normal paragraphs. Thanks!
