### PR TITLE
fix Password Hasher php-standalone example

### DIFF
--- a/security/passwords.rst
+++ b/security/passwords.rst
@@ -101,7 +101,7 @@ optionally some *algorithm options*:
             User::class => ['algorithm' => 'auto'],
 
             // auto hasher with custom options for all PasswordAuthenticatedUserInterface instances
-            User::class => [
+            PasswordAuthenticatedUserInterface::class => [
                 'algorithm' => 'auto',
                 'cost' => 15,
             ],


### PR DESCRIPTION
the php-standalone example for Password Hasher had a configuration for User twice, while the comment and other examples indicated, the second should've been a configuration for PasswordAuthenticatedUserInterface
