### PR TITLE
Tweaking name of Symfonycasts tutorial for Symfony 6

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -21,7 +21,7 @@ two-step process:
 .. admonition:: Screencast
     :class: screencast
 
-    Do you prefer video tutorials? Check out the `Stellar Development with Symfony`_
+    Do you prefer video tutorials? Check out the `Harmonious Development with Symfony`_
     screencast series.
 
 .. seealso::

--- a/setup.rst
+++ b/setup.rst
@@ -7,7 +7,7 @@ Installing & Setting up the Symfony Framework
 .. admonition:: Screencast
     :class: screencast
 
-    Do you prefer video tutorials? Check out the `Stellar Development with Symfony`_
+    Do you prefer video tutorials? Check out the `Harmonious Development with Symfony`_
     screencast series.
 
 .. _symfony-tech-requirements:


### PR DESCRIPTION
Hi!

Very minor: in just these 2 places, we include the screencast name. For Symfony 6, the name is "Harmonious" :).

Thanks!