### PR TITLE
[Form] Allow TranslatableInterface to the FormType help option

### DIFF
--- a/reference/forms/types/options/help.rst.inc
+++ b/reference/forms/types/options/help.rst.inc
@@ -1,7 +1,7 @@
 help
 ~~~~
 
-**type**: ``string`` or ``TranslatableMessage`` **default**: null
+**type**: ``string`` or ``TranslatableInterface`` **default**: null
 
 Allows you to define a help message for the form field, which by default is
 rendered below the field::


### PR DESCRIPTION
Symfony PR: https://github.com/symfony/symfony/pull/47050

Supports TranslatableInterface FormType help option.
