### PR TITLE
[Form] Additional hints when rendering the same form in different templates

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -455,6 +455,9 @@ possible paths:
     .. code-block:: twig
 
         {{ render(controller('App\\Controller\\TaskController::new')) }}
+        
+    But be careful becaues this might cause some extra work when it comes to submit and error handling.
+    Symfony Validation will get more complex when you render the same form in different routes.
 
 .. _validating-forms:
 


### PR DESCRIPTION
There is the following tip mentioned in the documentation (see chapter [Processing forms)](https://symfony.com/doc/current/forms.html#processing-forms):

```
If you need to render and process the same form in different templates, use the render() function to embed the controller that processes the form:

{{ render(controller('App\\Controller\\TaskController::new')) }}
```

In my point of view this can lead to extra work especially when it comes to validation and rendering error messages. 

So my proposal is to add a hint like
```
  But be careful because this might cause some extra work when it comes to submit and error handling.
  Symfony Validation will get more complex when you render the same form in different routes.
```


<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
