### PR TITLE
Add information about strict_mode for encore

### DIFF
--- a/frontend/encore/faq.rst
+++ b/frontend/encore/faq.rst
@@ -169,3 +169,24 @@ running it (e.g. when executing ``yarn encore dev``). Fix this issue calling to
     // ... the rest of the Encore configuration
 
 .. _`Webpack integration in PhpStorm`: https://www.jetbrains.com/help/phpstorm/using-webpack.html
+
+My functional tests are failing in CI
+-------------------------------------
+
+With something along the lines of
+
+.. code-block:: text
+
+    Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Could not find the entrypoints file from Webpack: the file "/var/www/html/public/build/entrypoints.json" does not exist.
+
+.. 
+
+This is happening because you did not build your encore assets, hence no ``entrypoints.json`` file. Plus encore is working in strict mode by default, which causes  twig functions ``encore_entry_*`` to panic.
+
+To solve that you can add this to your ``config/packages/test/webpack_encore.yaml``
+
+.. code-block:: yaml
+
+    webpack_encore:
+        strict_mode: false
+..


### PR DESCRIPTION
I guess it should be both in `5.4` and `6.0`, but actually will be useful down to whenever https://github.com/symfony/webpack-encore-bundle/pull/54 was merged

Personally, it took me quite a long time to determine and fix the cause of functional tests failing in CI. I know that stuff is kind of mentioned in `config/packages/webpack_encore.yaml`, but here are my excuses

* there is certain time gap between you first install webpack, write your functional tests (involved with actual HTML rendering), add some styles/scripts to template and setup CI to run these tests
* this stuff is not mentioned in the docs at all - `fgrep -RH strict_mode .` gives 0 results