### PR TITLE
[Standards] Freeze contractions decision in documentation standards

### DIFF
--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -190,6 +190,10 @@ In addition, documentation follows these rules:
   * simply
   * trivial
 
+* Contractions are allowed to be used across the documentation. This means
+  you're allowed to write ``you would`` as well as ``you'd``, ``it is`` as
+  well as ``it's``, etc.
+
 .. _`the Sphinx documentation`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
 .. _`Twig Coding Standards`: https://twig.symfony.com/doc/3.x/coding_standards.html
 .. _`reserved by the IANA`: https://tools.ietf.org/html/rfc2606#section-3


### PR DESCRIPTION
As a decision has been made in https://github.com/symfony/symfony-docs/pull/17765, I think this could be a good idea to freeze this in the documentation standards, in case someone is wondering again in the future.