### PR TITLE
[Form] Fix choice_label

### DIFF
--- a/reference/forms/types/enum.rst
+++ b/reference/forms/types/enum.rst
@@ -63,7 +63,7 @@ dots or spaces). If you need more flexibility for these labels, use the
 
     ->add('textAlign', EnumType::class, [
         'class' => TextAlign::class,
-        'choice_label' => match ($choice) {
+        'choice_label' => fn ($choice) => match ($choice) {
             TextAlign::Left => 'text_align.left.label',
             TextAlign::Center => 'text_align.center.label',
             TextAlign::Right  => 'text_align.right.label',


### PR DESCRIPTION
`match` cannot by used directly by `choice_label` as the `$choice` variable does not exist