### PR TITLE
[DependencyInjection] Improve url env var processor with type cast

### DIFF
--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -549,9 +549,9 @@ Symfony provides the following env var processors:
                 clients:
                     default:
                         hosts:
-                            - { host: '%env(key:host:url:MONGODB_URL)%', port: '%env(key:port:url:MONGODB_URL)%' }
-                        username: '%env(key:user:url:MONGODB_URL)%'
-                        password: '%env(key:pass:url:MONGODB_URL)%'
+                            - { host: '%env(string:key:host:url:MONGODB_URL)%', port: '%env(int:key:port:url:MONGODB_URL)%' }
+                        username: '%env(string:key:user:url:MONGODB_URL)%'
+                        password: '%env(string:key:pass:url:MONGODB_URL)%'
                 connections:
                     default:
                         database_name: '%env(key:path:url:MONGODB_URL)%'
@@ -566,8 +566,8 @@ Symfony provides the following env var processors:
                     https://symfony.com/schema/dic/services/services-1.0.xsd">
 
                 <mongodb:config>
-                    <mongodb:client name="default" username="%env(key:user:url:MONGODB_URL)%" password="%env(key:pass:url:MONGODB_URL)%">
-                        <mongodb:host host="%env(key:host:url:MONGODB_URL)%" port="%env(key:port:url:MONGODB_URL)%"/>
+                    <mongodb:client name="default" username="%env(string:key:user:url:MONGODB_URL)%" password="%env(string:key:pass:url:MONGODB_URL)%">
+                        <mongodb:host host="%env(string:key:host:url:MONGODB_URL)%" port="%env(int:key:port:url:MONGODB_URL)%"/>
                     </mongodb:client>
                     <mongodb:connections name="default" database_name="%env(key:path:url:MONGODB_URL)%"/>
                 </mongodb:config>
@@ -581,12 +581,12 @@ Symfony provides the following env var processors:
                     'default' => [
                         'hosts' => [
                             [
-                                'host' => '%env(key:host:url:MONGODB_URL)%',
-                                'port' => '%env(key:port:url:MONGODB_URL)%',
+                                'host' => '%env(string:key:host:url:MONGODB_URL)%',
+                                'port' => '%env(int:key:port:url:MONGODB_URL)%',
                             ],
                         ],
-                        'username' => '%env(key:user:url:MONGODB_URL)%',
-                        'password' => '%env(key:pass:url:MONGODB_URL)%',
+                        'username' => '%env(string:key:user:url:MONGODB_URL)%',
+                        'password' => '%env(string:key:pass:url:MONGODB_URL)%',
                     ],
                 ],
                 'connections' => [


### PR DESCRIPTION
Hi

I've tried on my symfony app v4.4, the `env(url:FOO)` env processor reading the doc at https://symfony.com/doc/4.4/configuration/env_var_processors.html

---

Without the changes proposed in this PR, I got: 

- with definition like this in an `app.yaml` file
    - `service.port: '%env(key:port:url:SERVICE_DSN)%'`
- the error
    - `Invalid type for path "service.port". Expected one of "bool", "int", "float", "string", but got one of "bool", "int", "float", "string", "array".`

but it works only like this: 

- `service.port: '%env(int:key:port:url:SERVICE_DSN)%'`
- same with `string:` for example a `key:user` or a `key:pass` fields from the url processor

---

Thus I am proposing this PR to correct the usage of this processor
If I am doing something wrong/incorrect, please answer what/why and feel free to close this PR!

Thank you :)

--------

Symfony 4.4.29
PHP 7.4.22
