### PR TITLE
[HttpFoundation] Update http_foundation.rst

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -162,15 +162,15 @@ exist::
     $request->query->get('bar', 'baz');
     // returns 'baz'
 
-When PHP imports the request query, it handles request parameters like
-``foo[bar]=baz`` in a special way as it creates an array. The ``get()`` method
-doesn't support returning arrays, so you need to use the following code::
+To access request parameters like ``foo[bar]=baz``, you can use the following code::
 
     // the query string is '?foo[bar]=baz'
 
-    // don't use $request->query->get('foo'); use the following instead:
-    $request->query->all('foo');
+    $request->query->get('foo');
     // returns ['bar' => 'baz']
+
+    $request->query->get('foo')['bar'];
+    // retuns "baz"
 
     // if the requested parameter does not exist, an empty array is returned:
     $request->query->all('qux');

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -170,7 +170,7 @@ To access request parameters like ``foo[bar]=baz``, you can use the following co
     // returns ['bar' => 'baz']
 
     $request->query->get('foo')['bar'];
-    // retuns "baz"
+    // returns "baz"
 
     // if the requested parameter does not exist, an empty array is returned:
     $request->query->all('qux');


### PR DESCRIPTION
I believe this is not the case anymore because The get() method returns an array

```
When PHP imports the request query, it handles request parameters like
``foo[bar]=baz`` in a special way as it creates an array. The ``get()`` method
doesn't support returning arrays, so you need to use the following code::
```

From what I can see, the ``get()`` method can return arrays. See image (https://ibb.co/qB0qHKc)

Given this url `contacts?foo[bar]=baz` .. I can do this

```
    $request->query->get('foo'); // returns ['bar' => 'baz']
```

Tested on a symfony 4.4 application.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
