### PR TITLE
[ErrorHandler] Add return type hints

### DIFF
--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -220,7 +220,7 @@ contents, create a new Normalizer that supports the ``FlattenException`` input::
 
     class MyCustomProblemNormalizer implements NormalizerInterface
     {
-        public function normalize($exception, string $format = null, array $context = [])
+        public function normalize($exception, string $format = null, array $context = []): array
         {
             return [
                 'content' => 'This is my custom problem normalizer.',
@@ -231,7 +231,7 @@ contents, create a new Normalizer that supports the ``FlattenException`` input::
             ];
         }
 
-        public function supportsNormalization($data, string $format = null)
+        public function supportsNormalization($data, string $format = null): bool
         {
             return $data instanceof FlattenException;
         }


### PR DESCRIPTION
Added return type hints for normalize & supportsNormalization

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
