### PR TITLE
[Console] docs(console): add caution for testing option

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -546,6 +546,15 @@ call ``setAutoExit(false)`` on it to get the command result in ``CommandTester``
         $application->setAutoExit(false);
 
         $tester = new ApplicationTester($application);
+        
+
+.. caution::
+
+    When testing ``InputOption::VALUE_NONE`` command option, be sure to pass an empty
+    value like so::
+    
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['--some-option' => '']);
 
 .. note::
 


### PR DESCRIPTION
Add a caution about `InputOption::VALUE_NONE` testing. Passing only a value without a key doesn't work and can lead to misunderstanding.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
