### PR TITLE
Contributing guidelines: make version reference older than current maintained version

### DIFF
--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -121,7 +121,7 @@ branch of the ``upstream`` remote, which is the original Symfony Docs repository
 Fixes should always be based on the **oldest maintained branch** which contains
 the error. Nowadays this is the ``4.4`` branch. If you are instead documenting a
 new feature, switch to the first Symfony version that included it, e.g.
-``upstream/3.1``.
+``upstream/5.4``.
 
 **Step 5.** Now make your changes in the documentation. Add, tweak, reword and
 even remove any content and do your best to comply with the


### PR DESCRIPTION
This is a very small PR.

In the contributing guidelines, there are two explicit versions. One sentence is about the oldest maintained version, and then there is a sentence making docs changes for newer features in newer versions. The example in the sentence should be newer than the oldest maintained version.