### PR TITLE
Update choice_translation_domain.rst.inc

### DIFF
--- a/reference/forms/types/options/choice_translation_domain.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain.rst.inc
@@ -1,7 +1,7 @@
 ``choice_translation_domain``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-DEFAULT_VALUE
+.. DEFAULT_VALUE
 
 This option determines if the choice values should be translated and in which
 translation domain.


### PR DESCRIPTION
To be honest, I am not sure how this works but this part does not work correctly - see https://symfony.com/doc/current/reference/forms/types/choice.html#choice-translation-domain (Symfony 6.1), choice_translation_domain is shown twice and placeholders are not processed.

This file is used in these:
/6.1/reference/forms/types/options/choice_translation_domain_enabled.rst.inc
/6.1/reference/forms/types/options/choice_translation_domain_disabled.rst.inc

The "fix" I did has not been checked.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
