### PR TITLE
Adding that you cannot access a session inside a constructor

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -149,6 +149,10 @@ if you type-hint an argument with :class:`Symfony\\Component\\HttpFoundation\\Re
         public function __construct(RequestStack $requestStack)
         {
             $this->requestStack = $requestStack;
+
+            // Accessing the session in the constructor is *NOT* reommended, since
+            // it might not be accessible yet or lead to unwanted side-effects
+            // $this->session = $requestStack->getSession();
         }
 
         public function someMethod()


### PR DESCRIPTION
Please double-check!
The info is taken from PhpStorm's Symfony Plugin: https://espend.de/phpstorm/plugin/symfony#inspections:

> A Session must not be used inside a constructor

I think this should be explained here, since doing `$this->session = $requestStack->getSession();` right in the constructor looked like a nice idea...