### PR TITLE
Update argument_value_resolver.rst

### DIFF
--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -65,7 +65,7 @@ Symfony ships with the following value resolvers in the
                 // this allows all values defined in the Enum
                 'suit' => new EnumRequirement(Suit::class),
                 // this restricts the possible values to the Enum values listed here
-                'suit' => new EnumRequirement([Suit::class, Suit::Diamonds, Suit::Spades]),
+                'suit' => new EnumRequirement([Suit::Diamonds, Suit::Spades]),
             ])]
             public function list(Suit $suit): Response
             {


### PR DESCRIPTION
Fix documentation for Built-In Value Resolvers:

The code in the current documentation produces an error when implemented like described. The fix is to not include the FQN of the Enum class, because an instance of BackedEnum is expected.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
