### PR TITLE
Method getCharset with proper returning type

### DIFF
--- a/reference/configuration/kernel.rst
+++ b/reference/configuration/kernel.rst
@@ -33,7 +33,7 @@ charset::
 
     class Kernel extends BaseKernel
     {
-        public function getCharset()
+        public function getCharset(): string
         {
             return 'ISO-8859-1';
         }


### PR DESCRIPTION
The method `getCharset` implemented by the example should return `string` type, like the `Symfony\Component\HttpKernel\Kernel` abstract class requires:

![image](https://user-images.githubusercontent.com/5428251/187910885-5a1fbde9-69c3-4c5e-88fd-d08958bfbd72.png)


<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
