### PR TITLE
[Security] Add documentation for `#[IsGranted]` and Voters

### DIFF
--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -164,7 +164,7 @@ listener in the Symfony application by creating a new service for it and
 
 .. configuration-block::
 
-    .. code-block:: attribute
+    .. code-block:: php-attributes
 
         // src/App/EventListener/SearchIndexer.php
         namespace App\EventListener;

--- a/security.rst
+++ b/security.rst
@@ -2288,7 +2288,7 @@ will happen:
 
 .. _security-securing-controller-annotations:
 
-Another way to secure one or more controller actions is to use an attribute.
+Another way to secure one or more controller actions is to use the ``#[IsGranted()]`` attribute.
 In the following example, all controller actions will require the
 ``ROLE_ADMIN`` permission, except for ``adminDashboard()``, which will require
 the ``ROLE_SUPER_ADMIN`` permission:


### PR DESCRIPTION
Added an example for using `#[IsGranted]` with voters and explained how to change the message and status code returned.