### PR TITLE
Deprecate the get() and has() shortcuts of AbstractController

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -244,7 +244,7 @@ Use Dependency Injection to Get Services
 
 If you extend the base ``AbstractController``, you can only access to the most
 common services (e.g ``twig``, ``router``, ``doctrine``, etc.), directly from the
-container via ``$this->container->get()`` or ``$this->get()``.
+container via ``$this->container->get()``.
 Instead, you must use dependency injection to fetch services by
 :ref:`type-hinting action method arguments <controller-accessing-services>` or
 constructor arguments.

--- a/forms.rst
+++ b/forms.rst
@@ -857,14 +857,15 @@ method::
 
     use App\Form\TaskType;
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\Form\FormFactoryInterface;
     // ...
 
     class TaskController extends AbstractController
     {
-        public function new(): Response
+        public function new(FormFactoryInterface $formFactory): Response
         {
             $task = ...;
-            $form = $this->get('form.factory')->createNamed('my_name', TaskType::class, $task);
+            $form = $formFactory->createNamed('my_name', TaskType::class, $task);
 
             // ...
         }


### PR DESCRIPTION
Fixes #15606.

We've been promoting service injection for long, so there weren't many `get()` occurrences to fix and I couldn't find any `has()` occurrence from AbstractController.

This PR leaves a `get()` usage on purpose in the `doctrine.rst` article because it was removed in another PR: #15607.