### PR TITLE
 Fix bugs seen by `_build/build.php` diagnostics in 5.4

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -350,20 +350,20 @@ Locks are created and managed in ``Stores``, which are classes that implement
 
 The component includes the following built-in store types:
 
-=========================================================  ======  ========  ======== =======
-Store                                                      Scope   Blocking  Expiring Sharing
-=========================================================  ======  ========  ======== =======
-:ref:`FlockStore <lock-store-flock>`                       local   yes       no       yes
-:ref:`MemcachedStore <lock-store-memcached>`               remote  no        yes      no
-:ref:`MongoDbStore <lock-store-mongodb>`                   remote  no        yes      no
-:ref:`PdoStore <lock-store-pdo>`                           remote  no        yes      no
-:ref:`DoctrineDbalStore <lock-store-dbal>`                 remote  no        yes      no
-:ref:`PostgreSqlStore <lock-store-pgsql>`                  remote  yes       no       yes
-:ref:`DoctrineDbalPostgreSqlStore <lock-store-dbal-pgsql>` remote  yes       no       yes
-:ref:`RedisStore <lock-store-redis>`                       remote  no        yes      yes
-:ref:`SemaphoreStore <lock-store-semaphore>`               local   yes       no       no
-:ref:`ZookeeperStore <lock-store-zookeeper>`               remote  no        no       no
-=========================================================  ======  ========  ======== =======
+==========================================================  ======  ========  ======== =======
+Store                                                       Scope   Blocking  Expiring Sharing
+==========================================================  ======  ========  ======== =======
+:ref:`FlockStore <lock-store-flock>`                        local   yes       no       yes
+:ref:`MemcachedStore <lock-store-memcached>`                remote  no        yes      no
+:ref:`MongoDbStore <lock-store-mongodb>`                    remote  no        yes      no
+:ref:`PdoStore <lock-store-pdo>`                            remote  no        yes      no
+:ref:`DoctrineDbalStore <lock-store-dbal>`                  remote  no        yes      no
+:ref:`PostgreSqlStore <lock-store-pgsql>`                   remote  yes       no       yes
+:ref:`DoctrineDbalPostgreSqlStore <lock-store-dbal-pgsql>`  remote  yes       no       yes
+:ref:`RedisStore <lock-store-redis>`                        remote  no        yes      yes
+:ref:`SemaphoreStore <lock-store-semaphore>`                local   yes       no       no
+:ref:`ZookeeperStore <lock-store-zookeeper>`                remote  no        no       no
+==========================================================  ======  ========  ======== =======
 
 .. _lock-store-flock:
 

--- a/reference/forms/types/enum.rst
+++ b/reference/forms/types/enum.rst
@@ -9,7 +9,7 @@ EnumType Field
    The ``EnumType`` form field was introduced in Symfony 5.4.
 
 A multi-purpose field used to allow the user to "choose" one or more options
-defined in a `PHP enumeration`_. It extends the :doc:`ChoiceType </refernce/forms/types/enum>`
+defined in a `PHP enumeration`_. It extends the :doc:`ChoiceType </reference/forms/types/enum>`
 field and defines the same options.
 
 +---------------------------+----------------------------------------------------------------------+


### PR DESCRIPTION
This PR fixes a broken reference and a table spacing issue found by the build script.

I dealt with the remaining diagnostics 
* from 4.4 in #16397.
* from 5.3 in #16398