### PR TITLE
Moving RexExp search to its own heading

### DIFF
--- a/components/string.rst
+++ b/components/string.rst
@@ -318,6 +318,16 @@ Methods to Search and Replace
     // checks if the string contents are exactly the same as the given contents
     u('foo')->equalsTo('foo'); // true
 
+    // checks if the string content match the given regular expression.
+    // You can pass flags for preg_match() as second argument. If PREG_PATTERN_ORDER
+    // or PREG_SET_ORDER are passed, preg_match_all() will be used.
+    u('avatar-73647.png')->match('/avatar-(\d+)\.png/');
+    // result = ['avatar-73647.png', '73647']
+    u('avatar-73647.png')->match('/avatar-(\d+)(-\d+)?\.png/', \PREG_UNMATCHED_AS_NULL);
+    // result = ['avatar-73647.png', '73647', null]
+    u('206-555-0100 and 800-555-1212')->match('/\d{3}-\d{3}-\d{4}/', \PREG_PATTERN_ORDER);
+    // result = [['206-555-0100', '800-555-1212']]
+
     // checks if the string contains any of the other given strings
     u('aeiou')->containsAny('a');                 // true
     u('aeiou')->containsAny(['ab', 'efg']);       // false
@@ -353,22 +363,6 @@ Methods to Search and Replace
 .. versionadded:: 5.1
 
     The ``containsAny()`` method was introduced in Symfony 5.1.
-
-::
-
-You can use ``match()`` to search with a Regular Expression::
-
-    u('avatar-73647.png')->match('/avatar-(\d+)\.png/');
-    // result = ['avatar-73647.png', '73647']
-
-By default, PHP's ``preg_match()`` is used, and you can pass search flags as second argument::
-
-    $string->match('/(a)(b)/', \PREG_UNMATCHED_AS_NULL);
-
-When passing ``\PREG_PATTERN_ORDER`` or ``\PREG_SET_ORDER``, PHP's ``preg_match_all()`` is used.
-Multiple flags can be set with the `|` operator::
-
-    $string->match('/(a)(b)/', \PREG_PATTERN_ORDER|\PREG_UNMATCHED_AS_NULL);
 
 Methods to Join, Split, Truncate and Reverse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/components/string.rst
+++ b/components/string.rst
@@ -318,10 +318,6 @@ Methods to Search and Replace
     // checks if the string contents are exactly the same as the given contents
     u('foo')->equalsTo('foo'); // true
 
-    // checks if the string content match the given regular expression
-    u('avatar-73647.png')->match('/avatar-(\d+)\.png/');
-    // result = ['avatar-73647.png', '73647']
-
     // checks if the string contains any of the other given strings
     u('aeiou')->containsAny('a');                 // true
     u('aeiou')->containsAny(['ab', 'efg']);       // false
@@ -357,6 +353,22 @@ Methods to Search and Replace
 .. versionadded:: 5.1
 
     The ``containsAny()`` method was introduced in Symfony 5.1.
+
+::
+
+You can use ``match()`` to search with a Regular Expression::
+
+    u('avatar-73647.png')->match('/avatar-(\d+)\.png/');
+    // result = ['avatar-73647.png', '73647']
+
+By default, PHP's ``preg_match()`` is used, and you can pass search flags as second argument::
+
+    $string->match('/(a)(b)/', \PREG_UNMATCHED_AS_NULL);
+
+When passing ``\PREG_PATTERN_ORDER`` or ``\PREG_SET_ORDER``, PHP's ``preg_match_all()`` is used.
+Multiple flags can be set with the `|` operator::
+
+    $string->match('/(a)(b)/', \PREG_PATTERN_ORDER|\PREG_UNMATCHED_AS_NULL);
 
 Methods to Join, Split, Truncate and Reverse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
See https://github.com/symfony/symfony/issues/45032#issuecomment-1017570333

I wanted to create a heading ("Search Using a Regular Expression") for this. Is `~~~~` the lowest level already? If yes, I'd suggest to drop the "Method Reference" heading, and promote all included "Methods to..." headings one level.