### PR TITLE
[Validator] Remove annotations from `exactly` option of Length constraint

### DIFF
--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -135,8 +135,7 @@ the given value's length is not **exactly** equal to this value.
 
     This option is the one being set by default when using the Length constraint
     without passing any named argument to it. This means that for example,
-    ``@Assert\Length(20)`` and ``@Assert\Length(exactly=20)`` are equivalent, as
-    well as ``#[Assert\Length(20)]`` and ``#[Assert\Length(exactly: 20)]``.
+    ``#[Assert\Length(20)]`` and ``#[Assert\Length(exactly: 20)]`` are equivalent.
 
 exactMessage
 ~~~~~~~~~~~~


### PR DESCRIPTION
Follow-up https://github.com/symfony/symfony-docs/pull/17764#discussion_r1073096785