### PR TITLE
[Security] Correcting bugs for provider and JSON login

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -498,7 +498,8 @@ will be able to authenticate (e.g. login form, API token, etc).
                     security: false
                 main:
                     lazy: true
-                    provider: users_in_memory
+                    # provider that you set earlier inside providers
+                    provider: app_user_provider
 
                     # activate different ways to authenticate
                     # https://symfony.com/doc/current/security.html#firewalls-authentication


### PR DESCRIPTION
On lines 501 and 502 I propose this change, because it confused me so much which provider to use, and in the case that you are explaining there you should use earlier configured app_user_provider, not users_in_memory.

On line 1043 I had a problem that $user is always null until I deleted the "?User" from parameters. I think that PHP gets confused here with the way it is written. And to say that now with that part removed everything works fine.

Thanks in advance and I hope that I contributed even a little as this is.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
