### PR TITLE
[DependencyInjection] Add support for `#[Autowire(lazy: true)]`

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -106,6 +106,29 @@ For example, to define your service as lazy use the following::
         // ...
     }
 
+You can also configure laziness when your service is injected with 
+:class:`Symfony\\Component\\DependencyInjection\\Attribute\\Autowire` attribute.
+For example, to inject your service as lazy use the following::
+
+    namespace App\Service;
+
+    use App\Twig\AppExtension;
+    use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+    class MessageGenerator
+    {
+        public function __construct(
+            #[Autowire(service: 'app.twig.app_extension', lazy: true)] ExtensionInterface $extension
+        ) {
+            // ...
+        }
+    }
+
+.. versionadded:: 6.3
+
+    The ``lazy`` argument of the `#[Autowire()]` attribute was introduced in
+    Symfony 6.3.
+
 Interface Proxifying
 --------------------
 


### PR DESCRIPTION
Fixes #18095 

I'm wondering if this argument should be documented [here](https://symfony.com/doc/current/service_container/autowiring.html#autowire-attribute) (where the attribute in mainly mentioned) or if it is fine to split considering the page about service lazy loading is relevant for this arg ? 