### PR TITLE
[Twig] Document the GitHub actions format in lint:twig

### DIFF
--- a/templates.rst
+++ b/templates.rst
@@ -612,6 +612,17 @@ errors. It's useful to run it before deploying your application to production
     # you can also show the deprecated features used in your templates
     $ php bin/console lint:twig --show-deprecations templates/email/
 
+When running the linter inside `GitHub Actions`_, the output is automatically
+adapted to the format required by GitHub, but you can force that format too:
+
+.. code-block:: terminal
+
+    $ php bin/console lint:twig --format=github
+
+.. versionadded:: 5.4
+
+    The ``github`` output format was introduced in Symfony 5.4.
+
 Inspecting Twig Information
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1163,3 +1174,4 @@ Learn more
 .. _`Twig template inheritance`: https://twig.symfony.com/doc/2.x/tags/extends.html
 .. _`Twig block tag`: https://twig.symfony.com/doc/2.x/tags/block.html
 .. _`Cross-Site Scripting`: https://en.wikipedia.org/wiki/Cross-site_scripting
+.. _`GitHub Actions`: https://docs.github.com/en/free-pro-team@latest/actions


### PR DESCRIPTION
Fixes #15555.