### PR TITLE
Update mailer.rst

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1576,3 +1576,8 @@ the :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\MailerAssertionsTrait`::
 .. _`default_socket_timeout`: https://www.php.net/manual/en/filesystem.configuration.php#ini.default-socket-timeout
 .. _`RFC 3986`: https://www.ietf.org/rfc/rfc3986.txt
 .. _`App Password`: https://support.google.com/accounts/answer/185833
+
+.. tip::
+
+    If you're using Messenger you should use ``$this->assertQueuedEmailCount(1);`` instead.
+    


### PR DESCRIPTION
It's not clear to me that `$this->assertEmailCount(1);` returns `0` when _Messenger_ is used
and does not concern queued messages.