### PR TITLE
[Routing] Add the 'attribute' value in routing annotation loaders

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -181,8 +181,9 @@ hold the kernel. Now it looks like this::
                 $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml')->prefix('/_profiler');
             }
 
-            // load the annotation routes
-            $routes->import(__DIR__.'/Controller/', 'annotation');
+            // load the routes defined as PHP attributes
+            // (use 'annotation' as the second argument if you define routes as annotations)
+            $routes->import(__DIR__.'/Controller/', 'attribute');
         }
 
         // optional, to use the standard Symfony cache directory

--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -70,7 +70,10 @@ Symfony provides several route loaders for the most common needs:
             // loads routes from the given routing file stored in some bundle
             $routes->import('@AcmeBundle/Resources/config/routing.yaml');
 
-            // loads routes from the PHP annotations of the controllers found in that directory
+            // loads routes from the PHP attributes (#[Route(...)]) of the controllers found in that directory
+            $routes->import('../src/Controller/', 'attribute');
+
+            // loads routes from the PHP annotations (@Route(...)) of the controllers found in that directory
             $routes->import('../src/Controller/', 'annotation');
 
             // loads routes from the YAML or XML files found in that directory
@@ -79,6 +82,11 @@ Symfony provides several route loaders for the most common needs:
             // loads routes from the YAML or XML files found in some bundle directory
             $routes->import('@AcmeOtherBundle/Resources/config/routing/', 'directory');
         };
+
+.. versionadded:: 6.1
+
+    The ``attribute`` value of the second argument of ``import()`` was introduced
+    in Symfony 6.1.
 
 .. note::
 


### PR DESCRIPTION
Fixes #16540.

I've left some occurrences of `annotation` in the main `routing.rst` article because I think they made sense. Mostly because, if I'm right, "annotation" loads both annotations and attributes but "attribute" only loads attributes.