### PR TITLE
[Form] Remove `:end-before:`, `:start-after:` as it's not used anymore

### DIFF
--- a/reference/forms/types/options/choice_translation_domain.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain.rst.inc
@@ -1,8 +1,6 @@
 ``choice_translation_domain``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-DEFAULT_VALUE
-
 This option determines if the choice values should be translated and in which
 translation domain.
 

--- a/reference/forms/types/options/choice_translation_domain_disabled.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain_disabled.rst.inc
@@ -1,7 +1,3 @@
-.. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
-    :end-before: DEFAULT_VALUE
-
 **type**: ``string``, ``boolean`` or ``null`` **default**: ``false``
 
 .. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
-    :start-after: DEFAULT_VALUE

--- a/reference/forms/types/options/choice_translation_domain_enabled.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain_enabled.rst.inc
@@ -1,7 +1,3 @@
-.. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
-    :end-before: DEFAULT_VALUE
-
 **type**: ``string``, ``boolean`` or ``null`` **default**: ``true``
 
 .. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
-    :start-after: DEFAULT_VALUE


### PR DESCRIPTION
Fixes #16466 (I deleted the branch of my old pr accidentally, so I recreate a new PR)

1. The `:end-before:`, `:start-after:` directives is not supported by the new ReST parser, so it is displayed in the page:
2. As you can see on this page, the 2 options are duplicated in several places in the documentation ([here](https://symfony.com/doc/4.4/reference/forms/types/date.html#choice-translation-domain) and [here](https://symfony.com/doc/4.4/reference/forms/types/choice.html#choice-translation-domain)) whereas it is not necessary.

![image](https://user-images.githubusercontent.com/53557695/180979316-95e78874-1cfc-45d2-a131-8d4198f766f5.png)

**Reviews are welcome! :)**
