### PR TITLE
[DependencyInjection] Typo on how default defaultIndexMethod work

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -804,9 +804,21 @@ array element. For example, to retrieve the ``handler_two`` handler::
 
 .. tip::
 
-    Just like the priority, you can also implement a static
-    ``getDefaultIndexName()`` method in the handlers and omit the
+    Just like the priority, if you set the attribute (``index_by``) on the :tagged_iterator, you can also implement a static
+    ``getDefault(``index_by``)Name()`` method in the handlers and omit the
     index attribute (``key``)::
+        
+
+        .. code-block:: yaml
+        
+        # config/services.yaml
+            services:
+                # ...
+
+                App\HandlerCollection:
+                    arguments: [!tagged_iterator { tag: 'app.handler', index_by: 'handler' }]
+                    
+    .. code-block:: php
 
         // src/Handler/One.php
         namespace App\Handler;
@@ -814,7 +826,7 @@ array element. For example, to retrieve the ``handler_two`` handler::
         class One
         {
             // ...
-            public static function getDefaultIndexName(): string
+            public static function getDefaultHandlerName(): string
             {
                 return 'handler_one';
             }


### PR DESCRIPTION
Following the documentation, I was trying the static method getDefaultIndexName() to have named tagged service and it didn't work. I looked at the code [here](https://github.com/symfony/symfony/blob/v5.4.1/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php#L44) in how I understand it, you have to declare the index_by attribute to be able to use the getDefault****Name() method.

I tryed to improve the documentation, but I think it could be better explained that what I did.
It is the same logique for the getDefault***Priority() method.