### PR TITLE
[Security] Add logout configuration for Clear-Site-Data header

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -428,6 +428,72 @@ user logs out::
             ],
         ]);
 
+clear_site_data
+~~~~~~~~~~~~~~~
+
+**type**: ``array`` **default**: ``[]``
+
+The Clear-Site-Data header clears browsing data (cookies, storage, cache) associated with the requesting website.
+It allows web developers to have more control over the data stored by a client browser for their origins.
+Allowed values are ``cache``, ``cookies``, ``storage`` and ``executionContexts``.
+And it's possible to use ``*`` as a wildcard for all directives::
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/security.yaml
+        security:
+            # ...
+
+            firewalls:
+                main:
+                    # ...
+                    logout:
+                        clear_site_data:
+                            - cookies
+                            - storage
+
+    .. code-block:: xml
+
+        <!-- config/packages/security.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <srv:container xmlns="http://symfony.com/schema/dic/security"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:srv="http://symfony.com/schema/dic/services"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd">
+
+            <config>
+                <!-- ... -->
+
+                <firewall name="main">
+                    <!-- ... -->
+                    <logout>
+                        <clear-site-data>cookies</clear-site-data>
+                        <clear-site-data>storage</clear-site-data>
+                    </logout>
+                </firewall>
+            </config>
+        </srv:container>
+
+    .. code-block:: php
+
+        // config/packages/security.php
+        $container->loadFromExtension('security', [
+            // ...
+            'firewalls' => [
+                'main' => [
+                    'logout' => [
+                        'clear-site-data' => [
+                            'cookies',
+                            'storage',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
 invalidate_session
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR is related to symfony/symfony#49306.

Enhance security by issuing a Clear-Site-Data header on logout.
* [Clear-Site-Data](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#sign_out_of_a_web_site) Documentation
* Example: https://www.w3.org/TR/clear-site-data/#example-signout

Add the documentation with code examples to the **Security Configuration Reference (SecurityBundle)**.
