### PR TITLE
[Routing] Fix path/example content of error route files

### DIFF
--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -155,32 +155,37 @@ automatically when installing ``symfony/framework-bundle``):
 
     .. code-block:: yaml
 
-        # config/routes/dev/framework.yaml
-        _errors:
-            resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
-            prefix:   /_error
+        # config/routes/framework.yaml
+        when@dev:
+            _errors:
+                resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+                prefix:   /_error
 
     .. code-block:: xml
 
-        <!-- config/routes/dev/framework.xml -->
+        <!-- config/routes/framework.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <routes xmlns="http://symfony.com/schema/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing
                 https://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <import resource="@FrameworkBundle/Resources/config/routing/errors.xml" prefix="/_error"/>
+            <when env="prod">
+                <import resource="@FrameworkBundle/Resources/config/routing/errors.xml" prefix="/_error"/>
+            </when>
         </routes>
 
     .. code-block:: php
 
-        // config/routes/dev/framework.php
+        // config/routes/framework.php
         use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
         return function (RoutingConfigurator $routes) {
-            $routes->import('@FrameworkBundle/Resources/config/routing/errors.xml')
-                ->prefix('/_error')
-            ;
+            if ('dev' === $container->env()) {
+                $routes->import('@FrameworkBundle/Resources/config/routing/errors.xml')
+                    ->prefix('/_error')
+                ;
+            }
         };
 
 With this route added, you can use URLs like these to preview the *error* page


### PR DESCRIPTION
Removed `dev` part from file location, adjusted code example. Recipes of framework bundle don't include `config/routes/dev/framework.yaml` file anymore but use `when@dev` block in `config/routes/framework.yaml`