### PR TITLE
Update http_kernel_httpkernelinterface.rst

### DIFF
--- a/create_framework/http_kernel_httpkernelinterface.rst
+++ b/create_framework/http_kernel_httpkernelinterface.rst
@@ -155,7 +155,7 @@ rest of the content? Edge Side Includes (`ESI`_) to the rescue! Instead of
 generating the whole content in one go, ESI allows you to mark a region of a
 page as being the content of a sub-request call:
 
-.. code-block:: text
+.. code-block:: xml
 
     This is the content of your page
 


### PR DESCRIPTION
The esi tag is not shown in the documentation page.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
