### PR TITLE
[ExpressionLanguage] Feature Null-coalescing operator

### DIFF
--- a/components/expression_language/syntax.rst
+++ b/components/expression_language/syntax.rst
@@ -343,6 +343,18 @@ Ternary Operators
 * ``foo ?: 'no'`` (equal to ``foo ? foo : 'no'``)
 * ``foo ? 'yes'`` (equal to ``foo ? 'yes' : ''``)
 
+Null-coalescing Operator
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is the same as the PHP's null-coalescing operator ``??`` which is a syntactic sugar for the use of a ternary 
+in conjunction with isset(). It returns the left hand-side if it exist and not ``null`` otherwise it returns the right hand-side.
+Note that coalescing can be chained.
+
+* ``foo ?? 'no'``
+* ``foo.baz ?? 'no'``
+* ``foo[3] ?? 'no'``
+* ``foo.baz ?? foo['baz'] ?? 'no'``
+
 Built-in Objects and Variables
 ------------------------------
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->

[ExpressionLanguage] [NEW FEATURE]

This PR introduces the support for null-coalescing operator ``??``.

The proposed change, includes a paragraph under the sub-page /expression_language/syntax to describe the new feature usage. The sub-paragraph has a title of **Null-coalescing operator** under the paragraph **Supported Operators**.

The actual work related to this Doc PR available as Symfony PR <!--https://github.com/symfony/symfony/pull/45795-->.
