### PR TITLE
Adding more info about chain provider

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -351,6 +351,8 @@ Symfony comes with several built-in user providers:
     Loads users from a configuration file;
 :ref:`Chain User Provider <security-chain-user-provider>`
     Merges two or more user providers into a new user provider.
+    Since each firewall has exactly *one* user provider, you can use this
+    to chain multiple providers together.
 
 The built-in user providers cover the most common needs for applications, but you
 can also create your own :ref:`custom user provider <security-custom-user-provider>`.


### PR DESCRIPTION
Reason: The info that this is the way to go if you need *multiple* providers was lost somehow since v4.4: https://symfony.com/doc/4.0/security/multiple_user_providers.html The wording is mostly taken from there.
