### PR TITLE
[Serializer] Add feature description for `AbstractNormalizer::REQUIRE_ALL_PROPERTIES` context option

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1265,7 +1265,8 @@ to ``true``::
 
 .. versionadded:: 6.3
 
-    The context flag was introduced in Symfony 6.3.
+    The ``AbstractNormalizer::PREVENT_NULLABLE_FALLBACK`` context option
+    was introduced in Symfony 6.3.
 
 Skipping Uninitialized Properties
 ---------------------------------

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1242,6 +1242,30 @@ to ``true``::
     $result = $normalizer->normalize($dummy, 'json', [AbstractObjectNormalizer::SKIP_NULL_VALUES => true]);
     // ['bar' => 'notNull']
 
+Preventing ``null`` value fallback for nullable properties
+----------------------------------------------------------
+
+By default, the Serializer will add `null` to nullable properties when the parameters for those are not provided.
+You can change this behavior by setting the ``AbstractNormalizer::PREVENT_NULLABLE_FALLBACK`` context option
+to ``true``::
+
+    class Dummy {
+        public function __construct(
+            public string $foo,
+            public ?string $bar,
+        )
+    }
+
+    $data = ['foo' => 'notNull'];
+
+    $normalizer = new ObjectNormalizer();
+    $result = $normalizer->denormalize($data, Dummy::class, 'json', [AbstractNormalizer::PREVENT_NULLABLE_FALLBACK => true]);
+    // throws Symfony\Component\Serializer\Exception\MissingConstructorArgumentException
+
+.. versionadded:: 6.3
+
+    The context flag was introduced in Symfony 6.3.
+
 Skipping Uninitialized Properties
 ---------------------------------
 

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1242,11 +1242,11 @@ to ``true``::
     $result = $normalizer->normalize($dummy, 'json', [AbstractObjectNormalizer::SKIP_NULL_VALUES => true]);
     // ['bar' => 'notNull']
 
-Preventing ``null`` Value Fallback for Nullable Properties
-----------------------------------------------------------
+Require all Properties
+----------------------
 
 By default, the Serializer will add ``null`` to nullable properties when the parameters for those are not provided.
-You can change this behavior by setting the ``AbstractNormalizer::PREVENT_NULLABLE_FALLBACK`` context option
+You can change this behavior by setting the ``AbstractNormalizer::REQUIRE_ALL_PROPERTIES`` context option
 to ``true``::
 
     class Dummy
@@ -1261,7 +1261,7 @@ to ``true``::
     $data = ['foo' => 'notNull'];
 
     $normalizer = new ObjectNormalizer();
-    $result = $normalizer->denormalize($data, Dummy::class, 'json', [AbstractNormalizer::PREVENT_NULLABLE_FALLBACK => true]);
+    $result = $normalizer->denormalize($data, Dummy::class, 'json', [AbstractNormalizer::REQUIRE_ALL_PROPERTIES => true]);
     // throws Symfony\Component\Serializer\Exception\MissingConstructorArgumentException
 
 .. versionadded:: 6.3

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1253,7 +1253,8 @@ to ``true``::
         public function __construct(
             public string $foo,
             public ?string $bar,
-        )
+        ) {
+        }
     }
 
     $data = ['foo' => 'notNull'];

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1245,7 +1245,7 @@ to ``true``::
 Preventing ``null`` value fallback for nullable properties
 ----------------------------------------------------------
 
-By default, the Serializer will add `null` to nullable properties when the parameters for those are not provided.
+By default, the Serializer will add ``null`` to nullable properties when the parameters for those are not provided.
 You can change this behavior by setting the ``AbstractNormalizer::PREVENT_NULLABLE_FALLBACK`` context option
 to ``true``::
 

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1242,7 +1242,7 @@ to ``true``::
     $result = $normalizer->normalize($dummy, 'json', [AbstractObjectNormalizer::SKIP_NULL_VALUES => true]);
     // ['bar' => 'notNull']
 
-Preventing ``null`` value fallback for nullable properties
+Preventing ``null`` Value Fallback for Nullable Properties
 ----------------------------------------------------------
 
 By default, the Serializer will add ``null`` to nullable properties when the parameters for those are not provided.

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1249,7 +1249,8 @@ By default, the Serializer will add ``null`` to nullable properties when the par
 You can change this behavior by setting the ``AbstractNormalizer::PREVENT_NULLABLE_FALLBACK`` context option
 to ``true``::
 
-    class Dummy {
+    class Dummy
+    {
         public function __construct(
             public string $foo,
             public ?string $bar,


### PR DESCRIPTION
This PR adds the feature description for the new context flag for the Serializer component introduced here: https://github.com/symfony/symfony/pull/49553