### PR TITLE
Fix build by correcting a typo

### DIFF
--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -269,7 +269,7 @@ or directly via PHP attributes:
 
 .. configuration-block::
 
-    .. conde-block:: php-attributes
+    .. code-block:: php-attributes
 
         // src/CommandBus.php
         namespace App;


### PR DESCRIPTION
The docs build is currently failing due to a typo. This PR fixes it