### PR TITLE
[ExpressionLanguage] Remove array element

### DIFF
--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -204,7 +204,6 @@ Examples::
         'life == everything',
         [
             'life' => 10,
-            'universe' => 10,
             'everything' => 22,
         ]
     );
@@ -213,7 +212,6 @@ Examples::
         'life > everything',
         [
             'life' => 10,
-            'universe' => 10,
             'everything' => 22,
         ]
     );


### PR DESCRIPTION
The expressions `life == everything` and `life > everything` don't require the `universe` element.