### PR TITLE
[Doctrine] Adds information on AsEntityListener attribute to the Doctrine event …

### DIFF
--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -353,6 +353,30 @@ with the ``doctrine.orm.entity_listener`` tag:
             ;
         };
 
+
+Doctrine Entity Listeners may also be defined using PHP attributes.  When using PHP attributes it is not necessary to create a service for the listener.
+
+    .. code-block:: php
+
+        // src/EventListener/UserChangedNotifier.php
+        namespace App\EventListener;
+
+        use App\Entity\User;
+        use Doctrine\Persistence\Event\LifecycleEventArgs;
+        use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+
+        #[AsEntityListener(event:'postUpdate',  method:'postUpdate', entity:User::class)]
+        class UserChangedNotifier
+        {
+            // the entity listener methods receive two arguments:
+            // the entity instance and the lifecycle event
+            public function postUpdate(User $user, LifecycleEventArgs $event): void
+            {
+                // ... do something to notify the changes
+            }
+        }
+
+
 Doctrine Lifecycle Subscribers
 ------------------------------
 


### PR DESCRIPTION
Doctrine Entity Listeners can also now be defined using the AsEntityListener attribute. 

This does not require the additional step of creating a service.

Documentation about this is missing from the documentation here (https://symfony.com/doc/current/doctrine/events.html#doctrine-entity-listeners).

This PR adds this to the Doctrine Entity Listeners documentation.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
