### PR TITLE
[Mailer] `max_per_second` option configurable via DSN

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -272,6 +272,15 @@ Other Options
 
         $dsn = 'smtps://smtp.example.com?ping_threshold=200'
 
+``max_per_second``
+    The number of messages to send per second (0 to disable this limitation)::
+
+        $dsn = 'smtps://smtp.example.com?max_per_second=2'
+
+    .. versionadded:: 6.2
+
+        The ``max_per_second`` option was introduced in Symfony 6.2.
+
 Creating & Sending Messages
 ---------------------------
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
AbstractTransport::setMaxPerSecond(float) was introduces in 5.1 but wan not configurable by dsn