### PR TITLE
Clarify how `CollectionType` entries are indexed

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -11,6 +11,8 @@ forms, which is useful when creating forms that expose one-to-many
 relationships (e.g. a product from where you can manage many related product
 photos).
 
+When rendered, existing collection entries are indexed by the keys of the array that is passed as the collection type field data.
+
 +---------------------------+--------------------------------------------------------------------------+
 | Rendered as               | depends on the `entry_type`_ option                                      |
 +---------------------------+--------------------------------------------------------------------------+


### PR DESCRIPTION
Clarifying the indexing for `CollectionType` entries prevents further confusion about how entries can be identified in the front end as well as when viewing the request data.