### PR TITLE
[DependencyInjection] Fix YAML example in "Defining a Service Locator" section

### DIFF
--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -256,9 +256,10 @@ argument of type ``service_locator``:
         # config/services.yaml
         services:
             App\CommandBus:
-                arguments: !service_locator
-                    App\FooCommand: '@app.command_handler.foo'
-                    App\BarCommand: '@app.command_handler.bar'
+                arguments: 
+                  - !service_locator
+                      App\FooCommand: '@app.command_handler.foo'
+                      App\BarCommand: '@app.command_handler.bar'
 
     .. code-block:: xml
 


### PR DESCRIPTION
Using this example in `v5.3.13` gives this error:

```
Symfony\Component\DependencyInjection\Definition::setArguments(): Argument #1 ($arguments) must be of type array, Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument given, called in /project/vendor/symfony/dependency-injection/Loader/YamlFileLoader.php on line 527
```

I assume this is because `!service_locator` is the first constructor argument but it's passed as an array of constructor arguments, in which case the example is not right.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
