### PR TITLE
[Form] Use a backed string enum in the EnumType example

### DIFF
--- a/reference/forms/types/enum.rst
+++ b/reference/forms/types/enum.rst
@@ -36,7 +36,7 @@ short) defined somewhere in your application. This enum has to be of type
     // src/Config/TextAlign.php
     namespace App\Config;
 
-    enum TextAlign
+    enum TextAlign: string
     {
         case Left = 'Left/Start aligned';
         case Center = 'Center/Middle aligned';


### PR DESCRIPTION
A backed enum must declare the type of backed enum. Not declaring it is
not valid.

See [PHP documentation](https://www.php.net/manual/en/language.enumerations.backed.php).

This PR is based on 5.4 since the EnumType appeared in this version.