### PR TITLE
[PHPUnitBridge] [PHPUnit Bridge] Remove the table that lists PHPUnit versions

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -844,18 +844,6 @@ configured by the ``SYMFONY_PHPUNIT_DIR`` env var, or in the same directory as
 the ``simple-phpunit`` if it is not provided. It's also possible to set this
 env var in the ``phpunit.xml.dist`` file.
 
-By default, these are the PHPUnit versions used depending on the installed PHP versions:
-
-=====================  ===============================
-Installed PHP version  PHPUnit version used by default
-=====================  ===============================
-PHP <= 5.5             PHPUnit 4.8
-PHP 5.6                PHPUnit 5.7
-PHP 7.0                PHPUnit 6.5
-PHP 7.1                PHPUnit 7.5
-PHP >= 7.2             PHPUnit 8.3
-=====================  ===============================
-
 If you have installed the bridge through Composer, you can run it by calling e.g.:
 
 .. code-block:: terminal
@@ -864,7 +852,7 @@ If you have installed the bridge through Composer, you can run it by calling e.g
 
 .. tip::
 
-    It's possible to change the base version of PHPUnit by setting the
+    It's possible to change the PHPUnit version by setting the
     ``SYMFONY_PHPUNIT_VERSION`` env var in the ``phpunit.xml.dist`` file (e.g.
     ``<server name="SYMFONY_PHPUNIT_VERSION" value="5.5"/>``). This is the
     preferred method as it can be committed to your version control repository.


### PR DESCRIPTION
Fixes #16146 by removing this information that depends on code and we don't have the resources to keep it updated continuously.

When running tests Symfony displays the used PhpUnit version, so we don't lose anything by removing this (outdated) information from docs.