### PR TITLE
fix command to run tests of Symfony

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -44,7 +44,7 @@ command:
 
 .. code-block:: terminal
 
-    $ php ./phpunit symfony
+    $ ./phpunit src/Symfony/
 
 The output should display ``OK``. If not, read the reported errors to figure out
 what's going on and if the tests are broken because of the new code.
@@ -57,7 +57,7 @@ what's going on and if the tests are broken because of the new code.
 
     .. code-block:: terminal
 
-        $ php ./phpunit src/Symfony/Component/Finder/
+        $ ./phpunit src/Symfony/Component/Finder/
 
 .. tip::
 


### PR DESCRIPTION
Taking a [suggestion](https://github.com/symfony/symfony/pull/47102#discussion_r935595323) from nicolas-grekas, I updated this part.

I was surprised to find something was wrong, I had this error:

```
PHPUnit 9.5.21 #StandWithUkraine

Cannot open file "symfony/".
```

By providing a path that exist, it works again.