### PR TITLE
[Security] Add complex example is_granted and/or is_granted

### DIFF
--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -34,6 +34,23 @@ and ``#[IsGranted()]`` attribute also accept an
                 // ...
             }
         }
+    .. code-block:: php-attributes
+
+        // src/Controller/MyController.php
+        namespace App\Controller;
+
+        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\ExpressionLanguage\Expression;
+        use Symfony\Component\HttpFoundation\Response;
+
+        class MyController extends AbstractController
+        {
+            #[IsGranted(new Expression('is_granted("ROLE_ADMIN") or is_granted("ROLE_MANAGER")'))]
+            public function index(): Response
+            {
+                // ...
+            }
+        }
 
     .. code-block:: php
 


### PR DESCRIPTION
Add complex example is_granted and/or is_granted

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
