### PR TITLE
[Console] Update questionhelper.rst

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -384,6 +384,9 @@ You can also use a validator with a hidden question::
         $helper = $this->getHelper('question');
 
         $question = new Question('Please enter your password');
+        $question->setNormalizer(function ($value) {
+            return null === $value ? '' : $value;
+        });
         $question->setValidator(function ($value) {
             if (trim($value) == '') {
                 throw new \Exception('The password cannot be empty');


### PR DESCRIPTION
hello,

when running the example as it is, a deprecation message is shown (i'm on PHP 8.1.6). the deprecation message says that ``trim(): Passing null to parameter #1 ($string) of type string is deprecated``.
what if we add a normalizer that returns an empty string when the entered value is `null` otherwise returns the user's intial input.  with this suggestion, the example works great

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
