### PR TITLE
[Security] Fix second Twig path reference to be consistent with the first reference

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -939,7 +939,7 @@ be ``authenticate``:
 
 .. code-block:: html+twig
 
-    {# templates/security/login.html.twig #}
+    {# templates/login/index.html.twig #}
 
     {# ... #}
     <form action="{{ path('login') }}" method="post">


### PR DESCRIPTION
I found an inconsistency in the Security documentation :

![image](https://user-images.githubusercontent.com/292402/171823645-2556f153-2002-4afc-adfe-f41e2e3919b7.png)

![image](https://user-images.githubusercontent.com/292402/171823749-83977ea5-fe25-47d3-8435-410ee6b34609.png)

This PR fix that.