### PR TITLE
[Form] Fixing "HTML5 color format" link

### DIFF
--- a/form/form_themes.rst
+++ b/form/form_themes.rst
@@ -128,7 +128,7 @@ order is important, because each theme overrides all the previous ones):
     {# apply multiple form themes but only to the form of this template #}
     {% form_theme form with [
         'foundation_5_layout.html.twig',
-        'forms/my_custom_theme.html.twig'
+        'form/my_custom_theme.html.twig'
     ] %}
 
     {# ... #}

--- a/reference/forms/types/color.rst
+++ b/reference/forms/types/color.rst
@@ -90,4 +90,4 @@ The default value is ``''`` (the empty string).
 
 .. include:: /reference/forms/types/options/trim.rst.inc
 
-.. _`HTML5 color format`: https://www.w3.org/TR/html52/sec-forms.html#color-state-typecolor
+.. _`HTML5 color format`: https://html.spec.whatwg.org/multipage/input.html#color-state-(type=color)


### PR DESCRIPTION
The link https://www.w3.org/TR/html52/sec-forms.html#color-state-typecolor redirects to https://html.spec.whatwg.org/multipage/forms.html#color-state-typecolor which is bad, it's seems to be https://html.spec.whatwg.org/multipage/input.html#color-state-(type=color) now.