### PR TITLE
[Translation] Typo

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -750,12 +750,12 @@ now use the following commands to push (upload) and pull (download) translations
     # push new local translations to the Loco provider for the French locale
     # and the validators domain.
     # it will **not** update existing translations already on the provider.
-    $ php bin/console translation:push loco --locales fr --domain validators
+    $ php bin/console translation:push loco --locales fr --domains validators
 
     # push new local translations and delete provider's translations that not
     # exists anymore in local files for the French locale and the validators domain.
     # it will **not** update existing translations already on the provider.
-    $ php bin/console translation:push loco --delete-missing --locales fr --domain validators
+    $ php bin/console translation:push loco --delete-missing --locales fr --domains validators
 
     # check out the command help to see its options (format, domains, locales, etc.)
     $ php bin/console translation:push --help
@@ -770,7 +770,7 @@ now use the following commands to push (upload) and pull (download) translations
     # pull new translations from the Loco provider to local files for the French
     # locale and the validators domain.
     # it will **not** overwrite your local files, only add new translations.
-    $ php bin/console translation:pull loco --locales fr --domain validators
+    $ php bin/console translation:pull loco --locales fr --domains validators
 
     # check out the command help to see its options (format, domains, locales, intl-icu, etc.)
     $ php bin/console translation:pull --help


### PR DESCRIPTION
There was a typo where the option `--domain` is in fact `--domains`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
