### PR TITLE
[Console] Clarify VALUE_IS_ARRAY usage

### DIFF
--- a/console/input.rst
+++ b/console/input.rst
@@ -217,7 +217,7 @@ There are four option variants you can use:
     This option may or may not have a value (e.g. ``--yell`` or
     ``--yell=loud``).
 
-You can combine ``VALUE_IS_ARRAY`` with ``VALUE_REQUIRED`` or
+You need to combine ``VALUE_IS_ARRAY`` with ``VALUE_REQUIRED`` or
 ``VALUE_OPTIONAL`` like this::
 
     $this


### PR DESCRIPTION
VALUE_IS_ARRAY can't be used alone and must be combined with VALUE_REQUIRED or VALUE_OPTIONAL else
we will get InvalidArgumentException('Impossible to have an option mode VALUE_IS_ARRAY if the option does not accept a value.')

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
