### PR TITLE
Explain the annotations.reader service

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -1197,6 +1197,12 @@ If you want to pass the second, you'll need to :ref:`manually wire the service <
     and the automatically loaded service will be passed - by default - when you type-hint
     ``SiteUpdateManager``. That's why creating the alias is a good idea.
 
+Caveats
+-------
+
+The service ``annotations.reader`` is available only if you have installed the
+``doctrine/annotations`` package with Composer.
+
 Learn more
 ----------
 


### PR DESCRIPTION
I had the following error:

> Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: The service "Liip\TestFixturesBundle\Services\DatabaseToolCollection" has a dependency on a non-existent service "annotations.reader".

It appeared after `doctrine/annotations` wasn't a dependency of `doctrine/persistence` anymore: https://github.com/doctrine/persistence/pull/197#issuecomment-1025863820

I didn't know where to put this note about `annotations.reader` but I think it should be explained in the documentation.