### PR TITLE
[Filesystem] Add third argument $lock to `Filesystem::appendToFile`

### DIFF
--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -311,9 +311,15 @@ The ``file.txt`` file contains ``Hello World`` now.
 contents at the end of some file::
 
     $filesystem->appendToFile('logs.txt', 'Email sent to user@example.com');
+    // with the third argument set to true you can lock the file when writing to it.
+    $filesystem->appendToFile('logs.txt', 'Email sent to user@example.com', true);
 
 If either the file or its containing directory doesn't exist, this method
 creates them before appending the contents.
+
+.. versionadded:: 5.4
+
+    The third argument ``$lock`` was introduced in Symfony 5.4.
 
 Error Handling
 --------------


### PR DESCRIPTION
related issue https://github.com/symfony/symfony-docs/issues/16028
