### PR TITLE
Fix the example for the When constraint

### DIFF
--- a/reference/constraints/When.rst
+++ b/reference/constraints/When.rst
@@ -69,7 +69,7 @@ One way to accomplish this is with the When constraint:
         {
             #[Assert\GreaterThan(0)]
             #[Assert\When(
-                expression: 'this.type == "percent"',
+                expression: 'this.getType() == "percent"',
                 constraints: [
                     new Assert\LessThanOrEqual(100, message: 'The value should be between 1 and 100!')
                 ],
@@ -87,7 +87,7 @@ One way to accomplish this is with the When constraint:
                 value:
                     - GreaterThan: 0
                     - When:
-                        expression: "this.type == 'percent'"
+                        expression: "this.getType() == 'percent'"
                         constraints:
                             - LessThanOrEqual:
                                 value: 100
@@ -105,7 +105,7 @@ One way to accomplish this is with the When constraint:
                     <constraint name="GreaterThan">0</constraint>
                     <constraint name="When">
                         <option name="expression">
-                            this.type == 'percent'
+                            this.getType() == 'percent'
                         </option>
                         <option name="constraints">
                             <constraint name="LessThanOrEqual">
@@ -132,7 +132,7 @@ One way to accomplish this is with the When constraint:
             {
                 $metadata->addPropertyConstraint('value', new Assert\GreaterThan(0));
                 $metadata->addPropertyConstraint('value', new Assert\When([
-                    'expression' => 'this.type == "percent"',
+                    'expression' => 'this.getType() == "percent"',
                     'constraints' => [
                         new Assert\LessThanOrEqual([
                             'value' => 100,


### PR DESCRIPTION
When evaluating the expression, the ExpressionLanguage does not have access to private properties of the object, as it runs from its outside. And contrary to Twig, ExpressionLanguage does not have the magic `.` operator that tries to find a getter when it cannot use the property.

See https://github.com/symfony/symfony/issues/49367 for a support request caused by this bad example.
