### PR TITLE
Proper line numbers for a Basic Controller example

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -59,10 +59,10 @@ This controller is pretty straightforward:
 * *line 7*: The class can technically be called anything, but it's suffixed
   with ``Controller`` by convention.
 
-* *line 12*: The action method is allowed to have a ``$max`` argument thanks to the
+* *line 10*: The action method is allowed to have a ``$max`` argument thanks to the
   ``{max}`` :doc:`wildcard in the route </routing>`.
 
-* *line 16*: The controller creates and returns a ``Response`` object.
+* *line 14*: The controller creates and returns a ``Response`` object.
 
 .. index::
    single: Controller; Routes and controllers


### PR DESCRIPTION
The lines that describe the method signature and the method return value (lines `12` and `16`, respectively), should be `10` and `14` since Symfony version `6.0`.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
