### PR TITLE
Typo fix

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -88,8 +88,10 @@ application behavior.
 :ref:`Use env vars in your project <config-env-vars>` to define these options
 and create multiple ``.env`` files to :ref:`configure env vars per environment <config-dot-env>`.
 
-Use Secret for Sensitive Information
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _use-secret-for-sensitive-information:
+
+Use Secrets for Sensitive Information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When your application has sensitive configuration - like an API key - you should
 store those securely via :doc:`Symfony’s secrets management system </configuration/secrets>`.


### PR DESCRIPTION
"Secret" should be plural "Secrets" in this context.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
