### PR TITLE
[Cache] Add return hint

### DIFF
--- a/http_cache/cache_invalidation.rst
+++ b/http_cache/cache_invalidation.rst
@@ -60,7 +60,7 @@ to support the ``PURGE`` HTTP method::
 
     class CacheKernel extends HttpCache
     {
-        protected function invalidate(Request $request, bool $catch = false)
+        protected function invalidate(Request $request, bool $catch = false): Response
         {
             if ('PURGE' !== $request->getMethod()) {
                 return parent::invalidate($request, $catch);


### PR DESCRIPTION
Return hint for invalidate added in V6.0

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
