### PR TITLE
Remove outdated versionadded 5.* directives

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -412,11 +412,6 @@ files directly in the ``config/packages/`` directory.
 
 .. tip::
 
-    .. versionadded:: 5.3
-
-        The ability to defined different environments in a single file was
-        introduced in Symfony 5.3.
-
     You can also define options for different environments in a single
     configuration file using the special ``when`` keyword:
 

--- a/http_client.rst
+++ b/http_client.rst
@@ -1688,10 +1688,6 @@ responses dynamically when it's called::
         $client = new MockHttpClient();
         $client->setResponseFactory($responses);
 
-    .. versionadded:: 5.4
-
-        The ``setResponseFactory()`` method was introduced in Symfony 5.4.
-
 If you need to test responses with HTTP status codes different than 200,
 define the ``http_code`` option::
 

--- a/serializer.rst
+++ b/serializer.rst
@@ -149,11 +149,6 @@ configuration:
             ;
         };
 
-.. versionadded:: 5.4
-
-    The ability to configure the ``default_context`` option in the
-    Serializer was introduced in Symfony 5.4.
-
 .. _serializer-using-serialization-groups-annotations:
 
 Using Serialization Groups Annotations

--- a/service_container.rst
+++ b/service_container.rst
@@ -225,10 +225,6 @@ each time you ask for it.
 Limiting Services to a specific Symfony Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.3
-
-    The ``#[When]`` attribute was introduced in Symfony 5.3.
-
 If you are using PHP 8.0 or later, you can use the ``#[When]`` PHP
 attribute to only register the class as a service in some environments::
 


### PR DESCRIPTION
Beginning with version 6.0, versionadded-directives for versions <6 must be removed (CI complains).
