### PR TITLE
Update CI to php 8.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
             -   name: "Set-up PHP"
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.1
                     coverage: none
                     tools: "composer:v2"
 
@@ -91,7 +91,7 @@ jobs:
           - name: Set-up PHP
             uses: shivammathur/setup-php@v2
             with:
-                php-version: 8.0
+                php-version: 8.1
                 coverage: none
 
           - name: Fetch branch from where the PR started


### PR DESCRIPTION
Noticed a build failure in https://github.com/symfony/symfony-docs/runs/5583435274?check_suite_focus=true which seems to be unrelated to my PR but rather to some changes in symfony 6.1.