### PR TITLE
clarify that Bundle and AbstractBundle are different

### DIFF
--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -319,12 +319,16 @@ In your extension, you can load this and dynamically set its arguments::
             // ... now use the flat $config array
         }
 
-Using the Bundle Class
-----------------------
+Using the AbstractBundle Class
+------------------------------
 
 .. versionadded:: 6.1
 
     The ``AbstractBundle`` class was introduced in Symfony 6.1.
+
+.. caution::
+
+    This is an alternative implementation to the above mentioned Bundle class. You can use one of these approaches but not both at the same time.
 
 Instead of creating an extension and configuration class, you can also
 extend :class:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle` to


### PR DESCRIPTION
Please see https://stackoverflow.com/questions/74704768/invalidconfigurationexception-with-custom-bundle-in-symfony6-2 for the details.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
