### PR TITLE
Tell composer action is need to regenerate autoload

### DIFF
--- a/components/runtime.rst
+++ b/components/runtime.rst
@@ -329,6 +329,9 @@ You can also configure ``extra.runtime`` in ``composer.json``:
         }
     }
 
+Then, update your Composer files (running ``composer dump-autoload``, for instance),
+so that the ``vendor/autoload_runtime.php`` files gets regenerated with the new option.
+
 The following options are supported by the ``SymfonyRuntime``:
 
 ``env`` (default: ``APP_ENV`` environment variable, or ``"dev"``)

--- a/configuration/override_dir_structure.rst
+++ b/configuration/override_dir_structure.rst
@@ -49,7 +49,7 @@ define the ``runtime.dotenv_path`` option in the ``composer.json`` file:
         }
     }
 
-Then, update your Composer files (running ``composer update``, for instance),
+Then, update your Composer files (running ``composer dump-autoload``, for instance),
 so that the ``vendor/autoload_runtime.php`` files gets regenerated with the new
 ``.env`` path.
 


### PR DESCRIPTION
Lost some time to understand why editing composer.json extra does not affect `autoload_runtime`

https://symfony.com/doc/current/configuration/override_dir_structure.html#override-the-environment-dotenv-files-directory has this sentence

I added this sentence to https://symfony.com/doc/current/components/runtime.html#using-options