### PR TITLE
[Security] Update impersonating_user.rst

### DIFF
--- a/security/impersonating_user.rst
+++ b/security/impersonating_user.rst
@@ -75,7 +75,52 @@ as the value to the current URL:
 .. tip::
 
     Instead of adding a ``_switch_user`` query string parameter, you can pass
-    the username in a ``HTTP_X_SWITCH_USER`` header.
+    the username in a ``HTTP_X_SWITCH_USER`` header. You can use this feature by adjusting the ``parameter`` setting:
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # config/packages/security.yaml
+            security:
+                # ...
+                firewalls:
+                    main:
+                        # ...
+                        switch_user: { parameter: HTTP_X_SWITCH_USER }
+
+        .. code-block:: xml
+
+            <!-- config/packages/security.xml -->
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <srv:container xmlns="http://symfony.com/schema/dic/security"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:srv="http://symfony.com/schema/dic/services"
+                xsi:schemaLocation="http://symfony.com/schema/dic/services
+                    https://symfony.com/schema/dic/services/services-1.0.xsd
+                    http://symfony.com/schema/dic/security
+                    https://symfony.com/schema/dic/security/security-1.0.xsd">
+                <config>
+                    <!-- ... -->
+                    <firewall name="main">
+                        <!-- ... -->
+                        <switch-user parameter="HTTP_X_SWITCH_USER"/>
+                    </firewall>
+                </config>
+            </srv:container>
+
+        .. code-block:: php
+
+            // config/packages/security.php
+            use Symfony\Config\SecurityConfig;
+            return static function (SecurityConfig $security) {
+                // ...
+                $security->firewall('main')
+                    // ...
+                    ->switchUser()
+                        ->parameter('HTTP_X_SWITCH_USER')
+                ;
+            };
 
 To switch back to the original user, use the special ``_exit`` username:
 


### PR DESCRIPTION
To use switching user feature via `HTTP_X_SWITCH_USER` header we have to set `switch_user.parameter: HTTP_X_SWITCH_USER` in security.yaml.

refs: https://github.com/symfony/symfony/issues/39907

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
