### PR TITLE
[Mailer] docs: add tip about listener priority to mailer.rst

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1056,6 +1056,14 @@ is sent::
         }
     }
 
+.. tip::
+
+    The ``MessageEvent`` is also used internally. Depending on your use case
+    you might need to set a lower or higher priority for your own listener.
+    For example, when you want to sign the message, make sure to use ``-1``
+    or lower so the body has already been rendered and will not change after
+    signing.
+
 Development & Debugging
 -----------------------
 


### PR DESCRIPTION
When signing or encrypting a message in a listener, it's important that the body has already been rendered - otherwise the signature will be invalid. As I spent a few hours to realize this, I suggest to add the attached tip to the documentation.

See https://github.com/symfony/symfony/issues/39354#issuecomment-894379296 for another example.
