### PR TITLE
Mentioning svelte as a valid loader override type

### DIFF
--- a/frontend/encore/advanced-config.rst
+++ b/frontend/encore/advanced-config.rst
@@ -230,6 +230,7 @@ The following loaders are configurable with ``configureLoaderRule()``:
   - ``sass`` (alias ``scss``)
   - ``less``
   - ``stylus``
+  - ``svelte``
   - ``vue``
   - ``eslint``
   - ``typescript`` (alias ``ts``)


### PR DESCRIPTION
Hi!

Minor tweak for https://github.com/symfony/webpack-encore/pull/781

We could also document svelte itself, though there is also a proposed UX svelte component which, if merged, would be an even better option (and it would leverage this new feature in Encore).

Cheers!