### PR TITLE
Adding single quotes around version param

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -48,7 +48,7 @@ Installation
     always use its very latest stable major version to get the most accurate
     deprecation report.
 
-If you plan to :ref:`write-assertions-about-deprecations` and use the regular
+If you plan to :ref:`write assertions about deprecations <write-assertions-about-deprecations>` and use the regular
 PHPUnit script (not the modified PHPUnit script provided by Symfony), you have
 to register a new `test listener`_ called ``SymfonyTestsListener``:
 

--- a/http_client.rst
+++ b/http_client.rst
@@ -814,6 +814,25 @@ ensure local networks are made inaccessible to the HTTP client::
     // but all the other requests, including other internal networks, will be allowed
     $client = new NoPrivateNetworkHttpClient(HttpClient::create(), ['104.26.14.0/23']);
 
+Profiling
+~~~~~~~~~
+
+When you are using the :class:`Symfony\\Component\\HttpClient\\TraceableHttpClient`,
+responses content will be kept in memory and may exhaust it.
+
+You can disable this behavior by setting the ``extra.trace_content`` option to ``false``
+in your requests::
+
+    $response = $client->request('GET', 'https://...', [
+        'extra' => ['trace_content' => false],
+    ]);
+
+This setting won’t affect other clients.
+
+.. versionadded:: 5.2
+
+    The ``extra.trace_content`` option was introduced in Symfony 5.2.
+
 Performance
 -----------
 

--- a/reference/constraints/Locale.rst
+++ b/reference/constraints/Locale.rst
@@ -128,6 +128,6 @@ Parameter        Description
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
-.. _`ICU format locale IDs`: http://userguide.icu-project.org/locale
+.. _`ICU format locale IDs`: https://unicode-org.github.io/icu/userguide/locale/
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 .. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes

--- a/setup.rst
+++ b/setup.rst
@@ -49,10 +49,10 @@ application:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ symfony new my_project_directory --version=6.0.* --webapp
+    $ symfony new my_project_directory --version='6.0.*' --webapp
 
     # run this if you are building a microservice, console application or API
-    $ symfony new my_project_directory --version=6.0.*
+    $ symfony new my_project_directory --version='6.0.*'
 
 The only difference between these two commands is the number of packages
 installed by default. The ``--webapp`` option installs all the packages that you
@@ -273,7 +273,7 @@ stable version. If you want to use an LTS version, add the ``--version`` option:
     $ symfony new my_project_directory --version=next
 
     # you can also select an exact specific Symfony version
-    $ symfony new my_project_directory --version=5.4.*
+    $ symfony new my_project_directory --version='5.4.*'
 
 The ``lts`` and ``next`` shortcuts are only available when using Symfony to
 create new projects. If you use Composer, you need to tell the exact version:


### PR DESCRIPTION
Adding single quotes around version param as otherwise getting this in zsh on MBP:

peter@Peters-MacBook-Pro-3 Projects % symfony new my_project_directory --version=6.0.* --webapp
zsh: no matches found: --version=6.0.*

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
