### PR TITLE
[Notifier] Corrected typo in notifier.rst

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -615,7 +615,7 @@ The
 :class:`Symfony\\Component\\Notifier\\Notification\\SmsNotificationInterface`
 and
 :class:`Symfony\\Component\\Notifier\\Notification\\EmailNotificationInterface`
-also exists to modify messages send to those channels.
+also exists to modify messages sent to those channels.
 
 Disabling Delivery
 ------------------


### PR DESCRIPTION
Replaced "send" by "sent".

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
