### PR TITLE
[Security] Fix the SecurityBundle\Security.php helper namespace

### DIFF
--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -233,7 +233,7 @@ The problem is now to get the current user and create a choice field that
 contains only this user's friends. This can be done by injecting the ``Security``
 service into the form type so you can get the current user object::
 
-    use Symfony\Bundle\SecurityBundle\Security\Security;
+    use Symfony\Bundle\SecurityBundle\Security;
     // ...
 
     class FriendMessageFormType extends AbstractType
@@ -260,7 +260,7 @@ security helper to fill in the listener logic::
     use App\Entity\User;
     use Doctrine\ORM\EntityRepository;
     use Symfony\Bridge\Doctrine\Form\Type\EntityType;
-    use Symfony\Bundle\SecurityBundle\Security\Security;
+    use Symfony\Bundle\SecurityBundle\Security;
     use Symfony\Component\Form\Extension\Core\Type\TextareaType;
     use Symfony\Component\Form\Extension\Core\Type\TextType;
     // ...

--- a/security.rst
+++ b/security.rst
@@ -598,12 +598,12 @@ Fetching the Firewall Configuration for a Request
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you need to get the configuration of the firewall that matched a given request,
-use the :class:`Symfony\\Bundle\\SecurityBundle\\Security\\Security` service::
+use the :class:`Symfony\\Bundle\\SecurityBundle\\Security` service::
 
     // src/Service/ExampleService.php
     // ...
 
-    use Symfony\Bundle\SecurityBundle\Security\Security;
+    use Symfony\Bundle\SecurityBundle\Security;
     use Symfony\Component\HttpFoundation\RequestStack;
 
     class ExampleService
@@ -1609,23 +1609,23 @@ Login Programmatically
 
 .. versionadded:: 6.2
 
-    The :class:`Symfony\Bundle\SecurityBundle\Security\Security <Symfony\\Bundle\\SecurityBundle\\Security\\Security>`
+    The :class:`Symfony\Bundle\SecurityBundle\Security <Symfony\\Bundle\\SecurityBundle\\Security>`
     class was introduced in Symfony 6.2. Prior to 6.2, it was called
     ``Symfony\Component\Security\Core\Security``.
 
 .. versionadded:: 6.2
 
-    The :method:`Symfony\\Bundle\\SecurityBundle\\Security\\Security::login`
+    The :method:`Symfony\\Bundle\\SecurityBundle\\Security::login`
     method was introduced in Symfony 6.2.
 
 You can log in a user programmatically using the `login()` method of the
-:class:`Symfony\\Bundle\\SecurityBundle\\Security\\Security` helper::
+:class:`Symfony\\Bundle\\SecurityBundle\\Security` helper::
 
     // src/Controller/SecurityController.php
     namespace App\Controller\SecurityController;
 
     use App\Security\Authenticator\ExampleAuthenticator;
-    use Symfony\Bundle\SecurityBundle\Security\Security;
+    use Symfony\Bundle\SecurityBundle\Security;
 
     class SecurityController
     {
@@ -1779,22 +1779,22 @@ Logout programmatically
 
 .. versionadded:: 6.2
 
-    The :class:`Symfony\Bundle\SecurityBundle\Security\Security <Symfony\\Bundle\\SecurityBundle\\Security\\Security>`
+    The :class:`Symfony\Bundle\SecurityBundle\Security <Symfony\\Bundle\\SecurityBundle\\Security>`
     class was introduced in Symfony 6.2. Prior to 6.2, it was called
     ``Symfony\Component\Security\Core\Security``.
 
 .. versionadded:: 6.2
 
-    The :method:`Symfony\\Bundle\\SecurityBundle\\Security\\Security::logout`
+    The :method:`Symfony\\Bundle\\SecurityBundle\\Security::logout`
     method was introduced in Symfony 6.2.
 
 You can logout user programmatically using the ``logout()`` method of the
-:class:`Symfony\\Bundle\\SecurityBundle\\Security\\Security` helper::
+:class:`Symfony\\Bundle\\SecurityBundle\\Security` helper::
 
     // src/Controller/SecurityController.php
     namespace App\Controller\SecurityController;
 
-    use Symfony\Bundle\SecurityBundle\Security\Security;
+    use Symfony\Bundle\SecurityBundle\Security;
 
     class SecurityController
     {
@@ -1896,12 +1896,12 @@ Fetching the User from a Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you need to get the logged in user from a service, use the
-:class:`Symfony\\Bundle\\SecurityBundle\\Security\\Security` service::
+:class:`Symfony\\Bundle\\SecurityBundle\\Security` service::
 
     // src/Service/ExampleService.php
     // ...
 
-    use Symfony\Bundle\SecurityBundle\Security\Security;
+    use Symfony\Bundle\SecurityBundle\Security;
 
     class ExampleService
     {
@@ -1925,7 +1925,7 @@ If you need to get the logged in user from a service, use the
 
 .. versionadded:: 6.2
 
-    The :class:`Symfony\\Bundle\\SecurityBundle\\Security\\Security` class
+    The :class:`Symfony\\Bundle\\SecurityBundle\\Security` class
     was introduced in Symfony 6.2. In previous Symfony versions this class was
     defined in ``Symfony\Component\Security\Core\Security``.
 
@@ -2333,7 +2333,7 @@ want to include extra details only for users that have a ``ROLE_SALES_ADMIN`` ro
 
       // ...
       use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-    + use Symfony\Bundle\SecurityBundle\Security\Security;
+    + use Symfony\Bundle\SecurityBundle\Security;
 
       class SalesReportManager
       {

--- a/security/impersonating_user.rst
+++ b/security/impersonating_user.rst
@@ -160,7 +160,7 @@ the impersonator user::
     // src/Service/SomeService.php
     namespace App\Service;
 
-    use Symfony\Bundle\SecurityBundle\Security\Security;
+    use Symfony\Bundle\SecurityBundle\Security;
     use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
     // ...
 
@@ -367,7 +367,7 @@ logic you want::
     // src/Security/Voter/SwitchToCustomerVoter.php
     namespace App\Security\Voter;
 
-    use Symfony\Bundle\SecurityBundle\Security\Security;
+    use Symfony\Bundle\SecurityBundle\Security;
     use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
     use Symfony\Component\Security\Core\Authorization\Voter\Voter;
     use Symfony\Component\Security\Core\User\UserInterface;

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -222,7 +222,7 @@ with ``ROLE_SUPER_ADMIN``::
     // src/Security/PostVoter.php
 
     // ...
-    use Symfony\Bundle\SecurityBundle\Security\Security;
+    use Symfony\Bundle\SecurityBundle\Security;
 
     class PostVoter extends Voter
     {

--- a/session/proxy_examples.rst
+++ b/session/proxy_examples.rst
@@ -110,7 +110,7 @@ can intercept the session before it is written::
     namespace App\Session;
 
     use App\Entity\User;
-    use Symfony\Bundle\SecurityBundle\Security\Security;
+    use Symfony\Bundle\SecurityBundle\Security;
     use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
 
     class ReadOnlySessionProxy extends SessionHandlerProxy


### PR DESCRIPTION
This PR fix the new `Security` helper namespace change introduced by this PR: https://github.com/symfony/symfony/pull/47760
(itself following https://github.com/symfony/symfony-docs/pull/17284)


Targeting 6.2 because the Security Helper class did not exists there before
