### PR TITLE
Fixing some documentation inaccuacy

### DIFF
--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -672,10 +672,12 @@ and in XML:
 
 .. code-block:: xml
 
-    <twig:config>
-        <twig:extension>twig.extension.foo</twig:extension>
-        <twig:extension>twig.extension.bar</twig:extension>
-    </twig:config>
+    <container xmlns="http://symfony.com/schema/dic/services" xmlns:twig="http://symfony.com/schema/dic/twig" >
+        <twig:config>
+            <twig:extension>twig.extension.foo</twig:extension>
+            <twig:extension>twig.extension.bar</twig:extension>
+        </twig:config>
+    </container>
 
 This difference can be removed in normalization by pluralizing the key used
 in XML. You can specify that you want a key to be pluralized in this way

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -95,7 +95,7 @@ you need a ``Product`` object to represent those products.
 You can use the ``make:entity`` command to create this class and any fields you
 need. The command will ask you some questions - answer them like done below:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console make:entity
 
@@ -260,7 +260,7 @@ But what if you need to add a new field property to ``Product``, like a
 ``description``? You can edit the class to add the new property. But, you can
 also use ``make:entity`` again:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console make:entity
 

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -41,7 +41,7 @@ In this case, you'll need a ``Category`` class, and a way to relate a
 
 Start by creating a ``Category`` entity with a ``name`` field:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console make:entity Category
 
@@ -101,7 +101,7 @@ the ``ManyToOne`` annotation. You can do this by hand, or by using the ``make:en
 command, which will ask you several questions about your relationship. If you're
 not sure of the answer, don't worry! You can always change the settings later:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console make:entity
 

--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -354,7 +354,7 @@ array).
 
 .. code-block:: html+twig
 
-    <option {% if choice is selectedchoice(value) %}selected="selected"{% endif %}>
+    <option {% if choice == selectedchoice(value) %}selected="selected"{% endif %}>
 
 .. _form-twig-rootform:
 
@@ -374,7 +374,7 @@ This test will check if the current ``form`` does not have a parent form view.
 
    {# DO THIS: this check is always reliable, even if the form defines a field called 'parent' #}
 
-    {% if form is rootform %}
+    {% if form == rootform %}
         {{ form_errors(form) }}
     {% endif %}
 
@@ -394,7 +394,7 @@ reference the variables on the ``name`` field, accessing the variables is
 done by using a public ``vars`` property on the
 :class:`Symfony\\Component\\Form\\FormView` object:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     <label for="{{ form.name.vars.id }}"
         class="{{ form.name.vars.required ? 'required' }}">


### PR DESCRIPTION
I am currently building a documentation validator [here](https://github.com/mamazu/documentation-parser) and using Symfony as one of the projects to test it on.

My changes include:
* changing the block types of bash to terminal since the code contained is not valid bash script
* replacing the `is` keyword in twig with == signs, alternatively `a is same as(b)` check
* adding prefix to the xml block to have the xml namespace `twig` defined.

More stuff that I found but I don't know if it worth fixing:
Some xml files have a comment of the filename before the opening xml tag. Which is not correct by the specification (and the PHP XML parser).
eg.
```xml
<!-- phpunit.xml.dist -->
<?xml version="1.0" encoding="UTF-8" ?>
<phpunit></phpunit>
```

Should this be moved as well?