### PR TITLE
[Form] Fix `selectedchoice` test link

### DIFF
--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -321,5 +321,5 @@ Field Variables
 
 .. tip::
 
-    It's significantly faster to use the :ref:`form-twig-selectedchoice`
+    It's significantly faster to use the :ref:`selectedchoice <form-twig-selectedchoice>`
     test instead when using Twig.


### PR DESCRIPTION
The current link looks buggy to me, before:

<img width="760" alt="Screenshot 2022-10-15 at 10 45 16 AM" src="https://user-images.githubusercontent.com/10107633/195977784-f123e610-fd48-48e5-a4c4-d465554abcd1.png">

After (with local rendering):

<img width="505" alt="Screenshot 2022-10-15 at 10 45 50 AM" src="https://user-images.githubusercontent.com/10107633/195977804-6105fa92-5ea2-44ff-ae40-d4891768deb8.png">