### PR TITLE
[Form] Minor deletion

### DIFF
--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -257,8 +257,9 @@ Renders any errors for the given field.
 
 .. caution::
 
-    In the :ref:`error messages of Bootstrap 4 Form Theme <reference-forms-bootstrap4-error-messages>`,
-    ``form_errors()`` is already included in ``form_label()``.
+    In the Bootstrap 4 form theme, ``form_errors()`` is already included in
+    ``form_label()``. Read more about this in the
+    :ref:`Bootstrap 4 theme documentation <reference-forms-bootstrap4-error-messages>`.
 
 .. _reference-forms-twig-widget:
 


### PR DESCRIPTION
Follow-up of https://github.com/symfony/symfony-docs/pull/15982
The point is that it's included in **label** (not in *errors*) ;-)

About the syntax: Would it be possible to add a link to RST/Spinx to the "edit" `<textarea>` on GitHub?