### PR TITLE
Add missing information about tsconfig.json

### DIFF
--- a/frontend/encore/typescript.rst
+++ b/frontend/encore/typescript.rst
@@ -20,6 +20,11 @@ Want to use `TypeScript`_? No problem! First, enable it:
     +     //.enableForkedTypeScriptTypesChecking()
       ;
 
+Then add a `tsconfig.json` file with the contents `{}` to the project folder,
+or in the folder where your TypeScript files are located, like the `/assets`
+folder. In `tsconfig.json` you can define more options on how to process
+TypeScript, but defining no additional options will already work.
+
 Then restart Encore. When you do, it will give you a command you can run to
 install any missing dependencies. After running that command and restarting
 Encore, you're done!


### PR DESCRIPTION
When introducing TypeScript in a project I noticed the current documentation is still missing the mandatory step of including a tsconfig.json file in the project - without it the error "The 'files' list in config file 'tsconfig.json' is empty" occurs.