### PR TITLE
[Doctrine] Recommend a better charset for MySQL

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -62,7 +62,7 @@ The following block shows all possible configuration keys:
                 unix_socket:          /tmp/mysql.sock
                 # the DBAL wrapperClass option
                 wrapper_class:        App\DBAL\MyConnectionWrapper
-                charset:              UTF8
+                charset:              utf8mb4
                 logging:              '%kernel.debug%'
                 platform_service:     App\DBAL\MyDatabasePlatformService
                 server_version:       '5.7'
@@ -96,7 +96,7 @@ The following block shows all possible configuration keys:
                     memory="true"
                     unix-socket="/tmp/mysql.sock"
                     wrapper-class="App\DBAL\MyConnectionWrapper"
-                    charset="UTF8"
+                    charset="utf8mb4"
                     logging="%kernel.debug%"
                     platform-service="App\DBAL\MyDatabasePlatformService"
                     server-version="5.7">


### PR DESCRIPTION
UTF8 is meant to be used when using PostgreSQL, and the example is
mainly about MySQL.

In the case of MySQL, utf8 is a deprecated charset and should not be
used.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
