### PR TITLE
[Serializer] Update serializer.rst

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1108,8 +1108,10 @@ always as a collection.
     behavior can be changed with the optional context key ``XmlEncoder::DECODER_IGNORED_NODE_TYPES``.
 
     Data with ``#comment`` keys are encoded to XML comments by default. This can be
-    changed with the optional ``$encoderIgnoredNodeTypes`` argument of the
-    ``XmlEncoder`` class constructor.
+    changed by adding the ``\XML_COMMENT_NODE`` option to the ``XmlEncoder::ENCODER_IGNORED_NODE_TYPES`` key of the ``$defaultContext``  of the
+    ``XmlEncoder`` class constructor or directly to the encode() method's $context argument.
+    
+        $xmlEncoder->encode($array, 'xml', [XmlEncoder::ENCODER_IGNORED_NODE_TYPES => [\XML_COMMENT_NODE]]);
 
 The ``XmlEncoder`` Context Options
 ..................................


### PR DESCRIPTION
Hello 

The `$encoderIgnoredNodeTypes` does not exist in the XmlEncoder's constructor and the $defaultContext argument should be used instead, So To escape the comments while encoding, we can either pass the `\XML_COMMENT_NODE` to the  `XmlEncoder::ENCODER_IGNORED_NODE_TYPES` context option in the constructor  or use it when calling the encode() method.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
