### PR TITLE
import function env to avoid fatal error if copying docs

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -54,6 +54,7 @@ over SMTP by configuring the DSN in your ``.env`` file (the ``user``,
     .. code-block:: php
 
         // config/packages/mailer.php
+        use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
         use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
         return static function (ContainerConfigurator $containerConfigurator): void {
@@ -1193,6 +1194,7 @@ This can be configured by replacing the ``dsn`` configuration entry with a
     .. code-block:: php
 
         // config/packages/mailer.php
+        use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
         use Symfony\Config\FrameworkConfig;
 
         return static function (FrameworkConfig $framework) {


### PR DESCRIPTION
If you copy and past the example code, or dont realise then you get a fatal error message as `env` is a function not within the global scope. 


<img width="1139" alt="ScreenShot-2023-02-02-21 25 27" src="https://user-images.githubusercontent.com/400092/216453124-166c7331-a0e6-4e1c-aff8-3aa6e4dfcc48.png">

This change in the docs just imports the function like phpStorm tells me to

```
use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
```