### PR TITLE
[Security] Reference the new request_matcher option

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2119,6 +2119,12 @@ would match ``/admin/foo`` but would also match URLs like ``/foo/admin``.
 
 Each ``access_control`` can also match on IP address, hostname and HTTP methods.
 It can also be used to redirect a user to the ``https`` version of a URL pattern.
+
+.. versionadded:: 6.1
+
+    Since Symfony 6.1, an access control rule can also be directly configured by passing a service
+    implementing `RequestMatcherInterface` through the `request_matcher` option.
+
 See :doc:`/security/access_control`.
 
 .. _security-securing-controller:

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -52,6 +52,9 @@ Take the following ``access_control`` entries as an example:
                 - { path: '^/admin', roles: ROLE_USER_IP, ips: '%env(TRUSTED_IPS)%' }
                 - { path: '^/admin', roles: ROLE_USER_IP, ips: [127.0.0.1, ::1, '%env(TRUSTED_IPS)%'] }
 
+                # Request matchers can be used to define access control rules
+                - { roles: ROLE_USER, request_matcher: App\Security\RequestMatcher\MyRequestMatcher }
+
     .. code-block:: xml
 
         <!-- config/packages/security.xml -->
@@ -82,6 +85,9 @@ Take the following ``access_control`` entries as an example:
                     <ip>::1</ip>
                     <ip>%env(TRUSTED_IPS)%</ip>
                 </rule>
+
+                <!-- Request matchers can be used to define access control rules -->
+                <rule role="ROLE_USER" request-matcher="App\Security\RequestMatcher\MyRequestMatcher"/>
             </config>
         </srv:container>
 
@@ -127,7 +133,17 @@ Take the following ``access_control`` entries as an example:
                 ->roles(['ROLE_USER_IP'])
                 ->ips(['127.0.0.1', '::1', '%env(TRUSTED_IPS)%'])
             ;
+
+            // Request matchers can be used to define access control rules
+            $security->accessControl()
+                ->roles(['ROLE_USER'])
+                ->requestMatcher('App\Security\RequestMatcher\MyRequestMatcher')
+            ;
         };
+
+.. versionadded:: 6.1
+
+    Support for access control rule definition based on a RequestMatcher was introduced in Symfony 6.1.
 
 For each incoming request, Symfony will decide which ``access_control``
 to use based on the URI, the client's IP address, the incoming host name,


### PR DESCRIPTION
Linked to https://github.com/symfony/symfony/pull/44670

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
