### PR TITLE
Fix wrong option flag name

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -500,7 +500,7 @@ the ``debug:firewall`` command:
 
     # displays the details of a specific firewall, including detailed information
     # about the event listeners for the firewall
-    $ php bin/console debug:firewall main --include-listeners
+    $ php bin/console debug:firewall main --events
 
 .. versionadded:: 5.3
 


### PR DESCRIPTION
It seems that the documented option doesn't exists in the new `debug:firewall` command
