### PR TITLE
Change recommended way to access array query string parameters

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -172,6 +172,10 @@ doesn't support returning arrays, so you need to use the following code::
     $request->query->all('foo');
     // returns ['bar' => 'baz']
 
+    // if the requested parameter does not exist, an empty array is returned:
+    $request->query->all('qux');
+    // returns []
+
     $request->query->get('foo[bar]');
     // returns null
 

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -169,7 +169,7 @@ doesn't support returning arrays, so you need to use the following code::
     // the query string is '?foo[bar]=baz'
 
     // don't use $request->query->get('foo'); use the following instead:
-    $request->query->all()['foo'];
+    $request->query->all('foo');
     // returns ['bar' => 'baz']
 
     $request->query->get('foo[bar]');


### PR DESCRIPTION
`$request->query->all()['foo'];` triggers an 'Undefined array key "foo"' error when `foo` doesn't exist. However `$request->query->all('foo');` return null  when `foo` doesn't exist (consistent with `$request->query->get('bar');` for accessing a string parameter `bar` which might not exist).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
