### PR TITLE
Adapt CsvEncoder `no_headers` context

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1104,7 +1104,8 @@ Option                  Description                                            D
                         with a ``\t`` character
 ``as_collection``       Always returns results as a collection, even if only   ``true``
                         one line is decoded.
-``no_headers``          Disables header in the encoded CSV                     ``false``
+``no_headers``          Setting to ``false`` will use first row as headers.    ``false``
+                        ``true`` generate numeric headers.
 ``output_utf8_bom``     Outputs special `UTF-8 BOM`_ along with encoded data   ``false``
 ======================= =====================================================  ==========================
 


### PR DESCRIPTION
Try fix #15243

Default behavior:
https://github.com/symfony/symfony/blob/c7a7cb8841bb54a68c967b3ea0e57024802b96ed/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php#L45-L60

With `no_headers`
https://github.com/symfony/symfony/blob/c7a7cb8841bb54a68c967b3ea0e57024802b96ed/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php#L647-L653