### PR TITLE
[Mailer] add Amazon SES to list of transports that support metadata

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1266,6 +1266,10 @@ The following transports only support tags:
 
 * OhMySMTP
 
+The following transports only support metadata:
+
+* Amazon SES
+
 Draft Emails
 ------------
 


### PR DESCRIPTION
Closes #16467.
