### PR TITLE
Hotfix Expression language example lower than

### DIFF
--- a/components/expression_language.rst
+++ b/components/expression_language.rst
@@ -41,7 +41,7 @@ way without using PHP and without introducing security problems:
     article.commentCount > 100 and article.category not in ["misc"]
 
     # Send an alert when
-    product.stock < 15
+    product.stock &lt; 15
 
 Expressions can be seen as a very restricted PHP sandbox and are immune to
 external injections as you must explicitly declare which variables are available


### PR DESCRIPTION
On this page https://symfony.com/doc/current/components/expression_language.html#how-can-the-expression-engine-help-me


`product.stock < 15` is not correctly displayed. I see `product.stock  15`

Examining html code is `<code>...product.stock  15</code>`.

Locally generated code is `<pre class="hljs text">...product.stock < 15...</pre>`


I found some places where `&lt` is used, I think it could fix rendering.
There is no other .rst file where `<` is used 