### PR TITLE
[Notifier] `from` is optional in Smsapi since 6.3

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -117,6 +117,7 @@ Yunpian          ``symfony/yunpian-notifier``           ``yunpian://APIKEY@defau
 
     The Bandwith, iSendPro, Plivo, RingCentral and Termii integrations were introduced
     in Symfony 6.3.
+    The ``from`` option in ``Smsapi`` DSN is optional since Symfony 6.3.
 
 To enable a texter, add the correct DSN in your ``.env`` file and
 configure the ``texter_transports``:


### PR DESCRIPTION
This PR aims to resolve https://github.com/symfony/symfony-docs/issues/17893.
On a related note, would it be a good idea to put all optional parameters of DSNs in the table above in square brackets?