### PR TITLE
[Serializer] Fix XML example of ignoring an attribute

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -489,9 +489,7 @@ Option 1: Using ``@Ignore`` Annotation
                 https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
         >
             <class name="App\Model\MyClass">
-                <attribute name="bar">
-                    <ignore>true</ignore>
-                </attribute>
+                <attribute name="bar" ignore="true"/>
             </class>
         </serializer>
 


### PR DESCRIPTION
The XML example for configuring the Serializer to ignore an attribute is incorrect. It shows `ignore` as a child element of `attribute` instead of as an attribute of `attribute`.

This causes the following exception:

```
In XmlUtils.php line 107:

  [Symfony\Component\Config\Util\Exception\XmlParsingException]
  [ERROR 1871] Element '{http://symfony.com/schema/dic/serializer-mapping}ignore': This element is not expected. Expected is one of ( {http://symfony.com/schema/dic/seri
  alizer-mapping}group, {http://symfony.com/schema/dic/serializer-mapping}context, {http://symfony.com/schema/dic/serializer-mapping}normalization_context, {http://symfo
  ny.com/schema/dic/serializer-mapping}denormalization_context ).
  ```
