### PR TITLE
Fix doc service deprecation

### DIFF
--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -349,7 +349,10 @@ or you decided not to maintain it anymore), you can deprecate its definition:
 
         # config/services.yaml
         App\Service\OldService:
-            deprecated: The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.
+            deprecated:
+                package: 'vendor-name/package-name'
+                version: '2.8'
+                message: The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.
 
     .. code-block:: xml
 


### PR DESCRIPTION
Hi,
Based on [this PR](https://github.com/symfony/symfony/pull/46814), I've followed [the doc](https://symfony.com/doc/current/service_container/alias_private.html#deprecating-services)

But when tests executed, I got [this error](https://github.com/symfony/symfony/pull/46814#issuecomment-1176361314)

So I propose to fix the doc accordingly here

Thank you