### PR TITLE
[Serializer] Update serializer.rst

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1108,7 +1108,7 @@ always as a collection.
     behavior can be changed with the optional context key ``XmlEncoder::DECODER_IGNORED_NODE_TYPES``.
 
     Data with ``#comment`` keys are encoded to XML comments by default. This can be
-    changed by adding the option `XmlEncoder::ENCODER_IGNORED_NODE_TYPES => [\XML_COMMENT_NODE]` in the context via the optional `$defaultContext` argument of the
+    changed by adding the option ``XmlEncoder::ENCODER_IGNORED_NODE_TYPES => [\XML_COMMENT_NODE]`` in the context via the optional `$defaultContext` argument of the
     ``XmlEncoder`` class constructor.
 
 The ``XmlEncoder`` Context Options

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1108,7 +1108,7 @@ always as a collection.
     behavior can be changed with the optional context key ``XmlEncoder::DECODER_IGNORED_NODE_TYPES``.
 
     Data with ``#comment`` keys are encoded to XML comments by default. This can be
-    changed with the optional ``$encoderIgnoredNodeTypes`` argument of the
+    changed by adding the option `XmlEncoder::ENCODER_IGNORED_NODE_TYPES => [\XML_COMMENT_NODE]` in the context via the optional `$defaultContext` argument of the
     ``XmlEncoder`` class constructor.
 
 The ``XmlEncoder`` Context Options


### PR DESCRIPTION
Hello
The optional  ``$encoderIgnoredNodeTypes`` argument is no longer available starting from the 5.0 version of XmlEncoder class (cf. https://github.com/symfony/symfony/blob/5.0/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php). This is why i suggest this correction.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
