### PR TITLE
Remove :orphan: as it's not used anymore

### DIFF
--- a/bundles/index.rst
+++ b/bundles/index.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 Bundles
 =======
 

--- a/components/filesystem/lock_handler.rst
+++ b/components/filesystem/lock_handler.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 LockHandler
 ===========
 


### PR DESCRIPTION
The `:orphan:` directive is not supported by the new ReST parser, so it is displayed in the page:

![image](https://user-images.githubusercontent.com/47313/154976077-bae28d20-df13-4efe-a041-6480eddd5367.png)

Let's remove it.
