### PR TITLE
[Encore] Add version support for the --public parameter and a small docker support section

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -81,6 +81,7 @@ whitelist:
         - '# username is your full Gmail or Google Apps email address'
         - '.. _`LDAP injection`: http://projects.webappsec.org/w/page/13246947/LDAP%20Injection'
         - '.. versionadded:: 1.9.0' # Encore
+        - '.. versionadded:: 1.8.2' # Encore
         - '.. versionadded:: 0.28.4' # Encore
         - '.. versionadded:: 2.4.0' # SwiftMailer
         - '.. versionadded:: 1.30' # Twig

--- a/frontend/encore/virtual-machine.rst
+++ b/frontend/encore/virtual-machine.rst
@@ -102,7 +102,7 @@ Docker support
 If you are using ``docker``, to set up a ``nodejs`` ``docker-compose`` setup
 that works with the ``localhost:8080`` domain, add:
 
-.. code-block:: yml
+.. code-block:: yaml
 
     services:
         nodejs:

--- a/frontend/encore/virtual-machine.rst
+++ b/frontend/encore/virtual-machine.rst
@@ -104,13 +104,19 @@ that works with the ``localhost:8080`` domain, add:
 
 .. code-block:: yml
 
-    nodejs:
-        image: node:16
-        working_dir: /var/www
-        volumes:
-          - ./:/var/www:rw,cached
-          - ~/.symfony/certs/default.p12:/root/.symfony/certs/default.p12
-        command: bash -c "yarn && yarn run dev-server --public https://localhost:8080 --host 0.0.0.0"
+    services:
+        nodejs:
+            image: node:16
+            working_dir: /var/www
+            ports:
+                - '8080:8080'
+            volumes:
+                - ./:/var/www:rw,cached
+                - ~/.symfony/certs/default.p12:/root/.symfony/certs/default.p12
+            command: bash -c "yarn && yarn run dev-server --public https://localhost:8080 --host 0.0.0.0 --https"
+
+You may need to load the ``https://localhost:8080`` url once with your browser
+and accept the security exception before our assets can be loaded correctly.
 
 Fix "Invalid Host header" Issue
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/frontend/encore/virtual-machine.rst
+++ b/frontend/encore/virtual-machine.rst
@@ -100,7 +100,8 @@ Docker support
 ~~~~~~~~~~~~~~
 
 If you are using ``docker``, to set up a ``nodejs`` ``docker-compose`` setup
-that works with the ``localhost:8080`` domain, add:
+that works with the ``localhost:8080`` domain, add this to your
+``docker-compose-yml`` file:
 
 .. code-block:: yaml
 

--- a/frontend/encore/virtual-machine.rst
+++ b/frontend/encore/virtual-machine.rst
@@ -58,6 +58,10 @@ If your Symfony application is running on a custom domain (e.g.
           }
       }
 
+.. versionadded:: 1.9.0
+
+    The ``--public`` option was added in Encore 1.9.0
+
 After restarting Encore and reloading your web page, you will probably see
 different issues in the web console:
 
@@ -91,6 +95,22 @@ connections:
 
     Make sure to run the development server inside your virtual machine only;
     otherwise other computers can have access to it.
+
+Docker support
+~~~~~~~~~~~~~~
+
+If you are using ``docker``, to set up a ``nodejs`` ``docker-compose`` setup
+that works with the ``localhost:8080`` domain, add:
+
+.. code-block:: yml
+
+    nodejs:
+        image: node:16
+        working_dir: /var/www
+        volumes:
+          - ./:/var/www:rw,cached
+          - ~/.symfony/certs/default.p12:/root/.symfony/certs/default.p12
+        command: bash -c "yarn && yarn run dev-server --public https://localhost:8080 --host 0.0.0.0"
 
 Fix "Invalid Host header" Issue
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/frontend/encore/virtual-machine.rst
+++ b/frontend/encore/virtual-machine.rst
@@ -58,9 +58,9 @@ If your Symfony application is running on a custom domain (e.g.
           }
       }
 
-.. versionadded:: 1.9.0
+.. versionadded:: 1.8.2
 
-    The ``--public`` option was added in Encore 1.9.0
+    The ``--public`` option was added in Encore 1.8.2
 
 After restarting Encore and reloading your web page, you will probably see
 different issues in the web console:
@@ -72,6 +72,25 @@ different issues in the web console:
 
 You still need to make other configuration changes, as explained in the
 following sections.
+
+If your Webpack Dev Server HMR hub is unreachable because it is located
+in a different url, you may use this option to tell webpack where to look
+for it:
+
+.. code-block:: diff
+
+    {
+          ...
+          "scripts": {
+    -        "dev-server": "encore dev-server",
+    +        "dev-server": "encore dev-server --public http://app.vm:8080 --client-web-socket-url ws://app.vm:8080/ws",
+              ...
+          }
+    }
+
+Note that in this particular case, ``--public`` will do the job of telling
+webpack where to locate its HMR hub. But there may be edge cases in which
+you may need to specify this as well.
 
 Allow External Access
 ~~~~~~~~~~~~~~~~~~~~~
@@ -114,10 +133,13 @@ that works with the ``localhost:8080`` domain, add this to your
             volumes:
                 - ./:/var/www:rw,cached
                 - ~/.symfony/certs/default.p12:/root/.symfony/certs/default.p12
-            command: bash -c "yarn && yarn run dev-server --public https://localhost:8080 --host 0.0.0.0 --https"
+            command: bash -c "yarn && yarn run dev-server --public https://localhost:8080 --host 0.0.0.0 --server-type https"
 
-You may need to load the ``https://localhost:8080`` url once with your browser
-and accept the security exception before our assets can be loaded correctly.
+.. note::
+
+    ``https``: You may need to load the ``https://localhost:8080`` url once
+    with your browser and accept the security exception before your assets
+    can be loaded correctly under https.
 
 Fix "Invalid Host header" Issue
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Reflects changes in: https://github.com/symfony/webpack-encore/pull/1095

Adds the version number at which this feature will be released, and it also adds a docker example for a nodejs box.

- [x] Test docker setup
