### PR TITLE
Simplify configuration env var example

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -495,7 +495,7 @@ This example shows how you could configure the database connection using an env 
         doctrine:
             dbal:
                 # by convention the env var names are always uppercase
-                url: '%env(resolve:DATABASE_URL)%'
+                url: '%env(DATABASE_URL)%'
             # ...
 
     .. code-block:: xml

--- a/configuration.rst
+++ b/configuration.rst
@@ -485,48 +485,44 @@ You can reference environment variables using the special syntax
 ``%env(ENV_VAR_NAME)%``. The values of these options are resolved at runtime
 (only once per request, to not impact performance).
 
-This example shows how you could configure the database connection using an env var:
+This example shows how you could configure the application secret using an env var:
 
 .. configuration-block::
 
     .. code-block:: yaml
 
-        # config/packages/doctrine.yaml
-        doctrine:
-            dbal:
-                # by convention the env var names are always uppercase
-                url: '%env(DATABASE_URL)%'
+        # config/packages/framework.yaml
+        framework:
+            # by convention the env var names are always uppercase
+            secret: '%env(APP_SECRET)%'
             # ...
 
     .. code-block:: xml
 
-        <!-- config/packages/doctrine.xml -->
+        <!-- config/packages/framework.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
             xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/doctrine
-                https://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+                https://symfony.com/schema/dic/services/services-1.0.xsd>
 
-            <doctrine:config>
+            <framework:config>
                 <!-- by convention the env var names are always uppercase -->
-                <doctrine:dbal url="%env(resolve:DATABASE_URL)%"/>
-            </doctrine:config>
+                <framework:secret url="%env(APP_SECRET)%"/>
+            </framework:config>
 
         </container>
 
     .. code-block:: php
 
-        // config/packages/doctrine.php
+        // config/packages/framework.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
         return static function (ContainerConfigurator $container) {
-            $container->extension('doctrine', [
-                'dbal' => [
+            $container->extension('framework', [
+                'secret' => [
                     // by convention the env var names are always uppercase
-                    'url' => '%env(resolve:DATABASE_URL)%',
+                    'url' => '%env(APP_SECRET)%',
                 ],
             ]);
         };

--- a/configuration.rst
+++ b/configuration.rst
@@ -506,10 +506,7 @@ This example shows how you could configure the application secret using an env v
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd>
 
-            <framework:config>
-                <!-- by convention the env var names are always uppercase -->
-                <framework:secret url="%env(APP_SECRET)%"/>
-            </framework:config>
+            <framework:config secret="%env(APP_SECRET)%"/>
 
         </container>
 
@@ -522,7 +519,7 @@ This example shows how you could configure the application secret using an env v
             $container->extension('framework', [
                 'secret' => [
                     // by convention the env var names are always uppercase
-                    'url' => '%env(APP_SECRET)%',
+                    'secret' => '%env(APP_SECRET)%',
                 ],
             ]);
         };

--- a/configuration.rst
+++ b/configuration.rst
@@ -503,8 +503,9 @@ This example shows how you could configure the application secret using an env v
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony
             xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd>
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd>
 
             <framework:config secret="%env(APP_SECRET)%"/>
 


### PR DESCRIPTION
Simplify here as the `resolve` is not needed, as reference it is documented in the dedicated doc page here
https://symfony.com/doc/current/configuration/env_var_processors.html