### PR TITLE
Fix MailPace mailer package name

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -108,7 +108,7 @@ Mailjet             ``composer require symfony/mailjet-mailer``
 Postmark            ``composer require symfony/postmark-mailer``
 SendGrid            ``composer require symfony/sendgrid-mailer``
 Sendinblue          ``composer require symfony/sendinblue-mailer``
-MailPace            ``composer require symfony/mailpace-mailer``
+MailPace            ``composer require symfony/mail-pace-mailer``
 Infobip             ``composer require symfony/infobip-mailer``
 ==================  ==============================================
 


### PR DESCRIPTION
Hi, this is just a little fix for the package name of the MailPace mailer

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
