### PR TITLE
[Messenger] Update messenger.rst

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -798,7 +798,7 @@ Forcing Retrying
 Sometimes handling a message must fail in a way that you *know* is temporary
 and must be retried. If you throw
 :class:`Symfony\\Component\\Messenger\\Exception\\RecoverableMessageHandlingException`,
-the message will always be retried.
+the message will always be retried infinitely and ``max_retries`` setting will be ignored.
 
 .. _messenger-failure-transport:
 


### PR DESCRIPTION
Is not specified that if you use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException the max_retries setting used in configuration will be ignored, and the message will be retried infinitely

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
