### PR TITLE
[PHPUnitBridge] Corrected Typo

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -229,7 +229,7 @@ Making Tests Fail
 By default, any non-legacy-tagged or any non-`@-silenced <@-silencing operator>`_
 deprecation notices will make tests fail. Alternatively, you can configure
 an arbitrary threshold by setting ``SYMFONY_DEPRECATIONS_HELPER`` to
-``max[total]=320`` for instance. It will make the tests fails only if a
+``max[total]=320`` for instance. It will make the tests fail only if a
 higher number of deprecation notices is reached (``0`` is the default
 value).
 


### PR DESCRIPTION
Removed extra "s" in "fails"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
