### PR TITLE
[Form] Fix typo

### DIFF
--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -134,7 +134,7 @@ variable exists and will be available in your form themes::
     the ``KernelTestCase`` instead and use the ``form.factory`` service to
     create the form.
 
-Testings Types Registered as Services
+Testing Types Registered as Services
 -------------------------------------
 
 Your form may be used as a service, as it depends on other services (e.g. the


### PR DESCRIPTION
Fixes a typo "Testings" -> "Testing"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
