### PR TITLE
Fix broken reference to CommandCompletionTester class

### DIFF
--- a/console/input.rst
+++ b/console/input.rst
@@ -368,7 +368,7 @@ Testing the Completion script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Console component comes with a special
-:class:`Symfony\\Component\\Console\\Test\\CommandCompletionTester`` class
+:class:`Symfony\\Component\\Console\\Tester\\CommandCompletionTester`` class
 to help you unit test the completion logic::
 
     // ...


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
