### PR TITLE
[Cache] 45036 add stale while revalidate and stale if error support

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -479,6 +479,8 @@ of methods to manipulate the HTTP headers related to the cache:
 * :method:`Symfony\\Component\\HttpFoundation\\Response::setExpires`
 * :method:`Symfony\\Component\\HttpFoundation\\Response::setMaxAge`
 * :method:`Symfony\\Component\\HttpFoundation\\Response::setSharedMaxAge`
+* :method:`Symfony\\Component\\HttpFoundation\\Response::setStaleIfError`
+* :method:`Symfony\\Component\\HttpFoundation\\Response::setStaleWhileRevalidate`
 * :method:`Symfony\\Component\\HttpFoundation\\Response::setTtl`
 * :method:`Symfony\\Component\\HttpFoundation\\Response::setClientTtl`
 * :method:`Symfony\\Component\\HttpFoundation\\Response::setLastModified`
@@ -506,6 +508,8 @@ call::
         'proxy_revalidate' => false,
         'max_age'          => 600,
         's_maxage'         => 600,
+        'stale_if_error'   => 86400,
+        'stale_while_revalidate' => 60,
         'immutable'        => true,
         'last_modified'    => new \DateTime(),
         'etag'             => 'abcdef',


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->

Q | A
-- | --
Branch? | 5.4
Bug fix? | no
New feature? | yes
Deprecations? | no
Tickets | -
License | MIT
Doc PR | -

<!--EndFragment-->
</body>
</html>

This PR allow support for RFC5861.
Meaning you can now use stale_while_revalidate and stale_if_error
https://httpwg.org/specs/rfc5861.html

Very interesting doc from Fastly on the subject:
https://developer.fastly.com/learning/concepts/stale/



