### PR TITLE
Update doctrine.rst

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -638,7 +638,7 @@ by the ``id`` column. If it's not found, a 404 page is generated.
 
 This behavior is enabled by default on all your controllers. You can
 disable it by setting the ``doctrine.orm.controller_resolver.auto_mapping``
-config option to ``false``.
+config option to ``false`` and also disable ``the sensio_framework_extra.request.auto_convert``
 
 When disabled, you can enable it individually on the desired controllers by
 using the ``MapEntity`` attribute::


### PR DESCRIPTION
Hello
I may have missed something but when keep the option `sensio_framework_extra.request.auto_convert` set to true and disable the `doctrine.orm.controller_resolver.auto_mapping` it still  getting data from the ParamConverter even though i have set the `#[MapEntity]`. the EntityValueResolver does not fetch data because of the condition 

```
if (\is_object($request->attributes->get($argument->getName()))) {
       return [];
}
```
But when i disabled the `sensio_framework_extra.request.auto_convert` data is fetched now with  the `MapEntity`.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
