### PR TITLE
[Form] Update create_form_type_extension.rst

### DIFF
--- a/form/create_form_type_extension.rst
+++ b/form/create_form_type_extension.rst
@@ -192,7 +192,7 @@ Specifically, you need to override the ``file_widget`` block:
 
     {% block file_widget %}
         {{ block('form_widget') }}
-        {% if image_url is not null %}
+        {% if image_url is defined and image_url is not null %}
             <img src="{{ asset(image_url) }}"/>
         {% endif %}
     {% endblock %}


### PR DESCRIPTION
Hello,
I think the condition `image_url is not null` is not enough as if we create a FileType form field without the `image_property` it causes an error. Adding `image_url is defined` is necessary  because the variable `image_url` is only defined and passed to the view when `image_property` is already defined.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
