### PR TITLE
[FrameworkBundle] Fix link to CacheInterface

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2554,7 +2554,7 @@ cache
 **type**: ``string``
 
 The service that is used to persist class metadata in a cache. The service
-has to implement the :class:`Symfony\\Component\\Validator\\Mapping\\Cache\\CacheInterface`.
+has to implement the :class:`Symfony\\Contracts\\Cache\\CacheInterface`.
 
 Set this option to ``validator.mapping.cache.doctrine.apc`` to use the APC
 cache provided by the Doctrine project.


### PR DESCRIPTION
Doc: https://symfony.com/doc/5.4/reference/configuration/framework.html#cache

The link “CacheInterface” leads to https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Validator/Mapping/Cache/CacheInterface.php and it results in a page not found.

I think the link should be https://github.com/symfony/cache-contracts/blob/main/CacheInterface.php instead.

Hopefully updating this namespace should fix the link.