### PR TITLE
[Form] Fix typo `choice_translation_domain` option

### DIFF
--- a/reference/forms/types/options/choice_translation_domain.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain.rst.inc
@@ -1,6 +1,3 @@
-``choice_translation_domain``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 This option determines if the choice values should be translated and in which
 translation domain.
 

--- a/reference/forms/types/options/choice_translation_domain_disabled.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain_disabled.rst.inc
@@ -1,3 +1,6 @@
+``choice_translation_domain``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 **type**: ``string``, ``boolean`` or ``null`` **default**: ``false``
 
 .. include:: /reference/forms/types/options/choice_translation_domain.rst.inc

--- a/reference/forms/types/options/choice_translation_domain_enabled.rst.inc
+++ b/reference/forms/types/options/choice_translation_domain_enabled.rst.inc
@@ -1,3 +1,6 @@
+``choice_translation_domain``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 **type**: ``string``, ``boolean`` or ``null`` **default**: ``true``
 
 .. include:: /reference/forms/types/options/choice_translation_domain.rst.inc


### PR DESCRIPTION
Sorry for my typo. 
For this PR, I fix my typo for the `choice_translation_domain` option which refers to my old PR #17063 . Actually the `type` and `default` is above option ([see](https://symfony.com/doc/4.4/reference/forms/types/date.html#choice-translation-domain)).


