### PR TITLE
[Cache] Reword "max lifetime" to "default lifetime"

### DIFF
--- a/components/cache/adapters/chain_adapter.rst
+++ b/components/cache/adapters/chain_adapter.rst
@@ -12,7 +12,7 @@ This adapter allows combining any number of the other
 fetched from the first adapter containing them and cache items are saved to all the
 given adapters. This exposes a simple and efficient method for creating a layered cache.
 
-The ChainAdapter must be provided an array of adapters and optionally a maximum cache
+The ChainAdapter must be provided an array of adapters and optionally a default cache
 lifetime as its constructor arguments::
 
     use Symfony\Component\Cache\Adapter\ChainAdapter;
@@ -21,8 +21,8 @@ lifetime as its constructor arguments::
         // The ordered list of adapters used to fetch cached items
         array $adapters,
 
-        // The max lifetime of items propagated from lower adapters to upper ones
-        $maxLifetime = 0
+        // The default lifetime of items propagated from lower adapters to upper ones
+        $defaultLifetime = 0
     );
 
 .. note::


### PR DESCRIPTION
The use of the word "maximum" here is not very clear; it's easy for somebody to mistakenly believe that this parameter limits the TTL of the higher caches to some maximum value.  For example, if the second cache returns a hit with a TTL of 3600, then `$maxLifetime = 60` would mean the first cache should use a TTL of 60 since that's the "maximum lifetime".   But looking at the code, that's not what happens - this parameter actually works as a **default** TTL for items without an expiry.

I believe this possible confusion is why the variable was renamed in [#26984](https://github.com/symfony/symfony/pull/26984) so let's update the documentation accordingly.  Hopefully this will prevent others from making the same misunderstandings that I did :)