### PR TITLE
Inappropriate usage of Parameter Conversion

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -1180,7 +1180,7 @@ the common configuration using options when importing the routes.
             /**
              * @Route("/{_locale}/posts/{slug}", name="show")
              */
-            public function show(Post $post): Response
+            public function show(string $slug): Response
             {
                 // ...
             }


### PR DESCRIPTION
Under the section `Route Groups and Prefixes`, the action `show` seems to make usage of `Parameter Conversion` technique, though there is no reference for the `Post` class in that code snippet.

I would suggest to replace the parameter `Post $post` to `string $slug` , matching the URL parameter defined above the method `show`.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
