### PR TITLE
Update reverse_engineering.rst

### DIFF
--- a/doctrine/reverse_engineering.rst
+++ b/doctrine/reverse_engineering.rst
@@ -9,8 +9,11 @@ How to Generate Entities from an Existing Database
     The ``doctrine:mapping:import`` command used to generate Doctrine entities
     from existing databases was deprecated by Doctrine in 2019 and it's no
     longer recommended to use it.
+    
+    As of march,2023 there is no replacement.
 
     Instead, you can use the ``make:entity`` command from `Symfony Maker Bundle`_
     to quickly generate the Doctrine entities of your application.
+    But it does not permit generating entities from existing database.
 
 .. _`Symfony Maker Bundle`: https://symfony.com/bundles/SymfonyMakerBundle/current/index.html


### PR DESCRIPTION
Precision for making it clear that "make:entity" does not permit to reverse-engineer a database to an entity

