### PR TITLE
[Mailer] Mailer: remove port 99 for requestbin.com

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -174,7 +174,6 @@ Sendgrid             sendgrid+smtp://KEY@default                n/a             
 
         # .env
         MAILER_DSN=mailgun+https://KEY:DOMAIN@requestbin.com
-        MAILER_DSN=mailgun+https://KEY:DOMAIN@requestbin.com:99
 
     Note that the protocol is *always* HTTPs and cannot be changed.
 


### PR DESCRIPTION
It looked strange when there were 2 examples with different ports, why use duplicated lines since the value of the second line will overwrite the value of the first one?

I can't find any reference to port 99 in the documentation of requestbin.com, so I suggest to keep only one example.