### PR TITLE
Document code-style for enums and class constants

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -210,8 +210,12 @@ Naming Conventions
 * Use `snake_case`_ for configuration parameters and Twig template variables
   (e.g. ``framework.csrf_protection``, ``http_status_code``);
 
-* Use namespaces for all PHP classes and `UpperCamelCase`_ for their names (e.g.
-  ``ConsoleLogger``);
+* Use `SCREAMING_SNAKE_CASE`_ for constants (e.g. ``InputArgument::IS_ARRAY``);
+
+* Use `UpperCamelCase`_ for enumeration cases (e.g. ``InputArgumentMode::IsArray``);
+
+* Use namespaces for all PHP classes, interfaces, traits and enums and
+  `UpperCamelCase`_ for their names (e.g. ``ConsoleLogger``);
 
 * Prefix all abstract classes with ``Abstract`` except PHPUnit ``*TestCase``.
   Please note some early Symfony classes do not follow this convention and
@@ -221,6 +225,9 @@ Naming Conventions
 * Suffix interfaces with ``Interface``;
 
 * Suffix traits with ``Trait``;
+
+* Don't use a dedicated suffix for classes or enumerations (e.g. like ``Class``
+  or ``Enum``), except for the cases listed below.
 
 * Suffix exceptions with ``Exception``;
 


### PR DESCRIPTION
This PR adds some naming conventions.

First of all, class constants. We seem to have an unwritten rule on how class constants should be named. I've made that rule explicit.

Secondly, it adds enumerations to the mix. Those are a new language element introduced in PHP 8.1. Our codebase does not have any enums yet (apart from test fixtures), so I think we should discuss the options before the first PR adding an enum to Symfony's public API arrives.

I took inspiration from the example code from the [RFC](https://wiki.php.net/rfc/enumerations). The most complete example is probably this one:

```php
enum UserStatus: string
{
  case Pending = 'P';
  case Active = 'A';
  case Suspended = 'S';
  case CanceledByUser = 'C';
}
```

I propose to adopt the naming conventions used by the RFC because they seem reasonable to me.

Fixes #16538, symfony/symfony#45516.