### PR TITLE
Fix wrong path (aka 404 error) for security_events.svg diagram

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2589,7 +2589,7 @@ Authentication Events
 
 .. raw:: html
 
-    <object data="../_images/security/security_events.svg" type="image/svg+xml"></object>
+    <object data="./_images/security/security_events.svg" type="image/svg+xml"></object>
 
 :class:`Symfony\\Component\\Security\\Http\\Event\\CheckPassportEvent`
     Dispatched after the authenticator created the :ref:`security passport <security-passport>`.


### PR DESCRIPTION
"../" ➤ "./"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
