### PR TITLE
[DependencyInjection] Fix missing quotes on service subscribers

### DIFF
--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -279,7 +279,7 @@ This is done by having ``getSubscribedServices()`` return an array of
             new SubscribedService('logger', LoggerInterface::class, attributes: new Autowire(service: 'monolog.logger.event')),
 
             // can event use parameters
-            new SubscribedService('env', string, attributes: new Autowire('%kernel.environment%')),
+            new SubscribedService('env', 'string', attributes: new Autowire('%kernel.environment%')),
 
             // Target
             new SubscribedService('event.logger', LoggerInterface::class, attributes: new Target('eventLogger')),


### PR DESCRIPTION
## Description
On the [service subscribers & locators doc](https://symfony.com/doc/current/service_container/service_subscribers_locators.html#add-dependency-injection-attributes), there was missing quotes on the second parameter of `Symfony\Contracts\Service\Attribute\SubscribedService` constructor