### PR TITLE
Fix type in alert comment about accessing session in constructor

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -150,7 +150,7 @@ if you type-hint an argument with :class:`Symfony\\Component\\HttpFoundation\\Re
         {
             $this->requestStack = $requestStack;
 
-            // Accessing the session in the constructor is *NOT* reommended, since
+            // Accessing the session in the constructor is *NOT* recommended, since
             // it might not be accessible yet or lead to unwanted side-effects
             // $this->session = $requestStack->getSession();
         }


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
