### PR TITLE
[Console] Fix incorrect example for `CommandCompletionTester`

### DIFF
--- a/console/input.rst
+++ b/console/input.rst
@@ -397,8 +397,10 @@ to help you unit test the completion logic::
             $this->assertSame(['Fabien', 'Fabrice', 'Wouter'], $suggestions);
 
             // complete the input with "Fa" as input
+            // note that the list does not reduce because the completion tester doesn't run any shell, 
+            // it only tests the PHP part of the completion logic, so it should always include all values
             $suggestions = $tester->complete(['Fa']);
-            $this->assertSame(['Fabien', 'Fabrice'], $suggestions);
+            $this->assertSame(['Fabien', 'Fabrice', 'Wouter'], $suggestions);
         }
     }
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
