### PR TITLE
Add details on `html_sanitizer` -> `allowed_link_schemes` config

### DIFF
--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -734,7 +734,8 @@ URLs of ``<a>`` elements:
                         force_https_urls: true
 
                         # specifies the allowed URL schemes. If the URL has a different scheme, the
-                        # attribute will be dropped
+                        # attribute will be dropped. 
+                        # This attribute must be defined, otherwise, href attribute will be removed from links anyway.
                         allowed_link_schemes: ['http', 'https', 'mailto']
 
                         # specifies the allowed hosts, the attribute will be dropped if the


### PR DESCRIPTION
Hello,

I had hard times getting HTMLSanitizer to work correctly: `href` attribute was always removed from `a` tag.

After a bunch of tests and searches, I found that `allowed_link_schemes` config parameter had to be set. 

This behaviour is logical but undocumented, so here is a quick edit to try to make it clearer.

Thanks

 PS: As a side note here was my initial (and not working) configuration. Not obvious why href was always removed.

```yaml
html_sanitizer:
    sanitizers:
        app.sanitizer:
            allow_safe_elements: true
            allow_elements:
                list: '*'
                table: 'class'
                code: '*'
                a: ['href']
            allowed_media_schemes: ['http', 'https', 'mailto']
            allow_relative_medias: false
```