### PR TITLE
unify expression: yarn run encore -> yarn encore

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -268,7 +268,7 @@ and restart Encore:
 .. code-block:: terminal
 
     # if you use the Yarn package manager
-    $ yarn run encore dev --watch
+    $ yarn run dev --watch
 
     # if you use the npm package manager
     $ npm run watch


### PR DESCRIPTION
This commit unifies expression on yarn: `yarn run encore ...` -> `yarn encore ...` same to above in the same page.