### PR TITLE
[Security] Remove enable authenticator manager from 6.0 docs

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -27,7 +27,6 @@ creates a ``security.yaml`` configuration file for you:
 
     # config/packages/security.yaml
     security:
-        enable_authenticator_manager: true
         # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
         password_hashers:
             Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
@@ -1354,8 +1353,6 @@ You must enable this using the ``login_throttling`` setting:
 
         # config/packages/security.yaml
         security:
-            # you must use the authenticator manager
-            enable_authenticator_manager: true
 
             firewalls:
                 # ...
@@ -2289,7 +2286,6 @@ the login page):
 
         # config/packages/security.yaml
         security:
-            enable_authenticator_manager: true
 
             # ...
             access_control:

--- a/security/custom_authenticator.rst
+++ b/security/custom_authenticator.rst
@@ -86,7 +86,6 @@ The authenticator can be enabled using the ``custom_authenticators`` setting:
 
         # config/packages/security.yaml
         security:
-            enable_authenticator_manager: true
 
             # ...
             firewalls:
@@ -179,7 +178,7 @@ can define what happens in these cases:
     If your login method is interactive, which means that the user actively
     logged into your application, you may want your authenticator to implement the
     :class:`Symfony\\Component\\Security\\Http\\Authenticator\\InteractiveAuthenticatorInterface`
-    so that it dispatches an 
+    so that it dispatches an
     :class:`Symfony\\Component\\Security\\Http\\Event\\InteractiveLoginEvent`
 
 .. _security-passport:

--- a/security/entry_point.rst
+++ b/security/entry_point.rst
@@ -18,7 +18,6 @@ You can configure this using the ``entry_point`` setting:
 
         # config/packages/security.yaml
         security:
-            enable_authenticator_manager: true
 
             # ...
             firewalls:

--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -14,13 +14,6 @@ This authentication method can help you eliminate most of the customer support
 related to authentication (e.g. I forgot my password, how can I change or reset
 my password, etc.)
 
-.. note::
-
-    Login links are only supported by Symfony when using the
-    :doc:`authenticator system </security>`. Before using this
-    authenticator, make sure you have enabled it with
-    ``enable_authenticator_manager: true`` in your ``security.yaml`` file.
-
 Using the Login Link Authenticator
 ----------------------------------
 


### PR DESCRIPTION
Related to #16218
