### PR TITLE
[Workflow] Improve Workflow Documentation

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -194,7 +194,10 @@ The configured property will be used via its implemented getter/setter methods b
     preferable to not configure it.
 
     A single state marking store uses a ``string`` to store the data. A multiple
-    state marking store uses an ``array`` to store the data.
+    state marking store uses an ``array`` to store the data. On both cases if no
+    state marking store is defined you have to return ``null``. So in the above
+    example should be defined a return type like ``App\Entity\BlogPost::getCurrentPlace(): ?array``
+    or like ``App\Entity\BlogPost::getCurrentPlace(): ?string``.
 
 .. tip::
 


### PR DESCRIPTION
As you can see on the `MethodMarkingStore` [implementation](https://github.com/symfony/symfony/blob/v6.2.4/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php#L64-L66), it checks if the `$marking` variable is `null` and not for empty `string` or empty `array`.

So I suggest adding these changes to the Docu to declare it out of any doubt. I notice these also on the workflow demo by @lyrixx, specifically [here](https://github.com/lyrixx/SFLive-Paris2016-Workflow/blob/master/src/Entity/Article.php#L15-L16) and [here](https://github.com/lyrixx/SFLive-Paris2016-Workflow/blob/master/src/Entity/Task.php#L15-L16).