### PR TITLE
[Doctrine] Fix an example of MapEntity

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -755,7 +755,7 @@ control behavior:
 
         #[Route('/product/{product_id}')]
         public function show(
-            #[MapEntity(id: 'product_id')] Product $product
+            #[MapEntity(id: 'product_id')] Product $product,
             Comment $comment
         ): Response {
         }
@@ -768,7 +768,7 @@ control behavior:
         #[Route('/product/{category}/{slug}/comments/{comment_slug}')]
         public function show(
             #[MapEntity(mapping: ['category' => 'category', 'slug' => 'slug'])]
-            Product $product
+            Product $product,
             #[MapEntity(mapping: ['comment_slug' => 'slug'])]
             Comment $comment
         ): Response {
@@ -781,7 +781,7 @@ control behavior:
         #[Route('/product/{slug}/{date}')]
         public function show(
             #[MapEntity(exclude: ['date'])]
-            Product $product
+            Product $product,
             \DateTime $date
         ): Response {
         }

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -755,8 +755,7 @@ control behavior:
 
         #[Route('/product/{product_id}')]
         public function show(
-            Product $product
-            #[MapEntity(id: 'product_id')]
+            #[MapEntity(id: 'product_id')] Product $product
             Comment $comment
         ): Response {
         }


### PR DESCRIPTION
I think this example is wrong because it looks like `#[MapEntity]` should be applied to `$product` instead of `$comment`.