### PR TITLE
Add note about `ResponseInterface::toStream()`

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1015,6 +1015,10 @@ following methods::
 
 .. note::
 
+    ``$response->toStream()`` is part of :class:`Symfony\\Component\\HttpClient\\Response\\StreamableInterface`.
+
+.. note::
+
     ``$response->getInfo()`` is non-blocking: it returns *live* information
     about the response. Some of them might not be known yet (e.g. ``http_code``)
     when you'll call it.


### PR DESCRIPTION
The docs for `HttpClient` mentions that [Symfony\Contracts\HttpClient\ResponseInterface](https://github.com/symfony/http-client-contracts/blob/main/ResponseInterface.php) provides a method `toStream` but looking at the source code one can see that this is not the case.

This PR removes the mention of `Symfony\Contracts\HttpClient\ResponseInterface::toStream` from the docs.
