### PR TITLE
update CI intro

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -3,7 +3,7 @@
 Running Symfony Tests
 =====================
 
-The Symfony project uses a third-party service which automatically runs tests
+The Symfony project uses a CI (Continuous Integration) service which automatically runs tests
 for any submitted :doc:`patch <pull_requests>`. If the new code breaks any test,
 the pull request will show an error message with a link to the full error details.
 


### PR DESCRIPTION
> The Symfony project uses a third-party service

It was true when tests where ran by Travis CI.

Now tests are run by GitHub Actions, which is not a third-party from GitHub's viewpoint.

I suggest a more generic approach: there is a CI service, no matter if it's internal or third-party.