### PR TITLE
Replace setting env/debug vars with options

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -205,7 +205,7 @@ Make sure you clear and warm-up your Symfony cache:
 
 .. code-block:: terminal
 
-    $ APP_ENV=prod APP_DEBUG=0 php bin/console cache:clear
+    $ php bin/console cache:clear --env=prod --no-debug
 
 E) Other Things!
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The `cache:clear` command already has built-in options for setting the environment and debug mode. I can't think of a reason why manually setting the environment variables should be preferred in this use case. 🤔