### PR TITLE
[Messenger] Correct PHP Code block for messenger resetOnMessage

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -768,10 +768,7 @@ reset the service container between two messages:
         return static function (FrameworkConfig $framework) {
             $messenger = $framework->messenger();
 
-            $messenger->transport('async')
-                ->dsn('%env(MESSENGER_TRANSPORT_DSN)%')
-                ->resetOnMessage(true)
-            ;
+            $messenger->resetOnMessage(true);
         };
 
 .. versionadded:: 5.4


### PR DESCRIPTION
This PHP code was incorrect. See the yaml and the XML and compare with the PHP and you can see that (or waste 30 mins like I did debugging to work it out haha) 

the method needs to be called on the MessengerConfig object and not chained after a dsn call, which will just give an undefined method error. 