### PR TITLE
[Form] Typo in validation_group_service_resolver.rst

### DIFF
--- a/form/validation_group_service_resolver.rst
+++ b/form/validation_group_service_resolver.rst
@@ -38,7 +38,7 @@ Then in your form, inject the resolver and set it as the ``validation_groups``::
     // src/Form/MyClassType.php;
     namespace App\Form;
 
-    use App\Validator\ValidationGroupResolver;
+    use App\Validation\ValidationGroupResolver;
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\OptionsResolver\OptionsResolver;
 


### PR DESCRIPTION
Corrected namespace of ValidationGroupResolver.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
