### PR TITLE
make following jquery example works

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -43,7 +43,8 @@ of your project. It already holds the basic config you need:
 
         .addEntry('app', './assets/app.js')
 
-        // ...
+        // Don't forget to uncomment If you want use following JQuery example code
+        .autoProvidejQuery()
     ;
 
     // ...


### PR DESCRIPTION
in this section: https://symfony.com/doc/5.4/frontend/encore/simple-example.html#requiring-javascript-modules

It's using jquery as example, so we should tell user that they have to enable autoProvidejQuery option to use jquery in following tutorial.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
