### PR TITLE
[DI] Documenting Abstract Bundle and Extension

### DIFF
--- a/bundles.rst
+++ b/bundles.rst
@@ -82,7 +82,7 @@ method to tell Symfony what is the root directory of your bundle path::
     {
         public function getPath(): string
         {
-            return \dirname(__DIR__);
+            return \dirname(__DIR__); // returns /path/to/Acme/TestBundle/
         }
     }
 
@@ -105,8 +105,8 @@ The directory structure of a bundle is meant to help to keep code consistent
 between all Symfony bundles. It follows a set of conventions, but is flexible
 to be adjusted if needed:
 
-``src/Controller/``
-    Contains the controllers of the bundle (e.g. ``RandomController.php``).
+``src/``
+    Contains mainly PHP classes related to the bundle logic (e.g. ``Controller/RandomController.php``).
 
 ``config/``
     Houses configuration, including routing configuration (e.g. ``routing.yaml``).
@@ -124,6 +124,25 @@ to be adjusted if needed:
 
 ``tests/``
     Holds all tests for the bundle.
+
+It's recommended to use the `PSR-4`_ autoload standard: use the namespace as key,
+and the location of the bundle's main class (relative to ``composer.json``)
+as value. As the main class is located in the ``src/`` directory of the bundle:
+
+.. code-block:: json
+
+    {
+        "autoload": {
+            "psr-4": {
+                "Acme\\TestBundle\\": "src/"
+            }
+        },
+        "autoload-dev": {
+            "psr-4": {
+                "Acme\\TestBundle\\Tests\\": "tests/"
+            }
+        }
+    }
 
 A bundle can be as small or large as the feature it implements. It contains
 only the files you need and nothing else.
@@ -143,3 +162,4 @@ Learn more
 * :doc:`/bundles/prepend_extension`
 
 .. _`third-party bundles`: https://github.com/search?q=topic%3Asymfony-bundle&type=Repositories
+.. _`PSR-4`: https://www.php-fig.org/psr/psr-4/

--- a/bundles.rst
+++ b/bundles.rst
@@ -46,12 +46,11 @@ Creating a Bundle
 This section creates and enables a new bundle to show there are only a few steps required.
 The new bundle is called AcmeTestBundle, where the ``Acme`` portion is an example
 name that should be replaced by some "vendor" name that represents you or your
-organization (e.g. ABCTestBundle for some company named ``ABC``).
+organization (e.g. AbcTestBundle for some company named ``Abc``).
 
-Start by creating a ``Acme/TestBundle/src/`` directory and adding a new file
-called ``AcmeTestBundle.php``::
+Start by adding creating a new class called ``AcmeTestBundle``::
 
-    // Acme/TestBundle/src/AcmeTestBundle.php
+    // src/AcmeTestBundle.php
     namespace Acme\TestBundle;
 
     use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
@@ -62,9 +61,10 @@ called ``AcmeTestBundle.php``::
 
 .. versionadded:: 6.1
 
-    The ``AbstractBundle`` was introduced in Symfony 6.1.
+    The :class:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle` was
+    introduced in Symfony 6.1.
 
-.. warning::
+.. caution::
 
     If your bundle must be compatible with previous Symfony versions you have to
     extend from the :class:`Symfony\\Component\\HttpKernel\\Bundle\\Bundle` instead.
@@ -96,7 +96,7 @@ between all Symfony bundles. It follows a set of conventions, but is flexible
 to be adjusted if needed:
 
 ``src/``
-    Contains mainly PHP classes related to the bundle logic (e.g. ``Controller/RandomController.php``).
+    Contains all PHP classes related to the bundle logic (e.g. ``Controller/RandomController.php``).
 
 ``config/``
     Houses configuration, including routing configuration (e.g. ``routing.yaml``).
@@ -115,32 +115,44 @@ to be adjusted if needed:
 ``tests/``
     Holds all tests for the bundle.
 
-It's recommended to use the `PSR-4`_ autoload standard: use the namespace as key,
-and the location of the bundle's main class (relative to ``composer.json``)
-as value. As the main class is located in the ``src/`` directory of the bundle:
+.. caution::
 
-.. code-block:: json
+    The recommended bundle structure was changed in Symfony 5, read the
+    `Symfony 4.4 bundle documentation`_ for information about the old
+    structure.
 
-    {
-        "autoload": {
-            "psr-4": {
-                "Acme\\TestBundle\\": "src/"
-            }
-        },
-        "autoload-dev": {
-            "psr-4": {
-                "Acme\\TestBundle\\Tests\\": "tests/"
+    When using the new ``AbstractBundle`` class, the bundle defaults to the
+    new structure. Override the ``Bundle::getPath()`` method to change to
+    the old structure::
+
+        class AcmeTestBundle extends AbstractBundle
+        {
+            public function getPath(): string
+            {
+                return __DIR__;
             }
         }
-    }
 
-A bundle can be as small or large as the feature it implements. It contains
-only the files you need and nothing else.
+.. tip::
 
-As you move through the guides, you'll learn how to persist objects to a
-database, create and validate forms, create translations for your application,
-write tests and much more. Each of these has their own place and role within
-the bundle.
+    It's recommended to use the `PSR-4`_ autoload standard: use the namespace as key,
+    and the location of the bundle's main class (relative to ``composer.json``)
+    as value. As the main class is located in the ``src/`` directory of the bundle:
+
+    .. code-block:: json
+
+        {
+            "autoload": {
+                "psr-4": {
+                    "Acme\\TestBundle\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Acme\\TestBundle\\Tests\\": "tests/"
+                }
+            }
+        }
 
 Learn more
 ----------
@@ -152,4 +164,5 @@ Learn more
 * :doc:`/bundles/prepend_extension`
 
 .. _`third-party bundles`: https://github.com/search?q=topic%3Asymfony-bundle&type=Repositories
+.. _`Symfony 4.4 bundle documentation`: https://symfony.com/doc/4.4/bundles.html#bundle-directory-structure
 .. _`PSR-4`: https://www.php-fig.org/psr/psr-4/

--- a/bundles.rst
+++ b/bundles.rst
@@ -48,17 +48,23 @@ The new bundle is called AcmeTestBundle, where the ``Acme`` portion is an exampl
 name that should be replaced by some "vendor" name that represents you or your
 organization (e.g. ABCTestBundle for some company named ``ABC``).
 
-Start by creating a ``src/Acme/TestBundle/`` directory and adding a new file
+Start by creating a ``Acme/TestBundle/src/`` directory and adding a new file
 called ``AcmeTestBundle.php``::
 
-    // src/Acme/TestBundle/AcmeTestBundle.php
-    namespace App\Acme\TestBundle;
+    // Acme/TestBundle/src/AcmeTestBundle.php
+    namespace Acme\TestBundle;
 
-    use Symfony\Component\HttpKernel\Bundle\Bundle;
+    use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 
-    class AcmeTestBundle extends Bundle
+    class AcmeTestBundle extends AbstractBundle
     {
     }
+
+.. versionadded:: 6.1
+
+    The ``AbstractBundle`` was introduced in Symfony 6.1. If your bundle must be compatible
+    with previous Symfony versions you have to extend from the :class:`Symfony\\Component\\HttpKernel\\Bundle\\Bundle`
+    instead.
 
 .. tip::
 
@@ -67,14 +73,27 @@ called ``AcmeTestBundle.php``::
     also choose to shorten the name of the bundle to simply TestBundle by naming
     this class TestBundle (and naming the file ``TestBundle.php``).
 
-This empty class is the only piece you need to create the new bundle. Though
+It's recommended to place your bundle class in the ``src/`` directory and keep out all the
+configuration files, templates, translations, etc. By default, Symfony determines the bundle path from the
+directory where the bundle class is placed, so you have to define the :method:`Symfony\\Component\\HttpKernel\\Bundle\\Bundle::getPath`
+method to tell Symfony what is the root directory of your bundle path::
+
+    class AcmeTestBundle extends AbstractBundle
+    {
+        public function getPath(): string
+        {
+            return \dirname(__DIR__);
+        }
+    }
+
+This almost empty class is the only piece you need to create the new bundle. Though
 commonly empty, this class is powerful and can be used to customize the behavior
 of the bundle. Now that you've created the bundle, enable it::
 
     // config/bundles.php
     return [
         // ...
-        App\Acme\TestBundle\AcmeTestBundle::class => ['all' => true],
+        Acme\TestBundle\AcmeTestBundle::class => ['all' => true],
     ];
 
 And while it doesn't do anything yet, AcmeTestBundle is now ready to be used.
@@ -86,26 +105,24 @@ The directory structure of a bundle is meant to help to keep code consistent
 between all Symfony bundles. It follows a set of conventions, but is flexible
 to be adjusted if needed:
 
-``Controller/``
+``src/Controller/``
     Contains the controllers of the bundle (e.g. ``RandomController.php``).
 
-``DependencyInjection/``
-    Holds certain Dependency Injection Extension classes, which may import service
-    configuration, register compiler passes or more (this directory is not
-    necessary).
-
-``Resources/config/``
+``config/``
     Houses configuration, including routing configuration (e.g. ``routing.yaml``).
 
-``Resources/views/``
-    Holds templates organized by controller name (e.g. ``Random/index.html.twig``).
+``templates/``
+    Holds templates organized by controller name (e.g. ``random/index.html.twig``).
 
-``Resources/public/``
+``translations/``
+    Holds translations organized by domain and locale (e.g. ``AcmeTestBundle.en.xlf``).
+
+``public/``
     Contains web assets (images, stylesheets, etc) and is copied or symbolically
     linked into the project ``public/`` directory via the ``assets:install`` console
     command.
 
-``Tests/``
+``tests/``
     Holds all tests for the bundle.
 
 A bundle can be as small or large as the feature it implements. It contains

--- a/bundles.rst
+++ b/bundles.rst
@@ -73,20 +73,7 @@ called ``AcmeTestBundle.php``::
     also choose to shorten the name of the bundle to simply TestBundle by naming
     this class TestBundle (and naming the file ``TestBundle.php``).
 
-It's recommended to place your bundle class in the ``src/`` directory and keep out all the
-configuration files, templates, translations, etc. By default, Symfony determines the bundle path from the
-directory where the bundle class is placed, so you have to define the :method:`Symfony\\Component\\HttpKernel\\Bundle\\Bundle::getPath`
-method to tell Symfony what is the root directory of your bundle path::
-
-    class AcmeTestBundle extends AbstractBundle
-    {
-        public function getPath(): string
-        {
-            return \dirname(__DIR__); // returns /path/to/Acme/TestBundle/
-        }
-    }
-
-This almost empty class is the only piece you need to create the new bundle. Though
+This empty class is the only piece you need to create the new bundle. Though
 commonly empty, this class is powerful and can be used to customize the behavior
 of the bundle. Now that you've created the bundle, enable it::
 

--- a/bundles.rst
+++ b/bundles.rst
@@ -62,9 +62,12 @@ called ``AcmeTestBundle.php``::
 
 .. versionadded:: 6.1
 
-    The ``AbstractBundle`` was introduced in Symfony 6.1. If your bundle must be compatible
-    with previous Symfony versions you have to extend from the :class:`Symfony\\Component\\HttpKernel\\Bundle\\Bundle`
-    instead.
+    The ``AbstractBundle`` was introduced in Symfony 6.1.
+
+.. warning::
+
+    If your bundle must be compatible with previous Symfony versions you have to
+    extend from the :class:`Symfony\\Component\\HttpKernel\\Bundle\\Bundle` instead.
 
 .. tip::
 

--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -465,7 +465,7 @@ which is already supported when your bundle extend from the :class:`Symfony\\Com
     }
 
 This method is a shortcut of the previous "Extension", "Configuration" and "TreeBuilder" convention,
-where you also have the possibility to import configuration definition from an external file::
+now you also have the possibility to import configuration definition from an external file::
 
     // Acme/FooBundle/config/definition.php
     use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
@@ -480,7 +480,7 @@ where you also have the possibility to import configuration definition from an e
 
 .. note::
 
-    The "configure()" method is called only at compiler time.
+    The "configure()" method is called only at compile time.
 
 .. _`FrameworkBundle Configuration`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
 .. _`TwigBundle Configuration`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php

--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -367,7 +367,7 @@ add this logic to the bundle class directly::
 .. tip::
 
     The ``AbstractBundle::configure()`` method also allows to import the
-    configuration definitino from one or more files::
+    configuration definition from one or more files::
 
         // src/AcmeSocialBundle.php
 

--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -431,6 +431,57 @@ Assuming the XSD file is called ``hello-1.0.xsd``, the schema location will be
         <!-- ... -->
     </container>
 
+Defining Configuration directly in your Bundle class
+----------------------------------------------------
+
+.. versionadded:: 6.1
+
+    The ``AbstractBundle`` class is introduced in Symfony 6.1.
+
+As another option, you can define the extension configuration directly in your Bundle
+class by implementing :class:`Symfony\\Component\\Config\\Definition\\ConfigurableInterface`,
+which is already supported when your bundle extend from the :class:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle`::
+
+    use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+    use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+
+    class AcmeFooBundle extends AbstractBundle
+    {
+        public function configure(DefinitionConfigurator $definition): void
+        {
+            // loads config definition from a file
+            $definition->import('../config/definition.php');
+
+            // loads config definition from multiple files (when it's too long you can split it)
+            $definition->import('../config/definition/*.php');
+
+            // if the configuration is short, consider adding it in this class
+            $definition->rootNode()
+                ->children()
+                    ->scalarNode('foo')->defaultValue('bar')->end()
+                ->end()
+            ;
+        }
+    }
+
+This method is a shortcut of the previous "Extension", "Configuration" and "TreeBuilder" convention,
+where you also have the possibility to import configuration definition from an external file::
+
+    // Acme/FooBundle/config/definition.php
+    use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+
+    return static function (DefinitionConfigurator $definition) {
+        $definition->rootNode()
+            ->children()
+                ->scalarNode('foo')->defaultValue('bar')->end()
+            ->end()
+        ;
+    };
+
+.. note::
+
+    The "configure()" method is called only at compiler time.
+
 .. _`FrameworkBundle Configuration`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
 .. _`TwigBundle Configuration`: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
 .. _`XML namespace`: https://en.wikipedia.org/wiki/XML_namespace

--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -187,4 +187,4 @@ them in place using the fluent interfaces.
 
 .. note::
 
-    The "loadExtension()" like "load()" method is called only at compiler time.
+    The "loadExtension()", as the "load()" method, are called only at compile time.

--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -147,3 +147,44 @@ the full classmap executing the ``dump-autoload`` command of Composer.
     This technique can't be used when the classes to compile use the ``__DIR__``
     or ``__FILE__`` constants, because their values will change when loading
     these classes from the ``classes.php`` file.
+
+Loading Services directly in your Bundle class
+----------------------------------------------
+
+.. versionadded:: 6.1
+
+    The ``AbstractBundle`` class is introduced in Symfony 6.1.
+
+Alternatively, you can define and load services configuration directly in a bundle class
+by extending from the :class:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle`
+and defining the :method:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle::loadExtension` method::
+
+    use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+    use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+    class AcmeFooBundle extends AbstractBundle
+    {
+        public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+        {
+            $container->parameters()
+                ->set('foo', $config['foo']);
+
+            $container->import('../config/services.php');
+
+            if ('bar' === $config['foo']) {
+                $container->services()
+                    ->set(Parser::class);
+            }
+        }
+    }
+
+This method is a shortcut of the previous "load()" method, but with more options
+to define and import the service configuration with less effort. The ``$config``
+argument is the previous ``$configs`` array but already merged and processed. And
+through the ``$container`` configurator you can import the services configuration
+from an external file in any supported format (php, yaml, xml) or simply define
+them in place using the fluent interfaces.
+
+.. note::
+
+    The "loadExtension()" like "load()" method is called only at compiler time.

--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -30,7 +30,7 @@ follow these conventions (but later you'll learn how to skip them if needed):
 
 This is how the extension of an AcmeHelloBundle should look like::
 
-    // src/Acme/HelloBundle/DependencyInjection/AcmeHelloExtension.php
+    // src/DependencyInjection/AcmeHelloExtension.php
     namespace Acme\HelloBundle\DependencyInjection;
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -87,7 +87,7 @@ but it is more common if you put these definitions in a configuration file
 (using the YAML, XML or PHP format).
 
 For instance, assume you have a file called ``services.xml`` in the
-``Resources/config/`` directory of your bundle, your ``load()`` method looks like::
+``config/`` directory of your bundle, your ``load()`` method looks like::
 
     use Symfony\Component\Config\FileLocator;
     use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -97,7 +97,7 @@ For instance, assume you have a file called ``services.xml`` in the
     {
         $loader = new XmlFileLoader(
             $container,
-            new FileLocator(__DIR__.'/../config')
+            new FileLocator(__DIR__.'/../../config')
         );
         $loader->load('services.xml');
     }

--- a/bundles/override.rst
+++ b/bundles/override.rst
@@ -12,7 +12,7 @@ features of a bundle.
 
     The bundle overriding mechanism means that you cannot use physical paths to
     refer to bundle's resources (e.g. ``__DIR__/config/services.xml``). Always
-    use logical paths in your bundles (e.g. ``@FooBundle/Resources/config/services.xml``)
+    use logical paths in your bundles (e.g. ``@FooBundle/config/services.xml``)
     and call the :ref:`locateResource() method <http-kernel-resource-locator>`
     to turn them into physical paths when needed.
 
@@ -23,12 +23,12 @@ Templates
 
 Third-party bundle templates can be overridden in the
 ``<your-project>/templates/bundles/<bundle-name>/`` directory. The new templates
-must use the same name and path (relative to ``<bundle>/Resources/views/``) as
+must use the same name and path (relative to ``<bundle>/templates/``) as
 the original templates.
 
-For example, to override the ``Resources/views/Registration/confirmed.html.twig``
-template from the FOSUserBundle, create this template:
-``<your-project>/templates/bundles/FOSUserBundle/Registration/confirmed.html.twig``
+For example, to override the ``templates/registration/confirmed.html.twig``
+template from the AcmeUserBundle, create this template:
+``<your-project>/templates/bundles/AcmeUserBundle/registration/confirmed.html.twig``
 
 .. caution::
 
@@ -43,9 +43,9 @@ extend from the original template, not from the overridden one:
 
 .. code-block:: twig
 
-    {# templates/bundles/FOSUserBundle/Registration/confirmed.html.twig #}
+    {# templates/bundles/AcmeUserBundle/registration/confirmed.html.twig #}
     {# the special '!' prefix avoids errors when extending from an overridden template #}
-    {% extends "@!FOSUser/Registration/confirmed.html.twig" %}
+    {% extends "@!AcmeUser/registration/confirmed.html.twig" %}
 
     {% block some_block %}
         ...
@@ -173,7 +173,7 @@ For this reason, you can override any bundle translation file from the main
 ``translations/`` directory, as long as the new file uses the same domain.
 
 For example, to override the translations defined in the
-``Resources/translations/FOSUserBundle.es.yml`` file of the FOSUserBundle,
-create a ``<your-project>/translations/FOSUserBundle.es.yml`` file.
+``translations/AcmeUserBundle.es.yaml`` file of the AcmeUserBundle,
+create a ``<your-project>/translations/AcmeUserBundle.es.yaml`` file.
 
 .. _`the Doctrine documentation`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/inheritance-mapping.html#overrides

--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -197,4 +197,4 @@ the supported formats (php, yaml, xml).
 
 .. note::
 
-    The "prependExtension()" like "prepend()" method is called only at compiler time.
+    The "prependExtension()" like "prepend()" method is called only at compile time.

--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -151,25 +151,20 @@ registered and the ``entity_manager_name`` setting for ``acme_hello`` is set to
             'use_acme_goodbye' => false,
         ]);
 
-More than one Bundle using PrependExtensionInterface
-----------------------------------------------------
-
-If there is more than one bundle that prepends the same extension and defines
-the same key, the bundle that is registered **first** will take priority:
-next bundles won't override this specific config setting.
-
-Prepending Extension directly in your Bundle class
---------------------------------------------------
+Prepending Extension in the Bundle Class
+----------------------------------------
 
 .. versionadded:: 6.1
 
     The ``AbstractBundle`` class is introduced in Symfony 6.1.
 
-By preference, you can append or prepend extension configuration directly in your Bundle
-class for any bundle by extending from the :class:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle`
-and defining the :method:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle::prependExtension` method::
+You can also append or prepend extension configuration directly in your
+Bundle class if you extend from the :class:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle`
+class and define the :method:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle::prependExtension`
+method::
 
     use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
     class FooBundle extends AbstractBundle
@@ -191,10 +186,13 @@ and defining the :method:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle
         }
     }
 
-This method is a shortcut of the previous "PrependExtensionInterface::prepend" method,
-allowing you also to import and append extension config from an external file in one of
-the supported formats (php, yaml, xml).
-
 .. note::
 
-    The "prependExtension()" like "prepend()" method is called only at compile time.
+    The ``prependExtension()`` method, like ``prepend()``, is called only at compile time.
+
+More than one Bundle using PrependExtensionInterface
+----------------------------------------------------
+
+If there is more than one bundle that prepends the same extension and defines
+the same key, the bundle that is registered **first** will take priority:
+next bundles won't override this specific config setting.

--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -157,3 +157,44 @@ More than one Bundle using PrependExtensionInterface
 If there is more than one bundle that prepends the same extension and defines
 the same key, the bundle that is registered **first** will take priority:
 next bundles won't override this specific config setting.
+
+Prepending Extension directly in your Bundle class
+--------------------------------------------------
+
+.. versionadded:: 6.1
+
+    The ``AbstractBundle`` class is introduced in Symfony 6.1.
+
+By preference, you can append or prepend extension configuration directly in your Bundle
+class for any bundle by extending from the :class:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle`
+and defining the :method:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle::prependExtension` method::
+
+    use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+    use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+    class FooBundle extends AbstractBundle
+    {
+        public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
+        {
+            // prepend
+            $builder->prependExtensionConfig('framework', [
+                'cache' => ['prefix_seed' => 'foo/bar'],
+            ]);
+
+            // append
+            $container->extension('framework', [
+                'cache' => ['prefix_seed' => 'foo/bar'],
+            ])
+
+            // append from file
+            $container->import('../config/packages/cache.php');
+        }
+    }
+
+This method is a shortcut of the previous "PrependExtensionInterface::prepend" method,
+allowing you also to import and append extension config from an external file in one of
+the supported formats (php, yaml, xml).
+
+.. note::
+
+    The "prependExtension()" like "prepend()" method is called only at compiler time.

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -99,8 +99,8 @@ that define your bundles, your services and your routes:
     ``RoutingConfigurator`` has methods that make adding routes in PHP more
     fun. You can also load external routing files (shown below).
 
-Advanced Example: Configuration, Twig, Annotations and the Web Debug Toolbar
-----------------------------------------------------------------------------
+Advanced Example: Twig, Annotations and the Web Debug Toolbar
+-------------------------------------------------------------
 
 The purpose of the ``MicroKernelTrait`` is *not* to have a single-file application.
 Instead, its goal to give you the power to choose your bundles and structure.

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -163,7 +163,6 @@ Now it looks like this::
         protected function configureContainer(ContainerConfigurator $c): void
         {
             $c->import(__DIR__.'/../config/framework.yaml');
-            $c->import(__DIR__.'/../config/web_profiler.yaml');
 
             // register all classes in /src/ as service
             $c->services()
@@ -171,6 +170,14 @@ Now it looks like this::
                 ->autowire()
                 ->autoconfigure()
             ;
+
+            // configure WebProfilerBundle only if the bundle is enabled
+            if (isset($this->bundles['WebProfilerBundle'])) {
+                $c->extension('web_profiler', [
+                    'toolbar' => true,
+                    'intercept_redirects' => false,
+                ]);
+            }
         }
 
         protected function configureRoutes(RoutingConfigurator $routes): void
@@ -229,10 +236,14 @@ add a service conditionally based on the ``foo`` value::
         public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
         {
             if ($config['foo']) {
-                $container->set('foo_service', new stdClass());
+                $container->set('foo_service', new \stdClass());
             }
         }
     }
+
+.. versionadded:: 6.1
+
+    The ``AbstractExtension`` class is introduced in Symfony 6.1.
 
 Unlike the previous kernel, this loads an external ``config/framework.yaml`` file,
 because the configuration started to get bigger:
@@ -271,46 +282,6 @@ because the configuration started to get bigger:
                 ->secret('SOME_SECRET')
                 ->profiler()
                     ->onlyExceptions(false)
-            ;
-        };
-
-As well as the ``config/web_profiler.yaml`` file:
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # config/web_profiler.yaml
-        when@dev:
-            web_profiler:
-                toolbar: true
-                intercept_redirects: false
-
-    .. code-block:: xml
-
-        <!-- config/web_profiler.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:framework="http://symfony.com/schema/dic/symfony"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
-            <!-- WebProfilerBundle is enabled only in the "dev" environment -->
-            <when env="dev">
-                <web-profiler:config toolbar="true" intercept-redirects="false"/>
-            </when>
-        </container>
-
-    .. code-block:: php
-
-        // config/web_profiler.php
-        use Symfony\Config\WebProfilerConfig;
-
-        return static function (WebProfilerConfig $webProfiler) {
-            $webProfiler
-                ->toolbar(true)
-                ->interceptRedirects(false)
             ;
         };
 

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -297,7 +297,9 @@ has one file in it::
 
     class MicroController extends AbstractController
     {
-        #[Route('/random/{limit}')]
+        /**
+         * @Route("/random/{limit}")
+         */
         public function randomNumber(int $limit): Response
         {
             $number = random_int(0, $limit);


### PR DESCRIPTION
Fixes #16669
PR https://github.com/symfony/symfony/pull/43701

ping @Nyholm @wouterj as you were interested in this feature/doc. Any suggestion to improve the wording is more than welcome!

---

I also updated other places to be aligned with the best practices doc.
I didn't remove the current convention to create bundles/extensions/configurations because they are still valid until 6.4 becomes the last LTS available. However, it's ok for apps using AbstractExtension.