### PR TITLE
Fix link reference in Upgrading to Symfony Flex

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -189,9 +189,9 @@ If you customize these paths, some files copied from a recipe still may contain
 references to the original path. In other words: you may need to update some things
 manually after a recipe is installed.
 
-.. _`default services.yaml file`: https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/config/services.yaml
+.. _`default services.yaml file`: https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/4.4/config/services.yaml
 .. _`shown in this example`: https://github.com/symfony/skeleton/blob/8e33fe617629f283a12bbe0a6578bd6e6af417af/composer.json#L24-L33
 .. _`shown in this example of the skeleton-project`: https://github.com/symfony/skeleton/blob/8e33fe617629f283a12bbe0a6578bd6e6af417af/composer.json#L44-L46
-.. _`copying Symfony's index.php source`: https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.4/public/index.php
-.. _`copying Symfony's bin/console source`: https://github.com/symfony/recipes/blob/master/symfony/console/3.4/bin/console
+.. _`copying Symfony's index.php source`: https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/4.4/public/index.php
+.. _`copying Symfony's bin/console source`: https://github.com/symfony/recipes/blob/master/symfony/console/4.4/bin/console
 .. _`Symfony Requirements Checker`: https://github.com/symfony/requirements-checker


### PR DESCRIPTION
## Changelog

Update the link url for "default services.yaml", "copying Symfony's index.php source" and "copying Symfony's bin/console source" files to point to 4.4 since this is the targetted version.

\+ the previous link for the bin/console was actually a dead link 404

