### PR TITLE
[Config] Add yaml anchors example to share config between environments

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -465,6 +465,12 @@ files directly in the ``config/packages/`` directory.
             when@test:
                 webpack_encore:
                     strict_mode: false
+                    
+            # you can use "Yaml anchors" to share config between multiple environments (make "test" config identical to "prod")
+            when@prod: &webpack_prod
+                webpack_encore:
+                    # ...
+            when@test: *webpack_prod
 
         .. code-block:: xml
 


### PR DESCRIPTION
This example can be useful to prevent duplicates configuration between multiple environments.

See https://github.com/symfony/symfony/issues/45506