### PR TITLE
Correct spelling & grammar in 4.4 components/expression_language/

### DIFF
--- a/components/expression_language/ast.rst
+++ b/components/expression_language/ast.rst
@@ -5,8 +5,8 @@
 Dumping and Manipulating the AST of Expressions
 ===============================================
 
-Manipulating or inspecting the expressions created with the ExpressionLanguage
-component is difficult because they are plain strings. A better approach is to
+It’s difficult to manipulate or inspect the expressions created with the ExpressionLanguage
+component, because the expressions are plain strings. A better approach is to
 turn those expressions into an AST. In computer science, `AST`_ (*Abstract
 Syntax Tree*) is *"a tree representation of the structure of source code written
 in a programming language"*. In Symfony, a ExpressionLanguage AST is a set of

--- a/components/expression_language/caching.rst
+++ b/components/expression_language/caching.rst
@@ -25,7 +25,7 @@ The ``evaluate()`` method needs to loop through the "nodes" (pieces of an
 expression saved in the ``ParsedExpression``) and evaluate them on the fly.
 
 To save time, the ``ExpressionLanguage`` caches the ``ParsedExpression`` so
-it can skip the tokenize and parse steps with duplicate expressions. The
+it can skip the tokenization and parsing steps with duplicate expressions. The
 caching is done by a PSR-6 `CacheItemPoolInterface`_ instance (by default, it
 uses an :class:`Symfony\\Component\\Cache\\Adapter\\ArrayAdapter`). You can
 customize this by creating a custom cache pool or using one of the available

--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -195,7 +195,7 @@ Comparison Operators
 
         $expressionLanguage->evaluate('not ("foo" matches "/bar/")'); // returns true
 
-    You must use parenthesis because the unary operator ``not`` has precedence
+    You must use parentheses because the unary operator ``not`` has precedence
     over the binary operator ``matches``.
 
 Examples::


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
