### PR TITLE
[Security] Replace deprecated `PassportInterface` occurrences by `Passport`

### DIFF
--- a/security/authenticator_manager.rst
+++ b/security/authenticator_manager.rst
@@ -300,7 +300,7 @@ method that fits most use-cases::
     use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
     use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
     use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
-    use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+    use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
     use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
     class ApiKeyAuthenticator extends AbstractAuthenticator
@@ -315,7 +315,7 @@ method that fits most use-cases::
             return $request->headers->has('X-AUTH-TOKEN');
         }
 
-        public function authenticate(Request $request): PassportInterface
+        public function authenticate(Request $request): Passport
         {
             $apiToken = $request->headers->get('X-AUTH-TOKEN');
             if (null === $apiToken) {
@@ -474,7 +474,7 @@ using :ref:`the user provider <security-user-providers>`::
                 $this->userRepository = $userRepository;
             }
 
-            public function authenticate(Request $request): PassportInterface
+            public function authenticate(Request $request): Passport
             {
                 // ...
 
@@ -570,11 +570,11 @@ would initialize the passport like this::
     use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
     use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
     use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
-    use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+    use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 
     class LoginAuthenticator extends AbstractAuthenticator
     {
-        public function authenticate(Request $request): PassportInterface
+        public function authenticate(Request $request): Passport
         {
             $password = $request->request->get('password');
             $username = $request->request->get('username');
@@ -604,7 +604,7 @@ would initialize the passport like this::
         {
             // ...
 
-            public function authenticate(Request $request): PassportInterface
+            public function authenticate(Request $request): Passport
             {
                 // ... process the request
 
@@ -616,7 +616,7 @@ would initialize the passport like this::
                 return $passport;
             }
 
-            public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+            public function createAuthenticatedToken(Passport $passport, string $firewallName): TokenInterface
             {
                 // read the attribute value
                 return new CustomOauthToken($passport->getUser(), $passport->getAttribute('scope'));


### PR DESCRIPTION
Fixes #15593 
