### PR TITLE
[Translation] Fix path to bundle translations

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -485,7 +485,7 @@ Translation Resource/File Names and Locations
 Symfony looks for message files (i.e. translations) in the following default locations:
 
 * the ``translations/`` directory (at the root of the project);
-* the ``Resources/translations/`` directory inside of any bundle.
+* the ``translations/`` directory inside of any bundle (or ``Resources/translations`` with Symfony < 6.1)
 
 The locations are listed here with the highest priority first. That is, you can
 override the translation messages of a bundle in the first directory.


### PR DESCRIPTION
Everything else in bundles has moved away from /Resources, so I think the path mentioned here isn't right.  