### PR TITLE
Replace annotation by attribute

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -214,9 +214,7 @@ email. First, create a constraint and override the ``getTargets()`` method::
 
     use Symfony\Component\Validator\Constraint;
 
-    /**
-     * @Annotation
-     */
+    #[\Attribute]
     class ConfirmedPaymentReceipt extends Constraint
     {
         public string $userDoesNotMatchMessage = 'User\'s e-mail address does not match that of the receipt';


### PR DESCRIPTION
Replace Annotation in custom constraint declaration by #[\Attribute] which is more up to date

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
