### PR TITLE
[Validator] Improve Image constraint invalid mime type message

### DIFF
--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -442,7 +442,7 @@ You can find a list of existing image mime types on the `IANA website`_.
 ``mimeTypesMessage``
 ~~~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``This file is not a valid image.``
+**type**: ``string`` **default**: ``The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.``
 
 ``minHeight``
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #16662

Changed the default message in case of incorrect mime type for the image constraint.

From 6.1 we will replace `This file is not a valid image.`  with this `The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.`.