### PR TITLE
[Cache] The Doctrine adapter is not a database adapter

### DIFF
--- a/components/cache/adapters/filesystem_adapter.rst
+++ b/components/cache/adapters/filesystem_adapter.rst
@@ -45,8 +45,7 @@ and cache root path as constructor parameters::
     choices. If throughput is paramount, the in-memory adapters
     (:ref:`Apcu <apcu-adapter>`, :ref:`Memcached <memcached-adapter>`, and
     :ref:`Redis <redis-adapter>`) or the database adapters
-    (:ref:`Doctrine <doctrine-adapter>` and :ref:`PDO <pdo-doctrine-adapter>`)
-    are recommended.
+    (:ref:`PDO <pdo-doctrine-adapter>`) are recommended.
 
 .. note::
 


### PR DESCRIPTION
The documentation for the file system cache adapter links to the Doctrine Cache adapter as one of the available "database adapters". Doctrine Cache is simply an older contract for caches, something like a predecessor to PSR-6.

Recommending this adapter as a database cache is wrong or at least misleading. Because of that I'd like to remove that link.