### PR TITLE
[Serializer] Reintroduce removed note

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -908,6 +908,11 @@ The Serializer component provides several built-in normalizers:
 
     The ``UidNormalizer`` normalization formats were introduced in Symfony 5.3.
 
+.. note::
+
+    You can also create your own Normalizer to use another structure. Read more at
+    :doc:`/serializer/custom_normalizer`.
+
 Certain normalizers are enabled by default when using the Serializer component
 in a Symfony application, additional ones can be enabled by tagging them with
 :ref:`serializer.normalizer <reference-dic-tags-serializer-normalizer>`.


### PR DESCRIPTION
Followup to #16371 

This note is present on the [4.4 branch](https://github.com/symfony/symfony-docs/blob/7b083f6118d6aa2649613a0bc54ba7eadcee1c79/components/serializer.rst?plain=1#L799-L802) but was removed on the 5.x branch with #14799 .

Since there is no other link to the custom normalizer docs on this page, I'd suggest adding it back. Also, this would make it consistent with the [Encoders section](https://github.com/symfony/symfony-docs/blob/09b9115337070d1adb69c22eaffa46c635da17d5/components/serializer.rst?plain=1#L999-L1002).