### PR TITLE
[Console] Revert RGB notation in console coloring

### DIFF
--- a/console/coloring.rst
+++ b/console/coloring.rst
@@ -58,10 +58,6 @@ Any hex color is supported for foreground and background colors. Besides that, t
 
     Support for bright colors was introduced in Symfony 5.3.
 
-.. versionadded:: 5.4
-
-    Support for RGB functional notation was introduced in Symfony 5.4.
-
 .. note::
 
     If the terminal doesn't support true colors, the nearest named color is used.
@@ -80,9 +76,6 @@ You can also set these colors and options directly inside the tag name::
 
     // using hexadecimal colors
     $output->writeln('<fg=#c0392b>foo</>');
-
-    // using RGB colors
-    $output->writeln('<fg=rgb(127, 255, 0)>foo</>');
 
     // black text on a cyan background
     $output->writeln('<fg=black;bg=cyan>foo</>');


### PR DESCRIPTION
As @ogizanagi said in https://github.com/symfony/symfony-docs/pull/15833#issuecomment-927339633, this change was ultimately reverted, so let's revert the docs too.