### PR TITLE
Add a note about using Gmail vs an Email catcher

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -12,7 +12,6 @@ integration, CSS inlining, file attachments and a lot more. Get them installed w
 
     $ composer require symfony/mailer
 
-
 .. _mailer-transport-setup:
 
 Transport Setup
@@ -105,14 +104,13 @@ native        ``native://default``                      Mailer uses the sendmail
 Using a 3rd Party Transport
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Instead of using your own SMTP server or sendmail binary, you can send emails via a 3rd party
-provider. Mailer supports several - install whichever you want:
+Instead of using your own SMTP server or sendmail binary, you can send emails
+via a 3rd party provider:
 
 ==================  ==============================================
 Service             Install with
 ==================  ==============================================
 Amazon SES          ``composer require symfony/amazon-mailer``
-Gmail               ``composer require symfony/google-mailer``
 MailChimp           ``composer require symfony/mailchimp-mailer``
 Mailgun             ``composer require symfony/mailgun-mailer``
 Mailjet             ``composer require symfony/mailjet-mailer``
@@ -121,6 +119,14 @@ SendGrid            ``composer require symfony/sendgrid-mailer``
 Sendinblue          ``composer require symfony/sendinblue-mailer``
 OhMySMTP            ``composer require symfony/oh-my-smtp-mailer``
 ==================  ==============================================
+
+.. note::
+
+    As a convenience, Symfony also provides support for Gmail (``composer
+    require symfony/google-mailer``), but this should not be used in
+    production. In development, you should probably use an :ref:`email catcher
+    <mail-catcher>` instead. Note that most supported providers also provide a
+    free tier.
 
 .. versionadded:: 5.2
 
@@ -1403,6 +1409,17 @@ is sent::
 
 Development & Debugging
 -----------------------
+
+.. _mail-catcher:
+
+Enabling an Email Catcher
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When developing locally, it is recommended to use an email catcher. If you have
+enabled Docker support via Symfony recipes, an email catcher is automatically
+configured. In addition, if you are using the :doc:`Symfony local web server
+</setup/symfony_server>`, the mailer DSN is automatically exposed via the
+:ref:`symfony binary Docker integration <symfony-server-docker>`.
 
 Disabling Delivery
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We have many people complaining about the difficulty to set up Gmail. But we should recommend not using it as this is not a good way to send emails from an application. I've also added a note about using an email catcher as I think this is the way to go in development (and automatically configured nowadays via our Docker integration).
