### PR TITLE
Remove reference to jQuery from examples code

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -281,9 +281,7 @@ On the rendered page, the result will look something like this:
     and you need to adjust the following JavaScript accordingly.
 
 Now add some JavaScript to read this attribute and dynamically add new tag forms
-when the user clicks the "Add a tag" link. This example uses `jQuery`_ and
-assumes you have it included somewhere on your page (e.g. using Symfony's
-:doc:`Webpack Encore </frontend>`).
+when the user clicks the "Add a tag" link.
 
 Add a ``<script>`` tag somewhere on your page to include the required
 functionality with JavaScript:
@@ -651,7 +649,7 @@ the relationship between the removed ``Tag`` and ``Task`` object.
     The Symfony community has created some JavaScript packages that provide the
     functionality needed to add, edit and delete elements of the collection.
     Check out the `@a2lix/symfony-collection`_ package for modern browsers and
-    the `symfony-collection`_ package based on jQuery for the rest of browsers.
+    the `symfony-collection`_ package based on `jQuery`_ for the rest of browsers.
 
 .. _`Owning Side and Inverse Side`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/unitofwork-associations.html
 .. _`jQuery`: http://jquery.com/


### PR DESCRIPTION
Remove reference to jQuery from examples code because it's not used anymore.