### PR TITLE
[Validator] Replace warning with caution for consistency

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -278,7 +278,7 @@ constructor of the Callback constraint::
         }
     }
 
-.. warning::
+.. caution::
 
     Using a ``Closure`` together with annotation configuration will disable the
     annotation cache for that class/property/method because ``Closure`` cannot


### PR DESCRIPTION
We had only one "warning" vs many "caution" blocks.
