### PR TITLE
[Security] Fix Response HTTP constant

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1073,7 +1073,7 @@ token (or whatever you need to return) and return the JSON response:
     +         if (null === $user) {
     +             return $this->json([
     +                 'message' => 'missing credentials',
-    +             ], Response::HTTP_UNAUTHENTICATED);
+    +             ], Response::HTTP_UNAUTHORIZED);
     +         }
     +
     +         $token = ...; // somehow create an API token for $user


### PR DESCRIPTION
`Response::HTTP_UNAUTHENTICATED` does not exist in the new 5.3 security documentation. I guess the correct constant is `Response::HTTP_UNAUTHORIZED` :sweat_smile: 