### PR TITLE
[Update force_https.rst] Replacing deprecated role: IS_AUTHENTICATED_ANONYMOUSLY

### DIFF
--- a/security/force_https.rst
+++ b/security/force_https.rst
@@ -24,9 +24,9 @@ access control:
 
                 access_control:
                     - { path: '^/secure', roles: ROLE_ADMIN, requires_channel: https }
-                    - { path: '^/login', roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
+                    - { path: '^/login', roles: PUBLIC_ACCESS, requires_channel: https }
                     # catch all other URLs
-                    - { path: '^/', roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
+                    - { path: '^/', roles: PUBLIC_ACCESS, requires_channel: https }
 
         .. code-block:: xml
 
@@ -47,11 +47,11 @@ access control:
                         role="ROLE_ADMIN"
                         requires-channel="https"/>
                     <rule path="^/login"
-                        role="IS_AUTHENTICATED_ANONYMOUSLY"
+                        role="PUBLIC_ACCESS"
                         requires-channel="https"
                     />
                     <rule path="^/"
-                        role="IS_AUTHENTICATED_ANONYMOUSLY"
+                        role="PUBLIC_ACCESS"
                         requires-channel="https"
                     />
                 </config>
@@ -73,13 +73,13 @@ access control:
 
                 $security->accessControl()
                     ->path('^/login')
-                    ->roles(['IS_AUTHENTICATED_ANONYMOUSLY'])
+                    ->roles(['PUBLIC_ACCESS'])
                     ->requiresChannel('https')
                 ;
 
                 $security->accessControl()
                     ->path('^/')
-                    ->roles(['IS_AUTHENTICATED_ANONYMOUSLY'])
+                    ->roles(['PUBLIC_ACCESS'])
                     ->requiresChannel('https')
                 ;
             };


### PR DESCRIPTION
Replacing deprecated role: IS_AUTHENTICATED_ANONYMOUSLY by PUBLIC_ACCESS role.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
