### PR TITLE
[Validator] Fix of the description of the mime type message option

### DIFF
--- a/reference/constraints/File.rst
+++ b/reference/constraints/File.rst
@@ -259,16 +259,7 @@ You can find a list of existing mime types on the `IANA website`_.
 The message displayed if the mime type of the file is not a valid mime type
 per the `mimeTypes`_ option.
 
-You can use the following parameters in this message:
-
-===============  ==============================================================
-Parameter        Description
-===============  ==============================================================
-``{{ file }}``   Absolute file path
-``{{ name }}``   Base file name
-``{{ type }}``   The MIME type of the given file
-``{{ types }}``  The list of allowed MIME types
-===============  ==============================================================
+.. include:: /reference/constraints/_parameters-mime-types-message-option.rst.inc
 
 ``notFoundMessage``
 ~~~~~~~~~~~~~~~~~~~

--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -442,7 +442,12 @@ You can find a list of existing image mime types on the `IANA website`_.
 ``mimeTypesMessage``
 ~~~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.``
+**type**: ``string`` **default**: ``This file is not a valid image.``
+
+The message ``The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.`` will be displayed 
+if the allowed `mimeTypes`_ are only a subset of ``image/*``.
+
+.. include:: /reference/constraints/_parameters-mime-types-message-option.rst.inc
 
 ``minHeight``
 ~~~~~~~~~~~~~

--- a/reference/constraints/_parameters-mime-types-message-option.rst.inc
+++ b/reference/constraints/_parameters-mime-types-message-option.rst.inc
@@ -1,0 +1,10 @@
+You can use the following parameters in this message:
+
+===============  ==============================================================
+Parameter        Description
+===============  ==============================================================
+``{{ file }}``   Absolute file path
+``{{ name }}``   Base file name
+``{{ type }}``   The MIME type of the given file
+``{{ types }}``  The list of allowed MIME types
+===============  ==============================================================


### PR DESCRIPTION
In this PR, I corrected the mistake I made [here.](https://github.com/symfony/symfony-docs/pull/16663)

I used the table of parameters of the `File` constraint to explain the different parameters in the `Image` constraint.

Can you do a review please?

@fancyweb ready for review :)
