### PR TITLE
Removing full URL of error page preview

### DIFF
--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -183,13 +183,10 @@ automatically when installing ``symfony/framework-bundle``):
             ;
         };
 
-With this route added, you can use URLs like these to preview the *error* page
-for a given status code as HTML or for a given status code and format.
+Now you can preview your error page on these two routes:
 
-.. code-block:: text
-
-     http://localhost/index.php/_error/{statusCode}
-     http://localhost/index.php/_error/{statusCode}.{format}
+* `/_error/{statusCode}` for HTML
+* `/_error/{statusCode}.{format}` for any other format
 
 .. _overriding-non-html-error-output:
 


### PR DESCRIPTION
Reason: The actual url (`http://localhost/index.php/` vs. `http://localhost` vs. `http://whatever` vs. ...) depends on the local web server config.
If you're using the recommended nginx config at https://symfony.com/doc/current/setup/web_server_configuration.html#nginx, you'd have to remove `internal;`. I thought about explaining this, but in the end there are probably too many possible server configs to cover them all...