### PR TITLE
Yet another attempt for consistent variable naming ;-)

### DIFF
--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -178,7 +178,7 @@ enforce different levels of service (free or paid):
         // config/packages/rate_limiter.php
         use Symfony\Config\FrameworkConfig;
 
-        return static function (FrameworkConfig $framework) {
+        return static function (FrameworkConfig $frameworkConfig) {
             $framework->rateLimiter()
                 ->limiter('anonymous_api')
                     // use 'sliding_window' if you prefer that policy


### PR DESCRIPTION
Following the convention you showed me in https://github.com/symfony/symfony-docs/pull/16560, the variable's name here should be `$config` ;-)

**So I'm suggesting: Always use the full class name as variable name (in config files)**: `$containerConfigurator`, `$frameworkConfig`, `$securityConfig`, etc.

