### PR TITLE
[Messenger] Update the namespace of `InMemoryTransport` class

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1681,7 +1681,7 @@ during a request::
     namespace App\Tests\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-    use Symfony\Component\Messenger\Transport\InMemoryTransport;
+    use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 
     class DefaultControllerTest extends WebTestCase
     {
@@ -1697,6 +1697,12 @@ during a request::
             $this->assertCount(1, $transport->getSent());
         }
     }
+
+.. versionadded:: 6.3
+
+    The namespace of the ``InMemoryTransport`` class changed in Symfony 6.3 from
+    ``Symfony\Component\Messenger\Transport\InMemoryTransport`` to
+    ``Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport``.
 
 The transport has a number of options:
 

--- a/messenger/custom-transport.rst
+++ b/messenger/custom-transport.rst
@@ -126,7 +126,7 @@ Here is a simplified example of a database transport::
 
 The implementation above is not runnable code but illustrates how a
 :class:`Symfony\\Component\\Messenger\\Transport\\TransportInterface` could
-be implemented. For real implementations see :class:`Symfony\\Component\\Messenger\\Transport\\InMemoryTransport`
+be implemented. For real implementations see :class:`Symfony\\Component\\Messenger\\Transport\\InMemory\\InMemoryTransport`
 and :class:`Symfony\\Component\\Messenger\\Bridge\\Doctrine\\Transport\\DoctrineReceiver`.
 
 Register your Factory


### PR DESCRIPTION
Fixes #17573