### PR TITLE
[Validator] `enable_annotations` also read attributes

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2578,7 +2578,7 @@ enable_annotations
 
 **type**: ``boolean`` **default**: ``false``
 
-If this option is enabled, validation constraints can be defined using annotations.
+If this option is enabled, validation constraints can be defined using annotations or attributes.
 
 translation_domain
 ..................
@@ -2787,7 +2787,7 @@ enable_annotations
 
 **type**: ``boolean`` **default**: ``false``
 
-If this option is enabled, serialization groups can be defined using annotations.
+If this option is enabled, serialization groups can be defined using annotations or attributes.
 
 .. seealso::
 


### PR DESCRIPTION
[AnnotationLoader](https://symfony.com/doc/current/components/validator/resources.html#the-annotationloader) doc tell attributes are read but in `enable_annotations` reference it's not said