### PR TITLE
[PropertyAccess] Document nullsafe operator usage

### DIFF
--- a/components/property_access.rst
+++ b/components/property_access.rst
@@ -63,6 +63,9 @@ method::
     // Symfony\Component\PropertyAccess\Exception\NoSuchIndexException
     $value = $propertyAccessor->getValue($person, '[age]');
 
+    // You can avoid the exception by adding the nullsafe operator
+    $value = $propertyAccessor->getValue($person, '[age?]');
+
 You can also use multi dimensional arrays::
 
     // ...
@@ -100,6 +103,36 @@ To read from properties, use the "dot" notation::
     $person->children = [$child];
 
     var_dump($propertyAccessor->getValue($person, 'children[0].firstName')); // 'Bar'
+
+.. tip::
+
+    You can give an object graph with nullable object.
+
+    Given an object graph ``comment.person.profile``, where ``person`` is optional (can be null),
+    you can call the property accessor with ``comment.person?.profile`` (using the nullsafe
+    operator) to avoid exception.
+
+    For example::
+
+        class Person
+        {
+        }
+        class Comment
+        {
+            public ?Person $person = null;
+            public string $message;
+        }
+
+        $comment = new Comment();
+        $comment->message = 'test';
+
+        // This code throws an exception of type
+        // Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException
+        var_dump($propertyAccessor->getValue($comment, 'person.firstname'));
+
+        // The code now returns null, instead of throwing an exception of type
+        // Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException,
+        var_dump($propertyAccessor->getValue($comment, 'person?.firstname')); // null
 
 .. caution::
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->

Doc PR for https://github.com/symfony/symfony/pull/47511