### PR TITLE
[DependencyInjection] Changing `enum:` example away from APP_ENV

### DIFF
--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -745,11 +745,13 @@ Symfony provides the following env var processors:
     Tries to convert an environment variable to an actual ``\BackedEnum`` value.
     This processor takes the fully qualified name of the ``\BackedEnum`` as an argument::
 
-        # App\Enum\Environment
+        // App\Enum\Suit.php
         enum Environment: string
         {
-            case Development = 'dev';
-            case Production = 'prod';
+            case Clubs = 'clubs';
+            case Spades = 'spades';
+            case Diamonds = 'diamonds';
+            case Hearts = 'hearts';
         }
 
     .. configuration-block::
@@ -758,7 +760,7 @@ Symfony provides the following env var processors:
 
             # config/services.yaml
             parameters:
-                typed_env: '%env(enum:App\Enum\Environment:APP_ENV)%'
+                suit: '%env(enum:App\Enum\Suit:CARD_SUIT)%'
 
         .. code-block:: xml
 
@@ -773,14 +775,17 @@ Symfony provides the following env var processors:
                     https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
                 <parameters>
-                    <parameter key="typed_env">%env(enum:App\Enum\Environment:APP_ENV)%</parameter>
+                    <parameter key="suit">%env(enum:App\Enum\Suit:CARD_SUIT)%</parameter>
                 </parameters>
             </container>
 
         .. code-block:: php
 
             // config/services.php
-            $container->setParameter('typed_env', '%env(enum:App\Enum\Environment:APP_ENV)%');
+            $container->setParameter('suit', '%env(enum:App\Enum\Suit:CARD_SUIT)%');
+
+    The value stored in the ``CARD_SUIT`` env var would be a string like `'spades'` but the
+    application will use the ``Suit::Spdes`` enum value.
 
     .. versionadded:: 6.2
 


### PR DESCRIPTION
https://symfony.com/doc/current/configuration/env_var_processors.html#built-in-environment-variable-processors

Reason: When I first read this, I was expecting that the Symfony-internal ways to get the environment (`{{ app.environment }}`, `$routingConfigurator->env()` ,etc.) would now return the enum. But this is not the case. So if you explain the new processor with exactly this example, there needs to be a caution box, explaining that Symfony's methods still return the string.

* If you don't agree with this change, I'd still open a separate PR to add the following info (taken from https://symfony.com/blog/new-in-symfony-6-2-improved-enum-support#enums-in-environment-variables), cause that's a missing piece of information here:

    > The value stored in the ``CARD_SUIT`` env var would be a string like `'spades'` but the
    > application will use the ``Suit::Spdes`` enum value.

* Besides, as the list of processors is getting longer and longer, I'd suggest to create a sub-heading for each (under "Built-In Environment Variable Processors") and sort them alphabetically, to get rid of the endless indentation, and improve scanability, and get them included in the TOC.
    Should I create a PR for this? If yes, for which version?