### PR TITLE
[Mailer] Add event subscriber example to mailer documentation

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1021,6 +1021,39 @@ you have a transport called ``async``, you can route the message there:
 Thanks to this, instead of being delivered immediately, messages will be sent to
 the transport to be handled later (see :ref:`messenger-worker`).
 
+Events
+------
+
+MessageEvent
+~~~~~~~~~~~~
+
+The MessageEvent allows the transformation of a Message and the Envelope before the email is sent::
+
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Component\Mailer\Event\MessageEvent;
+    use Symfony\Component\Mime\Email;
+
+    class MailerSubscriber implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents()
+        {
+            return [
+                MessageEvent::class => 'onMessage',
+            ];
+        }
+
+        public function onMessage(MessageEvent $event): void
+        {
+            $message = $event->getMessage();
+            if (!$message instanceof Email) {
+                return;
+            }
+
+            // do something with the message
+        }
+    }
+
+
 Development & Debugging
 -----------------------
 


### PR DESCRIPTION
I could not find something about events in the docs but could find the following event in the code.