### PR TITLE
[Security] Removing self-closing slash from `<input>`s

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -807,13 +807,13 @@ Finally, create or update the template:
 
         <form action="{{ path('app_login') }}" method="post">
             <label for="username">Email:</label>
-            <input type="text" id="username" name="_username" value="{{ last_username }}"/>
+            <input type="text" id="username" name="_username" value="{{ last_username }}">
 
             <label for="password">Password:</label>
-            <input type="password" id="password" name="_password"/>
+            <input type="password" id="password" name="_password">
 
             {# If you want to control the URL the user is redirected to on success
-            <input type="hidden" name="_target_path" value="/account"/> #}
+            <input type="hidden" name="_target_path" value="/account"> #}
 
             <button type="submit">login</button>
         </form>


### PR DESCRIPTION
I suggested the same for Symfony's templates, see https://github.com/symfony/symfony/pull/47715