### PR TITLE
[Security] Fix `versionadded` directive

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1940,7 +1940,7 @@ If you need to get the logged in user from a service, use the
 
     The :class:`Symfony\\Bundle\\SecurityBundle\\Security` class
     was introduced in Symfony 6.2. In previous Symfony versions this class was
-    defined in ``Symfony\Bundle\SecurityBundle\Security``.
+    defined in ``Symfony\Component\Security\Core\Security``.
 
 Fetch the User in a Template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
hello

the previous versions of symfony used the Symfony\Component\Security\Core\Security service.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
