### PR TITLE
[Notifier] add notification assertion in notifier doc

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -759,6 +759,19 @@ typical alert levels, which you can implement immediately using:
             ;
         };
 
+Testing Notifier
+----------------
+
+Symfony provides a :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\NotificationAssertionsTrait`
+which provide useful methods for testing your Notifier implementation.
+You can benefit from this class by using it directly or extending the :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase`.
+
+See :ref:`testing documentation <notifier-assertions>` for the list of available assertions.
+
+.. versionadded:: 6.2
+
+    The :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\NotificationAssertionsTrait` was introduced in Symfony 6.2.
+
 Disabling Delivery
 ------------------
 


### PR DESCRIPTION
While reading testing documentation I came across some assertions for notifications. I think it can be useful to talk about this directly in Notifier documentation too, WDYT ? 