### PR TITLE
[Frontend] Remove all Assetic references

### DIFF
--- a/_build/redirection_map
+++ b/_build/redirection_map
@@ -534,3 +534,5 @@
 /security/multiple_guard_authenticators /security/entry_point
 /security/guard_authentication /security/custom_authenticator
 /email /mailer
+/frontend/assetic /frontend
+/frontend/assetic/index /frontend

--- a/_build/spelling_word_list.txt
+++ b/_build/spelling_word_list.txt
@@ -3,7 +3,6 @@ Akamai
 analytics
 Ansi
 Ansible
-Assetic
 async
 authenticator
 authenticators

--- a/frontend.rst
+++ b/frontend.rst
@@ -92,7 +92,6 @@ Other Front-End Articles
     :hidden:
     :glob:
 
-    frontend/assetic/index
     frontend/encore/installation
     frontend/encore/simple-example
     frontend/encore/*

--- a/frontend/assetic/index.rst
+++ b/frontend/assetic/index.rst
@@ -1,8 +1,0 @@
-Assetic
-=======
-
-.. caution::
-
-    Using Assetic to manage web assets in Symfony applications is no longer
-    recommended. Instead, use :doc:`Webpack Encore </frontend>`, which bridges
-    Symfony applications with modern JavaScript-based tools to manage web assets.


### PR DESCRIPTION
We kept this placeholder article for some time, because some projects were still using Assetic. However, nowadays this is completely legacy, so I propose to remove it in 6.0 branch.