### PR TITLE
[Mailer] docs: Add the mime type in the example

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -390,9 +390,9 @@ file or stream::
     $email = (new Email())
         // ...
         // get the image contents from a PHP resource
-        ->embed(fopen('/path/to/images/logo.png', 'r'), 'logo')
+        ->embed(fopen('/path/to/images/logo.png', 'r'), 'logo', 'image/png')
         // get the image contents from an existing file
-        ->embedFromPath('/path/to/images/signature.gif', 'footer-signature')
+        ->embedFromPath('/path/to/images/signature.gif', 'footer-signature', 'image/gif')
     ;
 
 The second optional argument of both methods is the image name ("Content-ID" in
@@ -401,8 +401,9 @@ images inside the HTML contents::
 
     $email = (new Email())
         // ...
-        ->embed(fopen('/path/to/images/logo.png', 'r'), 'logo')
-        ->embedFromPath('/path/to/images/signature.gif', 'footer-signature')
+        ->embed(fopen('/path/to/images/logo.png', 'r'), 'logo', 'image/png')
+        ->embedFromPath('/path/to/images/signature.gif', 'footer-signature', 'image/gif')
+
         // reference images using the syntax 'cid:' + "image embed name"
         ->html('<img src="cid:logo"> ... <img src="cid:footer-signature"> ...')
     ;


### PR DESCRIPTION
While embedding images the examples don't have a mimetype. Some email clients will not show a image because of missing that mimetype.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
