### PR TITLE
Update associations.rst

### DIFF
--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -630,13 +630,15 @@ also generated a ``removeProduct()`` method::
 
         public function removeProduct(Product $product): self
         {
-            if ($this->products->contains($product)) {
-                $this->products->removeElement($product);
+            
+                // Returns true if removed, false if not found in the collection.
+                $removed = $this->products->removeElement($product);
+                
                 // set the owning side to null (unless already changed)
-                if ($product->getCategory() === $this) {
+                if ($removed && $product->getCategory() === $this) {
                     $product->setCategory(null);
                 }
-            }
+            
 
             return $this;
         }


### PR DESCRIPTION
I have a problem with large datasets where the checking to see if an element exists causes memory problems.

It turns out that the ArrayCollection method removeElement also has it's own check to see if the removed element exists.
So we're looping through the collection twice.

```
    /**
     * {@inheritDoc}
     */
    public function removeElement($element)
    {
        $key = array_search($element, $this->elements, true);

        if ($key === false) {
            return false;
        }

        unset($this->elements[$key]);

        return true;
    }```

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
