### PR TITLE
[DependencyInjection] Fix a reference to the article about expressions

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -467,7 +467,6 @@ Encore supports many more features! For a full list of what you can do, see
 .. _`WebpackEncoreBundle Configuration`: https://github.com/symfony/webpack-encore-bundle#configuration
 .. _`Stimulus`: https://stimulus.hotwired.dev/
 .. _`Stimulus Documentation`: https://stimulus.hotwired.dev/handbook/introduction
-.. _`Symfony UX Packages`: https://github.com/symfony/ux
 .. _`Symfony Stimulus Bridge`: https://github.com/symfony/stimulus-bridge
 .. _`Turbo`: https://turbo.hotwired.dev/
 .. _`symfony/ux-turbo`: https://symfony.com/bundles/ux-turbo/current/index.html

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -247,7 +247,7 @@ Using Expressions in Service Factories
     Using expressions as factories was introduced in Symfony 6.1.
 
 Instead of using PHP classes as a factory, you can also use
-:doc:`expressions </service_container/expressions>`. This allows you to
+:doc:`expressions </service_container/expression_language>`. This allows you to
 e.g. change the service based on a parameter:
 
 .. configuration-block::


### PR DESCRIPTION
Reported by Symfony Docs builder:

```
Errors for symfony / 6.1

Build errors from "2022-05-03 10:20:12"
Found invalid reference "/service_container/expressions" in file "service_container/factories"
Found invalid reference "/service_container/expressions" in file "service_container/factories"
```