### PR TITLE
User --webapp instead of --full

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -53,13 +53,13 @@ application:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ symfony new my_project_directory --version=5.3 --full
+    $ symfony new my_project_directory --version=5.3 --webapp
 
     # run this if you are building a microservice, console application or API
     $ symfony new my_project_directory --version=5.3
 
 The only difference between these two commands is the number of packages
-installed by default. The ``--full`` option installs all the packages that you
+installed by default. The ``--webapp`` option installs all the packages that you
 usually need to build web applications, so the installation size will be bigger.
 
 If you're not using the Symfony binary, run these commands to create the new
@@ -68,7 +68,9 @@ Symfony application using Composer:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ composer create-project symfony/website-skeleton:"^5.3" my_project_directory
+    $ composer create-project symfony/skeleton:"^5.3" my_project_directory
+    $ cd my_project_directory
+    $ composer require webapp
 
     # run this if you are building a microservice, console application or API
     $ composer create-project symfony/skeleton:"^5.3" my_project_directory


### PR DESCRIPTION
I'm preparing a blog post about the new `webapp` flag/package to explain the difference with the website skeleton, but I first like to update the docs.

Note that this only works as of 5.3 (so 4.4 should keep using the "old" way).

Related to https://github.com/symfony-cli/symfony-cli/pull/38
