### PR TITLE
Remove superfluous `:local: :depth: 1` entries from testing

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -523,10 +523,6 @@ The full signature of the ``request()`` method is::
 
 This allows you to create all types of requests you can think of:
 
-.. contents::
-    :local:
-    :depth: 1
-
 .. tip::
 
     The test client is available as the ``test.client`` service in the
@@ -671,10 +667,6 @@ Interacting with the Response
 Like a real browser, the Client and Crawler objects can be used to interact
 with the page you're served:
 
-.. contents::
-    :local:
-    :depth: 1
-
 .. _testing-links:
 
 Clicking on Links
@@ -814,10 +806,6 @@ your tests. Combined with test Client and the Crawler, this allows you to
 check anything you want.
 
 However, Symfony provides useful shortcut methods for the most common cases:
-
-.. contents::
-    :local:
-    :depth: 1
 
 .. versionadded:: 4.3
 


### PR DESCRIPTION
Fixes #16213

I don't know what they were for, but currently they're just rendered as-is:

![image](https://user-images.githubusercontent.com/424602/150183701-6524f8b5-4c2d-451a-be5c-62738e79fe19.png)

As they only exist on the testing page and nowhere else, I assume they can be deleted.