### PR TITLE
[DependencyInjection] [LazyServices] Add `#[Autoconfigure]` attribute mention

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -41,6 +41,8 @@ In order to use the lazy service instantiation, you will need to install the
 
     $ composer require symfony/proxy-manager-bridge
 
+.. _lazy-services_configuration:
+
 Configuration
 -------------
 
@@ -101,6 +103,26 @@ To check if your proxy works you can check the interface of the received object:
     over the ``lazy`` flag and directly instantiate the service as it would
     normally do.
 
+You can also configure your service's laziness thanks to the
+:class:`Symfony\\Component\\DependencyInjection\\Attribute\\Autoconfigure` attribute.
+The attribute has to be used like this::
+
+    namespace App\Twig;
+
+    use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+    use Twig\Extension\ExtensionInterface;
+
+    #[Autoconfigure(lazy: true)]
+    class AppExtension implements ExtensionInterface
+    {
+        // ...
+    }
+
+.. versionadded:: 5.4
+
+    The :class:`Symfony\\Component\\DependencyInjection\\Attribute\\Autoconfigure` attribute
+    was introduced in Symfony 5.4.
+
 Interface Proxifying
 --------------------
 
@@ -158,6 +180,27 @@ specific interfaces.
                 ->tag('proxy', ['interface' => ExtensionInterface::class])
             ;
         };
+
+Just like in the :ref:`Configuration <lazy-services_configuration>` section, you can
+use the :class:`Symfony\\Component\\DependencyInjection\\Attribute\\Autoconfigure`
+attribute to configure the interface to proxify by passing its FQCN as the ``lazy``
+parameter value::
+
+    namespace App\Twig;
+
+    use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+    use Twig\Extension\ExtensionInterface;
+
+    #[Autoconfigure(lazy: ExtensionInterface::class)]
+    class AppExtension implements ExtensionInterface
+    {
+        // ...
+    }
+
+.. versionadded:: 5.4
+
+    The :class:`Symfony\\Component\\DependencyInjection\\Attribute\\Autoconfigure` attribute
+    was introduced in Symfony 5.4.
 
 The virtual `proxy`_ injected into other services will only implement the
 specified interfaces and will not extend the original service class, allowing to


### PR DESCRIPTION
While watching @nicolas-grekas' SymfonyCon talk about lazy objects to give a try to https://github.com/symfony/symfony-docs/issues/16970, he told that the documentation about `#[Autoconfigure(lazy: ...)]` was missing. So here it is 😄 