### PR TITLE
[Messenger] Removing note docblock for `MessageHandlerInterface`

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -70,12 +70,6 @@ message class (or a message interface)::
         }
     }
 
-.. note::
-
-    You can also create a class without the attribute (e.g. if you're
-    using PHP 7.4), by implementing :class:`Symfony\\Component\\Messenger\\Handler\\MessageHandlerInterface`
-    instead.
-
 Thanks to :ref:`autoconfiguration <services-autoconfigure>` and the ``SmsNotification``
 type-hint, Symfony knows that this handler should be called when an ``SmsNotification``
 message is dispatched. Most of the time, this is all you need to do. But you can


### PR DESCRIPTION
The docblock note is no longer necessary  required from Symfony 6.0 onwards as it requires PHP 8.0.

What do you think?
