### PR TITLE
[Security] Add tip for using new isGrantedForUser() function

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2585,6 +2585,18 @@ want to include extra details only for users that have a ``ROLE_SALES_ADMIN`` ro
           // ...
       }
 
+.. tip::
+
+    Using ``isGranted()`` checks authorization against the currently logged in user. If you need to check
+    against a user that is not the one logged in or if checking authorization when the user session is not
+    available in a CLI context (example: message queue, cronjob) ``isGrantedForUser()`` can be used to set the
+    target user explicitly.
+
+    .. versionadded:: 7.3
+
+        The :method:`Symfony\\Bundle\\SecurityBundle\\Security::isGrantedForUser`
+        method was introduced in Symfony 7.3.
+
 If you're using the :ref:`default services.yaml configuration <service-container-services-load-example>`,
 Symfony will automatically pass the ``security.helper`` to your service
 thanks to autowiring and the ``Security`` type-hint.


### PR DESCRIPTION
Adds tip for using new `isGrantedForUser()` function from https://github.com/symfony/symfony/pull/48142