### PR TITLE
Encore : firewall replace with allowedHosts

### DIFF
--- a/frontend/encore/virtual-machine.rst
+++ b/frontend/encore/virtual-machine.rst
@@ -96,7 +96,7 @@ Fix "Invalid Host header" Issue
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Webpack will respond ``Invalid Host header`` when trying to access files from
-the dev-server. To fix this, set the ``firewall`` option:
+the dev-server. To fix this, set the ``allowedHosts`` option:
 
 .. code-block:: javascript
 
@@ -107,16 +107,15 @@ the dev-server. To fix this, set the ``firewall`` option:
         // ...
 
         .configureDevServerOptions(options => {
-            options.firewall = false;
+            options.allowedHosts = all;
         })
 
 .. caution::
 
-    Beware that `it's not recommended to disable the firewall`_ in general, but
-    here it's required to solve the issue when using Encore in a virtual machine.
+    Beware that `it's not recommended to set allowedHosts to all`_. Read the dedicated doc to select the value for your environment.
 
 .. _`VirtualBox`: https://www.virtualbox.org/
 .. _`VMWare`: https://www.vmware.com
 .. _`NFS`: https://en.wikipedia.org/wiki/Network_File_System
 .. _`polling`: https://webpack.js.org/configuration/watch/#watchoptionspoll
-.. _`it's not recommended to disable the firewall`: https://webpack.js.org/configuration/dev-server/#devserverdisablehostcheck
+.. _`it's not recommended to set allowedHosts to all`: https://webpack.js.org/configuration/dev-server/#devserverallowedhosts


### PR DESCRIPTION
The firewall option was removed since webpack-dev-server V4.0.0 and replace with allowedHosts.  
https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#bug-fixes-15