### PR TITLE
Remove check:security tip

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -242,13 +242,6 @@ update or replace compromised dependencies as soon as possible. The security
 check is done locally by fetching the public `PHP security advisories database`_,
 so your ``composer.lock`` file is not sent on the network.
 
-.. tip::
-
-    The ``check:security`` command terminates with a non-zero exit code if
-    any of your dependencies is affected by a known security vulnerability.
-    This way you can add it to your project build process and your continuous
-    integration workflows to make them fail when there are vulnerabilities.
-
 Symfony LTS Versions
 --------------------
 


### PR DESCRIPTION
As check:security command does not exist anymore, remove old tip for this command.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
