### PR TITLE
Add documentation about the Doctrine `EntityValueResolver`

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -88,6 +88,7 @@ whitelist:
         - '.. versionadded:: 1.11' # Messenger (Middleware / DoctrineBundle)
         - '.. versionadded:: 1.18' # Flex in setup/upgrade_minor.rst
         - '.. versionadded:: 1.0.0' # Encore
+        - '.. versionadded:: 2.7.1' # Doctrine
         - '0 => 123' # assertion for var_dumper - components/var_dumper.rst
         - '1 => "foo"' # assertion for var_dumper - components/var_dumper.rst
         - '123,' # assertion for var_dumper - components/var_dumper.rst

--- a/best_practices.rst
+++ b/best_practices.rst
@@ -246,13 +246,13 @@ Instead, you must use dependency injection to fetch services by
 :ref:`type-hinting action method arguments <controller-accessing-services>` or
 constructor arguments.
 
-Use EntityValueResolver If It Is Convenient
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use Entity Value Resolvers If They Are Convenient
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you're using :doc:`Doctrine </doctrine>`, then you can *optionally* use the
-`EntityValueResolver`_ to automatically query for an entity and pass it as an
-argument to your controller. It will also show a 404 page if no entity can be
-found.
+If you're using :doc:`Doctrine </doctrine>`, then you can *optionally* use
+the :ref:`EntityValueResolver <doctrine-entity-value-resolver>` to
+automatically query for an entity and pass it as an argument to your
+controller. It will also show a 404 page if no entity can be found.
 
 If the logic to get an entity from a route variable is more complex, instead of
 configuring the EntityValueResolver, it's better to make the Doctrine query
@@ -451,7 +451,6 @@ you must set up a redirection.
 .. _`Symfony Demo`: https://github.com/symfony/demo
 .. _`download Symfony`: https://symfony.com/download
 .. _`Composer`: https://getcomposer.org/
-.. _`ParamConverter`: https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
 .. _`feature toggles`: https://en.wikipedia.org/wiki/Feature_toggle
 .. _`smoke testing`: https://en.wikipedia.org/wiki/Smoke_testing_(software)
 .. _`Webpack`: https://webpack.js.org/

--- a/best_practices.rst
+++ b/best_practices.rst
@@ -246,16 +246,17 @@ Instead, you must use dependency injection to fetch services by
 :ref:`type-hinting action method arguments <controller-accessing-services>` or
 constructor arguments.
 
-Use ParamConverters If They Are Convenient
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use EntityValueResolver If It Is Convenient
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you're using :doc:`Doctrine </doctrine>`, then you can *optionally* use the
-`ParamConverter`_ to automatically query for an entity and pass it as an argument
-to your controller. It will also show a 404 page if no entity can be found.
+`EntityValueResolver`_ to automatically query for an entity and pass it as an
+argument to your controller. It will also show a 404 page if no entity can be
+found.
 
 If the logic to get an entity from a route variable is more complex, instead of
-configuring the ParamConverter, it's better to make the Doctrine query inside
-the controller (e.g. by calling to a :doc:`Doctrine repository method </doctrine>`).
+configuring the EntityValueResolver, it's better to make the Doctrine query
+inside the controller (e.g. by calling to a :doc:`Doctrine repository method </doctrine>`).
 
 Templates
 ---------


### PR DESCRIPTION
fixes #43854

This PR replaces the documentation about the Doctrine ParamterConverter by the new Entity ValueResolver.

It does not cover all the behaviors and possibilities. This was previously documented I the SensioFrameworkExtraBundle (https://symfony.com/bundles/SensioFrameworkExtraBundle/current/annotations/converters.html). I wonder where should I put such documentation for the EntityArgumentResolver ?