### PR TITLE
[DependencyInjection] add missing linter exception

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -91,6 +91,7 @@ whitelist:
         - '.. versionadded:: 1.8' # MakerBundle
         - '.. versionadded:: 1.18' # Flex in setup/upgrade_minor.rst
         - '.. versionadded:: 1.0.0' # Encore
+        - '.. versionadded:: 5.1' # Private Services
         - '0 => 123' # assertion for var_dumper - components/var_dumper.rst
         - '1 => "foo"' # assertion for var_dumper - components/var_dumper.rst
         - '123,' # assertion for var_dumper - components/var_dumper.rst


### PR DESCRIPTION
Referenced in https://github.com/symfony/symfony-docs/blob/5.4/service_container/alias_private.rst line 390
