### PR TITLE
[FrameworkBundle] Add documentation about using a DSN as the `session.handler_id`

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1364,10 +1364,55 @@ handler_id
 
 **type**: ``string`` **default**: ``'session.handler.native_file'``
 
-The service id used for session storage. The default value ``'session.handler.native_file'``
+The service id or DSN used for session storage. The default value ``'session.handler.native_file'``
 will let Symfony manage the sessions itself using files to store the session metadata.
-Set it to ``null`` to use the native PHP session mechanism.
-You can also :doc:`store sessions in a database </session/database>`.
+Set it to ``null`` to use the native PHP session mechanism. You can also provide a DSN to specify
+the used storage-directory or :doc:`store sessions in a database </session/database>`:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/framework.yaml
+        framework:
+            session:
+                # ...
+                handler_id: 'redis://localhost'
+                handler_id: '%env(REDIS_URL)%'
+                handler_id: '%env(resolve:DATABASE_URL)%'
+                handler_id: 'file://%kernel.project_dir%/var/sessions'
+
+    .. code-block:: xml
+
+        <!-- config/packages/framework.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+            <framework:config>
+                <framework:session enabled="true"
+                    handler-id="redis://localhost"
+                    handler-id="%env(REDIS_URL)%"
+                    handler-id="%env(resolve:DATABASE_URL)%"
+                    handler-id="file://%kernel.project_dir%/var/sessions"/>
+            </framework:config>
+        </container>
+
+    .. code-block:: php
+
+        // config/packages/framework.php
+        $container->loadFromExtension('framework', [
+            'session' => [
+                // ...
+                'handler_id' => 'redis://localhost',
+                'handler_id' => '%env(REDIS_URL)%',
+                'handler_id' => '%env(resolve:DATABASE_URL)%',
+                'handler_id' => 'file://%kernel.project_dir%/var/sessions',
+            ],
+        ]);
 
 .. _name:
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1377,9 +1377,6 @@ the used storage-directory or :doc:`store sessions in a database </session/datab
         framework:
             session:
                 # ...
-                handler_id: 'redis://localhost'
-                handler_id: '%env(REDIS_URL)%'
-                handler_id: '%env(resolve:DATABASE_URL)%'
                 handler_id: 'file://%kernel.project_dir%/var/sessions'
 
     .. code-block:: xml
@@ -1393,11 +1390,7 @@ the used storage-directory or :doc:`store sessions in a database </session/datab
                 https://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
             <framework:config>
-                <framework:session enabled="true"
-                    handler-id="redis://localhost"
-                    handler-id="%env(REDIS_URL)%"
-                    handler-id="%env(resolve:DATABASE_URL)%"
-                    handler-id="file://%kernel.project_dir%/var/sessions"/>
+                <framework:session enabled="true" handler-id="file://%kernel.project_dir%/var/sessions"/>
             </framework:config>
         </container>
 
@@ -1407,9 +1400,6 @@ the used storage-directory or :doc:`store sessions in a database </session/datab
         $container->loadFromExtension('framework', [
             'session' => [
                 // ...
-                'handler_id' => 'redis://localhost',
-                'handler_id' => '%env(REDIS_URL)%',
-                'handler_id' => '%env(resolve:DATABASE_URL)%',
                 'handler_id' => 'file://%kernel.project_dir%/var/sessions',
             ],
         ]);

--- a/session/database.rst
+++ b/session/database.rst
@@ -25,10 +25,7 @@ Besides specifying a service as the session-handler you can also provide a
         framework:
             session:
                 # ...
-                handler_id: 'redis://localhost'
-                handler_id: '%env(REDIS_URL)%'
-                handler_id: '%env(resolve:DATABASE_URL)%'
-                handler_id: 'file://%kernel.project_dir%/var/sessions'
+                handler_id: 'redis://password@redis-server:6379'
 
     .. code-block:: xml
 
@@ -41,11 +38,7 @@ Besides specifying a service as the session-handler you can also provide a
                 https://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
             <framework:config>
-                <framework:session enabled="true"
-                    handler-id="redis://localhost"
-                    handler-id="%env(REDIS_URL)%"
-                    handler-id="%env(resolve:DATABASE_URL)%"
-                    handler-id="file://%kernel.project_dir%/var/sessions"/>
+                <framework:session enabled="true" handler-id="redis://password@redis-server:6379"/>
             </framework:config>
         </container>
 
@@ -55,10 +48,7 @@ Besides specifying a service as the session-handler you can also provide a
         $container->loadFromExtension('framework', [
             'session' => [
                 // ...
-                'handler_id' => 'redis://localhost',
-                'handler_id' => '%env(REDIS_URL)%',
-                'handler_id' => '%env(resolve:DATABASE_URL)%',
-                'handler_id' => 'file://%kernel.project_dir%/var/sessions',
+                'handler_id' => 'redis://password@redis-server:6379',
             ],
         ]);
 

--- a/session/database.rst
+++ b/session/database.rst
@@ -11,6 +11,74 @@ across different servers.
 Symfony can store sessions in all kinds of databases (relational, NoSQL and
 key-value) but recommends key-value databases like Redis to get best performance.
 
+Define Session Storage by DSN
+-----------------------------
+
+Besides specifying a service as the session-handler you can also provide a
+"DSN" directly and let Symfony create the necessary services/clients:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/framework.yaml
+        framework:
+            session:
+                # ...
+                handler_id: 'redis://localhost'
+                handler_id: '%env(REDIS_URL)%'
+                handler_id: '%env(resolve:DATABASE_URL)%'
+                handler_id: 'file://%kernel.project_dir%/var/sessions'
+
+    .. code-block:: xml
+
+        <!-- config/packages/framework.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+            <framework:config>
+                <framework:session enabled="true"
+                    handler-id="redis://localhost"
+                    handler-id="%env(REDIS_URL)%"
+                    handler-id="%env(resolve:DATABASE_URL)%"
+                    handler-id="file://%kernel.project_dir%/var/sessions"/>
+            </framework:config>
+        </container>
+
+    .. code-block:: php
+
+        // config/packages/framework.php
+        $container->loadFromExtension('framework', [
+            'session' => [
+                // ...
+                'handler_id' => 'redis://localhost',
+                'handler_id' => '%env(REDIS_URL)%',
+                'handler_id' => '%env(resolve:DATABASE_URL)%',
+                'handler_id' => 'file://%kernel.project_dir%/var/sessions',
+            ],
+        ]);
+
+Supported DSN protocols are:
+
+- file (i.e.: ``file://%kernel.project_dir%/var/sessions``)
+- redis (i.e.: ``redis://redis-server:6379``)
+- rediss
+- memcached
+- pdo_oci
+- mssql
+- mysql
+- mysql2
+- pgsql
+- postgres
+- postgresql
+- sqlsrv
+- sqlite
+- sqlite3
+
 Store Sessions in a key-value Database (Redis)
 ----------------------------------------------
 


### PR DESCRIPTION
The option to provide a DSN as the `framework.session.handler_id` was introduced in v4.4 but is currently not documented. It was previously mentioned, but the section was removed at some point. 
I've reused the config-example from https://github.com/symfony/symfony-docs/pull/13227, and added it to both, the framework configuration reference and the page about using a database for session-storage (as the DSN can be used for file- or database-storage).
