### PR TITLE
Update custom_normalizer.rst

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -23,14 +23,13 @@ to customize the normalized data. To do that, leverage the ``ObjectNormalizer``:
     use App\Entity\Topic;
     use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
     use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-    use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
     class TopicNormalizer implements NormalizerInterface
     {
         private $router;
         private $normalizer;
 
-        public function __construct(UrlGeneratorInterface $router, ObjectNormalizer $normalizer)
+        public function __construct(UrlGeneratorInterface $router, NormalizerInterface $normalizer)
         {
             $this->router = $router;
             $this->normalizer = $normalizer;


### PR DESCRIPTION
From Symfony 6.1 if uses ObjectNormalizer on constructor throw the error: App\Serializer\Normalizer\DescriptionNormalizer::__construct(): Argument 1 ($normalizer) must be of type Symfony\Component\Serializer\Normalizer\ObjectNormalizer, Symfony\Component\Serializer\Debug\TraceableNormalizer given

