### PR TITLE
[Filesystem] Add docs for `Filesystem::mirror()` options

### DIFF
--- a/components/filesystem.rst
+++ b/components/filesystem.rst
@@ -255,7 +255,17 @@ contents of the source directory into the target one (use the
 :method:`Symfony\\Component\\Filesystem\\Filesystem::copy` method to copy single
 files)::
 
+    // mirror a directory
     $filesystem->mirror('/path/to/source', '/path/to/target');
+    // mirror with any options
+    $filesystem->mirror('/path/to/source', '/path/to/target', null, $options);
+
+The following options can be passed:
+
+ * ``override`` (default: ``false``): If true, target files newer than origin files are overwritten (see :method:`Symfony\\Component\\Filesystem\\Filesystem::copy`)
+ * ``copy_on_windows`` (default: ``false``): Whether to copy files instead of links on Windows. Since symfony/filesystem 6.4 this option is deprecated, use follow_symlinks instead.
+ * ``follow_symlinks`` (default: ``false``): Whether to copy files instead of links, where using symlinks in not working: windows, different drive, docker context not supporting symlinks.
+ * ``delete`` (default: ``false``): Whether to delete files that are not in the source directory.
 
 ``isAbsolutePath``
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR adds the options for `Filesystem::mirror()` including the renamed option `copy_on_windows` to `follow_symlinks` with deprecation the old option. The related PR in Symfony project is symfony/symfony#47969.
