### PR TITLE
[Form] Fix undefined variable

### DIFF
--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -59,7 +59,7 @@ The simplest ``TypeTestCase`` implementation looks like the following::
             $form = $this->factory->create(TestedType::class, $model);
 
             $expected = new TestObject();
-            // ...populate $object properties with the data stored in $formData
+            // ...populate $expected properties with the data stored in $formData
 
             // submit the data to the form directly
             $form->submit($formData);


### PR DESCRIPTION
There are no variables named `$object` in this method. I think the edited line is referring to the `$expected` variable.