### PR TITLE
[Logger] Use Monolog\LogRecord object instead of array for log processor

### DIFF
--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -32,7 +32,7 @@ using a processor::
         }
 
         // this method is called for each log record; optimize it to not hurt performance
-        public function __invoke(array $record)
+        public function __invoke(LogRecord $record): LogRecord
         {
             try {
                 $session = $this->requestStack->getSession();
@@ -45,7 +45,7 @@ using a processor::
 
             $sessionId = substr($session->getId(), 0, 8) ?: '????????';
 
-            $record['extra']['token'] = $sessionId.'-'.substr(uniqid('', true), -8);
+            $record->extra['token'] = $sessionId.'-'.substr(uniqid('', true), -8);
 
             return $record;
         }


### PR DESCRIPTION
Leverage new monolog as log records object (monolog >= v3) https://github.com/Seldaek/monolog/releases/tag/3.0.0

if we decide to keep the array (monolog <= v2), how can we document this? with inline comments ? with 2 code block?

see also https://packagist.org/packages/monolog/monolog/php-stats#3.0 that is why I target sf 6.1+

thx