### PR TITLE
Add paragraph about symfony-cli workers

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -277,6 +277,31 @@ server provides a ``run`` command to wrap them as follows:
     # stop the web server (and all the associated commands) when you are finished
     $ symfony server:stop
 
+Configuring Workers
+-------------------
+
+If you like processes to start automatically, along with the webserver
+(``symfony server:start``), you can add a configuration file to your project:
+
+.. code-block:: yaml
+
+    # .symfony.local.yaml
+    workers:
+        # pre-defined command to build and watch front-end assets
+        # yarn_encore_watch:
+        #     cmd: ['yarn', 'encore', 'dev', '--watch']
+        yarn_encore_watch: ~
+
+        # pre-defined command to start messenger consumer
+        # messenger_consume_async:
+        #     cmd: ['symfony', 'console', 'messenger:consume', 'async']
+        #     watch: ['config', 'src', 'templates', 'vendor']
+        messenger_consume_async: ~
+
+        # additional commands
+        spa:
+            cmd: ['yarn', '--cwd', './spa/', 'dev']
+
 Docker Integration
 ------------------
 


### PR DESCRIPTION
While having a look at the source code of the symfony-cli, I discovered this pretty handy feature of starting worker processes along with `symfony serve`. I couldn't find any documentation about this though, not even any hint about the config file.

See https://github.com/symfony-cli/symfony-cli/blob/main/local/project/config.go