### PR TITLE
[Security] Added documentation for IS_AUTHENTICATED

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2418,19 +2418,19 @@ Secondly, you can use a special "attribute" in place of a role::
 
     public function adminDashboard(): Response
     {
-        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED');
 
         // ...
     }
 
-You can use ``IS_AUTHENTICATED_FULLY`` anywhere roles are used: like
+You can use ``IS_AUTHENTICATED`` anywhere roles are used: like
 ``access_control`` or in Twig.
 
-``IS_AUTHENTICATED_FULLY`` isn't a role, but it kind of acts like one, and every
+``IS_AUTHENTICATED`` isn't a role, but it kind of acts like one, and every
 user that has logged in will have this. Actually, there are some special attributes
 like this:
 
-* ``IS_AUTHENTICATED_REMEMBERED``: *All* logged in users have this, even
+* ``IS_AUTHENTICATED_REMEMBERED``: Just like ``IS_AUTHENTICATED``, *all* logged in users have this, even
   if they are logged in because of a "remember me cookie". Even if you don't
   use the :doc:`remember me functionality </security/remember_me>`,
   you can use this to check if the user is logged in.


### PR DESCRIPTION
I believe that this part of the doc is wrong or might be confusing. In order to check if the user is *simply* logged in, they are suggesting using the `IS_AUTHENTICATED_FULLY` attribute. But later below, we learn that this attribute is the "stronger" one and that it cannot be used in that context because:
> This is similar to `IS_AUTHENTICATED_REMEMBERED`, but stronger. Users who are logged in only because of a "remember me cookie" will have `IS_AUTHENTICATED_REMEMBERED` but will not have `IS_AUTHENTICATED_FULLY`.

**So the appropriate attribute should have been `IS_AUTHENTICATED_REMEMBERED`**:
> **All logged-in users have this**, even if they are logged in because of a "remember me cookie". Even if you don't use the [remember me functionality](https://symfony.com/doc/current/security/remember_me.html), you can use this to check if the user is logged in.

But unfortunately, its name is misleading and it took me some long minutes to understand it and why it has been named like that.

After digging into the [AuthenticatedVoter](https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php) for a better understanding of these attributes, I stumbled upon an undocumented attribute called `IS_AUTHENTICATED`. 

I believe that this attribute should be present in the doc and should become the recommended one when checking if a user is *simply* logged in because its name is obviously clearer and better describes its intent.

I'm not sure why it's not documented but it has been brought by this https://github.com/symfony/symfony/commit/e3aca7f0c2c2fd67df786efacb2f1378f7fb78c1. 