### PR TITLE
Improve standalone console application doc for commands loading

### DIFF
--- a/components/console.rst
+++ b/components/console.rst
@@ -80,4 +80,3 @@ Learn more
     /console
     /components/console/*
     /console/*
-

--- a/components/console.rst
+++ b/components/console.rst
@@ -59,8 +59,16 @@ See the :doc:`/console` article for information about how to create commands.
 
 .. note::
 
-    Do not forget to leverage Composer's `autoload`_ feature
-    so that your Command can be used.
+    You have to register your command(s) path for autoloading
+    in the `composer.json` file::
+
+    {
+        "autoload": {
+            "psr-4": {
+                "App\\": "src/"
+            }
+        }
+    }
 
 Learn more
 ----------
@@ -73,4 +81,3 @@ Learn more
     /components/console/*
     /console/*
 
-.. _`autoload`: https://getcomposer.org/doc/04-schema.md#autoload

--- a/components/console.rst
+++ b/components/console.rst
@@ -46,13 +46,21 @@ First, you need to create a PHP script to define the console application::
 
     $application->run();
 
-Then, you can register the commands using
+Then, you can create and register the commands using
 :method:`Symfony\\Component\\Console\\Application::add`::
 
     // ...
-    $application->add(new GenerateAdminCommand());
+    // command file created in src/Command/CreateUserCommand.php
+    use App\Command\CreateUserCommand;
+    // ...
+    $application->add(new CreateUserCommand());
 
 See the :doc:`/console` article for information about how to create commands.
+
+.. note::
+
+    Do not forget to leverage Composer's `autoload`_ feature
+    so that your Command can be used.
 
 Learn more
 ----------
@@ -64,3 +72,5 @@ Learn more
     /console
     /components/console/*
     /console/*
+
+.. _`autoload`: https://getcomposer.org/doc/04-schema.md#autoload


### PR DESCRIPTION
Hi, I tried to improve this part of the doc to fix https://github.com/symfony/symfony-docs/issues/15583
Targeting v5.4 as actual lts
the command name change is to match the name of the command created in the referenced `:doc:/console` link