### PR TITLE
[Messenger] Fix broken link to DoctrineReceiver in Messenger in 6.0

### DIFF
--- a/messenger/custom-transport.rst
+++ b/messenger/custom-transport.rst
@@ -127,7 +127,7 @@ Here is a simplified example of a database transport::
 The implementation above is not runnable code but illustrates how a
 :class:`Symfony\\Component\\Messenger\\Transport\\TransportInterface` could
 be implemented. For real implementations see :class:`Symfony\\Component\\Messenger\\Transport\\InMemoryTransport`
-and :class:`Symfony\\Component\\Messenger\\Transport\\Doctrine\\DoctrineReceiver`.
+and :class:`Symfony\\Component\\Messenger\\Bridge\\Doctrine\\Transport\\DoctrineReceiver`.
 
 Register your Factory
 ---------------------


### PR DESCRIPTION
Came across a broken link to the `DoctrineReceiver` class when building my Azure transport.
EDIT: Oops, renamed the branch ! Here is the actual PR: https://github.com/symfony/symfony-docs/pull/16520