### PR TITLE
[Security] Deprecate always_authenticate_before_granting option

### DIFF
--- a/components/security/authentication.rst
+++ b/components/security/authentication.rst
@@ -302,6 +302,11 @@ request if you have session-based authentication, if ``always_authenticate_befor
 is enabled or if token is not authenticated before AccessListener is invoked.
 See ``security.interactive_login`` below if you need to do something when a user *actually* logs in.
 
+.. deprecated:: 5.4
+
+    The ``always_authenticate_before_granting`` option was deprecated in
+    Symfony 5.4 and it will be removed in Symfony 6.0.
+
 When a provider attempts authentication but fails (i.e. throws an ``AuthenticationException``),
 a ``security.authentication.failure`` event is dispatched. You could listen on
 the ``security.authentication.failure`` event, for example, in order to log

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -58,6 +58,11 @@ always_authenticate_before_granting
 
 **type**: ``boolean`` **default**: ``false``
 
+.. deprecated:: 5.4
+
+    The ``always_authenticate_before_granting`` option was deprecated in
+    Symfony 5.4 and it will be removed in Symfony 6.0.
+
 If ``true``, the user is asked to authenticate before each call to the
 ``isGranted()`` method in services and controllers or ``is_granted()`` from
 templates.


### PR DESCRIPTION
Fixes #15497.

I couldn't find any occurrences in the docs about the deprecated 4th and 5th argument of `AuthorizationChecker` or about the deprecated 5th argument of `AccessListener`, so there's nothing to do about them.