### PR TITLE
[Security] Minor tweak in a caution admonition

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -842,8 +842,9 @@ The form can look like anything, but it usually follows some conventions:
 
 .. caution::
 
-    This login form is currently not protected against CSRF attacks. Read
-    :ref:`form_login-csrf` on how to protect your login form.
+    This login form is not protected against CSRF attacks. Keep reading to learn
+    about :ref:`adding CSRF Protection in Login Forms <form_login-csrf>` in the
+    next section.
 
 And that's it! When you submit the form, the security system automatically
 reads the ``_username`` and ``_password`` POST parameter, loads the user via


### PR DESCRIPTION
Because of how automatic `ref` titles work, this caution reads a bit weirdly:

![image](https://user-images.githubusercontent.com/73419/147733496-815d2094-1e28-447a-941e-aaf6cc3a75ae.png)
