### PR TITLE
[Messenger] Describe resettable option for InMemoryTransport

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1539,6 +1539,15 @@ The transport has a number of options:
     Whether to serialize messages or not. This is useful to test an additional
     layer, especially when you use your own message serializer.
 
+``resettable`` (boolean, default: ``true``)
+     Whether to reset automatically during container resetting. This is useful
+     to have an option to check sent messages when running worker in tests with
+     `messenger.listener.reset_services` subscriber.
+
+.. versionadded:: 6.1
+
+     The ``resettable`` option was introduced in Symfony 6.1.
+
 .. note::
 
     All ``in-memory`` transports will be reset automatically after each test **in**

--- a/messenger.rst
+++ b/messenger.rst
@@ -1542,7 +1542,7 @@ The transport has a number of options:
 ``resettable`` (boolean, default: ``true``)
      Whether to reset automatically during container resetting. This is useful
      to have an option to check sent messages when running worker in tests with
-     `messenger.listener.reset_services` subscriber.
+     ``messenger.listener.reset_services`` subscriber.
 
 .. versionadded:: 6.1
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
