### PR TITLE
[Console] Remove some unneeded imports

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -448,8 +448,6 @@ Testing a Command that Expects Input
 If you want to write a unit test for a command which expects some kind of input
 from the command line, you need to set the inputs that the command expects::
 
-    use Symfony\Component\Console\Helper\HelperSet;
-    use Symfony\Component\Console\Helper\QuestionHelper;
     use Symfony\Component\Console\Tester\CommandTester;
 
     // ...


### PR DESCRIPTION
While reviewing #15728 I found a single occurrence of `HelperSet` in the docs. After checking the example, I think we can remove these unused imports.