### PR TITLE
[Messenger] Deprecate `MessageSubscriberInterface`

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1980,6 +1980,11 @@ A handler class can handle multiple messages or configure itself by implementing
         }
     }
 
+.. deprecated:: 6.2
+
+    :class:`Symfony\\Component\\Messenger\\Handler\\MessageSubscriberInterface` was deprecated in Symfony 6.2.
+    Use :class:`#[AsMessageHandler] <Symfony\\Component\\Messenger\\Attribute\\AsMessageHandler>` attribute instead.
+
 Binding Handlers to Different Transports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes #17319

For `MessageHandlerInterface` class, it's not necessary to create a deprecation directive because we display it more since Symfony 5.3 in Symfony doc. I have created a PR #17332 for removing note block as it is no longer necessary in Symfony 6.0.