### PR TITLE
Deprecate not configuring explicitly a provider for custom_authenticators when there is more than one registered provider

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -88,7 +88,7 @@ if you want to know a bundle name, you can add this to your command::
         
         // ... do something with the bundleName
         
-        return Commande::SUCCESS;
+        return Command::SUCCESS;
     }
 
 The user will be asked "Please enter the name of the bundle". They can type
@@ -124,7 +124,7 @@ from a predefined list::
 
         // ... do something with the color
         
-        return Commande::SUCCESS;
+        return Command::SUCCESS;
     }
 
 .. versionadded:: 5.2
@@ -166,7 +166,7 @@ this use :method:`Symfony\\Component\\Console\\Question\\ChoiceQuestion::setMult
         $colors = $helper->ask($input, $output, $question);
         $output->writeln('You have just selected: ' . implode(', ', $colors));
         
-        return Commande::SUCCESS;
+        return Command::SUCCESS;
     }
 
 Now, when the user enters ``1,2``, the result will be:
@@ -197,7 +197,7 @@ will be autocompleted as the user types::
         
         // ... do something with the bundleName
         
-        return Commande::SUCCESS;
+        return Command::SUCCESS;
     }
 
 In more complex use cases, it may be necessary to generate suggestions on the
@@ -236,7 +236,7 @@ provide a callback function to dynamically generate suggestions::
         
         // ... do something with the filePath
         
-        return Commande::SUCCESS;
+        return Command::SUCCESS;
     }
 
 Do not Trim the Answer
@@ -260,7 +260,7 @@ You can also specify if you want to not trim the answer by setting it directly w
         
         // ... do something with the name
         
-        return Commande::SUCCESS;
+        return Command::SUCCESS;
     }
 
 Accept Multiline Answers
@@ -291,7 +291,7 @@ the response to a question should allow multiline answers by passing ``true`` to
         
         // ... do something with the answer
         
-        return Commande::SUCCESS;
+        return Command::SUCCESS;
     }
 
 Multiline questions stop reading user input after receiving an end-of-transmission
@@ -319,7 +319,7 @@ convenient for passwords::
         
         // ... do something with the password
         
-        return Commande::SUCCESS;
+        return Command::SUCCESS;
     }
 
 .. caution::
@@ -351,7 +351,7 @@ convenient for passwords::
 
             // ...
             
-            return Commande::SUCCESS;
+            return Command::SUCCESS;
         }
 
 Normalizing the Answer
@@ -382,7 +382,7 @@ method::
         
         // ... do something with the bundleName
         
-        return Commande::SUCCESS;
+        return Command::SUCCESS;
     }
 
 .. caution::
@@ -426,7 +426,7 @@ method::
         
         // ... do something with the bundleName
         
-        return Commande::SUCCESS;
+        return Command::SUCCESS;
     }
 
 The ``$validator`` is a callback which handles the validation. It should
@@ -488,7 +488,7 @@ You can also use a validator with a hidden question::
         
         // ... do something with the password
         
-        return Commande::SUCCESS;
+        return Command::SUCCESS;
     }
 
 Testing a Command that Expects Input

--- a/security/custom_authenticator.rst
+++ b/security/custom_authenticator.rst
@@ -130,6 +130,12 @@ The authenticator can be enabled using the ``custom_authenticators`` setting:
             ;
         };
 
+.. deprecated:: 5.4
+
+    If you have registered multiple user providers, you must set the
+    ``provider`` key to one of the configured providers, even if your
+    custom authenticators don't use it. Not doing so is deprecated in Symfony 5.4.
+
 .. versionadded:: 5.2
 
     Starting with Symfony 5.2, the custom authenticator is automatically
@@ -185,7 +191,7 @@ can define what happens in these cases:
     If your login method is interactive, which means that the user actively
     logged into your application, you may want your authenticator to implement the
     :class:`Symfony\\Component\\Security\\Http\\Authenticator\\InteractiveAuthenticatorInterface`
-    so that it dispatches an 
+    so that it dispatches an
     :class:`Symfony\\Component\\Security\\Http\\Event\\InteractiveLoginEvent`
 
 .. _security-passport:


### PR DESCRIPTION

Fixes #16041
