### PR TITLE
Update git protocol in URL

### DIFF
--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -76,7 +76,7 @@ this value accordingly):
 .. code-block:: terminal
 
     $ cd projects/
-    $ git clone git://github.com/YOUR-GITHUB-USERNAME/symfony-docs.git
+    $ git clone git@github.com:YOUR-GITHUB-USERNAME/symfony-docs.git
 
 **Step 3.** Add the original Symfony docs repository as a "Git remote" executing
 this command:


### PR DESCRIPTION
Cloning into 'symfony-docs'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
