### PR TITLE
[FrameworkBundle] enable_annotations is enabled by default

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2512,7 +2512,7 @@ settings is configured.
 enable_annotations
 ..................
 
-**type**: ``boolean`` **default**: ``false``
+**type**: ``boolean`` **default**: ``true``
 
 If this option is enabled, validation constraints can be defined using annotations or attributes.
 
@@ -2720,7 +2720,7 @@ Whether to enable the ``serializer`` service or not in the service container.
 enable_annotations
 ..................
 
-**type**: ``boolean`` **default**: ``false``
+**type**: ``boolean`` **default**: ``true``
 
 If this option is enabled, serialization groups can be defined using annotations or attributes.
 


### PR DESCRIPTION
Not sure at 100% of the use of `FullStack` means [here](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php#L886), but in a default Symfony app `enable_annotations` seems to be true.

```bash
php bin/console config:dump-reference framework
```

```yaml
    validation:
        enabled:              true
        cache:                ~
        enable_annotations:   true

    # serializer configuration
    serializer:
        enabled:              true
        enable_annotations:   true
```

cf #12953