### PR TITLE
Fixed email link issue

### DIFF
--- a/contributing/code_of_conduct/care_team.rst
+++ b/contributing/code_of_conduct/care_team.rst
@@ -21,7 +21,7 @@ Members
 
 Here are all the members of the CARE team (in alphabetic order). You can contact
 any of them directly using the contact details below or you can also contact all
-of them at once by emailing **care@symfony.com**:
+of them at once by emailing ** care@symfony.com **.
 
 * **Timo Bakx**
 


### PR DESCRIPTION
Formatting (bold) breaks the mailto-link.

This ended up as: 
```
<a href="mailto:**care@symfony.com" class="reference internal">**care@symfony.com</a>**:
```