### PR TITLE
[IntegerType] fix rounding_mode default value

### DIFF
--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -35,7 +35,7 @@ Field Options
 ``rounding_mode``
 ~~~~~~~~~~~~~~~~~
 
-**type**: ``integer`` **default**: ``\NumberFormatter::ROUND_HALFUP``
+**type**: ``integer`` **default**: ``\NumberFormatter::ROUND_DOWN``
 
 By default, if the user enters a non-integer number, it will be rounded
 down. You have several configurable options for that rounding. Each option


### PR DESCRIPTION
change default value of rounding_mode option from \NumberFormatter::ROUND_HALFUP to default: \NumberFormatter::ROUND_DOWN  see https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
