### PR TITLE
Remove deployer as a recommended deployment tool

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -73,10 +73,6 @@ Using Build Scripts and other Tools
 There are also tools to help ease the pain of deployment. Some of them have been
 specifically tailored to the requirements of Symfony.
 
-`Deployer`_
-    This is another native PHP rewrite of Capistrano, with some ready recipes for
-    Symfony.
-
 `Ansistrano`_
     An Ansible role that allows you to configure a powerful deploy via YAML files.
 
@@ -263,7 +259,6 @@ Learn More
 .. _`Memcached`: http://memcached.org/
 .. _`Redis`: https://redis.io/
 .. _`Symfony plugin`: https://github.com/capistrano/symfony/
-.. _`Deployer`: https://deployer.org/
 .. _`Git Tagging`: https://git-scm.com/book/en/v2/Git-Basics-Tagging
 .. _`Platform.sh`: https://symfony.com/cloud
 .. _`Symfony CLI`: https://symfony.com/download


### PR DESCRIPTION
[Deployer](https://deployer.org) has been a recommended deployment tool since 2016. However I feel like the landscape has significantly changed since then and it should no longer be in the list of recommended tools, and even less at the top of this list.

The latest release of the tool which was flagged as stable is more than 2 years old (6.8.0 at the time of writing). The documentation at https://deployer.org/docs/6.x/getting-started warns that it is no longer maintained.

The new major, 7.x, for which work began ~21 months ago is still not flagged as stable. The latest release candidate is 4 months old at this point, and even though the project still has recent commits, I feel like it is not in a spot where it should be recommended to newcomers.