### PR TITLE
[Messenger] Add doc for default routing for messages

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -261,7 +261,13 @@ you can configure them to be sent to a transport:
 
 Thanks to this, the ``App\Message\SmsNotification`` will be sent to the ``async``
 transport and its handler(s) will *not* be called immediately. Any messages not
-matched under ``routing`` will still be handled immediately.
+matched under ``routing`` will still be handled immediately, i.e. synchronously.
+
+.. note::
+
+    You may use ``'*'`` as the message class. This will act as a default routing
+    rule for any message not matched under ``routing``. This is useful to ensure
+    no message is handled synchronously by default.
 
 You can also route classes by their parent class or interface. Or send messages
 to multiple transports:


### PR DESCRIPTION
Hello,

I recently got bit on production after deploying a code change. We created a new `FooMessage` & `FooHandler`, but didn't update the `messenger.yaml` to include routing information.

This caused `FooMessage` to be directly handled by the HTTP process that dispatched the message, instead of the CLI, consumer process of Messenger. This lead to various issues: missing env var in HTTP context, lack of monitoring/stats as we only looks for messages metrics in the `consumer` container, not the `api` one :)

Looking at the code, I discovered you may define a default transport, but couldn't find it in the doc.
