### PR TITLE
Standardize the name of the container configurator variable 6.1

### DIFF
--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -352,11 +352,11 @@ add this logic to the bundle class directly::
             ;
         }
 
-        public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+        public function loadExtension(array $config, ContainerConfigurator $containerConfigurator, ContainerBuilder $builder): void
         {
             // Contrary to the Extension class, the "$config" variable is already merged
             // and processed. You can use it directly to configure the service container.
-            $container->services()
+            $containerConfigurator->services()
                 ->get('acme.social.twitter_client')
                 ->arg(0, $config['twitter']['client_id'])
                 ->arg(1, $config['twitter']['client_secret'])

--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -131,18 +131,18 @@ method::
 
     class AcmeHelloBundle extends AbstractBundle
     {
-        public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+        public function loadExtension(array $config, ContainerConfigurator $containerConfigurator, ContainerBuilder $builder): void
         {
             // load an XML, PHP or Yaml file
-            $container->import('../config/services.xml');
+            $containerConfigurator->import('../config/services.xml');
 
             // you can also add or replace parameters and services
-            $container->parameters()
+            $containerConfigurator->parameters()
                 ->set('acme_hello.phrase', $config['phrase'])
             ;
 
             if ($config['scream']) {
-                $container->services()
+                $containerConfigurator->services()
                     ->get('acme_hello.printer')
                         ->class(ScreamingPrinter::class)
                 ;

--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -173,7 +173,7 @@ method::
 
     class FooBundle extends AbstractBundle
     {
-        public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
+        public function prependExtension(ContainerConfigurator $containerConfigurator, ContainerBuilder $builder): void
         {
             // prepend
             $builder->prependExtensionConfig('framework', [
@@ -181,12 +181,12 @@ method::
             ]);
 
             // append
-            $container->extension('framework', [
+            $containerConfigurator->extension('framework', [
                 'cache' => ['prefix_seed' => 'foo/bar'],
             ]);
 
             // append from file
-            $container->import('../config/packages/cache.php');
+            $containerConfigurator->import('../config/packages/cache.php');
         }
     }
 

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -93,10 +93,10 @@ Next, create an ``index.php`` file that defines the kernel class and runs it:
                 ];
             }
 
-            protected function configureContainer(ContainerConfigurator $c): void
+            protected function configureContainer(ContainerConfigurator $containerConfigurator): void
             {
                 // PHP equivalent of config/packages/framework.yaml
-                $c->extension('framework', [
+                $containerConfigurator->extension('framework', [
                     'secret' => 'S0ME_SECRET'
                 ]);
             }
@@ -325,7 +325,7 @@ add a service conditionally based on the ``foo`` value::
                 ->end();
         }
 
-        public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+        public function loadExtension(array $config, ContainerConfigurator $containerConfigurator, ContainerBuilder $builder): void
         {
             if ($config['foo']) {
                 $builder->register('foo_service', \stdClass::class);

--- a/notifier.rst
+++ b/notifier.rst
@@ -741,8 +741,8 @@ typical alert levels, which you can implement immediately using:
 
         use Symfony\Component\Notifier\FlashMessage\BootstrapFlashMessageImportanceMapper;
 
-        return function(ContainerConfigurator $configurator) {
-            $configurator->services()
+        return function(ContainerConfigurator $containerConfigurator) {
+            $containerConfigurator->services()
                 ->set('notifier.flash_message_importance_mapper', BootstrapFlashMessageImportanceMapper::class)
             ;
         };

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -298,8 +298,8 @@ e.g. change the service based on a parameter:
         use App\Email\NewsletterManagerInterface;
         use App\Email\NewsletterManagerFactory;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(NewsletterManagerInterface::class)
                 // use the "tracable_newsletter" service when debug is enabled, "newsletter" otherwise.

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -672,8 +672,8 @@ iterator, add the ``exclude`` option:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             // ...
 


### PR DESCRIPTION
Continue https://github.com/symfony/symfony-docs/issues/17381 on 6.1