### PR TITLE
use readonly in args of constructor, in components/

### DIFF
--- a/components/clock.rst
+++ b/components/clock.rst
@@ -50,7 +50,7 @@ determine the current time::
     class ExpirationChecker
     {
         public function __construct(
-            private ClockInterface $clock
+            private readonly ClockInterface $clock
         ) {}
 
         public function isExpired(DateTimeInterface $validUntil): bool

--- a/components/console/logger.rst
+++ b/components/console/logger.rst
@@ -20,7 +20,7 @@ PSR-3 compliant logger::
     class MyDependency
     {
         public function __construct(
-            private LoggerInterface $logger,
+            private readonly LoggerInterface $logger,
         ) {
         }
 

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -59,7 +59,7 @@ so this is passed into the constructor::
     class Mailer
     {
         public function __construct(
-            private readonly $transport,
+            private $transport,
         ) {
         }
 

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -59,7 +59,7 @@ so this is passed into the constructor::
     class Mailer
     {
         public function __construct(
-            private $transport,
+            private readonly $transport,
         ) {
         }
 

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -791,7 +791,7 @@ methods. You can inject this as a service anywhere in your application::
     class UserApiNormalizer
     {
         public function __construct(
-            private UrlHelper $urlHelper,
+            private readonly UrlHelper $urlHelper,
         ) {
         }
 

--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -235,8 +235,8 @@ you can create your own message sender::
     class ImportantActionToEmailSender implements SenderInterface
     {
         public function __construct(
-            private MailerInterface $mailer,
-            private string $toEmail,
+            private readonly MailerInterface $mailer,
+            private readonly string $toEmail,
         ) {
         }
 
@@ -284,8 +284,8 @@ do is to write your own CSV receiver::
     class NewOrdersFromCsvFileReceiver implements ReceiverInterface
     {
         public function __construct(
-            private SerializerInterface $serializer,
-            private string $filePath,
+            private readonly SerializerInterface $serializer,
+            private readonly string $filePath,
         ) {
         }
 

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -953,7 +953,7 @@ Consider the following example::
     class Foo
     {
         public function __construct(
-            private Bar $bar,
+            private readonly Bar $bar,
         ) {
         }
 

--- a/components/runtime.rst
+++ b/components/runtime.rst
@@ -406,8 +406,8 @@ is added in a new class implementing :class:`Symfony\\Component\\Runtime\\Runner
     class ReactPHPRunner implements RunnerInterface
     {
         public function __construct(
-            private RequestHandlerInterface $application,
-            private int $port,
+            private readonly RequestHandlerInterface $application,
+            private readonly int $port,
         ) {
         }
 

--- a/components/string.rst
+++ b/components/string.rst
@@ -554,7 +554,7 @@ the injected slugger is the same as the request locale::
     class MyService
     {
         public function __construct(
-            private SluggerInterface $slugger,
+            private readonly SluggerInterface $slugger,
         ) {
         }
 

--- a/components/uid.rst
+++ b/components/uid.rst
@@ -158,7 +158,7 @@ on the configuration you defined::
     class FooService
     {
         public function __construct(
-            private UuidFactory $uuidFactory,
+            private readonly UuidFactory $uuidFactory,
         ) {
         }
 
@@ -358,7 +358,7 @@ Like UUIDs, ULIDs have their own factory, ``UlidFactory``, that can be used to g
     class FooService
     {
         public function __construct(
-            private UlidFactory $ulidFactory,
+            private readonly UlidFactory $ulidFactory,
         ) {
         }
 


### PR DESCRIPTION
This is a follow-up of #18049

I only updated some constructors from the `components/` directory, to ensure that maintainers agree before modifying all the files.

Some files have been omitted because it looks like they must be initialized more than once:

https://github.com/symfony/symfony-docs/blob/9f8ca2889acba3fd3d769ce7ff76a400ec8b6acb/components/event_dispatcher.rst?plain=1#L300

https://github.com/symfony/symfony-docs/blob/9f8ca2889acba3fd3d769ce7ff76a400ec8b6acb/components/lock.rst?plain=1#L91-L92

And this example is about reading annotations, so I think it must be kept as is: https://github.com/symfony/symfony-docs/blob/9f8ca2889acba3fd3d769ce7ff76a400ec8b6acb/components/property_info.rst?plain=1#L438