### PR TITLE
Enable code blocks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,72 +74,67 @@ jobs:
                 with:
                     args: --short --error-format=github --cache-file=/github/workspace/.cache/doctor-rst.cache
 
-    # symfony-code-block-checker:
-    #     name: Code Blocks
-    #     runs-on: Ubuntu-20.04
-    #     continue-on-error: true
-    #     steps:
-    #       - name: Checkout code
-    #         uses: actions/checkout@v2
-    #         with:
-    #             path: 'docs'
+    symfony-code-block-checker:
+        name: Code Blocks
+        runs-on: Ubuntu-20.04
+        continue-on-error: true
+        steps:
+          - name: Checkout code
+            uses: actions/checkout@v2
+            with:
+                path: 'docs'
 
-    #       - name: Set-up PHP
-    #         uses: shivammathur/setup-php@v2
-    #         with:
-    #             php-version: 8.1
-    #             coverage: none
+          - name: Set-up PHP
+            uses: shivammathur/setup-php@v2
+            with:
+                php-version: 8.1
+                coverage: none
 
-    #       - name: Fetch branch from where the PR started
-    #         working-directory: docs
-    #         run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+          - name: Fetch branch from where the PR started
+            working-directory: docs
+            run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
 
-    #       - name: Find modified files
-    #         id: find-files
-    #         working-directory: docs
-    #         run: echo "::set-output name=files::$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep ".rst" | tr '\n' ' ')"
+          - name: Find modified files
+            id: find-files
+            working-directory: docs
+            run: echo "::set-output name=files::$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep ".rst" | tr '\n' ' ')"
 
-    #       - name: Get composer cache directory
-    #         id: composercache
-    #         working-directory: docs/_build
-    #         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+          - name: Get composer cache directory
+            id: composercache
+            working-directory: docs/_build
+            run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-    #       - name: Cache dependencies
-    #         if: ${{ steps.find-files.outputs.files }}
-    #         uses: actions/cache@v2
-    #         with:
-    #             path: ${{ steps.composercache.outputs.dir }}
-    #             key: ${{ runner.os }}-composer-codeBlocks-${{ hashFiles('_checker/composer.lock', '_sf_app/composer.lock') }}
-    #             restore-keys: ${{ runner.os }}-composer-codeBlocks-
+          - name: Cache dependencies
+            if: ${{ steps.find-files.outputs.files }}
+            uses: actions/cache@v2
+            with:
+                path: ${{ steps.composercache.outputs.dir }}
+                key: ${{ runner.os }}-composer-codeBlocks-${{ hashFiles('_checker/composer.lock', '_sf_app/composer.lock') }}
+                restore-keys: ${{ runner.os }}-composer-codeBlocks-
 
-    #       - name: Install dependencies
-    #         if: ${{ steps.find-files.outputs.files }}
-    #         run: composer create-project symfony-tools/code-block-checker:@dev _checker
+          - name: Install dependencies
+            if: ${{ steps.find-files.outputs.files }}
+            run: composer create-project symfony-tools/code-block-checker:@dev _checker
 
-    #       - name: Allow Flex
-    #         if: ${{ steps.find-files.outputs.files }}
-    #         run: |
-    #           composer config --no-plugins allow-plugins.symfony/flex true
+          - name: Install test application
+            if: ${{ steps.find-files.outputs.files }}
+            run: |
+              git clone -b ${{ github.base_ref }} --depth 5 --single-branch https://github.com/symfony-tools/symfony-application.git _sf_app
+              cd _sf_app
+              composer update
 
-    #       - name: Install test application
-    #         if: ${{ steps.find-files.outputs.files }}
-    #         run: |
-    #           git clone -b ${{ github.base_ref }} --depth 5 --single-branch https://github.com/symfony-tools/symfony-application.git _sf_app
-    #           cd _sf_app
-    #           composer update
+          - name: Generate baseline
+            if: ${{ steps.find-files.outputs.files }}
+            working-directory: docs
+            run: |
+              CURRENT=$(git rev-parse HEAD)
+              git checkout -m ${{ github.base_ref }}
+              ../_checker/code-block-checker.php verify:docs `pwd` ${{ steps.find-files.outputs.files }} --generate-baseline=baseline.json --symfony-application=`realpath ../_sf_app`
+              git checkout -m $CURRENT
+              cat baseline.json
 
-    #       - name: Generate baseline
-    #         if: ${{ steps.find-files.outputs.files }}
-    #         working-directory: docs
-    #         run: |
-    #           CURRENT=$(git rev-parse HEAD)
-    #           git checkout -m ${{ github.base_ref }}
-    #           ../_checker/code-block-checker.php verify:docs `pwd` ${{ steps.find-files.outputs.files }} --generate-baseline=baseline.json --symfony-application=`realpath ../_sf_app`
-    #           git checkout -m $CURRENT
-    #           cat baseline.json
-
-    #       - name: Verify examples
-    #         if: ${{ steps.find-files.outputs.files }}
-    #         working-directory: docs
-    #         run: |
-    #           ../_checker/code-block-checker.php verify:docs `pwd` ${{ steps.find-files.outputs.files }} --baseline=baseline.json --output-format=github --symfony-application=`realpath ../_sf_app`
+          - name: Verify examples
+            if: ${{ steps.find-files.outputs.files }}
+            working-directory: docs
+            run: |
+              ../_checker/code-block-checker.php verify:docs `pwd` ${{ steps.find-files.outputs.files }} --baseline=baseline.json --output-format=github --symfony-application=`realpath ../_sf_app`

--- a/_build/composer.json
+++ b/_build/composer.json
@@ -8,7 +8,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "require": {
         "php": ">=7.4",

--- a/security.rst
+++ b/security.rst
@@ -4,7 +4,6 @@
 Security
 ========
 
-
 Symfony provides many tools to secure your application. Some HTTP-related
 security tools, like :doc:`secure session cookies </session>` and
 :doc:`CSRF protection </security/csrf>` are provided by default. The


### PR DESCRIPTION
Revert 8f250a28a0b30a2a7e601efecd2ef23d8106e134

Revert fb505de41c695d00240ba40fb8380dac514051c3 from #17020

Tests were broken, see that example from #17098:

```
Run composer config --no-plugins allow-plugins.symfony/flex true
Error: File "./composer.json" cannot be found in the current directory

In ConfigCommand.php line 206:
                                                                   
  File "./composer.json" cannot be found in the current directory  
                                                                   

config [-g|--global] [-e|--editor] [-a|--auth] [--unset] [-l|--list] [-f|--file FILE] [--absolute] [-j|--json] [-m|--merge] [--append] [--source] [--] [<setting-key> [<setting-value>...]]

Error: Process completed with exit code 1.
```

[full output](https://github.com/symfony/symfony-docs/runs/7640214086?check_suite_focus=true)

It should not be necessary now that https://github.com/symfony-tools/symfony-application/pull/14 has been merged.