### PR TITLE
Fix issue 16298 - duplicate link

### DIFF
--- a/components/console.rst
+++ b/components/console.rst
@@ -63,5 +63,4 @@ Learn more
 
     /console
     /components/console/*
-    /components/console/helpers/index
     /console/*


### PR DESCRIPTION
This PR fixes the [duplicate Console Helpers link](https://github.com/symfony/symfony-docs/issues/16298).