### PR TITLE
[Doctrine] Adding caution box on dependecy injection

### DIFF
--- a/doctrine/custom_dql_functions.rst
+++ b/doctrine/custom_dql_functions.rst
@@ -146,4 +146,8 @@ In Symfony, you can register your custom DQL functions as follows:
                 ],
             ]);
 
+.. caution::
+
+    It is not possible to inject Symfony services or parameters into a custom DQL function.
+
 .. _`DQL User Defined Functions`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/cookbook/dql-user-defined-functions.html


### PR DESCRIPTION
I guessed this (based on trial and error), so please double-check!

Maybe add a second sentence like:
The reason is that the class is instantiated by Doctrine and not wired through Symfony's DI container.
