### PR TITLE
[Serializer] Documenting the new SKIP_UNINITIALIZED_VALUES option

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1181,15 +1181,23 @@ PHP 7.4 introduced typed properties, which have a new state - ``uninitialized``.
 This is different from the default ``null`` of untyped properties.
 When you try to access it before giving it an explicit value - you get an error.
 
-To avoid serializer throwing an error when serializing or normalizing an object with
-uninitialized properties - then you can set ``AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES`` to ``true``.
+By default, to avoid the Serializer throwing an error when serializing or normalizing an object with
+uninitialized properties, object normalizer catches these errors and ignores such properties.
+
+You can disable this behavior by setting the ``AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES`` context option to ``false``::
+
+    class Dummy {
+        public string $foo = 'initialized';
+        public string $bar; // uninitialized
+    }
+
+    $normalizer = new ObjectNormalizer();
+    $result = $normalizer->normalize(new Dummy(), 'json', [AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => false]);
+    // throws Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException as normalizer cannot read uninitialized properties
 
 .. note::
 
-    Error is thrown only if you inject a ``ClassMetadataFactory`` into the normalizer.
-    Otherwise the properties are checked with reflection and uninitialized ones are skipped.
-    This option is useful when, for example, you want to serialize subset of properties by serialization groups,
-    which requires the ``ClassMetadataFactory``
+    Calling ``PropertyNormalizer::normalize`` or ``GetSetMethodNormalizer::normalize`` with ``AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES`` context option set to ``false`` will throw an ``\Error`` instance if the given object has uninitialized properties as the normalizer cannot read them (directly or via getter/isser methods).
 
 .. versionadded:: 5.4
 

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1174,6 +1174,27 @@ to ``true``::
     $result = $normalizer->normalize($dummy, 'json', [AbstractObjectNormalizer::SKIP_NULL_VALUES => true]);
     // ['bar' => 'notNull']
 
+Skipping uninitialized properties
+---------------------------------
+
+PHP 7.4 introduced typed properties, which have a new state - ``uninitialized``.
+This is different from the default ``null`` of untyped properties.
+When you try to access it before giving it an explicit value - you get an error.
+
+To avoid serializer throwing an error when serializing or normalizing an object with
+uninitialized properties - then you can set ``AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES`` to ``true``.
+
+.. note::
+
+    Error is thrown only if you inject a ``ClassMetadataFactory`` into the normalizer.
+    Otherwise the properties are checked with reflection and uninitialized ones are skipped.
+    This option is useful when, for example, you want to serialize subset of properties by serialization groups,
+    which requires the ``ClassMetadataFactory``
+
+.. versionadded:: 5.4
+
+    The ``AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES`` constant was introduced in Symfony 5.4.
+
 .. _component-serializer-handling-circular-references:
 
 Handling Circular References


### PR DESCRIPTION
Documents changes introduced here: https://github.com/symfony/symfony/pull/41615
Original issue: https://github.com/symfony/symfony/issues/40578
Docs issue: https://github.com/symfony/symfony-docs/issues/15785