### PR TITLE
Update custom_normalizer.rst

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -22,18 +22,20 @@ to customize the normalized data. To do that, leverage the ``ObjectNormalizer``:
 
     use App\Entity\Topic;
     use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+    use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
     use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
     use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
-    class TopicNormalizer implements NormalizerInterface
+    class TopicNormalizer implements NormalizerInterface, NormalizerAwareInterface
     {
+        use NormalizerAwareTrait;
+        
         private $router;
         private $normalizer;
 
-        public function __construct(UrlGeneratorInterface $router, ObjectNormalizer $normalizer)
+        public function __construct(UrlGeneratorInterface $router)
         {
             $this->router = $router;
-            $this->normalizer = $normalizer;
         }
 
         public function normalize($topic, string $format = null, array $context = [])


### PR DESCRIPTION
Autowiring ObjectNormalizer has been deprecated since Symfony 6.1. Autowiring NormalizerInterface leads to a circular reference. The new way of doing things, as explained in:
https://symfonycasts.com/screencast/api-platform-security/normalizer-aware#avoiding-recursion-with-a-context-flan Is to implement a NormalizerAwareInterface and to use the NormalizerAwareTrait.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
