### PR TITLE
Fix assert statement

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -376,7 +376,7 @@ console::
 
             // the output of the command in the console
             $output = $commandTester->getDisplay();
-            $this->assertContains('Username: Wouter', $output);
+            $this->assertStringContainsString('Username: Wouter', $output);
 
             // ...
         }


### PR DESCRIPTION
In my local version of phpunit 9.5.9 `$this->assertContains` has the following signature:
```php
public static function assertContains($needle, iterable $haystack, string $message = ''): void
{
    //..
}
```

Where `$commandTester->getDisplay();` returns string and the test fails with


```
TypeError: Argument 2 passed to PHPUnit\Framework\Assert::assertContains() must be iterable, string given, called in..
```