### PR TITLE
[Messenger] Add config option `arguments` for amqp delay queues

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1810,6 +1810,13 @@ The transport has a number of options:
 ``delay[exchange_name]`` (default: ``delays``)
     Name of the exchange to be used for the delayed/retried messages
 
+``delay[arguments]`` (default: ``[]``)
+    Extra arguments for the delays queues
+
+    .. versionadded:: 7.1
+
+        The ``delay[arguments]`` option was introduced in Symfony 7.1.
+
 ``queues[name][arguments]``
     Extra arguments
 


### PR DESCRIPTION
Hi, this PR to allow to add extra arguments to the amqp delay queues that are automatically created.

* https://github.com/symfony/symfony/pull/48603
