### PR TITLE
Symfony CLI: fix config directory path

### DIFF
--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -79,7 +79,7 @@ server SSL certificate:
     +         options.server = {
     +             type: 'https',
     +             options: {
-    +                 pfx: path.join(process.env.HOME, '.symfony/certs/default.p12'),
+    +                 pfx: path.join(process.env.HOME, '.symfony5/certs/default.p12'),
     +             }
     +         }
     +     })

--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -254,7 +254,7 @@ domains work:
 
 .. tip::
 
-    If you prefer to use a different TLD, edit the ``~/.symfony/proxy.json``
+    If you prefer to use a different TLD, edit the ``~/.symfony5/proxy.json``
     file (where ``~`` means the path to your user directory) and change the
     value of the ``tld`` option from ``wip`` to any other TLD.
 


### PR DESCRIPTION
Symfony CLI config directory changed when Symfony CLI 5 was released, hence this change.