### PR TITLE
[Form] Remove repeated options in Form types

### DIFF
--- a/reference/forms/types/birthday.rst
+++ b/reference/forms/types/birthday.rst
@@ -20,35 +20,6 @@ option defaults to 120 years ago to the current year.
 +----------------------+-------------------------------------------------------------------------------+
 | Rendered as          | can be three select boxes or 1 or 3 text boxes, based on the `widget`_ option |
 +----------------------+-------------------------------------------------------------------------------+
-| Overridden options   | - `years`_                                                                    |
-+----------------------+-------------------------------------------------------------------------------+
-| Inherited options    | from the :doc:`DateType </reference/forms/types/date>`:                       |
-|                      |                                                                               |
-|                      | - `choice_translation_domain`_                                                |
-|                      | - `days`_                                                                     |
-|                      | - `placeholder`_                                                              |
-|                      | - `format`_                                                                   |
-|                      | - `input`_                                                                    |
-|                      | - `input_format`_                                                             |
-|                      | - `model_timezone`_                                                           |
-|                      | - `months`_                                                                   |
-|                      | - `view_timezone`_                                                            |
-|                      | - `widget`_                                                                   |
-|                      |                                                                               |
-|                      | from the :doc:`FormType </reference/forms/types/form>`:                       |
-|                      |                                                                               |
-|                      | - `attr`_                                                                     |
-|                      | - `data`_                                                                     |
-|                      | - `disabled`_                                                                 |
-|                      | - `help`_                                                                     |
-|                      | - `help_attr`_                                                                |
-|                      | - `help_html`_                                                                |
-|                      | - `inherit_data`_                                                             |
-|                      | - `invalid_message`_                                                          |
-|                      | - `invalid_message_parameters`_                                               |
-|                      | - `mapped`_                                                                   |
-|                      | - `row_attr`_                                                                 |
-+----------------------+-------------------------------------------------------------------------------+
 | Parent type          | :doc:`DateType </reference/forms/types/date>`                                 |
 +----------------------+-------------------------------------------------------------------------------+
 | Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\BirthdayType`        |

--- a/reference/forms/types/button.rst
+++ b/reference/forms/types/button.rst
@@ -9,14 +9,6 @@ A simple, non-responsive button.
 +----------------------+----------------------------------------------------------------------+
 | Rendered as          | ``button`` tag                                                       |
 +----------------------+----------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                            |
-| options              | - `attr_translation_parameters`_                                     |
-|                      | - `disabled`_                                                        |
-|                      | - `label`_                                                           |
-|                      | - `label_translation_parameters`_                                    |
-|                      | - `row_attr`_                                                        |
-|                      | - `translation_domain`_                                              |
-+----------------------+----------------------------------------------------------------------+
 | Parent type          | none                                                                 |
 +----------------------+----------------------------------------------------------------------+
 | Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\ButtonType` |

--- a/reference/forms/types/checkbox.rst
+++ b/reference/forms/types/checkbox.rst
@@ -14,27 +14,6 @@ if you want to handle submitted values like "0" or "false").
 +-------------+------------------------------------------------------------------------+
 | Rendered as | ``input`` ``checkbox`` field                                           |
 +-------------+------------------------------------------------------------------------+
-| Options     | - `false_values`_                                                      |
-|             | - `value`_                                                             |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                          |
-| options     | - `empty_data`_                                                        |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                              |
-| options     | - `data`_                                                              |
-|             | - `disabled`_                                                          |
-|             | - `error_bubbling`_                                                    |
-|             | - `error_mapping`_                                                     |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                          |
 +-------------+------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CheckboxType` |

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -12,44 +12,6 @@ To use this field, you must specify *either* ``choices`` or ``choice_loader`` op
 +-------------+------------------------------------------------------------------------------+
 | Rendered as | can be various tags (see below)                                              |
 +-------------+------------------------------------------------------------------------------+
-| Options     | - `choices`_                                                                 |
-|             | - `choice_attr`_                                                             |
-|             | - `choice_label`_                                                            |
-|             | - `choice_loader`_                                                           |
-|             | - `choice_name`_                                                             |
-|             | - `choice_translation_domain`_                                               |
-|             | - `choice_value`_                                                            |
-|             | - `expanded`_                                                                |
-|             | - `group_by`_                                                                |
-|             | - `multiple`_                                                                |
-|             | - `placeholder`_                                                             |
-|             | - `preferred_choices`_                                                       |
-+-------------+------------------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                                |
-| options     | - `empty_data`_                                                              |
-|             | - `error_bubbling`_                                                          |
-|             | - `trim`_                                                                    |
-+-------------+------------------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                                    |
-| options     | - `by_reference`_                                                            |
-|             | - `data`_                                                                    |
-|             | - `disabled`_                                                                |
-|             | - `error_mapping`_                                                           |
-|             | - `help`_                                                                    |
-|             | - `help_attr`_                                                               |
-|             | - `help_html`_                                                               |
-|             | - `inherit_data`_                                                            |
-|             | - `label`_                                                                   |
-|             | - `label_attr`_                                                              |
-|             | - `label_format`_                                                            |
-|             | - `mapped`_                                                                  |
-|             | - `required`_                                                                |
-|             | - `row_attr`_                                                                |
-|             | - `translation_domain`_                                                      |
-|             | - `label_translation_parameters`_                                            |
-|             | - `attr_translation_parameters`_                                             |
-|             | - `help_translation_parameters`_                                             |
-+-------------+------------------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                                |
 +-------------+------------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\ChoiceType`         |

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -14,30 +14,6 @@ photos).
 +-------------+-----------------------------------------------------------------------------+
 | Rendered as | depends on the `entry_type`_ option                                         |
 +-------------+-----------------------------------------------------------------------------+
-| Options     | - `allow_add`_                                                              |
-|             | - `allow_delete`_                                                           |
-|             | - `delete_empty`_                                                           |
-|             | - `entry_options`_                                                          |
-|             | - `entry_type`_                                                             |
-|             | - `prototype`_                                                              |
-|             | - `prototype_data`_                                                         |
-|             | - `prototype_name`_                                                         |
-+-------------+-----------------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                                   |
-| options     | - `by_reference`_                                                           |
-|             | - `empty_data`_                                                             |
-|             | - `error_bubbling`_                                                         |
-|             | - `error_mapping`_                                                          |
-|             | - `help`_                                                                   |
-|             | - `help_attr`_                                                              |
-|             | - `help_html`_                                                              |
-|             | - `label`_                                                                  |
-|             | - `label_attr`_                                                             |
-|             | - `label_format`_                                                           |
-|             | - `mapped`_                                                                 |
-|             | - `required`_                                                               |
-|             | - `row_attr`_                                                               |
-+-------------+-----------------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                               |
 +-------------+-----------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType`    |

--- a/reference/forms/types/color.rst
+++ b/reference/forms/types/color.rst
@@ -17,23 +17,6 @@ element.
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``color`` field (a text box)                              |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-|             | - `trim`_                                                           |
-+-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                       |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\ColorType` |

--- a/reference/forms/types/country.rst
+++ b/reference/forms/types/country.rst
@@ -21,38 +21,6 @@ the option manually, but then you should just use the ``ChoiceType`` directly.
 +-------------+-----------------------------------------------------------------------+
 | Rendered as | can be various tags (see :ref:`forms-reference-choice-tags`)          |
 +-------------+-----------------------------------------------------------------------+
-| Options     | - `alpha3`_                                                           |
-|             | - `choice_translation_locale`_                                        |
-+-------------+-----------------------------------------------------------------------+
-| Overridden  | - `choices`_                                                          |
-| options     | - `choice_translation_domain`_                                        |
-+-------------+-----------------------------------------------------------------------+
-| Inherited   | from the :doc:`ChoiceType </reference/forms/types/choice>`            |
-| options     |                                                                       |
-|             | - `error_bubbling`_                                                   |
-|             | - `error_mapping`_                                                    |
-|             | - `expanded`_                                                         |
-|             | - `multiple`_                                                         |
-|             | - `placeholder`_                                                      |
-|             | - `preferred_choices`_                                                |
-|             | - `trim`_                                                             |
-|             |                                                                       |
-|             | from the :doc:`FormType </reference/forms/types/form>`                |
-|             |                                                                       |
-|             | - `attr`_                                                             |
-|             | - `data`_                                                             |
-|             | - `disabled`_                                                         |
-|             | - `empty_data`_                                                       |
-|             | - `help`_                                                             |
-|             | - `help_attr`_                                                        |
-|             | - `help_html`_                                                        |
-|             | - `label`_                                                            |
-|             | - `label_attr`_                                                       |
-|             | - `label_format`_                                                     |
-|             | - `mapped`_                                                           |
-|             | - `required`_                                                         |
-|             | - `row_attr`_                                                         |
-+-------------+-----------------------------------------------------------------------+
 | Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                     |
 +-------------+-----------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CountryType` |

--- a/reference/forms/types/currency.rst
+++ b/reference/forms/types/currency.rst
@@ -14,36 +14,6 @@ manually, but then you should just use the ``ChoiceType`` directly.
 +-------------+------------------------------------------------------------------------+
 | Rendered as | can be various tags (see :ref:`forms-reference-choice-tags`)           |
 +-------------+------------------------------------------------------------------------+
-| Options     | - `choice_translation_locale`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `choices`_                                                           |
-| options     | - `choice_translation_domain`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | from the :doc:`ChoiceType </reference/forms/types/choice>`             |
-| options     |                                                                        |
-|             | - `error_bubbling`_                                                    |
-|             | - `expanded`_                                                          |
-|             | - `multiple`_                                                          |
-|             | - `placeholder`_                                                       |
-|             | - `preferred_choices`_                                                 |
-|             | - `trim`_                                                              |
-|             |                                                                        |
-|             | from the :doc:`FormType </reference/forms/types/form>` type            |
-|             |                                                                        |
-|             | - `attr`_                                                              |
-|             | - `data`_                                                              |
-|             | - `disabled`_                                                          |
-|             | - `empty_data`_                                                        |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
 +-------------+------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\CurrencyType` |

--- a/reference/forms/types/date.rst
+++ b/reference/forms/types/date.rst
@@ -15,37 +15,6 @@ and can understand a number of different input formats via the `input`_ option.
 +----------------------+-----------------------------------------------------------------------------+
 | Rendered as          | single text box or three select fields                                      |
 +----------------------+-----------------------------------------------------------------------------+
-| Options              | - `days`_                                                                   |
-|                      | - `placeholder`_                                                            |
-|                      | - `format`_                                                                 |
-|                      | - `html5`_                                                                  |
-|                      | - `input`_                                                                  |
-|                      | - `input_format`_                                                           |
-|                      | - `model_timezone`_                                                         |
-|                      | - `months`_                                                                 |
-|                      | - `view_timezone`_                                                          |
-|                      | - `widget`_                                                                 |
-|                      | - `years`_                                                                  |
-+----------------------+-----------------------------------------------------------------------------+
-| Overridden options   | - `by_reference`_                                                           |
-|                      | - `choice_translation_domain`_                                              |
-|                      | - `compound`_                                                               |
-|                      | - `data_class`_                                                             |
-|                      | - `error_bubbling`_                                                         |
-+----------------------+-----------------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                                   |
-| options              | - `data`_                                                                   |
-|                      | - `disabled`_                                                               |
-|                      | - `error_mapping`_                                                          |
-|                      | - `help`_                                                                   |
-|                      | - `help_attr`_                                                              |
-|                      | - `help_html`_                                                              |
-|                      | - `inherit_data`_                                                           |
-|                      | - `invalid_message`_                                                        |
-|                      | - `invalid_message_parameters`_                                             |
-|                      | - `mapped`_                                                                 |
-|                      | - `row_attr`_                                                               |
-+----------------------+-----------------------------------------------------------------------------+
 | Parent type          | :doc:`FormType </reference/forms/types/form>`                               |
 +----------------------+-----------------------------------------------------------------------------+
 | Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\DateType`          |

--- a/reference/forms/types/dateinterval.rst
+++ b/reference/forms/types/dateinterval.rst
@@ -17,38 +17,6 @@ or an array (see `input`_).
 +----------------------+----------------------------------------------------------------------------------+
 | Rendered as          | single text box, multiple text boxes or select fields - see the `widget`_ option |
 +----------------------+----------------------------------------------------------------------------------+
-| Options              | - `days`_                                                                        |
-|                      | - `hours`_                                                                       |
-|                      | - `minutes`_                                                                     |
-|                      | - `months`_                                                                      |
-|                      | - `seconds`_                                                                     |
-|                      | - `weeks`_                                                                       |
-|                      | - `input`_                                                                       |
-|                      | - `labels`_                                                                      |
-|                      | - `placeholder`_                                                                 |
-|                      | - `widget`_                                                                      |
-|                      | - `with_days`_                                                                   |
-|                      | - `with_hours`_                                                                  |
-|                      | - `with_invert`_                                                                 |
-|                      | - `with_minutes`_                                                                |
-|                      | - `with_months`_                                                                 |
-|                      | - `with_seconds`_                                                                |
-|                      | - `with_weeks`_                                                                  |
-|                      | - `with_years`_                                                                  |
-|                      | - `years`_                                                                       |
-+----------------------+----------------------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                                        |
-| options              | - `data`_                                                                        |
-|                      | - `disabled`_                                                                    |
-|                      | - `help`_                                                                        |
-|                      | - `help_attr`_                                                                   |
-|                      | - `help_html`_                                                                   |
-|                      | - `inherit_data`_                                                                |
-|                      | - `invalid_message`_                                                             |
-|                      | - `invalid_message_parameters`_                                                  |
-|                      | - `mapped`_                                                                      |
-|                      | - `row_attr`_                                                                    |
-+----------------------+----------------------------------------------------------------------------------+
 | Parent type          | :doc:`FormType </reference/forms/types/form>`                                    |
 +----------------------+----------------------------------------------------------------------------------+
 | Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\DateIntervalType`       |

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -15,46 +15,6 @@ the data can be a ``DateTime`` object, a string, a timestamp or an array.
 +----------------------+-----------------------------------------------------------------------------+
 | Rendered as          | single text box or three select fields                                      |
 +----------------------+-----------------------------------------------------------------------------+
-| Options              | - `choice_translation_domain`_                                              |
-|                      | - `date_format`_                                                            |
-|                      | - `date_label`_                                                             |
-|                      | - `date_widget`_                                                            |
-|                      | - `days`_                                                                   |
-|                      | - `placeholder`_                                                            |
-|                      | - `format`_                                                                 |
-|                      | - `hours`_                                                                  |
-|                      | - `html5`_                                                                  |
-|                      | - `input`_                                                                  |
-|                      | - `input_format`_                                                           |
-|                      | - `minutes`_                                                                |
-|                      | - `model_timezone`_                                                         |
-|                      | - `months`_                                                                 |
-|                      | - `seconds`_                                                                |
-|                      | - `time_label`_                                                             |
-|                      | - `time_widget`_                                                            |
-|                      | - `view_timezone`_                                                          |
-|                      | - `widget`_                                                                 |
-|                      | - `with_minutes`_                                                           |
-|                      | - `with_seconds`_                                                           |
-|                      | - `years`_                                                                  |
-+----------------------+-----------------------------------------------------------------------------+
-| Overridden options   | - `by_reference`_                                                           |
-|                      | - `compound`_                                                               |
-|                      | - `data_class`_                                                             |
-|                      | - `error_bubbling`_                                                         |
-+----------------------+-----------------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                                   |
-| options              | - `data`_                                                                   |
-|                      | - `disabled`_                                                               |
-|                      | - `help`_                                                                   |
-|                      | - `help_attr`_                                                              |
-|                      | - `help_html`_                                                              |
-|                      | - `inherit_data`_                                                           |
-|                      | - `invalid_message`_                                                        |
-|                      | - `invalid_message_parameters`_                                             |
-|                      | - `mapped`_                                                                 |
-|                      | - `row_attr`_                                                               |
-+----------------------+-----------------------------------------------------------------------------+
 | Parent type          | :doc:`FormType </reference/forms/types/form>`                               |
 +----------------------+-----------------------------------------------------------------------------+
 | Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\DateTimeType`      |

--- a/reference/forms/types/email.rst
+++ b/reference/forms/types/email.rst
@@ -10,23 +10,6 @@ The ``EmailType`` field is a text field that is rendered using the HTML5
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``email`` field (a text box)                              |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-|             | - `trim`_                                                           |
-+-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                       |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\EmailType` |

--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -12,49 +12,6 @@ objects from the database.
 +-------------+------------------------------------------------------------------+
 | Rendered as | can be various tags (see :ref:`forms-reference-choice-tags`)     |
 +-------------+------------------------------------------------------------------+
-| Options     | - `choice_label`_                                                |
-|             | - `class`_                                                       |
-|             | - `em`_                                                          |
-|             | - `query_builder`_                                               |
-+-------------+------------------------------------------------------------------+
-| Overridden  | - `choice_name`_                                                 |
-| options     | - `choice_value`_                                                |
-|             | - `choices`_                                                     |
-|             | - `data_class`_                                                  |
-+-------------+------------------------------------------------------------------+
-| Inherited   | from the :doc:`ChoiceType </reference/forms/types/choice>`:      |
-| options     |                                                                  |
-|             | - `choice_attr`_                                                 |
-|             | - `choice_translation_domain`_                                   |
-|             | - `expanded`_                                                    |
-|             | - `group_by`_                                                    |
-|             | - `multiple`_                                                    |
-|             | - `placeholder`_                                                 |
-|             | - `preferred_choices`_                                           |
-|             | - `translation_domain`_                                          |
-|             | - `trim`_                                                        |
-|             |                                                                  |
-|             | from the :doc:`FormType </reference/forms/types/form>`:          |
-|             |                                                                  |
-|             | - `attr`_                                                        |
-|             | - `data`_                                                        |
-|             | - `disabled`_                                                    |
-|             | - `empty_data`_                                                  |
-|             | - `error_bubbling`_                                              |
-|             | - `error_mapping`_                                               |
-|             | - `help`_                                                        |
-|             | - `help_attr`_                                                   |
-|             | - `help_html`_                                                   |
-|             | - `label`_                                                       |
-|             | - `label_attr`_                                                  |
-|             | - `label_format`_                                                |
-|             | - `mapped`_                                                      |
-|             | - `required`_                                                    |
-|             | - `row_attr`_                                                    |
-|             | - `label_translation_parameters`_                                |
-|             | - `attr_translation_parameters`_                                 |
-|             | - `help_translation_parameters`_                                 |
-+-------------+------------------------------------------------------------------+
 | Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                |
 +-------------+------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Bridge\\Doctrine\\Form\\Type\\EntityType`       |

--- a/reference/forms/types/file.rst
+++ b/reference/forms/types/file.rst
@@ -9,26 +9,6 @@ The ``FileType`` represents a file input in your form.
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``file`` field                                            |
 +-------------+---------------------------------------------------------------------+
-| Options     | - `multiple`_                                                       |
-+-------------+---------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                       |
-| options     | - `data_class`_                                                     |
-|             | - `empty_data`_                                                     |
-+-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `disabled`_                                                       |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-+-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                       |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\FileType`  |

--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -8,45 +8,6 @@ The ``FormType`` predefines a couple of options that are then available
 on all types for which ``FormType`` is the parent.
 
 +-----------+--------------------------------------------------------------------+
-| Options   | - `action`_                                                        |
-|           | - `allow_extra_fields`_                                            |
-|           | - `by_reference`_                                                  |
-|           | - `compound`_                                                      |
-|           | - `constraints`_                                                   |
-|           | - `data`_                                                          |
-|           | - `data_class`_                                                    |
-|           | - `empty_data`_                                                    |
-|           | - `error_bubbling`_                                                |
-|           | - `error_mapping`_                                                 |
-|           | - `extra_fields_message`_                                          |
-|           | - `help`_                                                          |
-|           | - `help_attr`_                                                     |
-|           | - `help_html`_                                                     |
-|           | - `help_translation_parameters`_                                   |
-|           | - `inherit_data`_                                                  |
-|           | - `invalid_message`_                                               |
-|           | - `invalid_message_parameters`_                                    |
-|           | - `label_attr`_                                                    |
-|           | - `label_format`_                                                  |
-|           | - `mapped`_                                                        |
-|           | - `method`_                                                        |
-|           | - `post_max_size_message`_                                         |
-|           | - `property_path`_                                                 |
-|           | - `required`_                                                      |
-|           | - `trim`_                                                          |
-|           | - `validation_groups`_                                             |
-+-----------+--------------------------------------------------------------------+
-| Inherited | - `attr`_                                                          |
-| options   | - `auto_initialize`_                                               |
-|           | - `block_name`_                                                    |
-|           | - `block_prefix`_                                                  |
-|           | - `disabled`_                                                      |
-|           | - `label`_                                                         |
-|           | - `row_attr`_                                                      |
-|           | - `translation_domain`_                                            |
-|           | - `label_translation_parameters`_                                  |
-|           | - `attr_translation_parameters`_                                   |
-+-----------+--------------------------------------------------------------------+
 | Parent    | none                                                               |
 +-----------+--------------------------------------------------------------------+
 | Class     | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType` |

--- a/reference/forms/types/hidden.rst
+++ b/reference/forms/types/hidden.rst
@@ -9,18 +9,6 @@ The hidden type represents a hidden input field.
 +-------------+----------------------------------------------------------------------+
 | Rendered as | ``input`` ``hidden`` field                                           |
 +-------------+----------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                        |
-| options     | - `error_bubbling`_                                                  |
-|             | - `required`_                                                        |
-+-------------+----------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                            |
-| options     | - `data`_                                                            |
-|             | - `empty_data`_                                                      |
-|             | - `error_mapping`_                                                   |
-|             | - `mapped`_                                                          |
-|             | - `property_path`_                                                   |
-|             | - `row_attr`_                                                        |
-+-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                        |
 +-------------+----------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\HiddenType` |

--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -16,30 +16,6 @@ integers. By default, all non-integer values (e.g. 6.78) will round down
 +-------------+-----------------------------------------------------------------------+
 | Rendered as | ``input`` ``number`` field                                            |
 +-------------+-----------------------------------------------------------------------+
-| Options     | - `grouping`_                                                         |
-|             | - `rounding_mode`_                                                    |
-+-------------+-----------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                         |
-| options     | - `scale`_                                                            |
-+-------------+-----------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                             |
-| options     | - `data`_                                                             |
-|             | - `disabled`_                                                         |
-|             | - `empty_data`_                                                       |
-|             | - `error_bubbling`_                                                   |
-|             | - `error_mapping`_                                                    |
-|             | - `help`_                                                             |
-|             | - `help_attr`_                                                        |
-|             | - `help_html`_                                                        |
-|             | - `invalid_message`_                                                  |
-|             | - `invalid_message_parameters`_                                       |
-|             | - `label`_                                                            |
-|             | - `label_attr`_                                                       |
-|             | - `label_format`_                                                     |
-|             | - `mapped`_                                                           |
-|             | - `required`_                                                         |
-|             | - `row_attr`_                                                         |
-+-------------+-----------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                         |
 +-------------+-----------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\IntegerType` |

--- a/reference/forms/types/language.rst
+++ b/reference/forms/types/language.rst
@@ -23,38 +23,6 @@ manually, but then you should just use the ``ChoiceType`` directly.
 +-------------+------------------------------------------------------------------------+
 | Rendered as | can be various tags (see :ref:`forms-reference-choice-tags`)           |
 +-------------+------------------------------------------------------------------------+
-| Options     | - `alpha3`_                                                            |
-|             | - `choice_translation_locale`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `choices`_                                                           |
-| options     | - `choice_translation_domain`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | from the :doc:`ChoiceType </reference/forms/types/choice>`             |
-| options     |                                                                        |
-|             | - `error_bubbling`_                                                    |
-|             | - `error_mapping`_                                                     |
-|             | - `expanded`_                                                          |
-|             | - `multiple`_                                                          |
-|             | - `placeholder`_                                                       |
-|             | - `preferred_choices`_                                                 |
-|             | - `trim`_                                                              |
-|             |                                                                        |
-|             | from the :doc:`FormType </reference/forms/types/form>`                 |
-|             |                                                                        |
-|             | - `attr`_                                                              |
-|             | - `data`_                                                              |
-|             | - `disabled`_                                                          |
-|             | - `empty_data`_                                                        |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
 +-------------+------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\LanguageType` |

--- a/reference/forms/types/locale.rst
+++ b/reference/forms/types/locale.rst
@@ -24,37 +24,6 @@ manually, but then you should just use the ``ChoiceType`` directly.
 +-------------+------------------------------------------------------------------------+
 | Rendered as | can be various tags (see :ref:`forms-reference-choice-tags`)           |
 +-------------+------------------------------------------------------------------------+
-| Options     | - `choice_translation_locale`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `choices`_                                                           |
-| options     | - `choice_translation_domain`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | from the :doc:`ChoiceType </reference/forms/types/choice>`             |
-| options     |                                                                        |
-|             | - `error_bubbling`_                                                    |
-|             | - `error_mapping`_                                                     |
-|             | - `expanded`_                                                          |
-|             | - `multiple`_                                                          |
-|             | - `placeholder`_                                                       |
-|             | - `preferred_choices`_                                                 |
-|             | - `trim`_                                                              |
-|             |                                                                        |
-|             | from the :doc:`FormType </reference/forms/types/form>`                 |
-|             |                                                                        |
-|             | - `attr`_                                                              |
-|             | - `data`_                                                              |
-|             | - `disabled`_                                                          |
-|             | - `empty_data`_                                                        |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
 +-------------+------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\LocaleType`   |

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -14,33 +14,6 @@ how the input and output of the data is handled.
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``text`` field                                            |
 +-------------+---------------------------------------------------------------------+
-| Options     | - `currency`_                                                       |
-|             | - `divisor`_                                                        |
-|             | - `grouping`_                                                       |
-|             | - `rounding_mode`_                                                  |
-|             | - `scale`_                                                          |
-+-------------+---------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                       |
-| options     |                                                                     |
-+-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `invalid_message`_                                                |
-|             | - `invalid_message_parameters`_                                     |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-+-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                       |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\MoneyType` |

--- a/reference/forms/types/number.rst
+++ b/reference/forms/types/number.rst
@@ -11,33 +11,6 @@ that you want to use for your number.
 +-------------+----------------------------------------------------------------------+
 | Rendered as | ``input`` ``text`` field                                             |
 +-------------+----------------------------------------------------------------------+
-| Options     | - `grouping`_                                                        |
-|             | - `html5`_                                                           |
-|             | - `input`_                                                           |
-|             | - `scale`_                                                           |
-|             | - `rounding_mode`_                                                   |
-+-------------+----------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                        |
-| options     |                                                                      |
-+-------------+----------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                            |
-| options     | - `data`_                                                            |
-|             | - `disabled`_                                                        |
-|             | - `empty_data`_                                                      |
-|             | - `error_bubbling`_                                                  |
-|             | - `error_mapping`_                                                   |
-|             | - `help`_                                                            |
-|             | - `help_attr`_                                                       |
-|             | - `help_html`_                                                       |
-|             | - `invalid_message`_                                                 |
-|             | - `invalid_message_parameters`_                                      |
-|             | - `label`_                                                           |
-|             | - `label_attr`_                                                      |
-|             | - `label_format`_                                                    |
-|             | - `mapped`_                                                          |
-|             | - `required`_                                                        |
-|             | - `row_attr`_                                                        |
-+-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                        |
 +-------------+----------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\NumberType` |

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -9,26 +9,6 @@ The ``PasswordType`` field renders an input password text box.
 +-------------+------------------------------------------------------------------------+
 | Rendered as | ``input`` ``password`` field                                           |
 +-------------+------------------------------------------------------------------------+
-| Options     | - `always_empty`_                                                      |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `trim`_                                                              |
-| options     |                                                                        |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                              |
-| options     | - `disabled`_                                                          |
-|             | - `empty_data`_                                                        |
-|             | - `error_bubbling`_                                                    |
-|             | - `error_mapping`_                                                     |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                          |
 +-------------+------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\PasswordType` |

--- a/reference/forms/types/percent.rst
+++ b/reference/forms/types/percent.rst
@@ -15,31 +15,6 @@ the input.
 +-------------+-----------------------------------------------------------------------+
 | Rendered as | ``input`` ``text`` field                                              |
 +-------------+-----------------------------------------------------------------------+
-| Options     | - `scale`_                                                            |
-|             | - `symbol`_                                                           |
-|             | - `type`_                                                             |
-+-------------+-----------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                         |
-| options     |                                                                       |
-+-------------+-----------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                             |
-| options     | - `data`_                                                             |
-|             | - `disabled`_                                                         |
-|             | - `empty_data`_                                                       |
-|             | - `error_bubbling`_                                                   |
-|             | - `error_mapping`_                                                    |
-|             | - `help`_                                                             |
-|             | - `help_attr`_                                                        |
-|             | - `help_html`_                                                        |
-|             | - `invalid_message`_                                                  |
-|             | - `invalid_message_parameters`_                                       |
-|             | - `label`_                                                            |
-|             | - `label_attr`_                                                       |
-|             | - `label_format`_                                                     |
-|             | - `mapped`_                                                           |
-|             | - `required`_                                                         |
-|             | - `row_attr`_                                                         |
-+-------------+-----------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                         |
 +-------------+-----------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\PercentType` |

--- a/reference/forms/types/radio.rst
+++ b/reference/forms/types/radio.rst
@@ -16,28 +16,6 @@ If you want to have a boolean field, use :doc:`CheckboxType </reference/forms/ty
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``radio`` field                                           |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | from the :doc:`CheckboxType </reference/forms/types/checkbox>`:     |
-| options     |                                                                     |
-|             | - `value`_                                                          |
-|             |                                                                     |
-|             | from the :doc:`FormType </reference/forms/types/form>`:             |
-|             |                                                                     |
-|             | - `attr`_                                                           |
-|             | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-+-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`CheckboxType </reference/forms/types/checkbox>`               |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType` |

--- a/reference/forms/types/range.rst
+++ b/reference/forms/types/range.rst
@@ -10,22 +10,6 @@ The ``RangeType`` field is a slider that is rendered using the HTML5
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``range`` field (slider in HTML5 supported browser)       |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-|             | - `trim`_                                                           |
-+-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                       |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RangeType` |

--- a/reference/forms/types/repeated.rst
+++ b/reference/forms/types/repeated.rst
@@ -12,27 +12,6 @@ accuracy.
 +-------------+------------------------------------------------------------------------+
 | Rendered as | input ``text`` field by default, but see `type`_ option                |
 +-------------+------------------------------------------------------------------------+
-| Options     | - `first_name`_                                                        |
-|             | - `first_options`_                                                     |
-|             | - `options`_                                                           |
-|             | - `second_name`_                                                       |
-|             | - `second_options`_                                                    |
-|             | - `type`_                                                              |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `error_bubbling`_                                                    |
-| options     |                                                                        |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                              |
-| options     | - `data`_                                                              |
-|             | - `error_mapping`_                                                     |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `invalid_message`_                                                   |
-|             | - `invalid_message_parameters`_                                        |
-|             | - `mapped`_                                                            |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                          |
 +-------------+------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\RepeatedType` |

--- a/reference/forms/types/reset.rst
+++ b/reference/forms/types/reset.rst
@@ -9,14 +9,6 @@ A button that resets all fields to their original values.
 +----------------------+---------------------------------------------------------------------+
 | Rendered as          | ``input`` ``reset`` tag                                             |
 +----------------------+---------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                           |
-| options              | - `attr_translation_parameters`_                                    |
-|                      | - `disabled`_                                                       |
-|                      | - `label`_                                                          |
-|                      | - `label_translation_parameters`_                                   |
-|                      | - `row_attr`_                                                       |
-|                      | - `translation_domain`_                                             |
-+----------------------+---------------------------------------------------------------------+
 | Parent type          | :doc:`ButtonType </reference/forms/types/button>`                   |
 +----------------------+---------------------------------------------------------------------+
 | Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\ResetType` |

--- a/reference/forms/types/search.rst
+++ b/reference/forms/types/search.rst
@@ -12,22 +12,6 @@ Read about the input search field at `DiveIntoHTML5.info`_
 +-------------+----------------------------------------------------------------------+
 | Rendered as | ``input search`` field                                               |
 +-------------+----------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                            |
-| options     | - `disabled`_                                                        |
-|             | - `empty_data`_                                                      |
-|             | - `error_bubbling`_                                                  |
-|             | - `error_mapping`_                                                   |
-|             | - `help`_                                                            |
-|             | - `help_attr`_                                                       |
-|             | - `help_html`_                                                       |
-|             | - `label`_                                                           |
-|             | - `label_attr`_                                                      |
-|             | - `label_format`_                                                    |
-|             | - `mapped`_                                                          |
-|             | - `required`_                                                        |
-|             | - `row_attr`_                                                        |
-|             | - `trim`_                                                            |
-+-------------+----------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                        |
 +-------------+----------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\SearchType` |

--- a/reference/forms/types/submit.rst
+++ b/reference/forms/types/submit.rst
@@ -9,18 +9,6 @@ A submit button.
 +----------------------+----------------------------------------------------------------------+
 | Rendered as          | ``button`` ``submit`` tag                                            |
 +----------------------+----------------------------------------------------------------------+
-| Options              | - `validate`_                                                        |
-+----------------------+----------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                            |
-| options              | - `attr_translation_parameters`_                                     |
-|                      | - `disabled`_                                                        |
-|                      | - `label`_                                                           |
-|                      | - `label_format`_                                                    |
-|                      | - `label_translation_parameters`_                                    |
-|                      | - `row_attr`_                                                        |
-|                      | - `translation_domain`_                                              |
-|                      | - `validation_groups`_                                               |
-+----------------------+----------------------------------------------------------------------+
 | Parent type          | :doc:`ButtonType </reference/forms/types/button>`                    |
 +----------------------+----------------------------------------------------------------------+
 | Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\SubmitType` |

--- a/reference/forms/types/tel.rst
+++ b/reference/forms/types/tel.rst
@@ -16,23 +16,6 @@ to input phone numbers.
 +-------------+---------------------------------------------------------------------+
 | Rendered as | ``input`` ``tel`` field (a text box)                                |
 +-------------+---------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                           |
-| options     | - `data`_                                                           |
-|             | - `disabled`_                                                       |
-|             | - `empty_data`_                                                     |
-|             | - `error_bubbling`_                                                 |
-|             | - `error_mapping`_                                                  |
-|             | - `help`_                                                           |
-|             | - `help_attr`_                                                      |
-|             | - `help_html`_                                                      |
-|             | - `label`_                                                          |
-|             | - `label_attr`_                                                     |
-|             | - `label_format`_                                                   |
-|             | - `mapped`_                                                         |
-|             | - `required`_                                                       |
-|             | - `row_attr`_                                                       |
-|             | - `trim`_                                                           |
-+-------------+---------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                       |
 +-------------+---------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TelType`   |

--- a/reference/forms/types/text.rst
+++ b/reference/forms/types/text.rst
@@ -9,26 +9,6 @@ The TextType field represents the most basic input text field.
 +-------------+--------------------------------------------------------------------+
 | Rendered as | ``input`` ``text`` field                                           |
 +-------------+--------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                          |
-| options     | - `data`_                                                          |
-|             | - `disabled`_                                                      |
-|             | - `empty_data`_                                                    |
-|             | - `error_bubbling`_                                                |
-|             | - `error_mapping`_                                                 |
-|             | - `help`_                                                          |
-|             | - `help_attr`_                                                     |
-|             | - `help_html`_                                                     |
-|             | - `label`_                                                         |
-|             | - `label_attr`_                                                    |
-|             | - `label_format`_                                                  |
-|             | - `mapped`_                                                        |
-|             | - `required`_                                                      |
-|             | - `row_attr`_                                                      |
-|             | - `trim`_                                                          |
-+-------------+--------------------------------------------------------------------+
-| Overridden  | - `compound`_                                                      |
-| options     |                                                                    |
-+-------------+--------------------------------------------------------------------+
 | Parent type | :doc:`FormType </reference/forms/types/form>`                      |
 +-------------+--------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TextType` |

--- a/reference/forms/types/textarea.rst
+++ b/reference/forms/types/textarea.rst
@@ -9,23 +9,6 @@ Renders a ``textarea`` HTML element.
 +-------------+------------------------------------------------------------------------+
 | Rendered as | ``textarea`` tag                                                       |
 +-------------+------------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                              |
-| options     | - `data`_                                                              |
-|             | - `disabled`_                                                          |
-|             | - `empty_data`_                                                        |
-|             | - `error_bubbling`_                                                    |
-|             | - `error_mapping`_                                                     |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-|             | - `trim`_                                                              |
-+-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                          |
 +-------------+------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TextareaType` |

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -15,39 +15,6 @@ stored as a ``DateTime`` object, a string, a timestamp or an array.
 +----------------------+-----------------------------------------------------------------------------+
 | Rendered as          | can be various tags (see below)                                             |
 +----------------------+-----------------------------------------------------------------------------+
-| Options              | - `choice_translation_domain`_                                              |
-|                      | - `placeholder`_                                                            |
-|                      | - `hours`_                                                                  |
-|                      | - `html5`_                                                                  |
-|                      | - `input`_                                                                  |
-|                      | - `input_format`_                                                           |
-|                      | - `minutes`_                                                                |
-|                      | - `model_timezone`_                                                         |
-|                      | - `reference_date`_                                                         |
-|                      | - `seconds`_                                                                |
-|                      | - `view_timezone`_                                                          |
-|                      | - `widget`_                                                                 |
-|                      | - `with_minutes`_                                                           |
-|                      | - `with_seconds`_                                                           |
-+----------------------+-----------------------------------------------------------------------------+
-| Overridden options   | - `by_reference`_                                                           |
-|                      | - `compound`_                                                               |
-|                      | - `data_class`_                                                             |
-|                      | - `error_bubbling`_                                                         |
-+----------------------+-----------------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                                   |
-| options              | - `data`_                                                                   |
-|                      | - `disabled`_                                                               |
-|                      | - `error_mapping`_                                                          |
-|                      | - `help`_                                                                   |
-|                      | - `help_attr`_                                                              |
-|                      | - `help_html`_                                                              |
-|                      | - `inherit_data`_                                                           |
-|                      | - `invalid_message`_                                                        |
-|                      | - `invalid_message_parameters`_                                             |
-|                      | - `mapped`_                                                                 |
-|                      | - `row_attr`_                                                               |
-+----------------------+-----------------------------------------------------------------------------+
 | Parent type          | FormType                                                                    |
 +----------------------+-----------------------------------------------------------------------------+
 | Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TimeType`          |

--- a/reference/forms/types/timezone.rst
+++ b/reference/forms/types/timezone.rst
@@ -17,39 +17,6 @@ manually, but then you should just use the ``ChoiceType`` directly.
 +-------------+------------------------------------------------------------------------+
 | Rendered as | can be various tags (see :ref:`forms-reference-choice-tags`)           |
 +-------------+------------------------------------------------------------------------+
-| Options     | - `input`_                                                             |
-|             | - `intl`_                                                              |
-|             | - `regions`_                                                           |
-+-------------+------------------------------------------------------------------------+
-| Overridden  | - `choices`_                                                           |
-| options     | - `choice_translation_domain`_                                         |
-+-------------+------------------------------------------------------------------------+
-| Inherited   | from the :doc:`ChoiceType </reference/forms/types/choice>`             |
-| options     |                                                                        |
-|             | - `expanded`_                                                          |
-|             | - `multiple`_                                                          |
-|             | - `placeholder`_                                                       |
-|             | - `preferred_choices`_                                                 |
-|             | - `trim`_                                                              |
-|             |                                                                        |
-|             | from the :doc:`FormType </reference/forms/types/form>`                 |
-|             |                                                                        |
-|             | - `attr`_                                                              |
-|             | - `data`_                                                              |
-|             | - `disabled`_                                                          |
-|             | - `empty_data`_                                                        |
-|             | - `error_bubbling`_                                                    |
-|             | - `error_mapping`_                                                     |
-|             | - `help`_                                                              |
-|             | - `help_attr`_                                                         |
-|             | - `help_html`_                                                         |
-|             | - `label`_                                                             |
-|             | - `label_attr`_                                                        |
-|             | - `label_format`_                                                      |
-|             | - `mapped`_                                                            |
-|             | - `required`_                                                          |
-|             | - `row_attr`_                                                          |
-+-------------+------------------------------------------------------------------------+
 | Parent type | :doc:`ChoiceType </reference/forms/types/choice>`                      |
 +-------------+------------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\TimezoneType` |

--- a/reference/forms/types/url.rst
+++ b/reference/forms/types/url.rst
@@ -11,25 +11,6 @@ have a protocol.
 +-------------+-------------------------------------------------------------------+
 | Rendered as | ``input url`` field                                               |
 +-------------+-------------------------------------------------------------------+
-| Options     | - `default_protocol`_                                             |
-+-------------+-------------------------------------------------------------------+
-| Inherited   | - `attr`_                                                         |
-| options     | - `data`_                                                         |
-|             | - `disabled`_                                                     |
-|             | - `empty_data`_                                                   |
-|             | - `error_bubbling`_                                               |
-|             | - `error_mapping`_                                                |
-|             | - `help`_                                                         |
-|             | - `help_attr`_                                                    |
-|             | - `help_html`_                                                    |
-|             | - `label`_                                                        |
-|             | - `label_attr`_                                                   |
-|             | - `label_format`_                                                 |
-|             | - `mapped`_                                                       |
-|             | - `required`_                                                     |
-|             | - `row_attr`_                                                     |
-|             | - `trim`_                                                         |
-+-------------+-------------------------------------------------------------------+
 | Parent type | :doc:`TextType </reference/forms/types/text>`                     |
 +-------------+-------------------------------------------------------------------+
 | Class       | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\UrlType` |

--- a/reference/forms/types/week.rst
+++ b/reference/forms/types/week.rst
@@ -19,30 +19,6 @@ the data can be a string or an array.
 +----------------------+-----------------------------------------------------------------------------+
 | Rendered as          | single text box, two text boxes or two select fields                        |
 +----------------------+-----------------------------------------------------------------------------+
-| Options              | - `choice_translation_domain`_                                              |
-|                      | - `placeholder`_                                                            |
-|                      | - `html5`_                                                                  |
-|                      | - `input`_                                                                  |
-|                      | - `widget`_                                                                 |
-|                      | - `weeks`_                                                                  |
-|                      | - `years`_                                                                  |
-+----------------------+-----------------------------------------------------------------------------+
-| Overridden options   | - `compound`_                                                               |
-|                      | - `empty_data`_                                                             |
-|                      | - `error_bubbling`_                                                         |
-+----------------------+-----------------------------------------------------------------------------+
-| Inherited            | - `attr`_                                                                   |
-| options              | - `data`_                                                                   |
-|                      | - `disabled`_                                                               |
-|                      | - `help`_                                                                   |
-|                      | - `help_attr`_                                                              |
-|                      | - `help_html`_                                                              |
-|                      | - `inherit_data`_                                                           |
-|                      | - `invalid_message`_                                                        |
-|                      | - `invalid_message_parameters`_                                             |
-|                      | - `mapped`_                                                                 |
-|                      | - `row_attr`_                                                               |
-+----------------------+-----------------------------------------------------------------------------+
 | Parent type          | :doc:`FormType </reference/forms/types/form>`                               |
 +----------------------+-----------------------------------------------------------------------------+
 | Class                | :class:`Symfony\\Component\\Form\\Extension\\Core\\Type\\WeekType`          |


### PR DESCRIPTION
Similar to what we did in #16042, this removes the duplicated information in Form Types pages.