### PR TITLE
[Logger] Tweak a section heading

### DIFF
--- a/logging/channels_handlers.rst
+++ b/logging/channels_handlers.rst
@@ -99,10 +99,9 @@ can do it in any (or all) environments:
     such handler will ignore this configuration and will process every message
     passed to them.
 
-YAML Specification
-------------------
+.. _yaml-specification:
 
-You can specify the configuration by many forms:
+You can specify the configuration in different ways:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
The title `YAML Specification` is very misleading in this page:

https://symfony.com/doc/current/logging/channels_handlers.html#yaml-specification

This section has nothing to do with the YAML specification, so it's weird to find it as the first result when searching for the YAML specification. Instead, people would expect to find this page:

https://symfony.com/doc/current/reference/formats/yaml.html

