### PR TITLE
[QuickTour] improve Symfony v6.1 requires PHP v8.1+

### DIFF
--- a/quick_tour/flex_recipes.rst
+++ b/quick_tour/flex_recipes.rst
@@ -23,10 +23,10 @@ are included in your ``composer.json`` file:
 
     "require": {
         "...",
-        "symfony/console": "^4.1",
-        "symfony/flex": "^1.0",
-        "symfony/framework-bundle": "^4.1",
-        "symfony/yaml": "^4.1"
+        "symfony/console": "^6.1",
+        "symfony/flex": "^2.0",
+        "symfony/framework-bundle": "^6.1",
+        "symfony/yaml": "^6.1"
     }
 
 This makes Symfony different from any other PHP framework! Instead of starting with
@@ -86,10 +86,8 @@ Thanks to Flex, after one command, you can start using Twig immediately:
     - class DefaultController
     + class DefaultController extends AbstractController
       {
-           /**
-            * @Route("/hello/{name}")
-            */
-           public function index($name)
+           #[Route('/hello/{name}', methods: ['GET'])]
+           public function index(string $name): Response
            {
     -        return new Response("Hello $name!");
     +        return $this->render('default/index.html.twig', [
@@ -159,16 +157,15 @@ Are you building an API? You can already return JSON from any controller::
     namespace App\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\JsonResponse;
     use Symfony\Component\Routing\Annotation\Route;
 
     class DefaultController extends AbstractController
     {
         // ...
 
-        /**
-         * @Route("/api/hello/{name}")
-         */
-        public function apiExample($name)
+        #[Route('/api/hello/{name}', methods: ['GET'])]
+        public function apiHello(string$name): JsonResponse
         {
             return $this->json([
                 'name' => $name,

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -27,14 +27,13 @@ use the logger in a controller, add a new argument type-hinted with ``LoggerInte
 
     use Psr\Log\LoggerInterface;
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Routing\Annotation\Route;
 
     class DefaultController extends AbstractController
     {
-        /**
-         * @Route("/hello/{name}")
-         */
-        public function index($name, LoggerInterface $logger)
+        #[Route('/hello/{name}', methods: ['GET'])]
+        public function index(string $name, LoggerInterface $logger): Response
         {
             $logger->info("Saying hello to $name!");
 
@@ -93,7 +92,7 @@ this code directly in your controller, create a new class::
 
     class GreetingGenerator
     {
-        public function getRandomGreeting()
+        public function getRandomGreeting(): string
         {
             $greetings = ['Hey', 'Yo', 'Aloha'];
             $greeting = $greetings[array_rand($greetings)];
@@ -102,7 +101,7 @@ this code directly in your controller, create a new class::
         }
     }
 
-Great! You can use this immediately in your controller::
+Great! You can use it immediately in your controller::
 
     <?php
     // src/Controller/DefaultController.php
@@ -111,14 +110,13 @@ Great! You can use this immediately in your controller::
     use App\GreetingGenerator;
     use Psr\Log\LoggerInterface;
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Routing\Annotation\Route;
 
     class DefaultController extends AbstractController
     {
-        /**
-         * @Route("/hello/{name}")
-         */
-        public function index($name, LoggerInterface $logger, GreetingGenerator $generator)
+        #[Route('/hello/{name}', methods: ['GET'])]
+        public function index(string $name, LoggerInterface $logger, GreetingGenerator $generator): Response
         {
             $greeting = $generator->getRandomGreeting();
 
@@ -141,14 +139,11 @@ difference is that it's done in the constructor:
 
       class GreetingGenerator
       {
-    +     private $logger;
-    +
-    +     public function __construct(LoggerInterface $logger)
+    +     public function __construct(private readonly LoggerInterface $logger)
     +     {
-    +         $this->logger = $logger;
     +     }
 
-          public function getRandomGreeting()
+          public function getRandomGreeting(): string
           {
               // ...
 
@@ -178,11 +173,8 @@ that extends ``AbstractExtension``::
 
     class GreetExtension extends AbstractExtension
     {
-        private $greetingGenerator;
-
-        public function __construct(GreetingGenerator $greetingGenerator)
+        public function __construct(private readonly GreetingGenerator $greetingGenerator)
         {
-            $this->greetingGenerator = $greetingGenerator;
         }
 
         public function getFilters()
@@ -192,7 +184,7 @@ that extends ``AbstractExtension``::
             ];
         }
 
-        public function greetUser($name)
+        public function greetUser(string $name): string
         {
             $greeting =  $this->greetingGenerator->getRandomGreeting();
 

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -14,7 +14,7 @@ safe & easy!) and offers long-term support.
 Downloading Symfony
 -------------------
 
-First, make sure you've installed `Composer`_ and have PHP 8.0.2 or higher.
+First, make sure you've installed `Composer`_ and have PHP 8.1 or higher.
 
 Ready? In a terminal, run:
 
@@ -88,7 +88,7 @@ method inside::
 
     class DefaultController
     {
-        public function index()
+        public function index(): Response
         {
             return new Response('Hello!');
         }
@@ -125,7 +125,7 @@ like a wildcard that matches anything. And it gets better! Update the controller
       class DefaultController
       {
     -     public function index()
-    +     public function index($name)
+    +     public function index(string $name): Response
           {
     -         return new Response('Hello!');
     +         return new Response("Hello $name!");
@@ -164,10 +164,9 @@ Instead, add the route *right above* the controller method:
 
       class DefaultController
       {
-    +    /**
-    +     * @Route("/hello/{name}")
-    +     */
-           public function index($name) {
+    +      #[Route('/hello/{name}', methods: ['GET'])]
+           public function index(string $name): Response
+           {
                // ...
            }
       }
@@ -187,10 +186,8 @@ in ``DefaultController``::
     {
         // ...
 
-        /**
-         * @Route("/simplicity")
-         */
-        public function simple()
+        #[Route('/simplicity', methods: ['GET'])]
+        public function simple(): Response
         {
             return new Response('Simple! Easy! Great!');
         }


### PR DESCRIPTION
Those pages are indexed, but found no direct link to them (I do not know why :s)
While fixing the required [php v](https://github.com/symfony/symfony-docs/pull/17107/files#diff-329c56dd24f471b82f8f56003889ce976ac7e295a91308891fab064076bdb1d9R17), took chance to improve code example as well

<img width="1000" alt="Capture d’écran 2022-08-03 à 21 18 13" src="https://user-images.githubusercontent.com/1358361/182691485-3f381e75-3f21-473c-8a03-153662e2cd0d.png">

