### PR TITLE
Update getContainerExtension()

### DIFF
--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -54,10 +54,11 @@ method to return the instance of the extension::
 
     // ...
     use Acme\HelloBundle\DependencyInjection\UnconventionalExtensionClass;
+    use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
     class AcmeHelloBundle extends Bundle
     {
-        public function getContainerExtension()
+        public function getContainerExtension(): ?ExtensionInterface
         {
             return new UnconventionalExtensionClass();
         }


### PR DESCRIPTION
Since Symfony 6.x call to getContainerExtension() has evolved. Now, it's necessary to set a return type, else it generates this error :
```php
Declaration of Acme\TestBundle\AcmeTestBundle::getContainerExtension() must be compatible with Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension(): ?Symfony\Component\DependencyInjection\Extension\ExtensionInterface
```

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
