### PR TITLE
[Form] Inserted a warning about a limitation of model transformers

### DIFF
--- a/form/data_transformers.rst
+++ b/form/data_transformers.rst
@@ -482,6 +482,21 @@ Which transformer you need depends on your situation.
 
 To use the view transformer, call ``addViewTransformer()``.
 
+.. caution::
+
+    Be careful with model transformers and
+    :doc:`Collection </reference/forms/types/collection>` field types: As the
+    Collection's children are created early at `PRE_SET_DATA` by its
+    `ResizeFormListener`, their data is populated later from the Norm Data. So
+    your model transformer cannot reduce the number of items within the
+    Collection (i.e. filtering out some items), as in that case the collection
+    ends up with some empty children.
+    
+    A possible workaround for that limitation could be not using the underlying
+    object directly, but a DTO (Data Transfer Object) instead, that implements
+    the transformation of such incompatible data structures.
+    
+
 So why Use the Model Transformer?
 ---------------------------------
 


### PR DESCRIPTION
There is a surprising limitation of model transformers, that cannot filter out items for a Collection field type. Took me a whole day to find out, so here is a warning about that. See https://github.com/symfony/symfony/issues/36469 for details. (Maybe that issue should be linked for further details?).
