### PR TITLE
Removing note about `Kernel` configuration

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -183,12 +183,6 @@ the ``BlogController``:
             ;
         };
 
-.. versionadded:: 5.1
-
-    Starting from Symfony 5.1, by default Symfony only loads the routes defined
-    in YAML format. If you define routes in XML and/or PHP formats, update the
-    ``src/Kernel.php`` file to add support for the ``.xml`` and ``.php`` file extensions.
-
 .. _routing-matching-http-methods:
 
 Matching HTTP Methods


### PR DESCRIPTION
Since 5.4, there's nothing to configure anymore in the kernel: https://github.com/symfony/recipes/blob/main/symfony/framework-bundle/5.4/src/Kernel.php So PHP&XML routes are loaded automatically - or aren't they?
