### PR TITLE
Switching to PHP-version-agnostic socket file

### DIFF
--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -56,7 +56,7 @@ The **minimum configuration** to get your application running under Nginx is:
         # }
 
         location ~ ^/index\.php(/|$) {
-            fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
+            fastcgi_pass unix:/var/run/php/php-fpm.sock;
             fastcgi_split_path_info ^(.+\.php)(/.*)$;
             include fastcgi_params;
 
@@ -265,7 +265,7 @@ Apache with PHP-FPM
 To make use of PHP-FPM with Apache, you first have to ensure that you have
 the FastCGI process manager ``php-fpm`` binary and Apache's FastCGI module
 installed (for example, on a Debian based system you have to install the
-``libapache2-mod-fastcgi`` and ``php7.4-fpm`` packages).
+``libapache2-mod-fastcgi`` and ``php<version>-fpm`` packages).
 
 PHP-FPM uses so-called *pools* to handle incoming FastCGI requests. You can
 configure an arbitrary number of pools in the FPM configuration. In a pool
@@ -280,7 +280,7 @@ listen on. Each pool can also be run under a different UID and GID:
     group = www-data
 
     ; use a unix domain socket
-    listen = /var/run/php/php7.4-fpm.sock
+    listen = /var/run/php/php-fpm.sock
 
     ; or listen on a TCP socket
     listen = 127.0.0.1:9000
@@ -378,7 +378,7 @@ instead:
 
 .. code-block:: apache
 
-    FastCgiExternalServer /usr/lib/cgi-bin/php7-fcgi -socket /var/run/php/php7.4-fpm.sock -pass-header Authorization
+    FastCgiExternalServer /usr/lib/cgi-bin/php7-fcgi -socket /var/run/php/php-fpm.sock -pass-header Authorization
 
 .. _`Apache documentation`: https://httpd.apache.org/docs/
 .. _`FastCgiExternalServer`: https://docs.oracle.com/cd/B31017_01/web.1013/q20204/mod_fastcgi.html#FastCgiExternalServer


### PR DESCRIPTION
Page: https://symfony.com/doc/5.4/setup/web_server_configuration.html

This makes upgrading to a new PHP version so much easier (I just did that). If the PHP version is hardcoded in every domain's config file, it's a hassle to update them.

On the other hand: `/var/run/php/php-fpm.sock` is a symlink to the most recently installed PHP version, so this is what most people want probably.

I hope this doesn't interfere with the change I did in https://github.com/symfony/symfony-docs/pull/17882 on the 6.2 branch.
