### PR TITLE
Document PHP compatibility

### DIFF
--- a/contributing/community/releases.rst
+++ b/contributing/community/releases.rst
@@ -101,6 +101,22 @@ deprecations, you can upgrade to the new major version (e.g. 5.0) without
 effort, because it contains the same features (the only difference are the
 deprecated features, which your project no longer uses).
 
+PHP Compatibility
+-----------------
+
+The **minimum** PHP version is decided for each major Symfony version by consensus
+amongst the :doc:`core team </contributing/code/core_team>` and documented as
+part of the :ref:`technical requirements for running Symfony applications
+<symfony-tech-requirements>`.
+
+Throughout each Symfony release's support lifetime, all released versions of PHP
+including new major versions will be supported. In this way, the **maximum** supported
+version of PHP for a maintained Symfony release is the latest released
+one that is publicly available.
+
+For out-of-support releases of Symfony, the latest PHP version at time of EOL is the last
+supported PHP version. Newer versions of PHP may or may not function.
+
 Rationale
 ---------
 

--- a/setup.rst
+++ b/setup.rst
@@ -20,6 +20,10 @@ Before creating your first Symfony application you must:
 * Install PHP 7.1 or higher and these PHP extensions (which are installed and
   enabled by default in most PHP 7 installations): `Ctype`_, `iconv`_, `JSON`_,
   `PCRE`_, `Session`_, `SimpleXML`_, and `Tokenizer`_;
+
+  * Note that all newer, released versions of PHP will be supported during the
+    lifetime of each Symfony release (including new major versions).
+    For example, PHP 8.0 is supported.
 * `Install Composer`_, which is used to install PHP packages.
 
 Optionally, you can also `install Symfony CLI`_. This creates a binary called


### PR DESCRIPTION
ref https://github.com/symfony/symfony/issues/42993

This makes it, at least to me, a lot clearer what the policy is re which Symfony versions will support which versions of PHP. Please correct me if I've misunderstood anything - I am most unsure about how the minimal PHP version is chosen - obviously I've seen the `RFC` labeled issues, but am I correct in assuming this is ultimately decided by the core team before each major release?

I suggested mentioning this on https://symfony.com/releases too but I think the website might be closed-source?