### PR TITLE
Bump license year of code

### DIFF
--- a/contributing/code/license.rst
+++ b/contributing/code/license.rst
@@ -5,7 +5,7 @@ Symfony Code License
 
 Symfony code is released under `the MIT license`_:
 
-Copyright (c) 2004-2020 Fabien Potencier
+Copyright (c) 2004-2021 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I was reading some sub pages of https://symfony.com/doc/current/contributing/index.html and found this
Ref https://github.com/symfony/symfony/blob/4.4/LICENSE