### PR TITLE
[HttpClient] Add `ServerSentEvent::getArrayData()` to get the SSE's data decoded as an array directly

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1425,6 +1425,16 @@ to wrap your HTTP client, open a connection to a server that responds with a
         }
     }
 
+.. tip::
+
+    If you know that the content of the ``ServerSentEvent`` is in the JSON format, you can
+    use the :method:`Symfony\\Component\\HttpClient\\Chunk\\ServerSentEvent::getArrayData`
+    method to directly get the decoded JSON in an array.
+
+.. versionadded:: 6.3
+
+    The ``ServerSentEvent::getArrayData()`` method was introduced in Symfony 6.3.
+
 Interoperability
 ----------------
 


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony-docs/issues/18142