### PR TITLE
Replace --webapp for --full

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -49,13 +49,13 @@ application:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ symfony new my_project_directory --version="6.1.*" --webapp
+    $ symfony new my_project_directory --version="6.1.*" --full
 
     # run this if you are building a microservice, console application or API
     $ symfony new my_project_directory --version="6.1.*"
 
 The only difference between these two commands is the number of packages
-installed by default. The ``--webapp`` option installs all the packages that you
+installed by default. The ``--full`` option installs all the packages that you
 usually need to build web applications, so the installation size will be bigger.
 
 If you're not using the Symfony binary, run these commands to create the new


### PR DESCRIPTION
--webapp is not longer a valid option when using Symfony CLI version (v4.26.3).
This changes proposes to change --webapp to --full.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
