### PR TITLE
Doctrine metadata_cache_driver config key deprecation

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -241,7 +241,7 @@ to cache each of Doctrine ORM elements (queries, results, etc.):
             # ...
 
             # the "metadata_cache_driver" configuration key is deprecated 
-            # from Doctrine Bundle 2.3
+            # since Doctrine Bundle 2.3
             metadata_cache_driver:
                 type: pool
                 pool: doctrine.system_cache_pool

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -239,6 +239,9 @@ to cache each of Doctrine ORM elements (queries, results, etc.):
     doctrine:
         orm:
             # ...
+
+            # the "metadata_cache_driver" configuration key is deprecated 
+            # from Doctrine Bundle 2.3
             metadata_cache_driver:
                 type: pool
                 pool: doctrine.system_cache_pool


### PR DESCRIPTION
It's worth mentioning and probably soon remove `metadata_cache_driver` configuration key.
ref: 
https://github.com/symfony/recipes/blob/master/doctrine/doctrine-bundle/2.4/config/packages/prod/doctrine.yaml
https://github.com/doctrine/DoctrineBundle/blob/2.3.x/DependencyInjection/Configuration.php#L709

It's reported in deprecation logs and profiler but leaving this can lead to issues connecting with EasyAdminBundle 2.x.

