### PR TITLE
[Testing] update deprecation

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -609,7 +609,7 @@ to simulate a login request::
         public function testVisitingWhileLoggedIn()
         {
             $client = static::createClient();
-            $userRepository = static::$container->get(UserRepository::class);
+            $userRepository = static::getContainer()->get(UserRepository::class);
 
             // retrieve the test user
             $testUser = $userRepository->findOneByEmail('john.doe@example.com');


### PR DESCRIPTION
```deprecated since Symfony 5.3, use static::getContainer() instead```