### PR TITLE
Add quotations marks

### DIFF
--- a/doctrine/reverse_engineering.rst
+++ b/doctrine/reverse_engineering.rst
@@ -103,7 +103,7 @@ run:
     $ php bin/console make:entity --regenerate App
 
     // generates getter/setter methods for one specific Entity
-    $ php bin/console make:entity --regenerate App\Entity\Country
+    $ php bin/console make:entity --regenerate "App\Entity\Country"
 
 .. note::
 


### PR DESCRIPTION
Add quotations marks in generates getter/setter methods for one specific Entity example, current example command return "[ERROR] No entities were found in the "AppEntityAdwordsCountry" namespace."

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
