### PR TITLE
Fix dependency injection PHP sample code

### DIFF
--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -297,9 +297,9 @@ config files:
                 ->set('mailer.transport', 'sendmail')
             ;
 
-            $container->services()
-                ->set('mailer', 'Mailer')
-                    ->args(['%mailer.transport%'])
+            $services = $container->services();
+            $services->set('mailer', 'Mailer')
+                ->args(['%mailer.transport%'])
 
             $services->set('mailer', 'Mailer')
                 // the param() method was introduced in Symfony 5.2.


### PR DESCRIPTION
I've just noticed that there is an error in the code sample:

```php
namespace Symfony\Component\DependencyInjection\Loader\Configurator;

return static function (ContainerConfigurator $container) {
    $container->parameters()
        // ...
        ->set('mailer.transport', 'sendmail')
    ;

    $container->services()
        ->set('mailer', 'Mailer')
            ->args(['%mailer.transport%'])

    $services->set('mailer', 'Mailer')
        // the param() method was introduced in Symfony 5.2.
        ->args([param('mailer.transport')])
    ;

    $services->set('newsletter_manager', 'NewsletterManager')
        // In versions earlier to Symfony 5.1 the service() function was called ref()
        ->call('setMailer', [service('mailer')])
    ;
};
```

The `$services` is not defined.