### PR TITLE
Update Contracts to 3.0 version

### DIFF
--- a/components/contracts.rst
+++ b/components/contracts.rst
@@ -61,7 +61,7 @@ convention. For example:
     {
         "...": "...",
         "provide": {
-            "symfony/cache-implementation": "1.0"
+            "symfony/cache-implementation": "3.0"
         }
     }
 


### PR DESCRIPTION
Fixes #15517.

Although the code PR makes many changes and adds lots of return types ... I couldn't find any other possible fix in the docs. We already use return types for all these methods (e.g. all of our `getSubscribedServices()` methods already return `array`).