### PR TITLE
[Validator] replace expressionLanguageSyntax with new expressionSyntax

### DIFF
--- a/reference/constraints.rst
+++ b/reference/constraints.rst
@@ -14,7 +14,6 @@ Validation Constraints Reference
    constraints/Type
 
    constraints/Email
-   constraints/ExpressionLanguageSyntax (deprecated)
    constraints/ExpressionSyntax
    constraints/Length
    constraints/Url

--- a/reference/constraints/map.rst.inc
+++ b/reference/constraints/map.rst.inc
@@ -16,7 +16,7 @@ String Constraints
 ~~~~~~~~~~~~~~~~~~
 
 * :doc:`Email </reference/constraints/Email>`
-* :doc:`ExpressionLanguageSyntax </reference/constraints/ExpressionLanguageSyntax>`
+* :doc:`ExpressionSyntax </reference/constraints/ExpressionSyntax>`
 * :doc:`Length </reference/constraints/Length>`
 * :doc:`Url </reference/constraints/Url>`
 * :doc:`Regex </reference/constraints/Regex>`


### PR DESCRIPTION
As expressionSyntax deprecates expressionLanguageSyntax, replace it from constraint's list

[Related code PR](https://github.com/symfony/symfony/pull/45623)