### PR TITLE
[DependencyInjection] Update configurators.rst

### DIFF
--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -181,10 +181,10 @@ all the classes are already loaded as services. All you need to do is specify th
             // override the services to set the configurator
             // In versions earlier to Symfony 5.1 the service() function was called ref()
             $services->set(NewsletterManager::class)
-                ->configurator(service(EmailConfigurator::class), 'configure');
+                ->configurator([service(EmailConfigurator::class), 'configure']);
 
             $services->set(GreetingCardManager::class)
-                ->configurator(service(EmailConfigurator::class), 'configure');
+                ->configurator([service(EmailConfigurator::class), 'configure']);
         };
 
 .. _configurators-invokable:


### PR DESCRIPTION
The first configuration example (PHP) at https://symfony.com/doc/current/service_container/configurators.html#using-the-configurator will never work because ConfiguratorTrait::configurator(string|array|ReferenceConfigurator $configurator) expect only one parameter. Configurator will try to call special __invoke() (which is probably undefined at this point) method while the user expects to call configure() method. We must provide an array in this case.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
