### PR TITLE
Add missing import for `LogRecord` class in processors code example

### DIFF
--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -19,6 +19,7 @@ using a processor::
     // src/Logger/SessionRequestProcessor.php
     namespace App\Logger;
 
+    use Monolog\LogRecord;
     use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
     use Symfony\Component\HttpFoundation\RequestStack;
 


### PR DESCRIPTION
The code example on the [processors page](https://symfony.com/doc/current/logging/processors.html) uses the "LogRecord" class (starting with Symfony version 6.2) but is missing the corresponding import for the class.
