### PR TITLE
[Doctrine] Cleaning up the config code samples

### DIFF
--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -1,7 +1,7 @@
 .. index::
    single: Doctrine; Multiple entity managers
 
-How to Work with multiple Entity Managers and Connections
+How to Work with Multiple Entity Managers and Connections
 =========================================================
 
 You can use multiple Doctrine entity managers or connections in a Symfony
@@ -32,20 +32,12 @@ The following configuration code shows how you can configure two entity managers
         # config/packages/doctrine.yaml
         doctrine:
             dbal:
-                default_connection: default
                 connections:
                     default:
-                        # configure these for your database server
                         url: '%env(resolve:DATABASE_URL)%'
-                        driver: 'pdo_mysql'
-                        server_version: '5.7'
-                        charset: utf8mb4
                     customer:
-                        # configure these for your database server
-                        url: '%env(resolve:DATABASE_CUSTOMER_URL)%'
-                        driver: 'pdo_mysql'
-                        server_version: '5.7'
-                        charset: utf8mb4
+                        url: '%env(resolve:CUSTOMER_DATABASE_URL)%'
+                default_connection: default
             orm:
                 default_entity_manager: default
                 entity_managers:
@@ -82,20 +74,12 @@ The following configuration code shows how you can configure two entity managers
 
             <doctrine:config>
                 <doctrine:dbal default-connection="default">
-                    <!-- configure these for your database server -->
                     <doctrine:connection name="default"
                         url="%env(resolve:DATABASE_URL)%"
-                        driver="pdo_mysql"
-                        server_version="5.7"
-                        charset="utf8mb4"
                     />
 
-                    <!-- configure these for your database server -->
                     <doctrine:connection name="customer"
-                        url="%env(resolve:DATABASE_CUSTOMER_URL)%"
-                        driver="pdo_mysql"
-                        server_version="5.7"
-                        charset="utf8mb4"
+                        url="%env(resolve:CUSTOMER_DATABASE_URL)%"
                     />
                 </doctrine:dbal>
 
@@ -131,37 +115,28 @@ The following configuration code shows how you can configure two entity managers
         use Symfony\Config\DoctrineConfig;
 
         return static function (DoctrineConfig $doctrine) {
-            $doctrine->dbal()->defaultConnection('default');
-
-            // configure these for your database server
+            // Connections:
             $doctrine->dbal()
                 ->connection('default')
-                ->url(env('DATABASE_URL')->resolve())
-                ->driver('pdo_mysql')
-                ->serverVersion('5.7')
-                ->charset('utf8mb4');
-
-            // configure these for your database server
+                ->url(env('DATABASE_URL')->resolve());
             $doctrine->dbal()
                 ->connection('customer')
-                ->url(env('DATABASE_CUSTOMER_URL')->resolve())
-                ->driver('pdo_mysql')
-                ->serverVersion('5.7')
-                ->charset('utf8mb4');
-
+                ->url(env('CUSTOMER_DATABASE_URL')->resolve());
+            $doctrine->dbal()->defaultConnection('default');
+            
+            // Entity Managers:
             $doctrine->orm()->defaultEntityManager('default');
-            $emDefault = $doctrine->orm()->entityManager('default');
-            $emDefault->connection('default');
-            $emDefault->mapping('Main')
+            $defaultEntityManager = $doctrine->orm()->entityManager('default');
+            $defaultEntityManager->connection('default');
+            $defaultEntityManager->mapping('Main')
                 ->isBundle(false)
                 ->type('annotation')
                 ->dir('%kernel.project_dir%/src/Entity/Main')
                 ->prefix('App\Entity\Main')
                 ->alias('Main');
-
-            $emCustomer = $doctrine->orm()->entityManager('customer');
-            $emCustomer->connection('customer');
-            $emCustomer->mapping('Customer')
+            $customerEntityManager = $doctrine->orm()->entityManager('customer');
+            $customerEntityManager->connection('customer');
+            $customerEntityManager->mapping('Customer')
                 ->isBundle(false)
                 ->type('annotation')
                 ->dir('%kernel.project_dir%/src/Entity/Customer')


### PR DESCRIPTION
Page: https://symfony.com/doc/5.4/doctrine/multiple_entity_managers.html

Things I've changed:
1. Moved `defaultConnection` downwards (YAML & PHP). Setting the default *before* defining any connection looked awkward.
2. Removed `driver`, `server_version`, `charset`. As I see it on https://symfony.com/doc/current/doctrine.html#configuring-the-database, the recommended way is to set this inside `.env`. Besides, it distracts from the important points here.
3. Renamed `DATABASE_CUSTOMER_URL` to `CUSTOMER_DATABASE_URL` - in accordance with the way the dependency injection works: `EntityManagerInterface $customerEntityManager`.
    Plus renaming `emDefault` to `defaultEntityManager` in PHP config.