### PR TITLE
Aligning link text to actual page title

### DIFF
--- a/frontend.rst
+++ b/frontend.rst
@@ -40,7 +40,7 @@ Getting Started
 ...............
 
 * :doc:`Installation </frontend/encore/installation>`
-* :doc:`First Example </frontend/encore/simple-example>`
+* :doc:`Setting up your Project </frontend/encore/simple-example>`
 
 Adding more Features
 ....................


### PR DESCRIPTION
Suggestion: It would be better to change the filename `simple-example` too.
