### PR TITLE
[4.4][UX] Removing extra links from rebasing

### DIFF
--- a/reference/forms/types/map.rst.inc
+++ b/reference/forms/types/map.rst.inc
@@ -41,9 +41,7 @@ Other Fields
 
 * :doc:`CheckboxType </reference/forms/types/checkbox>`
 * :doc:`FileType </reference/forms/types/file>`
-* `DropzoneType`_
 * :doc:`RadioType </reference/forms/types/radio>`
-* `CropperType`_ (to crop images with JavaScript)
 
 Symfony UX Fields
 ~~~~~~~~~~~~~~~~~
@@ -52,12 +50,6 @@ These types are part of the :doc:`Symfony UX initiative </frontend/ux>`:
 
 * `CropperType`_ (using Cropper.js)
 * `DropzoneType`_
-
-UID Fields
-~~~~~~~~~~
-
-* :doc:`UuidType </reference/forms/types/uuid>`
-* :doc:`UlidType </reference/forms/types/ulid>`
 
 Field Groups
 ~~~~~~~~~~~~


### PR DESCRIPTION
Hi!

I merged #16404 a bit too quickly. I had rebased that from 5.4 to 4.4, and when I did, I duplicated a few things that I should not have. This fixes that :).

Cheers!