### PR TITLE
[Form] [Forms] rounding default const up to down

### DIFF
--- a/reference/forms/types/options/rounding_mode.rst.inc
+++ b/reference/forms/types/options/rounding_mode.rst.inc
@@ -1,7 +1,14 @@
 rounding_mode
 ~~~~~~~~~~~~~
 
-**type**: ``integer`` **default**: ``\NumberFormatter::ROUND_HALFUP``
+**type**: ``integer``
+
+* IntegerType
+**default**: ``\NumberFormatter::ROUND_DOWN``
+
+* MoneyType and NumberType
+**default**: ``\NumberFormatter::ROUND_HALF_UP``
+
 
 If a submitted number needs to be rounded (based on the `scale`_ option), you
 have several configurable options for that rounding. Each option is a constant


### PR DESCRIPTION
Hi,
Just a fix about a default rounding const.

![image](https://user-images.githubusercontent.com/11288901/165517891-1ac183ec-4e33-44e6-b8aa-44c8824a5800.png)

More details : https://github.com/symfony/symfony/blob/60ce5a3dfbd90fad60cd39fcb3d7bf7888a48659/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php#L49



