### PR TITLE
[Validator] Add hint for testing custom constraints

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -801,6 +801,49 @@ You can also validate all the classes stored in a given directory:
 
     $ php bin/console debug:validator src/Entity
 
+Testing Custom Constraints
+-------------------------
+
+Since custom constraints contain meaningful logic for your application, writing tests is crucial. You can use the ``ConstraintValidatorTestCase`` to write unit tests for custom constraints:
+
+.. code-block:: php
+    class IsFalseValidatorTest extends ConstraintValidatorTestCase
+    {
+        protected function createValidator()
+        {
+            return new IsFalseValidator();
+        }
+        
+        public function testNullIsValid()
+        {
+            $this->validator->validate(null, new IsFalse());
+
+            $this->assertNoViolation();
+        }
+
+        /**
+         * @dataProvider provideInvalidConstraints
+         */
+        public function testTrueIsInvalid(IsFalse $constraint)
+        {
+            $this->validator->validate(true, $constraint);
+
+            $this->buildViolation('myMessage')
+                ->setParameter('{{ value }}', 'true')
+                ->setCode(IsFalse::NOT_FALSE_ERROR)
+                ->assertRaised();
+        }
+
+        public function provideInvalidConstraints(): iterable
+        {
+            yield 'Doctrine style' => [new IsFalse([
+                'message' => 'myMessage',
+            ])];
+            yield 'named parameters' => [new IsFalse(message: 'myMessage')];
+        }
+        
+    }
+
 Final Thoughts
 --------------
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->

I created some custom constraints lately and I stumbled upon the TestCase that symfony developers are using for testing out-of-the-box constraints like IsNull constraints. Since there is no hint in the docs about the ConstraintValidatorTestCase class, I thought it would be a great idea to add this to the docs. This class helped me alot when testing my constraints :)
