### PR TITLE
[Bundles] [Bundle] Fix code example about prepend config

### DIFF
--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -80,22 +80,18 @@ in case a specific other bundle is not registered::
             }
         }
 
-        // process the configuration of AcmeHelloExtension
+        // get the configuration of AcmeHelloExtension (it's a list of configuration)
         $configs = $container->getExtensionConfig($this->getAlias());
 
-        // resolve config parameters e.g. %kernel.debug% to its boolean value
-        $resolvingBag = $container->getParameterBag();
-        $configs = $resolvingBag->resolveValue($configs);
-        
-        // use the Configuration class to generate a config array with
-        // the settings "acme_hello"
-        $config = $this->processConfiguration(new Configuration(), $configs);
-
-        // check if entity_manager_name is set in the "acme_hello" configuration
-        if (isset($config['entity_manager_name'])) {
-            // prepend the acme_something settings with the entity_manager_name
-            $config = ['entity_manager_name' => $config['entity_manager_name']];
-            $container->prependExtensionConfig('acme_something', $config);
+        // iterate in reverse to preserve the original order after prepending the config
+        foreach (array_reverse($configs) as $config) {
+            // check if entity_manager_name is set in the "acme_hello" configuration
+            if (isset($config['entity_manager_name'])) {
+                // prepend the acme_something settings with the entity_manager_name
+                $container->prependExtensionConfig('acme_something', [
+                    'entity_manager_name' => $config['entity_manager_name'],
+                ]);
+            }
         }
     }
 


### PR DESCRIPTION
See issue https://github.com/symfony/symfony/issues/40198

The prepend mechanism happens before resolving any parameters and env vars, so at this moment the raw configs are not yet ready to be normalized and merged.

Note that you can prepend a raw config like this one without any problem:
```php
$container->prependExtensionConfig('foo', [
    'enabled' => '%kernel.debug%', // or '%env(bool:DEBUG_ENABLED)%'
]);
```

Now, if you want to add an extension config based on another extension config, what you have to do is to prepend this config iterating over the other one without merging, e.g.:
```php
$configs = $container->getExtensionConfig('foo');

// iterate in reverse to preserve the original order after prepending config
foreach (array_reverse($configs) as $config) {
    $container->prependExtensionConfig('bar', [ 
        'enabled' => $config['enabled'], // raw value
    ]);
}
```
Where `$config['enabled']` can be a boolean value, a parameter, or an env var. It doesn't matter because the real value will be determined by Symfony after resolving, normalizing, and merging all configs.

Note also that you can't be 100% sure that `$container->getExtensionConfig('foo')` will return all configs because there could be another extension (being executed after) appending config to your own `foo` extension, and then the final config could differ.

About conditional configuration, it's harder to handle here. Even if you can resolve the parameter or env var to know the real value you should never pass the resolved value to another config, otherwise, something like this https://github.com/symfony/symfony/issues/40198#issuecomment-809409666 will happen, especially when env vars are used.

Therefore, the current documentation is error-prone as is, so I suggest using the iteration approach instead to avoid any issue with parameters and env vars.