### PR TITLE
[Serializer] Corrected typo in serializer.rst

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -972,7 +972,7 @@ Option                          Description                                     
 ``xml_version``                 Sets the XML version attribute                     ``1.1``
 ``xml_encoding``                Sets the XML encoding attribute                    ``utf-8``
 ``xml_standalone``              Adds standalone attribute in the generated XML     ``true``
-``xml_type_cast_attributes``    This provides the ability to forgot the attribute  ``true``
+``xml_type_cast_attributes``    This provides the ability to forget the attribute  ``true``
                                 type casting
 ``xml_root_node_name``          Sets the root node name                            ``response``
 ``as_collection``               Always returns results as a collection, even if    ``false``


### PR DESCRIPTION
Replace "forgot" by "forget".

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
