### PR TITLE
[Security] Adding needsRehash()

### DIFF
--- a/security/passwords.rst
+++ b/security/passwords.rst
@@ -830,6 +830,12 @@ If you need to create your own, it needs to follow these rules:
 
             return $passwordIsValid;
         }
+
+        public function needsRehash(string $hashedPassword): bool
+        {
+            // Check if a password hash would benefit from rehashing
+            return $needsRehash;
+        }
     }
 
 Now, define a password hasher using the ``id`` setting:


### PR DESCRIPTION
Page: https://symfony.com/doc/5.4/security/passwords.html#custom-password-hasher

Adding this to comply with `PasswordHasherInterface`

* I didn't check if this is really required in v5.4 already (but for sure in 6.2)