### PR TITLE
Ensure config blocks are consistent

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -421,8 +421,8 @@ The end user can provide values in any configuration file:
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd">
-
+                https://symfony.com/schema/dic/services/services-1.0.xsd"
+        >
             <parameters>
                 <parameter key="acme_blog.author.email">fabien@example.com</parameter>
             </parameters>
@@ -432,7 +432,13 @@ The end user can provide values in any configuration file:
     .. code-block:: php
 
         // config/services.php
-        $container->setParameter('acme_blog.author.email', 'fabien@example.com');
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return static function (ContainerConfigurator $container) {
+            $container->parameters()
+                ->set('acme_blog.author.email', 'fabien@example.com')
+            ;
+        };
 
 Retrieve the configuration parameters in your code from the container::
 

--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -20,19 +20,22 @@ as integration of other related components:
 
     .. code-block:: yaml
 
+        # config/packages/framework.yaml
         framework:
             form: true
 
     .. code-block:: xml
 
+        <!-- config/packages/framework.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:framework="http://symfony.com/schema/dic/symfony"
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/symfony
-                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+        >
             <framework:config>
                 <framework:form/>
             </framework:config>
@@ -40,9 +43,14 @@ as integration of other related components:
 
     .. code-block:: php
 
-        $container->loadFromExtension('framework', [
-            'form' => true,
-        ]);
+        // config/packages/framework.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return static function (ContainerConfigurator $container) {
+            $container->extension('framework', [
+                'form' => true,
+            ]);
+        };
 
 Using the Bundle Extension
 --------------------------
@@ -69,24 +77,28 @@ can add some configuration that looks like this:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:acme-social="http://example.org/schema/dic/acme_social"
             xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd">
-
+                https://symfony.com/schema/dic/services/services-1.0.xsd"
+        >
             <acme-social:config>
-                <acme-social:twitter client-id="123" client-secret="your_secret"/>
+                <acme-social:twitter client-id="123"
+                    client-secret="your_secret"
+                />
             </acme-social:config>
-
-            <!-- ... -->
         </container>
 
     .. code-block:: php
 
         // config/packages/acme_social.php
-        $container->loadFromExtension('acme_social', [
-            'twitter' => [
-                'client_id'     => 123,
-                'client_secret' => 'your_secret',
-            ],
-        ]);
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return static function (ContainerConfigurator $container) {
+            $container->extension('acme_social', [
+                'twitter' => [
+                    'client_id'     => 123,
+                    'client_secret' => 'your_secret',
+                ],
+            ]);
+        };
 
 The basic idea is that instead of having the user override individual
 parameters, you let the user configure just a few, specifically created,
@@ -242,8 +254,8 @@ For example, imagine your bundle has the following example config:
     <container xmlns="http://symfony.com/schema/dic/services"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/dic/services
-            https://symfony.com/schema/dic/services/services-1.0.xsd">
-
+            https://symfony.com/schema/dic/services/services-1.0.xsd"
+    >
         <services>
             <service id="acme.social.twitter_client" class="Acme\SocialBundle\TwitterClient">
                 <argument></argument> <!-- will be filled in with client_id dynamically -->
@@ -423,8 +435,8 @@ Assuming the XSD file is called ``hello-1.0.xsd``, the schema location will be
         xsi:schemaLocation="http://symfony.com/schema/dic/services
             https://symfony.com/schema/dic/services/services-1.0.xsd
             http://acme_company.com/schema/dic/hello
-            https://acme_company.com/schema/dic/hello/hello-1.0.xsd">
-
+            https://acme_company.com/schema/dic/hello/hello-1.0.xsd"
+    >
         <acme-hello:config>
             <!-- ... -->
         </acme-hello:config>

--- a/bundles/override.rst
+++ b/bundles/override.rst
@@ -139,8 +139,8 @@ to a new validation group:
         <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping
-                https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
-
+                https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd"
+        >
             <class name="FOS\UserBundle\Model\User">
                 <property name="plainPassword">
                     <constraint name="NotBlank">

--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -127,29 +127,35 @@ registered and the ``entity_manager_name`` setting for ``acme_hello`` is set to
                 http://example.org/schema/dic/acme_something
                 https://example.org/schema/dic/acme_something/acme_something-1.0.xsd
                 http://example.org/schema/dic/acme_other
-                https://example.org/schema/dic/acme_something/acme_other-1.0.xsd">
-
+                https://example.org/schema/dic/acme_something/acme_other-1.0.xsd"
+        >
             <acme-something:config use-acme-goodbye="false">
                 <!-- ... -->
                 <acme-something:entity-manager-name>non_default</acme-something:entity-manager-name>
             </acme-something:config>
 
-            <acme-other:config use-acme-goodbye="false"/>
+            <acme-other:config use-acme-goodbye="false">
+                <!-- ... -->
+            </acme-other:config>
 
         </container>
 
     .. code-block:: php
 
         // config/packages/acme_something.php
-        $container->loadFromExtension('acme_something', [
-            // ...
-            'use_acme_goodbye' => false,
-            'entity_manager_name' => 'non_default',
-        ]);
-        $container->loadFromExtension('acme_other', [
-            // ...
-            'use_acme_goodbye' => false,
-        ]);
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return static function (ContainerConfigurator $container) {
+            $container->extension('acme_something', [
+                // ...
+                'use_acme_goodbye' => false,
+                'entity_manager_name' => 'non_default',
+            ]);
+            $container->extension('acme_other', [
+                // ...
+                'use_acme_goodbye' => false,
+            ]);
+        };
 
 More than one Bundle using PrependExtensionInterface
 ----------------------------------------------------

--- a/cache.rst
+++ b/cache.rst
@@ -77,10 +77,11 @@ adapter (template) they use by using the ``app`` and ``system`` key like:
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/symfony
-                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+        >
             <framework:config>
-                <framework:cache app="cache.adapter.filesystem"
+                <framework:cache
+                    app="cache.adapter.filesystem"
                     system="cache.adapter.system"
                 />
             </framework:config>
@@ -89,12 +90,16 @@ adapter (template) they use by using the ``app`` and ``system`` key like:
     .. code-block:: php
 
         // config/packages/cache.php
-        $container->loadFromExtension('framework', [
-            'cache' => [
-                'app' => 'cache.adapter.filesystem',
-                'system' => 'cache.adapter.system',
-            ],
-        ]);
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return static function (ContainerConfigurator $container) {
+            $container->extension('framework', [
+                'cache' => [
+                    'app' => 'cache.adapter.filesystem',
+                    'system' => 'cache.adapter.system',
+                ],
+            ]);
+        };
 
 The Cache component comes with a series of adapters pre-configured:
 
@@ -140,8 +145,8 @@ will create pools with service IDs that follow the pattern ``cache.[type]``.
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/symfony
-                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+        >
             <framework:config>
                 <!--
                 default_doctrine_provider: Service: cache.doctrine
@@ -164,23 +169,27 @@ will create pools with service IDs that follow the pattern ``cache.[type]``.
     .. code-block:: php
 
         // config/packages/cache.php
-        $container->loadFromExtension('framework', [
-            'cache' => [
-                // Only used with cache.adapter.filesystem
-                'directory' => '%kernel.cache_dir%/pools',
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-                // Service: cache.doctrine
-                'default_doctrine_provider' => 'app.doctrine_cache',
-                // Service: cache.psr6
-                'default_psr6_provider' => 'app.my_psr6_service',
-                // Service: cache.redis
-                'default_redis_provider' => 'redis://localhost',
-                // Service: cache.memcached
-                'default_memcached_provider' => 'memcached://localhost',
-                // Service: cache.pdo
-                'default_pdo_provider' => 'doctrine.dbal.default_connection',
-            ],
-        ]);
+        return static function (ContainerConfigurator $container) {
+            $container->extension('framework', [
+                'cache' => [
+                    // Only used with cache.adapter.filesystem
+                    'directory' => '%kernel.cache_dir%/pools',
+
+                    // Service: cache.doctrine
+                    'default_doctrine_provider' => 'app.doctrine_cache',
+                    // Service: cache.psr6
+                    'default_psr6_provider' => 'app.my_psr6_service',
+                    // Service: cache.redis
+                    'default_redis_provider' => 'redis://localhost',
+                    // Service: cache.memcached
+                    'default_memcached_provider' => 'memcached://localhost',
+                    // Service: cache.pdo
+                    'default_pdo_provider' => 'doctrine.dbal.default_connection',
+                ],
+            ]);
+        };
 
 Creating Custom (Namespaced) Pools
 ----------------------------------
@@ -233,8 +242,8 @@ You can also create more customized pools:
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/symfony
-                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+        >
             <framework:config>
                 <framework:cache default-memcached-provider="memcached://localhost">
                     <!-- creates a "custom_thing.cache" service
@@ -264,43 +273,47 @@ You can also create more customized pools:
     .. code-block:: php
 
         // config/packages/cache.php
-        $container->loadFromExtension('framework', [
-            'cache' => [
-                'default_memcached_provider' => 'memcached://localhost',
-                'pools' => [
-                    // creates a "custom_thing.cache" service
-                    // autowireable via "CacheInterface $customThingCache"
-                    // uses the "app" cache configuration
-                    'custom_thing.cache' => [
-                        'adapter' => 'cache.app',
-                    ],
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-                    // creates a "my_cache_pool" service
-                    // autowireable via "CacheInterface $myCachePool"
-                    'my_cache_pool' => [
-                        'adapter' => 'cache.adapter.filesystem',
-                    ],
+        return static function (ContainerConfigurator $container) {
+            $container->extension('framework', [
+                'cache' => [
+                    'default_memcached_provider' => 'memcached://localhost',
+                    'pools' => [
+                        // creates a "custom_thing.cache" service
+                        // autowireable via "CacheInterface $customThingCache"
+                        // uses the "app" cache configuration
+                        'custom_thing.cache' => [
+                            'adapter' => 'cache.app',
+                        ],
 
-                    // uses the default_memcached_provider from above
-                    'acme.cache' => [
-                        'adapter' => 'cache.adapter.memcached',
-                    ],
+                        // creates a "my_cache_pool" service
+                        // autowireable via "CacheInterface $myCachePool"
+                        'my_cache_pool' => [
+                            'adapter' => 'cache.adapter.filesystem',
+                        ],
 
-                    // control adapter's configuration
-                    'foobar.cache' => [
-                        'adapter' => 'cache.adapter.memcached',
-                        'provider' => 'memcached://user:password@example.com',
-                    ],
+                        // uses the default_memcached_provider from above
+                        'acme.cache' => [
+                            'adapter' => 'cache.adapter.memcached',
+                        ],
 
-                    // uses the "foobar.cache" pool as its backend but controls
-                    // the lifetime and (like all pools) has a separate cache namespace
-                    'short_cache' => [
-                        'adapter' => 'foobar.cache',
-                        'default_lifetime' => 60,
+                        // control adapter's configuration
+                        'foobar.cache' => [
+                            'adapter' => 'cache.adapter.memcached',
+                            'provider' => 'memcached://user:password@example.com',
+                        ],
+
+                        // uses the "foobar.cache" pool as its backend but controls
+                        // the lifetime and (like all pools) has a separate cache namespace
+                        'short_cache' => [
+                            'adapter' => 'foobar.cache',
+                            'default_lifetime' => 60,
+                        ],
                     ],
                 ],
-            ],
-        ]);
+            ]);
+        };
 
 Each pool manages a set of independent cache keys: keys from different pools
 *never* collide, even if they share the same backend. This is achieved by prefixing
@@ -342,6 +355,8 @@ with either :class:`Symfony\\Contracts\\Cache\\CacheInterface` or
 
             # config/services.yaml
             services:
+                # ...
+
                 app.cache.adapter.redis:
                     parent: 'cache.adapter.redis'
                     tags:
@@ -354,9 +369,11 @@ with either :class:`Symfony\\Contracts\\Cache\\CacheInterface` or
             <container xmlns="http://symfony.com/schema/dic/services"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://symfony.com/schema/dic/services
-                    https://symfony.com/schema/dic/services/services-1.0.xsd">
-
+                    https://symfony.com/schema/dic/services/services-1.0.xsd"
+            >
                 <services>
+                    <!-- ... -->
+
                     <service id="app.cache.adapter.redis" parent="cache.adapter.redis">
                         <tag name="cache.pool" namespace="my_custom_namespace"/>
                     </service>
@@ -368,12 +385,14 @@ with either :class:`Symfony\\Contracts\\Cache\\CacheInterface` or
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return function(ContainerConfigurator $configurator) {
-                $services = $configurator->services();
+            return function(ContainerConfigurator $container) {
+                $container->services()
+                    // ...
 
-                $services->set('app.cache.adapter.redis')
-                    ->parent('cache.adapter.redis')
-                    ->tag('cache.pool', ['namespace' => 'my_custom_namespace']);
+                    ->set('app.cache.adapter.redis')
+                        ->parent('cache.adapter.redis')
+                        ->tag('cache.pool', ['namespace' => 'my_custom_namespace'])
+                ;
             };
 
 Custom Provider Options
@@ -415,11 +434,14 @@ and use that when configuring the pool.
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/symfony
-                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+        >
             <framework:config>
                 <framework:cache>
-                    <framework:pool name="cache.my_redis" adapter="cache.adapter.redis" provider="app.my_custom_redis_provider"/>
+                    <framework:pool name="cache.my_redis"
+                        adapter="cache.adapter.redis"
+                        provider="app.my_custom_redis_provider"
+                    />
                 </framework:cache>
             </framework:config>
 
@@ -438,27 +460,34 @@ and use that when configuring the pool.
     .. code-block:: php
 
         // config/packages/cache.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Symfony\Component\Cache\Adapter\RedisAdapter;
 
-        $container->loadFromExtension('framework', [
-            'cache' => [
-                'pools' => [
-                    'cache.my_redis' => [
-                        'adapter' => 'cache.adapter.redis',
-                        'provider' => 'app.my_custom_redis_provider',
+        return static function (ContainerConfigurator $container) {
+            $container->extension('framework', [
+                'cache' => [
+                    'pools' => [
+                        'cache.my_redis' => [
+                            'adapter' => 'cache.adapter.redis',
+                            'provider' => 'app.my_custom_redis_provider',
+                        ],
                     ],
                 ],
-            ],
-        ]);
+            ]);
 
-        $container->register('app.my_custom_redis_provider', \Redis::class)
-            ->setFactory([RedisAdapter::class, 'createConnection'])
-            ->addArgument('redis://localhost')
-            ->addArgument([
-                'retry_interval' => 2,
-                'timeout' => 10
-            ])
-        ;
+            $container->services()
+                ->set('app.my_custom_redis_provider', \Redis::class)
+                    ->factory([RedisAdapter::class, 'createConnection'])
+                    ->args([
+                        'redis://localhost',
+                        [
+                            'retry_interval' => 2,
+                            'timeout' => 10,
+                        ]
+                    ])
+            ;
+        };
 
 Creating a Cache Chain
 ----------------------
@@ -506,11 +535,14 @@ Symfony stores the item automatically in all the missing pools.
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:framework="http://symfony.com/schema/dic/symfony"
             xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd">
-
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+        >
             <framework:config>
                 <framework:cache>
-                    <framework:pool name="my_cache_pool" default-lifetime="31536000">
+                    <framework:pool name="my_cache_pool"
+                        default-lifetime="31536000"> <!-- One year -->
                         <framework:adapter name="cache.adapter.array"/>
                         <framework:adapter name="cache.adapter.apcu"/>
                         <framework:adapter name="cache.adapter.redis" provider="redis://user:password@example.com"/>
@@ -522,20 +554,24 @@ Symfony stores the item automatically in all the missing pools.
     .. code-block:: php
 
         // config/packages/cache.php
-        $container->loadFromExtension('framework', [
-            'cache' => [
-                'pools' => [
-                    'my_cache_pool' => [
-                        'default_lifetime' => 31536000, // One year
-                        'adapters' => [
-                            'cache.adapter.array',
-                            'cache.adapter.apcu',
-                            ['name' => 'cache.adapter.redis', 'provider' => 'redis://user:password@example.com'],
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return static function (ContainerConfigurator $container) {
+            $container->extension('framework', [
+                'cache' => [
+                    'pools' => [
+                        'my_cache_pool' => [
+                            'default_lifetime' => 31536000, // One year
+                            'adapters' => [
+                                'cache.adapter.array',
+                                'cache.adapter.apcu',
+                                ['name' => 'cache.adapter.redis', 'provider' => 'redis://user:password@example.com'],
+                            ],
                         ],
                     ],
                 ],
-            ],
-        ]);
+            ]);
+        };
 
 Using Cache Tags
 ----------------
@@ -602,11 +638,14 @@ to enable this feature. This could be added by using the following configuration
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd
                 http://symfony.com/schema/dic/symfony
-                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+        >
             <framework:config>
                 <framework:cache>
-                  <framework:pool name="my_cache_pool" adapter="cache.adapter.redis" tags="true"/>
+                    <framework:pool name="my_cache_pool"
+                        adapter="cache.adapter.redis"
+                        tags="true"
+                    />
                 </framework:cache>
             </framework:config>
         </container>
@@ -614,16 +653,20 @@ to enable this feature. This could be added by using the following configuration
     .. code-block:: php
 
         // config/packages/cache.php
-        $container->loadFromExtension('framework', [
-            'cache' => [
-                'pools' => [
-                    'my_cache_pool' => [
-                        'adapter' => 'cache.adapter.redis',
-                        'tags' => true,
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return static function (ContainerConfigurator $container) {
+            $container->extension('framework', [
+                'cache' => [
+                    'pools' => [
+                        'my_cache_pool' => [
+                            'adapter' => 'cache.adapter.redis',
+                            'tags' => true,
+                        ],
                     ],
                 ],
-            ],
-        ]);
+            ]);
+        };
 
 Tags are stored in the same pool by default. This is good in most scenarios. But
 sometimes it might be better to store the tags in a different pool. That could be
@@ -651,12 +694,17 @@ achieved by specifying the adapter.
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:framework="http://symfony.com/schema/dic/symfony"
             xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd">
-
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+        >
             <framework:config>
                 <framework:cache>
-                  <framework:pool name="my_cache_pool" adapter="cache.adapter.redis" tags="tag_pool"/>
-                  <framework:pool name="tag_pool" adapter="cache.adapter.apcu"/>
+                    <framework:pool name="my_cache_pool"
+                        adapter="cache.adapter.redis"
+                        tags="tag_pool"
+                    />
+                    <framework:pool name="tag_pool" adapter="cache.adapter.apcu"/>
                 </framework:cache>
             </framework:config>
         </container>
@@ -664,19 +712,23 @@ achieved by specifying the adapter.
     .. code-block:: php
 
         // config/packages/cache.php
-        $container->loadFromExtension('framework', [
-            'cache' => [
-                'pools' => [
-                    'my_cache_pool' => [
-                        'adapter' => 'cache.adapter.redis',
-                        'tags' => 'tag_pool',
-                    ],
-                    'tag_pool' => [
-                        'adapter' => 'cache.adapter.apcu',
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return static function (ContainerConfigurator $container) {
+            $container->extension('framework', [
+                'cache' => [
+                    'pools' => [
+                        'my_cache_pool' => [
+                            'adapter' => 'cache.adapter.redis',
+                            'tags' => 'tag_pool',
+                        ],
+                        'tag_pool' => [
+                            'adapter' => 'cache.adapter.apcu',
+                        ],
                     ],
                 ],
-            ],
-        ]);
+            ]);
+        };
 
 .. note::
 

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -259,15 +259,16 @@ config files:
             newsletter_manager:
                 class:     NewsletterManager
                 calls:
-                    - setMailer: ['@mailer']
+                    - [setMailer, ['@mailer']]
 
     .. code-block:: xml
 
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
-
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd"
+        >
             <parameters>
                 <!-- ... -->
                 <parameter key="mailer.transport">sendmail</parameter>
@@ -290,23 +291,20 @@ config files:
 
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $configurator) {
-            $configurator->parameters()
+        return static function (ContainerConfigurator $container) {
+            $container->parameters()
                 // ...
                 ->set('mailer.transport', 'sendmail')
             ;
 
-            $services = $configurator->services();
+            $container->services()
+                ->set('mailer', 'Mailer')
+                    ->args(['%mailer.transport%'])
 
-            $services->set('mailer', 'Mailer')
-                ->args(['%mailer.transport%'])
-            ;
-
-            $services->set('newsletter_manager', 'NewsletterManager')
-                ->call('setMailer', [ref('mailer')])
+                ->set('newsletter_manager', 'NewsletterManager')
+                    ->call('setMailer', [ref('mailer')])
             ;
         };
-
 
 Learn More
 ----------

--- a/components/dependency_injection/_imports-parameters-note.rst.inc
+++ b/components/dependency_injection/_imports-parameters-note.rst.inc
@@ -19,8 +19,8 @@
             <container xmlns="http://symfony.com/schema/dic/services"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://symfony.com/schema/dic/services
-                    https://symfony.com/schema/dic/services/services-1.0.xsd">
-
+                    https://symfony.com/schema/dic/services/services-1.0.xsd"
+            >
                 <imports>
                     <import resource="%kernel.project_dir%/somefile.yaml"/>
                 </imports>
@@ -29,4 +29,8 @@
         .. code-block:: php
 
             // config/services.php
-            $loader->import('%kernel.project_dir%/somefile.yaml');
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return static function (ContainerConfigurator $container) {
+                $container->import('%kernel.project_dir%/somefile.yaml');
+            };

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -200,13 +200,16 @@ The XML version of the config would then look like this:
     <?xml version="1.0" encoding="UTF-8" ?>
     <container xmlns="http://symfony.com/schema/dic/services"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:acme_demo="http://www.example.com/symfony/schema/"
-        xsi:schemaLocation="http://www.example.com/symfony/schema/ https://www.example.com/symfony/schema/hello-1.0.xsd">
-
-        <acme_demo:config>
+        xmlns:acme-demo="http://www.example.com/schema/dic/acme_demo"
+        xsi:schemaLocation="http://symfony.com/schema/dic/services
+            https://symfony.com/schema/dic/services/services-1.0.xsd
+            http://www.example.com/schema/dic/acme_demo
+            https://www.example.com/schema/dic/acme_demo/acme_demo-1.0.xsd"
+    >
+        <acme-demo:config>
             <acme_demo:foo>fooValue</acme_demo:foo>
             <acme_demo:bar>barValue</acme_demo:bar>
-        </acme_demo:config>
+        </acme-demo:config>
     </container>
 
 .. note::

--- a/components/http_foundation/session_configuration.rst
+++ b/components/http_foundation/session_configuration.rst
@@ -187,21 +187,26 @@ configuration:
             xmlns:framework="http://symfony.com/schema/dic/symfony"
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
+                http://symfony.com/schema/dic/symfony
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+        >
             <framework:config>
-                <framework:session gc_probability="null"/>
+                <framework:session gc-probability="null"/>
             </framework:config>
         </container>
 
     .. code-block:: php
 
         // config/packages/framework.php
-        $container->loadFromExtension('framework', [
-            'session' => [
-                'gc_probability' => null,
-            ],
-        ]);
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return static function (ContainerConfigurator $container) {
+            $container->extension('framework', [
+                'session' => [
+                    'gc_probability' => null,
+                ],
+            ]);
+        };
 
 You can configure these settings by passing ``gc_probability``, ``gc_divisor``
 and ``gc_maxlifetime`` in an array to the constructor of

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -816,6 +816,8 @@ faster alternative to the
 
         # config/services.yaml
         services:
+            # ...
+
             get_set_method_normalizer:
                 class: Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer
                 tags: [serializer.normalizer]
@@ -827,9 +829,11 @@ faster alternative to the
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd">
-
+                https://symfony.com/schema/dic/services/services-1.0.xsd"
+        >
             <services>
+                <!-- ... -->
+
                 <service id="get_set_method_normalizer" class="Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer">
                     <tag name="serializer.normalizer"/>
                 </service>
@@ -843,11 +847,11 @@ faster alternative to the
 
         use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
-
-            $services->set('get_set_method_normalizer', GetSetMethodNormalizer::class)
-                ->tag('serializer.normalizer')
+        return static function (ContainerConfigurator $container) {
+            $container->services()
+                // ...
+                ->set('get_set_method_normalizer', GetSetMethodNormalizer::class)
+                    ->tag('serializer.normalizer')
             ;
         };
 

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -131,22 +131,27 @@ the :ref:`dump_destination option <configuration-debug-dump_destination>` of the
 
         <!-- config/packages/debug.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/debug"
+        <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:debug="http://symfony.com/schema/dic/debug"
             xsi:schemaLocation="http://symfony.com/schema/dic/services
                 https://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/debug https://symfony.com/schema/dic/debug/debug-1.0.xsd">
-
+                http://symfony.com/schema/dic/debug
+                https://symfony.com/schema/dic/debug/debug-1.0.xsd"
+        >
             <debug:config dump-destination="tcp://%env(VAR_DUMPER_SERVER)%"/>
         </container>
 
     .. code-block:: php
 
         // config/packages/debug.php
-        $container->loadFromExtension('debug', [
-           'dump_destination' => 'tcp://%env(VAR_DUMPER_SERVER)%',
-        ]);
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return static function (ContainerConfigurator $container) {
+            $container->extension('debug', [
+                'dump_destination' => 'tcp://%env(VAR_DUMPER_SERVER)%',
+            ]);
+        };
 
 Outside a Symfony application, use the :class:`Symfony\\Component\\VarDumper\\Dumper\\ServerDumper` class::
 


### PR DESCRIPTION
Given some more love to 4.4 before it's EOL.

To avoid tons of conflict when merging upstream, if accepted, it should be reverted in 5.4, I'll send PRs dedicated to 5.4..
