### PR TITLE
[Mailer] Ignore X-Transport while signing

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1062,7 +1062,7 @@ key but not a certificate::
     $signedEmail = $signer->sign($email, (new DkimOptions())
         ->bodyCanon('relaxed')
         ->headerCanon('relaxed')
-        ->headersToIgnore(['Message-ID'])
+        ->headersToIgnore(['Message-ID', 'X-Transport'])
         ->toArray()
     );
 


### PR DESCRIPTION
It is unclear that X-Transport must be ignored when signing email with using multiple transports in application:
https://github.com/symfony/symfony/issues/39354#issuecomment-894452945