### PR TITLE
[Pull Requests] Fix Symfony upstream URL as `git://` isn't supported by Github anymore.

### DIFF
--- a/contributing/code/pull_requests.rst
+++ b/contributing/code/pull_requests.rst
@@ -99,7 +99,7 @@ Get the Symfony source code:
 .. code-block:: terminal
 
       $ cd symfony
-      $ git remote add upstream git://github.com/symfony/symfony.git
+      $ git remote add upstream https://github.com/symfony/symfony.git
 
 Check that the current Tests Pass
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
See: https://github.blog/2021-09-01-improving-git-protocol-security-github/
It is impossible to fetch anything now with the `git://` URL.

```bash
symfony$ git fetch upstream
fatal: erreur distante : 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
