### PR TITLE
[Session] Fix an RST syntax issue

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -1129,9 +1129,6 @@ These are parameters that you can configure:
 ``expiry_field`` (default ``expires_at``):
     The name of the field where to store the session lifetime.
 
-.. index::
-    single: Sessions, saving locale
-
 Migrating Between Session Handlers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes this issue:

<img width="931" alt="error-1" src="https://user-images.githubusercontent.com/73419/223742820-e638aa9a-6856-4a90-8113-7ac41fce863e.png">
