### PR TITLE
[Security] User in expression cannot be "anon"

### DIFF
--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -44,7 +44,8 @@ syntax, see :doc:`/components/expression_language/syntax`.
 Inside the expression, you have access to a number of variables:
 
 ``user``
-    The user object (or the string ``anon`` if you're not authenticated).
+    An instance of :class:`Symfony\\Component\\Security\\Core\\User\\UserInterface` that represents the current user
+    or ``null`` if you're not authenticated.
 ``role_names``
     An array with the string representation of the roles the user has. This array
     includes any roles granted indirectly via the :ref:`role hierarchy <security-role-hierarchy>` but it


### PR DESCRIPTION
Since Symfony 6.0, the `TokenInterface::getUser()` method [always returns an instance of `UserInterface` or `null`](https://github.com/symfony/symfony/blob/aee9ea5be25036706cb7dfd3047d48dad0f8e892/UPGRADE-6.0.md?plain=1#L242), and since the [`ExpressionVoter` fetches the user from the token](https://github.com/symfony/symfony/blob/aee9ea5be25036706cb7dfd3047d48dad0f8e892/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php#L82), it shouldn't be possible for it to be `anon` any more.