### PR TITLE
Remove extra backticks from sidebar header

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -194,7 +194,7 @@ attributes).
     When setting a response for the ``kernel.request`` event, the propagation
     is stopped. This means listeners with lower priority won't be executed.
 
-.. sidebar:: ``kernel.request`` in the Symfony Framework
+.. sidebar:: kernel.request in the Symfony Framework
 
     The most important listener to ``kernel.request`` in the Symfony Framework
     is the :class:`Symfony\\Component\\HttpKernel\\EventListener\\RouterListener`.


### PR DESCRIPTION
Remove the extra backticks from sidebar header

Currently looks like this: 
![image](https://user-images.githubusercontent.com/18466481/138285021-05c6ad0a-a3ad-437a-be68-6e93a37c01e2.png)
