### PR TITLE
[DependencyInjection] Update autowiring.rst

### DIFF
--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -371,8 +371,7 @@ dealing with the ``TransformerInterface``.
 .. tip::
 
     When using a `service definition prototype`_, if only one service is
-    discovered that implements an interface, and that interface is also
-    discovered in the same file, configuring the alias is not mandatory
+    discovered that implements an interface, configuring the alias is not mandatory
     and Symfony will automatically create one.
 
 Dealing with Multiple Implementations of the Same Type


### PR DESCRIPTION
I removed this sentence because there is no obligation that the interface should be in the same file as the class
====> and that interface is also discovered in the same file
