### PR TITLE
[Form] Fix mistake about the reason of the limitation of the timestamp in 32bit systems

### DIFF
--- a/reference/forms/types/options/_date_limitation.rst.inc
+++ b/reference/forms/types/options/_date_limitation.rst.inc
@@ -1,7 +1,7 @@
 .. caution::
 
     If ``timestamp`` is used, ``DateType`` is limited to dates between
-    Fri, 13 Dec 1901 20:45:54 GMT and Tue, 19 Jan 2038 03:14:07 GMT on 32bit
-    systems. This is due to a `limitation in PHP itself`_.
+    Fri, 13 Dec 1901 20:45:54 UTC and Tue, 19 Jan 2038 03:14:07 UTC on 32bit
+    systems. This is due to an integer overflow bug in 32bit systems known as the `Year 2038 problem`_.
 
-.. _limitation in PHP itself: https://www.php.net/manual/en/function.date.php#refsect1-function.date-changelog
+.. _Year 2038 problem: https://en.wikipedia.org/wiki/Year_2038_problem


### PR DESCRIPTION
In the docs of the forms `DateType` field, we can read the following warning:

> If `timestamp` is used, `DateType` is limited to dates between Fri, 13 Dec 1901 20:45:54 GMT and Tue, 19 Jan 2038 03:14:07 GMT on 32bit systems. This is due to a [limitation in PHP itself](https://www.php.net/manual/en/function.date.php#refsect1-function.date-changelog).

The limitation is actually not specific to PHP, but related to the [Year 2038 problem](https://en.wikipedia.org/wiki/Year_2038_problem) that affects all 32bits systems.
Just proposing a change to the docs to correct the information. :)

(I'm sorry if it reminds another similar bug from the end of the last century :eyes:)

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
