### PR TITLE
[Form] fix EntityType with multiple=true return type

### DIFF
--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -236,7 +236,16 @@ These options inherit from the :doc:`ChoiceType </reference/forms/types/choice>`
 
 .. include:: /reference/forms/types/options/group_by.rst.inc
 
-.. include:: /reference/forms/types/options/multiple.rst.inc
+``multiple``
+~~~~~~~~~~~~
+
+**type**: ``boolean`` **default**: ``false``
+
+If true, the user will be able to select multiple options (as opposed
+to choosing just one option). Depending on the value of the ``expanded``
+option, this will render either a select tag or checkboxes if true and
+a select tag or radio buttons if false. The returned value will be a
+Doctrine's Array Collection.
 
 .. note::
 


### PR DESCRIPTION
Small fix for #16805 about return type in form with multiple option

I'm doing this on version 4.4 because it's the older maintained, but maybe we need to correct further? 