### PR TITLE
[Form] Fix multiples duplicates and remove :end-before:, :start-after: as it's not used anymore

### DIFF
--- a/reference/forms/types/options/choice_translation_domain.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain.rst.inc
@@ -1,8 +1,6 @@
 ``choice_translation_domain``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-DEFAULT_VALUE
-
 This option determines if the choice values should be translated and in which
 translation domain.
 

--- a/reference/forms/types/options/choice_translation_domain_disabled.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain_disabled.rst.inc
@@ -1,7 +1,3 @@
-.. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
-    :end-before: DEFAULT_VALUE
-
 **type**: ``string``, ``boolean`` or ``null`` **default**: ``false``
 
 .. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
-    :start-after: DEFAULT_VALUE

--- a/reference/forms/types/options/choice_translation_domain_enabled.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain_enabled.rst.inc
@@ -1,7 +1,3 @@
-.. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
-    :end-before: DEFAULT_VALUE
-
 **type**: ``string``, ``boolean`` or ``null`` **default**: ``true``
 
 .. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
-    :start-after: DEFAULT_VALUE


### PR DESCRIPTION
Fixes #16466 

For this PR, I fixed 2 files ( `choice_translation_domain_enabled.rst.inc` and `choice_translation_domain_disabled.rst.inc` ) which generated a duplication of the option `choice_translation_domain` in several pages, like [here](https://symfony.com/doc/4.4/reference/forms/types/date.html#choice-translation-domain) and [here](https://symfony.com/doc/4.4/reference/forms/types/choice.html#choice-translation-domain) and more....

On these 2 files, I deleted `:end-before:`, `:start-after:` and `DEFAULT_VALUE` because they are no longer used, following the change of the RST parser.

Unfortunately, I can't test the documentation locally ( probably related to this [issue](https://github.com/symfony/symfony-docs/issues/16449) ) to check the rendering.
