### PR TITLE
Add a warning about native://default for Mailer

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -93,6 +93,11 @@ native        ``native://default``                      Mailer uses the sendmail
                                                         in the ``sendmail_path`` setting of ``php.ini``. On Windows
                                                         hosts, Mailer fallbacks to ``smtp`` and ``smtp_port``
                                                         ``php.ini`` settings when ``sendmail_path`` is not configured.
+                                                        Be warned that if ``php.ini`` uses the ``sendmail -t`` command,
+                                                        you won't have error reporting and ``Bcc`` headers won't be removed.
+                                                        It's highly recommended to NOT use this DSN as you cannot control
+                                                        how sendmail is configured (prefer using ``sendmail://default``
+                                                        if possible).
 ============  ========================================  ==============================================================
 
 Using a 3rd Party Transport


### PR DESCRIPTION
This is a follow-up for https://github.com/symfony/symfony/pull/44567.

The `native://default` DSN for mailer should never be used.

