### PR TITLE
Replace an URL by a URL

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -647,7 +647,7 @@ Resolving a URI
 
     The :class:`Symfony\\Component\\DomCrawler\\UriResolver` helper class was added in Symfony 5.1.
 
-The :class:`Symfony\\Component\\DomCrawler\\UriResolver` class takes an URI
+The :class:`Symfony\\Component\\DomCrawler\\UriResolver` class takes a URI
 (relative, absolute, fragment, etc.) and turns it into an absolute URI against
 another given base URI::
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2359,7 +2359,7 @@ package:
 
 .. note::
 
-    If an URL is set, the JSON manifest is downloaded on each request using the `http_client`_.
+    If a URL is set, the JSON manifest is downloaded on each request using the `http_client`_.
 
 .. _reference-assets-strict-mode:
 


### PR DESCRIPTION
Same changes than PR https://github.com/symfony/symfony/pull/48351 in docs

Fix misspelling. Replace "an" by "a".

    Although the U at the first of URL is a vowel, the abbreviation is pronounced “you-are-ell.” Because the letter Y is a consonant in this case, use a rather than an.

[Which-is-correct-a-URL-or-an-URL](https://www.techtarget.com/whatis/feature/Which-is-correct-a-URL-or-an-URL)