### PR TITLE
Deprecate the proxy-manager package

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -33,8 +33,8 @@ until you interact with the proxy in some way.
 
 .. versionadded:: 6.2
 
-    Starting from Symfony 6.2, you don't have to install any package (e.g.
-    ``symfony/proxy-manager-bridge``) in order to use the lazy service instantiation.
+    Starting from Symfony 6.2, service laziness is supported out of the box
+    without having to install any additional package.
 
 Configuration
 -------------


### PR DESCRIPTION
Fixes #17531.

I didn't find any other occurrence of `proxy-manager`. In Symfony 6.2 removed almost everything about it, so let's remove this last mention.