### PR TITLE
[Console] Added a note about the behavior of the command question helper

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -66,6 +66,34 @@ the second argument is not provided, ``true`` is assumed.
 
     The regex defaults to ``/^y/i``.
 
+.. note::
+
+    When your output implements ``ConsoleOutputInterface`` the ``stderr`` output is used using :method:`ConsoleOutputInterface::getErrorOutput`.
+    This output might have a different formatter than the default one. This might lead to unexpected results.
+    If this is the case, you can apply custom styles directly on to the error output::
+
+        use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+        use Symfony\Component\Console\Output\ConsoleOutputInterface;
+        use Symfony\Component\Console\Question\Question;
+
+        // ...
+        public function execute(InputInterface $input, OutputInterface $output)
+        {
+            // ...
+            $question = new Question('Please enter the name of the bundle', 'AcmeDemoBundle');
+
+            if($output instanceof ConsoleOutputInterface) {
+                $output = $output->getErrorOutput();
+            }
+
+            $outputStyle = new OutputFormatterStyle('red', 'yellow', ['bold', 'blink']);
+            $output->getFormatter()->setStyle('fire', $outputStyle);
+
+            $bundleName = $helper->ask($input, $output, $question);
+        }
+
+    More information on formatting can be found on the :doc:`/components/console/helpers/formatterhelper` page.
+
 Asking the User for Information
 -------------------------------
 


### PR DESCRIPTION
While checking this open issue (https://github.com/symfony/symfony/issues/39946), I noticed that the behavior is correct and a bug was fixed with Symfony 5.1.9. 

However, from my point of view, the necessary help was missing in the documentation, which I have added here. 

If the change is accepted like this, the other Symfony issue can be closed as well. 

For some background on this situation, it's worth reading through the comments here: https://github.com/symfony/symfony/pull/38991