### PR TITLE
[Cache] Fix Cache Couchbase duplicate page titles

### DIFF
--- a/components/cache/adapters/couchbasebucket_adapter.rst
+++ b/components/cache/adapters/couchbasebucket_adapter.rst
@@ -4,7 +4,7 @@
 
 .. _couchbase-adapter:
 
-Couchbase Cache Adapter
+Couchbase Bucket Cache Adapter
 =======================
 
 .. versionadded:: 5.1

--- a/components/cache/adapters/couchbasecollection_adapter.rst
+++ b/components/cache/adapters/couchbasecollection_adapter.rst
@@ -4,12 +4,12 @@
 
 .. _couchbase-collection-adapter:
 
-Couchbase Cache Adapter
+Couchbase Collection Cache Adapter
 =======================
 
 .. versionadded:: 5.4
 
-    The Couchbase Cache Adapter was introduced in Symfony 5.4.
+    The CouchbaseCollectionAdapter was introduced in Symfony 5.4.
 
 This adapter stores the values in-memory using one (or more) `Couchbase server`_
 instances. Unlike the :ref:`APCu adapter <apcu-adapter>`, and similarly to the


### PR DESCRIPTION
The [Cache Component](https://symfony.com/doc/5.4/components/cache.html) page seemed to have duplicate entries in the TOC, this resolves the problem by naming both pages properly. The issue appeared in the 5.4 docs and thereafter (as `CouchbaseCollectionAdapter` was added in 5.4), but not before.
