### PR TITLE
[Security] Creating a route for logout is always required even if the default value is used

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -382,8 +382,7 @@ the current firewall and not the other ones.
 
 **type**: ``string`` **default**: ``/logout``
 
-The path which triggers logout. If you change it from the default value ``/logout``,
-you need to set up a route with a matching path.
+The path which triggers logout. You need to set up a route with a matching path.
 
 target
 ~~~~~~


### PR DESCRIPTION
According to https://symfony.com/doc/current/security.html#logging-out and the fact that there is no default logout route defined in Symfony (at least I didn't find one).
