### PR TITLE
Add hint about variables_order ini setting required

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -792,7 +792,9 @@ the right situation:
   but the overrides only apply to one environment.
 
 *Real* environment variables always win over env vars created by any of the
-``.env`` files.
+``.env`` files. This behavior depends on
+`variables_order <http://php.net/manual/en/ini.core.php#ini.variables-order>`_ to
+contain an ``E`` to expose the ``$_ENV`` superglobal.
 
 The ``.env`` and ``.env.<environment>`` files should be committed to the
 repository because they are the same for all developers and machines. However,


### PR DESCRIPTION
I read about _real environment variables always winning_, when using dotenv - but my setup did not work like this. And I noticed that my [variables_order](https://www.php.net/manual/en/ini.core.php#ini.variables-order) ini setting was set to the default of debian production settings, which does not expose `$_ENV` by default.

Thus I added a sentence right behind stating that this depends on `$_ENV` superglobal being filled, which also needs [variables_order](https://www.php.net/manual/en/ini.core.php#ini.variables-order) to contain an uppercase `E`.