### PR TITLE
Fix choice translation domain doc

### DIFF
--- a/reference/forms/types/options/choice_translation_domain.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain.rst.inc
@@ -1,7 +1,7 @@
 ``choice_translation_domain``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-DEFAULT_VALUE
+|DEFAULT_VALUE|
 
 This option determines if the choice values should be translated and in which
 translation domain.

--- a/reference/forms/types/options/choice_translation_domain_disabled.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain_disabled.rst.inc
@@ -3,5 +3,4 @@
 
 **type**: ``string``, ``boolean`` or ``null`` **default**: ``false``
 
-.. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
     :start-after: DEFAULT_VALUE

--- a/reference/forms/types/options/choice_translation_domain_disabled.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain_disabled.rst.inc
@@ -1,6 +1,3 @@
 .. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
-    :end-before: DEFAULT_VALUE
 
-**type**: ``string``, ``boolean`` or ``null`` **default**: ``false``
-
-    :start-after: DEFAULT_VALUE
+.. |DEFAULT_VALUE| replace:: **type**: ``string``, ``boolean`` or ``null`` **default**: ``false``

--- a/reference/forms/types/options/choice_translation_domain_enabled.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain_enabled.rst.inc
@@ -1,6 +1,3 @@
 .. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
-    :end-before: DEFAULT_VALUE
 
-**type**: ``string``, ``boolean`` or ``null`` **default**: ``true``
-
-    :start-after: DEFAULT_VALUE
+.. |DEFAULT_VALUE| replace:: **type**: ``string``, ``boolean`` or ``null`` **default**: ``true``

--- a/reference/forms/types/options/choice_translation_domain_enabled.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain_enabled.rst.inc
@@ -3,5 +3,4 @@
 
 **type**: ``string``, ``boolean`` or ``null`` **default**: ``true``
 
-.. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
     :start-after: DEFAULT_VALUE


### PR DESCRIPTION
Hello,

The block for the `choice_translation_domain` appear twice on the documentation of the types with this options, besides this the default value wasn't displayed correctly. This should fix the problem.
