### PR TITLE
[Console] Add inline command register example

### DIFF
--- a/components/console.rst
+++ b/components/console.rst
@@ -52,6 +52,20 @@ Then, you can register the commands using
     // ...
     $application->add(new GenerateAdminCommand());
 
+You can also register inline commands and define their behavior thanks to the
+``Command::setCode()`` method::
+
+    // ...
+    $application->register('generate-admin')
+        ->addArgument('username', InputArgument::REQUIRED)
+        ->setCode(function (InputInterface $input, OutputInterface $output): int {
+            // ...
+
+            return Command::SUCCESS;
+        });
+
+This is useful when creating a :doc:`single-command application </components/console/single_command_tool>`.
+
 See the :doc:`/console` article for information about how to create commands.
 
 Learn more


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony-docs/issues/16214

I was brief on the example. Since there is already an example of using `setCode` in the doc, I think it was only necessary to mention the possibility to do that in the main page of the Console component, before referring to the single-line command page with more details.