### PR TITLE
Removing references to flex.symfony.com

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -368,4 +368,4 @@ Go Deeper with HTTP & Framework Fundamentals
 .. _`Twig`: https://twig.symfony.com
 .. _`Composer`: https://getcomposer.org
 .. _`Stellar Development with Symfony`: https://symfonycasts.com/screencast/symfony/setup
-.. _`Flex recipes`: https://flex.symfony.com
+.. _`Flex recipes`: https://github.com/symfony/recipes/blob/flex/main/RECIPES.md

--- a/quick_tour/flex_recipes.rst
+++ b/quick_tour/flex_recipes.rst
@@ -53,7 +53,7 @@ It's a way for a library to automatically configure itself by adding and modifyi
 files. Thanks to recipes, adding features is seamless and automated: install a package
 and you're done!
 
-You can find a full list of recipes and aliases by going to `https://flex.symfony.com`_.
+You can find a full list of recipes and aliases inside `RECIPES.md on the recipes repository`_.
 
 What did this recipe do? In addition to automatically enabling the feature in
 ``config/bundles.php``, it added 3 things:
@@ -264,6 +264,6 @@ and it's the most important yet. I want to show you how Symfony empowers you to 
 build features *without* sacrificing code quality or performance. It's all about
 the service container, and it's Symfony's super power. Read on: about :doc:`/quick_tour/the_architecture`.
 
-.. _`https://flex.symfony.com`: https://flex.symfony.com
+.. _`RECIPES.md on the recipes repository`: https://github.com/symfony/recipes/blob/flex/main/RECIPES.md
 .. _`API Platform`: https://api-platform.com/
 .. _`Twig`: https://twig.symfony.com/


### PR DESCRIPTION
Hi!

flex.symfony.com is gone and will remain gone (it's actually helping people discover the root issue: https://github.com/symfony/flex/issues/909 ), but we DO have a `RECIPES.md` list of the recipes available.

Cheers!