### PR TITLE
Adds proper escaping for php service config format

### DIFF
--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -67,7 +67,7 @@ to another service: ``App\Mailer``. One way to do this is with an expression:
             $services->set(MailerConfiguration::class);
 
             $services->set(Mailer::class)
-                ->args([expr("service('App\\Mail\\MailerConfiguration').getMailerMethod()")]);
+                ->args([expr("service('App\\\\Mail\\\\MailerConfiguration').getMailerMethod()")]);
         };
 
 To learn more about the expression language syntax, see :doc:`/components/expression_language/syntax`.


### PR DESCRIPTION
php configs need `\\\\`, `\\` are not enough.

`"service('App\\Mailer')"` compiles into `AppMailer` ,  `"service('App\\\\Mailer')"` compiles correctly into `App\Mailer`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
