### PR TITLE
[Security] Deleting useless controller

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1650,24 +1650,6 @@ Next, you need to create a route for this URL (but not a controller):
 
 .. configuration-block::
 
-    .. code-block:: php-attributes
-
-        // src/Controller/SecurityController.php
-        namespace App\Controller;
-
-        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-        use Symfony\Component\Routing\Annotation\Route;
-
-        class SecurityController extends AbstractController
-        {
-            #[Route('/logout', name: 'app_logout', methods: ['GET'])]
-            public function logout()
-            {
-                // controller can be blank: it will never be called!
-                throw new \Exception('Don\'t forget to activate logout in security.yaml');
-            }
-        }
-
     .. code-block:: yaml
 
         # config/routes.yaml


### PR DESCRIPTION
As already pointed out by @linaori in https://github.com/symfony/symfony-docs/pull/10423#discussion_r222777195, it's quite useless to create an empty controller, just for the route. So the recommended way should be to add it in `routes.php` - as with YAML and XML.

* There is a `.. code-block:: php` (which I was just about to add) in the source, but it's not shown on the website at https://symfony.com/doc/6.0/security.html#logging-out - why is that?
* I'm submitting this to 6.0 (instead of 5.4) because of https://github.com/symfony/symfony-docs/pull/17142 - to avoid a conflict.
