### PR TITLE
[4.4] routing: move annotation on kernel to micro kernel page

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -331,3 +331,24 @@ As before you can use the :doc:`Symfony Local Web Server
     $ symfony server:start
 
 Then visit the page in your browser: http://localhost:8000/random/10
+
+Define routes in the Kernel with annotations
+--------------------------------------------
+
+You first have to enable annotations (see :ref:`routing-creating-routes-as-annotations`).
+
+Then you have to declare that Symfony must read the annotations in the Kernel
+by updating the configuration:
+
+.. code-block:: diff
+
+      # config/routes/annotations.yaml
+      controllers:
+          resource: ../../src/Controller/
+          type: annotation
+
+    +kernel:
+    +    resource: ../../src/Kernel.php
+    +    type: annotation
+
+You'll be able to declare routes with annotations in your ``Kernel``.

--- a/routing.rst
+++ b/routing.rst
@@ -39,10 +39,6 @@ following configuration file:
         resource: ../../src/Controller/
         type: annotation
 
-    kernel:
-        resource: ../../src/Kernel.php
-        type: annotation
-
 This configuration tells Symfony to look for routes defined as annotations in
 any PHP class stored in the ``src/Controller/`` directory.
 

--- a/routing.rst
+++ b/routing.rst
@@ -20,6 +20,8 @@ provide the same features and performance, so choose your favorite.
 :ref:`Symfony recommends annotations <best-practice-controller-annotations>`
 because it's convenient to put the route and controller in the same place.
 
+.. _routing-creating-routes-as-annotations:
+
 Creating Routes as Annotations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
With the current text, Symfony will search for routes in `Controller/` and the `Kernel`:

https://github.com/symfony/symfony-docs/blob/90edeb3732002aa9a13582c01b9cb92aa85eebbf/routing.rst?plain=1#L37-L47

Yet the sentence after the conf doesn't mention the `Kernel`.

I suggest to remove it since most users won't put routes in their Kernel, and ~~explain it in the context of a micro app (I'll open an issue if necessary)~~ update: I did it in this PR.

---

On second thought, I think that adding a dependency to declare routes as annotations in the `Kernel` somehow contradicts the goal of a micro kernel architecture, routes can be [defined through PHP with `configureRoutes()`](https://symfony.com/doc/4.4/configuration/micro_kernel_trait.html#advanced-example-twig-annotations-and-the-web-debug-toolbar) and it should be enough for most cases. What do you think?

References:
- https://github.com/symfony/recipes/commit/49370eb45b995dcfbe1cd3a08606918a9f478682
- https://github.com/symfony/recipes/pull/735