### PR TITLE
Update page_creation.rst

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -163,7 +163,7 @@ To get a list of *all* of the routes in your system, use the ``debug:router`` co
 
     $ php bin/console debug:router
 
-You should see your ``app_lucky_number`` route at the very top:
+You should see your ``app_lucky_number`` route in the list:
 
 ================== ======== ======== ====== ===============
  Name               Method   Scheme   Host   Path


### PR DESCRIPTION
I did not see app_lucky_number at the top as described, it was somewhere in the list nearer the bottom among other routes (e.g. _profiler_home,  _profiler_search)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
