### PR TITLE
[Messenger] Add sessionToken option to SQS transport

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1563,6 +1563,7 @@ The transport has a number of options:
 ``queue_name``          Name of the queue                       messages
 ``region``              Name of the AWS region                  eu-west-1
 ``secret_key``          AWS secret key                          must be urlencoded
+``session_token``       AWS session token
 ``visibility_timeout``  Amount of seconds the message will      Queue's configuration
                         not be visible (`Visibility Timeout`_)
 ``wait_time``           `Long polling`_ duration in seconds     20


### PR DESCRIPTION
Added new `session_token` in SQS Transport options
