### PR TITLE
[Routing] Fix some internal references links

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -873,11 +873,12 @@ Special Parameters
 In addition to your own parameters, routes can include any of the following
 special parameters created by Symfony:
 
+.. _routing-format-parameter:
+.. _routing-locale-parameter:
+
 ``_controller``
     This parameter is used to determine which controller and action is executed
     when the route is matched.
-
-.. _routing-format-parameter:
 
 ``_format``
     The matched value is used to set the "request format" of the ``Request`` object.
@@ -887,8 +888,6 @@ special parameters created by Symfony:
 ``_fragment``
     Used to set the fragment identifier, which is the optional last part of a URL that
     starts with a ``#`` character and is used to identify a portion of a document.
-
-.. _routing-locale-parameter:
 
 ``_locale``
     Used to set the :ref:`locale <translation-locale-url>` on the request.


### PR DESCRIPTION
As you can see in this screenshot:

![](https://user-images.githubusercontent.com/73419/180944403-976be0b2-96e9-4f32-8a36-041771b6b9af.jpg)

The list of parameters is rendered as 3 separate lists. This is because references are not supported in the middle of the list of items. So, given that the list is short, I propose to move references to the beginning of the list to fix this. Links will point to that beginning of the list, but readers can quickly see all parameters, so this could be fine.
