### PR TITLE
Correct spelling & grammar in 4.4 messenger/

### DIFF
--- a/messenger/dispatch_after_current_bus.rst
+++ b/messenger/dispatch_after_current_bus.rst
@@ -126,7 +126,7 @@ will not be rolled back.
     If ``WhenUserRegisteredThenSendWelcomeEmail`` throws an exception, that
     exception will be wrapped into a ``DelayedMessageHandlingException``. Using
     ``DelayedMessageHandlingException::getExceptions`` will give you all
-    exceptions that are thrown while handing a message with the
+    exceptions that are thrown while handling a message with the
     ``DispatchAfterCurrentBusStamp``.
 
 The ``dispatch_after_current_bus`` middleware is enabled by default. If you're

--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -235,7 +235,7 @@ Debugging the Buses
 -------------------
 
 The ``debug:messenger`` command lists available messages & handlers per bus.
-You can also restrict the list to a specific bus by providing its name as argument.
+You can also restrict the list to a specific bus by providing its name as an argument.
 
 .. code-block:: terminal
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
