### PR TITLE
Correct spelling & grammar in 4.4 components/dependency_injection/

### DIFF
--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -358,8 +358,8 @@ methods described in :doc:`/service_container/definitions`.
     method call if some required service is not available.
 
 A common use-case of compiler passes is to search for all service definitions
-that have a certain tag in order to process dynamically plug each into some
-other service. See the section on :ref:`service tags <service-container-compiler-pass-tags>`
+that have a certain tag, in order to dynamically plug each one into other services.
+See the section on :ref:`service tags <service-container-compiler-pass-tags>`
 for an example.
 
 .. _components-di-separate-compiler-passes:

--- a/components/dependency_injection/workflow.rst
+++ b/components/dependency_injection/workflow.rst
@@ -25,7 +25,7 @@ container exists. The kernel has a debug setting and if this is false,
 the cached version is used if it exists. If debug is true then the kernel
 :doc:`checks to see if configuration is fresh </components/config/caching>`
 and if it is, the cached version of the container is used. If not then the
-container is built from the application-level configuration and the bundles's
+container is built from the application-level configuration and the bundles'
 extension configuration.
 
 Read :ref:`Dumping the Configuration for Performance <components-dependency-injection-dumping>`


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
