### PR TITLE
fix: bind to the correct host port

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -295,7 +295,7 @@ Consider the following configuration:
     # docker-compose.yaml
     services:
         database:
-            ports: [3306]
+            ports: ["3306:3306"]
 
 The web server detects that a service exposing port ``3306`` is running for the
 project. It understands that this is a MySQL service and creates environment
@@ -313,7 +313,7 @@ label to override the environment variables prefix:
     # docker-compose.yaml
     services:
         db:
-            ports: [3306]
+            ports: ["3306:3306"]
             labels:
                 com.symfony.server.service-prefix: 'DATABASE'
 
@@ -393,7 +393,7 @@ check the "Symfony Server" section in the web debug toolbar; you'll see that
         # docker-compose.yaml
         services:
             db:
-                ports: [3306]
+                ports: ["3306:3306"]
                 labels:
                     com.symfony.server.service-ignore: true
 


### PR DESCRIPTION
By default, Docker will bind to a random host port when a specific port is exposed, meaning you can get this:

```
$ docker-compose ps
          Name                       Command             State                           Ports                        
----------------------------------------------------------------------------------------------------------------------
twitter-proxy_database_1   docker-entrypoint.sh mysqld   Up      0.0.0.0:49156->3306/tcp,:::49156->3306/tcp, 33060/tcp
```

This also means the service is not recognized (at least it wasn't for me).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
