### PR TITLE
call `fetchAllAssociative` for a result set not a statement

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -853,10 +853,10 @@ In addition, you can query directly with SQL if you need to::
                 ORDER BY p.price ASC
                 ';
             $stmt = $conn->prepare($sql);
-            $stmt->execute(['price' => $price]);
+            $resultSet = $stmt->executeQuery(['price' => $price]);
 
             // returns an array of arrays (i.e. a raw data set)
-            return $stmt->fetchAllAssociative();
+            return $resultSet->fetchAllAssociative();
         }
     }
 


### PR DESCRIPTION
`fetchAllAssociative()` is not available for class "Doctrine\DBAL\Statement"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
