### PR TITLE
[Security] Add link to page with expressions

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1092,6 +1092,7 @@ Authorization (Denying Access)
 .. toctree::
     :maxdepth: 1
 
+    security/expressions
     security/voters
     security/securing_services
     security/access_control

--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -1,7 +1,7 @@
 .. index::
    single: Expressions in the Framework
 
-Security: Complex Access Controls with Expressions
+Complex Access Controls with Expressions
 ==================================================
 
 .. seealso::
@@ -14,7 +14,7 @@ accepts an :class:`Symfony\\Component\\ExpressionLanguage\\Expression` object::
 
     // src/Controller/MyController.php
     namespace App\Controller;
-    
+
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\ExpressionLanguage\Expression;
     use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
The [page that explains how expressions can be used for access control](https://symfony.com/doc/4.4/security/expressions.html) isn't linked anywhere in the security section, making it really hard to find. The only place where it is linked is on the [expression syntax page](https://symfony.com/doc/4.4/components/expression_language/syntax.html).