### PR TITLE
[Session] Adding `FlashBagInterface`

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -249,6 +249,8 @@ needs.
     You can use the
     :method:`Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface::peek`
     method instead to retrieve the message while keeping it in the bag.
+    Instead of doing ``$request->getSession()->getFlashBag()``, you can also inject the
+    ``Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface``.
 
 Configuration
 -------------


### PR DESCRIPTION
Page: https://symfony.com/doc/5.4/session.html#flash-messages

Info is taken from https://github.com/symfony/symfony/issues/39222#issuecomment-1210412275

**Hold on!**
After clearing the cache, I'm now getting:
> Cannot autowire argument $flashBag of "...": it references interface "Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface" but no such service exists. Did you create a class that implements this interface?