### PR TITLE
Update extension.rst

### DIFF
--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -34,7 +34,7 @@ This is how the extension of an AcmeHelloBundle should look like::
     namespace Acme\HelloBundle\DependencyInjection;
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
-    use Symfony\Component\DependencyInjection\Extension\Extension;
+    use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
     class AcmeHelloExtension extends Extension
     {


### PR DESCRIPTION
when using  `DependencyInjection\Extension\Extension`, the `addAnnotatedClassesToCompile` is not available. so it should be mentionned that we need to use `HttpKernel\DependencyInjection\Extension` instead when the method `addAnnotatedClassesToCompile`  must be used

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
