### PR TITLE
Constructor property promotion - part 1

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -533,12 +533,9 @@ the same key could be invalidated with one function call::
 
     class SomeClass
     {
-        private $myCachePool;
-
         // using autowiring to inject the cache pool
-        public function __construct(TagAwareCacheInterface $myCachePool)
+        public function __construct(private TagAwareCacheInterface $myCachePool)
         {
-            $this->myCachePool = $myCachePool;
         }
 
         public function someMethod()

--- a/components/console/logger.rst
+++ b/components/console/logger.rst
@@ -19,11 +19,8 @@ PSR-3 compliant logger::
 
     class MyDependency
     {
-        private $logger;
-
-        public function __construct(LoggerInterface $logger)
+        public function __construct(private LoggerInterface $logger)
         {
-            $this->logger = $logger;
         }
 
         public function doStuff()

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -58,11 +58,8 @@ so this is passed into the constructor::
 
     class Mailer
     {
-        private $transport;
-
-        public function __construct($transport)
+        public function __construct(private $transport)
         {
-            $this->transport = $transport;
         }
 
         // ...
@@ -99,11 +96,8 @@ like this::
 
     class NewsletterManager
     {
-        private $mailer;
-
-        public function __construct(\Mailer $mailer)
+        public function __construct(private \Mailer $mailer)
         {
-            $this->mailer = $mailer;
         }
 
         // ...

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -298,11 +298,8 @@ order. Start by creating this custom event class and documenting it::
     {
         public const NAME = 'order.placed';
 
-        protected $order;
-
-        public function __construct(Order $order)
+        public function __construct(protected Order $order)
         {
-            $this->order = $order;
         }
 
         public function getOrder(): Order

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -27,11 +27,8 @@ Imagine you have a ``Mailer`` class which has four options: ``host``,
 
     class Mailer
     {
-        protected $options;
-
-        public function __construct(array $options = [])
+        public function __construct(protected array $options = [])
         {
-            $this->options = $options;
         }
     }
 

--- a/components/runtime.rst
+++ b/components/runtime.rst
@@ -412,13 +412,8 @@ is added in a new class implementing :class:`Symfony\\Component\\Runtime\\Runner
 
     class ReactPHPRunner implements RunnerInterface
     {
-        private $application;
-        private $port;
-
-        public function __construct(RequestHandlerInterface $application, int $port)
+        public function __construct(private RequestHandlerInterface $application, private int $port)
         {
-            $this->application = $application;
-            $this->port = $port;
         }
 
         public function run(): int

--- a/form/validation_group_service_resolver.rst
+++ b/form/validation_group_service_resolver.rst
@@ -13,14 +13,8 @@ parameter::
 
     class ValidationGroupResolver
     {
-        private $service1;
-
-        private $service2;
-
-        public function __construct($service1, $service2)
+        public function __construct(private $service1, private $service2)
         {
-            $this->service1 = $service1;
-            $this->service2 = $service2;
         }
 
         public function __invoke(FormInterface $form): array
@@ -44,11 +38,8 @@ Then in your form, inject the resolver and set it as the ``validation_groups``::
 
     class MyClassType extends AbstractType
     {
-        private $groupResolver;
-
-        public function __construct(ValidationGroupResolver $groupResolver)
+        public function __construct(private ValidationGroupResolver $groupResolver)
         {
-            $this->groupResolver = $groupResolver;
         }
 
         // ...

--- a/messenger.rst
+++ b/messenger.rst
@@ -35,11 +35,8 @@ serialized::
 
     class SmsNotification
     {
-        private $content;
-
-        public function __construct(string $content)
+        public function __construct(private string $content)
         {
-            $this->content = $content;
         }
 
         public function getContent(): string

--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -27,14 +27,10 @@ to customize the normalized data. To do that, leverage the ``ObjectNormalizer``:
 
     class TopicNormalizer implements ContextAwareNormalizerInterface
     {
-        private $router;
-        private $normalizer;
-
-        public function __construct(UrlGeneratorInterface $router, ObjectNormalizer $normalizer)
-        {
-            $this->router = $router;
-            $this->normalizer = $normalizer;
-        }
+        public function __construct(
+            private UrlGeneratorInterface $router,
+            private ObjectNormalizer $normalizer
+        ) {}
 
         public function normalize($topic, string $format = null, array $context = [])
         {

--- a/session/locale_sticky_session.rst
+++ b/session/locale_sticky_session.rst
@@ -26,11 +26,8 @@ correct locale however you want::
 
     class LocaleSubscriber implements EventSubscriberInterface
     {
-        private $defaultLocale;
-
-        public function __construct(string $defaultLocale = 'en')
+        public function __construct(private string $defaultLocale = 'en')
         {
-            $this->defaultLocale = $defaultLocale;
         }
 
         public function onKernelRequest(RequestEvent $event)


### PR DESCRIPTION
PHP 8 is min. version for the Symfony 6 so let's use Constructor property promotion.

It's part 1, because when last time I edited 60+ files, the PR was waiting to be merged for months :).
