### PR TITLE
[Config] Add Kernel method override example for php/xml formats

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -65,7 +65,26 @@ shown in these three formats.
     Starting from Symfony 5.1, by default Symfony only loads the configuration
     files defined in YAML format. If you define configuration in XML and/or PHP
     formats, update the ``src/Kernel.php`` file to add support for the ``.xml``
-    and ``.php`` file extensions.
+    and ``.php`` file extensions by overriding the
+    :method:`Symfony\\Component\\HttpKernel\\Kernel::configureContainer` method::
+
+        // src/Kernel.php
+        use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+        private function configureContainer(ContainerConfigurator $container): void
+        {
+            $configDir = $this->getConfigDir();
+
+            $container->import($configDir.'/{packages}/*.{yaml,php}');
+            $container->import($configDir.'/{packages}/'.$this->environment.'/*.{yaml,php}');
+
+            if (is_file($configDir.'/services.yaml')) {
+                $container->import($configDir.'/services.yaml');
+                $container->import($configDir.'/{services}_'.$this->environment.'.yaml');
+            } else {
+                $container->import($configDir.'/{services}.php');
+            }
+        }
 
 There isn't any practical difference between formats. In fact, Symfony
 transforms and caches all of them into PHP before running the application, so


### PR DESCRIPTION
The docs for version 5.4 aren't clear on what needs to be updated to add support for the `xml` and `php` config formats.
With previous versions this wasn't a problem since the `Kernel` class in the recipe had a [`configureContainer` method](https://github.com/symfony/recipes/blob/c88ce965a50fe33073750247066da9d7a23845c1/symfony/framework-bundle/5.3/src/Kernel.php#L14) so it was easy to infer what needs to be done. However, starting with version 5.4 the method was moved to the [`MicroKernelTrait`](https://github.com/symfony/symfony/blob/c9a5155f677c31202770f78921c0afd45be6625c/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php#L50) and [removed from the recipe](https://github.com/symfony/recipes/blob/c88ce965a50fe33073750247066da9d7a23845c1/symfony/framework-bundle/5.4/src/Kernel.php#L10) making it a lot harder to know what exactly needs to be done to get `php`/`xml` formats working.