### PR TITLE
Add UrlHelper section to HttpFoundation docs

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -783,6 +783,38 @@ The following example shows how to detect if the user agent prefers "safe" conte
         $response->setContentSafe();
 
         return $response;
+
+UrlHelper
+-------
+
+Generating absolute (and relative) URLs for a given path is a common need
+in lots of applications. In Twig templates this is trivial thanks to the
+absolute_url() and relative_path() functions. The same functionality can
+be found in the :class:`Symfony\\Component\\HttpFoundation\\UrlHelper` class,
+which can be injected as a service anywhere in your application. This class
+provides two public methods called getAbsoluteUrl() and getRelativePath()::
+
+    // src/Normalizer/UserApiNormalizer.php
+
+    namespace App\Normalizer;
+
+    use Symfony\Component\HttpFoundation\UrlHelper;
+
+    class UserApiNormalizer
+    {
+        private UrlHelper $urlHelper;
+
+        public function __construct(UrlHelper $urlHelper)
+        {
+            $this->urlHelper = $urlHelper;
+        }
+
+        public function normalize($user)
+        {
+            return [
+                'avatar' => $this->urlHelper->getAbsoluteUrl($user->avatar()->path()),
+            ];
+        }
     }
 
 Learn More


### PR DESCRIPTION
I was recently looking for a way to generate absolute URLs for assets in a service, and I finally stumbled upon the UrlHelper class after reading [this blog post](https://symfony.com/blog/new-in-symfony-4-3-url-helper), but I couldn't find any mention of it in the docs when searching for absolute_url() or anything related.

I then saw [this comment on the original PR](https://github.com/symfony/symfony/pull/30862#issuecomment-480574045), but saw no such PR for the docs.

This is my first contribution to the docs so any feedback is welcome.