### PR TITLE
[Security] Added a note regarding the loginUser() method

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -625,6 +625,11 @@ You can pass any
 :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\TestBrowserToken` object and
 stores in the session of the test client.
 
+.. note::
+
+    Stateless firewalls cannot use ``loginUser()`` prior to requests by design.
+    Instead you should add the correct token (i.e. header) in each ``request()`` call.
+
 Making AJAX Requests
 ....................
 


### PR DESCRIPTION
As @javiereguiluz [stated](https://github.com/symfony/symfony/pull/32850), this method won't work for 100% of Symfony users. This is my case. I'm testing some protected API routes and the firewall is using a custom authenticator that relies on a custom header called "x-api-key". After spending hours trying to understand what I did wrong in my tests, I decided to dig into the code that defines the `loginUser()` method and noticed that [it can only work with session-based authentication](https://github.com/symfony/symfony/blob/18ab810a8d6d4c17497303df17e931261d542fce/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php#L139). 

This little note could have saved me some time, so I believe it could help future users as well who are in the same case as me.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
