### PR TITLE
[DependencyInjection] PHP configuration: Fixing consistency

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -235,7 +235,7 @@ reusable configuration value. By convention, parameters are defined under the
 
         use App\Entity\BlogPost;
 
-        return static function (ContainerConfigurator $container) {
+        return static function (ContainerConfigurator $configurator) {
             $container->parameters()
                 // the parameter name is an arbitrary string (the 'app.' prefix is recommended
                 // to better differentiate your parameters from Symfony parameters).


### PR DESCRIPTION
At https://symfony.com/doc/current/service_container.html#creating-configuring-services-in-the-container the variable is called `$configurator`. I don't know which name is better, but they should be consistent.
