### PR TITLE
[Lock] docs(lock): fix typo in symfony lock documentation

### DIFF
--- a/lock.rst
+++ b/lock.rst
@@ -190,7 +190,7 @@ Locking a Dynamic Resource
 
 Sometimes the application is able to cut the resource into small pieces in order
 to lock a small subset of process and let other through. In our previous example
-with see how to lock the ``$pdf->getOrCreatePdf('terms-of-use')`` for everybody,
+we've seen how to lock the ``$pdf->getOrCreatePdf('terms-of-use')`` for everybody,
 now let's see how to lock ``$pdf->getOrCreatePdf($version)`` only for
 processes asking for the same ``$version``::
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
