### PR TITLE
Replace Route annotations with attributes, remove Route annotation configuration block

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -256,9 +256,7 @@ has one file in it::
 
     class MicroController extends AbstractController
     {
-        /**
-         * @Route("/random/{limit}")
-         */
+        #[Route('/random/{limit}')]
         public function randomNumber(int $limit): Response
         {
             $number = random_int(0, $limit);

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -39,24 +39,6 @@ a service like: ``App\Controller\HelloController::index``:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/HelloController.php
-        namespace App\Controller;
-
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class HelloController
-        {
-            /**
-             * @Route("/hello", name="hello", methods={"GET"})
-             */
-            public function index()
-            {
-                // ...
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/HelloController.php
@@ -117,25 +99,6 @@ which is a common practice when following the `ADR pattern`_
 (Action-Domain-Responder):
 
 .. configuration-block::
-
-    .. code-block:: php-annotations
-
-        // src/Controller/Hello.php
-        namespace App\Controller;
-
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        /**
-         * @Route("/hello/{name}", name="hello")
-         */
-        class Hello
-        {
-            public function __invoke($name = 'World')
-            {
-                return new Response(sprintf('Hello %s!', $name));
-            }
-        }
 
     .. code-block:: php-attributes
 

--- a/controller/soap_web_service.rst
+++ b/controller/soap_web_service.rst
@@ -66,9 +66,7 @@ can be retrieved via ``/soap?wsdl``::
 
     class HelloServiceController extends AbstractController
     {
-        /**
-         * @Route("/soap")
-         */
+        #[Route('/soap')]
         public function index(HelloService $helloService)
         {
             $soapServer = new \SoapServer('/path/to/hello.wsdl');

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -133,9 +133,7 @@ Finally, you need to update the code of the controller that handles the form::
 
     class ProductController extends AbstractController
     {
-        /**
-         * @Route("/product/new", name="app_product_new")
-         */
+        #[Route('/product/new', name: 'app_product_new')]
         public function new(Request $request, SluggerInterface $slugger)
         {
             $product = new Product();

--- a/lock.rst
+++ b/lock.rst
@@ -171,9 +171,7 @@ To lock the default resource, autowire the lock factory using
 
     class PdfController extends AbstractController
     {
-        /**
-         * @Route("/download/terms-of-use.pdf")
-         */
+        #[Route('/download/terms-of-use.pdf')]
         public function downloadPdf(LockFactory $factory, MyPdfGeneratorService $pdf)
         {
             $lock = $factory->createLock('pdf-creation');
@@ -212,9 +210,7 @@ processes asking for the same ``$version``::
 
     class PdfController extends AbstractController
     {
-        /**
-         * @Route("/download/{version}/terms-of-use.pdf")
-         */
+        #[Route('/download/{version}/terms-of-use.pdf')]
         public function downloadPdf($version, LockFactory $lockFactory, MyPdfGeneratorService $pdf)
         {
             $lock = $lockFactory->createLock($version);

--- a/notifier/chatters.rst
+++ b/notifier/chatters.rst
@@ -17,9 +17,7 @@ you to send messages to chat services like Slack or Telegram::
 
     class CheckoutController extends AbstractController
     {
-        /**
-         * @Route("/checkout/thankyou")
-         */
+        #[Route('/checkout/thankyou')]
         public function thankyou(ChatterInterface $chatter)
         {
             $message = (new ChatMessage('You got a new invoice for 15 EUR.'))

--- a/notifier/texters.rst
+++ b/notifier/texters.rst
@@ -16,9 +16,7 @@ you to send SMS messages::
 
     class SecurityController
     {
-        /**
-         * @Route("/login/success")
-         */
+        #[Route('/login/success')]
         public function loginSuccess(TexterInterface $texter)
         {
             $sms = new SmsMessage(

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -106,24 +106,6 @@ You can now add your route directly *above* the controller:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/LuckyController.php
-
-        // ...
-        + use Symfony\Component\Routing\Annotation\Route;
-
-        class LuckyController
-        {
-        +   /**
-        +    * @Route("/lucky/number")
-        +    */
-            public function number(): Response
-            {
-                // this looks exactly the same
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/LuckyController.php
@@ -257,9 +239,7 @@ variable so you can use it in Twig::
 
     class LuckyController extends AbstractController
     {
-        /**
-         * @Route("/lucky/number")
-         */
+        #[Route('/lucky/number')]
         public function number(): Response
         {
             $number = random_int(0, 100);

--- a/quick_tour/flex_recipes.rst
+++ b/quick_tour/flex_recipes.rst
@@ -86,9 +86,7 @@ Thanks to Flex, after one command, you can start using Twig immediately:
     - class DefaultController
     + class DefaultController extends AbstractController
       {
-           /**
-            * @Route("/hello/{name}")
-            */
+           #[Route('/hello/{name}')]
            public function index($name)
            {
     -        return new Response("Hello $name!");
@@ -165,9 +163,7 @@ Are you building an API? You can already return JSON from any controller::
     {
         // ...
 
-        /**
-         * @Route("/api/hello/{name}")
-         */
+        #[Route('/api/hello/{name}')]
         public function apiExample($name)
         {
             return $this->json([

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -31,9 +31,7 @@ use the logger in a controller, add a new argument type-hinted with ``LoggerInte
 
     class DefaultController extends AbstractController
     {
-        /**
-         * @Route("/hello/{name}")
-         */
+        #[Route('/hello/{name}')]
         public function index($name, LoggerInterface $logger)
         {
             $logger->info("Saying hello to $name!");
@@ -115,9 +113,7 @@ Great! You can use this immediately in your controller::
 
     class DefaultController extends AbstractController
     {
-        /**
-         * @Route("/hello/{name}")
-         */
+        #[Route('/hello/{name}')]
         public function index($name, LoggerInterface $logger, GreetingGenerator $generator)
         {
             $greeting = $generator->getRandomGreeting();

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -164,15 +164,13 @@ Instead, add the route *right above* the controller method:
 
       class DefaultController
       {
-    +    /**
-    +     * @Route("/hello/{name}")
-    +     */
+    +      #[Route('/hello/{name}')]
            public function index($name) {
                // ...
            }
       }
 
-This works just like before! But by using annotations, the route and controller
+This works just like before! But by using attributes, the route and controller
 live right next to each other. Need another page? Add another route and method
 in ``DefaultController``::
 
@@ -187,9 +185,7 @@ in ``DefaultController``::
     {
         // ...
 
-        /**
-         * @Route("/simplicity")
-         */
+        #[Route('/simplicity')]
         public function simple()
         {
             return new Response('Simple! Easy! Great!');

--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -13,7 +13,7 @@ the data can be a ``DateTime`` object, a string, a timestamp or an array.
 +---------------------------+-----------------------------------------------------------------------------+
 | Underlying Data Type      | can be ``DateTime``, string, timestamp, or array (see the ``input`` option) |
 +---------------------------+-----------------------------------------------------------------------------+
-| Rendered as               | single text box or five select fields                                      |
+| Rendered as               | single text box or five select fields                                       |
 +---------------------------+-----------------------------------------------------------------------------+
 | Default invalid message   | Please enter a valid date and time.                                         |
 +---------------------------+-----------------------------------------------------------------------------+

--- a/routing.rst
+++ b/routing.rst
@@ -15,70 +15,42 @@ provides other useful features, like generating SEO-friendly URLs (e.g.
 Creating Routes
 ---------------
 
-Routes can be configured in YAML, XML, PHP or using either attributes or
-annotations. All formats provide the same features and performance, so choose
+Routes can be configured in YAML, XML, PHP or using attributes.
+All formats provide the same features and performance, so choose
 your favorite.
 :ref:`Symfony recommends attributes <best-practice-controller-annotations>`
 because it's convenient to put the route and controller in the same place.
 
-Creating Routes as Attributes or Annotations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Creating Routes as Attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-PHP attributes and annotations allow to define routes next to the code of the
+PHP attributes allow to define routes next to the code of the
 :doc:`controllers </controller>` associated to those routes. Attributes are
 native in PHP 8 and higher versions, so you can use them right away.
 
-In PHP 7 and earlier versions you can use annotations (via the Doctrine Annotations
-library), but first you'll need to install the following dependency in your project:
-
-.. code-block:: terminal
-
-    $ composer require doctrine/annotations
-
-Regardless of what you use (attributes or annotations) you need to add a bit of
-configuration to your project before using them. If your project uses
+You need to add a bit of configuration to your project before using them. If your project uses
 :ref:`Symfony Flex <symfony-flex>`, this file is already created for you.
-Otherwise, create the following file manually (the ``type: annotation`` option
-also applies to attributes, so you can keep it):
+Otherwise, create the following file manually:
 
 .. code-block:: yaml
 
-    # config/routes/annotations.yaml
+    # config/routes/attributes.yaml
     controllers:
         resource: ../../src/Controller/
-        type: annotation
+        type: attribute
 
     kernel:
         resource: ../../src/Kernel.php
-        type: annotation
+        type: attribute
 
 This configuration tells Symfony to look for routes defined as
-annotations/attributes in any PHP class stored in the ``src/Controller/``
+attributes in any PHP class stored in the ``src/Controller/``
 directory.
 
 Suppose you want to define a route for the ``/blog`` URL in your application. To
 do so, create a :doc:`controller class </controller>` like the following:
 
 .. configuration-block::
-
-    .. code-block:: php-annotations
-
-        // src/Controller/BlogController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class BlogController extends AbstractController
-        {
-            /**
-             * @Route("/blog", name="blog_list")
-             */
-            public function list()
-            {
-                // ...
-            }
-        }
 
     .. code-block:: php-attributes
 
@@ -193,34 +165,6 @@ Use the ``methods`` option to restrict the verbs each route should respond to:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/BlogApiController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class BlogApiController extends AbstractController
-        {
-            /**
-             * @Route("/api/posts/{id}", methods={"GET","HEAD"})
-             */
-            public function show(int $id): Response
-            {
-                // ... return a JSON response with the post
-            }
-
-            /**
-             * @Route("/api/posts/{id}", methods={"PUT"})
-             */
-            public function edit(int $id): Response
-            {
-                // ... edit a post
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/BlogApiController.php
@@ -308,33 +252,6 @@ Use the ``condition`` option if you need some route to match based on some
 arbitrary matching logic:
 
 .. configuration-block::
-
-    .. code-block:: php-annotations
-
-        // src/Controller/DefaultController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class DefaultController extends AbstractController
-        {
-            /**
-             * @Route(
-             *     "/contact",
-             *     name="contact",
-             *     condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'"
-             * )
-             *
-             * expressions can also include configuration parameters:
-             * condition: "request.headers.get('User-Agent') matches '%app.allowed_browsers%'"
-             */
-            public function contact(): Response
-            {
-                // ...
-            }
-        }
 
     .. code-block:: php-attributes
 
@@ -497,31 +414,6 @@ defined as ``/blog/{slug}``:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/BlogController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class BlogController extends AbstractController
-        {
-            // ...
-
-            /**
-             * @Route("/blog/{slug}", name="blog_show")
-             */
-            public function show(string $slug): Response
-            {
-                // $slug will equal the dynamic part of the URL
-                // e.g. at /blog/yay-routing, then $slug='yay-routing'
-
-                // ...
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/BlogController.php
@@ -600,34 +492,6 @@ will use the route which was defined first. To fix this, add some validation to
 the ``{page}`` parameter using the ``requirements`` option:
 
 .. configuration-block::
-
-    .. code-block:: php-annotations
-
-        // src/Controller/BlogController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class BlogController extends AbstractController
-        {
-            /**
-             * @Route("/blog/{page}", name="blog_list", requirements={"page"="\d+"})
-             */
-            public function list(int $page): Response
-            {
-                // ...
-            }
-
-            /**
-             * @Route("/blog/{slug}", name="blog_show")
-             */
-            public function show(string $slug): Response
-            {
-                // ...
-            }
-        }
 
     .. code-block:: php-attributes
 
@@ -737,26 +601,6 @@ concise, but it can decrease route readability when requirements are complex:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/BlogController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class BlogController extends AbstractController
-        {
-            /**
-             * @Route("/blog/{page<\d+>}", name="blog_list")
-             */
-            public function list(int $page): Response
-            {
-                // ...
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/BlogController.php
@@ -823,26 +667,6 @@ default values are defined in the arguments of the controller action. In the
 other configuration formats they are defined with the ``defaults`` option:
 
 .. configuration-block::
-
-    .. code-block:: php-annotations
-
-        // src/Controller/BlogController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class BlogController extends AbstractController
-        {
-            /**
-             * @Route("/blog/{page}", name="blog_list", requirements={"page"="\d+"})
-             */
-            public function list(int $page = 1): Response
-            {
-                // ...
-            }
-        }
 
     .. code-block:: php-attributes
 
@@ -929,26 +753,6 @@ parameter:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/BlogController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class BlogController extends AbstractController
-        {
-            /**
-             * @Route("/blog/{page<\d+>?1}", name="blog_list")
-             */
-            public function list(int $page): Response
-            {
-                // ...
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/BlogController.php
@@ -1020,37 +824,6 @@ optional ``priority`` parameter in those routes to control their priority:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/BlogController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class BlogController extends AbstractController
-        {
-            /**
-             * This route has a greedy pattern and is defined first.
-             *
-             * @Route("/blog/{slug}", name="blog_show")
-             */
-            public function show(string $slug)
-            {
-                // ...
-            }
-
-            /**
-             * This route could not be matched without defining a higher priority than 0.
-             *
-             * @Route("/blog/list", name="blog_list", priority=2)
-             */
-            public function list()
-            {
-                // ...
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/BlogController.php
@@ -1112,9 +885,7 @@ controller action. Instead of ``string $slug``, add ``BlogPost $post``::
     {
         // ...
 
-        /**
-         * @Route("/blog/{slug}", name="blog_show")
-         */
+        #[Roue('/blog/{slug}', name: 'blog_show')]
         public function show(BlogPost $post): Response
         {
             // $post is the object whose slug matches the routing parameter
@@ -1161,33 +932,6 @@ and in route imports. Symfony defines some special attributes with the same name
 (except for the leading underscore) so you can define them easier:
 
 .. configuration-block::
-
-    .. code-block:: php-annotations
-
-        // src/Controller/ArticleController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class ArticleController extends AbstractController
-        {
-            /**
-             * @Route(
-             *     "/articles/{_locale}/search.{_format}",
-             *     locale="en",
-             *     format="html",
-             *     requirements={
-             *         "_locale": "en|fr",
-             *         "_format": "html|xml",
-             *     }
-             * )
-             */
-            public function search(): Response
-            {
-            }
-        }
 
     .. code-block:: php-attributes
 
@@ -1272,26 +1016,6 @@ the controllers of the routes:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/BlogController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class BlogController extends AbstractController
-        {
-            /**
-             * @Route("/blog/{page}", name="blog_index", defaults={"page": 1, "title": "Hello world!"})
-             */
-            public function index(int $page, string $title): Response
-            {
-                // ...
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/BlogController.php
@@ -1364,26 +1088,6 @@ For example, if the ``token`` value in the ``/share/{token}`` route contains a
 A possible solution is to change the parameter requirements to be more permissive:
 
 .. configuration-block::
-
-    .. code-block:: php-annotations
-
-        // src/Controller/DefaultController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class DefaultController extends AbstractController
-        {
-            /**
-             * @Route("/share/{token}", name="share", requirements={"token"=".+"})
-             */
-            public function share($token): Response
-            {
-                // ...
-            }
-        }
 
     .. code-block:: php-attributes
 
@@ -1575,43 +1279,12 @@ It's common for a group of routes to share some options (e.g. all routes related
 to the blog start with ``/blog``) That's why Symfony includes a feature to share
 route configuration.
 
-When defining routes as attributes or annotations, put the common configuration
-in the ``#[Route]`` attribute (or ``@Route`` annotation) of the controller
-class. In other routing formats, define the common configuration using options
+When defining routes as attributes, put the common configuration
+in the ``#[Route]`` attribute of the controller class.
+In other routing formats, define the common configuration using options
 when importing the routes.
 
 .. configuration-block::
-
-    .. code-block:: php-annotations
-
-        // src/Controller/BlogController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        /**
-         * @Route("/blog", requirements={"_locale": "en|es|fr"}, name="blog_")
-         */
-        class BlogController extends AbstractController
-        {
-            /**
-             * @Route("/{_locale}", name="index")
-             */
-            public function index(): Response
-            {
-                // ...
-            }
-
-            /**
-             * @Route("/{_locale}/posts/{slug}", name="show")
-             */
-            public function show(Post $post): Response
-            {
-                // ...
-            }
-        }
 
     .. code-block:: php-attributes
 
@@ -1799,9 +1472,7 @@ information in a controller via the ``Request`` object::
 
     class BlogController extends AbstractController
     {
-        /**
-         * @Route("/blog", name="blog_list")
-         */
+        #[Route('/blog', name: 'blog_list')]
         public function list(Request $request): Response
         {
             $routeName = $request->attributes->get('_route');
@@ -1984,34 +1655,6 @@ host name:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/MainController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class MainController extends AbstractController
-        {
-            /**
-             * @Route("/", name="mobile_homepage", host="m.example.com")
-             */
-            public function mobileHomepage(): Response
-            {
-                // ...
-            }
-
-            /**
-             * @Route("/", name="homepage")
-             */
-            public function homepage(): Response
-            {
-                // ...
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/MainController.php
@@ -2087,40 +1730,6 @@ multi-tenant applications) and these parameters can be validated too with
 ``requirements``:
 
 .. configuration-block::
-
-    .. code-block:: php-annotations
-
-        // src/Controller/MainController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class MainController extends AbstractController
-        {
-            /**
-             * @Route(
-             *     "/",
-             *     name="mobile_homepage",
-             *     host="{subdomain}.example.com",
-             *     defaults={"subdomain"="m"},
-             *     requirements={"subdomain"="m|mobile"}
-             * )
-             */
-            public function mobileHomepage(): Response
-            {
-                // ...
-            }
-
-            /**
-             * @Route("/", name="homepage")
-             */
-            public function homepage(): Response
-            {
-                // ...
-            }
-        }
 
     .. code-block:: php-attributes
 
@@ -2249,29 +1858,6 @@ a different URL per each :doc:`translation locale </translation/locale>`. This
 avoids the need for duplicating routes, which also reduces the potential bugs:
 
 .. configuration-block::
-
-    .. code-block:: php-annotations
-
-        // src/Controller/CompanyController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class CompanyController extends AbstractController
-        {
-            /**
-             * @Route({
-             *     "en": "/about-us",
-             *     "nl": "/over-ons"
-             * }, name="about_us")
-             */
-            public function about(): Response
-            {
-                // ...
-            }
-        }
 
     .. code-block:: php-attributes
 
@@ -2453,25 +2039,6 @@ session shouldn't be used when matching a request:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/MainController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class MainController extends AbstractController
-        {
-            /**
-             * @Route("/", name="homepage", stateless=true)
-             */
-            public function homepage()
-            {
-                // ...
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/MainController.php
@@ -2564,9 +2131,7 @@ use the ``generateUrl()`` helper::
 
     class BlogController extends AbstractController
     {
-        /**
-         * @Route("/blog", name="blog_list")
-         */
+        #[Route('/blog', name: 'blog_list')]
         public function list(): Response
         {
             // generate a URL with no route arguments
@@ -2851,26 +2416,6 @@ Outside of console commands, use the ``schemes`` option to define the scheme of
 each route explicitly:
 
 .. configuration-block::
-
-    .. code-block:: php-annotations
-
-        // src/Controller/SecurityController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class SecurityController extends AbstractController
-        {
-            /**
-             * @Route("/login", name="login", schemes={"https"})
-             */
-            public function login(): Response
-            {
-                // ...
-            }
-        }
 
     .. code-block:: php-attributes
 

--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -7,7 +7,7 @@ How to Create a custom Route Loader
 Basic applications can define all their routes in a single configuration file -
 usually ``config/routes.yaml`` (see :ref:`routing-creating-routes`).
 However, in most applications it's common to import routes definitions from
-different resources: PHP annotations or attributes in controller files, YAML, XML
+different resources: PHP attributes in controller files, YAML, XML
 or PHP files stored in some directory, etc.
 
 Built-in Route Loaders
@@ -24,10 +24,10 @@ Symfony provides several route loaders for the most common needs:
             # loads routes from the given routing file stored in some bundle
             resource: '@AcmeBundle/Resources/config/routing.yaml'
 
-        app_annotations:
-            # loads routes from the PHP annotations of the controllers found in that directory
+        app_attributes:
+            # loads routes from the PHP attributes of the controllers found in that directory
             resource: '../src/Controller/'
-            type:     annotation
+            type:     attribute
 
         app_directory:
             # loads routes from the YAML, XML or PHP files found in that directory
@@ -51,8 +51,8 @@ Symfony provides several route loaders for the most common needs:
             <!-- loads routes from the given routing file stored in some bundle -->
             <import resource="@AcmeBundle/Resources/config/routing.yaml"/>
 
-            <!-- loads routes from the PHP annotations of the controllers found in that directory -->
-            <import resource="../src/Controller/" type="annotation"/>
+            <!-- loads routes from the PHP attributes of the controllers found in that directory -->
+            <import resource="../src/Controller/" type="attribute"/>
 
             <!-- loads routes from the YAML or XML files found in that directory -->
             <import resource="../legacy/routing/" type="directory"/>
@@ -70,8 +70,8 @@ Symfony provides several route loaders for the most common needs:
             // loads routes from the given routing file stored in some bundle
             $routes->import('@AcmeBundle/Resources/config/routing.yaml');
 
-            // loads routes from the PHP annotations of the controllers found in that directory
-            $routes->import('../src/Controller/', 'annotation');
+            // loads routes from the PHP attributes of the controllers found in that directory
+            $routes->import('../src/Controller/', 'attribute');
 
             // loads routes from the YAML or XML files found in that directory
             $routes->import('../legacy/routing/', 'directory');
@@ -103,7 +103,7 @@ Loading Routes
 The routes in a Symfony application are loaded by the
 :class:`Symfony\\Bundle\\FrameworkBundle\\Routing\\DelegatingLoader`.
 This loader uses several other loaders (delegates) to load resources of
-different types, for instance YAML files or ``@Route`` annotations in controller
+different types, for instance YAML files or ``#[Route]`` attributes in controller
 files. The specialized loaders implement
 :class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`
 and therefore have two important methods:
@@ -119,7 +119,7 @@ Take these lines from the ``routes.yaml``:
         # config/routes.yaml
         controllers:
             resource: ../src/Controller/
-            type: annotation
+            type: attribute
 
     .. code-block:: xml
 
@@ -130,7 +130,7 @@ Take these lines from the ``routes.yaml``:
             xsi:schemaLocation="http://symfony.com/schema/routing
                 https://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <import resource="../src/Controller" type="annotation"/>
+            <import resource="../src/Controller" type="attribute"/>
         </routes>
 
     .. code-block:: php
@@ -139,13 +139,13 @@ Take these lines from the ``routes.yaml``:
         use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
         return function (RoutingConfigurator $routes) {
-            $routes->import('../src/Controller', 'annotation');
+            $routes->import('../src/Controller', 'attribute');
         };
 
 When the main loader parses this, it tries all registered delegate loaders and calls
 their :method:`Symfony\\Component\\Config\\Loader\\LoaderInterface::supports`
 method with the given resource (``../src/Controller/``)
-and type (``annotation``) as arguments. When one of the loader returns ``true``,
+and type (``attribute``) as arguments. When one of the loader returns ``true``,
 its :method:`Symfony\\Component\\Config\\Loader\\LoaderInterface::load` method
 will be called, which should return a :class:`Symfony\\Component\\Routing\\RouteCollection`
 containing :class:`Symfony\\Component\\Routing\\Route` objects.
@@ -219,7 +219,7 @@ tag it manually with ``routing.route_loader``.
 Creating a custom Loader
 ------------------------
 
-To load routes from some custom source (i.e. from something other than annotations,
+To load routes from some custom source (i.e. from something other than attributes,
 YAML or XML files), you need to create a custom route loader. This loader
 has to implement :class:`Symfony\\Component\\Config\\Loader\\LoaderInterface`.
 
@@ -439,7 +439,7 @@ configuration file - you can call the
 
     The resource name and type of the imported routing configuration can
     be anything that would normally be supported by the routing configuration
-    loader (YAML, XML, PHP, annotation, etc.).
+    loader (YAML, XML, PHP, attribute, etc.).
 
 .. note::
 

--- a/security.rst
+++ b/security.rst
@@ -1650,26 +1650,6 @@ Next, you need to create a route for this URL (but not a controller):
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/SecurityController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class SecurityController extends AbstractController
-        {
-            /**
-             * @Route("/logout", name="app_logout", methods={"GET"})
-             */
-            public function logout(): void
-            {
-                // controller can be blank: it will never be called!
-                throw new \Exception('Don\'t forget to activate logout in security.yaml');
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/SecurityController.php

--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -86,27 +86,8 @@ intercept requests to this route:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/SecurityController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class SecurityController extends AbstractController
-        {
-            /**
-             * @Route("/login_check", name="login_check")
-             */
-            public function check()
-            {
-                throw new \LogicException('This code should never be reached');
-            }
-        }
-        
     .. code-block:: php-attributes
-    
+
         // src/Controller/SecurityController.php
         namespace App\Controller;
 
@@ -177,9 +158,7 @@ this interface::
 
     class SecurityController extends AbstractController
     {
-        /**
-         * @Route("/login", name="login")
-         */
+        #[Route('/login', name: 'login')]
         public function requestLoginLink(LoginLinkHandlerInterface $loginLinkHandler, UserRepository $userRepository, Request $request)
         {
             // check if login form is submitted
@@ -250,9 +229,7 @@ number::
 
     class SecurityController extends AbstractController
     {
-        /**
-         * @Route("/login", name="login")
-         */
+        #[Route('/login', name: 'login')]
         public function requestLoginLink(NotifierInterface $notifier, LoginLinkHandlerInterface $loginLinkHandler, UserRepository $userRepository, Request $request)
         {
             if ($request->isMethod('POST')) {
@@ -628,9 +605,7 @@ user create this POST request (e.g. by clicking a button)::
 
     class SecurityController extends AbstractController
     {
-        /**
-         * @Route("/login_check", name="login_check")
-         */
+        #[Route('/login_check', name: 'login_check')]
         public function check(Request $request)
         {
             // get the login link query parameters
@@ -771,9 +746,7 @@ features such as the locale used to generate the link::
 
     class SecurityController extends AbstractController
     {
-        /**
-         * @Route("/login", name="login")
-         */
+        #[Route('/login', name: 'login')]
         public function requestLoginLink(LoginLinkHandlerInterface $loginLinkHandler, Request $request)
         {
             // check if login form is submitted

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -73,9 +73,7 @@ code like this::
     // ...
     class PostController extends AbstractController
     {
-        /**
-         * @Route("/posts/{id}", name="post_show")
-         */
+        #[Route('/posts/{id}', name: 'post_show')]
         public function show($id): Response
         {
             // get a Post object - e.g. query for it
@@ -87,9 +85,7 @@ code like this::
             // ...
         }
 
-        /**
-         * @Route("/posts/{id}/edit", name="post_edit")
-         */
+        #[Route('/posts/{id}/edit', name: 'post_edit')]
         public function edit($id): Response
         {
             // get a Post object - e.g. query for it

--- a/service_container.rst
+++ b/service_container.rst
@@ -38,9 +38,7 @@ service's class or interface name. Want to :doc:`log </logging>` something? No p
 
     class ProductController extends AbstractController
     {
-        /**
-         * @Route("/products")
-         */
+        #[Route('/products')]
         public function list(LoggerInterface $logger): Response
         {
             $logger->info('Look, I just used a service!');

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -136,9 +136,7 @@ Now, you can use the ``TwitterClient`` service immediately in a controller::
 
     class DefaultController extends AbstractController
     {
-        /**
-         * @Route("/tweet", methods={"POST"})
-         */
+        #[Route('/tweet')]
         public function tweet(TwitterClient $twitterClient, Request $request): Response
         {
             // fetch $user, $key, $status from the POST'ed data

--- a/templates.rst
+++ b/templates.rst
@@ -188,34 +188,6 @@ Consider the following routing configuration:
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/BlogController.php
-        namespace App\Controller;
-
-        // ...
-        use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class BlogController extends AbstractController
-        {
-            /**
-             * @Route("/", name="blog_index")
-             */
-            public function index(): Response
-            {
-                // ...
-            }
-
-            /**
-             * @Route("/article/{slug}", name="blog_post")
-             */
-            public function show(string $slug): Response
-            {
-                // ...
-            }
-        }
-
     .. code-block:: php-attributes
 
         // src/Controller/BlogController.php

--- a/translation/locale.rst
+++ b/translation/locale.rst
@@ -64,28 +64,6 @@ A better policy is to include the locale in the URL using the
 
 .. configuration-block::
 
-    .. code-block:: php-annotations
-
-        // src/Controller/ContactController.php
-        namespace App\Controller;
-
-        // ...
-        class ContactController extends AbstractController
-        {
-            /**
-             * @Route(
-             *     "/{_locale}/contact",
-             *     name="contact",
-             *     requirements={
-             *         "_locale": "en|fr|de",
-             *     }
-             * )
-             */
-            public function contact()
-            {
-            }
-        }
-        
     .. code-block:: php-attributes
 
         // src/Controller/ContactController.php


### PR DESCRIPTION
As discussed in #16877, this PR replaces all `@Route` annotations with `#[Route]` attributes.

It also remove Route annotation configuration block.

I only replaced the `@Route` annotations to simplify the review and get some initial feedback. Depending on them, I will adjust the changes and submit other PR to replace the other type of annotations if it's ok for you!