### PR TITLE
[Validator] move the documentation of the match option to the right place

### DIFF
--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -302,6 +302,20 @@ Parameter          Description
 ``{{ value }}``    The current (invalid) value
 =================  ============================================================
 
+
+match
+~~~~~
+
+**type**: ``boolean`` **default**: ``true``
+
+When this option is ``false``, the constraint checks that the given value is
+not one of the values defined in the ``choices`` option. In practice, it makes
+the ``Choice`` constraint behave like a ``NotChoice`` constraint.
+
+.. versionadded:: 6.2
+
+    The ``match`` option was introduced in Symfony 6.2.
+
 ``message``
 ~~~~~~~~~~~
 

--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -195,19 +195,6 @@ correct types will be assigned to the model.
 
 .. include:: /reference/forms/types/options/group_by.rst.inc
 
-match
-~~~~~
-
-**type**: ``boolean`` **default**: ``true``
-
-When this option is ``false``, the constraint checks that the given value is
-not one of the values defined in the ``choices`` option. In practice, it makes
-the ``Choice`` constraint behave like a ``NotChoice`` constraint.
-
-.. versionadded:: 6.2
-
-    The ``match`` option was introduced in Symfony 6.2.
-
 .. include:: /reference/forms/types/options/multiple.rst.inc
 
 .. include:: /reference/forms/types/options/placeholder.rst.inc


### PR DESCRIPTION
This option is part of the Choice validation constraint, but does not belong to the ChoiceType from the Form component.
