### PR TITLE
[Config] Note that env vars are not always compatible with options

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -602,6 +602,10 @@ You can reference environment variables using the special syntax
 ``%env(ENV_VAR_NAME)%``. The values of these options are resolved at runtime
 (only once per request, to not impact performance).
 
+Note that not all config options are compatible with environment variables. There are
+`cases <https://github.com/symfony/symfony/issues/39902>`_ which may require refactoring
+the config definition in order to work with environment variables.
+
 This example shows how you could configure the database connection using an env var:
 
 .. configuration-block::


### PR DESCRIPTION
There are cases where environment variables cannot be used in 
place of regular configuration options. This commit makes the limitation 
explicit.

From https://github.com/symfony/symfony/issues/39902

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
