### PR TITLE
[Lock] Removed RetryTillSaveStore class (no longer needed)

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -106,15 +106,12 @@ can be created, pass ``true`` as the argument of the ``acquire()`` method. This
 is called a **blocking lock** because the execution of your application stops
 until the lock is acquired.
 
-Some of the built-in ``Store`` classes support this feature. When they don't,
-they can be decorated with the ``RetryTillSaveStore`` class::
+Some of the built-in ``Store`` classes support this feature.
 
     use Symfony\Component\Lock\LockFactory;
     use Symfony\Component\Lock\Store\RedisStore;
-    use Symfony\Component\Lock\Store\RetryTillSaveStore;
 
     $store = new RedisStore(new \Predis\Client('tcp://localhost:6379'));
-    $store = new RetryTillSaveStore($store);
     $factory = new LockFactory($store);
 
     $lock = $factory->createLock('notification-flush');


### PR DESCRIPTION
Fixes #16785 

For this PR, I removed `RetryTillSaveStore` class, because this class became obsolete from Symfony 5.2 and was removed from Symfony 6.0 as shown [here](https://github.com/symfony/symfony/pull/38296/files#diff-14c53c18273c57073d28f8dd3b4fab7253f5df427aea52b9a1c0a815dea3bea2).

