### PR TITLE
[Validator] Add attributes documentation of composite constraints

### DIFF
--- a/reference/constraints/All.rst
+++ b/reference/constraints/All.rst
@@ -39,6 +39,23 @@ entry in that array:
             protected $favoriteColors = [];
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/User.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        // IMPORTANT: nested attributes requires PHP 8.1 or higher
+        class User
+        {
+            #[Assert\All([
+                new Assert\NotBlank,
+                new Assert\Length(min: 5),
+            ])]
+            protected $favoriteColors = [];
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -92,6 +109,11 @@ entry in that array:
                 ]));
             }
         }
+
+.. versionadded:: 5.4
+
+    The ``#[All]`` PHP attribute was introduced in Symfony 5.4 and requires
+    PHP 8.1 (which added nested attribute support).
 
 Now, each entry in the ``favoriteColors`` array will be validated to not
 be blank and to be at least 5 characters long.

--- a/reference/constraints/AtLeastOneOf.rst
+++ b/reference/constraints/AtLeastOneOf.rst
@@ -60,6 +60,31 @@ The following constraints ensure that:
             protected $grades;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Student.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        // IMPORTANT: nested attributes requires PHP 8.1 or higher
+        class Student
+        {
+            #[Assert\AtLeastOneOf([
+                new Assert\Regex('/#/'),
+                new Assert\Length(min: 10),
+            ])]
+            protected $plainPassword;
+
+            #[Assert\AtLeastOneOf([
+                new Assert\Count(min: 3),
+                new Assert\All(
+                    new Assert\GreaterThanOrEqual(5)
+                ),
+            ])]
+            protected $grades;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -148,6 +173,11 @@ The following constraints ensure that:
                 ]));
             }
         }
+
+.. versionadded:: 5.4
+
+    The ``#[AtLeastOneOf]`` PHP attribute was introduced in Symfony 5.4 and
+    requires PHP 8.1 (which added nested attribute support).
 
 Options
 -------

--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -88,6 +88,35 @@ following:
             ];
         }
 
+    .. code-block:: php-attributes
+
+        // src/Entity/Author.php
+        namespace App\Entity;
+
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        // IMPORTANT: nested attributes requires PHP 8.1 or higher
+        class Author
+        {
+            #[Assert\Collection(
+                fields: [
+                    'personal_email' => new Assert\Email,
+                    'short_bio' => [
+                        new Assert\NotBlank,
+                        new Assert\Length(
+                            max: 100,
+                            maxMessage: 'Your short bio is too long!'
+                        )
+                    ]
+                ],
+                allowMissingFields: true,
+            )]
+            protected $profileData = [
+                'personal_email' => '...',
+                'short_bio' => '...',
+            ];
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -161,6 +190,11 @@ following:
                 ]));
             }
         }
+
+.. versionadded:: 5.4
+
+    The ``#[Collection]`` PHP attribute was introduced in Symfony 5.4 and
+    requires PHP 8.1 (which added nested attribute support).
 
 Presence and Absence of Fields
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/reference/constraints/Sequentially.rst
+++ b/reference/constraints/Sequentially.rst
@@ -67,6 +67,27 @@ You can validate each of these constraints sequentially to solve these issues:
             public $address;
         }
 
+    .. code-block:: php-attributes
+
+        // src/Localization/Place.php
+        namespace App\Localization;
+
+        use App\Validator\Constraints as AcmeAssert;
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        // IMPORTANT: nested attributes requires PHP 8.1 or higher
+        class Place
+        {
+            #[Assert\Sequentially([
+                new Assert\NotNull,
+                new Assert\Type('string'),
+                new Assert\Length(min: 10),
+                new Assert\Regex(Place::ADDRESS_REGEX),
+                new AcmeAssert\Geolocalizable,
+            ])]
+            public $address;
+        }
+
     .. code-block:: yaml
 
         # config/validator/validation.yaml
@@ -127,6 +148,11 @@ You can validate each of these constraints sequentially to solve these issues:
                 ]));
             }
         }
+
+.. versionadded:: 5.4
+
+    The ``#[Sequentially]`` PHP attribute was introduced in Symfony 5.4 and
+    requires PHP 8.1 (which added nested attribute support).
 
 Options
 -------


### PR DESCRIPTION
Related pull-request: https://github.com/symfony/symfony/pull/41994

Not really sure how to precise it only works for attributes in PHP 8.1, not 8.0. If you have a solution, please let me know!