### PR TITLE
Standardize the name of the container configurator variable 6.2

### DIFF
--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -423,8 +423,8 @@ Symfony provides the following env var processors:
             // config/services.php
             use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-            return static function (ContainerConfigurator $configurator): void {
-                $container = $configurator->services()
+            return static function (ContainerConfigurator $containerConfigurator): void {
+                $container = $containerConfigurator->services()
                     ->set(\RedisCluster::class, \RedisCluster::class)->args([null, '%env(shuffle:csv:REDIS_NODES)%']);
             };
 

--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -183,8 +183,8 @@ order in which user checkers are called::
         use App\Security\AccountEnabledUserChecker;
         use App\Security\APIAccessAllowedUserChecker;
 
-        return function(ContainerConfigurator $configurator) {
-            $services = $configurator->services();
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
 
             $services->set(AccountEnabledUserChecker::class)
                 ->tag('security.user_checker.api', ['priority' => 10])


### PR DESCRIPTION
Continue https://github.com/symfony/symfony-docs/issues/17381 on 6.2