### PR TITLE
[PHPUnitBridge] Correct time type return

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -500,7 +500,7 @@ is mocked so it uses the mocked time if no timestamp is specified.
 Other functions with an optional timestamp parameter that defaults to ``time()``
 will still use the system time instead of the mocked time. This means that you
 may need to change some code in your tests. For example, instead of ``new DateTime()``,
-you should use ``DateTime::createFromFormat('U', time())`` to use the mocked
+you should use ``DateTime::createFromFormat('U', (string) time())`` to use the mocked
 ``time()`` function.
 
 To use the ``ClockMock`` class in your test, add the ``@group time-sensitive``


### PR DESCRIPTION
time function returns an int, while DateTime::createFromFormat requires a string!

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
