### PR TITLE
[Framework] clearified base_uri behavior with extra examples

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -963,16 +963,21 @@ every request.
 
 Here are some common examples of how ``base_uri`` merging works in practice:
 
-=======================  ==================  ==========================
-``base_uri``             Relative URI        Actual Requested URI
-=======================  ==================  ==========================
-http://example.org       /bar                http://example.org/bar
-http://example.org/foo   /bar                http://example.org/bar
-http://example.org/foo   bar                 http://example.org/bar
-http://example.org/foo/  bar                 http://example.org/foo/bar
-http://example.org       http://symfony.com  http://symfony.com
-http://example.org/?bar  bar                 http://example.org/bar
-=======================  ==================  ==========================
+==========================  ==================  ==========================
+``base_uri``                Relative URI        Actual Requested URI
+==========================  ==================  ==========================
+http://example.org          /bar                http://example.org/bar
+http://example.org/foo      /bar                http://example.org/bar
+http://example.org/foo      bar                 http://example.org/bar
+http://example.org/foo/     /bar                http://example.org/bar
+http://example.org/foo/     bar                 http://example.org/foo/bar
+http://example.org          http://symfony.com  http://symfony.com
+http://example.org/?bar     bar                 http://example.org/bar
+http://example.org/api/v4   /bar                http://example.org/bar
+http://example.org/api/v4/  /bar                http://example.org/bar
+http://example.org/api/v4   bar                 http://example.org/api/bar
+http://example.org/api/v4/  bar                 http://example.org/api/v4/bar
+==========================  ==================  ==========================
 
 bindto
 ......


### PR DESCRIPTION
added some more examples with an extra directory depth. this should better document the behavior for the `base_uri` parameter in combination with the leading slash in the relative url.

took some "reallife" url as example as `foo/bar/baz` wouldn't be so clear with only one letter difference between `bar` and `baz`. i only added one "foo" url and the urls with `api` in the path, the others rows are only changed because of the new intending. even if some of the examples are redundant i personally would keep them as the extra examples clearify the behavior.

cost me quite some time to figure that out. hope this small addition helps people not to fall for the same.

related to: https://github.com/symfony/symfony/issues/39724