### PR TITLE
[Security] Fix tag attribute in event XML example

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2561,7 +2561,7 @@ for these events.
 
                     <service id="App\EventListener\CustomLogoutSubscriber">
                         <tag name="kernel.event_subscriber"
-                             dispacher="security.event_dispatcher.main"
+                             dispatcher="security.event_dispatcher.main"
                          />
                     </service>
                 </services>


### PR DESCRIPTION
This corrects the spelling of the "dispatcher" attribute (from "dispacher").