### PR TITLE
Standardize the name of the container builder variable 5.4

### DIFF
--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -221,7 +221,7 @@ force validation (e.g. if an additional option was passed, an exception will be
 thrown)::
 
     // src/Acme/SocialBundle/DependencyInjection/AcmeSocialExtension.php
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $containerBuilder)
     {
         $configuration = new Configuration();
 
@@ -263,15 +263,15 @@ In your extension, you can load this and dynamically set its arguments::
     use Symfony\Component\Config\FileLocator;
     use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $containerBuilder)
     {
-        $loader = new XmlFileLoader($container, new FileLocator(dirname(__DIR__).'/Resources/config'));
+        $loader = new XmlFileLoader($containerBuilder, new FileLocator(dirname(__DIR__).'/Resources/config'));
         $loader->load('services.xml');
 
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $definition = $container->getDefinition('acme.social.twitter_client');
+        $definition = $containerBuilder->getDefinition('acme.social.twitter_client');
         $definition->replaceArgument(0, $config['twitter']['client_id']);
         $definition->replaceArgument(1, $config['twitter']['client_secret']);
     }
@@ -292,7 +292,7 @@ In your extension, you can load this and dynamically set its arguments::
         class AcmeHelloExtension extends ConfigurableExtension
         {
             // note that this method is called loadInternal and not load
-            protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
+            protected function loadInternal(array $mergedConfig, ContainerBuilder $containerBuilder)
             {
                 // ...
             }
@@ -308,7 +308,7 @@ In your extension, you can load this and dynamically set its arguments::
     (e.g. by overriding configurations and using :phpfunction:`isset` to check
     for the existence of a value). Be aware that it'll be very hard to support XML::
 
-        public function load(array $configs, ContainerBuilder $container)
+        public function load(array $configs, ContainerBuilder $containerBuilder)
         {
             $config = [];
             // let resources override the previous set value

--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -38,7 +38,7 @@ This is how the extension of an AcmeHelloBundle should look like::
 
     class AcmeHelloExtension extends Extension
     {
-        public function load(array $configs, ContainerBuilder $container)
+        public function load(array $configs, ContainerBuilder $containerBuilder)
         {
             // ... you'll load the files here later
         }
@@ -93,10 +93,10 @@ For instance, assume you have a file called ``services.xml`` in the
     use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
     // ...
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $containerBuilder)
     {
         $loader = new XmlFileLoader(
-            $container,
+            $containerBuilder,
             new FileLocator(__DIR__.'/../Resources/config')
         );
         $loader->load('services.xml');
@@ -119,7 +119,7 @@ they are compiled when generating the application cache to improve the overall
 performance. Define the list of annotated classes to compile in the
 ``addAnnotatedClassesToCompile()`` method::
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $containerBuilder)
     {
         // ...
 

--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -35,7 +35,7 @@ To give an Extension the power to do this, it needs to implement
     {
         // ...
 
-        public function prepend(ContainerBuilder $container)
+        public function prepend(ContainerBuilder $containerBuilder)
         {
             // ...
         }
@@ -56,15 +56,15 @@ a configuration setting in multiple bundles as well as disable a flag in multipl
 in case a specific other bundle is not registered::
 
     // src/Acme/HelloBundle/DependencyInjection/AcmeHelloExtension.php
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $containerBuilder)
     {
         // get all bundles
-        $bundles = $container->getParameter('kernel.bundles');
+        $bundles = $containerBuilder->getParameter('kernel.bundles');
         // determine if AcmeGoodbyeBundle is registered
         if (!isset($bundles['AcmeGoodbyeBundle'])) {
             // disable AcmeGoodbyeBundle in bundles
             $config = ['use_acme_goodbye' => false];
-            foreach ($container->getExtensions() as $name => $extension) {
+            foreach ($containerBuilder->getExtensions() as $name => $extension) {
                 switch ($name) {
                     case 'acme_something':
                     case 'acme_other':
@@ -74,21 +74,21 @@ in case a specific other bundle is not registered::
                         // note that if the user manually configured
                         // use_acme_goodbye to true in config/services.yaml
                         // then the setting would in the end be true and not false
-                        $container->prependExtensionConfig($name, $config);
+                        $containerBuilder->prependExtensionConfig($name, $config);
                         break;
                 }
             }
         }
 
         // get the configuration of AcmeHelloExtension (it's a list of configuration)
-        $configs = $container->getExtensionConfig($this->getAlias());
+        $configs = $containerBuilder->getExtensionConfig($this->getAlias());
 
         // iterate in reverse to preserve the original order after prepending the config
         foreach (array_reverse($configs) as $config) {
             // check if entity_manager_name is set in the "acme_hello" configuration
             if (isset($config['entity_manager_name'])) {
                 // prepend the acme_something settings with the entity_manager_name
-                $container->prependExtensionConfig('acme_something', [
+                $containerBuilder->prependExtensionConfig('acme_something', [
                     'entity_manager_name' => $config['entity_manager_name'],
                 ]);
             }

--- a/cache.rst
+++ b/cache.rst
@@ -468,14 +468,14 @@ and use that when configuring the pool.
         use Symfony\Component\DependencyInjection\ContainerBuilder;
         use Symfony\Config\FrameworkConfig;
 
-        return static function (ContainerBuilder $container, FrameworkConfig $framework) {
+        return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework) {
             $framework->cache()
                 ->pool('cache.my_redis')
                     ->adapters(['cache.adapter.redis'])
                     ->provider('app.my_custom_redis_provider');
 
 
-            $container->register('app.my_custom_redis_provider', \Redis::class)
+            $containerBuilder->register('app.my_custom_redis_provider', \Redis::class)
                 ->setFactory([RedisAdapter::class, 'createConnection'])
                 ->addArgument('redis://localhost')
                 ->addArgument([

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -64,10 +64,10 @@ A very simple extension may just load configuration files into the container::
 
     class AcmeDemoExtension implements ExtensionInterface
     {
-        public function load(array $configs, ContainerBuilder $container)
+        public function load(array $configs, ContainerBuilder $containerBuilder)
         {
             $loader = new XmlFileLoader(
-                $container,
+                $containerBuilder,
                 new FileLocator(__DIR__.'/../Resources/config')
             );
             $loader->load('services.xml');
@@ -135,7 +135,7 @@ are loaded::
 The values from those sections of the config files are passed into the first
 argument of the ``load()`` method of the extension::
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $containerBuilder)
     {
         $foo = $configs[0]['foo']; //fooValue
         $bar = $configs[0]['bar']; //barValue
@@ -161,7 +161,7 @@ you could access the config value this way::
     use Symfony\Component\Config\Definition\Processor;
     // ...
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $containerBuilder)
     {
         $configuration = new Configuration();
         $processor = new Processor();
@@ -222,13 +222,13 @@ The processed config value can now be added as container parameters as if
 it were listed in a ``parameters`` section of the config file but with the
 additional benefit of merging multiple files and validation of the configuration::
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $containerBuilder)
     {
         $configuration = new Configuration();
         $processor = new Processor();
         $config = $processor->processConfiguration($configuration, $configs);
 
-        $container->setParameter('acme_demo.FOO', $config['foo']);
+        $containerBuilder->setParameter('acme_demo.FOO', $config['foo']);
 
         // ...
     }
@@ -237,14 +237,14 @@ More complex configuration requirements can be catered for in the Extension
 classes. For example, you may choose to load a main service configuration
 file but also load a secondary one only if a certain parameter is set::
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $containerBuilder)
     {
         $configuration = new Configuration();
         $processor = new Processor();
         $config = $processor->processConfiguration($configuration, $configs);
 
         $loader = new XmlFileLoader(
-            $container,
+            $containerBuilder,
             new FileLocator(__DIR__.'/../Resources/config')
         );
         $loader->load('services.xml');
@@ -295,11 +295,11 @@ method is called by implementing
     {
         // ...
 
-        public function prepend(ContainerBuilder $container)
+        public function prepend(ContainerBuilder $containerBuilder)
         {
             // ...
 
-            $container->prependExtensionConfig($name, $config);
+            $containerBuilder->prependExtensionConfig($name, $config);
 
             // ...
         }
@@ -326,7 +326,7 @@ compilation::
 
     class AcmeDemoExtension implements ExtensionInterface, CompilerPassInterface
     {
-        public function process(ContainerBuilder $container)
+        public function process(ContainerBuilder $containerBuilder)
         {
             // ... do something during the compilation
         }
@@ -380,7 +380,7 @@ class implementing the ``CompilerPassInterface``::
 
     class CustomPass implements CompilerPassInterface
     {
-        public function process(ContainerBuilder $container)
+        public function process(ContainerBuilder $containerBuilder)
         {
             // ... do something during the compilation
         }

--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -107,8 +107,8 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\FrameworkConfig;
 
-            return static function (ContainerBuilder $container, FrameworkConfig $framework) {
-                $container->setParameter('env(SECRET)', 'some_secret');
+            return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework) {
+                $containerBuilder->setParameter('env(SECRET)', 'some_secret');
                 $framework->secret(env('SECRET')->string());
             };
 
@@ -153,8 +153,8 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\FrameworkConfig;
 
-            return static function (ContainerBuilder $container, FrameworkConfig $framework) {
-                $container->setParameter('env(HTTP_METHOD_OVERRIDE)', 'true');
+            return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework) {
+                $containerBuilder->setParameter('env(HTTP_METHOD_OVERRIDE)', 'true');
                 $framework->httpMethodOverride(env('HTTP_METHOD_OVERRIDE')->bool());
             };
 
@@ -245,8 +245,8 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\SecurityConfig;
 
-            return static function (ContainerBuilder $container, SecurityConfig $security) {
-                $container->setParameter('env(HEALTH_CHECK_METHOD)', 'Symfony\Component\HttpFoundation\Request::METHOD_HEAD');
+            return static function (ContainerBuilder $containerBuilder, SecurityConfig $security) {
+                $containerBuilder->setParameter('env(HEALTH_CHECK_METHOD)', 'Symfony\Component\HttpFoundation\Request::METHOD_HEAD');
                 $security->accessControl()
                     ->path('^/health-check$')
                     ->methods([env('HEALTH_CHECK_METHOD')->const()]);
@@ -296,8 +296,8 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\FrameworkConfig;
 
-            return static function (ContainerBuilder $container, FrameworkConfig $framework) {
-                $container->setParameter('env(TRUSTED_HOSTS)', '["10.0.0.1", "10.0.0.2"]');
+            return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework) {
+                $containerBuilder->setParameter('env(TRUSTED_HOSTS)', '["10.0.0.1", "10.0.0.2"]');
                 $framework->trustedHosts(env('TRUSTED_HOSTS')->json());
             };
 
@@ -385,8 +385,8 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\FrameworkConfig;
 
-            return static function (ContainerBuilder $container, FrameworkConfig $framework) {
-                $container->setParameter('env(TRUSTED_HOSTS)', '10.0.0.1,10.0.0.2');
+            return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework) {
+                $containerBuilder->setParameter('env(TRUSTED_HOSTS)', '10.0.0.1,10.0.0.2');
                 $framework->trustedHosts(env('TRUSTED_HOSTS')->csv());
             };
 

--- a/configuration/using_parameters_in_dic.rst
+++ b/configuration/using_parameters_in_dic.rst
@@ -138,9 +138,9 @@ And set it in the constructor of ``Configuration`` via the ``Extension`` class::
     {
         // ...
 
-        public function getConfiguration(array $config, ContainerBuilder $container)
+        public function getConfiguration(array $config, ContainerBuilder $containerBuilder)
         {
-            return new Configuration($container->getParameter('kernel.debug'));
+            return new Configuration($containerBuilder->getParameter('kernel.debug'));
         }
     }
 

--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -343,9 +343,9 @@ compiler pass ``AddEventAliasesPass``::
 
     class Kernel extends BaseKernel
     {
-        protected function build(ContainerBuilder $container)
+        protected function build(ContainerBuilder $containerBuilder)
         {
-            $container->addCompilerPass(new AddEventAliasesPass([
+            $containerBuilder->addCompilerPass(new AddEventAliasesPass([
                 MyCustomEvent::class => 'my_custom_event',
             ]));
         }

--- a/security.rst
+++ b/security.rst
@@ -1586,7 +1586,7 @@ and set the ``limiter`` option to its service ID:
         use Symfony\Config\FrameworkConfig;
         use Symfony\Config\SecurityConfig;
 
-        return static function (ContainerBuilder $container, FrameworkConfig $framework, SecurityConfig $security) {
+        return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework, SecurityConfig $security) {
             $framework->rateLimiter()
                 ->limiter('username_ip_login')
                     ->policy('token_bucket')
@@ -1602,7 +1602,7 @@ and set the ``limiter`` option to its service ID:
                     ->interval('15 minutes')
             ;
 
-            $container->register('app.login_rate_limiter', DefaultLoginRateLimiter::class)
+            $containerBuilder->register('app.login_rate_limiter', DefaultLoginRateLimiter::class)
                 ->setArguments([
                     // 1st argument is the limiter for IP
                     new Reference('limiter.ip_login'),

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -91,8 +91,8 @@ Take the following ``access_control`` entries as an example:
         use Symfony\Component\DependencyInjection\ContainerBuilder;
         use Symfony\Config\SecurityConfig;
 
-        return static function (ContainerBuilder $container, SecurityConfig $security) {
-            $container->setParameter('env(TRUSTED_IPS)', '10.0.0.1, 10.0.0.2');
+        return static function (ContainerBuilder $containerBuilder, SecurityConfig $security) {
+            $containerBuilder->setParameter('env(TRUSTED_IPS)', '10.0.0.1, 10.0.0.2');
             // ...
 
             $security->accessControl()

--- a/service_container/compiler_passes.rst
+++ b/service_container/compiler_passes.rst
@@ -26,9 +26,9 @@ Compiler passes are registered in the ``build()`` method of the application kern
 
         // ...
 
-        protected function build(ContainerBuilder $container): void
+        protected function build(ContainerBuilder $containerBuilder): void
         {
-            $container->addCompilerPass(new CustomPass());
+            $containerBuilder->addCompilerPass(new CustomPass());
         }
     }
 
@@ -54,14 +54,14 @@ and process the services inside the ``process()`` method::
 
         // ...
 
-        public function process(ContainerBuilder $container): void
+        public function process(ContainerBuilder $containerBuilder): void
         {
             // in this method you can manipulate the service container:
             // for example, changing some container service:
-            $container->getDefinition('app.some_private_service')->setPublic(true);
+            $containerBuilder->getDefinition('app.some_private_service')->setPublic(true);
 
             // or processing tagged services:
-            foreach ($container->findTaggedServiceIds('some_tag') as $id => $tags) {
+            foreach ($containerBuilder->findTaggedServiceIds('some_tag') as $id => $tags) {
                 // ...
             }
         }
@@ -83,11 +83,11 @@ method in the extension)::
 
     class MyBundle extends Bundle
     {
-        public function build(ContainerBuilder $container): void
+        public function build(ContainerBuilder $containerBuilder): void
         {
-            parent::build($container);
+            parent::build($containerBuilder);
 
-            $container->addCompilerPass(new CustomPass());
+            $containerBuilder->addCompilerPass(new CustomPass());
         }
     }
 

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -490,7 +490,7 @@ will share identical locators among all the services referencing them::
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Reference;
 
-    public function process(ContainerBuilder $container): void
+    public function process(ContainerBuilder $containerBuilder): void
     {
         // ...
 
@@ -499,9 +499,9 @@ will share identical locators among all the services referencing them::
             'logger' => new Reference('logger'),
         ];
 
-        $myService = $container->findDefinition(MyService::class);
+        $myService = $containerBuilder->findDefinition(MyService::class);
 
-        $myService->addArgument(ServiceLocatorTagPass::register($container, $locateableServices));
+        $myService->addArgument(ServiceLocatorTagPass::register($containerBuilder, $locateableServices));
     }
 
 Indexing the Collection of Services

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -128,9 +128,9 @@ In a Symfony application, call this method in your kernel class::
     {
         // ...
 
-        protected function build(ContainerBuilder $container): void
+        protected function build(ContainerBuilder $containerBuilder): void
         {
-            $container->registerForAutoconfiguration(CustomInterface::class)
+            $containerBuilder->registerForAutoconfiguration(CustomInterface::class)
                 ->addTag('app.custom_tag')
             ;
         }
@@ -144,9 +144,9 @@ In a Symfony bundle, call this method in the ``load()`` method of the
     {
         // ...
 
-        public function load(array $configs, ContainerBuilder $container): void
+        public function load(array $configs, ContainerBuilder $containerBuilder): void
         {
-            $container->registerForAutoconfiguration(CustomInterface::class)
+            $containerBuilder->registerForAutoconfiguration(CustomInterface::class)
                 ->addTag('app.custom_tag')
             ;
         }
@@ -307,17 +307,17 @@ container for any services with the ``app.mail_transport`` tag::
 
     class MailTransportPass implements CompilerPassInterface
     {
-        public function process(ContainerBuilder $container): void
+        public function process(ContainerBuilder $containerBuilder): void
         {
             // always first check if the primary service is defined
-            if (!$container->has(TransportChain::class)) {
+            if (!$containerBuilder->has(TransportChain::class)) {
                 return;
             }
 
-            $definition = $container->findDefinition(TransportChain::class);
+            $definition = $containerBuilder->findDefinition(TransportChain::class);
 
             // find all service IDs with the app.mail_transport tag
-            $taggedServices = $container->findTaggedServiceIds('app.mail_transport');
+            $taggedServices = $containerBuilder->findTaggedServiceIds('app.mail_transport');
 
             foreach ($taggedServices as $id => $tags) {
                 // add the transport service to the TransportChain service
@@ -344,9 +344,9 @@ or from your kernel::
     {
         // ...
 
-        protected function build(ContainerBuilder $container): void
+        protected function build(ContainerBuilder $containerBuilder): void
         {
-            $container->addCompilerPass(new MailTransportPass());
+            $containerBuilder->addCompilerPass(new MailTransportPass());
         }
     }
 
@@ -482,7 +482,7 @@ use this, update the compiler::
 
     class TransportCompilerPass implements CompilerPassInterface
     {
-        public function process(ContainerBuilder $container): void
+        public function process(ContainerBuilder $containerBuilder): void
         {
             // ...
 


### PR DESCRIPTION
Like `ContainerConfigurator $containerConfigurator`, use always `ContainerBuilder $containerBuilder`.

I think `$container` can be confusing