### PR TITLE
Adding Upgrading Section

### DIFF
--- a/form/bootstrap5.rst
+++ b/form/bootstrap5.rst
@@ -87,6 +87,15 @@ If you prefer to apply the Bootstrap styles on a form to form basis, include the
     container. If you override the ``row_attr`` class option, the ``mb-3`` will
     be override too and you will need to explicitly add it.
 
+Upgrading from Bootstrap 4
+--------------------------
+
+* ``form_row()`` is now rendering the error messages *after* the ``<input>`` element.
+So if you're sometimes rendering ``form_widget()`` manually, you need to change the order to:
+.. code-block:: html+twig
+    {{ form_widget(form.foo) }}
+    {{ form_errors(form.foo) }}
+
 Error Messages
 --------------
 


### PR DESCRIPTION
This text is (somewhat) a duplicate of https://symfony.com/doc/current/form/bootstrap5.html#error-messages - if you agree *in principle* that adding an upgrade section is a good idea, I'll see if I can improve this.

Second list item would be to remove all `radio-custom`, `checkbox-custom`, and `switch-custom` https://symfony.com/doc/current/form/bootstrap4.html#custom-forms

Plus maybe a link to https://getbootstrap.com/docs/5.1/migration/
