### PR TITLE
Move myself alongside the inactive Core team members.

### DIFF
--- a/contributing/code/core_team.rst
+++ b/contributing/code/core_team.rst
@@ -65,7 +65,6 @@ Active Core Members
   * **Ryan Weaver** (`weaverryan`_);
   * **Robin Chalas** (`chalasr`_);
   * **Maxime Steinhausser** (`ogizanagi`_);
-  * **Samuel Rozé** (`sroze`_);
   * **Yonel Ceruto** (`yceruto`_);
   * **Tobias Nyholm** (`Nyholm`_);
   * **Wouter De Jong** (`wouterj`_);
@@ -106,7 +105,8 @@ Symfony contributions:
 * **Jordi Boggiano** (`Seldaek`_);
 * **Lukas Kahwe Smith** (`lsmith77`_);
 * **Jules Pietri** (`HeahDude`_);
-* **Jakub Zalas** (`jakzal`_).
+* **Jakub Zalas** (`jakzal`_);
+* **Samuel Rozé** (`sroze`_).
 
 Core Membership Application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**What a fun ride!** This community is the best I've been working with, full of talented and caring people. I've learnt so much by fixing @nicolas-grekas' broken tests or convincing @fabpot to ship this Messenger component. I also hope that this modest contribution to the ever-growing list of components inspires others to do the same, give back to an open-source project that enabled me as an engineer to be always more productive and enables us all to focus on solving worlds' problems rather than re-inventing the wheel again.

**I won't have much time for Symfony in the coming 12 months, at least.** For a fair chunk of time already, I have not been able to devote enough time to maintaining and evolving Symfony, and it will remain the same for a little while: I want to focus my energy on building mission-driven startups and it requires my full attention to make them successful. It means I'm not really a Core Team member anymore, so let's make it official so the list can be expanded with great people that have the time I don't.

@symfony/mergers thank you so much for your continuous work and care for this amazing project, I know it can only continue to shine. See you in the real world at some conferences, I'm sure ❤️ 