### PR TITLE
Add assets to the documentation

### DIFF
--- a/bundles.rst
+++ b/bundles.rst
@@ -98,6 +98,9 @@ to be adjusted if needed:
 ``src/``
     Contains all PHP classes related to the bundle logic (e.g. ``Controller/RandomController.php``).
 
+``assets/``
+    Contains javascript, css, images and other assets related to the bundle that are not in ``/public`` (e.g. stimulus controllers)
+    
 ``config/``
     Houses configuration, including routing configuration (e.g. ``routing.yaml``).
 


### PR DESCRIPTION
'assets' used to be in the /Resources folder, but seems like it should be at the root now, like config and views/templates.

I'm guessing that if package.json is in right place, then flex will register the stimulus controller, although I haven't been able to do that yet: https://github.com/symfony/flex/issues/919