### PR TITLE
[Form] Update form_collections.rst

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -531,7 +531,7 @@ First, add a "delete this tag" link to each tag form:
 
 .. code-block:: javascript
 
-    const tags = document.querySelectorAll('ul.tags')
+    const tags = document.querySelectorAll('ul.tags li')
     tags.forEach((tag) => {
         addTagFormDeleteLink(tag)
     })


### PR DESCRIPTION
Hi,

I followed the instruction, and if you add a delete button to the `<ul>` parent, you have a delete button with no `li` to delete.

Thanks

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
