### PR TITLE
Typo and grammar fix in http_foundation.rst

### DIFF
--- a/create_framework/http_foundation.rst
+++ b/create_framework/http_foundation.rst
@@ -11,7 +11,7 @@ top of the Symfony components is better than creating a framework from scratch.
 
     We won't talk about the traditional benefits of using a framework when
     working on big applications with more than a few developers; the Internet
-    has already plenty of good resources on that topic.
+    already has plenty of good resources on that topic.
 
 Even if the "application" we wrote in the previous chapter was simple enough,
 it suffers from a few problems::
@@ -265,7 +265,7 @@ So, the ``getClientIp()`` method works securely in all circumstances. You can
 use it in all your projects, whatever the configuration is, it will behave
 correctly and safely. That's one of the goals of using a framework. If you were
 to write a framework from scratch, you would have to think about all these
-cases by yourself. Why not using a technology that already works?
+cases by yourself. Why not use a technology that already works?
 
 .. note::
 


### PR DESCRIPTION
One typo fix and re-ordered wording of a sentence for correct English grammar.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
