### PR TITLE
Update Twig links and change symfony/var-dumper package installation command

### DIFF
--- a/components/form.rst
+++ b/components/form.rst
@@ -784,4 +784,4 @@ Learn more
     /form/*
 
 .. _Twig: https://twig.symfony.com
-.. _`Twig Configuration`: https://twig.symfony.com/doc/2.x/intro.html
+.. _`Twig Configuration`: https://twig.symfony.com/doc/3.x/intro.html

--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -191,7 +191,7 @@ In addition, documentation follows these rules:
   * trivial
 
 .. _`the Sphinx documentation`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
-.. _`Twig Coding Standards`: https://twig.symfony.com/doc/2.x/coding_standards.html
+.. _`Twig Coding Standards`: https://twig.symfony.com/doc/3.x/coding_standards.html
 .. _`reserved by the IANA`: https://tools.ietf.org/html/rfc2606#section-3
 .. _`American English`: https://en.wikipedia.org/wiki/American_English
 .. _`American English Oxford Dictionary`: https://www.lexico.com/definition/american_english

--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -443,4 +443,4 @@ Variable                Usage
     variables a particular field has, find the source code for the form
     field (and its parent fields) and look at the above two functions.
 
-.. _`the Twig documentation`: https://twig.symfony.com/doc/2.x/templates.html#test-operator
+.. _`the Twig documentation`: https://twig.symfony.com/doc/3.x/templates.html#test-operator

--- a/form/form_themes.rst
+++ b/form/form_themes.rst
@@ -656,5 +656,5 @@ is a collection of fields (e.g. a whole form), and not just an individual field:
 .. _`Foundation CSS framework`: https://get.foundation/
 .. _`tailwind_2_layout.html.twig`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Twig/Resources/views/Form/tailwind_2_layout.html.twig
 .. _`Tailwind CSS form plugin`: https://tailwindcss-forms.vercel.app/
-.. _`Twig "use" tag`: https://twig.symfony.com/doc/2.x/tags/use.html
-.. _`Twig parent() function`: https://twig.symfony.com/doc/2.x/functions/parent.html
+.. _`Twig "use" tag`: https://twig.symfony.com/doc/3.x/tags/use.html
+.. _`Twig parent() function`: https://twig.symfony.com/doc/3.x/functions/parent.html

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -344,5 +344,5 @@ If set to ``true``, Symfony shows an exception whenever a Twig variable,
 attribute or method doesn't exist. If set to ``false`` these errors are ignored
 and the non-existing values are replaced by ``null``.
 
-.. _`the optimizer extension`: https://twig.symfony.com/doc/2.x/api.html#optimizer-extension
+.. _`the optimizer extension`: https://twig.symfony.com/doc/3.x/api.html#optimizer-extension
 .. _`XSS attacks`: https://en.wikipedia.org/wiki/Cross-site_scripting

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -1333,6 +1333,6 @@ Then, tag it with the ``validator.initializer`` tag (it has no options).
 For an example, see the ``DoctrineInitializer`` class inside the Doctrine
 Bridge.
 
-.. _`Twig's documentation`: https://twig.symfony.com/doc/2.x/advanced.html#creating-an-extension
-.. _`Twig Loader`: https://twig.symfony.com/doc/2.x/api.html#loaders
+.. _`Twig's documentation`: https://twig.symfony.com/doc/3.x/advanced.html#creating-an-extension
+.. _`Twig Loader`: https://twig.symfony.com/doc/3.x/api.html#loaders
 .. _`PHP class preloading`: https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.preload

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -669,4 +669,4 @@ The ``app`` variable is injected automatically by Symfony in all templates and
 provides access to lots of useful application information. Read more about the
 :ref:`Twig global app variable <twig-app-variable>`.
 
-.. _`default filters and functions defined by Twig`: https://twig.symfony.com/doc/2.x/#reference
+.. _`default filters and functions defined by Twig`: https://twig.symfony.com/doc/3.x/#reference

--- a/templates.rst
+++ b/templates.rst
@@ -707,7 +707,7 @@ First, make sure that the VarDumper component is installed in the application:
 
 .. code-block:: terminal
 
-    $ composer require symfony/var-dumper
+    $ composer require --dev symfony/var-dumper
 
 Then, use either the ``{% dump %}`` tag or the ``{{ dump() }}`` function
 depending on your needs:
@@ -1217,16 +1217,16 @@ Learn more
     /templating/*
 
 .. _`Twig`: https://twig.symfony.com
-.. _`tags`: https://twig.symfony.com/doc/2.x/tags/index.html
-.. _`filters`: https://twig.symfony.com/doc/2.x/filters/index.html
-.. _`functions`: https://twig.symfony.com/doc/2.x/functions/index.html
-.. _`with_context`: https://twig.symfony.com/doc/2.x/functions/include.html
-.. _`Twig template loader`: https://twig.symfony.com/doc/2.x/api.html#loaders
-.. _`Twig raw filter`: https://twig.symfony.com/doc/2.x/filters/raw.html
-.. _`Twig output escaping docs`: https://twig.symfony.com/doc/2.x/api.html#escaper-extension
+.. _`tags`: https://twig.symfony.com/doc/3.x/tags/index.html
+.. _`filters`: https://twig.symfony.com/doc/3.x/filters/index.html
+.. _`functions`: https://twig.symfony.com/doc/3.x/functions/index.html
+.. _`with_context`: https://twig.symfony.com/doc/3.x/functions/include.html
+.. _`Twig template loader`: https://twig.symfony.com/doc/3.x/api.html#loaders
+.. _`Twig raw filter`: https://twig.symfony.com/doc/3.x/filters/raw.html
+.. _`Twig output escaping docs`: https://twig.symfony.com/doc/3.x/api.html#escaper-extension
 .. _`snake case`: https://en.wikipedia.org/wiki/Snake_case
-.. _`Twig template inheritance`: https://twig.symfony.com/doc/2.x/tags/extends.html
-.. _`Twig block tag`: https://twig.symfony.com/doc/2.x/tags/block.html
+.. _`Twig template inheritance`: https://twig.symfony.com/doc/3.x/tags/extends.html
+.. _`Twig block tag`: https://twig.symfony.com/doc/3.x/tags/block.html
 .. _`Cross-Site Scripting`: https://en.wikipedia.org/wiki/Cross-site_scripting
 .. _`GitHub Actions`: https://docs.github.com/en/free-pro-team@latest/actions
 .. _`UX Twig Component`: https://symfony.com/bundles/ux-twig-component/current/index.html

--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -170,7 +170,7 @@ If you're using the default ``services.yaml`` configuration, this will already
 work! Otherwise, :ref:`create a service <service-container-creating-service>`
 for this class and :doc:`tag your service </service_container/tags>` with ``twig.runtime``.
 
-.. _`Twig Extensions`: https://twig.symfony.com/doc/2.x/advanced.html#creating-an-extension
-.. _`default Twig filters and functions`: https://twig.symfony.com/doc/2.x/#reference
+.. _`Twig Extensions`: https://twig.symfony.com/doc/3.x/advanced.html#creating-an-extension
+.. _`default Twig filters and functions`: https://twig.symfony.com/doc/3.x/#reference
 .. _`official Twig extensions`: https://github.com/twigphp?q=extra
-.. _`global variables`: https://twig.symfony.com/doc/2.x/advanced.html#id1
+.. _`global variables`: https://twig.symfony.com/doc/3.x/advanced.html#id1


### PR DESCRIPTION
Update Twig links from version 2 to 3
Change symfony/var-dumper package installation command in the development environment