### PR TITLE
Usage of "Constructor Promotion" for PHP >= 8.0.2

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -2193,12 +2193,8 @@ the :class:`Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface` class
 
     class SomeService
     {
-        private $router;
-
-        public function __construct(UrlGeneratorInterface $router)
-        {
-            $this->router = $router;
-        }
+        public function __construct(private UrlGeneratorInterface $router)
+        {}
 
         public function someMethod()
         {
@@ -2312,13 +2308,9 @@ Now you'll get the expected results when generating URLs in your commands::
 
     class SomeCommand extends Command
     {
-        private $router;
-
-        public function __construct(RouterInterface $router)
+        public function __construct(private RouterInterface $router)
         {
             parent::__construct();
-
-            $this->router = $router;
         }
 
         protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
Symfony version [6.0 requires PHP 8.0.2](https://symfony.com/doc/6.0/setup.html#technical-requirements) or higher, so I would suggest to make usage of the [ `Constructor Promotion`](https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.promotion)  feature.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
