### PR TITLE
[Messenger] Remove mention to unsupported `prefetch_count` config option

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1187,7 +1187,6 @@ The transport has a number of options:
 ``password``                                  Password to use to connect to the AMQP service
 ``persistent``                                                                                   ``'false'``
 ``port``                                      Port of the AMQP service
-``prefetch_count``
 ``read_timeout``                              Timeout in for income activity. Note: 0 or
                                               greater seconds. May be fractional.
 ``retry``


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
`prefetch_count` was removed in https://github.com/symfony/symfony/pull/41319