### PR TITLE
[HttpClient] Update http client testing section

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1471,8 +1471,6 @@ Testing Request Data
 
 The ``MockResponse`` class comes with some helper methods to test the request:
 
-* ``getRequestMethod()`` - returns the HTTP method;
-* ``getRequestUrl()`` - returns the URL the request would be sent to;
 * ``getRequestOptions()`` - returns an array containing other information about
   the request such as headers, query parameters, body content etc.
 
@@ -1487,12 +1485,6 @@ Usage example::
             'Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l',
         ],
     ]);
-
-    $mockResponse->getRequestMethod();
-    // returns "DELETE"
-
-    $mockResponse->getRequestUrl();
-    // returns "https://example.com/api/article/1337"
 
     $mockResponse->getRequestOptions()['headers'];
     // returns ["Accept: */*", "Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l"]
@@ -1567,8 +1559,6 @@ test it in a real application::
             $responseData = $service->createArticle($requestData);
 
             // Assert
-            self::assertSame('POST', $mockResponse->getRequestMethod());
-            self::assertSame('https://example.com/api/article', $mockResponse->getRequestUrl());
             self::assertContains(
                 'Content-Type: application/json',
                 $mockResponse->getRequestOptions()['headers']


### PR DESCRIPTION
I have remove all references to MockResponse::getRequestMethod and MockResponse::getRequestUrl as these were added in 5.2

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
