### PR TITLE
Update copy-files.rst

### DIFF
--- a/frontend/encore/copy-files.rst
+++ b/frontend/encore/copy-files.rst
@@ -63,11 +63,11 @@ To render inside Twig, use the ``asset()`` function:
 
 .. code-block:: html+twig
 
-    {# assets/images/logo.png was copied to public/build/logo.png #}
-    <img src="{{ asset('build/logo.png') }}" alt="ACME logo">
+    {# assets/images/logo.png was copied to public/build/images/logo.png #}
+    <img src="{{ asset('build/images/logo.png') }}" alt="ACME logo">
 
-    {# assets/images/subdir/logo.png was copied to public/build/subdir/logo.png #}
-    <img src="{{ asset('build/subdir/logo.png') }}" alt="ACME logo">
+    {# assets/images/subdir/logo.png was copied to public/build/images/subdir/logo.png #}
+    <img src="{{ asset('build/images/subdir/logo.png') }}" alt="ACME logo">
 
 Make sure you've enabled the :ref:`json_manifest_path <load-manifest-files>` option,
 which tells the ``asset()`` function to read the final paths from the ``manifest.json``


### PR DESCRIPTION
I believe the documentation is wrong. Webpack copies the images into build/images, not build/.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
