### PR TITLE
[Security] Add deprecation information for is_anonymous

### DIFF
--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -24,7 +24,7 @@ accepts an :class:`Symfony\\Component\\ExpressionLanguage\\Expression` object::
         public function index(): Response
         {
             $this->denyAccessUnlessGranted(new Expression(
-                '"ROLE_ADMIN" in role_names or (not is_anonymous() and user.isSuperAdmin())'
+                '"ROLE_ADMIN" in role_names or (is_authenticated() and user.isSuperAdmin())'
             ));
 
             // ...
@@ -77,6 +77,11 @@ Additionally, you have access to a number of functions inside the expression:
     second argument with the object where permission is checked on. It's
     equivalent to using the :ref:`isGranted() method <security-isgranted>`
     from the security service.
+
+.. deprecated:: 5.4
+
+   The ``is_anonymous()`` function is
+   deprecated since Symfony 5.4.
 
 .. sidebar:: ``is_remember_me()`` is different than checking ``IS_AUTHENTICATED_REMEMBERED``
 


### PR DESCRIPTION
Don't know in which issue or pr this happend but I found in the UPGRADE-5.4.md that the `is_anonymous()` function is deprecated. Instead the `is_authenticated()` function should be used.

https://github.com/symfony/symfony/blob/5.4/UPGRADE-5.4.md#security
> Deprecate AuthenticationTrustResolverInterface::isAnonymous() and the is_anonymous() expression function as anonymous no longer exists in version 6, use the isFullFledged() or the new isAuthenticated() instead if you want to check if the request is (fully) authenticated

How do we handle the upmerge? The deprecation information must be removed in 6.0 and the general information about the function in line 67-70. Should I create a follow up PR?