### PR TITLE
[Console] add SignalableCommandInterface link

### DIFF
--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -190,7 +190,7 @@ Listeners receive a
 
 If you use the Console component inside a Symfony application, commands can
 handle signals themselves. To do so, implement the
-``SignalableCommandInterface`` and subscribe to one or more signals::
+:class:`Symfony\\Component\\Console\\Command\\SignalableCommandInterface` and subscribe to one or more signals::
 
     // src/Command/SomeCommand.php
     namespace App\Command;
@@ -208,7 +208,7 @@ handle signals themselves. To do so, implement the
             return [\SIGINT, \SIGTERM];
         }
 
-        public function handleSignal(int $signal)
+        public function handleSignal(int $signal): void
         {
             if (\SIGINT === $signal) {
                 // ...


### PR DESCRIPTION
Add SignalableCommandInterface link & return hint for handleSignal

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
