### PR TITLE
documentation is incomplete the variable form._token is missing

### DIFF
--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -74,6 +74,16 @@ control over how each form field is rendered, so you can fully customize them:
         </div>
     </div>
 
+.. caution::
+
+   If you're rendering each field manually, make sure you don't forget the
+   ``_token`` field that is automatically added for CSRF protection.
+
+   You can also use ``{{ form_rest(form) }}`` (recommended) to render any
+   fields that aren't rendered manually. See
+   :ref:`the form_rest() documentation <reference-forms-twig-rest>` below for
+   more information.
+
 .. note::
 
     Later in this article you can find the full reference of these Twig


### PR DESCRIPTION
documentation is incomplete the variable form._token is missing: https://symfony.com/doc/current/form/form_customization.html#form-variables-reference

external resource: https://stackoverflow.com/a/23455805/17161735