### PR TITLE
Removing note about `Kernel` configuration, part 2

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -149,12 +149,6 @@ the ``BlogController``:
             ;
         };
 
-.. note::
-
-    By default Symfony only loads the routes defined in YAML format. If you
-    define routes in XML and/or PHP formats, update the ``src/Kernel.php`` file
-    to add support for the ``.xml`` and ``.php`` file extensions.
-
 .. _routing-matching-http-methods:
 
 Matching HTTP Methods


### PR DESCRIPTION
Second part of https://github.com/symfony/symfony-docs/pull/17515 for reworded note
