### PR TITLE
[BrowserKit] reinitialize server parameters on restart

### DIFF
--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -295,7 +295,7 @@ history::
     $crawler = $client->forward();
 
 You can delete the client's history with the ``restart()`` method. This will
-also delete all the cookies, and reinitialize the $_SERVER parameters (e.g. HTTP headers)::
+also delete all the cookies, and reinitialize the ``$_SERVER`` parameters (e.g. HTTP headers)::
 
     use Acme\Client;
 

--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -295,14 +295,14 @@ history::
     $crawler = $client->forward();
 
 You can delete the client's history with the ``restart()`` method. This will
-also delete all the cookies::
+also delete all the cookies, and reinitialize the $_SERVER parameters (e.g. HTTP headers)::
 
     use Acme\Client;
 
     $client = new Client();
     $client->request('GET', '/');
 
-    // reset the client (history and cookies are cleared too)
+    // reset the client (history, cookies and $_SERVER parameters are cleared too)
     $client->restart();
 
 .. _component-browserkit-external-requests:


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
