### PR TITLE
[Symfony UX] reference React component in React page

### DIFF
--- a/frontend/encore/reactjs.rst
+++ b/frontend/encore/reactjs.rst
@@ -6,6 +6,10 @@ Enabling React.js
 
     Do you prefer video tutorials? Check out the `React.js screencast series`_.
 
+.. tip::
+
+    Check out live demos of Symfony UX React component at `https://ux.symfony.com/react`_!
+    
 Using React? First add some dependencies with Yarn:
 
 .. code-block:: terminal
@@ -36,3 +40,4 @@ Encore, you're done!
 Your ``.js`` and ``.jsx`` files will now be transformed through ``babel-preset-react``.
 
 .. _`React.js screencast series`: https://symfonycasts.com/screencast/reactjs
+.. _`https://ux.symfony.com/react`: https://ux.symfony.com/react


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
