### PR TITLE
[Redis Cache Adapter] Add hint about supported eviction policies of `RedisTagAwareAdapter`

### DIFF
--- a/components/cache/adapters/redis_adapter.rst
+++ b/components/cache/adapters/redis_adapter.rst
@@ -212,6 +212,8 @@ try to add data when no memory is available. An example setting could look as fo
 
     maxmemory 100mb
     maxmemory-policy allkeys-lru
+    
+When using the :class:`Symfony\\Component\\Cache\\Adapter\\RedisTagAwareAdapter`, only ``noeviction`` and ``volatile-*`` eviction policies are supported by the adapter. We recommend ``volatile-lru`` though.
 
 Read more about this topic in the offical `Redis LRU Cache Documentation`_.
 


### PR DESCRIPTION
RedisTagAwareAdapter only supports `noeviction` and `volatile-*` eviction policies, so the former Redis config recommendation will disable saving via the adapter, at all.

![image](https://user-images.githubusercontent.com/1265783/143009207-6b674782-f257-40ed-a794-977bb48b3d47.png)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
