### PR TITLE
Add hint how to debug argument resolver order

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -242,6 +242,13 @@ Otherwise, set a priority lower than ``100`` to make sure the argument resolver
 is not triggered when the ``Request`` attribute is present (for example, when
 passing the user along sub-requests).
 
+To ensure your resolvers are added in the right position you can run the following
+command to see which argument resolvers are present and in which order they run.
+
+.. code-block:: terminal
+    
+    $ php bin/console debug:container debug.argument_resolver.inner --show-arguments
+
 .. tip::
 
     As you can see in the ``UserValueResolver::supports()`` method, the user


### PR DESCRIPTION
I guess having a specific command for debugging those would be even better, but this does the job fairly ok:

```
bin/console debug:container debug.argument_resolver.inner --show-arguments

Information for Service "debug.argument_resolver.inner"
=======================================================

 Responsible for resolving the arguments passed to an action.

 ---------------- ----------------------------------------------------------
  Option           Value
 ---------------- ----------------------------------------------------------
  Service ID       debug.argument_resolver.inner
  Class            Symfony\Component\HttpKernel\Controller\ArgumentResolver
  Tags             -
  Public           no
  Synthetic        no
  Lazy             no
  Shared           yes
  Abstract         no
  Autowired        no
  Autoconfigured   no
  Arguments        Service(argument_metadata_factory)
                   Iterator (10 element(s))
                   - Service(debug.App\ArgumentResolver\PackageResolver)
                   - Service(debug.App\ArgumentResolver\UserResolver)
                   - Service(debug.argument_resolver.request_attribute)
                   - Service(debug.argument_resolver.request)
                   - Service(debug.argument_resolver.session)
                   - Service(debug.security.user_value_resolver)
                   - Service(debug.argument_resolver.service)
                   - Service(debug.argument_resolver.default)
                   - Service(debug.argument_resolver.variadic)
                   - Service(debug.argument_resolver.not_tagged_controller)
 ---------------- ----------------------------------------------------------


 ! [NOTE] The "debug.argument_resolver.inner" service or alias has been removed or inlined when the container was
 !        compiled.
```