### PR TITLE
add alternative method to force version with symfony/flex

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -228,6 +228,8 @@ with Symfony Flex to install a specific Symfony version:
 
     # this requires Symfony 5.x for all Symfony packages
     export SYMFONY_REQUIRE=5.*
+    # alternative method: write to the composer.json file
+    # composer config extra.symfony.require "5.*"
 
     # install Symfony Flex in the CI environment
     composer global require --no-progress --no-scripts --no-plugins symfony/flex


### PR DESCRIPTION
I find it more consistent to use `composer` on all steps instead of the environment variable `SYMFONY_REQUIRE`.

So I propose to explain this method.