### PR TITLE
[DependencyInjection] Remove not implemented behavior

### DIFF
--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -309,8 +309,6 @@ or directly via PHP attributes:
                     <argument type="service_locator">
                         <argument key="App\FooCommand" type="service" id="app.command_handler.foo"/>
                         <argument key="App\BarCommand" type="service" id="app.command_handler.bar"/>
-                        <!-- if the element has no key, the ID of the original service is used -->
-                        <argument type="service" id="app.command_handler.baz"/>
                     </argument>
                 </service>
             </services>
@@ -331,8 +329,6 @@ or directly via PHP attributes:
                     // In versions earlier to Symfony 5.1 the service() function was called ref()
                     'App\FooCommand' => service('app.command_handler.foo'),
                     'App\BarCommand' => service('app.command_handler.bar'),
-                    // if the element has no key, the ID of the original service is used
-                    service('app.command_handler.baz'),
                 ])]);
         };
 


### PR DESCRIPTION
Currently numeric keys are used, but it will be deprecated and changed in 7.0.

Deprecation: symfony/symfony#48686
New behavior: symfony/symfony#48653
