### PR TITLE
refactor(console): wrong method used in DebugFormatterHelper

### DIFF
--- a/components/console/helpers/debug_formatter.rst
+++ b/components/console/helpers/debug_formatter.rst
@@ -117,7 +117,7 @@ Stopping a Program
 ------------------
 
 When a program is stopped, you can use
-:method:`Symfony\\Component\\Console\\Helper\\DebugFormatterHelper::run` to
+:method:`Symfony\\Component\\Console\\Helper\\DebugFormatterHelper::stop` to
 notify this to the users::
 
     // ...


### PR DESCRIPTION
Hi 👋🏻 

The documentation mentioned the `run` method which does not exist, it seems that `stop()` is the right method.

Thanks for the feedback 🙂 
