### PR TITLE
[Security] Add hint about #[CurrentUser] to the argument_value_resolver page

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -49,9 +49,10 @@ In addition, some components and official bundles provide other value resolvers:
 
 :class:`Symfony\\Component\\Security\\Http\\Controller\\UserValueResolver`
     Injects the object that represents the current logged in user if type-hinted
-    with ``UserInterface``. Default value can be set to ``null`` in case
-    the controller can be accessed by anonymous users. It requires installing
-    the :doc:`SecurityBundle </security>`.
+    with ``UserInterface``. You can also type-hint your own ``User`` class but you
+    must then add the ``#[CurrentUser]`` attribute to the argument. Default value
+    can be set to ``null`` in case  the controller can be accessed by anonymous
+    users. It requires installing the :doc:`SecurityBundle </security>`.
 
 Adding a Custom Value Resolver
 ------------------------------


### PR DESCRIPTION
Right now it's only mentioned in some totally random place in https://symfony.com/doc/6.1/security.html#json-login so not so discoverable if you haven't read the "What's new" blog posts.