### PR TITLE
[Validator] Fix a valid Date and Time constraint format

### DIFF
--- a/reference/constraints/Date.rst
+++ b/reference/constraints/Date.rst
@@ -2,7 +2,7 @@ Date
 ====
 
 Validates that a value is a valid date, meaning a string (or an object that can
-be cast into a string) that follows a valid ``YYYY-MM-DD`` format.
+be cast into a string) that follows a valid ``Y-m-d`` format.
 
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`

--- a/reference/constraints/Time.rst
+++ b/reference/constraints/Time.rst
@@ -2,7 +2,7 @@ Time
 ====
 
 Validates that a value is a valid time, meaning a string (or an object that can
-be cast into a string) that follows a valid ``HH:MM:SS`` format.
+be cast into a string) that follows a valid ``H:i:s`` format.
 
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`


### PR DESCRIPTION
I noticed that the date and time format specified at the start of the documentation is not correct, it should be **Y-m-d** for Date and **H:i:s** for Time instead of YYYY-MM-DD and HH:MM:SS