### PR TITLE
Update type declaration for Doctrine DBAL Connection

### DIFF
--- a/doctrine/dbal.rst
+++ b/doctrine/dbal.rst
@@ -47,7 +47,7 @@ object::
     // src/Controller/UserController.php
     namespace App\Controller;
 
-    use Doctrine\DBAL\Driver\Connection;
+    use Doctrine\DBAL\Connection;
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\HttpFoundation\Response;
 


### PR DESCRIPTION
In doctrine/dbal 3.0.0 Doctrine\DBAL\Driver\Connection has become an
internal interface and the wrapper-level Doctrine\DBAL\Connection should
be used.

Related:

https://github.com/doctrine/dbal/releases/tag/3.0.0
https://github.com/doctrine/dbal/pull/4159