### PR TITLE
[Messenger] added example for limit consuming to specific queue / queues

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -604,11 +604,17 @@ transport is always bound to an exchange. By default, the worker consumes from a
 queues attached to the exchange of the specified transport. However, there are use
 cases to want a worker to only consume from specific queues.
 
-You can limit the worker to only process messages from specific queues:
+You can limit the worker to only process messages from specific queue:
 
 .. code-block:: terminal
 
     $ php bin/console messenger:consume my_transport --queues=fasttrack
+
+Or you can limit the worker to only process messages from specific queues:
+
+.. code-block:: terminal
+
+    $ php bin/console messenger:consume my_transport --queues=fasttrack1 --queues=fasttrack2
 
 To allow using the ``queues`` option, the receiver must implement the
 :class:`Symfony\\Component\\Messenger\\Transport\\Receiver\\QueueReceiverInterface`.


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
