### PR TITLE
[Serializer] improve documentation of default_context for the serializer

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2752,6 +2752,9 @@ A map with default context options that will be used with each ``serialize`` and
 call. This can be used for example to set the json encoding behavior by setting ``json_encode_options``
 to a `json_encode flags bitmask`_.
 
+You can inspect the :ref:`serializer context builders <serializer-using-context-builders>`
+to discover the available settings.
+
 php_errors
 ~~~~~~~~~~
 

--- a/serializer.rst
+++ b/serializer.rst
@@ -130,6 +130,7 @@ configuration:
             serializer:
                 default_context:
                     enable_max_depth: true
+                    yaml_indentation: 2
 
     .. code-block:: xml
 
@@ -137,7 +138,7 @@ configuration:
         <framework:config>
             <!-- ... -->
             <framework:serializer>
-                <default-context enable-max-depth="true"/>
+                <default-context enable-max-depth="true" yaml-indentation="2"/>
             </framework:serializer>
         </framework:config>
 
@@ -146,11 +147,13 @@ configuration:
         // config/packages/framework.php
         use Symfony\Config\FrameworkConfig;
         use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+        use Symfony\Component\Serializer\Encoder\YamlEncoder;
 
         return static function (FrameworkConfig $framework) {
             $framework->serializer()
                 ->defaultContext([
-                    AbstractObjectNormalizer::ENABLE_MAX_DEPTH => true
+                    AbstractObjectNormalizer::ENABLE_MAX_DEPTH => true,
+                    YamlEncoder::YAML_INDENTATION => 2,
                 ])
             ;
         };


### PR DESCRIPTION
additional info for https://github.com/symfony/symfony-docs/pull/17310

fix #17306

the code example will only work once https://github.com/symfony/symfony/pull/47243 is merged