### PR TITLE
Add additional number examples due to changes in ExpressionLanguage for 6.1

### DIFF
--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -14,7 +14,7 @@ Supported Literals
 The component supports:
 
 * **strings** - single and double quotes (e.g. ``'hello'``)
-* **numbers** - e.g. ``103``
+* **numbers** - e.g. ``103``, ``0.787``, ``.1234``, ``188_165.1_178``, ``-.7_189e+10```
 * **arrays** - using JSON-like notation (e.g. ``[1, 2]``)
 * **hashes** - using JSON-like notation (e.g. ``{ foo: 'bar' }``)
 * **booleans** - ``true`` and ``false``


### PR DESCRIPTION
Added other number examples related to https://github.com/symfony/symfony/pull/44073.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
