### PR TITLE
[Serializer] Remove note about installing the FrameworkExtraBundle for using annotations

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -84,13 +84,7 @@ possible to set the priority of the tag in order to decide the matching order.
 Using Serialization Groups Annotations
 --------------------------------------
 
-To use annotations, first add support for them via the SensioFrameworkExtraBundle:
-
-.. code-block:: terminal
-
-    $ composer require sensio/framework-extra-bundle
-
-Next, add the :ref:`@Groups annotations <component-serializer-attributes-groups-annotations>`
+You can add the :ref:`@Groups annotations <component-serializer-attributes-groups-annotations>`
 to your class::
 
     // src/Entity/Product.php


### PR DESCRIPTION
The FrameworkExtraBundle was never required to use Serializer's annotations ; the loader is part of the component (but still requires doctrine annotations of course).