### PR TITLE
[Cache] Use `path` instead of `url` in SSI documentation

### DIFF
--- a/http_cache/ssi.rst
+++ b/http_cache/ssi.rst
@@ -22,7 +22,7 @@ The SSI instructions are done via HTML comments:
             <!-- ... some content -->
 
             <!-- Embed the content of another page here -->
-            <!--#include virtual="http://..." -->
+            <!--#include virtual="/..." -->
 
             <!-- ... more content -->
         </body>
@@ -117,8 +117,8 @@ The profile index page has not public caching, but the GDPR block has
     {# you can use a controller reference #}
     {{ render_ssi(controller('App\\Controller\\ProfileController::gdpr')) }}
 
-    {# ... or a URL #}
-    {{ render_ssi(url('profile_gdpr')) }}
+    {# ... or a path #}
+    {{ render_ssi(path('profile_gdpr')) }}
 
 The ``render_ssi`` twig helper will generate something like:
 


### PR DESCRIPTION
By using `url` SSI tags will include the host which is likely to not work as, unlike ESI, SSI is meant to be used at the webserver level which most of the time only handles SSI as paths.