### PR TITLE
Minor formatting tweaks in the Core Team article

### DIFF
--- a/contributing/code/core_team.rst
+++ b/contributing/code/core_team.rst
@@ -24,27 +24,21 @@ The Symfony Core groups, in descending order of priority, are as follows:
 
 1. **Project Leader**
 
-* Elects members in any other group;
-* Merges pull requests in all Symfony repositories.
+   * Elects members in any other group;
+   * Merges pull requests in all Symfony repositories.
 
 2. **Mergers Team**
 
-* Merge pull requests on the main Symfony repository.
+   * Merge pull requests on the main Symfony repository.
 
 In addition, there are other groups created to manage specific topics:
 
-**Security Team**
+* **Security Team**: manages the whole security process (triaging reported vulnerabilities,
+  fixing the reported issues, coordinating the release of security fixes, etc.)
 
-* Manage the whole security process (triaging reported vulnerabilities, fixing
-  the reported issues, coordinating the release of security fixes, etc.)
+* **Recipes Team**: manages the recipes in the main and contrib recipe repositories.
 
-**Recipes Team**
-
-* Manage the recipes in the main and contrib recipe repositories.
-
-**Documentation Team**
-
-* Manage the whole `symfony-docs repository`_.
+* **Documentation Team**: manages the whole `symfony-docs repository`_.
 
 Active Core Members
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In the first list, we must indent the nested list to avoid this rendering issue (where each `<ol>` element is labeled `1`):

![](https://user-images.githubusercontent.com/73419/142830871-01695a62-f41f-4ec8-ad80-d37ad88e1073.png)

The second tweak is to make the other `<ul>` list a bit more compact.