### PR TITLE
Update LoggerInterface GitHub Link

### DIFF
--- a/logging.rst
+++ b/logging.rst
@@ -41,7 +41,7 @@ To log a message, inject the default logger in your controller or service::
     }
 
 The ``logger`` service has different methods for different logging levels/priorities.
-See `LoggerInterface`_ for a list of all of the methods on the logger.
+See .. _LoggerInterface: https://github.com/php-fig/log/blob/master/src/LoggerInterface.php for a list of all of the methods on the logger.
 
 Monolog
 -------


### PR DESCRIPTION
On this line 'The logger service has different methods for different logging levels/priorities. See LoggerInterface for a list of all of the methods on the logger.' the LoggerInterface link leads to a 404 GitHub page. This PR is to update it to the correct link.

