### PR TITLE
[Form] Document using TranslatableMessage for label and choice_label

### DIFF
--- a/reference/forms/types/options/choice_label.rst.inc
+++ b/reference/forms/types/options/choice_label.rst.inc
@@ -25,6 +25,7 @@ more control::
 
             // or if you want to translate some key
             //return 'form.choice.'.$key;
+            //return new TranslatableMessage($key, false === $choice ? [] : ['%status%' => $value], 'store');
         },
     ]);
 

--- a/reference/forms/types/options/label.rst.inc
+++ b/reference/forms/types/options/label.rst.inc
@@ -1,10 +1,26 @@
 ``label``
 ~~~~~~~~~
 
-**type**: ``string`` **default**: The label is "guessed" from the field name
+**type**: ``string`` or ``TranslatableMessage`` **default**: The label is "guessed" from the field name
 
 Sets the label that will be used when rendering the field. Setting to ``false``
-will suppress the label. The label can also be set in the template:
+will suppress the label.
+
+    use Symfony\Component\Translation\TranslatableMessage;
+
+    $builder
+        ->add('zipCode', null, [
+            'label' => 'The ZIP/Postal code',
+        ])
+
+    // ...
+
+    ->add('zipCode', null, [
+            'label' => new TranslatableMessage('address.zipCode', ['%country%' => $country], 'address'),
+        ])
+    ;
+
+The label can also be set in the template:
 
 .. configuration-block::
 


### PR DESCRIPTION
Document using TranslatableMessage for label and choice_label like form help ([15527](https://github.com/symfony/symfony-docs/pull/15527))