### PR TITLE
Change secure.php.net link to php.net

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -145,7 +145,7 @@ the console::
             '',
         ]);
 
-        // the value returned by someMethod() can be an iterator (https://secure.php.net/iterator)
+        // the value returned by someMethod() can be an iterator (https://php.net/iterator)
         // that generates and returns the messages with the 'yield' PHP keyword
         $output->writeln($this->someMethod());
 

--- a/reference/forms/types/options/date_input_format_description.rst.inc
+++ b/reference/forms/types/options/date_input_format_description.rst.inc
@@ -5,4 +5,4 @@
 If the ``input`` option is set to ``string``, this option specifies the format
 of the date. This must be a valid `PHP date format`_.
 
-.. _`PHP date format`: https://secure.php.net/manual/en/function.date.php
+.. _`PHP date format`: https://php.net/manual/en/function.date.php

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -237,4 +237,4 @@ Form Variables
 |              |             | contains the input type to use (``datetime``, ``date`` or ``time``). |
 +--------------+-------------+----------------------------------------------------------------------+
 
-.. _`PHP time format`: https://secure.php.net/manual/en/function.date.php
+.. _`PHP time format`: https://php.net/manual/en/function.date.php


### PR DESCRIPTION
The subdomain `secure` is not needed as php.net supports https

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
