### PR TITLE
Adding a page about Symfony & Docker

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -71,6 +71,7 @@ whitelist:
         - '/``.yml``/'
         - '/(.*)\.orm\.yml/' # currently DoctrineBundle only supports .yml
         - '/rst-class/'
+        - /docker-compose\.yml/
     lines:
         - 'in config files, so the old ``app/config/config_dev.yml`` goes to'
         - '#. The most important config file is ``app/config/services.yml``, which now is'

--- a/setup.rst
+++ b/setup.rst
@@ -122,6 +122,8 @@ In production, you should install a webserver like Nginx or Apache and
 method can also be used if you're not using the Symfony local web server for
 development.
 
+.. _symfony-binary-web-server:
+
 However for local development, the most convenient way of running Symfony is by
 using the :doc:`local web server </setup/symfony_server>` provided by the
 ``symfony`` binary. This local server provides among other things support for
@@ -144,6 +146,11 @@ the server by pressing ``Ctrl+C`` from your terminal.
 
     The web server works with any PHP application, not only Symfony projects,
     so it's a very useful generic development tool.
+
+Symfony Docker Integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you'd like to use Docker with Symfony, see :doc:`setup/docker`
 
 .. _symfony-flex:
 
@@ -303,6 +310,7 @@ Learn More
     :maxdepth: 1
     :glob:
 
+    setup/docker
     setup/homestead
     setup/web_server_configuration
     setup/*

--- a/setup/docker.rst
+++ b/setup/docker.rst
@@ -1,0 +1,56 @@
+.. index:: Docker
+
+Using Docker with Symfony
+=========================
+
+Can you use Docker with Symfony? Of course! And several tools exist to help,
+depending on your needs.
+
+Complete Docker Environment
+---------------------------
+
+If you'd like a complete Docker environment (i.e. where PHP, web server, database,
+etc. are all in Docker), check out `https://github.com/dunglas/symfony-docker`_.
+
+Alternatively, you can install PHP on your local machine and use the
+:ref:`symfony binary Docker integration <symfony-server-docker>`. In both cases,
+you can take advantage of automatic Docker configuration from :ref:`Symfony Flex <symfony-flex>`.
+
+Flex Recipes & Docker Configuration
+-----------------------------------
+
+The :ref:`Flex recipe <symfony-flex>` for some packages also include Docker configuration.
+For example, when you run ``composer require doctrine`` (to get ``symfony/orm-pack``),
+your ``docker-compose.yml`` file will automatically be updated to include a
+``database`` service.
+
+The first time you install a recipe containing Docker config, Flex will ask you
+if you want to include it. Or, you can set your preference in ``composer.json``,
+by seting the ``symfony.extra.docker`` config to ``true`` or ``false``.
+
+Some recipes also include additions to your ``Dockerfile``. To get those changes,
+you need to already have a ``Dockerfile`` at the root of your app *with* the
+following code somewhere inside:
+
+.. code-block:: text
+
+    ###> recipes ###
+    ###< recipes ###
+
+The recipe will find this section and add the changes inside. If you're using
+`https://github.com/dunglas/symfony-docker`_, you'll already have this.
+
+After installing the package, rebuild your containers by running:
+
+.. code-block:: terminal
+
+    $ docker-compose up --build
+
+Symfony Binary Web Server and Docker Support
+--------------------------------------------
+
+If you're using the :ref:`symfony binary web server` (e.g. ``symfony server:start``),
+then it can automatically detect your Docker services and expose them as environment
+variables. See :ref:`symfony-server-docker`.
+
+.. _`https://github.com/dunglas/symfony-docker`: https://github.com/dunglas/symfony-docker

--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -281,7 +281,7 @@ Docker Integration
 ------------------
 
 The local Symfony server provides full `Docker`_ integration for projects that
-use it.
+use it. To learn more about Docker & Symfony, see :doc:`docker`.
 
 When the web server detects that Docker Compose is running for the project, it
 automatically exposes some environment variables.


### PR DESCRIPTION
Hi!

This relates to https://github.com/symfony/flex/pull/829.

When you search the web for "symfony docker", I don't get an symfony.com results. The new article is short, but I think covers the most important things. It also documents (I think for the first time) the Flex + Docker configuration.

Cheers!