### PR TITLE
[Security] Update firewall_restriction.rst

### DIFF
--- a/security/firewall_restriction.rst
+++ b/security/firewall_restriction.rst
@@ -215,7 +215,7 @@ If the above options don't fit your needs you can configure any service implemen
         security:
             firewalls:
                 secured_area:
-                    request_matcher: app.firewall.secured_area.request_matcher
+                    request_matcher: App\Security\CustomRequestMatcher
                     # ...
 
     .. code-block:: xml


### PR DESCRIPTION
hello, 

i may suggest this correction: 

the correction assumes the the custom request matcher is **App\Security\CustomRequestMatcher**.

the `request_matcher` option is the service id. it should be mentionned before that  the `app.firewall.secured_area.request_matcher` is the service ID / or an alias like the following : 

```
     app.firewall.secured_area.request_matcher:
        alias: App\Security\RequestMatcher
```

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
