### PR TITLE
Add information about flex plugin allowance

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -227,7 +227,7 @@ Require a Specific Symfony Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use the special ``SYMFONY_REQUIRE`` environment variable together
-with Symfony Flex to install a specific Symfony version:
+with Symfony to install a specific Symfony version:
 
 .. code-block:: bash
 
@@ -235,6 +235,7 @@ with Symfony Flex to install a specific Symfony version:
     export SYMFONY_REQUIRE=5.*
 
     # install Symfony Flex in the CI environment
+    composer global config --no-plugins allow-plugins.symfony/flex true
     composer global require --no-progress --no-scripts --no-plugins symfony/flex
 
     # install the dependencies (using --prefer-dist and --no-progress is


### PR DESCRIPTION
With the recent change of composer policy around plugins, it is better to turn on plugins before requiring it 

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
