### PR TITLE
[Notifier] Fix documentation symfony notifier

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -697,7 +697,7 @@ and its ``asChatMessage()`` method::
     use Symfony\Component\Notifier\Message\ChatMessage;
     use Symfony\Component\Notifier\Notification\ChatNotificationInterface;
     use Symfony\Component\Notifier\Notification\Notification;
-    use Symfony\Component\Notifier\Recipient\SmsRecipientInterface;
+    use Symfony\Component\Notifier\Recipient\RecipientInterface;
 
     class InvoiceNotification extends Notification implements ChatNotificationInterface
     {
@@ -710,10 +710,11 @@ and its ``asChatMessage()`` method::
 
         public function asChatMessage(RecipientInterface $recipient, string $transport = null): ?ChatMessage
         {
-            // Add a custom emoji if the message is sent to Slack
+            // Add a custom subject and emoji if the message is sent to Slack
             if ('slack' === $transport) {
-                return (new ChatMessage('You\'re invoiced '.$this->price.' EUR.'))
-                    ->emoji('money');
+                $this->subject('You\'re invoiced '.strval($this->price).' EUR.');
+                $this->emoji("money");
+                return ChatMessage::fromNotification($this);
             }
 
             // If you return null, the Notifier will create the ChatMessage


### PR DESCRIPTION
Hi there :wave: 

After following [the notifier doc](https://symfony.com/doc/current/notifier.html#customize-notification-messages) to send slack notifications, I think there is a problem at the message customization step : 
- I successfully get a slack notification, but when we go to the "Notifications" tab of the Symfony profiler I have an error message "`Impossible to invoke a method ("getSubject") on a variable null" ` 
![image](https://user-images.githubusercontent.com/95386861/175016223-b48f5011-f596-4fb5-9200-ee3e5b894830.png)
- when i dump the created ChatMessage, i see that the notification is empty.
![image](https://user-images.githubusercontent.com/95386861/175016085-86229a23-464e-43b6-8c9a-2dd6f887acc3.png)

=>  Reading the ChatMessage class, it seems that the static method **fromNotification** can solves this problem _(check PR proposal)_

The other fixes are more obvious:
- use RecipientInterface instead of SmsRecipientInterface since in the asChatMessage we use the RecipientInterface
- strval on price in the message since price is an integer
- method emoji on notification not on ChatMessage as the doc is telling us

_(FYI this is my first public PR on github)_



<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
