### PR TITLE
[Notifier] Fix `notifier.flash_message_importance_mapper` service definition

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -717,7 +717,8 @@ typical alert levels, which you can implement immediately using:
 
         # config/services.yaml
         services:
-            notifier.flash_message_importance_mapper: Symfony\Component\Notifier\FlashMessage\BootstrapFlashMessageImportanceMapper
+            notifier.flash_message_importance_mapper: 
+                class: Symfony\Component\Notifier\FlashMessage\BootstrapFlashMessageImportanceMapper
 
     .. code-block:: xml
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
