### PR TITLE
Add note about custom port being ignored by specific mailer transport DSN

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -236,6 +236,17 @@ OhMySMTP             ohmysmtp+smtp://API_TOKEN@default                    n/a   
 
     Note that the protocol is *always* HTTPs and cannot be changed.
 
+.. note::
+
+    The specific transports, e.g. ``mailgun+smtp`` are designed to work without any manual configuration.
+    Changing the port by appending it to your DSN is not supported for any of these ``<provider>+smtp` transports.
+    If you need to change the port, use the ``smtp`` transport instead, like so:
+
+    .. code-block:: env
+
+        # .env
+        MAILER_DSN=smtp://KEY:DOMAIN@smtp.eu.mailgun.org.com:25
+
 High Availability
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
See https://github.com/symfony/symfony/pull/49768

Seems like there has been some confusion about this:
* https://github.com/symfony/symfony/issues/46979
* https://github.com/symfony/symfony/discussions/44794

People start with the default they're given by the docs, e.g. `sendgrid+smtp` and then try to append `:<port>` to configure it, which doesn't work.

As far as I know, the official recommendation is to use the regular `smtp` transport instead when using custom config: https://github.com/symfony/symfony/issues/36224#issuecomment-1083194321
