### PR TITLE
[Form] Remove useless quotes for `render_rest` attribute

### DIFF
--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -204,7 +204,7 @@ article) unless you set ``render_rest`` to false:
 .. code-block:: twig
 
     {# don't render unrendered fields #}
-    {{ form_end(form, {'render_rest': false}) }}
+    {{ form_end(form, {render_rest: false}) }}
 
 .. _reference-forms-twig-label:
 


### PR DESCRIPTION
Quotes are useless here, it's clearer without