### PR TITLE
Allowmin PHP req to change for a minor Symfony version

### DIFF
--- a/contributing/community/releases.rst
+++ b/contributing/community/releases.rst
@@ -104,7 +104,7 @@ deprecated features, which your project no longer uses).
 PHP Compatibility
 -----------------
 
-The **minimum** PHP version is decided for each major Symfony version by consensus
+The **minimum** PHP version is decided for each **major** Symfony version by consensus
 amongst the :doc:`core team </contributing/code/core_team>` and documented as
 part of the :ref:`technical requirements for running Symfony applications
 <symfony-tech-requirements>`.
@@ -116,6 +116,12 @@ one that is publicly available.
 
 For out-of-support releases of Symfony, the latest PHP version at time of EOL is the last
 supported PHP version. Newer versions of PHP may or may not function.
+
+.. note::
+
+    By exception to the rule, bumping the minimum **minor** version of PHP is
+    possible for a **minor** Symfony version when this helps fix important
+    issues.
 
 Rationale
 ---------

--- a/setup.rst
+++ b/setup.rst
@@ -21,9 +21,6 @@ Before creating your first Symfony application you must:
   enabled by default in most PHP 7 installations): `Ctype`_, `iconv`_, `JSON`_,
   `PCRE`_, `Session`_, `SimpleXML`_, and `Tokenizer`_;
 
-  * Note that all newer, released versions of PHP will be supported during the
-    lifetime of each Symfony release (including new major versions).
-    For example, PHP 8.0 is supported.
 * `Install Composer`_, which is used to install PHP packages.
 
 Optionally, you can also `install Symfony CLI`_. This creates a binary called


### PR DESCRIPTION
Clarify our policy about bumping the PHP minimum requirement on a Symfony minor version.
