### PR TITLE
[Mailer] Capitalise From and Bcc header names in global mailer configuration

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -535,8 +535,8 @@ and headers.
                     sender: 'fabien@example.com'
                     recipients: ['foo@example.com', 'bar@example.com']
                 headers:
-                    from: 'Fabien <fabien@example.com>'
-                    bcc: 'baz@example.com'
+                    From: 'Fabien <fabien@example.com>'
+                    Bcc: 'baz@example.com'
                     X-Custom-Header: 'foobar'
 
     .. code-block:: xml
@@ -558,8 +558,8 @@ and headers.
                         <framework:recipients>foo@example.com</framework:recipients>
                         <framework:recipients>bar@example.com</framework:recipients>
                     </framework:envelope>
-                    <framework:header name="from">Fabien &lt;fabien@example.com&gt;</framework:header>
-                    <framework:header name="bcc">baz@example.com</framework:header>
+                    <framework:header name="From">Fabien &lt;fabien@example.com&gt;</framework:header>
+                    <framework:header name="Bcc">baz@example.com</framework:header>
                     <framework:header name="X-Custom-Header">foobar</framework:header>
                 </framework:mailer>
             </framework:config>
@@ -578,8 +578,8 @@ and headers.
                     ->recipients(['foo@example.com', 'bar@example.com'])
             ;
 
-            $mailer->header('from')->value('Fabien <fabien@example.com>');
-            $mailer->header('bcc')->value('baz@example.com');
+            $mailer->header('From')->value('Fabien <fabien@example.com>');
+            $mailer->header('Bcc')->value('baz@example.com');
             $mailer->header('X-Custom-Header')->value('foobar');
         };
 


### PR DESCRIPTION
If the `From` header name is not capitalised, the header is replaced by the `Sender` address in the Mime component's Message object:
 https://github.com/symfony/symfony/blob/6a52b66da0d35b21031bb344e79522f73d60e05a/src/Symfony/Component/Mime/Message.php#L76-L81

I capitalised `Bcc` as well because the component also looks for this header in a case-sensitive way.

