### PR TITLE
Shortening a bit

### DIFF
--- a/frontend/encore/installation.rst
+++ b/frontend/encore/installation.rst
@@ -2,8 +2,6 @@ Installing Encore
 =================
 
 First, make sure you `install Node.js`_ and also the `Yarn package manager`_.
-The following instructions depend on whether you are installing Encore in a
-Symfony application or not.
 
 Installing Encore in Symfony Applications
 -----------------------------------------
@@ -15,10 +13,8 @@ project:
 
     $ composer require symfony/webpack-encore-bundle
 
-    # if you use the Yarn package manager
     $ yarn install
-
-    # if you use the npm package manager
+    # or
     $ npm install
 
 If you are using :ref:`Symfony Flex <symfony-flex>`, this will install and enable


### PR DESCRIPTION
Question: The text under the code block ("If you are using...") refers to `composer install`, not to `yarn/npm install`. So it would be cleaner to move the latter into a separate code block. But what does it actually do? In my case, `npm install` did nothing :-)

Second question: Since this is Symfony 4.4 docs, is anybody still using Symfony *without* Flex?

Third question: What is `package.json` supposed to look like so far? Mine is:
```json
{
  "dependencies": {
    "@forevolve/bootstrap-dark": "^1.2.0-g6c89781692",
    "bootstrap": "^5.1.3"
  }
}
```
...which is probably not correct, since `npm run dev` results in:
> Missing script: "dev"

I'm guessing that the answer is that the code under "Installing Encore in non Symfony Applications" is in fact required *in any case*, isn't it?