### PR TITLE
Fix `empty_data` option description of `TextareaType`

### DIFF
--- a/reference/forms/types/textarea.rst
+++ b/reference/forms/types/textarea.rst
@@ -35,7 +35,9 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
 .. include:: /reference/forms/types/options/empty_data_declaration.rst.inc
 
-The default value is ``''`` (the empty string).
+From an HTTP perspective, submitted data is always a string or an array of strings.
+So by default, the form will treat any empty string as null. If you prefer to get
+an empty string, explicitly set the ``empty_data`` option to an empty string.
 
 .. include:: /reference/forms/types/options/empty_data_description.rst.inc
 


### PR DESCRIPTION
The `empty_data` option behave the same for `TextareaType` and `TextType` but the description of the option for `TextareaType` is wrong.

This PR replace the description of the `empty_data` option of `TextareaType` by the one of `TextType` (see https://github.com/symfony/symfony-docs/commit/5cfff92158a47453ebf4977891c23ba7224da8ce)