### PR TITLE
Remove reference to a removed configuration key

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2167,19 +2167,6 @@ Whether or not to enable validation support.
 This option will automatically be set to ``true`` when one of the child
 settings is configured.
 
-.. _reference-validation-cache:
-
-cache
-.....
-
-**type**: ``string``
-
-The service that is used to persist class metadata in a cache. The service
-has to implement the :class:`Symfony\\Component\\Validator\\Mapping\\Cache\\CacheInterface`.
-
-Set this option to ``validator.mapping.cache.doctrine.apc`` to use the APC
-cache provided by the Doctrine project.
-
 .. _reference-validation-enable_annotations:
 
 enable_annotations


### PR DESCRIPTION
See https://github.com/symfony/symfony-docs/issues/17260 for more details (more specifically, [this comment](https://github.com/symfony/symfony-docs/issues/17260#issuecomment-1255056666))



<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
