### PR TITLE
[ci] allow flex to run in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,6 +116,11 @@ jobs:
             if: ${{ steps.find-files.outputs.files }}
             run: composer create-project symfony-tools/code-block-checker:@dev _checker
 
+          - name: Allow Flex
+            if: ${{ steps.find-files.outputs.files }}
+            run: |
+              composer config --no-plugins allow-plugins.symfony/flex true
+
           - name: Install test application
             if: ${{ steps.find-files.outputs.files }}
             run: |


### PR DESCRIPTION
Since Composer 2.3.9 unless you explicitly allow/disallow a plugin (flex in our case), an error is thrown (halts our CI run) before any tests are actually ran. (Code Blocks)
