### PR TITLE
Prepare security.rst for Symfony 5.4

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -327,7 +327,7 @@ Use this service to hash the passwords:
 
 As another example, in the ``RegistrationController`` class of your app, where you create and persist a new User entity, you will also use the ``UserPasswordHasherInterface`` service to hash the user's password.
 
-.. code-block:: registration-password-hash
+.. code-block:: php
 
     class RegistrationController extends AbstractController
     {
@@ -501,16 +501,30 @@ you to control *every* part of the authentication process (see the next section)
     Facebook or Twitter (social login), check out the `HWIOAuthBundle`_ community
     bundle.
 
-Authentication Manager
+Authenticator Managers
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The authentication manager is a class that gives you *complete* control over your
+The authenticator manager is a class that gives you *complete* control over your
 authentication process. There are many different ways to build an authenticator;
 here are a few common use-cases:
 
 * :doc:`/security/form_login_setup`
 * :doc:`/security/authenticator_manager` – see this for the most detailed
   description of authenticator managers and how they work
+
+Guard Authenticators
+~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 5.3
+
+    Guard authenticators are deprecated since Symfony 5.3 in favor of the
+    :doc:`new authenticator manager system </security/authenticator_manager>`
+    referenced in the previous section.
+
+If you still need to use the deprecated Guard Authenticators, then please refer to the
+separate documentation page:
+
+* :doc:`/security/guard_authentication`
 
 Limiting Login Attempts
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1022,7 +1036,7 @@ will happen:
 Thanks to the SensioFrameworkExtraBundle, you can also secure your controller
 using annotations or attributes:
 
-.. code-block:: sensio-securing-controllers
+.. code-block:: php
 
     .. code-block:: php-annotations
 
@@ -1060,16 +1074,14 @@ using annotations or attributes:
 
         /**
         * Require ROLE_ADMIN for *every* controller method in this class.
-        *
-        * #[IsGranted('ROLE_ADMIN')]
         */
+        #[IsGranted('ROLE_ADMIN')]
         class AdminController extends AbstractController
         {
             /**
             * Require ROLE_ADMIN for only this controller method.
-            *
-            * #[IsGranted('ROLE_ADMIN')]
             */
+            #[IsGranted('ROLE_ADMIN')]
             public function adminDashboard(): Response
             {
                 // ...
@@ -1154,7 +1166,7 @@ There are several special attributes that you can use:
   :doc:`remember me functionality </security/remember_me>` (i.e. a
   remember-me cookie), have this attribute.
 
-* ``IS_IMPERSONATOR``: When the current user is 
+* ``IS_IMPERSONATOR``: When the current user is
   :doc:`impersonating another user </security/impersonating_user>` in this
   session, this attribute will match.
 
@@ -1169,7 +1181,7 @@ There are several special attributes that you can use:
 
 * ``PUBLIC_ACCESS``: All users, including unauthenticated users, will have this attribute.
 
-If you really need to know if a request was made by an unauthenticated user, then check for *not* ``IS_AUTHENTICATED``.
+If you really need to know if a request was made by an unauthenticated user, then check for **not** ``IS_AUTHENTICATED``.
 
 .. _retrieving-the-user-object:
 

--- a/security.rst
+++ b/security.rst
@@ -514,6 +514,11 @@ you to control *every* part of the authentication process (see the next section)
 Authenticator Managers
 ~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 5.1
+
+    Authenticator-based security was introduced in Symfony 5.1 and is now the
+    recommended method to use.
+
 The authenticator manager is a class that gives you *complete* control over your
 authentication process. There are many different ways to build an authenticator;
 here are a few common use-cases:
@@ -529,7 +534,7 @@ Guard Authenticators
 
     Guard authenticators are deprecated since Symfony 5.3 in favor of the
     :doc:`new authenticator manager system </security/authenticator_manager>`
-    referenced in the previous section.
+    referenced in the previous section. They will be removed in Symfony 6.
 
 If you still need to use the deprecated Guard Authenticators, then please refer to the
 separate documentation page:

--- a/security.rst
+++ b/security.rst
@@ -1029,8 +1029,8 @@ using annotations or attributes:
         // src/Controller/SecurityController.php
         namespace App\Controller;
 
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
         use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
         /**
         * Require ROLE_ADMIN for *every* controller method in this class.
@@ -1055,8 +1055,8 @@ using annotations or attributes:
         // src/Controller/SecurityController.php
         namespace App\Controller;
 
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
         use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
         /**
         * Require ROLE_ADMIN for *every* controller method in this class.
@@ -1154,8 +1154,8 @@ There are several special attributes that you can use:
   :doc:`remember me functionality </security/remember_me>` (i.e. a
   remember-me cookie), have this attribute.
 
-* ``IS_IMPERSONATOR``: When the current user is
-  :doc:`impersonating another user</security/impersonating_user>` in this
+* ``IS_IMPERSONATOR``: When the current user is 
+  :doc:`impersonating another user </security/impersonating_user>` in this
   session, this attribute will match.
 
 * ``IS_AUTHENTICATED``: *All* authenticated users have this attribute, regardless of the method

--- a/security.rst
+++ b/security.rst
@@ -328,6 +328,16 @@ Use this service to hash the passwords:
 As another example, in the ``RegistrationController`` class of your app, where you create and persist a new User entity, you will also use the ``UserPasswordHasherInterface`` service to hash the user's password.
 
 .. code-block:: php
+    // src/App/Controller/RegistrationController.php
+    namespace App\Controller;
+
+    use App\Entity\User;
+    use App\Form\RegistrationFormType;
+    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+    use Symfony\Component\Routing\Annotation\Route;
 
     class RegistrationController extends AbstractController
     {


### PR DESCRIPTION
I thought I'd make a first pass at modifying security.rst for 5.4. It's far from perfect, but I think it's a solid base to work from.

I tried to adapt my software to 5.4 using the existing security.rst and found it a frustrating process. Hence the effort to rewrite some sections.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
