### PR TITLE
[Doctrine] Restore tip regarding schema filtering during migrations

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1439,6 +1439,36 @@ a table named ``messenger_messages``.
 Or, to create the table yourself, set the ``auto_setup`` option to ``false`` and
 :ref:`generate a migration <doctrine-creating-the-database-tables-schema>`.
 
+.. tip::
+
+    To avoid tools like Doctrine Migrations from trying to remove this table because
+    it's not part of your normal schema, you can set the ``schema_filter`` option:
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # config/packages/doctrine.yaml
+            doctrine:
+                dbal:
+                    schema_filter: '~^(?!messenger_messages)~'
+
+        .. code-block:: xml
+
+            # config/packages/doctrine.xml
+            <doctrine:dbal schema-filter="~^(?!messenger_messages)~"/>
+
+        .. code-block:: php
+
+            # config/packages/doctrine.php
+            $container->loadFromExtension('doctrine', [
+                'dbal' => [
+                    'schema_filter'  => '~^(?!messenger_messages)~',
+                    // ...
+                ],
+                // ...
+            ]);
+
 .. caution::
 
     The datetime property of the messages stored in the database uses the


### PR DESCRIPTION
Restores the tip regarding how to disable doctrine from trying to remove messages table when creating a migration.

I couldn't pinpoint exactly why the tip was removed, and looking at https://github.com/symfony/symfony/issues/37626 they were unsure here as well.