### PR TITLE
[Routing] Document the PSR-4 route loader

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -37,15 +37,22 @@ Otherwise, create the following file manually:
     # config/routes/attributes.yaml
     controllers:
         resource: ../../src/Controller/
-        type: attribute
+        type: attribute@App\Controller
 
     kernel:
-        resource: ../../src/Kernel.php
+        resource: App\Kernel
         type: attribute
 
-This configuration tells Symfony to look for routes defined as
-attributes in any PHP class stored in the ``src/Controller/``
-directory.
+This configuration tells Symfony to look for routes defined as attributes on
+classes declared in the ``App\Controller`` namespace which are stored in the
+``src/Controller/`` directory which follows the PSR-4 standard. In addition,
+our kernel can act as a controller as well which is especially useful for small
+applications that use Symfony as a microframework.
+
+.. versionadded:: 6.2
+
+    The possibility to suffix the ``attribute`` resource type with a PSR-4
+    namespace root was introduced in Symfony 6.2.
 
 Suppose you want to define a route for the ``/blog`` URL in your application. To
 do so, create a :doc:`controller class </controller>` like the following:

--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -24,9 +24,19 @@ Symfony provides several route loaders for the most common needs:
             # loads routes from the given routing file stored in some bundle
             resource: '@AcmeBundle/Resources/config/routing.yaml'
 
+        app_psr4:
+            # loads routes from the PHP attributes of the controllers found in the given PSR-4 namespace root
+            resource: '../src/Controller/'
+            type:     attribute@App\Controller
+
         app_attributes:
             # loads routes from the PHP attributes of the controllers found in that directory
             resource: '../src/Controller/'
+            type:     attribute
+
+        app_class_attributes:
+            # loads routes from the PHP attributes of the given class
+            resource: App\Controller\MyController
             type:     attribute
 
         app_directory:
@@ -51,8 +61,14 @@ Symfony provides several route loaders for the most common needs:
             <!-- loads routes from the given routing file stored in some bundle -->
             <import resource="@AcmeBundle/Resources/config/routing.yaml"/>
 
+            <!-- loads routes from the PHP attributes of the controllers found in the given PSR-4 namespace root -->
+            <import resource="../src/Controller/" type="attribute@App\Controller"/>
+
             <!-- loads routes from the PHP attributes of the controllers found in that directory -->
             <import resource="../src/Controller/" type="attribute"/>
+
+            <!-- loads routes from the PHP attributes of the given class -->
+            <import resource="App\Controller\MyController" type="attribute"/>
 
             <!-- loads routes from the YAML or XML files found in that directory -->
             <import resource="../legacy/routing/" type="directory"/>
@@ -70,8 +86,16 @@ Symfony provides several route loaders for the most common needs:
             // loads routes from the given routing file stored in some bundle
             $routes->import('@AcmeBundle/Resources/config/routing.yaml');
 
-            // loads routes from the PHP attributes (#[Route(...)]) of the controllers found in that directory
+            // loads routes from the PHP attributes (#[Route(...)])
+            // of the controllers found in the given PSR-4 namespace root
+            $routes->import('../src/Controller/', 'attribute@App\Controller');
+
+            // loads routes from the PHP attributes (#[Route(...)])
+            // of the controllers found in that directory
             $routes->import('../src/Controller/', 'attribute');
+
+            // loads routes from the PHP attributes (#[Route(...)]) of the given class
+            $routes->import('App\Controller\MyController', 'attribute');
 
             // loads routes from the YAML or XML files found in that directory
             $routes->import('../legacy/routing/', 'directory');
@@ -84,6 +108,11 @@ Symfony provides several route loaders for the most common needs:
 
     The ``attribute`` value of the second argument of ``import()`` was introduced
     in Symfony 6.1.
+
+.. versionadded:: 6.2
+
+    The possibility to suffix the ``attribute`` resource type with a PSR-4
+    namespace root was introduced in Symfony 6.2.
 
 .. note::
 


### PR DESCRIPTION
This PR documents symfony/symfony#47916

Although the PR does not deprecate `AnnotationDirectoryLoader` and `AnnotationFileLoader`, I chose to recommend only the new `Psr4DirectoryLoader` and `AnnotationDirectoryLoader` in `routing.rst`. In `routing/custom_route_loader.rst`, all four loaders are listed for completeness.

Using a class name as resource instead of a file path has always worked, but wasn't documented for some reason. I have added examples for that as well.