### PR TITLE
[Encore] Fix webpack-dev-server documentation

### DIFF
--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -54,6 +54,7 @@ method in your ``webpack.config.js`` file:
         // ...
 
         .configureDevServerOptions(options => {
+            options.http2 = true;
             options.https = {
                 key: '/path/to/server.key',
                 cert: '/path/to/server.crt',
@@ -77,13 +78,15 @@ server SSL certificate:
       // webpack.config.js
       // ...
     + const path = require('path');
+    + const fs = require('fs');
 
       Encore
           // ...
 
     +     .configureDevServerOptions(options => {
+    +         options.http2 = true;
     +         options.https = {
-    +             pfx: path.join(process.env.HOME, '.symfony/certs/default.p12'),
+    +             pfx: fs.readFileSync(path.join(process.env.HOME, '.symfony/certs/default.p12')),
     +         }
     +     })
 


### PR DESCRIPTION
This addresses an error you get with `webpack-dev-server` where the `pfx` option actually needs a file stream to be able to work (and not just the file path). With the current example, it throws an error. The addition of the `http2` option is so that we stick better to `webpack`'s documentation (https://webpack.js.org/configuration/dev-server/#devserverhttp2) where config samples often pair `http2=true` with other `https` stuff.

This affects doc starting from 5.4 up. The documentation for 4.4 is different and may be using an older version of `webpack-dev-server` (but I haven't tested this in a real world scenario).