### PR TITLE
Fix RST syntax of some tables

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -144,14 +144,14 @@ This table shows the full list of available DSN formats for each third
 party provider:
 
 ==================== ========================================== =========================================== ========================================
- Provider             SMTP                                       HTTP                                        API
+Provider             SMTP                                       HTTP                                        API
 ==================== ========================================== =========================================== ========================================
- Amazon SES           ses+smtp://USERNAME:PASSWORD@default       ses+https://ACCESS_KEY:SECRET_KEY@default   ses+api://ACCESS_KEY:SECRET_KEY@default
- Google Gmail         gmail+smtp://USERNAME:PASSWORD@default     n/a                                         n/a
- Mailchimp Mandrill   mandrill+smtp://USERNAME:PASSWORD@default  mandrill+https://KEY@default                mandrill+api://KEY@default
- Mailgun              mailgun+smtp://USERNAME:PASSWORD@default   mailgun+https://KEY:DOMAIN@default          mailgun+api://KEY:DOMAIN@default
- Postmark             postmark+smtp://ID@default                 n/a                                         postmark+api://KEY@default
- Sendgrid             sendgrid+smtp://KEY@default                n/a                                         sendgrid+api://KEY@default
+Amazon SES           ses+smtp://USERNAME:PASSWORD@default       ses+https://ACCESS_KEY:SECRET_KEY@default   ses+api://ACCESS_KEY:SECRET_KEY@default
+Google Gmail         gmail+smtp://USERNAME:PASSWORD@default     n/a                                         n/a
+Mailchimp Mandrill   mandrill+smtp://USERNAME:PASSWORD@default  mandrill+https://KEY@default                mandrill+api://KEY@default
+Mailgun              mailgun+smtp://USERNAME:PASSWORD@default   mailgun+https://KEY:DOMAIN@default          mailgun+api://KEY:DOMAIN@default
+Postmark             postmark+smtp://ID@default                 n/a                                         postmark+api://KEY@default
+Sendgrid             sendgrid+smtp://KEY@default                n/a                                         sendgrid+api://KEY@default
 ==================== ========================================== =========================================== ========================================
 
 .. caution::

--- a/messenger.rst
+++ b/messenger.rst
@@ -1017,7 +1017,7 @@ The transport has a number of options:
 Options defined under ``options`` take precedence over ones defined in the DSN.
 
 ==================  =====================================  ======================
-     Option         Description                            Default
+Option              Description                            Default
 ==================  =====================================  ======================
 table_name          Name of the table                      messenger_messages
 queue_name          Name of the queue (a column in the     default
@@ -1066,7 +1066,7 @@ A number of options can be configured via the DSN or via the ``options`` key
 under the transport in ``messenger.yaml``:
 
 ==================  =====================================  =========================
-     Option               Description                      Default
+Option              Description                            Default
 ==================  =====================================  =========================
 stream              The Redis stream name                  messages
 group               The Redis consumer group name          symfony

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -166,9 +166,9 @@ To get a list of *all* of the routes in your system, use the ``debug:router`` co
 You should see your ``app_lucky_number`` route in the list:
 
 ================== ======== ======== ====== ===============
- Name               Method   Scheme   Host   Path
+Name               Method   Scheme   Host   Path
 ================== ======== ======== ====== ===============
- app_lucky_number   ANY      ANY      ANY    /lucky/number
+app_lucky_number   ANY      ANY      ANY    /lucky/number
 ================== ======== ======== ====== ===============
 
 You will also see debugging routes besides ``app_lucky_number`` -- more on


### PR DESCRIPTION
The new parser is very strict, so we can't have leading spaces in headers or rows.