### PR TITLE
[Translation] Add new cases covered by PhpAstExtractor

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -476,6 +476,8 @@ The ``translation:extract`` command looks for missing translations in:
 * Any PHP file/class stored in the ``src/`` directory that creates
   :ref:`translatable-objects` using the constructor or the ``t()`` method or calls
   the ``trans()`` method.
+* Any PHP file/class stored in the ``src/`` directory that uses
+  :ref:`Constraints Attributes <validation-constraints>`  with ``*message`` named argument(s).
 
 .. _translation-resource-locations:
 


### PR DESCRIPTION
In https://github.com/symfony/symfony/pull/46161, we rewrite the PHP Translation extractor. It covers more cases, like named arguments. 
Documentation needed to be updated consequently.