### PR TITLE
[ExpressionLanguage] Deprecate loose comparisons when using the "in" operator

### DIFF
--- a/components/expression_language.rst
+++ b/components/expression_language.rst
@@ -432,6 +432,13 @@ For example::
 
 The ``$inGroup`` would evaluate to ``true``.
 
+.. deprecated:: 6.3
+
+    In Symfony versions previous to 6.3, ``in`` and ``not in`` operators
+    were using loose comparison. Using these operators with variables of
+    different types is now deprecated, and these operators will be using
+    strict comparison from Symfony 7.0.
+
 Numeric Operators
 .................
 


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony-docs/issues/17796