### PR TITLE
Removed not needed jQuery mention

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -281,9 +281,7 @@ On the rendered page, the result will look something like this:
     and you need to adjust the following JavaScript accordingly.
 
 Now add some JavaScript to read this attribute and dynamically add new tag forms
-when the user clicks the "Add a tag" link. This example uses `jQuery`_ and
-assumes you have it included somewhere on your page (e.g. using Symfony's
-:doc:`Webpack Encore </frontend>`).
+when the user clicks the "Add a tag" link.
 
 Add a ``<script>`` tag somewhere on your page to include the required
 functionality with JavaScript:


### PR DESCRIPTION
Removed mention of required jQuery library for example of "allow_add" in Form Collections. Since 5.3 example is pure javascript

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
