### PR TITLE
Update _ux-libraries.rst.inc

### DIFF
--- a/frontend/_ux-libraries.rst.inc
+++ b/frontend/_ux-libraries.rst.inc
@@ -1,18 +1,18 @@
 * `ux-turbo`_: Integration with `Turbo Drive`_ for a single-page-app experience
 * `ux-live-component`_: Build Dynamic Interfaces with Zero JavaScript
 * `ux-twig-component`_: Build Twig Components Backed by a PHP Class
+* `ux-swup`_: Integration with Swup
 * `ux-chartjs`_: Easy charts with Chart.js
 * `ux-lazy-image`_: Optimize Image Loading with BlurHash
 * `ux-cropperjs`_: Form Type and tools for cropping images
 * `ux-dropzone`_: Form type for stylized "drop zone" for file uploads
-* `ux-swup`_: Integration with Swup
 
 .. _`ux-turbo`: https://symfony.com/bundles/ux-turbo/current/index.html
 .. _`ux-live-component`: https://symfony.com/bundles/ux-live-component/current/index.html
 .. _`ux-twig-component`: https://symfony.com/bundles/ux-twig-component/current/index.html
+.. _`ux-swup`: https://symfony.com/bundles/ux-swup/current/index.html
 .. _`ux-chartjs`: https://symfony.com/bundles/ux-chartjs/current/index.html
 .. _`ux-lazy-image`: https://symfony.com/bundles/ux-lazy-image/current/index.html
 .. _`ux-cropperjs`: https://symfony.com/bundles/ux-cropperjs/current/index.html
 .. _`ux-dropzone`: https://symfony.com/bundles/ux-dropzone/current/index.html
-.. _`ux-swup`: https://symfony.com/bundles/ux-swup/current/index.html
 .. _`Turbo Drive`: https://turbo.hotwired.dev/


### PR DESCRIPTION
I was reading some doc on twig/live component and arrived on this page,
As it seems they are not alpha ordered, for me the Swup integration could be defined upper as it is a more global lib than the chart or dropzone