### PR TITLE
add alternative method for symfony/flex

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -236,6 +236,25 @@ with Symfony Flex to install a specific Symfony version:
     # recommended to have a better output and faster download time)
     composer update --prefer-dist --no-progress
 
+Alternatively, you can also install Flex as a dev dependency of the project:
+
+.. code-block:: bash
+
+    # in your local environment, allow symfony/flex and install it to run tasks
+    composer config --no-plugins allow-plugins.symfony/flex true
+    composer require --dev symfony/flex
+
+    # commit the updated composer.json file
+
+Then you can require a specific Symfony version:
+
+.. code-block:: bash
+
+    # in the CI environment, this requires Symfony 5.x for all Symfony packages
+    composer config extra.symfony.require "5.*"
+
+    composer update --prefer-dist --no-progress
+
 .. caution::
 
     If you want to cache your Composer dependencies, **do not** cache the


### PR DESCRIPTION
I propose another way to use `symfony/flex/ in a bundle:
- install `symfony/flex` as a dependency of the project, not only on the CI
- use `composer config …` instead of relying on a variable (it's more consistent in my humble opinion)
- don't use the global config, Seldaek suggested to not use it:

> I'm well aware of that part but I don't understand the point of having it globally installed then. For those use cases, the project itself should really require symfony/flex in composer.json to ensure it's always present.

Source: https://github.com/shivammathur/setup-php/issues/611#issuecomment-1175920907

This way may also replace the previous block.