### PR TITLE
[Validator] Add Validation::createCallable()

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -397,6 +397,22 @@ If you reach this max number it will use the default value. Using ``null`` means
 the amount of attempts is infinite. The user will be asked as long as they provide an
 invalid answer and will only be able to proceed if their input is valid.
 
+.. tip::
+
+    You can even use the :doc:`Validator </validation>` component to
+    validate the input by using the :method:`Symfony\\Component\\Validator\\Validation::createCallable`
+    method::
+
+        use Symfony\Component\Validator\Constraints\Regex;
+        use Symfony\Component\Validator\Validation;
+
+        $question = new Question('Please enter the name of the bundle', 'AcmeDemoBundle');
+        $validation = Validation::createCallable(new Regex([
+            'pattern' => '/^[a-zA-Z]+Bundle$',
+            'message' => 'The name of the bundle should be suffixed with \'Bundle\'',
+        ]));
+        $question->setValidator($validation);
+
 Validating a Hidden Response
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -376,6 +376,21 @@ returns ``true`` for acceptable values and ``false`` for invalid values::
         // return true or false
     });
 
+.. tip::
+
+    You can even use the :doc:`Validator </validation>` component to validate the
+    input by using the :method:`Symfony\\Component\\Validator\\Validation::createValidCallable`
+    method::
+
+        use Symfony\Component\OptionsResolver\OptionsResolver;
+        use Symfony\Component\Validator\Constraints\Length;
+        use Symfony\Component\Validator\Validation;
+
+        // ...
+        $resolver->setAllowedValues('transport', Validation::createValidCallable(
+            new Length(['min' => 10 ])
+        ));
+
 In sub-classes, you can use :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::addAllowedValues`
 to add additional allowed values without erasing the ones already set.
 

--- a/validation.rst
+++ b/validation.rst
@@ -231,6 +231,30 @@ Inside the template, you can output the list of errors exactly as needed:
     a :class:`Symfony\\Component\\Validator\\ConstraintViolation` object.
 
 .. index::
+   single: Validation; Callables
+
+Validation Callables
+~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.1
+
+    ``Validation::createCallable()`` was introduced in Symfony 5.1.
+
+.. versionadded:: 5.3
+
+    ``Validation::createValidCallable()`` was introduced in Symfony 5.3.
+
+The ``Validation`` also allows you to create a closure to validate values
+against a set of constraints (e.g. in :doc:`Console </components/console/helpers/questionhelper>`
+or :doc:`OptionsResolver </components/options_resolver>`):
+
+:method:`Symfony\\Component\\Validator\\Validation::createCallable`
+    This returns a closure that throws ``ValidationFailedException`` when the
+    constraints aren't matched.
+:method:`Symfony\\Component\\Validator\\Validation::createValidCallable`
+    This returns a closure that returns ``false`` when the constraints aren't matched.
+
+.. index::
    single: Validation; Constraints
 
 .. _validation-constraints:


### PR DESCRIPTION
I just took the examples from https://symfony.com/blog/new-in-symfony-5-1-validator-improvements#validation-callables and https://github.com/symfony/symfony-docs/issues/15093

Fixes #13045
Fixes #15093 
