### PR TITLE
[HttpClient] Add note about a required decoration priority > 5

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1634,6 +1634,10 @@ If you want to extend the behavior of a base HTTP client, you can use
         }
     }
 
+.. note::
+
+    A decoration priority higher than 5 is required to affect scoped clients
+
 A decorator like this one is useful in cases where processing the requests'
 arguments is enough. By decorating the ``on_progress`` option, you can
 even implement basic monitoring of the response. However, since calling


### PR DESCRIPTION
In https://github.com/symfony/symfony/pull/47836 the decoration priority of the `TraceableHttpClient` services had been increased to 5. This results in the own decorator with a default priority of 5 is not added to the chain of any scoped client.

As this is not obvious and caused some trouble for us, I like to add the info to the documentation.

Increasing the priority is only needed when `TraceableHttpClient` is decorated but I am not sure how to word the condition, nor if this is really important to tell here.