### PR TITLE
[Form] Remove evasive `getOrigin` sentence

### DIFF
--- a/components/form.rst
+++ b/components/form.rst
@@ -749,7 +749,6 @@ method to access the list of errors. It returns a
     $errors = $form['firstName']->getErrors();
 
     // a FormErrorIterator instance in a flattened structure
-    // use getOrigin() to determine the form causing the error
     $errors = $form->getErrors(true);
 
     // a FormErrorIterator instance representing the form tree structure


### PR DESCRIPTION
Remove evasive `getOrigin` sentence as suggested in https://github.com/symfony/symfony-docs/issues/17670#issuecomment-1373714770

Close #17670