### PR TITLE
[Lock] Add reference tip for the InMemoryStore lock

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -667,6 +667,14 @@ PHP process is terminated::
     Zookeeper does not require a TTL as the nodes used for locking are ephemeral
     and die when the PHP process is terminated.
 
+InMemoryStore
+~~~~~~~~~~~~~
+
+.. tip::
+
+    An ``InMemoryStore`` is available for saving lock in memory during a process,
+    and can be useful for testing.
+
 Reliability
 -----------
 


### PR DESCRIPTION
Ref https://github.com/symfony/symfony-docs/issues/15604
Original doc PR is https://github.com/symfony/symfony-docs/pull/14364
I did not added it in the main locks table as it is a "special" one, but can still be useful :)