### PR TITLE
Language codes: 'ISO 639-2' specified to 'ISO 639-2 (2T)'

### DIFF
--- a/reference/constraints/Language.rst
+++ b/reference/constraints/Language.rst
@@ -101,7 +101,7 @@ alpha3
 **type**: ``boolean`` **default**: ``false``
 
 If this option is ``true``, the constraint checks that the value is a
-`ISO 639-2`_ three-letter code (e.g. French = ``fra``) instead of the default
+`ISO 639-2 (2T)`_ three-letter code (e.g. French = ``fra``) instead of the default
 `ISO 639-1`_ two-letter code (e.g. French = ``fr``).
 
 .. include:: /reference/constraints/_groups-option.rst.inc
@@ -129,4 +129,4 @@ Parameter        Description
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-.. _`ISO 639-2`: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
+.. _`ISO 639-2 (2T)`: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes


### PR DESCRIPTION
Specification of the ISO 639-2 language codes to ISO 639-2 2T (terminological code).
See: [[Intl] Language code 2B/2T #15897](https://github.com/symfony/symfony-docs/issues/15897#issuecomment-940162002)