### PR TITLE
[Messenger] tidy MESSENGER_CONSUMER_NAME surrounds

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1504,7 +1504,7 @@ sentinel_master          String, if null or empty Sentinel      null
     There should never be more than one ``messenger:consume`` command running with the same
     combination of ``stream``, ``group`` and ``consumer``, or messages could end up being
     handled more than once. If you run multiple queue workers, ``consumer`` can be set to an
-    environment variable (like ``%env(MESSENGER_CONSUMER_NAME)%``) set by Supervisor
+    environment variable, like ``%env(MESSENGER_CONSUMER_NAME)%``, set by Supervisor
     (example below) or any other service used to manage the worker processes.
     In a container environment, the ``HOSTNAME`` can be used as the consumer name, since
     there is only one worker per container/host. If using Kubernetes to orchestrate the


### PR DESCRIPTION
I am an idiot. 

I have a 27" Mac so the docs renders max-width - looks like this:

<img width="816" alt="Screenshot 2022-01-30 at 01 29 44" src="https://user-images.githubusercontent.com/400092/151683246-a7f45a93-7fdc-4765-96e6-df948d2f2ebc.png">

When I see 

> can be set to an environment variable (like %env(MESSENGER_CONSUMER_NAME)%) set by Supervisor 

due to the way the page flow of this paragraph is (see screenshot), I copy and pasted `%env(MESSENGER_CONSUMER_NAME)%)` which obviously has a confusing, and not instantly spotted closing bracket. 

This PR simply removes the brackets in favour of commas, so that the next person doesnt waste 30 mins trying to work out why his env vars were not being replaced. 

take it or leave it, if you dont think the PR has merit, or if you agree Im an idiot, then no worries, it can be closed :) 

