### PR TITLE
[Encore] [Frontend]  Replace deprecated encore public path option

### DIFF
--- a/frontend/encore/virtual-machine.rst
+++ b/frontend/encore/virtual-machine.rst
@@ -44,7 +44,7 @@ in the web console:
     ...
 
 If your Symfony application is running on a custom domain (e.g.
-``http://app.vm``), you must configure the public path explicitly in your
+``http://app.vm``), you must configure the URL to the web socket server explicitly in your
 ``package.json``:
 
 .. code-block:: diff
@@ -53,7 +53,7 @@ If your Symfony application is running on a custom domain (e.g.
           ...
           "scripts": {
     -        "dev-server": "encore dev-server",
-    +        "dev-server": "encore dev-server --public http://app.vm:8080",
+    +        "dev-server": "encore dev-server --client-web-socket-url http://app.vm:8080",
               ...
           }
       }
@@ -81,8 +81,8 @@ connections:
       {
           ...
           "scripts": {
-    -        "dev-server": "encore dev-server --public http://app.vm:8080",
-    +        "dev-server": "encore dev-server --public http://app.vm:8080 --host 0.0.0.0",
+    -        "dev-server": "encore dev-server --client-web-socket-url http://app.vm:8080",
+    +        "dev-server": "encore dev-server --client-web-socket-url http://app.vm:8080 --host 0.0.0.0",
               ...
           }
       }


### PR DESCRIPTION
Hi,

this updates the documentation to math the current encore configuration options.

The `public `option was repalced by the `client-web-socket-url` according to the migration guide [here](https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md). with the PR [here](https://github.com/symfony/webpack-encore/pull/1058).

Closes  #15887
