### PR TITLE
Corrected typo in error_pages.rst

### DIFF
--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -319,7 +319,7 @@ error pages.
 .. note::
 
     If your listener calls ``setThrowable()`` on the
-    :class:`Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent`,
+    :class:`Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent`
     event, propagation will be stopped and the response will be sent to
     the client.
 


### PR DESCRIPTION
Removed extra comma before "event" word.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
