### PR TITLE
[Console] docs(test): add array example for options with CommandTester

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -372,6 +372,8 @@ console::
 
                 // prefix the key with two dashes when passing options,
                 // e.g: '--some-option' => 'option_value',
+                // use brackets for testing array value,
+                // e.g: '--some-option' => ['option_value'],
             ]);
 
             // the output of the command in the console


### PR DESCRIPTION
This PR adds an example of how we can set an array input as option using the CommandTester.

It's not so difficult to find the way by ourselves but it doesn't seem to be explicit somewhere.