### PR TITLE
[Configuration] Multiple environments in a single file

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -412,11 +412,13 @@ files directly in the ``config/packages/`` directory.
 
 .. tip::
 
-    You can also define options for different environments in a single configuration file.
-
     .. versionadded:: 5.3
 
-        The ability to defined different environments in a single file was introduced in Symfony 5.3.
+        The ability to defined different environments in a single file was
+        introduced in Symfony 5.3.
+
+    You can also define options for different environments in a single
+    configuration file using the special ``when`` keyword:
 
     .. configuration-block::
 
@@ -429,10 +431,12 @@ files directly in the ``config/packages/`` directory.
                 strict_mode: true
                 cache: false
 
+            # cache is enabled only in the "prod" environment
             when@prod:
                 webpack_encore:
                     cache: true
 
+            # disable strict mode only in the "test" environment
             when@test:
                 webpack_encore:
                     strict_mode: false
@@ -447,20 +451,20 @@ files directly in the ``config/packages/`` directory.
                     https://symfony.com/schema/dic/services/services-1.0.xsd
                     http://symfony.com/schema/dic/symfony
                     https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-                <webpack-encore:config>
-                    <!-- ... -->
-                </webpack-encore:config>
+                <webpack-encore:config
+                    output-path="%kernel.project_dir%/public/build"
+                    strict-mode="true"
+                    cache="false"
+                />
 
+                <!-- cache is enabled only in the "test" environment -->
                 <when env="prod">
-                    <webpack-encore:config>
-                        <!-- ... -->
-                    </webpack-encore:config>
+                    <webpack-encore:config cache="true"/>
                 </when>
 
+                <!-- disable strict mode only in the "test" environment -->
                 <when env="test">
-                    <webpack-encore:config>
-                        <!-- ... -->
-                    </webpack-encore:config>
+                    <webpack-encore:config strict-mode="false"/>
                 </when>
             </container>
 
@@ -468,43 +472,25 @@ files directly in the ``config/packages/`` directory.
 
             // config/packages/framework.php
             use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-            use Symfony\Config\FrameworkConfig;
+            use Symfony\Config\WebpackEncoreConfig;
 
-            return static function (FrameworkConfig $framework, ContainerConfigurator $container) {
-                // ...
+            return static function (WebpackEncoreConfig $webpackEncore, ContainerConfigurator $container) {
+                $webpackEncore
+                    ->outputPath('%kernel.project_dir%/public/build')
+                    ->strictMode(true)
+                    ->cache(false)
+                ;
 
+                // cache is enabled only in the "prod" environment
                 if ('prod' === $container->env()) {
-                    // ...
+                    $webpackEncore->cache(true);
                 }
 
+                // disable strict mode only in the "test" environment
                 if ('test' === $container->env()) {
-                    $framework->test(true);
-                    $framework->session()->storageFactoryId('session.storage.mock_file');
+                    $webpackEncore->strictMode(false);
                 }
             };
-    
-    Also, if you are using PHP 8.0 or later, you can use the PHP attribute ``#[When]`` to tell that a class should only be registered as services in some environments :
-    
-    .. configuration-block::
-
-        .. code-block:: php-attributes
-
-            use Symfony\Component\DependencyInjection\Attribute\When;
-
-            #[When(env: 'dev')]
-            class SomeClass
-            {
-                // ...
-            }
-
-            // you can apply more than one attribute to the same class:
-
-            #[When(env: 'dev')]
-            #[When(env: 'test')]
-            class AnotherClass
-            {
-                // ...
-            }
 
 .. seealso::
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -410,6 +410,102 @@ In reality, each environment differs only somewhat from others. This means that
 all environments share a large base of common configuration, which is put in
 files directly in the ``config/packages/`` directory.
 
+.. tip::
+
+    You can also define options for different environments in a single configuration file.
+
+    .. versionadded:: 5.3
+
+        The ability to defined different environments in a single file was introduced in Symfony 5.3.
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # config/packages/webpack_encore.yaml
+            webpack_encore:
+                # ...
+                output_path: '%kernel.project_dir%/public/build'
+                strict_mode: true
+                cache: false
+
+            when@prod:
+                webpack_encore:
+                    cache: true
+
+            when@test:
+                webpack_encore:
+                    strict_mode: false
+
+        .. code-block:: xml
+
+            <!-- config/packages/webpack_encore.xml -->
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <container xmlns="http://symfony.com/schema/dic/services"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://symfony.com/schema/dic/services
+                    https://symfony.com/schema/dic/services/services-1.0.xsd
+                    http://symfony.com/schema/dic/symfony
+                    https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+                <webpack-encore:config>
+                    <!-- ... -->
+                </webpack-encore:config>
+
+                <when env="prod">
+                    <webpack-encore:config>
+                        <!-- ... -->
+                    </webpack-encore:config>
+                </when>
+
+                <when env="test">
+                    <webpack-encore:config>
+                        <!-- ... -->
+                    </webpack-encore:config>
+                </when>
+            </container>
+
+        .. code-block:: php
+
+            // config/packages/framework.php
+            use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+            use Symfony\Config\FrameworkConfig;
+
+            return static function (FrameworkConfig $framework, ContainerConfigurator $container) {
+                // ...
+
+                if ('prod' === $container->env()) {
+                    // ...
+                }
+
+                if ('test' === $container->env()) {
+                    $framework->test(true);
+                    $framework->session()->storageFactoryId('session.storage.mock_file');
+                }
+            };
+    
+    Also, if you are using PHP 8.0 or later, you can use the PHP attribute ``#[When]`` to tell that a class should only be registered as services in some environments :
+    
+    .. configuration-block::
+
+        .. code-block:: php-attributes
+
+            use Symfony\Component\DependencyInjection\Attribute\When;
+
+            #[When(env: 'dev')]
+            class SomeClass
+            {
+                // ...
+            }
+
+            // you can apply more than one attribute to the same class:
+
+            #[When(env: 'dev')]
+            #[When(env: 'test')]
+            class AnotherClass
+            {
+                // ...
+            }
+
 .. seealso::
 
     See the ``configureContainer()`` method of

--- a/service_container.rst
+++ b/service_container.rst
@@ -222,6 +222,35 @@ each time you ask for it.
     If you'd prefer to manually wire your service, that's totally possible: see
     :ref:`services-explicitly-configure-wire-services`.
 
+Limiting Services to a specific Symfony Environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.3
+
+    The ``#[When]`` attribute was introduced in Symfony 5.3.
+
+If you are using PHP 8.0 or later, you can use the ``#[When]`` PHP
+attribute to only register the class as a service in some environments::
+
+    use Symfony\Component\DependencyInjection\Attribute\When;
+
+    // SomeClass is only registered in the "dev" environment
+
+    #[When(env: 'dev')]
+    class SomeClass
+    {
+        // ...
+    }
+
+    // you can also apply more than one When attribute to the same class
+
+    #[When(env: 'dev')]
+    #[When(env: 'test')]
+    class AnotherClass
+    {
+        // ...
+    }
+
 .. _services-constructor-injection:
 
 Injecting Services/Config into a Service


### PR DESCRIPTION
As @BafS  mentioned in the Symfony slack, the new Symfony 5.3 feature about defining options for different environments in a single file is not documented, apart from [this blog post](https://symfony.com/blog/new-in-symfony-5-3-configure-multiple-environments-in-a-single-file). I could not find anything about it in the documentation either.

Here is a proposal to include the blog post in the documentation.

I put it in a `tip` section. Perhaps it is worth putting it in a new section below  `Configuration Environments` (or as a subsection) ? :thinking: 
