### PR TITLE
Update service documentation with udpate recipe files

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -170,8 +170,11 @@ each time you ask for it.
                 # makes classes in src/ available to be used as services
                 # this creates a service per class whose id is the fully-qualified class name
                 App\:
-                    resource: '../src/*'
-                    exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+                    resource: '../src/'
+                    exclude:
+                        - '../src/DependencyInjection/'
+                        - '../src/Entity/'
+                        - '../src/Kernel.php'
 
                 # ...
 
@@ -190,7 +193,7 @@ each time you ask for it.
 
                     <!-- makes classes in src/ available to be used as services -->
                     <!-- this creates a service per class whose id is the fully-qualified class name -->
-                    <prototype namespace="App\" resource="../src/*" exclude="../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}"/>
+                    <prototype namespace="App\" resource="../src/" exclude="../src/{DependencyInjection,Entity,Kernel.php}"/>
 
                     <!-- ... -->
 
@@ -212,8 +215,8 @@ each time you ask for it.
 
                 // makes classes in src/ available to be used as services
                 // this creates a service per class whose id is the fully-qualified class name
-                $services->load('App\\', '../src/*')
-                    ->exclude('../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}');
+                $services->load('App\\', '../src/')
+                    ->exclude('../src/{DependencyInjection,Entity,Kernel.php}');
             };
 
     .. tip::
@@ -425,8 +428,8 @@ pass here. No problem! In your configuration, you can explicitly set this argume
 
             # same as before
             App\:
-                resource: '../src/*'
-                exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+                resource: '../src/'
+                exclude: '../src/{DependencyInjection,Entity,Kernel.php}'
 
             # explicitly configure the service
             App\Service\SiteUpdateManager:
@@ -448,8 +451,8 @@ pass here. No problem! In your configuration, you can explicitly set this argume
                 <!-- Same as before -->
 
                 <prototype namespace="App\"
-                    resource="../src/*"
-                    exclude="../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}"
+                    resource="../src/"
+                    exclude="../src/{DependencyInjection,Entity,Kernel.php}"
                 />
 
                 <!-- Explicitly configure the service -->
@@ -470,8 +473,8 @@ pass here. No problem! In your configuration, you can explicitly set this argume
             // ...
 
             // same as before
-            $services->load('App\\', '../src/*')
-                ->exclude('../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}');
+            $services->load('App\\', '../src/')
+                ->exclude('../src/{DependencyInjection,Entity,Kernel.php}');
 
             $services->set(SiteUpdateManager::class)
                 ->arg('$adminEmail', 'manager@example.com')
@@ -956,8 +959,8 @@ key. For example, the default Symfony configuration contains this:
             # makes classes in src/ available to be used as services
             # this creates a service per class whose id is the fully-qualified class name
             App\:
-                resource: '../src/*'
-                exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+                resource: '../src/'
+                exclude: '../src/{DependencyInjection,Entity,Kernel.php}'
 
     .. code-block:: xml
 
@@ -971,7 +974,7 @@ key. For example, the default Symfony configuration contains this:
             <services>
                 <!-- ... same as before -->
 
-                <prototype namespace="App\" resource="../src/*" exclude="../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}"/>
+                <prototype namespace="App\" resource="../src/" exclude="../src/{DependencyInjection,Entity,Kernel.php}"/>
             </services>
         </container>
 
@@ -985,8 +988,8 @@ key. For example, the default Symfony configuration contains this:
 
             // makes classes in src/ available to be used as services
             // this creates a service per class whose id is the fully-qualified class name
-            $services->load('App\\', '../src/*')
-                ->exclude('../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}');
+            $services->load('App\\', '../src/')
+                ->exclude('../src/{DependencyInjection,Entity,Kernel.php}');
         };
 
 .. tip::


### PR DESCRIPTION
The asterisk was removed some time ago as not required and the Tests and Migrations are also were also removed from exclude.


See discussion about asterisk here: https://github.com/symfony/recipes/pull/802#discussion_r455856843