### PR TITLE
Fix typo in traditional web application command

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -64,7 +64,7 @@ Symfony application using Composer:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ composer create-project symfony/skeleton my_project_directory
+    $ composer create-project symfony/website-skeleton my_project_directory
     $ cd my_project_directory
     $ composer require webapp
 


### PR DESCRIPTION
There is a missing in the traditional web application composer command.

Change: composer create-project symfony/skeleton my_project_directory
To: composer create-project symfony/website-skeleton my_project_directory

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
