### PR TITLE
Use a better name than "class Foo"

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -499,9 +499,9 @@ is dispatched, are passed as arguments to the listener::
     use Symfony\Contracts\EventDispatcher\Event;
     use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-    class Foo
+    class MySubscriber
     {
-        public function myEventListener(Event $event, $eventName, EventDispatcherInterface $dispatcher)
+        public function myEventListener(Event $event, string $eventName, EventDispatcherInterface $dispatcher)
         {
             // ... do something with the event name
         }


### PR DESCRIPTION
It took me a while to figure out what represent `class Foo`

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
