### PR TITLE
[Mailer] Update example to use Address format

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -551,7 +551,7 @@ and headers.
         framework:
             mailer:
                 envelope:
-                    sender: 'fabien@example.com'
+                    sender: 'Fabien <fabien@example.com>'
                     recipients: ['foo@example.com', 'bar@example.com']
                 headers:
                     From: 'Fabien <fabien@example.com>'
@@ -573,7 +573,7 @@ and headers.
             <framework:config>
                 <framework:mailer>
                     <framework:envelope>
-                        <framework:sender>fabien@example.com</framework:sender>
+                        <framework:sender>Fabien &lt;fabien@example.com&gt;</framework:sender>
                         <framework:recipients>foo@example.com</framework:recipients>
                         <framework:recipients>bar@example.com</framework:recipients>
                     </framework:envelope>
@@ -593,7 +593,7 @@ and headers.
             $mailer = $framework->mailer();
             $mailer
                 ->envelope()
-                    ->sender('fabien@example.com')
+                    ->sender('Fabien <fabien@example.com>')
                     ->recipients(['foo@example.com', 'bar@example.com'])
             ;
 


### PR DESCRIPTION
It seems strange to me that the example for the From headers uses the full Address format, whereas the sender envelope does not.

I believe it is possible to use it here, so thought I would expand on the example to show how you can set both the display name and email address when configuring the sender envelope globally.