### PR TITLE
[Serializer] fix(serializer): missing empty_array_as_object in example

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -102,12 +102,15 @@ resources. This context is passed to all normalizers. For example:
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\DateTimeNormalizer` uses
   ``datetime_format`` key as date time format;
 * :class:`Symfony\\Component\\Serializer\\Normalizer\\AbstractObjectNormalizer`
-  uses ``empty_iterable_as_object`` to represent empty objects as ``{}`` instead
+  uses ``preserve_empty_objects`` to represent empty objects as ``{}`` instead
+  of ``[]`` in JSON.
+* :class:`Symfony\\Component\\Serializer\\Serializer`
+  uses ``empty_array_as_object`` to represent empty arrays as ``{}`` instead
   of ``[]`` in JSON.
 
 .. versionadded:: 5.4
 
-    The usage of the ``empty_array_as_object`` option by default in the
+    The usage of the ``empty_array_as_object`` option in the
     Serializer was introduced in Symfony 5.4.
 
 You can pass the context as follows::


### PR DESCRIPTION
This PR:
- Replaces `empty_iterable_as_object` by `preserve_empty_objects`, like it should be.
- Adds `empty_array_as_object` to example in Serializer Context.
- Removes the mention `by default`, since it's `false` by default.

Related:
- https://github.com/symfony/symfony-docs/issues/15554
- https://github.com/symfony/symfony-docs/pull/15580
- https://github.com/symfony/symfony/pull/42240
- https://github.com/symfony/symfony/pull/42297