### PR TITLE
[Testing] Minor tweaks in the main testing article

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -222,7 +222,7 @@ If you need to customize some environment variables for your tests (e.g. the
 ``DATABASE_URL`` used by Doctrine), you can do that by overriding anything you
 need in your ``.env.test`` file:
 
-.. code-block:: text
+.. code-block:: env
 
     # .env.test
 
@@ -268,7 +268,7 @@ the container is stored in ``static::getContainer()``::
             $newsletterGenerator = $container->get(NewsletterGenerator::class);
             $newsletter = $newsletterGenerator->generateMonthlyNews(...);
 
-            $this->assertEquals(..., $newsletter->getContent());
+            $this->assertEquals('...', $newsletter->getContent());
         }
     }
 


### PR DESCRIPTION
@wouterj do you know why we use `.. code-block:: env` instead of `.. code-block:: bash` for the highlighting of `.env` files? I don't know if `env` highlighting is standard or if we had to do something to support it ... but `bash` seems more natural and it should be standard. Thanks.