### PR TITLE
[Mercure] Update the default JWT secret

### DIFF
--- a/mercure.rst
+++ b/mercure.rst
@@ -114,7 +114,8 @@ MercureBundle will use it to automatically generate and sign the needed JWTs.
 In addition to these environment variables,
 MercureBundle provides a more advanced configuration:
 
-* ``secret``: the key to use to sign the JWT (all other options, beside ``algorithm``, ``subscribe``, and ``publish`` will be ignored)
+* ``secret``: the key to use to sign the JWT - A key of the same size as the hash output (for instance, 256 bits for
+"HS256") or larger MUST be used. (all other options, beside ``algorithm``, ``subscribe``, and ``publish`` will be ignored)
 * ``publish``: a list of topics to allow publishing to when generating the JWT (only usable when ``secret``, or ``factory`` are provided)
 * ``subscribe``: a list of topics to allow subscribing to when generating the JWT (only usable when ``secret``, or ``factory`` are provided)
 * ``algorithm``: The algorithm to use to sign the JWT (only usable when ``secret`` is provided)
@@ -132,7 +133,7 @@ MercureBundle provides a more advanced configuration:
                 default:
                     url: https://mercure-hub.example.com/.well-known/mercure
                     jwt:
-                        secret: '!ChangeMe!'
+                        secret: '!ChangeThisMercureHubJWTSecretKey!'
                         publish: ['foo', 'https://example.com/foo']
                         subscribe: ['bar', 'https://example.com/bar']
                         algorithm: 'hmac.sha256'
@@ -150,7 +151,7 @@ MercureBundle provides a more advanced configuration:
                 url="https://mercure-hub.example.com/.well-known/mercure"
             >
                 <jwt
-                    secret="!ChangeMe!"
+                    secret="!ChangeThisMercureHubJWTSecretKey!"
                     algorithm="hmac.sha256"
                     provider="My\Provider"
                     factory="My\Factory"
@@ -172,7 +173,7 @@ MercureBundle provides a more advanced configuration:
                 'default' => [
                     'url' => 'https://mercure-hub.example.com/.well-known/mercure',
                     'jwt' => [
-                        'secret' => '!ChangeMe!',
+                        'secret' => '!ChangeThisMercureHubJWTSecretKey!',
                         'publish' => ['foo', 'https://example.com/foo'],
                         'subscribe' => ['bar', 'https://example.com/bar'],
                         'algorithm' => 'hmac.sha256',


### PR DESCRIPTION
The secret must now be a key of the same size as the hash output (for instance, 256 bits for "HS256") or larger to avoid error in lcobucci/jwt ^4.2.
See: https://github.com/symfony/mercure/issues/89
See: https://github.com/lcobucci/jwt/releases/tag/4.2.0
