### PR TITLE
[Twig] Fix global variable name in XML config

### DIFF
--- a/templating/global_variables.rst
+++ b/templating/global_variables.rst
@@ -92,7 +92,7 @@ the ``@`` character, which is the usual syntax to
 
             <twig:config>
                 <!-- ... -->
-                <twig:global key="foo" id="App\Generator\UuidGenerator" type="service"/>
+                <twig:global key="uuid" id="App\Generator\UuidGenerator" type="service"/>
             </twig:config>
         </container>
 


### PR DESCRIPTION
In the XML example, the global variable is named "foo" instead of "uuid".

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
