### PR TITLE
[Mailer] Adding the `sandbox` option in Mailjet API

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -171,13 +171,17 @@ Amazon SES           ses+smtp://USERNAME:PASSWORD@default                 ses+ht
 Google Gmail         gmail+smtp://USERNAME:APP-PASSWORD@default           n/a                                         n/a
 Mailchimp Mandrill   mandrill+smtp://USERNAME:PASSWORD@default            mandrill+https://KEY@default                mandrill+api://KEY@default
 Mailgun              mailgun+smtp://USERNAME:PASSWORD@default             mailgun+https://KEY:DOMAIN@default          mailgun+api://KEY:DOMAIN@default
-Mailjet              mailjet+smtp://ACCESS_KEY:SECRET_KEY@default         n/a                                         mailjet+api://ACCESS_KEY:SECRET_KEY@default
+Mailjet              mailjet+smtp://ACCESS_KEY:SECRET_KEY@default         n/a                                         mailjet+api://ACCESS_KEY:SECRET_KEY@default?sandbox=false
 MailPace             mailpace+api://API_TOKEN@default                     n/a                                         mailpace+api://API_TOKEN@default
 Postmark             postmark+smtp://ID@default                           n/a                                         postmark+api://KEY@default
 Sendgrid             sendgrid+smtp://KEY@default                          n/a                                         sendgrid+api://KEY@default
 Sendinblue           sendinblue+smtp://USERNAME:PASSWORD@default          n/a                                         sendinblue+api://KEY@default
 Infobip              infobip+smtp://KEY@default                           n/a                                         infobip+api://KEY@BASE_URL
 ==================== ==================================================== =========================================== ========================================
+
+.. versionadded:: 6.3
+
+    The ``sandbox`` option in ``Mailjet`` API was introduced in Symfony 6.3.
 
 .. caution::
 


### PR DESCRIPTION
Fixes #17939

I don't know if here it is better to add a `.. note::` block instead of the `?sandbox=false` option (which by default is `false`) in Mailjet API DSN.

What do you think?