### PR TITLE
update command bus pattern link

### DIFF
--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -720,4 +720,4 @@ and compose your services with them::
     as this will include the trait name, not the class name. Instead, use
     ``__CLASS__.'::'.__FUNCTION__`` as the service id.
 
-.. _`Command pattern`: https://en.wikipedia.org/wiki/Command_pattern
+.. _`Command pattern`: https://ducmanhphan.github.io/2020-12-02-command-bus-pattern/


### PR DESCRIPTION
The current link takes you to the command pattern, the proposed one takes you to the command bus pattern.
In your documentation example you are describing the proposed ones but linking to the gang of four command pattern.