### PR TITLE
[DependencyInjection] Add a warning about tagged services needing to be after the glob definition

### DIFF
--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -181,7 +181,7 @@ with the ``doctrine.event_listener`` tag:
         # config/services.yaml
         services:
             # ...
-
+            # It is very important that this definition goes after 'App\:' or it will get overwritten
             App\EventListener\SearchIndexer:
                 tags:
                     -
@@ -206,6 +206,8 @@ with the ``doctrine.event_listener`` tag:
                 <!-- ... -->
 
                 <!--
+                    It is very important that this definition goes after 'App\' or it will get overwritten
+                    
                     * 'event' is the only required option that defines the lifecycle listener
                     * 'priority': used when multiple subscribers or listeners are associated to the same event
                     *             (default priority = 0; higher numbers = listener is run earlier)
@@ -293,6 +295,7 @@ with the ``doctrine.orm.entity_listener`` tag:
         services:
             # ...
 
+            # It is very important that this definition goes after 'App\:' or it will get overwritten
             App\EventListener\UserChangedNotifier:
                 tags:
                     -
@@ -321,10 +324,11 @@ with the ``doctrine.orm.entity_listener`` tag:
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:doctrine="http://symfony.com/schema/dic/doctrine">
             <services>
-                <!-- ... -->
+                <!-- It is very important that this definition goes after 'App\' or it will get overwritten -->
 
                 <service id="App\EventListener\UserChangedNotifier">
                     <!--
+                    
                         * These are the options required to define the entity listener:
                         *   * name
                         *   * event
@@ -458,6 +462,7 @@ Doctrine connection to use) you must do that in the manual service configuration
         services:
             # ...
 
+            # It is very important that this definition goes after 'App\:' or it will get overwritten
             App\EventListener\DatabaseActivitySubscriber:
                 tags:
                     - name: 'doctrine.event_subscriber'
@@ -479,6 +484,8 @@ Doctrine connection to use) you must do that in the manual service configuration
                 <!-- ... -->
 
                 <!--
+                    It is very important that this definition goes after 'App\' or it will get overwritten
+                    
                     * 'priority': used when multiple subscribers or listeners are associated to the same event
                     *             (default priority = 0; higher numbers = listener is run earlier)
                     * 'connection': restricts the listener to a specific Doctrine connection


### PR DESCRIPTION
It took me 2hours to debug and figure out why my listener wasn't working while following the doc, when it's just because the tag definition was not being applied

Basically just declaring it like this
```yaml

  App\EventListener\MyListener:
    tags:
      -
        name: 'doctrine.orm.entity_listener'
        event: 'postUpdate'
        entity: 'App\Entity\MyEntity'
        
  # makes classes in src/ available to be used as services
  # this creates a service per class whose id is the fully-qualified class name
  App\:
    resource: '../src/'
    exclude:
      - '../src/DependencyInjection/'
      - '../src/Entity/'
      - '../src/Kernel.php'
```

When for it to work it needs to be like 

```yaml
  # makes classes in src/ available to be used as services
  # this creates a service per class whose id is the fully-qualified class name
  App\:
    resource: '../src/'
    exclude:
      - '../src/DependencyInjection/'
      - '../src/Entity/'
      - '../src/Kernel.php'
      
  App\EventListener\MyListener:
    tags:
      -
        name: 'doctrine.orm.entity_listener'
        event: 'postUpdate'
        entity: 'App\Entity\MyEntity'
        
```

This mistake is so easy to make it deserves a proper warning