### PR TITLE
[Messenger] remove wrong `versionadded` for `AsMessageHandler`

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -76,10 +76,6 @@ message class (or a message interface)::
     methods. You may use the attribute on as many methods in a single class as you
     like, allowing you to group the handling of multiple related types of messages.
 
-.. versionadded:: 6.1
-
-    Support for ``#[AsMessageHandler]`` on methods was introduced in Symfony 6.1.
-
 Thanks to :ref:`autoconfiguration <services-autoconfigure>` and the ``SmsNotification``
 type-hint, Symfony knows that this handler should be called when an ``SmsNotification``
 message is dispatched. Most of the time, this is all you need to do. But you can


### PR DESCRIPTION
as this attribute was added in 5.4 (Class exist in 5.4 branch and this post mention it too https://symfony.com/blog/new-in-symfony-5-4-messenger-improvements).

This message is also not present in 6.0 branch but present on 6.1, 6.2 and 6.3 branches, this may be an error.

.. versionadded:: 6.1
    Support for ``#[AsMessageHandler]`` on methods was introduced in Symfony 6.1.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
