### PR TITLE
Deleting npm from yarn code block

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -70,9 +70,6 @@ To build the assets, run the following if you use the Yarn package manager:
     # on deploy, create a production build
     $ yarn encore production
 
-    # if you use the npm package manager
-    $ npm install react react-dom prop-types --save
-
 If you use the npm package manager, run the following commands instead:
 
 .. code-block:: terminal


### PR DESCRIPTION
`npm install react` looks totally out of place here, isn't it?
