### PR TITLE
[Messenger] Fix: Redis Sentinel support - aligning paramaters with co…

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1369,12 +1369,12 @@ redeliver_timeout        Timeout before retrying a pending      ``3600``
 claim_interval           Interval on which pending/abandoned    ``60000`` (1 Minute)
                          messages should be checked for to
                          claim - in milliseconds
-sentinel_persistent_id   String, if null connection is          null
+persistent_id            String, if null connection is          null
                          non-persistent.
-sentinel_retry_interval  Int, value in milliseconds             ``0``
-sentinel_read_timeout    Float, value in seconds                ``0``
+retry_interval           Int, value in milliseconds             ``0``
+read_timeout             Float, value in seconds                ``0``
                          default indicates unlimited
-sentinel_timeout         Float, value in seconds                ``0``
+timeout                  Float, value in seconds                ``0``
                          default indicates unlimited
 sentinel_master          String, if null or empty Sentinel      null
                          support is disabled


### PR DESCRIPTION
[Messenger] Fix: Redis Sentinel support - aligning paramaters with constructor

original PR [https://github.com/symfony/symfony-docs/pull/16113](https://github.com/symfony/symfony-docs/pull/16113)
