### PR TITLE
[Form] explain how to use getOrigin()

### DIFF
--- a/components/form.rst
+++ b/components/form.rst
@@ -753,7 +753,8 @@ method to access the list of errors. It returns a
     $errors = $form['firstName']->getErrors();
 
     // a FormErrorIterator instance in a flattened structure
-    // use getOrigin() to determine the form causing the error
+    // use getOrigin() on a child to determine the form causing the error
+    // e.g. $form->getErrors(true)[0]->getOrigin();
     $errors = $form->getErrors(true);
 
     // a FormErrorIterator instance representing the form tree structure


### PR DESCRIPTION
`getOrigin()` should be used on each child but I think it would be too long to explain here.