### PR TITLE
[Validator] Update constraint Type types

### DIFF
--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -206,22 +206,24 @@ This required option defines the type or collection of types allowed for the
 given value. Each type is either the FQCN (fully qualified class name) of some
 PHP class/interface or a valid PHP datatype (checked by PHP's ``is_()`` functions):
 
-* :phpfunction:`array <is_array>`
 * :phpfunction:`bool <is_bool>`
-* :phpfunction:`callable <is_callable>`
-* :phpfunction:`float <is_float>`
-* :phpfunction:`double <is_double>`
+* :phpfunction:`boolean <is_bool>`
 * :phpfunction:`int <is_int>`
-* :phpfunction:`integer <is_integer>`
-* :phpfunction:`iterable <is_iterable>`
-* :phpfunction:`long <is_long>`
-* :phpfunction:`null <is_null>`
+* :phpfunction:`integer <is_int>`
+* :phpfunction:`long <is_int>`
+* :phpfunction:`float <is_float>`
+* :phpfunction:`double <is_float>`
+* :phpfunction:`real <is_float>`
 * :phpfunction:`numeric <is_numeric>`
-* :phpfunction:`object <is_object>`
-* :phpfunction:`real <is_real>`
-* :phpfunction:`resource <is_resource>`
-* :phpfunction:`scalar <is_scalar>`
 * :phpfunction:`string <is_string>`
+* :phpfunction:`scalar <is_scalar>`
+* :phpfunction:`array <is_array>`
+* :phpfunction:`iterable <is_iterable>`
+* :phpfunction:`countable <is_countable>`
+* :phpfunction:`callable <is_callable>`
+* :phpfunction:`object <is_object>`
+* :phpfunction:`resource <is_resource>`
+* :phpfunction:`null <is_null>`
 
 Also, you can use ``ctype_*()`` functions from corresponding
 `built-in PHP extension`_. Consider `a list of ctype functions`_:


### PR DESCRIPTION
Follow of #17665 

New sort is same like code https://github.com/symfony/symfony/blob/ed96673e64ebaca3f47012c230823dcddd59a2ba/src/Symfony/Component/Validator/Constraints/TypeValidator.php#L23-L52

No type is deprecated so for now I think we should document all available types