### PR TITLE
[Logger] Change $requestStack to $this->requestStack

### DIFF
--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -35,7 +35,7 @@ using a processor::
         public function __invoke(array $record)
         {
             try {
-                $session = $requestStack->getSession();
+                $session = $this->requestStack->getSession();
             } catch (SessionNotFoundException $e) {
                 return;
             }


### PR DESCRIPTION
Within the __invoke() method a call was made to $requestStack. This update will use the private $requestStack property as defined in the SessionRequestProcessor class.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
