### PR TITLE
[Flex] Replace orm-pack with orm

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -74,7 +74,7 @@ manual steps:
 
    .. code-block:: terminal
 
-       $ composer require annotations asset orm-pack twig \
+       $ composer require annotations asset orm twig \
          logger mailer form security translation validator
        $ composer require --dev dotenv maker-bundle orm-fixtures profiler
 


### PR DESCRIPTION
Replace `orm-pack` alias with `orm`.

See https://github.com/symfony/flex/issues/820

> We don't autogenerate aliases for `symfony/*-pack` anymore.