### PR TITLE
Local development Docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+/.git
+/_build/doctrees
+/_build/spelling
+/_build/html
+/_build/logs.txt
+/_build/vendor
+/_build/output
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
-FROM  python:2-stretch as builder
+FROM python:2-alpine as builder
 
 WORKDIR /www
 
 COPY ./_build/.requirements.txt _build/
 
-RUN pip install  pip==9.0.1 wheel==0.29.0 \
+RUN apk add \
+    git \
+    make
+
+RUN pip install pip==9.0.1 wheel==0.29.0 \
     && pip install -r _build/.requirements.txt
 
 COPY . /www
 
 RUN make -C _build html
 
-FROM  nginx:latest
+FROM nginx:alpine
 
 COPY --from=builder /www/_build/html /usr/share/nginx/html


### PR DESCRIPTION
When building the local development Docker image, a huge context is sent to the Docker daemon. Even worse, the whole image is usually rebuilt instead of Docker layer caching reusing the previous builds of the same image.

Example output
```
~/C/G/symfony-docs (request-locales|✔) $ docker build . -t symfony-docs
Sending build context to Docker daemon  164.4MB
Step 1/8 : FROM  python:2-stretch as builder
2-stretch: Pulling from library/python
7568c21980bd: Pull complete
4a9f2207c812: Pull complete
6fe350d2b140: Pull complete
d95a2fdc8b3d: Pull complete

# ...
```

The problem is 2 things
- a locally built `_build` directory is sent with the Docker context
- The `.git` directory is sent with the Docker context
Both are not needed in the build process.


This has been fixed with a `.dockerignore` file, see the documentation here: https://docs.docker.com/engine/reference/builder/#dockerignore-file

New output:
```
~/C/G/symfony-docs (docker-performance|✔) $ docker build . -t symfony-docs
Sending build context to Docker daemon  12.88MB
Step 1/9 : FROM python:2-alpine as builder
2-alpine: Pulling from library/python
aad63a933944: Already exists
259d822268fb: Already exists

# ...
```

Next, the much smaller `alpine` variants of the base images can be used, which is smaller to download. The Python 2 and Nginx base image both have an alpine variant.
