### PR TITLE
[Security] X509 `user_identifier` parameter

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -666,6 +666,7 @@ X.509 Authentication
                         provider:    your_user_provider
                         user:        SSL_CLIENT_S_DN_Email
                         credentials: SSL_CLIENT_S_DN
+                        user_identifier: emailAddress
 
     .. code-block:: xml
 
@@ -687,6 +688,7 @@ X.509 Authentication
                     <x509 provider="your_user_provider"
                         user="SSL_CLIENT_S_DN_Email"
                         credentials="SSL_CLIENT_S_DN"
+                        user_identifier="emailAddress"
                     />
                 </firewall>
             </config>
@@ -703,6 +705,7 @@ X.509 Authentication
                 ->provider('your_user_provider')
                 ->user('SSL_CLIENT_S_DN_Email')
                 ->credentials('SSL_CLIENT_S_DN')
+                ->user_identifier('emailAddress')
             ;
         };
 
@@ -723,7 +726,18 @@ If the ``user`` parameter is not available, the name of the ``$_SERVER``
 parameter containing the full "distinguished name" of the certificate
 (exposed by e.g. Nginx).
 
-Symfony identifies the value following ``emailAddress=`` in this parameter.
+By default, Symfony identifies the value following ``emailAddress=`` in this parameter.
+This can be changed using the ``user_identifier`` parameter.
+
+user_identifier
+...........
+
+**type**: ``string`` **default**: ``emailAddress``
+
+The ``user_identifier`` parameter is used to find the user identifier in the
+"distinguished name" e.g. ``Subject: C=FR, O=My Organization, CN=user1, emailAddress=user1@myorg.fr``.
+
+By setting this parameter to ``CN``, the returned user identifier will be the "Common Name" ``user1``
 
 .. _reference-security-firewall-remote-user:
 

--- a/security.rst
+++ b/security.rst
@@ -1314,11 +1314,11 @@ ways:
 #. First, it tries the ``SSL_CLIENT_S_DN_Email`` server parameter, which is
    exposed by Apache;
 #. If it is not set (e.g. when using Nginx), it uses ``SSL_CLIENT_S_DN`` and
-   matches the value following ``emailAddress=``.
+   matches the value following ``emailAddress``.
 
-You can customize the name of both parameters under the ``x509`` key. See
-:ref:`the configuration reference <reference-security-firewall-x509>` for
-more details.
+You can customize the name of the three parameters under the ``x509`` key.
+See :ref:`the configuration reference <reference-security-firewall-x509>`
+for more details.
 
 Remote Users
 ~~~~~~~~~~~~


### PR DESCRIPTION
See #17580

**❓ Question**: I am not sure about the PHP configuration `->user_identifier('emailAddress')`? Should I create the corresponding method or is it guessed by the `SecurityConfig` object?