### PR TITLE
Add `getter` and `setter` in the section on basic form options

### DIFF
--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -76,6 +76,20 @@ The actual default value of this option depends on other field options:
 
 .. include:: /reference/forms/types/options/form_attr.rst.inc
 
+``getter``
+~~~~~~~~~~
+
+**type**: ``callable`` **default**: ``null``
+
+When provided, this callable will be invoked to read the value from
+the underlying object that will be used to populate the form field.
+
+More details are available in the section on :doc:`/form/data_mappers`.
+
+.. versionadded:: 5.2
+
+    Form mapping callbacks were added in Symfony 5.2.
+
 .. include:: /reference/forms/types/options/help.rst.inc
 
 .. include:: /reference/forms/types/options/help_attr.rst.inc
@@ -111,6 +125,20 @@ The actual default value of this option depends on other field options:
 .. _reference-form-option-required:
 
 .. include:: /reference/forms/types/options/required.rst.inc
+
+``setter``
+~~~~~~~~~~
+
+**type**: ``callable`` **default**: ``null``
+
+When provided, this callable will be invoked to map the form value
+back to the underlying object.
+
+More details are available in the section on :doc:`/form/data_mappers`.
+
+.. versionadded:: 5.2
+
+    Form mapping callbacks were added in Symfony 5.2.
 
 .. include:: /reference/forms/types/options/trim.rst.inc
 


### PR DESCRIPTION
`getter` and `setter` were first documented in #14241, but only on the subpage on Data Mappers.

I usually check the general Form Options page when I look for a feature like this, so my suggestion is to mention it there as well.