### PR TITLE
[HttpKernel] Add a controller argument resolver for backed enums

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -20,6 +20,10 @@ Built-In Value Resolvers
 Symfony ships with the following value resolvers in the
 :doc:`HttpKernel component </components/http_kernel>`:
 
+:class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolver\\BackedEnumValueResolver`
+    Attempts to resolve a backed enum case from a route path parameter that matches the name of the argument.
+    Leads to a 404 Not Found response if the value isn't a valid backing value for the enum type.
+
 :class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolver\\RequestAttributeValueResolver`
     Attempts to find a request attribute that matches the name of the argument.
 


### PR DESCRIPTION
Fixes #16357

Adding a ref to the `BackedEnumValueResolver` introduced in 6.1 to https://symfony.com/doc/current/controller/argument_value_resolver.html

Added before `RequestAttributeValueResolver` since it has a higher priority.

Don't know however where we could showcase such an example:

Given:

```php
namespace App\Model;

enum Suit: string 
{
    case Hearts = 'H';
    case Diamonds = 'D';
    case Clubs = 'C';
    case Spades = 'S';
}
```

and the controller:

```php
class CardController
{
    #[Route('/cards/{suit}')]
    public function list(Suit $suit): Response
    {
        // [...]
    }
}
```

A request to `/cards/H` would inject the `Suit::Hearts` enum case into the controller `$suit` argument.