### PR TITLE
[Translation] Fix typo: Unexpected arrow for hash key

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -304,7 +304,7 @@ using PHP's :phpclass:`MessageFormatter` class. Read more about this in
 
     .. code-block:: twig
 
-       {{ message|trans({'%name%': '...', '%count%' => 1}, 'app') }}
+       {{ message|trans({'%name%': '...', '%count%': 1}, 'app') }}
 
     The ``message`` variable must include all the different versions of this
     message based on the value of the ``count`` parameter. For example:


### PR DESCRIPTION
Replace arrow by colon