### PR TITLE
[HttpClient] Expanding on HTTP compression

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -373,11 +373,6 @@ immediately instead of waiting to receive the response::
 This component also supports :ref:`streaming responses <http-client-streaming-responses>`
 for full asynchronous applications.
 
-.. note::
-
-    HTTP compression and chunked transfer encoding are automatically enabled when
-    both your PHP runtime and the remote server support them.
-
 Authentication
 ~~~~~~~~~~~~~~
 
@@ -757,6 +752,20 @@ the transport explicitly, use the following classes to create the client::
 When using this component in a full-stack Symfony application, this behavior is
 not configurable and cURL will be used automatically if the cURL PHP extension
 is installed and enabled. Otherwise, the native PHP streams will be used.
+
+HTTP Compression
+~~~~~~~~~~~~~~~~
+
+A HTTP header ``Accept-Encoding: gzip`` is added automatically if ...
+
+* cURL Client: ... cURL was compiled with ZLib support (see ``php --ri curl``)
+* Native Http Client: ... `Zlib PHP extension`_ is installed
+
+If the server does respond with a gzipped response, it's decoded transparently.
+
+To disable HTTP compression, send an ``Accept-Encoding: identity`` HTTP header.
+
+Chunked transfer encoding is enabled automatically if both your PHP runtime and the remote server supports it.
 
 HTTP/2 Support
 ~~~~~~~~~~~~~~
@@ -1571,6 +1580,7 @@ test it in a real application::
     }
 
 .. _`cURL PHP extension`: https://www.php.net/curl
+.. _`Zlib PHP extension`: https://www.php.net/zlib
 .. _`PSR-17`: https://www.php-fig.org/psr/psr-17/
 .. _`PSR-18`: https://www.php-fig.org/psr/psr-18/
 .. _`HTTPlug`: https://github.com/php-http/httplug/#readme


### PR DESCRIPTION
I moved the note downwards, because two things should be explained before it:
* cURL and Native Client
* How to send an HTTP header

Besides, it not that important to have it explained right on top; and it fits nicely in the "Performance" section.

The info is taken from https://github.com/symfony/symfony-docs/issues/17216#issuecomment-1222494905