### PR TITLE
[Doctrine] Proper line numbers on Doctrine Persisting example

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -394,21 +394,21 @@ Take a look at the previous example in more detail:
 
 .. _doctrine-entity-manager:
 
-* **line 14** The ``ManagerRegistry $doctrine`` argument tells Symfony to
+* **line 13** The ``ManagerRegistry $doctrine`` argument tells Symfony to
   :ref:`inject the Doctrine service <services-constructor-injection>` into the
   controller method.
 
-* **line 16** The ``$doctrine->getManager()`` method gets Doctrine's
+* **line 15** The ``$doctrine->getManager()`` method gets Doctrine's
   *entity manager* object, which is the most important object in Doctrine. It's
   responsible for saving objects to, and fetching objects from, the database.
 
-* **lines 18-21** In this section, you instantiate and work with the ``$product``
+* **lines 17-20** In this section, you instantiate and work with the ``$product``
   object like any other normal PHP object.
 
-* **line 24** The ``persist($product)`` call tells Doctrine to "manage" the
+* **line 23** The ``persist($product)`` call tells Doctrine to "manage" the
   ``$product`` object. This does **not** cause a query to be made to the database.
 
-* **line 27** When the ``flush()`` method is called, Doctrine looks through
+* **line 26** When the ``flush()`` method is called, Doctrine looks through
   all of the objects that it's managing to see if they need to be persisted
   to the database. In this example, the ``$product`` object's data doesn't
   exist in the database, so the entity manager executes an ``INSERT`` query,


### PR DESCRIPTION
Fixing the lines references for the Doctrine Persisting Object example.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
