### PR TITLE
[HTTP Foundation] Improve sentence to avoid repetition

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -252,8 +252,10 @@ Accessing the Session
 ~~~~~~~~~~~~~~~~~~~~~
 
 If you have a session attached to the request, you can access it via the
-:method:`Symfony\\Component\\HttpFoundation\\Request::getSession` method or the
-:method:`Symfony\\Component\\HttpFoundation\\RequestStack::getSession` method;
+:method:`Symfony\\Component\\HttpFoundation\\Request::getSession` method 
+from the :class:`Symfony\\Component\\HttpFoundation\\Request` class or the
+:method:`Symfony\\Component\\HttpFoundation\\RequestStack::getSession` method
+from the :class:`Symfony\\Component\\HttpFoundation\\RequestStack` class;
 the
 :method:`Symfony\\Component\\HttpFoundation\\Request::hasPreviousSession`
 method tells you if the request contains a session which was started in one of


### PR DESCRIPTION
 ![image](https://user-images.githubusercontent.com/13469986/139455954-97e6e3e1-acf9-4524-871c-29af9e2b85dd.png)

When you read the sentence without taking into account the links' destination, you get the impression that there is a duplication.

(This was introduced by #14898)