### PR TITLE
Update http_kernel_controller_resolver.rst

### DIFF
--- a/create_framework/http_kernel_controller_resolver.rst
+++ b/create_framework/http_kernel_controller_resolver.rst
@@ -78,7 +78,7 @@ resolver from HttpKernel::
     $controller = $controllerResolver->getController($request);
     $arguments = $argumentResolver->getArguments($request, $controller);
 
-    $response = call_user_func_array($controller, $arguments);
+    $response = call_user_func_array($controller, ...$arguments);
 
 .. note::
 
@@ -190,7 +190,7 @@ Let's conclude with the new version of our framework::
         $controller = $controllerResolver->getController($request);
         $arguments = $argumentResolver->getArguments($request, $controller);
 
-        $response = call_user_func_array($controller, $arguments);
+        $response = call_user_func_array($controller, ...$arguments);
     } catch (Routing\Exception\ResourceNotFoundException $exception) {
         $response = new Response('Not Found', 404);
     } catch (Exception $exception) {


### PR DESCRIPTION
I stumbled upon an exception:  Uncaught TypeError: LeapYearController::index(): Argument #1 ($year) must be of type int, array given, called in /var/www/web/front.php on line 32 and defined in /var/www/src/routes.php:10

And this makes sense: getArguments() returns indeed an array with the parameters for the Controller method. However, the index method in the LeapYearController (or in general any controller) does not expect an array but single variables.

`(new LeapYearController)->index(['year' => 2000]) `is wrong, and this is happening here when an array is passed into call_user_func(). 

Fix: use spread operator for array destructuring / unpacking to pass in array values as variables. This is on PHP8.1 btw.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
