### PR TITLE
[Form][Security] Consistent naming of `FormLoginAuthenticator`

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -660,7 +660,7 @@ Form Login
 
 Most websites have a login form where users authenticate using an
 identifier (e.g. email address or username) and a password. This
-functionality is provided by the *form login authenticator*.
+functionality is provided by the built-in :class:`Symfony\\Component\\Security\\Http\Authenticator\\FormLoginAuthenticator`.
 
 First, create a controller for the login form:
 
@@ -691,7 +691,7 @@ First, create a controller for the login form:
         }
     }
 
-Then, enable the form login authenticator using the ``form_login`` setting:
+Then, enable the ``FormLoginAuthenticator`` using the ``form_login`` setting:
 
 .. configuration-block::
 
@@ -784,8 +784,8 @@ Edit the login controller to render the login form:
           }
       }
 
-Don't let this controller confuse you. Its job is only to *render* the form:
-the ``form_login`` authenticator will handle the form *submission* automatically.
+Don't let this controller confuse you. Its job is only to *render* the form.
+The ``FormLoginAuthenticator`` will handle the form *submission* automatically.
 If the user submits an invalid email or password, that authenticator will store
 the error and redirect back to this controller, where we read the error (using
 ``AuthenticationUtils``) so that it can be displayed back to the user.
@@ -857,7 +857,7 @@ To review the whole process:
 #. The ``/login`` page renders login form via the route and controller created
    in this example;
 #. The user submits the login form to ``/login``;
-#. The security system (i.e. the ``form_login`` authenticator) intercepts the
+#. The security system (i.e. the ``FormLoginAuthenticator``) intercepts the
    request, checks the user's submitted credentials, authenticates the user if
    they are correct, and sends the user back to the login form if they are not.
 


### PR DESCRIPTION
Reason: Make it more clear that we're always talking about the same **built-in** thing.

URL: https://symfony.com/doc/5.4/security.html