### PR TITLE
[FrameworkBundle] Change exceptions title level

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3476,7 +3476,7 @@ a normal workflow or a state machine. Read :doc:`this article </workflow/workflo
 to know their differences.
 
 exceptions
-""""""""""
+~~~~~~~~~~
 
 **type**: ``array``
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
On [this page](https://symfony.com/doc/5.4/reference/configuration/framework.html#exceptions), `exceptions` is a top level configuration option so it should have a higher title level and appear in the table of content.

To my understanding, this should fix it