### PR TITLE
[Security] Removing "Most applications will only need one firewall"

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -827,8 +827,7 @@ The name of the ``$_SERVER`` parameter holding the user identifier.
 Firewall Context
 ~~~~~~~~~~~~~~~~
 
-Most applications will only need one :ref:`firewall <firewalls-authentication>`.
-But if your application *does* use multiple firewalls, you'll notice that
+If your application uses multiple :ref:`firewalls <firewalls-authentication>`, you'll notice that
 if you're authenticated in one firewall, you're not automatically authenticated
 in another. In other words, the systems don't share a common "context":
 each firewall acts like a separate security system.


### PR DESCRIPTION
Page: https://symfony.com/doc/5.4/reference/configuration/security.html#firewall-context

Follow-up of https://github.com/symfony/symfony-docs/pull/17864, so to say
