### PR TITLE
[Security] format `login()` properly

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1631,7 +1631,7 @@ Login Programmatically
     The :method:`Symfony\\Bundle\\SecurityBundle\\Security::login`
     method was introduced in Symfony 6.2.
 
-You can log in a user programmatically using the `login()` method of the
+You can log in a user programmatically using the ``login()`` method of the
 :class:`Symfony\\Bundle\\SecurityBundle\\Security` helper::
 
     // src/Controller/SecurityController.php


### PR DESCRIPTION
On https://symfony.com/doc/6.2/security.html#login-programmatically

It appeared as plain text:

> ![image](https://user-images.githubusercontent.com/2071331/220127490-4beb30ee-31c5-4dc2-98e2-74433c60d3c5.png)
