### PR TITLE
[Mercure] Remove wrong parameter in MockHub

### DIFF
--- a/mercure.rst
+++ b/mercure.rst
@@ -576,7 +576,7 @@ You can instead make use of the `MockHub`::
     {
         public function testPublishing()
         {
-            $hub = new MockHub('default', 'https://internal/.well-known/mercure', new StaticTokenProvider('foo'), function(Update $update): string {
+            $hub = new MockHub('https://internal/.well-known/mercure', new StaticTokenProvider('foo'), function(Update $update): string {
                 // $this->assertTrue($update->isPrivate());
 
                 return 'id';


### PR DESCRIPTION
There is no parameter in `MockHub` to specify the hub name (`default`)

`MockHub` constructor : https://github.com/symfony/mercure/blob/main/src/MockHub.php#L30-L35

```php
    /**
     * @param (callable(Update): string) $publisher
     */
    public function __construct(
        string $url,
        TokenProviderInterface $jwtProvider,
        callable $publisher,
        TokenFactoryInterface $jwtFactory = null,
        string $publicUrl = null
    )
```

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
