### PR TITLE
[Routing] Adding full example for a Service in Route Condition

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -379,7 +379,27 @@ You can also use these functions:
 ``service(string $alias)``
     Returns a routing condition service.
     You'll have to add the ``#[AsRoutingConditionService]`` attribute or ``routing.condition_service``
-    tag to your service if you want to use it in the condition.
+    tag to your service if you want to use it in the condition::
+    
+    
+        // Controller (using an alias):
+        #[Route(condition: "service('route_checker').check(request)")]
+        // Or without alias:
+        #[Route(condition: "service('Ap\\\Service\\\RouteChecker').check(request)")]
+    
+    .. code-block:: php
+
+        use Symfony\Bundle\FrameworkBundle\Routing\Attribute\AsRoutingConditionService;
+        use Symfony\Component\HttpFoundation\Request;
+
+        #[AsRoutingConditionService(alias: 'route_checker')]
+        class RouteChecker
+        {
+            public function check(Request $request): bool
+            {
+                // ...
+            }
+        }
 
 .. versionadded:: 6.1
 


### PR DESCRIPTION
Reasons:
* There needs to be an example on how to pass any information to this callback service. I merely *guessed* the `route` syntax - it's not even explained at https://symfony.com/blog/new-in-symfony-6-1-services-in-route-conditions - is there a better way to do it?
* How to call a method from this service wasn't explained (the `.check()` part)
* This method needs to return `bool`?

I don't think it's a good idea to add those code blocks inside this indented "list" - will it even work? So probably it's better to create a dedicated paragraph (or even heading) for Services in Route Conditions. But you need to tell me how (i.e. what structure you have in mind).