### PR TITLE
[Config] Remove obsolete warning about INI files

### DIFF
--- a/components/config/resources.rst
+++ b/components/config/resources.rst
@@ -4,13 +4,6 @@
 Loading Resources
 =================
 
-.. caution::
-
-    The ``IniFileLoader`` parses the file contents using the
-    :phpfunction:`parse_ini_file` function. Therefore, you can only set
-    parameters to string values. To set parameters to other data types
-    (e.g. boolean, integer, etc), the other loaders are recommended.
-    
 Loaders populate the application's configuration from different sources
 like YAML files. The Config component defines the interface for such
 loaders. The :doc:`Dependency Injection </components/dependency_injection>`


### PR DESCRIPTION
Spotted thanks to https://github.com/symfony/symfony-docs/issues/17232#issuecomment-1234274374

Since https://github.com/symfony/symfony/pull/20232 the claim that “you can only set parameters to string values” is not valid anymore.