### PR TITLE
[Security] Make login redirection logic available to programmatic login

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1657,7 +1657,12 @@ You can log in a user programmatically using the ``login()`` method of the
             // you can also log in on a different firewall
             $security->login($user, 'form_login', 'other_firewall');
 
-            // ... redirect the user, e.g. to their account page
+            // use the redirection logic applied to regular login,
+            $redirectResponse = $security->login($user);
+            return $redirectResponse;
+            // or use a specific redirection logic
+            // (redirect the user to its account page for instance)
+            // ...
         }
     }
 


### PR DESCRIPTION
Make regular login redirection logic available in programmatic login as proposed in https://github.com/symfony/symfony/pull/48582 .

User can ignore the redirectResponse and implement its own redirection logic.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
