### PR TITLE
[Intl] Language codes: 'ISO 639-2' specified to 'ISO 639-2 (2T)'

### DIFF
--- a/components/intl.rst
+++ b/components/intl.rst
@@ -69,7 +69,7 @@ Language and Script Names
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``Languages`` class provides access to the name of all languages
-according to the `ISO 639-1 alpha-2`_ list and the `ISO 639-2 alpha-3`_ list::
+according to the `ISO 639-1 alpha-2`_ list and the `ISO 639-2 alpha-3 (2T)`_ list::
 
     use Symfony\Component\Intl\Languages;
 
@@ -416,4 +416,4 @@ Learn more
 .. _`UTC/GMT time offsets`: https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
 .. _`daylight saving time (DST)`: https://en.wikipedia.org/wiki/Daylight_saving_time
 .. _`ISO 639-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_639-1
-.. _`ISO 639-2 alpha-3`: https://en.wikipedia.org/wiki/ISO_639-2
+.. _`ISO 639-2 alpha-3 (2T)`: https://en.wikipedia.org/wiki/ISO_639-2

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -74,7 +74,7 @@ alpha3
 
     The ``alpha3`` option was introduced in Symfony 4.4.
 
-If this option is ``true``, the choice values use the `ISO 639-2 alpha-3`_
+If this option is ``true``, the choice values use the `ISO 639-2 alpha-3 (2T)`_
 three-letter codes (e.g. French = ``fra``) instead of the default
 `ISO 639-1 alpha-2`_ two-letter codes (e.g. French = ``fr``).
 
@@ -156,5 +156,5 @@ The actual default value of this option depends on other field options:
 .. include:: /reference/forms/types/options/row_attr.rst.inc
 
 .. _`ISO 639-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_639-1
-.. _`ISO 639-2 alpha-3`: https://en.wikipedia.org/wiki/ISO_639-2
+.. _`ISO 639-2 alpha-3 (2T)`: https://en.wikipedia.org/wiki/ISO_639-2
 .. _`International Components for Unicode`: http://site.icu-project.org


### PR DESCRIPTION
Specification of the ISO 639-2 language codes to ISO 639-2 2T (terminological code).
See: [[Intl] Language code 2B/2T #15897](https://github.com/symfony/symfony-docs/issues/15897#issuecomment-940162002)