### PR TITLE
[HttpClient] HttpClientInterface::setResponseFactory method

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1678,6 +1678,23 @@ responses dynamically when it's called::
     $client = new MockHttpClient($callback);
     $response = $client->request('...'); // calls $callback to get the response
 
+.. tip::
+
+    Instead of using the first argument, you can also set the (list of)
+    responses or callbacks using the ``setResponseFactory()`` method::
+
+        $responses = [
+            new MockResponse($body1, $info1),
+            new MockResponse($body2, $info2),
+        ];
+
+        $client = new MockHttpClient();
+        $client->setResponseFactory($responses);
+
+    .. versionadded:: 5.4
+
+        The ``setResponseFactory()`` method was introduced in Symfony 5.4.
+
 If you need to test responses with HTTP status codes different than 200,
 define the ``http_code`` option::
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
