### PR TITLE
Take also $_ENV into consideration when resolving APP_RUNTIME and APP…

### DIFF
--- a/components/runtime.rst
+++ b/components/runtime.rst
@@ -87,7 +87,7 @@ which uses PHP's ``$_SERVER``, ``$_POST``, ``$_GET``, ``$_FILES`` and
 ``$_SESSION`` superglobals. You may also use a custom Runtime (e.g. to
 integrate with Swoole or AWS Lambda).
 
-Use the ``APP_RUNTIME`` environment variable or by specifying the
+Use the ``APP_RUNTIME`` environment variable (PHP's ``$_SERVER`` is used first, then ``$_ENV``) or by specifying the
 ``extra.runtime.class`` in ``composer.json`` to change the Runtime class:
 
 .. code-block:: json


### PR DESCRIPTION
…_RUNTIME_OPTIONS

On docker apache containers to get env variable into $_SERVER other configuration steps are needed. This is unnecessary since they are already available in $_ENV. Or maybe we can use getenv()? I'm preparing a PR for it (will be done in a bit)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
