### PR TITLE
[Messenger] Fix typo in amqp option name user -> login

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1233,6 +1233,7 @@ The transport has a number of options:
                                               calls.
 ``host``                                      Hostname of the AMQP service
 ``key``                                       Path to the client key in PEM format.
+``login``                                     Username to use to connect the AMQP service
 ``password``                                  Password to use to connect to the AMQP service
 ``persistent``                                                                                   ``'false'``
 ``port``                                      Port of the AMQP service
@@ -1241,7 +1242,6 @@ The transport has a number of options:
                                               greater seconds. May be fractional.
 ``retry``
 ``sasl_method``
-``user``                                      Username to use to connect the AMQP service
 ``verify``                                    Enable or disable peer verification. If peer
                                               verification is enabled then the common name in
                                               the server certificate must match the server


### PR DESCRIPTION

This will fix https://github.com/symfony/symfony-docs/issues/15566