### PR TITLE
[FrameworkBundle] Rename translation:update to translation:extract

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -1021,7 +1021,7 @@ translation.extractor
 **Purpose**: To register a custom service that extracts messages from a
 file
 
-When executing the ``translation:update`` command, it uses extractors to
+When executing the ``translation:extract`` command, it uses extractors to
 extract translation messages from a file. By default, the Symfony Framework
 has a :class:`Symfony\\Bridge\\Twig\\Translation\\TwigExtractor` and a
 :class:`Symfony\\Component\\Translation\\Extractor\\PhpExtractor`, which

--- a/translation.rst
+++ b/translation.rst
@@ -466,21 +466,26 @@ Extracting Translation Contents and Updating Catalogs Automatically
 
 The most time-consuming tasks when translating an application is to extract all
 the template contents to be translated and to keep all the translation files in
-sync. Symfony includes a command called ``translation:update`` that helps you
+sync. Symfony includes a command called ``translation:extract`` that helps you
 with these tasks:
 
 .. code-block:: terminal
 
     # shows all the messages that should be translated for the French language
-    $ php bin/console translation:update --dump-messages fr
+    $ php bin/console translation:extract --dump-messages fr
 
     # updates the French translation files with the missing strings for that locale
-    $ php bin/console translation:update --force fr
+    $ php bin/console translation:extract --force fr
 
     # check out the command help to see its options (prefix, output format, domain, sorting, etc.)
-    $ php bin/console translation:update --help
+    $ php bin/console translation:extract --help
 
-The ``translation:update`` command looks for missing translations in:
+.. deprecated:: 5.4
+
+    Support for ``translation:update`` was deprecated in Symfony 5.4
+    and it will be removed in Symfony 6.0.
+
+The ``translation:extract`` command looks for missing translations in:
 
 * Templates stored in the ``templates/`` directory (or any other directory
   defined in the :ref:`twig.default_path <config-twig-default-path>` and


### PR DESCRIPTION
Ref https://github.com/symfony/symfony-docs/issues/16023
The code has been merged in https://github.com/symfony/symfony/pull/43758

I'm not 100% sure about the position of the deprecated block, let me know if I have to move it elsewhere.
