### PR TITLE
[Routing] rewrite incorrect sentence

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -824,8 +824,7 @@ Parameter Conversion
 
 A common routing need is to convert the value stored in some parameter (e.g. an
 integer acting as the user ID) into another value (e.g. the object that
-represents the user). This feature is called "param converter" and is only
-available when using annotations to define routes.
+represents the user). This feature is called "param converter".
 
 In case you didn't run this command before, run it now to add support for
 annotations and "param converters":


### PR DESCRIPTION
This bit of documentation: `This feature is called "param converter" and is only available when using annotations to define routes.` Would imply that the param converter is only enabled for routes that are defined through annotations. But I believe this is not case.
This pull request rewrites this sentence and would hopefully prevent other people from also spending a lot of time unnecessarily. 