### PR TITLE
Use `s-maxage` instead of `max-age` for ESI

### DIFF
--- a/http_cache/esi.rst
+++ b/http_cache/esi.rst
@@ -174,9 +174,8 @@ of the main page::
     {
         public function latest($maxPerPage)
         {
-            // ...
-            $response->setPublic();
-            $response->setMaxAge(60);
+            // sets to public and adds some expiration
+            $response->setSharedMaxAge(60);
 
             return $response;
         }


### PR DESCRIPTION
Seems like there is no reason to use `max-age` header for ESI blocks (https://book.varnish-software.com/4.0/chapters/VCL_Basics.html#the-initial-value-of-beresp-ttl).
So similarly to https://github.com/SerheyDolgushev/symfony-docs/blame/5.3/http_cache/ssi.rst#L108 it should use `s-maxage`.
