### PR TITLE
Fix invalid interface mention in security.rst

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2503,9 +2503,9 @@ However, in some cases, this process can cause unexpected authentication problem
 If you're having problems authenticating, it could be that you *are* authenticating
 successfully, but you immediately lose authentication after the first redirect.
 
-In that case, review the serialization logic (e.g. ``SerializableInterface``) on
+In that case, review the serialization logic (e.g. ``\Serializable`` interface) on
 you user class (if you have any) to make sure that all the fields necessary are
-serialized.
+serialized and also exclude all the fields not necessary to be serialized (relations).
 
 Comparing Users Manually with EquatableInterface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/security.rst
+++ b/security.rst
@@ -2503,9 +2503,10 @@ However, in some cases, this process can cause unexpected authentication problem
 If you're having problems authenticating, it could be that you *are* authenticating
 successfully, but you immediately lose authentication after the first redirect.
 
-In that case, review the serialization logic (e.g. ``\Serializable`` interface) on
-you user class (if you have any) to make sure that all the fields necessary are
-serialized and also exclude all the fields not necessary to be serialized (relations).
+In that case, review the serialization logic (e.g. the ``__serialize()`` or
+``serialize()`` methods) on you user class (if you have any) to make sure
+that all the fields necessary are serialized and also exclude all the
+fields not necessary to be serialized (e.g. Doctrine relations).
 
 Comparing Users Manually with EquatableInterface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
SerializableInterface doesn't exist, I assume it was meant to be https://www.php.net/manual/en/class.serializable.php, the motivation behind this change is described here https://stackoverflow.com/questions/42074225/symfony-userinterface-is-serializing-the-entire-massive-user-entity/71816482#71816482

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
