### PR TITLE
[Notifier] do not display todo doc on site

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -749,9 +749,9 @@ all configured texter and chatter transports only in the ``dev`` (and/or
                 slack: 'null://null'
 
 .. TODO
-    - Using the message bus for asynchronous notification
-    - Describe notifier monolog handler
-    - Describe notification_on_failed_messages integration
+..    - Using the message bus for asynchronous notification
+..    - Describe notifier monolog handler
+..    - Describe notification_on_failed_messages integration
 
 Learn more
 ----------


### PR DESCRIPTION
I've noticed on bottom of [Notifier page](https://symfony.com/doc/5.4/notifier.html) a todo block displayed on site, just a small change to hide it