### PR TITLE
[Security] Update ldap.rst

### DIFF
--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -70,6 +70,8 @@ An LDAP client can be configured using the built-in
         services:
             Symfony\Component\Ldap\Ldap:
                 arguments: ['@Symfony\Component\Ldap\Adapter\ExtLdap\Adapter']
+                tags:
+                    - ldap
             Symfony\Component\Ldap\Adapter\ExtLdap\Adapter:
                 arguments:
                     -   host: my-server


### PR DESCRIPTION
## Overview

Without the tags I was getting this error:

> Cannot check credentials using the "Symfony\Component\Ldap\Ldap" ldap service, as such service is not found. Did you maybe forget to add the "ldap" service tag to this service?
