### PR TITLE
Tell about COMPOSER_ROOT_VERSION when not working on the default branch

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -24,6 +24,16 @@ tests, such as Doctrine, Twig and Monolog. To do so,
 
     $ composer update
 
+.. tip::
+
+    Dependencies might fail to update and in this case Composer might need you to
+    tell it what Symfony version you are working on.
+    To do so set ``COMPOSER_ROOT_VERSION`` variable, e.g.:
+
+    .. code-block:: terminal
+
+        $ COMPOSER_ROOT_VERSION=4.4.x-dev composer update
+
 .. _running:
 
 Running the Tests


### PR DESCRIPTION
Just hit https://github.com/symfony/symfony-docs/pull/13710 so here it goes again!