### PR TITLE
[DependencyInjection] Fix example for Autowire attribute

### DIFF
--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -629,7 +629,7 @@ and even :doc:`complex expressions </service_container/expression_language>`::
             bool $debugMode,
 
             // and expressions
-            #[Autowire(expression: 'service("App\\Mail\\MailerConfiguration").getMailerMethod()')]
+            #[Autowire(expression: 'service("App\\\Mail\\\MailerConfiguration").getMailerMethod()')]
             string $mailerMethod
         ) {
         }


### PR DESCRIPTION
I just noticed that the container will internally resolve the service name to "AppMailMailerConfiguration" if backslashes are not double-escaped.
