### PR TITLE
[Doctrine] Update doctrine.rst

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -397,10 +397,10 @@ you can query the database directly:
 
 .. code-block:: terminal
 
-    $ php bin/console doctrine:query:sql 'SELECT * FROM product'
+    $ php bin/console dbal:run-sql 'SELECT * FROM product'
 
     # on Windows systems not using Powershell, run this command instead:
-    # php bin/console doctrine:query:sql "SELECT * FROM product"
+    # php bin/console dbal:run-sql "SELECT * FROM product"
 
 Take a look at the previous example in more detail:
 


### PR DESCRIPTION
Update deprecated command to new Doctrine 2.2 syntax
```
User Deprecated: Since doctrine/doctrine-bundle 2.2: The "Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunSqlDoctrineCommand" (doctrine:query:sql) is deprecated, use dbal:run-sql command instead.
```
