### PR TITLE
[Twig] Remove obsolete comments about Twig versions

### DIFF
--- a/components/form.rst
+++ b/components/form.rst
@@ -223,10 +223,6 @@ to bootstrap or access Twig and add the :class:`Symfony\\Bridge\\Twig\\Extension
         // ...
         ->getFormFactory();
 
-.. versionadded:: 1.30
-
-    The ``Twig\RuntimeLoader\FactoryRuntimeLoader`` was introduced in Twig 1.30.
-
 The exact details of your `Twig Configuration`_ will vary, but the goal is
 always to add the :class:`Symfony\\Bridge\\Twig\\Extension\\FormExtension`
 to Twig, which gives you access to the Twig functions for rendering forms.

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -67,10 +67,10 @@ autoescape_service
 
 **type**: ``string`` **default**: ``null``
 
-As of Twig 1.17, the escaping strategy applied by default to the template is
-determined during compilation time based on the filename of the template. This
-means for example that the contents of a ``*.html.twig`` template are escaped
-for HTML and the contents of ``*.js.twig`` are escaped for JavaScript.
+The escaping strategy applied by default to the template is determined during
+compilation time based on the filename of the template. This means for example
+that the contents of a ``*.html.twig`` template are escaped for HTML and the
+contents of ``*.js.twig`` are escaped for JavaScript.
 
 This option allows to define the Symfony service which will be used to determine
 the default escaping applied to the template.

--- a/templating/twig_extension.rst
+++ b/templating/twig_extension.rst
@@ -103,10 +103,6 @@ this command to confirm that your new filter was successfully registered:
 Creating Lazy-Loaded Twig Extensions
 ------------------------------------
 
-.. versionadded:: 1.35
-
-    Support for lazy-loaded extensions was introduced in Twig 1.35.0 and 2.4.4.
-
 Including the code of the custom filters/functions in the Twig extension class
 is the simplest way to create extensions. However, Twig must initialize all
 extensions before rendering any template, even if the template doesn't use an


### PR DESCRIPTION
As of Symfony 5.4, the minimum version of Twig that is supported is 2.13. So, all these comments are not relevant anymore.
