### PR TITLE
docs(DomCrawler): remove hint about html5-php library

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -70,13 +70,6 @@ tree.
     isn't meant to dump content, you can see the "fixed" version of your HTML
     by :ref:`dumping it <component-dom-crawler-dumping>`.
 
-.. note::
-
-    If you need better support for HTML5 contents or want to get rid of the
-    inconsistencies of PHP's DOM extension, install the `html5-php library`_.
-    The DomCrawler component will use it automatically when the content has
-    an HTML5 doctype.
-
 Node Filtering
 ~~~~~~~~~~~~~~
 
@@ -650,5 +643,3 @@ Learn more
 
 * :doc:`/testing`
 * :doc:`/components/css_selector`
-
-.. _`html5-php library`: https://github.com/Masterminds/html5-php


### PR DESCRIPTION
html5-php is mandatory after https://github.com/symfony/symfony/pull/44170

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
