### PR TITLE
 Fix the 'From' header to display the sender's name in MailHog

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -485,7 +485,7 @@ and headers.
                     sender: 'fabien@example.com'
                     recipients: ['foo@example.com', 'bar@example.com']
                 headers:
-                    from: 'Fabien <fabien@example.com>'
+                    From: 'Fabien <fabien@example.com>'
                     bcc: 'baz@example.com'
                     X-Custom-Header: 'foobar'
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
