### PR TITLE
[Routing] Document the Requirement constants in routing.rst

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -774,6 +774,12 @@ URL                       Route          Parameters
 
 .. tip::
 
+    The :class:`Symfony\\Component\\Routing\\Requirement\\Requirement` enum
+    contains a collection of commonly used regular-expression constants such as
+    digits, dates and UUIDs which can be used as route parameter requirements.
+
+.. tip::
+
     Route requirements (and route paths too) can include
     :ref:`configuration parameters <configuration-parameters>`, which is useful to
     define complex regular expressions once and reuse them in multiple routes.


### PR DESCRIPTION
Fixes #16718

https://github.com/symfony/symfony/pull/45528 by @fancyweb introduced the `Symfony\Component\Routing\Requirement\Requirement` enum in Symfony 6.1, as a solution for https://github.com/symfony/symfony/issues/26524.

It was blogged about in https://symfony.com/blog/new-in-symfony-6-1-improved-routing-requirements-and-utf-8-parameters, but I couldn't find it anywhere in the Routing documentation.

This PR adds a small hint about the use of the `Requirement` enum for common route requirements:

![The Requirement enum contains a collection of commonly used regular-expression constants such as digits, dates and UUIDs which can be used as route parameter requirements.](https://user-images.githubusercontent.com/1055691/176497123-24b9bf6e-1b79-4385-baee-0eb132ae8944.png)

I'm open for suggestions to further improve this. I decided to use a small info block instead without code examples, because it doesn't seem to be a big feature and I'm not sure how well it is supported across all configuration formats. Let me know if you would like to see some code examples.