### PR TITLE
[Validator] Doctrine annotations is not required anymore for validator

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -23,8 +23,14 @@ install the validator before using it:
 
 .. code-block:: terminal
 
-    $ composer require symfony/validator doctrine/annotations
+    $ composer require symfony/validator
+    
+If your project still use annotations, ``doctrine/annotations`` is also needed:  
 
+.. code-block:: terminal
+
+    $ composer require doctrine/annotations
+    
 .. note::
 
     If your application doesn't use Symfony Flex, you might need to do some


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
