### PR TITLE
[Symfony CLI] Show usage of new command `symfony proxy:url`

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -237,7 +237,14 @@ domains work:
 
 .. code-block:: terminal
 
-    $ https_proxy=http://127.0.0.1:7080 curl https://my-domain.wip
+    # Example with curl
+    $ https_proxy=$(symfony proxy:url) curl https://my-domain.wip
+
+    # Example with Blackfire and curl
+    $ https_proxy=$(symfony proxy:url) blackfire curl https://my-domain.wip
+
+    # Example with Cypress
+    $ https_proxy=$(symfony proxy:url) ./node_modules/bin/cypress open
 
 .. note::
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->

Related to https://github.com/symfony-cli/symfony-cli/pull/233

Thanks!
