### PR TITLE
[Doctrine] Update multiple_entity_managers.rst

### DIFF
--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -43,7 +43,6 @@ The following configuration code shows how you can configure two entity managers
                         mappings:
                             Main:
                                 is_bundle: false
-                                type: annotation
                                 dir: '%kernel.project_dir%/src/Entity/Main'
                                 prefix: 'App\Entity\Main'
                                 alias: Main
@@ -52,7 +51,6 @@ The following configuration code shows how you can configure two entity managers
                         mappings:
                             Customer:
                                 is_bundle: false
-                                type: annotation
                                 dir: '%kernel.project_dir%/src/Entity/Customer'
                                 prefix: 'App\Entity\Customer'
                                 alias: Customer
@@ -85,7 +83,6 @@ The following configuration code shows how you can configure two entity managers
                         <doctrine:mapping
                             name="Main"
                             is_bundle="false"
-                            type="annotation"
                             dir="%kernel.project_dir%/src/Entity/Main"
                             prefix="App\Entity\Main"
                             alias="Main"
@@ -96,7 +93,6 @@ The following configuration code shows how you can configure two entity managers
                         <doctrine:mapping
                             name="Customer"
                             is_bundle="false"
-                            type="annotation"
                             dir="%kernel.project_dir%/src/Entity/Customer"
                             prefix="App\Entity\Customer"
                             alias="Customer"
@@ -127,7 +123,6 @@ The following configuration code shows how you can configure two entity managers
             $defaultEntityManager->connection('default');
             $defaultEntityManager->mapping('Main')
                 ->isBundle(false)
-                ->type('annotation')
                 ->dir('%kernel.project_dir%/src/Entity/Main')
                 ->prefix('App\Entity\Main')
                 ->alias('Main');
@@ -135,7 +130,6 @@ The following configuration code shows how you can configure two entity managers
             $customerEntityManager->connection('customer');
             $customerEntityManager->mapping('Customer')
                 ->isBundle(false)
-                ->type('annotation')
                 ->dir('%kernel.project_dir%/src/Entity/Customer')
                 ->prefix('App\Entity\Customer')
                 ->alias('Customer')


### PR DESCRIPTION
in this symfony version the "annotation" type for mappings should be treated as deprecated, or at least reported with a comment

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
