### PR TITLE
[Console] Remove double backslash in console.rst

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -406,7 +406,7 @@ console::
 .. note::
 
     When using the Console component in a standalone project, use
-    :class:`Symfony\\Component\\Console\\Application <Symfony\\Component\\Console\\Application>`
+    :class:`Symfony\\Component\\Console\\Application <Symfony\Component\Console\Application>`
     and extend the normal ``\PHPUnit\Framework\TestCase``.
 
 Logging Command Errors


### PR DESCRIPTION
Remove double backslash in console.rst

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
