### PR TITLE
Correct spelling & grammar in 4.4 service_container/

### DIFF
--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -186,7 +186,7 @@ If there is *not* a service whose id exactly matches the type, a clear exception
 will be thrown.
 
 Autowiring is a great way to automate configuration, and Symfony tries to be as
-*predictable* and clear as possible.
+*predictable* and as clear as possible.
 
 .. _service-autowiring-alias:
 
@@ -273,7 +273,7 @@ class is type-hinted.
 
 .. versionadded:: 4.2
 
-    Since Monolog Bundle 3.5 each channel bind into container by type-hinted alias.
+    Since Monolog Bundle 3.5 each channel binds into the container by type-hinted alias.
     More info in the part about :ref:`how to autowire monolog channels <monolog-autowire-channels>`.
 
 .. _autowiring-interface-alias:

--- a/service_container/injection_types.rst
+++ b/service_container/injection_types.rst
@@ -196,7 +196,7 @@ This approach is useful if you need to configure your service according to your 
 so, here's the advantages of immutable-setters:
 
 * Immutable setters works with optional dependencies, this way, if you don't need
-  a dependency, the setter don't need to be called.
+  a dependency, the setter doesn't need to be called.
 
 * Like the constructor injection, using immutable setters force the dependency to stay
   the same during the lifetime of a service.


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
