### PR TITLE
[Workflow] add back information on accessing the context in guard events

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -382,14 +382,14 @@ order:
 
         $workflow->apply($subject, $transitionName, [Workflow::DISABLE_ANNOUNCE_EVENT => true]);
 
-    The context is accessible in all events::
+The context is accessible in all events except for the ``workflow.guard`` events::
 
-        // $context must be an array
-        $context = ['context_key' => 'context_value'];
-        $workflow->apply($subject, $transitionName, $context);
+    // $context must be an array
+    $context = ['context_key' => 'context_value'];
+    $workflow->apply($subject, $transitionName, $context);
 
-        // in an event listener (workflow.guard events)
-        $context = $event->getContext(); // returns ['context']
+    // in an event listener (workflow.guard events)
+    $context = $event->getContext(); // returns ['context']
 
 .. note::
 


### PR DESCRIPTION
This information was present in older versions of the documentation, but
got lost when the `versionadded` directive was removed in the `6.0` branch.


see https://github.com/symfony/symfony/issues/40742#issuecomment-1020523013
