### PR TITLE
[HttpClient] Clarify which is the top level exception for http client if you want to catch everything

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -924,10 +924,22 @@ In case the response was canceled using ``$response->cancel()``,
 Handling Exceptions
 ~~~~~~~~~~~~~~~~~~~
 
+There are three types of exceptions, all of which implement the
+:class:`Symfony\\Contracts\\HttpClient\\Exception\\ExceptionInterface`:
+
+* Exceptions implementing the :class:`Symfony\\Contracts\\HttpClient\\Exception\\HttpExceptionInterface`
+  are thrown when your code does not handle the status codes in the 300-599 range.
+
+* Exceptions implementing the :class:`Symfony\\Contracts\\HttpClient\\Exception\\TransportExceptionInterface`
+  are thrown when a lower level issue occurs.
+
+* Exceptions implementing the :class:`Symfony\\Contracts\\HttpClient\\Exception\\DecodingExceptionInterface`
+  are thrown when a content-type cannot be decoded to the expected representation.
+
 When the HTTP status code of the response is in the 300-599 range (i.e. 3xx,
 4xx or 5xx) your code is expected to handle it. If you don't do that, the
-``getHeaders()``, ``getContent()`` and ``toArray()`` methods throw an appropriate exception, all of
-which implement the :class:`Symfony\\Contracts\\HttpClient\\Exception\\HttpExceptionInterface`::
+``getHeaders()``, ``getContent()`` and ``toArray()`` methods throw an appropriate exception, which will
+implement the :class:`Symfony\\Contracts\\HttpClient\\Exception\\HttpExceptionInterface`::
 
     // the response of this request will be a 403 HTTP error
     $response = $client->request('GET', 'https://httpbin.org/status/403');
@@ -967,17 +979,6 @@ component. No errors will be unnoticed: if you don't write the code to handle
 errors, exceptions will notify you when needed. On the other hand, if you write
 the error-handling code, you will opt-out from these fallback mechanisms as the
 destructor won't have anything remaining to do.
-
-There are three types of exceptions:
-
-* Exceptions implementing the :class:`Symfony\\Contracts\\HttpClient\\Exception\\HttpExceptionInterface`
-  are thrown when your code does not handle the status codes in the 300-599 range.
-
-* Exceptions implementing the :class:`Symfony\\Contracts\\HttpClient\\Exception\\TransportExceptionInterface`
-  are thrown when a lower level issue occurs.
-
-* Exceptions implementing the :class:`Symfony\\Contracts\\HttpClient\\Exception\\DecodingExceptionInterface`
-  are thrown when a content-type cannot be decoded to the expected representation.
 
 Concurrent Requests
 -------------------


### PR DESCRIPTION
The fact that right now https://symfony.com/doc/current/http_client.html#handling-exceptions starts by mentioning ` an appropriate exception, all of
which implement the [...]HttpExceptionInterface` is kinda misleading as that is only the interface for http-status-codes exceptions, not for all http client exceptions.