### PR TITLE
[Messenger] fix(middleware): DoctrineBridge middleware

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1647,7 +1647,7 @@ Middleware for Doctrine
 
 .. versionadded:: 1.11
 
-    The following Doctrine middleware was introduced in DoctrineBundle 1.11.
+    The following Doctrine middleware was introduced in DoctrineBridge 1.11.
 
 If you use Doctrine in your app, a number of optional middleware exist that you
 may want to use:


### PR DESCRIPTION
Hi 👋🏻 

It seems that the documentation mention the DoctrineBundle which is not in charge of adding middleware as they're defined in the bridge: https://github.com/symfony/symfony/tree/6.1/src/Symfony/Bridge/Doctrine/Messenger

Thanks for the feedback and have a great day 🙂 