### PR TITLE
Update doctrine.rst

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -30,8 +30,8 @@ as well as the MakerBundle, which will help generate some code:
 
 .. code-block:: terminal
 
-    $ composer require symfony/orm-pack
     $ composer require --dev symfony/maker-bundle
+    $ composer require symfony/orm-pack
 
 Configuring the Database
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
When testing this with a fresh install of Symfony 6.1, I ran into an issue with the order of commands for installing Doctrine. When I did the maker-bundle first, the orm-pack worked fine. Before, I got several errors regarding the versions of the existing packages being wrong.
