### PR TITLE
[Workflow] Workflow - Add a note about guards events and ability to save some CPU

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -509,6 +509,16 @@ missing a title::
 
     The optional second argument of ``setBlocked()`` was introduced in Symfony 5.1.
 
+.. note::
+
+    When using guard listeners which imply intensive workloads (CPU, Database
+    or longer-running code blocks), if you only want them to be fired when strictly
+    necessary (only when ``Workflow::can()`` or ``Workflow::apply()`` is executed),
+    be sure to disable ``Workflow::DISABLE_ANNOUNCE_EVENT`` as indicated in
+    :ref:`Choosing which Events to Dispatch <workflow-chosing-events-to-dispatch>`
+
+.. _workflow-chosing-events-to-dispatch:
+
 Choosing which Events to Dispatch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
As a follow up of https://github.com/symfony/symfony/issues/45172, I'm adding a note mentioning ability to disable announce events to lower calls in guard events.

Had to add a reference to next paragraph in case it would move elsewhere 🙂

This is my first doc PR so don't hesitate to guide me 🙂

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
