### PR TITLE
Adding global namespace to `Throwable`

### DIFF
--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -284,7 +284,7 @@ the request that will be dispatched to your controller. In addition, your contro
 will be passed two parameters:
 
 ``exception``
-    The original :class:`Throwable` instance being handled.
+    The original :class:`\Throwable` instance being handled.
 
 ``logger``
     A :class:`\\Symfony\\Component\\HttpKernel\\Log\\DebugLoggerInterface`


### PR DESCRIPTION
* I hope this is the right syntax - don't know what `:class:` is for...
* This only works if you add `(..., ?\Throwable $exception=null)` to the controllers arguments list. Shouldn't this be mentioned too?
