### PR TITLE
In version 5.3 cannot render a form without calling createView ()

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -274,15 +274,14 @@ Now that the form has been created, the next step is to render it::
             // ...
 
             $form = $this->createForm(TaskType::class, $task);
-
+ 
             return $this->renderForm('task/new.html.twig', [
-                'form' => $form,
+                'form' => $form->createView(),
             ]);
         }
     }
 
-In versions prior to Symfony 5.3, controllers used the method
-``$this->render('...', ['form' => $form->createView()])`` to render the form.
+
 The ``renderForm()`` method abstracts this logic and it also sets the 422 HTTP
 status code in the response automatically when the submitted form is not valid.
 


### PR DESCRIPTION
Error:

Argument 1 passed to Symfony\Component\Form\FormRenderer::renderBlock() must be an instance of Symfony\Component\Form\FormView, instance of Symfony\Component\Form\Form given, called in E:\sf5\demo\var\cache\dev\twig\87\875b007af353289dd9d70e9f457a6f897428b826155f87d6ca53849c4ebaf64c.php on line 98

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
