### PR TITLE
Add Mandatory use Alias createQueryBuilder method will cause an excep…

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -828,6 +828,12 @@ based on PHP conditions)::
         }
     }
 
+
+.. caution::
+
+    Be careful the use of Aliases is mandatory, not passing the alias to the createQueryBuilder method will cause an exception..
+    
+
 Querying with SQL
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
…tion.

Add Mandatory use Alias createQueryBuilder method will cause an exception.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
