### PR TITLE
[Standards] Improve code standards about exception and error messages

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -179,6 +179,12 @@ Structure
 
 * Exception and error message strings must be concatenated using :phpfunction:`sprintf`;
 
+* Exception and error messages must not contain backticks, even when referring to a
+  technical element (such as a method name for example). Double quotes must be used
+  at all time;
+
+* Exception and error messages must start with a capital letter and finish with a dot ``.``;
+
 * Do not use ``else``, ``elseif``, ``break`` after ``if`` and ``case`` conditions
   which return or throw something;
 


### PR DESCRIPTION
After this one being merged https://github.com/symfony/symfony/pull/49829, I think the coding standards about exception can be improved a bit :+1: 