### PR TITLE
[HttpCache] Inject `$env` in example

### DIFF
--- a/http_cache.rst
+++ b/http_cache.rst
@@ -114,7 +114,7 @@ Use the ``framework.http_cache`` option to enable the proxy for the
         // config/packages/framework.php
         use Symfony\Config\FrameworkConfig;
 
-        return static function (FrameworkConfig $framework) use ($env) {
+        return static function (FrameworkConfig $framework, string $env) {
             if ('prod' === $env) {
                 $framework->httpCache()->enabled(true);
             }


### PR DESCRIPTION
A sort of followup to #17639, IMO makes the example a bit clearer.