### PR TITLE
[Contributing] [Code] Add a step for forking in "Proposing a Change"

### DIFF
--- a/contributing/code/pull_requests.rst
+++ b/contributing/code/pull_requests.rst
@@ -87,6 +87,8 @@ Get the Symfony source code:
 
 * Fork the `Symfony repository`_ (click on the "Fork" button);
 
+* Uncheck the "Copy the ``X.Y`` branch only";
+
 * After the "forking action" has completed, clone your fork locally
   (this will create a ``symfony`` directory):
 


### PR DESCRIPTION
In order to improve the Developer Experience for a new contributor, especially a beginner, the documentation should ask him to uncheck the "Copy the ``X.Y`` branch only" option when he forks the Symfony repository from the GitHub website.

If he does not uncheck this option, he will not be able to switch branch to work on the right version of the framework while the documentation asks him to do so (step 3, section ["Choose the right Branch"](https://symfony.com/doc/current/contributing/code/pull_requests.html#choose-the-right-branch)).

