### PR TITLE
Changing versionadded from 6.2 to 6.2.1

### DIFF
--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -794,9 +794,9 @@ Symfony provides the following env var processors:
             // config/services.php
             $container->setParameter('typed_env', '%env(enum:App\Enum\Environment:APP_ENV)%');
 
-    .. versionadded:: 6.2
+    .. versionadded:: 6.2.1
 
-        The ``env(enum:...)`` env var processor was introduced in Symfony 6.2.
+        The ``env(enum:...)`` env var processor was introduced in Symfony 6.2.1.
 
 It is also possible to combine any number of processors:
 


### PR DESCRIPTION
Reason: This isn't really working in 6.2.0 - see https://github.com/symfony/symfony/issues/48498 and the linked bugfix there.

Don't know how you want to deal with such a case, but I'm figuring that just changing the version number would be a nice idea to communicate it :-)