### PR TITLE
Update "Web debug toolbar" profiler docs

### DIFF
--- a/profiler.rst
+++ b/profiler.rst
@@ -193,23 +193,35 @@ production. To do that, create an :doc:`event subscriber </event_dispatcher>`
 and listen to the :ref:`kernel.response <component-http-kernel-kernel-response>`
 event::
 
+
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
     use Symfony\Component\HttpKernel\Event\ResponseEvent;
+    use Symfony\Component\HttpKernel\KernelInterface;
 
     // ...
-
-    public function onKernelResponse(ResponseEvent $event)
-    {
-        if (!$event->getKernel()->isDebug()) {
-            return;
+    
+    class MySubscriber implements EventSubscriberInterface {
+        public function __construct(
+            private KernelInterface $kernel,
+        ) {
         }
+        
+        // ...
 
-        $request = $event->getRequest();
-        if (!$request->isXmlHttpRequest()) {
-            return;
+        public function onKernelResponse(ResponseEvent $event)
+        {
+            if (!$this->kernel->isDebug()) {
+                return;
+            }
+
+            $request = $event->getRequest();
+            if (!$request->isXmlHttpRequest()) {
+                return;
+            }
+
+            $response = $event->getResponse();
+            $response->headers->set('Symfony-Debug-Toolbar-Replace', 1);
         }
-
-        $response = $event->getResponse();
-        $response->headers->set('Symfony-Debug-Toolbar-Replace', 1);
     }
 
 .. index::


### PR DESCRIPTION
Hello,

I believe I encountered the situation than https://github.com/symfony/symfony/discussions/42439

The current [docs](https://symfony.com/doc/current/profiler.html#updating-the-web-debug-toolbar-after-ajax-requests) on updating the Web debug toolbar after XHR requests suggest to use `$event->getKernel()->isDebug()`.

I am using Symfony 6.2, and this results in an attribute error on `isDebug()`. This seems to be because `getKernel()` returns an object that implements `HttpKernelInterface`, which does not define `isDebug()`. However, this method is available on `KernelInterace`.

I was able to get the intended behavior by injecting the kernel via the constructor, as shown in this documentation update proposal.

I checked as follows:

* Run the app with `APP_ENV=dev`. The toolbar shows up and I can see `Symfony-Debug-Toolbar-Replace: 1` in the XHR requests (I'm using [Turbo Frames](https://turbo.hotwired.dev/handbook/frames))
* Run with `APP_ENV=prod`. The toolbar doesn't show up, _and_ I cannot see `Symfony-Debug-Toolbar-Replace: 1` in the XHR requests anymore.

I am targeting `5.4` as the base branch as per the contribution guidelines, given that it should be possible to inject the `KernelInterface` in Symfony 5.4 as well.