### PR TITLE
[HttpClient][Mime] support overwriting form encoding

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -636,6 +636,7 @@ will transfer file uploads in binary encoding. But you can enforce Base64::
     );
 
 .. versionadded:: 6.3
+
     The `encoding` parameter was introduced in Symfony 6.3.
 
 .. tip::

--- a/http_client.rst
+++ b/http_client.rst
@@ -630,7 +630,7 @@ according to the ``multipart/form-data`` content-type. The
 By default, :class:`Symfony\\Component\\Mime\\Part\\Multipart\\FormDataPart`
 will transfer file uploads in binary encoding. But you can enforce Base64::
 
-    DataPart::fromPath('/path/to/uploaded/file', null, null, 'base64')
+    $fileField = DataPart::fromPath('/path/to/uploaded/file', null, null, 'base64');
 
 .. tip::
 

--- a/http_client.rst
+++ b/http_client.rst
@@ -630,7 +630,13 @@ according to the ``multipart/form-data`` content-type. The
 By default, :class:`Symfony\\Component\\Mime\\Part\\Multipart\\FormDataPart`
 will transfer file uploads in binary encoding. But you can enforce Base64::
 
-    $fileField = DataPart::fromPath('/path/to/uploaded/file', null, null, 'base64');
+    $fileField = DataPart::fromPath(
+        path: '/path/to/uploaded/file',
+        encoding: 'base64'
+    );
+
+.. versionadded:: 6.3
+    The `encoding` parameter was introduced in Symfony 6.3.
 
 .. tip::
 

--- a/http_client.rst
+++ b/http_client.rst
@@ -627,6 +627,11 @@ according to the ``multipart/form-data`` content-type. The
         'body' => $formData->bodyToIterable(),
     ]);
 
+By default, :class:`Symfony\\Component\\Mime\\Part\\Multipart\\FormDataPart`
+will transfer file uploads in binary encoding. But you can enforce Base64::
+
+    DataPart::fromPath('/path/to/uploaded/file', null, null, 'base64')
+
 .. tip::
 
     When using multidimensional arrays the :class:`Symfony\\Component\\Mime\\Part\\Multipart\\FormDataPart`


### PR DESCRIPTION
It's not really relevant to the Mime / Email docs because that will use Base64 by default.

I've tried to keep it short, i'm not sure it's good though.

See PR https://github.com/symfony/symfony/pull/49587 and issue symfony/symfony#49315