### PR TITLE
[DependencyInjection] Fix docs referencing an incorrect PHP function

### DIFF
--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -293,10 +293,10 @@ argument of type ``service_locator``:
 
             $services->set(CommandBus::class)
                 ->args([service_locator([
-                    'App\FooCommand' => ref('app.command_handler.foo'),
-                    'App\BarCommand' => ref('app.command_handler.bar'),
+                    'App\FooCommand' => service('app.command_handler.foo'),
+                    'App\BarCommand' => service('app.command_handler.bar'),
                     // if the element has no key, the ID of the original service is used
-                    ref('app.command_handler.baz'),
+                    service('app.command_handler.baz'),
                 ])]);
         };
 


### PR DESCRIPTION
Looks like some leftover? At least, there is no `ref` function 🤔 