### PR TITLE
Remove not needed tip from 'How to Upload Files'

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -213,21 +213,6 @@ You can use the following code to link to the PDF brochure of a product:
 
     <a href="{{ asset('uploads/brochures/' ~ product.brochureFilename) }}">View brochure (PDF)</a>
 
-.. tip::
-
-    When creating a form to edit an already persisted item, the file form type
-    still expects a :class:`Symfony\\Component\\HttpFoundation\\File\\File`
-    instance. As the persisted entity now contains only the relative file path,
-    you first have to concatenate the configured upload path with the stored
-    filename and create a new ``File`` class::
-
-        use Symfony\Component\HttpFoundation\File\File;
-        // ...
-
-        $product->setBrochureFilename(
-            new File($this->getParameter('brochures_directory').'/'.$product->getBrochureFilename())
-        );
-
 Creating an Uploader Service
 ----------------------------
 


### PR DESCRIPTION
> When creating a form to edit an already persisted item, the file form type
>     still expects a :class:`Symfony\\Component\\HttpFoundation\\File\\File`
>     instance.

The file form type is not mapped so it doesn't matter.

`$product->setBrochureFilename()` this expects a string, not a `File` instance.

Actually when you edit already persisted item you don't need to pass anything to `$product->setBrochureFilename()` since this field is not actually in the form type and it won't get handled (which is fine). The suggested tip is not needed.