### PR TITLE
Fix UX package list Dropzone display

### DIFF
--- a/frontend/_ux-libraries.rst.inc
+++ b/frontend/_ux-libraries.rst.inc
@@ -4,7 +4,7 @@
 * `ux-chartjs`_: Easy charts with `Chart.js`_ (`see demo <https://ux.symfony.com/chartjs>`_)
 * `ux-cropperjs`_: Form Type and tools for cropping images (`see demo <https://ux.symfony.com/cropperjs>`_)
 * `ux-dropzone`_: Form Type for stylized "drop zone" for file uploads
-   (`see demo <https://ux.symfony.com/dropzone>`_)
+  (`see demo <https://ux.symfony.com/dropzone>`_)
 * `ux-lazy-image`_: Optimize Image Loading with BlurHash
   (`see demo <https://ux.symfony.com/lazy-image>`_)
 * `ux-live-component`_: Build Dynamic Interfaces with Zero JavaScript


### PR DESCRIPTION
Hi,

Very little small PR to fix this in the docs:

![image](https://user-images.githubusercontent.com/3929498/203985723-fc46e5c1-f058-4326-9fbd-1684db1ea12e.png)
