### PR TITLE
Adding `use`

### DIFF
--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -124,7 +124,7 @@ this by extending from :class:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractB
 and defining the :method:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle::loadExtension`
 method::
 
-    // ...
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
     use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 


### PR DESCRIPTION
* `ContainerBuilder` was missing (this is the first occurrence of **AcmeHelloBundle** on this page)
* According to https://symfony.com/doc/current/bundles.html#creating-a-bundle, there are no other `use`s in this file, so I removed the `// ...` comment.