### PR TITLE
Fix typo in routing

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -408,7 +408,7 @@ You can also use these functions:
         // Controller (using an alias):
         #[Route(condition: "service('route_checker').check(request)")]
         // Or without alias:
-        #[Route(condition: "service('Ap\\\Service\\\RouteChecker').check(request)")]
+        #[Route(condition: "service('App\\\Service\\\RouteChecker').check(request)")]
 
 .. versionadded:: 6.1
 


### PR DESCRIPTION
There was a typo in the Matching expression section : Ap\ instead of App\

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
