### PR TITLE
Fix bugs seen by `_build/build.php` diagnostics in 6.0

### DIFF
--- a/form/bootstrap5.rst
+++ b/form/bootstrap5.rst
@@ -83,6 +83,8 @@ If you prefer to apply the Bootstrap styles on a form to form basis, include the
     container. If you override the ``row_attr`` class option, the ``mb-3`` will
     be overridden too and you will need to explicitly add it.
 
+.. _reference-forms-bootstrap5-error-messages:
+
 Error Messages
 --------------
 


### PR DESCRIPTION
This PR fixes a broken reference found by the build script.

I dealt with the remaining diagnostics 
* from 4.4 in #16397.
* from 5.3 in #16398
* from 5.4 in #16399