### PR TITLE
[Doctrine] MakerBundle 1.3 is too old to reference

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -85,10 +85,7 @@ whitelist:
         - '.. versionadded:: 2.4.0' # SwiftMailer
         - '.. versionadded:: 1.30' # Twig
         - '.. versionadded:: 1.35' # Twig
-        - '.. versionadded:: 1.2' # MakerBundle
-        - '.. versionadded:: 1.11' # MakerBundle
-        - '.. versionadded:: 1.3' # MakerBundle
-        - '.. versionadded:: 1.8' # MakerBundle
+        - '.. versionadded:: 1.11' # Messenger (Middleware / DoctrineBundle)
         - '.. versionadded:: 1.18' # Flex in setup/upgrade_minor.rst
         - '.. versionadded:: 1.0.0' # Encore
         - '0 => 123' # assertion for var_dumper - components/var_dumper.rst

--- a/controller.rst
+++ b/controller.rst
@@ -153,7 +153,7 @@ and ``redirect()`` methods::
 
         // redirects to a route and maintains the original query string parameters
         return $this->redirectToRoute('blog_show', $request->query->all());
-        
+
         // redirects to the current route (e.g. for Post/Redirect/Get pattern):
         return $this->redirectToRoute($request->attributes->get('_route'));
 
@@ -314,10 +314,6 @@ use:
     created: templates/product/index.html.twig
     created: templates/product/new.html.twig
     created: templates/product/show.html.twig
-
-.. versionadded:: 1.2
-
-    The ``make:crud`` command was introduced in MakerBundle 1.2.
 
 .. index::
    single: Controller; Managing errors

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -127,11 +127,6 @@ need. The command will ask you some questions - answer them like done below:
     >
     (press enter again to finish)
 
-.. versionadded:: 1.3
-
-    The interactive behavior of the ``make:entity`` command was introduced
-    in MakerBundle 1.3.
-
 Whoa! You now have a new ``src/Entity/Product.php`` file::
 
     // src/Entity/Product.php


### PR DESCRIPTION
MakerBundle 1.2/1.3 were released back in 2018. We're at `v1.44.0` now. I don't think we need to reference this anymore.