### PR TITLE
[Workflow] MarkingStore: remove "arguments" and add "property"

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3485,7 +3485,7 @@ marking_store
 
 Each marking store can define any of these options:
 
-* ``arguments`` (**type**: ``array``)
+* ``property`` (**type**: ``string`` **default**: ``'marking'``)
 * ``service`` (**type**: ``string``)
 * ``type`` (**type**: ``string`` **allow value**: ``'method'``)
 


### PR DESCRIPTION
Node "arguments" being deleted from SF 5.0, I think we could delete it in doc. I selected 6.2 as base but all docs from 5.0 should be updated.
On the contrary, the node "property" is missing.

Sorry if my contribution is clumsy, it is only the second/third. :)

```yaml
#... 
workflows:
          # Prototype
          name:
              audit_trail:
                  enabled:              false
              type:                 state_machine # One of "workflow"; "state_machine"
              marking_store:
                  # "arguments" does not exist anymore from SF5.0 <-----
                  type:                 ~ # One of "method"
                  property:             marking
                  service:              ~
              supports:             []
              support_strategy:     ~
              initial_marking:      []

              # Select which Transition events should be dispatched for this Workflow
              events_to_dispatch:

                  # Examples:
                  - workflow.enter
                  - workflow.transition
# ...
```