### PR TITLE
[Mailer] Fixing "envelope recipient"

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3382,8 +3382,8 @@ recipients
 
 **type**: ``array``
 
-Recipients used by the ``Mailer``. Keep in mind that this setting override
-recipients set in the code.
+The "envelope recipient" which is used as the value of ``RCPT TO``  during the
+the `SMTP session`_. This value overrides any other sender set in the code.
 
 .. configuration-block::
 


### PR DESCRIPTION
Second part of https://github.com/symfony/symfony-docs/pull/15240

The link `SMTP session` depends on https://github.com/symfony/symfony-docs/pull/15616
