### PR TITLE
[Doctrine] Update doctrine.rst

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -768,7 +768,7 @@ control behavior:
 
         #[Route('/product/{category}/{slug}/comments/{comment_slug}')]
         public function show(
-            #[MapEntity(mapping: ['date' => 'date', 'slug' => 'slug'])]
+            #[MapEntity(mapping: ['category' => 'category', 'slug' => 'slug'])]
             Product $product
             #[MapEntity(mapping: ['comment_slug' => 'slug'])]
             Comment $comment
@@ -777,7 +777,7 @@ control behavior:
 
 ``exclude``
     Configures the properties that should be used in the ``findOneBy()``
-    method by *excluding* one or more properties so that not *all* are used:
+    method by *excluding* one or more properties so that not *all* are used::
 
         #[Route('/product/{slug}/{date}')]
         public function show(


### PR DESCRIPTION
An example of MapEntity Options "exclude" have a wrong paragraph formatting (this is : when :: is expected). An example of MapEntity Options "mapping" contains a property is not synced with a placeholder (there is no 'date' in the route).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
