### PR TITLE
Added option in Constraint class

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -43,6 +43,8 @@ First you need to create a Constraint class and extend :class:`Symfony\\Componen
         class ContainsAlphanumeric extends Constraint
         {
             public $message = 'The string "{{ string }}" contains an illegal character: it can only contain letters or numbers.';
+            //Option with default value
+            public $mode = 'strict';
         }
 
 Add ``@Annotation`` or ``#[\Attribute]`` to the constraint class if you want to


### PR DESCRIPTION
It's somewhat misleading if the option accessed in in the AcmeEntity class is not defined in the Constraint.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
