### PR TITLE
[Filesystem] Minor tweaks

### DIFF
--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -32,24 +32,12 @@ endpoint for filesystem operations::
         echo "An error occurred while creating your directory at ".$exception->getPath();
     }
 
-.. note::
-
-    Methods :method:`Symfony\\Component\\Filesystem\\Filesystem::mkdir`,
-    :method:`Symfony\\Component\\Filesystem\\Filesystem::exists`,
-    :method:`Symfony\\Component\\Filesystem\\Filesystem::touch`,
-    :method:`Symfony\\Component\\Filesystem\\Filesystem::remove`,
-    :method:`Symfony\\Component\\Filesystem\\Filesystem::chmod`,
-    :method:`Symfony\\Component\\Filesystem\\Filesystem::chown` and
-    :method:`Symfony\\Component\\Filesystem\\Filesystem::chgrp` can receive a
-    string, an array or any object implementing :phpclass:`Traversable` as
-    the target argument.
-
 ``mkdir``
 ~~~~~~~~~
 
 :method:`Symfony\\Component\\Filesystem\\Filesystem::mkdir` creates a directory recursively.
 On POSIX filesystems, directories are created with a default mode value
-`0777`. You can use the second argument to set your own mode::
+``0777``. You can use the second argument to set your own mode::
 
     $filesystem->mkdir('/tmp/photos', 0700);
 


### PR DESCRIPTION
The `note` is unneeded because each method includes the same note in its description.