### PR TITLE
[Serializer] Update serializer.rst

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -639,8 +639,8 @@ If you are using isser methods (methods prefixed by ``is``, like
 ``App\Model\Person::isSportsperson()``), the Serializer component will
 automatically detect and use it to serialize related attributes.
 
-The ``ObjectNormalizer`` also takes care of methods starting with ``has``, ``add``
-and ``remove``.
+The ``ObjectNormalizer`` also takes care of methods starting with ``has`` and
+``get``.
 
 Using Callbacks to Serialize Properties with Object Instances
 -------------------------------------------------------------


### PR DESCRIPTION
I have checked  ``ObjectNormalizer`` and I found only methods start by (is, has,  get,  and  can) can be detected automatically for normalising them

Am I wrong?