### PR TITLE
Remove mention of metadata_cache_driver

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -179,7 +179,6 @@ that the ORM resolves to:
             proxy_namespace: Proxies
             proxy_dir: '%kernel.cache_dir%/doctrine/orm/Proxies'
             default_entity_manager: default
-            metadata_cache_driver: array
             query_cache_driver: array
             result_cache_driver: array
 
@@ -198,8 +197,6 @@ can be placed directly under ``doctrine.orm`` config level.
         orm:
             # ...
             query_cache_driver:
-                # ...
-            metadata_cache_driver:
                 # ...
             result_cache_driver:
                 # ...


### PR DESCRIPTION
As per
* doctrine/doctrine-bundle recipe (https://github.com/symfony/recipes/commit/b294873ff19d490c9d28c6a5e1120a139c4f3427#diff-2fdea05ded3928f852182177081cdd21c533951c0642388fa1303988702310a0)
* and doctrine/doctrine-bundle itself ([UPGRADE-2.3.md](https://github.com/doctrine/DoctrineBundle/blob/2.4.3/UPGRADE-2.3.md), [commit](https://github.com/doctrine/DoctrineBundle/commit/011cb9622788602505dc3e9f8e518428e9572aa9))

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
