### PR TITLE
[EventDispatcher] Document the #AsEventListener attribute

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -402,6 +402,49 @@ Take the following example of a subscriber that subscribes to the
         }
     }
 
+You can also leverage the :class:`Symfony\\Component\\EventDispatcher\\Attribute\\AsEventListener`
+attribute to configure your class as a listener on event::
+
+    namespace App\EventListener;
+
+    use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+    #[AsEventListener]
+    final class MyListener
+    {
+        public function __invoke(CustomEvent $event): void
+        {
+            // ...
+        }
+    }
+
+or any of a class methods like so::
+
+    namespace App\EventListener;
+
+    use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+    #[AsEventListener(event: CustomEvent::class, method: 'onCustomEvent')]
+    #[AsEventListener(event: 'foo', priority: 42)]
+    #[AsEventListener(event: 'bar', method: 'onBarEvent')]
+    final class MyMultiListener
+    {
+        public function onCustomEvent(CustomEvent $event): void
+        {
+            // ...
+        }
+
+        public function onFoo(): void
+        {
+            // ...
+        }
+
+        public function onBarEvent(): void
+        {
+            // ...
+        }
+    }
+
 This is very similar to a listener class, except that the class itself can
 tell the dispatcher which events it should listen to. To register a subscriber
 with the dispatcher, use the


### PR DESCRIPTION
Document the AsEventListener attribute

Ref https://github.com/symfony/symfony/issues/47015 (did not found any doc thus opened an issue at first)
For the code example, I've taken inspiration on the related PR:

- https://github.com/symfony/symfony/commit/2ab3caf0806ace9e5c1fdaec14bb94391b0fc8e1#diff-57b112e725705bbbf01380b0d11c9a8fe16ea69d85d1d3e618eceeb8b58094ce
- https://github.com/symfony/symfony/commit/2ab3caf0806ace9e5c1fdaec14bb94391b0fc8e1#diff-73a6a14d3288b358a21c0f47ecc1ec78c05e933b66e9a647e5013b2cab002b89