### PR TITLE
[Console] Update questionhelper.rst

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -410,7 +410,7 @@ invalid answer and will only be able to proceed if their input is valid.
 
         $question = new Question('Please enter the name of the bundle', 'AcmeDemoBundle');
         $validation = Validation::createCallable(new Regex([
-            'pattern' => '/^[a-zA-Z]+Bundle$',
+            'pattern' => '/^[a-zA-Z]+Bundle$/',
             'message' => 'The name of the bundle should be suffixed with \'Bundle\'',
         ]));
         $question->setValidator($validation);


### PR DESCRIPTION
hello

the example shows a warning (preg_match(): No ending delimiter'/' found). to solve it, we need to add the ``/`` at the end of the regex.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
