### PR TITLE
[ExpressionLanguage] Fix link anchors in expression_language.rst #16295

### DIFF
--- a/components/expression_language.rst
+++ b/components/expression_language.rst
@@ -105,7 +105,7 @@ PHP type (including objects)::
     )); // displays "Honeycrisp"
 
 For more information, see the :doc:`/components/expression_language/syntax`
-entry, especially :ref:`component-expression-objects` and :ref:`component-expression-arrays`.
+entry, especially :ref:`Working with Objects <component-expression-objects>` and :ref:`Working with Arrays <component-expression-arrays>`.
 
 .. caution::
 


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/16295