### PR TITLE
Update alias_private.rst

### DIFF
--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -342,7 +342,10 @@ or you decided not to maintain it anymore), you can deprecate its definition:
 
         # config/services.yaml
         App\Service\OldService:
-            deprecated: The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.
+            deprecated: 
+                package: 'vendor-name/package-name'
+                version: 2.8
+                message: 'The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.'
 
     .. code-block:: xml
 
@@ -354,7 +357,9 @@ or you decided not to maintain it anymore), you can deprecate its definition:
 
             <services>
                 <service id="App\Service\OldService">
-                    <deprecated>The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.</deprecated>
+                    <deprecated package="acme/package" version="1.2">
+                        The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.
+                    </deprecated>
                 </service>
             </services>
         </container>
@@ -370,7 +375,11 @@ or you decided not to maintain it anymore), you can deprecate its definition:
             $services = $configurator->services();
 
             $services->set(OldService::class)
-                ->deprecate('The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.');
+                ->deprecate(
+                    'vendor-name/package-name',
+                    '2.8',
+                    'The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.'
+                );
         };
 
 Now, every time this service is used, a deprecation warning is triggered,


### PR DESCRIPTION
Hello, 

I think even when using the Service ID, the `package` and `version` options are mendatory because when using `deprecated: XXX` a message error is shown informing that the attribute "package"/"version" of the "deprecated" option is missing

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
