### PR TITLE
Standardize the name of the container configurator variable

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -442,8 +442,8 @@ The end user can provide values in any configuration file:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container) {
-            $container->parameters()
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->parameters()
                 ->set('acme_blog.author.email', 'fabien@example.com')
             ;
         };

--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -145,13 +145,13 @@ registered and the ``entity_manager_name`` setting for ``acme_hello`` is set to
         // config/packages/acme_something.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container) {
-            $container->extension('acme_something', [
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->extension('acme_something', [
                 // ...
                 'use_acme_goodbye' => false,
                 'entity_manager_name' => 'non_default',
             ]);
-            $container->extension('acme_other', [
+            $containerConfigurator->extension('acme_other', [
                 // ...
                 'use_acme_goodbye' => false,
             ]);

--- a/cache.rst
+++ b/cache.rst
@@ -387,8 +387,8 @@ with either :class:`Symfony\\Contracts\\Cache\\CacheInterface` or
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return function(ContainerConfigurator $configurator) {
-                $configurator->services()
+            return function(ContainerConfigurator $containerConfigurator) {
+                $containerConfigurator->services()
                     // ...
 
                     ->set('app.cache.adapter.redis')

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -291,13 +291,13 @@ config files:
 
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container) {
-            $container->parameters()
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->parameters()
                 // ...
                 ->set('mailer.transport', 'sendmail')
             ;
 
-            $services = $container->services();
+            $services = $containerConfigurator->services();
             $services->set('mailer', 'Mailer')
                 ->args(['%mailer.transport%'])
             ;

--- a/components/dependency_injection/_imports-parameters-note.rst.inc
+++ b/components/dependency_injection/_imports-parameters-note.rst.inc
@@ -31,6 +31,6 @@
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (ContainerConfigurator $container) {
-                $container->import('%kernel.project_dir%/somefile.yaml');
+            return static function (ContainerConfigurator $containerConfigurator) {
+                $containerConfigurator->import('%kernel.project_dir%/somefile.yaml');
             };

--- a/components/http_foundation/session_configuration.rst
+++ b/components/http_foundation/session_configuration.rst
@@ -200,8 +200,8 @@ configuration:
         // config/packages/framework.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container) {
-            $container->extension('framework', [
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->extension('framework', [
                 'session' => [
                     'gc_probability' => null,
                 ],

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -998,8 +998,8 @@ faster alternative to the
 
         use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 
-        return static function (ContainerConfigurator $container) {
-            $container->services()
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->services()
                 // ...
                 ->set('get_set_method_normalizer', GetSetMethodNormalizer::class)
                     ->tag('serializer.normalizer')

--- a/components/uid.rst
+++ b/components/uid.rst
@@ -452,7 +452,7 @@ configuration in your application before using these commands:
         use Symfony\Component\Uid\Command\InspectUlidCommand;
         use Symfony\Component\Uid\Command\InspectUuidCommand;
 
-        return static function (ContainerConfigurator $configurator): void {
+        return static function (ContainerConfigurator $containerConfigurator): void {
             // ...
 
             $services

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -147,8 +147,8 @@ the :ref:`dump_destination option <configuration-debug-dump_destination>` of the
         // config/packages/debug.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container) {
-            $container->extension('debug', [
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->extension('debug', [
                 'dump_destination' => 'tcp://%env(VAR_DUMPER_SERVER)%',
             ]);
         };

--- a/configuration.rst
+++ b/configuration.rst
@@ -78,18 +78,18 @@ shown in these three formats.
         {
             // ...
 
-            private function configureContainer(ContainerConfigurator $container): void
+            private function configureContainer(ContainerConfigurator $containerConfigurator): void
             {
                 $configDir = $this->getConfigDir();
 
-                $container->import($configDir.'/{packages}/*.{yaml,php}');
-                $container->import($configDir.'/{packages}/'.$this->environment.'/*.{yaml,php}');
+                $containerConfigurator->import($configDir.'/{packages}/*.{yaml,php}');
+                $containerConfigurator->import($configDir.'/{packages}/'.$this->environment.'/*.{yaml,php}');
 
                 if (is_file($configDir.'/services.yaml')) {
-                    $container->import($configDir.'/services.yaml');
-                    $container->import($configDir.'/{services}_'.$this->environment.'.yaml');
+                    $containerConfigurator->import($configDir.'/services.yaml');
+                    $containerConfigurator->import($configDir.'/{services}_'.$this->environment.'.yaml');
                 } else {
-                    $container->import($configDir.'/{services}.php');
+                    $containerConfigurator->import($configDir.'/{services}.php');
                 }
             }
         }
@@ -163,17 +163,17 @@ configuration files, even if they use a different format:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container) {
-            $container->import('legacy_config.php');
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->import('legacy_config.php');
 
             // glob expressions are also supported to load multiple files
-            $container->import('/etc/myapp/*.yaml');
+            $containerConfigurator->import('/etc/myapp/*.yaml');
 
             // the third optional argument of import() is 'ignore_errors'
             // 'ignore_errors' set to 'not_found' silently discards errors if the loaded file doesn't exist
-            $container->import('my_config_file.yaml', null, 'not_found');
+            $containerConfigurator->import('my_config_file.yaml', null, 'not_found');
             // 'ignore_errors' set to true silently discards all errors (including invalid code and not found)
-            $container->import('my_config_file.yaml', null, true);
+            $containerConfigurator->import('my_config_file.yaml', null, true);
         };
 
         // ...
@@ -262,8 +262,8 @@ reusable configuration value. By convention, parameters are defined under the
 
         use App\Entity\BlogPost;
 
-        return static function (ContainerConfigurator $container) {
-            $container->parameters()
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->parameters()
                 // the parameter name is an arbitrary string (the 'app.' prefix is recommended
                 // to better differentiate your parameters from Symfony parameters).
                 ->set('app.admin_email', 'something@example.com')
@@ -334,8 +334,8 @@ configuration file using a special syntax: wrap the parameter name in two ``%``
         // config/packages/some_package.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container) {
-            $container->extension('some_package', [
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->extension('some_package', [
                 // any string surrounded by two % is replaced by that parameter value
                 'email_address' => '%app.admin_email%',
 
@@ -371,8 +371,8 @@ configuration file using a special syntax: wrap the parameter name in two ``%``
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (ContainerConfigurator $container) {
-                $container->parameters()
+            return static function (ContainerConfigurator $containerConfigurator) {
+                $containerConfigurator->parameters()
                     ->set('url_pattern', 'http://symfony.com/?foo=%%s&amp;bar=%%d');
             };
 
@@ -508,7 +508,7 @@ files directly in the ``config/packages/`` directory.
             use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
             use Symfony\Config\WebpackEncoreConfig;
 
-            return static function (WebpackEncoreConfig $webpackEncore, ContainerConfigurator $container) {
+            return static function (WebpackEncoreConfig $webpackEncore, ContainerConfigurator $containerConfigurator) {
                 $webpackEncore
                     ->outputPath('%kernel.project_dir%/public/build')
                     ->strictMode(true)
@@ -516,12 +516,12 @@ files directly in the ``config/packages/`` directory.
                 ;
 
                 // cache is enabled only in the "prod" environment
-                if ('prod' === $container->env()) {
+                if ('prod' === $containerConfigurator->env()) {
                     $webpackEncore->cache(true);
                 }
 
                 // disable strict mode only in the "test" environment
-                if ('test' === $container->env()) {
+                if ('test' === $containerConfigurator->env()) {
                     $webpackEncore->strictMode(false);
                 }
             };
@@ -642,8 +642,8 @@ This example shows how you could configure the database connection using an env 
         // config/packages/doctrine.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container) {
-            $container->extension('doctrine', [
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->extension('doctrine', [
                 'dbal' => [
                     // by convention the env var names are always uppercase
                     'url' => env('DATABASE_URL')->resolve(),
@@ -991,8 +991,8 @@ doesn't work for parameters:
 
         use App\Service\MessageGenerator;
 
-        return static function (ContainerConfigurator $container) {
-            $container->parameters()
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->parameters()
                 ->set('app.contents_dir', '...');
 
             $container->services()
@@ -1048,8 +1048,8 @@ whenever a service/controller defines a ``$projectDir`` argument, use this:
 
         use App\Controller\LuckyController;
 
-        return static function (ContainerConfigurator $container) {
-            $container->services()
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->services()
                 ->defaults()
                     // pass this value to any $projectDir argument for any service
                     // that's created in this file (including controller arguments)

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -43,10 +43,10 @@ Next, create an ``index.php`` file that defines the kernel class and runs it::
             ];
         }
 
-        protected function configureContainer(ContainerConfigurator $c): void
+        protected function configureContainer(ContainerConfigurator $containerConfigurator): void
         {
             // PHP equivalent of config/packages/framework.yaml
-            $c->extension('framework', [
+            $containerConfigurator->extension('framework', [
                 'secret' => 'S0ME_SECRET'
             ]);
         }
@@ -88,7 +88,7 @@ that define your bundles, your services and your routes:
 **registerBundles()**
     This is the same ``registerBundles()`` that you see in a normal kernel.
 
-**configureContainer(ContainerConfigurator $c)**
+**configureContainer(ContainerConfigurator $containerConfigurator)**
     This method builds and configures the container. In practice, you will use
     ``extension()`` to configure different bundles (this is the equivalent
     of what you see in a normal ``config/packages/*`` file). You can also register
@@ -191,12 +191,12 @@ hold the kernel. Now it looks like this::
             return $bundles;
         }
 
-        protected function configureContainer(ContainerConfigurator $c): void
+        protected function configureContainer(ContainerConfigurator $containerConfigurator): void
         {
-            $c->import(__DIR__.'/../config/framework.yaml');
+            $containerConfigurator->import(__DIR__.'/../config/framework.yaml');
 
             // register all classes in /src/ as service
-            $c->services()
+            $containerConfigurator->services()
                 ->load('App\\', __DIR__.'/*')
                 ->autowire()
                 ->autoconfigure()
@@ -204,7 +204,7 @@ hold the kernel. Now it looks like this::
 
             // configure WebProfilerBundle only if the bundle is enabled
             if (isset($this->bundles['WebProfilerBundle'])) {
-                $c->extension('web_profiler', [
+                $containerConfigurator->extension('web_profiler', [
                     'toolbar' => true,
                     'intercept_redirects' => false,
                 ]);

--- a/configuration/multiple_kernels.rst
+++ b/configuration/multiple_kernels.rst
@@ -106,16 +106,16 @@ files so they don't collide with the files from ``src/Kernel.php``::
             return $this->getProjectDir().'/var/log/api';
         }
 
-        protected function configureContainer(ContainerConfigurator $container): void
+        protected function configureContainer(ContainerConfigurator $containerConfigurator): void
         {
-            $container->import('../config/api/{packages}/*.yaml');
-            $container->import('../config/api/{packages}/'.$this->environment.'/*.yaml');
+            $containerConfigurator->import('../config/api/{packages}/*.yaml');
+            $containerConfigurator->import('../config/api/{packages}/'.$this->environment.'/*.yaml');
 
             if (is_file(\dirname(__DIR__).'/config/api/services.yaml')) {
-                $container->import('../config/api/services.yaml');
-                $container->import('../config/api/{services}_'.$this->environment.'.yaml');
+                $containerConfigurator->import('../config/api/services.yaml');
+                $containerConfigurator->import('../config/api/{services}_'.$this->environment.'.yaml');
             } else {
-                $container->import('../config/api/{services}.php');
+                $containerConfigurator->import('../config/api/{services}.php');
             }
         }
 

--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -233,8 +233,8 @@ and adding a priority.
 
         use App\ArgumentResolver\UserValueResolver;
 
-        return static function (ContainerConfigurator $container) {
-            $services = $configurator->services();
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(UserValueResolver::class)
                 ->tag('controller.argument_value_resolver', ['priority' => 50])

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -321,8 +321,8 @@ Then, define a service for this class:
 
         use App\Service\FileUploader;
 
-        return static function (ContainerConfigurator $container) {
-            $services = $configurator->services();
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(FileUploader::class)
                 ->arg('$targetDirectory', '%brochures_directory%')

--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -227,8 +227,8 @@ with the ``doctrine.event_listener`` tag:
 
         use App\EventListener\SearchIndexer;
 
-        return static function (ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             // listeners are applied by default to all Doctrine connections
             $services->set(SearchIndexer::class)
@@ -360,8 +360,8 @@ with the ``doctrine.orm.entity_listener`` tag:
         use App\Entity\User;
         use App\EventListener\UserChangedNotifier;
 
-        return static function (ContainerConfigurator $container) {
-            $services = $configurator->services();
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(UserChangedNotifier::class)
                 ->tag('doctrine.orm.entity_listener', [
@@ -501,8 +501,8 @@ Doctrine connection to use) you must do that in the manual service configuration
 
         use App\EventListener\DatabaseActivitySubscriber;
 
-        return static function (ContainerConfigurator $container) {
-            $services = $configurator->services();
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(DatabaseActivitySubscriber::class)
                 ->tag('doctrine.event_subscriber'[

--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -104,8 +104,8 @@ using a special "tag":
 
         use App\EventListener\ExceptionListener;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(ExceptionListener::class)
                 ->tag('kernel.event_listener', ['event' => 'kernel.exception'])

--- a/frontend/custom_version_strategy.rst
+++ b/frontend/custom_version_strategy.rst
@@ -144,8 +144,8 @@ After creating the strategy PHP class, register it as a Symfony service.
         use App\Asset\VersionStrategy\GulpBusterVersionStrategy;
         use Symfony\Component\DependencyInjection\Definition;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(GulpBusterVersionStrategy::class)
                 ->args(

--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -207,8 +207,8 @@ you can determine the message bus based on an implemented interface:
         use App\MessageHandler\CommandHandlerInterface;
         use App\MessageHandler\QueryHandlerInterface;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             // ...
 

--- a/profiler/data_collector.rst
+++ b/profiler/data_collector.rst
@@ -290,8 +290,8 @@ you'll need to configure the data collector explicitly:
 
         use App\DataCollector\RequestCollector;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(RequestCollector::class)
                 ->tag('data_collector', [

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -122,8 +122,8 @@ services:
         use App\Lock\PostgresqlLock;
         use App\Lock\SqliteLock;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set('app.mysql_lock', MysqlLock::class);
             $services->set('app.postgresql_lock', PostgresqlLock::class);
@@ -184,8 +184,8 @@ the generic ``app.lock`` service can be defined as follows:
         use App\Lock\PostgresqlLock;
         use App\Lock\SqliteLock;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set('app.mysql_lock', MysqlLock::class);
             $services->set('app.postgresql_lock', PostgresqlLock::class);

--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -331,8 +331,8 @@ Now define a service for the ``ExtraLoader``:
 
         use App\Routing\ExtraLoader;
 
-        return static function (ContainerConfigurator $container) {
-            $services = $configurator->services();
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(ExtraLoader::class)
                 ->tag('routing.loader')

--- a/security.rst
+++ b/security.rst
@@ -2601,8 +2601,8 @@ for these events.
 
             use App\EventListener\LogoutSubscriber;
 
-            return function(ContainerConfigurator $configurator) {
-                $services = $configurator->services();
+            return function(ContainerConfigurator $containerConfigurator) {
+                $services = $containerConfigurator->services();
 
                 $services->set(LogoutSubscriber::class)
                     ->tag('kernel.event_subscriber', [

--- a/service_container.rst
+++ b/service_container.rst
@@ -212,9 +212,9 @@ each time you ask for it.
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return function(ContainerConfigurator $configurator) {
+            return function(ContainerConfigurator $containerConfigurator) {
                 // default configuration for services in *this* file
-                $services = $configurator->services()
+                $services = $containerConfigurator->services()
                     ->defaults()
                         ->autowire()      // Automatically injects dependencies in your services.
                         ->autoconfigure() // Automatically registers your services as commands, event subscribers, etc.
@@ -505,7 +505,7 @@ pass here. No problem! In your configuration, you can explicitly set this argume
 
         use App\Service\SiteUpdateManager;
 
-        return function(ContainerConfigurator $configurator) {
+        return function(ContainerConfigurator $containerConfigurator) {
             // ...
 
             // same as before
@@ -580,8 +580,8 @@ parameter and in PHP config use the ``service()`` function:
 
         use App\Service\MessageGenerator;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(MessageGenerator::class)
                 // In versions earlier to Symfony 5.1 the service() function was called ref()
@@ -687,7 +687,7 @@ But, you can control this and pass in a different logger:
 
         use App\Service\MessageGenerator;
 
-        return function(ContainerConfigurator $configurator) {
+        return function(ContainerConfigurator $containerConfigurator) {
             // ... same code as before
 
             // explicitly configure the service
@@ -788,8 +788,8 @@ You can also use the ``bind`` keyword to bind specific arguments by name or type
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\DependencyInjection\Reference;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services()
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services()
                 ->defaults()
                     // pass this value to any $adminEmail argument for any service
                     // that's defined in this file (including controller arguments)
@@ -923,7 +923,7 @@ setting:
 
         use App\Service\PublicService;
 
-        return function(ContainerConfigurator $configurator) {
+        return function(ContainerConfigurator $containerConfigurator) {
             // ... same as code before
 
             // explicitly configure the service
@@ -980,7 +980,7 @@ key. For example, the default Symfony configuration contains this:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $configurator) {
+        return function(ContainerConfigurator $containerConfigurator) {
             // ...
 
             // makes classes in src/ available to be used as services
@@ -1162,7 +1162,7 @@ admin email. In this case, each needs to have a unique service id:
         use App\Service\MessageGenerator;
         use App\Service\SiteUpdateManager;
 
-        return function(ContainerConfigurator $configurator) {
+        return function(ContainerConfigurator $containerConfigurator) {
             // ...
 
             // site_update_manager.superadmin is the service's id

--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -58,8 +58,8 @@ You can also control the ``public`` option on a service-by-service basis:
 
         use App\Service\Foo;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(Foo::class)
                 ->public();
@@ -130,8 +130,8 @@ services.
 
         use App\Mail\PhpMailer;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(PhpMailer::class)
                 ->private();
@@ -278,8 +278,8 @@ The following example shows how to inject an anonymous service into another serv
         use App\AnonymousBar;
         use App\Foo;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(Foo::class)
                 // In versions earlier to Symfony 5.1 the inline_service() function was called inline()
@@ -330,8 +330,8 @@ Using an anonymous service as a factory looks like this:
         use App\AnonymousBar;
         use App\Foo;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(Foo::class)
                 ->factory([inline_service(AnonymousBar::class), 'constructFoo']);
@@ -376,8 +376,8 @@ or you decided not to maintain it anymore), you can deprecate its definition:
 
         use App\Service\OldService;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(OldService::class)
                 ->deprecate(

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -107,8 +107,8 @@ both services:
     .. code-block:: php
 
         // config/services.php
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services()
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services()
                 ->defaults()
                     ->autowire()
                     ->autoconfigure()
@@ -246,7 +246,7 @@ adding a service alias:
 
         use App\Util\Rot13Transformer;
 
-        return function(ContainerConfigurator $configurator) {
+        return function(ContainerConfigurator $containerConfigurator) {
             // ...
 
             // the id is not a class, so it won't be used for autowiring
@@ -353,7 +353,7 @@ To fix that, add an :ref:`alias <service-autowiring-alias>`:
         use App\Util\Rot13Transformer;
         use App\Util\TransformerInterface;
 
-        return function(ContainerConfigurator $configurator) {
+        return function(ContainerConfigurator $containerConfigurator) {
             // ...
 
             $services->set(Rot13Transformer::class);
@@ -497,7 +497,7 @@ the injection::
         use App\Util\TransformerInterface;
         use App\Util\UppercaseTransformer;
 
-        return function(ContainerConfigurator $configurator) {
+        return function(ContainerConfigurator $containerConfigurator) {
             // ...
 
             $services->set(Rot13Transformer::class)->autowire();

--- a/service_container/calls.rst
+++ b/service_container/calls.rst
@@ -69,7 +69,7 @@ To configure the container to call the ``setLogger`` method, use the ``calls`` k
 
         use App\Service\MessageGenerator;
 
-        return function(ContainerConfigurator $configurator) {
+        return function(ContainerConfigurator $containerConfigurator) {
             // ...
 
             $services->set(MessageGenerator::class)

--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -172,8 +172,8 @@ all the classes are already loaded as services. All you need to do is specify th
         use App\Mail\GreetingCardManager;
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             // Registers all 4 classes as services, including App\Mail\EmailConfigurator
             $services->load('App\\', '../src/*');
@@ -242,8 +242,8 @@ Services can be configured via invokable configurators (replacing the
         use App\Mail\GreetingCardManager;
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             // Registers all 4 classes as services, including App\Mail\EmailConfigurator
             $services->load('App\\', '../src/*');

--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -61,7 +61,7 @@ to another service: ``App\Mailer``. One way to do this is with an expression:
         use App\Mail\MailerConfiguration;
         use App\Mailer;
 
-        return function(ContainerConfigurator $configurator) {
+        return function(ContainerConfigurator $containerConfigurator) {
             // ...
 
             $services->set(MailerConfiguration::class);
@@ -116,8 +116,8 @@ via a ``container`` variable. Here's another example:
 
         use App\Mailer;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(Mailer::class)
                 ->args([expr("container.hasParameter('some_param') ? parameter('some_param') : 'default_value'")]);

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -83,8 +83,8 @@ create its object:
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerStaticFactory;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(NewsletterManager::class)
                 // the first argument is the class and the second argument is the static method
@@ -154,8 +154,8 @@ Configuration of the service container then looks like this:
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerFactory;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             // first, create a service for the factory
             $services->set(NewsletterManagerFactory::class);
@@ -233,8 +233,8 @@ method name:
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerFactory;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(NewsletterManager::class)
                 ->factory(service(InvokableNewsletterManagerFactory::class));
@@ -293,8 +293,8 @@ previous examples takes the ``templating`` service as an argument:
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerFactory;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(NewsletterManager::class)
                 ->factory([service(NewsletterManagerFactory::class), 'createNewsletterManager'])

--- a/service_container/import.rst
+++ b/service_container/import.rst
@@ -123,12 +123,12 @@ a relative or absolute path to the imported file:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $configurator) {
-            $configurator->import('services/mailer.php');
+        return function(ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->import('services/mailer.php');
             // If you want to import a whole directory:
-            $configurator->import('services/');
+            $containerConfigurator->import('services/');
 
-            $services = $configurator->services()
+            $services = $containerConfigurator->services()
                 ->defaults()
                     ->autowire()
                     ->autoconfigure()

--- a/service_container/injection_types.rst
+++ b/service_container/injection_types.rst
@@ -74,8 +74,8 @@ service container configuration:
 
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(NewsletterManager::class)
                 // In versions earlier to Symfony 5.1 the service() function was called ref()
@@ -277,8 +277,8 @@ that accepts the dependency::
 
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(NewsletterManager::class)
                 ->call('setMailer', [service('mailer')]);
@@ -359,8 +359,8 @@ Another possibility is setting public fields of the class directly::
 
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set('app.newsletter_manager', NewsletterManager::class)
                 ->property('mailer', service('mailer'));

--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -76,8 +76,8 @@ You can mark the service as ``lazy`` by manipulating its definition:
 
         use App\Twig\AppExtension;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(AppExtension::class)->lazy();
         };
@@ -150,8 +150,8 @@ specific interfaces.
         use App\Twig\AppExtension;
         use Twig\Extension\ExtensionInterface;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(AppExtension::class)
                 ->lazy()

--- a/service_container/optional_dependencies.rst
+++ b/service_container/optional_dependencies.rst
@@ -38,8 +38,8 @@ if the service does not exist:
 
         use App\Newsletter\NewsletterManager;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(NewsletterManager::class)
                 // In versions earlier to Symfony 5.1 the service() function was called ref()
@@ -95,8 +95,8 @@ call if the service exists and remove the method call if it does not:
 
         use App\Newsletter\NewsletterManager;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(NewsletterManager::class)
                 ->call('setLogger', [service('logger')->ignoreOnInvalid()])

--- a/service_container/parent_services.rst
+++ b/service_container/parent_services.rst
@@ -122,8 +122,8 @@ avoid duplicated service definitions:
         use App\Repository\DoctrinePostRepository;
         use App\Repository\DoctrineUserRepository;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(BaseDoctrineRepository::class)
                 ->abstract()
@@ -232,8 +232,8 @@ the child class:
         use App\Repository\DoctrineUserRepository;
         // ...
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(BaseDoctrineRepository::class)
                 // ...

--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -44,8 +44,8 @@ When overriding an existing definition, the original service is lost:
         use App\Mailer;
         use App\NewMailer;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(Mailer::class);
 
@@ -101,8 +101,8 @@ but keeps a reference of the old one as ``.inner``:
         use App\DecoratingMailer;
         use App\Mailer;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(Mailer::class);
 
@@ -164,8 +164,8 @@ automatically changed to ``'.inner'``):
         use App\DecoratingMailer;
         use App\Mailer;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(Mailer::class);
 
@@ -236,8 +236,8 @@ automatically changed to ``'.inner'``):
             use App\DecoratingMailer;
             use App\Mailer;
 
-            return function(ContainerConfigurator $configurator) {
-                $services = $configurator->services();
+            return function(ContainerConfigurator $containerConfigurator) {
+                $services = $containerConfigurator->services();
 
                 $services->set(Mailer::class);
 
@@ -298,8 +298,8 @@ the ``decoration_priority`` option. Its value is an integer that defaults to
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(\Foo::class);
 
@@ -385,8 +385,8 @@ ordered services, each one decorating the next:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container) {
-            $container->services()
+        return function(ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->services()
                 ->stack('decorated_foo_stack', [
                     inline_service(\Baz::class)->args([service('.inner')]),
                     inline_service(\Bar::class)->args([service('.inner')]),
@@ -468,8 +468,8 @@ advanced example of composition:
         use App\Decorated;
         use App\Decorator;
 
-        return function(ContainerConfigurator $container) {
-            $container->services()
+        return function(ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->services()
                 ->set('some_decorator', Decorator::class)
 
                 ->stack('embedded_stack', [
@@ -586,8 +586,8 @@ Three different behaviors are available:
 
         use Symfony\Component\DependencyInjection\ContainerInterface;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(Foo::class);
 

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -231,8 +231,8 @@ service type to a service.
 
         use App\CommandBus;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(CommandBus::class)
                 ->tag('container.service_subscriber', ['key' => 'logger', 'id' => 'monolog.logger.event']);
@@ -323,8 +323,8 @@ or directly via PHP attributes:
 
         use App\CommandBus;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(CommandBus::class)
                 ->args([service_locator([
@@ -409,8 +409,8 @@ other services. To do so, create a new service definition using the
 
         use Symfony\Component\DependencyInjection\ServiceLocator;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set('app.command_handler_locator', ServiceLocator::class)
                 // In versions earlier to Symfony 5.1 the service() function was called ref()
@@ -471,8 +471,8 @@ Now you can inject the service locator in any other services:
 
         use App\CommandBus;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(CommandBus::class)
                 ->args([service('app.command_handler_locator')]);
@@ -562,8 +562,8 @@ of the ``key`` tag attribute (as defined in the ``index_by`` locator option):
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(App\Handler\One::class)
                 ->tag('app.handler', ['key' => 'handler_one'])
@@ -652,8 +652,8 @@ attribute to the locator service defining the name of this custom method:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $configurator) {
-            $configurator->services()
+        return function(ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->services()
                 ->set(App\HandlerCollection::class)
                     ->args([tagged_locator('app.handler', 'key', 'myOwnMethodName')])
             ;

--- a/service_container/shared.rst
+++ b/service_container/shared.rst
@@ -36,8 +36,8 @@ in your service definition:
 
         use App\SomeNonSharedService;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(SomeNonSharedService::class)
                 ->share(false);

--- a/service_container/synthetic_services.rst
+++ b/service_container/synthetic_services.rst
@@ -66,8 +66,8 @@ configuration:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             // synthetic services don't specify a class
             $services->set('app.synthetic_service')

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -41,8 +41,8 @@ example:
 
         use App\Twig\AppExtension;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(AppExtension::class)
                 ->tag('twig.extension');
@@ -107,8 +107,8 @@ If you want to apply tags automatically for your own services, use the
 
         use App\Security\CustomInterface;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             // this config only applies to the services created by this file
             $services
@@ -217,8 +217,8 @@ Then, define the chain as a service:
 
         use App\Mail\TransportChain;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(TransportChain::class);
         };
@@ -271,8 +271,8 @@ For example, you may add the following transports as services:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(\MailerSmtpTransport::class)
                 // the param() method was introduced in Symfony 5.2.
@@ -438,8 +438,8 @@ To answer this, change the service declaration:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(\MailerSmtpTransport::class)
                 // the param() method was introduced in Symfony 5.2.
@@ -590,8 +590,8 @@ directly via PHP attributes:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(App\Handler\One::class)
                 ->tag('app.handler')
@@ -655,8 +655,8 @@ the number, the earlier the tagged service will be located in the collection:
 
         use App\Handler\One;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(One::class)
                 ->tag('app.handler', ['priority' => 20])
@@ -715,8 +715,8 @@ you can define it in the configuration of the collecting service:
 
         use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 
-        return function (ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             // ...
 
@@ -787,8 +787,8 @@ indexed by the ``key`` attribute:
         use App\Handler\Two;
         use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 
-        return function (ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(One::class)
                 ->tag('app.handler', ['key' => 'handler_one']);
@@ -885,8 +885,8 @@ array element. For example, to retrieve the ``handler_two`` handler::
             use App\HandlerCollection;
             use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 
-            return function (ContainerConfigurator $configurator) {
-                $services = $configurator->services();
+            return function (ContainerConfigurator $containerConfigurator) {
+                $services = $containerConfigurator->services();
 
                 // ...
 

--- a/session.rst
+++ b/session.rst
@@ -240,8 +240,8 @@ your ``Session`` object with the default ``AttributeBag`` by the ``NamespacedAtt
         use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
         use Symfony\Component\HttpFoundation\Session\Session;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set('session', Session::class)
                 ->public()

--- a/session/database.rst
+++ b/session/database.rst
@@ -249,8 +249,8 @@ first register a new handler service with your database credentials:
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
-        return static function (ContainerConfigurator $container) {
-            $services = $configurator->services();
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(PdoSessionHandler::class)
                 ->args([
@@ -354,8 +354,8 @@ passed to the ``PdoSessionHandler`` service:
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
-        return static function (ContainerConfigurator $container) {
-            $services = $configurator->services();
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(PdoSessionHandler::class)
                 ->args([
@@ -524,8 +524,8 @@ the MongoDB connection as argument:
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
 
-        return static function (ContainerConfigurator $container) {
-            $services = $configurator->services();
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(MongoDbSessionHandler::class)
                 ->args([
@@ -633,8 +633,8 @@ configure these values with the second argument passed to the
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
 
-        return static function (ContainerConfigurator $container) {
-            $services = $configurator->services();
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(MongoDbSessionHandler::class)
                 ->args([

--- a/testing.rst
+++ b/testing.rst
@@ -360,8 +360,8 @@ the ``test`` environment as follows:
         use App\Contracts\Repository\NewsRepositoryInterface;
         use App\Repository\NewsRepository;
 
-        return static function (ContainerConfigurator $container) {
-            $container->services()
+        return static function (ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->services()
                 // redefine the alias as it should be while making it public
                 ->alias(NewsRepositoryInterface::class, NewsRepository::class)
                     ->public()


### PR DESCRIPTION
#17381

Use always `ContainerConfigurator $containerConfigurator` instead of `$container` or `$configurator`