### PR TITLE
[Validator] [Validation] Add idiomatic way to check if there constraint violations

### DIFF
--- a/validation/raw_values.rst
+++ b/validation/raw_values.rst
@@ -106,6 +106,8 @@ object, which acts like an array of errors. Each error in the collection
 is a :class:`Symfony\\Component\\Validator\\ConstraintViolation` object,
 which holds the error message on its ``getMessage()`` method.
 
+You can determine if the list contains any violations using the ``isEmpty()`` method.
+
 .. note::
 
     When using groups with the


### PR DESCRIPTION
The ConstraintViolationList class cannot be used with PHP's built-in function empty(...) because it is an object, so we have to use the non-idiomatic count($violationList) === 0 or $violationList->count() === 0.

It would be better to have a more idiomatic way to determine if any violations exist via an isEmpty() method.

Relevant PR https://github.com/symfony/symfony/pull/43643

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
