### PR TITLE
Fix link to isCsrfTokenValid() for 5.3+

### DIFF
--- a/security/csrf.rst
+++ b/security/csrf.rst
@@ -150,7 +150,7 @@ generate a CSRF token in the template and store it as a hidden form field:
     </form>
 
 Then, get the value of the CSRF token in the controller action and use the
-:method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerTrait::isCsrfTokenValid`
+:method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController::isCsrfTokenValid`
 method to check its validity::
 
     use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
effectively reverting #15738 on 5.3+ as the trait is not present there