### PR TITLE
[Messenger] Fix check_delayed_interval option in messenger doctrine psqltransport

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1359,7 +1359,7 @@ in the table.
 Option                   Description                                 Default
 =======================  ==========================================  ======================
 use_notify               Whether to use LISTEN/NOTIFY.               true
-check_delayed_interval   The interval to check for delayed           1000
+check_delayed_interval   The interval to check for delayed           60000
                          messages, in milliseconds.
                          Set to 0 to disable checks.
 get_notify_timeout       The length of time to wait for a            0


### PR DESCRIPTION
https://github.com/symfony/doctrine-messenger/blob/62897fdc6bce5106405faa9ddfa005c6dced6ffc/Transport/PostgreSqlConnection.php#L33