### PR TITLE
Fix ~20 typos in different sections of the documentation

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -245,7 +245,7 @@ the fact that a controller should always return a ``Response`` object.
 Use Dependency Injection to Get Services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you extend the base ``AbstractController``, you can only access to the most
+If you extend the base ``AbstractController``, you can only get access to the most
 common services (e.g ``twig``, ``router``, ``doctrine``, etc.), directly from the
 container via ``$this->container->get()``.
 Instead, you must use dependency injection to fetch services by
@@ -289,7 +289,7 @@ Define your Forms as PHP Classes
 
 Creating :ref:`forms in classes <creating-forms-in-classes>` allows to reuse
 them in different parts of the application. Besides, not creating forms in
-controllers simplify the code and maintenance of the controllers.
+controllers simplifies the code and maintenance of the controllers.
 
 Add Form Buttons in Templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -388,7 +388,7 @@ Use Webpack Encore to Process Web Assets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Web assets are things like CSS, JavaScript and image files that make the
-frontend of your site looks and works great. `Webpack`_ is the leading JavaScript
+frontend of your site look and work great. `Webpack`_ is the leading JavaScript
 module bundler that compiles, transforms and packages assets for usage in a browser.
 
 :doc:`Webpack Encore </frontend>` is a JavaScript library that gets rid of most

--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -174,7 +174,7 @@ provides access to the form properties (e.g. ``$form->getUri()``,
 Custom Header Handling
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The optional HTTP headers passed to the ``request()`` method follows the FastCGI
+The optional HTTP headers passed to the ``request()`` method follow the FastCGI
 request format (uppercase, underscores instead of dashes and prefixed with ``HTTP_``).
 Before saving those headers to the request, they are lower-cased, with ``HTTP_``
 stripped, and underscores converted into dashes.

--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -293,7 +293,7 @@ to display it can be customized::
 .. caution::
 
     For performance reasons, Symfony redraws the screen once every 100ms. If this is too
-    fast or to slow for your application, use the methods
+    fast or too slow for your application, use the methods
     :method:`Symfony\\Component\\Console\\Helper\\ProgressBar::minSecondsBetweenRedraws` and
     :method:`Symfony\\Component\\Console\\Helper\\ProgressBar::maxSecondsBetweenRedraws`::
 

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -9,7 +9,7 @@ The HttpKernel Component
     The HttpKernel component provides a structured process for converting
     a ``Request`` into a ``Response`` by making use of the EventDispatcher
     component. It's flexible enough to create a full-stack framework (Symfony),
-    a micro-framework (Silex) or an advanced CMS system (Drupal).
+    a micro-framework (Silex) or an advanced CMS (Drupal).
 
 Installation
 ------------

--- a/components/property_access.rst
+++ b/components/property_access.rst
@@ -5,7 +5,7 @@
 The PropertyAccess Component
 ============================
 
-    The PropertyAccess component provides function to read and write from/to an
+    The PropertyAccess component provides functions to read and write from/to an
     object or array using a simple string notation.
 
 Installation

--- a/configuration/front_controllers_and_kernel.rst
+++ b/configuration/front_controllers_and_kernel.rst
@@ -247,7 +247,7 @@ the directory of the environment you're using (most commonly ``dev/`` while
 developing and debugging). While it can vary, the ``var/cache/dev/`` directory
 includes the following:
 
-``srcApp_KernelDevDebugContainer.php``
+``App_KernelDevDebugContainer.php``
     The cached "service container" that represents the cached application
     configuration.
 

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -103,7 +103,7 @@ Advanced Example: Twig, Annotations and the Web Debug Toolbar
 -------------------------------------------------------------
 
 The purpose of the ``MicroKernelTrait`` is *not* to have a single-file application.
-Instead, its goal to give you the power to choose your bundles and structure.
+Instead, its goal is to give you the power to choose your bundles and structure.
 
 First, you'll probably want to put your PHP classes in an ``src/`` directory. Configure
 your ``composer.json`` file to load from there:

--- a/create_framework/http_foundation.rst
+++ b/create_framework/http_foundation.rst
@@ -176,20 +176,20 @@ fingertips thanks to a nice and simple API::
     // the URI being requested (e.g. /about) minus any query parameters
     $request->getPathInfo();
 
-    // retrieve GET and POST variables respectively
+    // retrieves GET and POST variables respectively
     $request->query->get('foo');
     $request->request->get('bar', 'default value if bar does not exist');
 
-    // retrieve SERVER variables
+    // retrieves SERVER variables
     $request->server->get('HTTP_HOST');
 
     // retrieves an instance of UploadedFile identified by foo
     $request->files->get('foo');
 
-    // retrieve a COOKIE value
+    // retrieves a COOKIE value
     $request->cookies->get('PHPSESSID');
 
-    // retrieve an HTTP request header, with normalized, lowercase keys
+    // retrieves a HTTP request header, with normalized, lowercase keys
     $request->headers->get('host');
     $request->headers->get('content-type');
 

--- a/deployment.rst
+++ b/deployment.rst
@@ -65,7 +65,7 @@ Using Platforms as a Service
 
 Using a Platform as a Service (PaaS) can be a great way to deploy your Symfony
 app quickly. There are many PaaS, but we recommend `Platform.sh`_ as it
-provides a dedicated Symfony integration and help fund the Symfony development.
+provides a dedicated Symfony integration and helps fund the Symfony development.
 
 Using Build Scripts and other Tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -592,7 +592,7 @@ To update a relationship in the database, you *must* set the relationship on the
 *owning* side. The owning side is always where the ``ManyToOne`` mapping is set
 (for a ``ManyToMany`` relation, you can choose which side is the owning side).
 
-Does this means it's not possible to call ``$category->addProduct()`` or
+Does this mean it's not possible to call ``$category->addProduct()`` or
 ``$category->removeProduct()`` to update the database? Actually, it *is* possible,
 thanks to some clever code that the ``make:entity`` command generated::
 

--- a/migration.rst
+++ b/migration.rst
@@ -130,7 +130,7 @@ It is quite common for an existing application to either not have a test suite
 at all or have low code coverage. Introducing unit tests for this code is
 likely not cost effective as the old code might be replaced with functionality
 from Symfony components or might be adapted to the new application.
-Additionally legacy code tends to be hard to write tests for making the process
+Additionally legacy code tends to be hard to write tests for, making the process
 slow and cumbersome.
 
 Instead of providing low level tests, that ensure each class works as expected, it

--- a/notifier/chatters.rst
+++ b/notifier/chatters.rst
@@ -23,7 +23,7 @@ you to send messages to chat services like Slack or Telegram::
         public function thankyou(ChatterInterface $chatter)
         {
             $message = (new ChatMessage('You got a new invoice for 15 EUR.'))
-                // if not set explicitly, the message is send to the
+                // if not set explicitly, the message is sent to the
                 // default transport (the first one configured)
                 ->transport('slack');
 

--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -359,7 +359,7 @@ the :class:`Symfony\\Component\\RateLimiter\\Reservation` object returned by the
 Storing Rate Limiter State
 --------------------------
 
-All rate limiter policies require to store their state(e.g. how many hits were
+All rate limiter policies require to store their state (e.g. how many hits were
 already made in the current time window). By default, all limiters use the
 ``cache.rate_limiter`` cache pool created with the :doc:`Cache component </cache>`.
 

--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -366,7 +366,7 @@ value.
 ``maxPixelsMessage``
 ~~~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``The image has to many pixels ({{ pixels }} pixels).
+**type**: ``string`` **default**: ``The image has too many pixels ({{ pixels }} pixels).
 Maximum amount expected is {{ max_pixels }} pixels.``
 
 The error message if the amount of pixels of the image exceeds `maxPixels`_.

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -13,7 +13,7 @@ the data can be a ``DateTime`` object, a string, a timestamp or an array.
 +---------------------------+-----------------------------------------------------------------------------+
 | Underlying Data Type      | can be ``DateTime``, string, timestamp, or array (see the ``input`` option) |
 +---------------------------+-----------------------------------------------------------------------------+
-| Rendered as               | single text box or three select fields                                      |
+| Rendered as               | single text box or five select fields                                      |
 +---------------------------+-----------------------------------------------------------------------------+
 | Default invalid message   | Please enter a valid date and time.                                         |
 +---------------------------+-----------------------------------------------------------------------------+

--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -7,8 +7,8 @@ How to Create a custom Route Loader
 Basic applications can define all their routes in a single configuration file -
 usually ``config/routes.yaml`` (see :ref:`routing-creating-routes`).
 However, in most applications it's common to import routes definitions from
-different resources: PHP annotations in controller files, YAML, XML or PHP
-files stored in some directory, etc.
+different resources: PHP annotations or attributes in controller files, YAML, XML
+or PHP files stored in some directory, etc.
 
 Built-in Route Loaders
 ----------------------
@@ -214,7 +214,7 @@ tag it manually with ``routing.route_loader``.
 
 .. tip::
 
-    If your service is invokable, you don't need to precise the method to use.
+    If your service is invokable, you don't need to specify the method to use.
 
 Creating a custom Loader
 ------------------------

--- a/security.rst
+++ b/security.rst
@@ -995,7 +995,7 @@ Enable the authenticator using the ``json_login`` setting:
     mandatory wildcards - e.g. ``/login/{foo}`` where ``foo`` has no
     default value).
 
-The authenticator runs when a client request the ``check_path``. First,
+The authenticator runs when a client requests the ``check_path``. First,
 create a controller for this path:
 
 .. code-block:: terminal
@@ -1078,7 +1078,7 @@ That's it! To summarize the process:
             "password": "MyPassword"
         }
 #. The security system intercepts the request, checks the user's submitted
-   credentials and authenticates the user. If the credentials is incorrect,
+   credentials and authenticates the user. If the credentials are incorrect,
    an HTTP 401 Unauthorized JSON response is returned, otherwise your
    controller is run;
 #. Your controller creates the correct response:

--- a/security/remember_me.rst
+++ b/security/remember_me.rst
@@ -87,9 +87,9 @@ which is defined using the ``APP_SECRET`` environment variable.
 After enabling the ``remember_me`` system in the configuration, there are a
 couple more things to do before remember me works correctly:
 
-#. :ref:`Add an opt-in checkbox to active remember me <security-remember-me-activate>`;
+#. :ref:`Add an opt-in checkbox to activate remember me <security-remember-me-activate>`;
 #. :ref:`Use an authenticator that supports remember me <security-remember-me-authenticator>`;
-#. Optionally, :ref:`configure the how remember me cookies are stored and validated <security-remember-me-storage>`.
+#. Optionally, :ref:`configure how remember me cookies are stored and validated <security-remember-me-storage>`.
 
 After this, the remember me cookie will be created upon successful
 authentication. For some pages/actions, you can
@@ -131,7 +131,7 @@ checkbox must have a name of ``_remember_me``:
 .. note::
 
     Optionally, you can configure a custom name for this checkbox using the
-    ``remember_me_parameter`` setting under the ``remember_me`` section.
+    ``name`` setting under the ``remember_me`` section.
 
 Always activating Remember Me
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -19,7 +19,7 @@ Static Factories
 Suppose you have a factory that configures and returns a new ``NewsletterManager``
 object by calling the static ``createNewsletterManager()`` method::
 
-    // src/Email\NewsletterManagerStaticFactory.php
+    // src/Email/NewsletterManagerStaticFactory.php
     namespace App\Email;
 
     // ...

--- a/session.rst
+++ b/session.rst
@@ -78,7 +78,7 @@ sessions, check their default configuration:
 Setting the ``handler_id`` config option to ``null`` means that Symfony will
 use the native PHP session mechanism. The session metadata files will be stored
 outside of the Symfony application, in a directory controlled by PHP. Although
-this usually simplify things, some session expiration related options may not
+this usually simplifies things, some session expiration related options may not
 work as expected if other applications that write to the same directory have
 short max lifetime settings.
 


### PR DESCRIPTION
These are various corrections to typos / minor inconsistencies in different sections of the documentation that I found while doing a deep dive into v6.1.