### PR TITLE
Typo in the Route attribute definition

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -885,7 +885,7 @@ controller action. Instead of ``string $slug``, add ``BlogPost $post``::
     {
         // ...
 
-        #[Roue('/blog/{slug}', name: 'blog_show')]
+        #[Route('/blog/{slug}', name: 'blog_show')]
         public function show(BlogPost $post): Response
         {
             // $post is the object whose slug matches the routing parameter


### PR DESCRIPTION
Under the section `Parameter Conversion` there is a typo in the code block definition of the route `blog_show` (line 13 of the code block).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
