### PR TITLE
[Filesystem] Update filesystem.rst

### DIFF
--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -438,15 +438,13 @@ Especially when storing many paths, the amount of duplicated information is
 noticeable. You can use :method:`Symfony\\Component\\Filesystem\\Path::getLongestCommonBasePath`
 to check a list of paths for a common base path::
 
-    $paths = [
+    Path::getLongestCommonBasePath(
         '/var/www/vhosts/project/httpdocs/config/config.yaml',
         '/var/www/vhosts/project/httpdocs/config/routing.yaml',
         '/var/www/vhosts/project/httpdocs/config/services.yaml',
         '/var/www/vhosts/project/httpdocs/images/banana.gif',
-        '/var/www/vhosts/project/httpdocs/uploads/images/nicer-banana.gif',
-    ];
-
-    Path::getLongestCommonBasePath($paths);
+        '/var/www/vhosts/project/httpdocs/uploads/images/nicer-banana.gif'
+    );
     // => /var/www/vhosts/project/httpdocs
 
 Use this path together with :method:`Symfony\\Component\\Filesystem\\Path::makeRelative`


### PR DESCRIPTION
Hello, 

According to the `getLongestCommonBasePath` signature, the method accepts a variadic string parameter $paths and not an array. It means when calling the `Path::getLongestCommonBasePath` with an array, a `TypeError` occurs. 
I think even the PHPDoc of the `Path::getLongestCommonBasePath` should be updated too as it is mentionned that it can accept an array argument.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
