### PR TITLE
Fix/bootstrap turbo docs

### DIFF
--- a/frontend/encore/bootstrap.rst
+++ b/frontend/encore/bootstrap.rst
@@ -73,6 +73,25 @@ Now, require bootstrap from any of your JavaScript files:
         $('[data-toggle="popover"]').popover();
     });
 
+Using Bootstrap with Turbo
+---------------------------
+
+If you are using bootstrap with Turbo Drive, to allow your JavaScript to load on each page change,
+wrap the initialization in a ``turbo:load`` event listener:
+
+.. code-block:: javascript
+
+    // app.js
+
+    // this waits for Turbo Drive to load
+    document.addEventListener('turbo:load', function (e) {
+        // this enables bootstrap tooltips globally
+        let tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+        let tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+            return new Tooltip(tooltipTriggerEl)
+        });
+    });
+
 Using other Bootstrap / jQuery Plugins
 --------------------------------------
 


### PR DESCRIPTION
Add a note and code example in the "Using Bootstrap CSS & JS" docs. 
If a user is using Turbo Drive with bootstrap to wrap their javascript in a `turbo:load` event listener. 