### PR TITLE
Add caution on the framework kernel secret

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -37,6 +37,11 @@ used to add more entropy to security related operations. Its value should
 be a series of characters, numbers and symbols chosen randomly and the
 recommended length is around 32 characters.
 
+.. caution::
+
+    This configuration option's value is a real secret. You should treat it
+    with a lot of care.
+
 In practice, Symfony uses this value for encrypting the cookies used
 in the :doc:`remember me functionality </security/remember_me>` and for
 creating signed URIs when using :ref:`ESI (Edge Side Includes) <edge-side-includes>`.


### PR DESCRIPTION
Hi, small caution on the doc according to this framework config value, I think it is usefull

Related to https://github.com/symfony/symfony/issues/38021 and https://github.com/symfony/symfony/issues/38021#issuecomment-685712783

After my attempt at https://github.com/symfony/recipes/pull/1005 and https://github.com/symfony/symfony/issues/38021#issuecomment-953215989
