### PR TITLE
[Serializer] Add information about DateTimeValueResolver

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -59,6 +59,15 @@ Symfony ships with the following value resolvers in the
 :class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolver\\RequestAttributeValueResolver`
     Attempts to find a request attribute that matches the name of the argument.
 
+:class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolver\\DateTimeValueResolver`
+    Attempts to find a request attribute that matches the name of the argument
+    and injects a ``DateTimeInterface`` object if type-hinted with a class
+    extending ``DateTimeInterface``.
+
+    By default any input that can be parsed as a date string by PHP is accepted.
+    You can restrict how the input can be formatted with the
+    :class:`Symfony\\Component\\HttpKernel\\Attribute\\MapDateTime` attribute.
+
 :class:`Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolver\\RequestValueResolver`
     Injects the current ``Request`` if type-hinted with ``Request`` or a class
     extending ``Request``.


### PR DESCRIPTION
Adds documentation for symfony/symfony#45589.

I think it would be a good idea to explain how to use the `MapDateTime` attribute, but I opted to keep it brief.
