### PR TITLE
[EventDispatcher] Update event_dispatcher.rst

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -161,7 +161,7 @@ You can add multiple ``#[AsEventListener()]`` attributes to configure different 
 
     use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
-    #[AsEventListener(event: CustomEvent::class, method: 'onCustomEvent')]
+    #[AsEventListener(event: CustomEvent::NAME, method: 'onCustomEvent')]
     #[AsEventListener(event: 'foo', priority: 42)]
     #[AsEventListener(event: 'bar', method: 'onBarEvent')]
     final class MyMultiListener


### PR DESCRIPTION
To listen to an event, we have to provide the name of the event, not its class.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
