### PR TITLE
[PropertyInfo] Update property_info.rst

### DIFF
--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -323,13 +323,13 @@ this returns ``true`` if:
   ``@var SomeClass<DateTime>``, ``@var SomeClass<integer,string>``,
   ``@var Doctrine\Common\Collections\Collection<App\Entity\SomeEntity>``, etc.)
 
-``Type::getCollectionKeyType()`` & ``Type::getCollectionValueType()``
+``Type::getCollectionKeyType()`` & ``Type::getCollectionValueTypes()``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the property is a collection, additional type objects may be returned
 for both the key and value types of the collection (if the information is
 available), via the :method:`Type::getCollectionKeyType() <Symfony\\Component\\PropertyInfo\\Type::getCollectionKeyType>`
-and :method:`Type::getCollectionValueType() <Symfony\\Component\\PropertyInfo\\Type::getCollectionValueType>`
+and :method:`Type::getCollectionValueTypes() <Symfony\\Component\\PropertyInfo\\Type::getCollectionValueTypes>`
 methods.
 
 .. _`components-property-info-extractors`:


### PR DESCRIPTION
Since Symfony 6.1 the Method `Type::getCollectionValueType() : ?self` (5.0) was changed to `Type::getCollectionValueTypes() : array` (6.1) the Docs are missleading and i ran into an error after migrating to 6.1

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
