### PR TITLE
"Creating Pages" not responsive

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -165,11 +165,13 @@ To get a list of *all* of the routes in your system, use the ``debug:router`` co
 
 You should see your ``app_lucky_number`` route in the list:
 
-================== ======== ======== ====== ===============
-Name               Method   Scheme   Host   Path
-================== ======== ======== ====== ===============
-app_lucky_number   ANY      ANY      ANY    /lucky/number
-================== ======== ======== ====== ===============
+.. code-block:: terminal
+
+    ----------------  -------  -------  -----  --------------
+    Name              Method   Scheme   Host   Path
+    ----------------  -------  -------  -----  --------------
+    app_lucky_number  ANY      ANY      ANY    /lucky/number
+    ----------------  -------  -------  -----  --------------
 
 You will also see debugging routes besides ``app_lucky_number`` -- more on
 the debugging routes in the next section.


### PR DESCRIPTION
I noticed that while reading this page on my mobile device (a Samsung Galaxy S22), the content was not fully responsive, which was quite annoying to scroll horizontally to read.

![image](https://user-images.githubusercontent.com/5428251/185074455-6dfcd6ab-2220-4143-86b0-38b312c12424.png)


While debugging this issue, I figure out that removing the "table" element under the `The bin/console Command` section resolved the problem (~ not entirely sure why).

I am proposing displaying the console output of the command `php bin/console debug:router` as a terminal block.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
