### PR TITLE
[ExpressionLanguage] Add support for Nullsafe syntax for accessing object's properties and methods

### DIFF
--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -102,6 +102,42 @@ JavaScript::
 
 This will print out ``Hi Hi Hi!``.
 
+Nullsafe operator
+~~~~~~~~~~~~~~~~~
+
+Working with mutable objects can be, sometimes, error prone.
+The ``?.`` syntax can help avoid unnecessary and redundant checks
+when trying to access properties or methods on an object with dynamic structure::
+
+    class Apple
+    {
+        public $variety;
+    }
+
+    $apple = new Apple();
+    $apple->variety = 'Honeycrisp';
+
+    var_dump($expressionLanguage->evaluate(
+        'fruit?.color',
+        [
+            'fruit' => $apple,
+        ]
+    ));
+
+This will print out ``null`` instead of throwing an ``Exception``.
+
+Similarly::
+
+    var_dump($expressionLanguage->evaluate(
+        'fruit?.eatMe()',
+        [
+            'fruit' => $apple,
+        ]
+    ));
+
+Will print out ``null`` since the method ``eatMe()`` we trying to access
+on the same ``Apple`` object does not exist.
+
 .. _component-expression-functions:
 
 Working with Functions


### PR DESCRIPTION
[ExpressionLanguage] [NEW FEATURE]

This PR introduces the support for `nullsafe operator` in expressions that works with accessing object's properties and methods.

The proposed change here, includes a paragraph under the sub-page `/expression_language/syntax` to describe the new feature usage. The sub-paragraph has a title of `Nullsafe operator` under the paragraph `Working with Objects`.

The actual work related to this Doc PR available as Symfony PR [#45795](https://github.com/symfony/symfony/pull/45795).