### PR TITLE
Force SimpleBus https url

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -357,4 +357,4 @@ Learn more
     /messenger/*
 
 .. _`blog posts about command buses`: https://matthiasnoback.nl/tags/command%20bus/
-.. _`SimpleBus project`: http://docs.simplebus.io/en/latest/
+.. _`SimpleBus project`: https://docs.simplebus.io/en/latest/


### PR DESCRIPTION
SimpleBus allows https and there is no redirection

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
