### PR TITLE
[ExpressionLanguage][Validator] Mention the validator.expression_language service

### DIFF
--- a/components/expression_language.rst
+++ b/components/expression_language.rst
@@ -19,7 +19,11 @@ Installation
 .. include:: /components/require_autoload.rst.inc
 
 How can the Expression Engine Help Me?
---------------------------------------
+
+.. _how-can-the-expression-engine-help-me:
+
+How can the Expression Language Help Me?
+----------------------------------------
 
 The purpose of the component is to allow users to use expressions inside
 configuration for more complex logic. For some examples, the Symfony Framework

--- a/reference/constraints/Expression.rst
+++ b/reference/constraints/Expression.rst
@@ -250,6 +250,12 @@ For more information about the expression and what variables are available
 to you, see the :ref:`expression <reference-constraint-expression-option>`
 option details below.
 
+.. tip::
+
+    Internally, this expression validator constraint uses a service called
+    ``validator.expression_language`` to evaluate the expressions. You can
+    decorate or extend that service to fit your own needs.
+
 Options
 -------
 


### PR DESCRIPTION
Fixes #14673.

Not sure if it's correct, and not sure if it's OK to not add the `versionadded` directive because this was included in 5.3.