### PR TITLE
[Serializer] Skip calling `ContextBuilder::toArray()` when possible

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1222,7 +1222,7 @@ you can use "context builders" to define the context using a fluent interface::
         ->withGroups(['group1', 'group2']);
 
     $contextBuilder = (new CsvEncoderContextBuilder())
-        ->withContext($contextBuilder->toArray())
+        ->withContext($contextBuilder)
         ->withDelimiter(';');
 
     $serializer->serialize($something, 'csv', $contextBuilder->toArray());

--- a/serializer.rst
+++ b/serializer.rst
@@ -185,7 +185,7 @@ To create a more complex (de)serialization context, you can chain them using the
         ->withGroups(['group1', 'group2']);
 
     $contextBuilder = (new CsvEncoderContextBuilder())
-        ->withContext($contextBuilder->toArray())
+        ->withContext($contextBuilder)
         ->withDelimiter(';');
 
     $serializer->serialize($something, 'csv', $contextBuilder->toArray());

--- a/serializer/custom_context_builders.rst
+++ b/serializer/custom_context_builders.rst
@@ -65,9 +65,10 @@ context key, you can create a dedicated context builder::
     // src/Serializer/LegacyContextBuilder
     namespace App\Serializer;
 
+    use Symfony\Component\Serializer\Context\ContextBuilderInterface;
     use Symfony\Component\Serializer\Context\ContextBuilderTrait;
 
-    final class LegacyContextBuilder
+    final class LegacyContextBuilder implements ContextBuilderInterface
     {
         use ContextBuilderTrait;
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->

Leverages https://github.com/symfony/symfony/pull/46179