### PR TITLE
docs: fix links to phpunit docs

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -458,4 +458,4 @@ you must set up a redirection.
 .. _`feature toggles`: https://en.wikipedia.org/wiki/Feature_toggle
 .. _`smoke testing`: https://en.wikipedia.org/wiki/Smoke_testing_(software)
 .. _`Webpack`: https://webpack.js.org/
-.. _`PHPUnit data providers`: https://phpunit.readthedocs.io/en/stable/writing-tests-for-phpunit.html#data-providers
+.. _`PHPUnit data providers`: https://phpunit.readthedocs.io/en/9.5/writing-tests-for-phpunit.html#data-providers

--- a/create_framework/unit_testing.rst
+++ b/create_framework/unit_testing.rst
@@ -220,6 +220,6 @@ Symfony code.
 Now that we are confident (again) about the code we have written, we can
 safely think about the next batch of features we want to add to our framework.
 
-.. _`PHPUnit`: https://phpunit.readthedocs.io/en/stable/
-.. _`test doubles`: https://phpunit.readthedocs.io/en/stable/test-doubles.html
+.. _`PHPUnit`: https://phpunit.readthedocs.io/en/9.5/
+.. _`test doubles`: https://phpunit.readthedocs.io/en/9.5/test-doubles.html
 .. _`XDebug`: https://xdebug.org/

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -243,4 +243,4 @@ guessers using the :method:`Symfony\\Component\\Form\\Test\\FormIntegrationTestC
 and :method:`Symfony\\Component\\Form\\Test\\FormIntegrationTestCase::getTypeGuessers`
 methods.
 
-.. _`PHPUnit data providers`: https://phpunit.readthedocs.io/en/stable/writing-tests-for-phpunit.html#data-providers
+.. _`PHPUnit data providers`: https://phpunit.readthedocs.io/en/9.5/writing-tests-for-phpunit.html#data-providers

--- a/testing.rst
+++ b/testing.rst
@@ -935,12 +935,12 @@ Learn more
 
 .. _`PHPUnit`: https://phpunit.de/
 .. _`documentation`: https://phpunit.readthedocs.io/
-.. _`Writing Tests for PHPUnit`: https://phpunit.readthedocs.io/en/stable/writing-tests-for-phpunit.html
-.. _`PHPUnit documentation`: https://phpunit.readthedocs.io/en/stable/configuration.html
+.. _`Writing Tests for PHPUnit`: https://phpunit.readthedocs.io/en/9.5/writing-tests-for-phpunit.html
+.. _`PHPUnit documentation`: https://phpunit.readthedocs.io/en/9.5/configuration.html
 .. _`unit test`: https://en.wikipedia.org/wiki/Unit_testing
 .. _`DAMADoctrineTestBundle`: https://github.com/dmaicher/doctrine-test-bundle
 .. _`DoctrineFixturesBundle documentation`: https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html
 .. _`SymfonyMakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
 .. _`symfony/panther`: https://github.com/symfony/panther
-.. _`PHPUnit Assertion`: https://phpunit.readthedocs.io/en/stable/assertions.html
+.. _`PHPUnit Assertion`: https://phpunit.readthedocs.io/en/9.5/assertions.html
 .. _`section 4.1.18 of RFC 3875`: https://tools.ietf.org/html/rfc3875#section-4.1.18


### PR DESCRIPTION
phpUnit does not have the /stable/ url in the docs anymore.

The exact Version has now to be set.
https://phpunit.readthedocs.io/en/9.5/test-doubles.html

@sebastianbergmann 
Is there any chance that /stable/ will be redirect to the correct branch in the near future?
This would be a better solution in my point of view, instead of changing the url here (any many other Repos, websites, ...). 