### PR TITLE
[Form] Update choice_loader.rst.inc

### DIFF
--- a/reference/forms/types/options/choice_loader.rst.inc
+++ b/reference/forms/types/options/choice_loader.rst.inc
@@ -42,9 +42,9 @@ better performance::
 
     class ConstantsType extends AbstractType
     {
-        public static function getExtendedTypes(): iterable
+        public function getParent(): string
         {
-            return [ChoiceType::class];
+            return ChoiceType::class;
         }
 
         public function configureOptions(OptionsResolver $resolver)


### PR DESCRIPTION
Hello, 
I think it is better to extend the class `ConstantsType` from the `Form\AbstractTypeExtension` instead. As we're using the function `getExtendedTypes` i think it might be better. This method is available in the `AbstractTypeExtension`  class and not in the `AbstractType` class. I might be wrong but here we're about to create a type extension from the ChoiceType.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
