### PR TITLE
[Messenger] Fix example config

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -719,10 +719,11 @@ reset the service container between two messages:
         # config/packages/messenger.yaml
         framework:
             messenger:
+                reset_on_message: true
                 transports:
                     async:
                         dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
-                        reset_on_message: true
+                        
 
     .. code-block:: xml
 


### PR DESCRIPTION
The reset_on_message config is in messenger and not in async.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
