### PR TITLE
Remove reference to obsolete Psr7ServerRequestResolver

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -64,11 +64,6 @@ In addition, some components and official bundles provide other value resolvers:
     The ``SecurityUserValueResolver`` was deprecated in Symfony 4.1 in favor of
     :class:`Symfony\\Component\\Security\\Http\\Controller\\UserValueResolver`.
 
-``Psr7ServerRequestResolver``
-    Injects a `PSR-7`_ compliant version of the current request if type-hinted
-    with ``RequestInterface``, ``MessageInterface`` or ``ServerRequestInterface``.
-    It requires installing the `SensioFrameworkExtraBundle`_.
-
 Adding a Custom Value Resolver
 ------------------------------
 
@@ -266,5 +261,3 @@ passing the user along sub-requests).
 .. _`@ParamConverter`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
 .. _`yield`: https://www.php.net/manual/en/language.generators.syntax.php
 .. _`SecurityBundle`: https://github.com/symfony/security-bundle
-.. _`PSR-7`: https://www.php-fig.org/psr/psr-7/
-.. _`SensioFrameworkExtraBundle`: https://github.com/sensiolabs/SensioFrameworkExtraBundle


### PR DESCRIPTION
The Psr7ServerRequestResolver has been removed in a previous version of SensioFrameworkExtraBundle so remove the reference from the docs.

If a better solution for now would be to add a notice like: "has been removed in version x of SensioFrameworkExtraBundle", let me know and I can change it.