### PR TITLE
Adding "Technical Requirements"

### DIFF
--- a/frontend.rst
+++ b/frontend.rst
@@ -31,14 +31,14 @@ to solve the most common Webpack use cases.
     But it can be used in any PHP application and even with other server side
     programming languages!
 
-.. _encore-toc:
-
 Technical Requirements
 ----------------------
 
-* Node.js on your development machine(s)
-* Yarn or npm on your development machine(s)
+* `Node.js`_ on your development machine(s)
+* `Yarn`_ or npm on your development machine(s)
 * No requirements on your production machine(s)
+
+.. _encore-toc:
 
 Encore Documentation
 --------------------
@@ -118,3 +118,5 @@ Other Front-End Articles
 .. _`Symfony`: https://symfony.com/
 .. _`Full API`: https://github.com/symfony/webpack-encore/blob/master/index.js
 .. _`Webpack Encore screencast series`: https://symfonycasts.com/screencast/webpack-encore
+.. _`Node.js`: https://nodejs.org/
+.. _`Yarn`: https://yarnpkg.com/

--- a/frontend.rst
+++ b/frontend.rst
@@ -33,6 +33,13 @@ to solve the most common Webpack use cases.
 
 .. _encore-toc:
 
+Technical Requirements
+----------------------
+
+* Node.js on your development machine(s)
+* Yarn or npm on your development machine(s)
+* No requirements on your production machine(s)
+
 Encore Documentation
 --------------------
 


### PR DESCRIPTION
Like at EasyAdmin: https://symfony.com/bundles/EasyAdminBundle/current/index.html#technical-requirements

Rationales:
* Make clear what's needed, as early as possible
* Make clear *where* it's needed (dev or prod machine), cause for most libraries this is not clear at all; and some people just cannot modify the prod machine, so any requirement there would be a show-stopper.

@javiereguiluz: Do you agree in principle?
Then I would add some links (Node, etc.) and also remove identical infos from subsequent pages.

