### PR TITLE
Deleting broken links

### DIFF
--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -8,48 +8,6 @@ The ``FormType`` predefines a couple of options that are then available
 on all types for which ``FormType`` is the parent.
 
 +---------------------------+--------------------------------------------------------------------+
-| Options                   | - `action`_                                                        |
-|                           | - `allow_extra_fields`_                                            |
-|                           | - `by_reference`_                                                  |
-|                           | - `compound`_                                                      |
-|                           | - `constraints`_                                                   |
-|                           | - `data`_                                                          |
-|                           | - `data_class`_                                                    |
-|                           | - `empty_data`_                                                    |
-|                           | - `error_bubbling`_                                                |
-|                           | - `error_mapping`_                                                 |
-|                           | - `extra_fields_message`_                                          |
-|                           | - `form_attr`_                                                     |
-|                           | - `help`_                                                          |
-|                           | - `help_attr`_                                                     |
-|                           | - `help_html`_                                                     |
-|                           | - `help_translation_parameters`_                                   |
-|                           | - `inherit_data`_                                                  |
-|                           | - `invalid_message`_                                               |
-|                           | - `invalid_message_parameters`_                                    |
-|                           | - `label_attr`_                                                    |
-|                           | - `label_format`_                                                  |
-|                           | - `mapped`_                                                        |
-|                           | - `method`_                                                        |
-|                           | - `post_max_size_message`_                                         |
-|                           | - `property_path`_                                                 |
-|                           | - `required`_                                                      |
-|                           | - `trim`_                                                          |
-|                           | - `validation_groups`_                                             |
-+---------------------------+--------------------------------------------------------------------+
-| Inherited options         | - `attr`_                                                          |
-|                           | - `auto_initialize`_                                               |
-|                           | - `block_name`_                                                    |
-|                           | - `block_prefix`_                                                  |
-|                           | - `disabled`_                                                      |
-|                           | - `label`_                                                         |
-|                           | - `label_html`_                                                    |
-|                           | - `row_attr`_                                                      |
-|                           | - `translation_domain`_                                            |
-|                           | - `label_translation_parameters`_                                  |
-|                           | - `attr_translation_parameters`_                                   |
-|                           | - `priority`_                                                      |
-+---------------------------+--------------------------------------------------------------------+
 | Default invalid message   | This value is not valid.                                           |
 +---------------------------+--------------------------------------------------------------------+
 | Legacy invalid message    | This value is not valid.                                           |


### PR DESCRIPTION
All links in this table were broken. And on https://symfony.com/doc/current/reference/forms/types/form.html there's a (new?) list above this table anyway. Which one is supposed to stay and which to go?
