### PR TITLE
Typo in security.rst

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2556,7 +2556,7 @@ If you're having problems authenticating, it could be that you *are* authenticat
 successfully, but you immediately lose authentication after the first redirect.
 
 In that case, review the serialization logic (e.g. the ``__serialize()`` or
-``serialize()`` methods) on you user class (if you have any) to make sure
+``serialize()`` methods) in the user class (if you have any) to make sure
 that all the fields necessary are serialized and also exclude all the
 fields not necessary to be serialized (e.g. Doctrine relations).
 


### PR DESCRIPTION
Corrected expression, "in you user class"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
