### PR TITLE
[Mailer] Add a way to change the Bus transport dynamically

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1333,6 +1333,18 @@ disable asynchronous delivery.
     The :method:`Symfony\\Component\\Mailer\\Transport\\Smtp\\SmtpTransport::stop`
     method was made public in Symfony 6.1.
 
+Bus transport can also be selected by
+adding an ``X-Bus-Transport`` header (which will remove automatically from
+the final message)::
+
+    // Use the bus transport "app.another_bus":
+    $email->getHeaders()->addTextHeader('X-Bus-Transport', 'app.another_bus');
+    $mailer->send($email);
+
+.. versionadded:: 6.2
+
+    The ``X-Bus-Transport`` header support was introduced in Symfony 6.2.
+
 Adding Tags and Metadata to Emails
 ----------------------------------
 


### PR DESCRIPTION
Try complete #17127 


I took example on `X-Transport` header https://symfony.com/doc/current/mailer.html#multiple-email-transports