### PR TITLE
[Doctrine] Include % as a Special Character in URIs

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -61,7 +61,7 @@ The database connection information is stored as an environment variable called
 .. caution::
 
     If the username, password, host or database name contain any character considered
-    special in a URI (such as ``+``, ``@``, ``$``, ``#``, ``/``, ``:``, ``*``, ``!``),
+    special in a URI (such as ``+``, ``@``, ``$``, ``#``, ``/``, ``:``, ``*``, ``!``, ``%``),
     you must encode them. See `RFC 3986`_ for the full list of reserved characters or
     use the :phpfunction:`urlencode` function to encode them. In this case you need to
     remove the ``resolve:`` prefix in ``config/packages/doctrine.yaml`` to avoid errors:


### PR DESCRIPTION
Docs for Doctrine customization should explain that a `%` char might be special in urlencoded string input.