### PR TITLE
[Serializer] Fix XML example of ignoring an attribute redux

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -517,9 +517,7 @@ Option 1: Using ``@Ignore`` Annotation
                 https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
         >
             <class name="App\Model\MyClass">
-                <attribute name="bar">
-                    <ignore>true</ignore>
-                </attribute>
+                <attribute name="bar" ignore="true"/>
             </class>
         </serializer>
 


### PR DESCRIPTION
This effectively reopens #16824, which could not be reopened because of a rebase after the PR was closed.