### PR TITLE
[Security] WIP -  make:security:form-login is now available in MakerBundle

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -662,7 +662,33 @@ Most websites have a login form where users authenticate using an
 identifier (e.g. email address or username) and a password. This
 functionality is provided by the *form login authenticator*.
 
-First, create a controller for the login form:
+`MakerBundle` has a new ``make:security:form-login`` command that was introduced
+in ``v1.x.x`` that will generate the controller, twig template, and configure
+``security.yaml`` after answering a couple of questions:
+
+.. code-block:: terminal
+
+    $ php bin/console make:security:form-login
+
+     Choose a name for the controller class (e.g. SecurityController) [SecurityController]:
+     > SecurityController
+
+     Do you want to generate a '/logout' URL? (yes/no) [yes]:
+     > y
+
+     created: src/Controller/SecurityController.php
+     created: templates/security/login.html.twig
+     updated: config/packages/security.yaml
+
+
+      Success!
+
+
+     Next: Review and adapt the login template: security/login.html.twig to suite your needs.
+
+WooHoo! You're all set to start authenticating users.
+
+If you prefer to do this manually, first, create a controller for the login form:
 
 .. code-block:: terminal
 


### PR DESCRIPTION
MakerBundle is going to introduce a new command to generate and configure the files needed for `FormLogin` in SecurityBundle.

Not sure if we should completely remove the "manual" howto in the docs or go with something like I have here.

Note: Command name and output subject to change until we merge, I'll update this PR accordingly. In the meantime, feedback welcomed!

Note: Additional `make:security:*` commands to follow shortly.

## Blockers:

- [x] Merge https://github.com/symfony/maker-bundle/pull/1244
- [x] Release MakerBundle `1.49.0`
