### PR TITLE
[Form] Fix constants

### DIFF
--- a/reference/forms/types/options/rounding_mode.rst.inc
+++ b/reference/forms/types/options/rounding_mode.rst.inc
@@ -2,13 +2,13 @@ rounding_mode
 ~~~~~~~~~~~~~
 
 **type**: ``integer`` **default**: ``\NumberFormatter::ROUND_DOWN`` for ``IntegerType``
-and ``\NumberFormatter::ROUND_HALF_UP`` for ``MoneyType`` and ``NumberType``
+and ``\NumberFormatter::ROUND_HALFUP`` for ``MoneyType`` and ``NumberType``
 
 * IntegerType
 **default**: ``\NumberFormatter::ROUND_DOWN``
 
 * MoneyType and NumberType
-**default**: ``\NumberFormatter::ROUND_HALF_UP``
+**default**: ``\NumberFormatter::ROUND_HALFUP``
 
 
 If a submitted number needs to be rounded (based on the `scale`_ option), you


### PR DESCRIPTION
See down in the file
```
* ``\NumberFormatter::ROUND_HALFUP`` Round towards the
  "nearest neighbor". If both neighbors are equidistant, round up. It rounds
  ``2.5`` to ``3``, ``1.6`` and ``1.5`` to ``2`` and ``1.4`` to ``1``.
```