### PR TITLE
[Security] Add caution on symfony cli web server exposing env vars on private network

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -11,6 +11,13 @@ other features that sooner or later you'll need when developing web projects.
 Moreover, the server is not tied to Symfony and you can also use it with any
 PHP application and even with HTML or single page applications.
 
+.. caution::
+
+    This server will automatically expose all environment variables available
+    in the CLI tool context, **which can lead to security issues**.
+    One should assert that its server is not accessible on local network without
+    consent.
+
 Installation
 ------------
 


### PR DESCRIPTION
Hi,

One can understood that this web server is a great tool for development purposes but this addition should be added imho for knowledge :)

Context:

when checking some local data accessible on local network with coworker
we arrived to display a symfony cli served app profiler (obviously it is in `dev` env)
and in the profiler > request/response panel > server parameters > regular env vars => **thus exposing also symfony unrelated env vars which are included**

friendly ping @wuchen90 ^^