### PR TITLE
Update profiler.rst

### DIFF
--- a/profiler.rst
+++ b/profiler.rst
@@ -195,7 +195,7 @@ event::
 
     public function onKernelResponse(ResponseEvent $event)
     {
-        if (!$this->getKernel()->isDebug()) {
+        if (!$event->getKernel()->isDebug()) {
             return;
         }
 


### PR DESCRIPTION
the getKernel() method is available in $event rather than $this, however the $event->getKernel() refers to the \Symfony\Component\HttpKernel\HttpKernel which does not have the isDebug()-method.

Perhaps a full event subscriber class could be included to make it more complete?

Same problem applies  on 5.3, 5.4 and 6.0 as well. 

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
