### PR TITLE
Remove duplicate entry "empty_data" in EntityType

### DIFF
--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -332,16 +332,12 @@ type:
 .. include:: /reference/forms/types/options/disabled.rst.inc
 
 .. include:: /reference/forms/types/options/empty_data.rst.inc
-    :end-before: DEFAULT_PLACEHOLDER
 
 The actual default value of this option depends on other field options:
 
 * If ``multiple`` is ``false`` and ``expanded`` is ``false``, then ``''``
   (empty string);
 * Otherwise ``[]`` (empty array).
-
-.. include:: /reference/forms/types/options/empty_data.rst.inc
-    :start-after: DEFAULT_PLACEHOLDER
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 


### PR DESCRIPTION
This fix is not related to a bug nor a new feature, but just the "empty_data" is present twice in this page : https://symfony.com/doc/current/reference/forms/types/entity.html

I'm not really sure about the ":end-before: DEFAULT_PLACEHOLDER" and "start-before" part.