### PR TITLE
[Security] Move Passport Attributes to their own section

### DIFF
--- a/security/custom_authenticator.rst
+++ b/security/custom_authenticator.rst
@@ -342,39 +342,39 @@ would initialize the passport like this::
         }
     }
 
-.. tip::
-
-    Besides badges, passports can define attributes, which allows the
-    ``authenticate()`` method to store arbitrary information in the
-    passport to access it from other authenticator methods (e.g.
-    ``createAuthenticatedToken()``)::
-
-        // ...
-        use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
-
-        class LoginAuthenticator extends AbstractAuthenticator
-        {
-            // ...
-
-            public function authenticate(Request $request): PassportInterface
-            {
-                // ... process the request
-
-                $passport = new SelfValidatingPassport(new UserBadge($username), []);
-
-                // set a custom attribute (e.g. scope)
-                $passport->setAttribute('scope', $oauthScope);
-
-                return $passport;
-            }
-
-            public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
-            {
-                // read the attribute value
-                return new CustomOauthToken($passport->getUser(), $passport->getAttribute('scope'));
-            }
-        }
+Passport Attributes
+-------------------
 
 .. versionadded:: 5.2
 
     Passport attributes were introduced in Symfony 5.2.
+
+Besides badges, passports can define attributes, which allows the ``authenticate()``
+method to store arbitrary information in the passport to access it from other
+authenticator methods (e.g. ``createAuthenticatedToken()``)::
+
+    // ...
+    use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+
+    class LoginAuthenticator extends AbstractAuthenticator
+    {
+        // ...
+
+        public function authenticate(Request $request): PassportInterface
+        {
+            // ... process the request
+
+            $passport = new SelfValidatingPassport(new UserBadge($username), []);
+
+            // set a custom attribute (e.g. scope)
+            $passport->setAttribute('scope', $oauthScope);
+
+            return $passport;
+        }
+
+        public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+        {
+            // read the attribute value
+            return new CustomOauthToken($passport->getUser(), $passport->getAttribute('scope'));
+        }
+    }


### PR DESCRIPTION
I think attributes are important enough to move them to their own section, which also allows them to appear in the page TOC.