### PR TITLE
[Form][Security] Configure field_name under framework.form

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -335,6 +335,15 @@ settings is configured.
 
     For more details, see :doc:`/forms`.
 
+.. _reference-form-field-name:
+
+field_name
+..........
+
+**type**: ``string`` **default**: ``_token``
+
+This is the field name that you should give to the CSRF token field of your forms.
+
 .. _reference-framework-csrf-protection:
 
 csrf_protection
@@ -357,14 +366,14 @@ can also :ref:`disable CSRF protection on individual forms <form-csrf-customizat
 .. configuration-block::
 
     .. code-block:: yaml
-    
+
         # config/packages/framework.yaml
         framework:
             # ...
             csrf_protection: true
-            
+
     .. code-block:: xml
-    
+
         <!-- config/packages/framework.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
@@ -378,9 +387,9 @@ can also :ref:`disable CSRF protection on individual forms <form-csrf-customizat
                 <framework:csrf-protection enabled="true"/>
             </framework:config>
         </container>
-        
+
     .. code-block:: php
-    
+
         // config/packages/framework.php
         use Symfony\Config\FrameworkConfig;
         return static function (FrameworkConfig $framework) {


### PR DESCRIPTION
Found a missing `field_name` configuration parameter under `framework.form` according to https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php#L170.