### PR TITLE
[DependencyInjection] Fix confusion of HttpKernel and Kernel

### DIFF
--- a/components/dependency_injection/workflow.rst
+++ b/components/dependency_injection/workflow.rst
@@ -21,7 +21,7 @@ Working with a Cached Container
 -------------------------------
 
 Before building it, the kernel checks to see if a cached version of the
-container exists. The HttpKernel has a debug setting and if this is false,
+container exists. The kernel has a debug setting and if this is false,
 the cached version is used if it exists. If debug is true then the kernel
 :doc:`checks to see if configuration is fresh </components/config/caching>`
 and if it is, the cached version of the container is used. If not then the


### PR DESCRIPTION
The mentioned debug setting is part of the (abstract) class Kernel, i.e. "the" kernel, not the class HttpKernel
