### PR TITLE
Update upgrade_major.rst

### DIFF
--- a/setup/upgrade_major.rst
+++ b/setup/upgrade_major.rst
@@ -291,10 +291,10 @@ Classes in the ``vendor/`` directory are always ignored.
 
            # Add type declarations to all internal, final, tests and private methods.
            # Update the "php" parameter to match your minimum required PHP version
-           $ SYMFONY_DEPRECATIONS_HELPER="force=1&php=7.4" ./vendor/bin/patch-type-declarations
+           $ SYMFONY_PATCH_TYPE_DECLARATIONS="force=1&php=7.4" ./vendor/bin/patch-type-declarations
 
            # Add PHPDoc to the leftover public and protected methods
-           $ SYMFONY_DEPRECATIONS_HELPER="force=phpdoc&php=7.4" ./vendor/bin/patch-type-declarations
+           $ SYMFONY_PATCH_TYPE_DECLARATIONS="force=phpdoc&php=7.4" ./vendor/bin/patch-type-declarations
 
        After running the scripts, check your classes and add more ``@return``
        PHPDoc where they are missing. The deprecations and patch script
@@ -312,7 +312,7 @@ Classes in the ``vendor/`` directory are always ignored.
        .. code-block:: terminal
 
            # Update the "php" parameter to match your minimum required PHP version
-           $ SYMFONY_DEPRECATIONS_HELPER="force=2&php=7.4" ./vendor/bin/patch-type-declarations
+           $ SYMFONY_PATCH_TYPE_DECLARATIONS="force=2&php=7.4" ./vendor/bin/patch-type-declarations
 
        Now, you can safely allow ``^6.0`` for the Symfony dependencies.
 


### PR DESCRIPTION
Seems that `SYMFONY_PATCH_TYPE_DECLARATIONS` must be used instead of `SYMFONY_DEPRECATIONS_HELPER` in sample for open source maintainers

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
