### PR TITLE
Add return types in docs to avoid generating more legacy code

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -170,7 +170,7 @@ retrieved from the token storage::
             $this->security = $security;
         }
 
-        public function supports(Request $request, ArgumentMetadata $argument)
+        public function supports(Request $request, ArgumentMetadata $argument): bool
         {
             if (User::class !== $argument->getType()) {
                 return false;
@@ -179,7 +179,7 @@ retrieved from the token storage::
             return $this->security->getUser() instanceof User;
         }
 
-        public function resolve(Request $request, ArgumentMetadata $argument)
+        public function resolve(Request $request, ArgumentMetadata $argument): iterable
         {
             yield $this->security->getUser();
         }


### PR DESCRIPTION
I am not entirely sure if this goes against a policy or not, but I wanted to fix this and also use it to raise the point in case it wasn't raised yet.

While copy-pasting this code from the docs to get started on an arg value resolver, I then instantly got `Method "Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface::supports()" might add "bool" as a native return type declaration in the future. Do the same in implementation "App\ArgumentResolver\PackageResolver" now to avoid errors or add an explicit @return annotation to suppress this message.` in my deprecation log.

This feature was added in Symfony 5.x IIRC which means PHP 7.2+ support, so return types including iterable are fully supported, no reason to advise anyone to not use them as far as I can tell :)