### PR TITLE
[DependencyInjection] docs : update autowiring.rst

### DIFF
--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -464,6 +464,7 @@ the injection::
 
                 # If you wanted to choose the non-default service and do not
                 # want to use a named autowiring alias, wire it manually:
+                # arguments:
                 #     $transformer: '@App\Util\UppercaseTransformer'
                 # ...
 


### PR DESCRIPTION
Add missing `arguments` key in `services.yaml` code block example - [#dealing-with-multiple-implementations-of-the-same-type](https://symfony.com/doc/4.4/service_container/autowiring.html#dealing-with-multiple-implementations-of-the-same-type) section.
