### PR TITLE
Fix bugs seen by `_build/build.php` diagnostics in 5.3

### DIFF
--- a/setup/docker.rst
+++ b/setup/docker.rst
@@ -49,7 +49,7 @@ After installing the package, rebuild your containers by running:
 Symfony Binary Web Server and Docker Support
 --------------------------------------------
 
-If you're using the :ref:`symfony binary web server` (e.g. ``symfony server:start``),
+If you're using the :ref:`symfony binary web server <symfony-local-web-server>` (e.g. ``symfony server:start``),
 then it can automatically detect your Docker services and expose them as environment
 variables. See :ref:`symfony-server-docker`.
 


### PR DESCRIPTION
This PR fixes a broken reference found by the build script.

I dealt with the remaining diagnostics from 4.4 in #16397.

Fixes the following diagnostic emitted by `_build/build.php`:
```
Found invalid reference "symfony binary web server" in file
```
"setup/docker"