### PR TITLE
[Doctrine] Update associations.rst

### DIFF
--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -676,7 +676,7 @@ that behavior, use the `orphanRemoval`_ option inside ``Category``:
 
         // ...
 
-        #[ORM\OneToMany(targetEntity: Product::class, mappedBy: "category", orphanRemoval=true)]
+        #[ORM\OneToMany(targetEntity: Product::class, mappedBy: "category", orphanRemoval: true)]
         private $products;
 
 


### PR DESCRIPTION
syntax error in orphanRemoval=true

In the Attributes code example #[ORM\OneToMany(mappedBy: 'user', targetEntity: Recipe::class, orphanRemoval=true)], doesn't work because of wrong syntax.
should be #[ORM\OneToMany(mappedBy: 'user', targetEntity: Recipe::class, orphanRemoval: true)]

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
