### PR TITLE
[Notifier] Remove Firebase transport from Push Channel list

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -356,7 +356,6 @@ integration with these push services:
 ==============  ====================================  =================================================================================
 Service         Package                               DSN
 ==============  ====================================  =================================================================================
-Firebase        ``symfony/firebase-notifier``          ``firebase://USERNAME:PASSWORD@default``
 Expo            ``symfony/expo-notifier``              ``expo://Token@default``
 OneSignal       ``symfony/one-signal-notifier``        ``onesignal://APP_ID:API_KEY@default?defaultRecipientId=DEFAULT_RECIPIENT_ID''``
 ==============  ====================================  =================================================================================


### PR DESCRIPTION
`FirebaseTransport` supports `ChatMessage` and not supports `TexterTransport` which indicated in Documentation.