### PR TITLE
[Messenger] Fix the referencing of the redis transport in an explanation

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -709,7 +709,7 @@ and ``user`` to the Unix user on your server.
 If you use the Redis Transport, note that each worker needs a unique consumer
 name to avoid the same message being handled by multiple workers. One way to
 achieve this is to set an environment variable in the Supervisor configuration
-file, which you can then refer to in ``messenger.yaml`` (see Redis section above):
+file, which you can then refer to in ``messenger.yaml`` (see Redis section below):
 
 .. code-block:: ini
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->

This is just a minor fix, currently it says "see the Redis section above", although the Redis section comes after this reference.