### PR TITLE
[Translation] Remove reference to PHP Templates in translation

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -437,16 +437,6 @@ The ``trans`` filter can be used to translate *variable texts* and complex expre
     Note that this only influences the current template, not any "included"
     template (in order to avoid side effects).
 
-PHP Templates
-~~~~~~~~~~~~~
-
-The translator service is accessible in PHP templates through the
-``translator`` helper:
-
-.. code-block:: html+php
-
-    <?= $view['translator']->trans('Symfony is great') ?>
-
 Forcing the Translator Locale
 -----------------------------
 


### PR DESCRIPTION
In the documentation there was a reference to the old PHP Templates.
This might be confusing to new users that do not know this was removed in newer versions
