### PR TITLE
[Routing] doc for env() function in route condition

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -414,6 +414,11 @@ and can use any of these variables created by Symfony:
     The :ref:`Symfony Request <component-http-foundation-request>` object that
     represents the current request.
 
+Additionnal functions are provided:
+
+``env(string $name)``
+    Read a variable using :doc:`Environment Variable Processors <configuration/env_var_processors>`
+
 Behind the scenes, expressions are compiled down to raw PHP. Because of this,
 using the ``condition`` key causes no extra overhead beyond the time it takes
 for the underlying PHP to execute.


### PR DESCRIPTION
Fix #13247 for symfony/symfony#35747

Very useful to match host based on env var.

```yaml
blog_list:
    path: /blog
    # the controller value has the format 'controller_class::method_name'
    controller: App\Controller\BlogController::list
    condition: "context.getHost() == env('APP_MAIN_HOST')"
```