### PR TITLE
[Messenger] Update documentation of messenger:failed:show

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -924,8 +924,17 @@ to retry them:
 
 .. code-block:: terminal
 
-    # see all messages in the failure transport
+    # see all messages in the failure transport with a default limit of 50
     $ php bin/console messenger:failed:show
+    
+    # see the 10 first messages
+    $ php bin/console messenger:failed:show --max=10
+
+    # see only MyClass messages
+    $ php bin/console messenger:failed:show --class-filter='MyClass'
+
+    # see the number of messages by message class
+    $ php bin/console messenger:failed:show --stats
 
     # see details about a specific failure
     $ php bin/console messenger:failed:show 20 -vv


### PR DESCRIPTION
This continues #14689 to make it mergeable in 6.2 branch.