### PR TITLE
[Kernel] Mention extra interfaces in `MicroKernel` section

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -102,6 +102,44 @@ that define your bundles, your services and your routes:
     ``RouteCollectionBuilder`` has methods that make adding routes in PHP more
     fun. You can also load external routing files (shown below).
 
+Adding Interfaces to "Micro" Kernel
+-----------------------------------
+
+When using the ``MicroKernelTrait``, you can also implement the
+``CompilerPassInterface`` to automatically register the kernel itself as a
+compiler pass as explained in the dedicated
+:ref:`compiler pass section <kernel-as-compiler-pass>`.
+
+It is also possible to implement the ``EventSubscriberInterface`` to handle
+events directly from the kernel, again it will be registered automatically::
+
+    // ...
+    use App\Exception\Danger;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+    use Symfony\Component\HttpKernel\KernelEvents;
+
+    class Kernel extends BaseKernel implements EventSubscriberInterface
+    {
+        use MicroKernelTrait;
+
+        // ...
+
+        public function onKernelException(ExceptionEvent $event): void
+        {
+            if ($event->getException() instanceof Danger) {
+                $event->setResponse(new Response('It\'s dangerous to go alone. Take this ⚔'));
+            }
+        }
+
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                KernelEvents::EXCEPTION => 'onKernelException',
+            ];
+        }
+    }
+
 Advanced Example: Twig, Annotations and the Web Debug Toolbar
 -------------------------------------------------------------
 

--- a/service_container/compiler_passes.rst
+++ b/service_container/compiler_passes.rst
@@ -32,6 +32,8 @@ Compiler passes are registered in the ``build()`` method of the application kern
         }
     }
 
+.. _kernel-as-compiler-pass:
+
 One of the most common use-cases of compiler passes is to work with :doc:`tagged
 services </service_container/tags>`. In those cases, instead of creating a
 compiler pass, you can make the kernel implement


### PR DESCRIPTION
Fixes #8277.

Feature was added in 3.4, so no need for a `versionadded` directive.