### PR TITLE
Fix confusing example of type-hinting the Request object

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -381,7 +381,7 @@ object. To access it in your controller, add it as an argument and
     use Symfony\Component\HttpFoundation\Response;
     // ...
 
-    public function index(Request $request, string $firstName, string $lastName): Response
+    public function index(Request $request): Response
     {
         $page = $request->query->get('page', 1);
 


### PR DESCRIPTION
As far as I can see, this piece of doc is incorrect as `$firstName` and `$lastName` wouldn't be injected properly there and the piece of doc in question is not about those two parameters either.

As such I propose to remove them from the example to prevent any confusion.