### PR TITLE
[Doctrine] Update example to match actual make::entity output

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -135,19 +135,19 @@ Whoa! You now have a new ``src/Entity/Product.php`` file::
     use App\Repository\ProductRepository;
     use Doctrine\ORM\Mapping as ORM;
 
-     #[ORM\Entity(repositoryClass: ProductRepository::class)]
+    #[ORM\Entity(repositoryClass: ProductRepository::class)]
     class Product
     {
         #[ORM\Id]
         #[ORM\GeneratedValue]
         #[ORM\Column]
-        private int $id;
+        private ?int $id = null;
 
         #[ORM\Column(length: 255)]
-        private string $name;
+        private ?string $name = null;
 
         #[ORM\Column]
-        private int $price;
+        private ?int $price = null;
 
         public function getId(): ?int
         {


### PR DESCRIPTION
From slack

![image](https://user-images.githubusercontent.com/9253091/215199944-ecc4544f-62c8-435d-928d-e219b1c5e732.png)

It's a new behavior since maker 1.44.0 released July 26th, 2022
https://github.com/symfony/maker-bundle/pull/1147

(New example is based on local execution)
