### PR TITLE
[Filesystem] filesystem > readlink: remove function declaration

### DIFF
--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -214,9 +214,7 @@ systems (unlike PHP's :phpfunction:`readlink` function)::
 
 Its behavior is the following::
 
-    public function readlink($path, $canonicalize = false)
-
-* When ``$canonicalize`` is ``false``:
+* When ``$canonicalize`` is ``false`` (the default value):
     * if ``$path`` does not exist or is not a link, it returns ``null``.
     * if ``$path`` is a link, it returns the next direct target of the link without considering the existence of the target.
 


### PR DESCRIPTION
I think that `public function` was confusing here: we don't want to define this method but we want to know how to use it.

The code will be more consistent with the other examples.