### PR TITLE
Deprecate the Request::get() method

### DIFF
--- a/create_framework/front_controller.rst
+++ b/create_framework/front_controller.rst
@@ -38,7 +38,7 @@ Let's see it in action::
     // framework/index.php
     require_once __DIR__.'/init.php';
 
-    $name = $request->get('name', 'World');
+    $name = $request->attributes->get('name', 'World');
 
     $response->setContent(sprintf('Hello %s', htmlspecialchars($name, ENT_QUOTES, 'UTF-8')));
     $response->send();
@@ -98,7 +98,7 @@ Such a script might look like the following::
 And here is for instance the new ``hello.php`` script::
 
     // framework/hello.php
-    $name = $request->get('name', 'World');
+    $name = $request->attributes->get('name', 'World');
     $response->setContent(sprintf('Hello %s', htmlspecialchars($name, ENT_QUOTES, 'UTF-8')));
 
 In the ``front.php`` script, ``$map`` associates URL paths with their
@@ -190,7 +190,7 @@ And the ``hello.php`` script can now be converted to a template:
 .. code-block:: html+php
 
     <!-- example.com/src/pages/hello.php -->
-    <?php $name = $request->get('name', 'World') ?>
+    <?php $name = $request->attributes->get('name', 'World') ?>
 
     Hello <?= htmlspecialchars($name, ENT_QUOTES, 'UTF-8') ?>
 

--- a/create_framework/http_foundation.rst
+++ b/create_framework/http_foundation.rst
@@ -141,7 +141,7 @@ Now, let's rewrite our application by using the ``Request`` and the
 
     $request = Request::createFromGlobals();
 
-    $name = $request->get('name', 'World');
+    $name = $request->attributes->get('name', 'World');
 
     $response = new Response(sprintf('Hello %s', htmlspecialchars($name, ENT_QUOTES, 'UTF-8')));
 


### PR DESCRIPTION
Fixes #15590.

We don't use `Request::get` anywhere in Symfony Docs ... but this "Create Framework" tutorial had some occurrences.