### PR TITLE
Remove anonymous configuration from firewall

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -383,9 +383,7 @@ important section is ``firewalls``:
                 ->security(false);
 
             $security->firewall('main')
-                ->lazy(true)
-                
-                ;
+                ->lazy(true);
         };
 
 A "firewall" is your authentication system: the configuration below it defines

--- a/security.rst
+++ b/security.rst
@@ -348,7 +348,6 @@ important section is ``firewalls``:
                     pattern: ^/(_(profiler|wdt)|css|images|js)/
                     security: false
                 main:
-                    anonymous: true
                     lazy: true
 
     .. code-block:: xml
@@ -369,7 +368,6 @@ important section is ``firewalls``:
                     security="false"/>
 
                 <firewall name="main"
-                    anonymous="true"
                     lazy="true"/>
             </config>
         </srv:container>
@@ -386,7 +384,8 @@ important section is ``firewalls``:
 
             $security->firewall('main')
                 ->lazy(true)
-                ->anonymous();
+                
+                ;
         };
 
 A "firewall" is your authentication system: the configuration below it defines


### PR DESCRIPTION
Remove `anonymous:` config as it throws an exception

On clean install, adding `anonymous`  config gets this error: 
![image](https://user-images.githubusercontent.com/9363039/130499876-d7ee2cb8-9bf7-4481-8af9-ba7c02d4641e.png)


