### PR TITLE
Fix com.symfony.server.service-ignore value

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -370,7 +370,7 @@ check the "Symfony Server" section in the web debug toolbar; you'll see that
 .. note::
 
     If you don't want environment variables to be exposed for a service, set
-    the ``com.symfony.server.service-ignore`` label to ``true``:
+    the ``com.symfony.server.service-ignore`` label to ``"True"``:
 
     .. code-block:: yaml
 
@@ -379,7 +379,7 @@ check the "Symfony Server" section in the web debug toolbar; you'll see that
             db:
                 ports: [3306]
                 labels:
-                    com.symfony.server.service-ignore: true
+                    com.symfony.server.service-ignore: "True"
 
 If your Docker Compose file is not at the root of the project, use the
 ``COMPOSE_FILE`` and ``COMPOSE_PROJECT_NAME`` environment variables to define


### PR DESCRIPTION
`true` does not work. Only `"True"` does work (code : https://github.com/symfony-cli/symfony-cli/blob/v5.2.0/envs/docker.go#L148).
