### PR TITLE
[Validator] Add missing dot

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -179,7 +179,7 @@ message:
 .. code-block:: text
 
     Object(App\Entity\Author).name:
-        This value should not be blank
+        This value should not be blank.
 
 If you insert a value into the ``name`` property, the happy success message
 will appear.


### PR DESCRIPTION
The default NotBlank constraint message ends with a dot.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
