### PR TITLE
Update HTML Sanitizer doc for `max_input_length` option

### DIFF
--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -932,7 +932,7 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
         );
 
 Configure max input length
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Using this option, you can change the default max input length of ``20000`` characters.
 Any input longer than this value will be truncated.

--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -931,12 +931,11 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
                 ->allowRelativeMedias()
         );
 
-Configure Max input length
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Max Input Length
+~~~~~~~~~~~~~~~~
 
 To prevent DoS attacks, the HTML sanitizer limits the input length to ``20000`` by default.
-Using this option, you can change the max input length.
-Inputs longer than this value will be truncated.
+Using this option, you can change the max input length, Inputs longer than this value will be truncated.
 
 .. configuration-block::
 
@@ -950,8 +949,7 @@ Inputs longer than this value will be truncated.
                         # ...
 
                         # specifies the max input length. Inputs longer than this value will be
-                        # truncated (default: 20000)
-                        max_input_length: 20000
+                        max_input_length: 30000 # default: 20000
 
     .. code-block:: xml
 

--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -931,6 +931,75 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
                 ->allowRelativeMedias()
         );
 
+Configure max input length
+~~~~~~~~~~~~~~~~~~~~~
+
+Using this option, you can change the default max input length of ``20000`` characters.
+Any input longer than this value will be truncated.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/html_sanitizer.yaml
+        framework:
+            html_sanitizer:
+                sanitizers:
+                    app.post_sanitizer:
+                        # ...
+
+                        # specifies the max input length. Inputs longer than this value will be
+                        # truncated (default: 20000)
+                        max_input_length: 20000
+
+    .. code-block:: xml
+
+        <!-- config/packages/html_sanitizer.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+            <framework:config>
+                <framework:html-sanitizer>
+                    <framework:sanitizer name="app.post_sanitizer">
+                        <!-- specifies the max input length. Inputs longer than this value will be
+                            truncated (default: 20000) -->
+                        <framework:max-input-length>20000</framework:max-input-length>
+                    </framework:sanitizer>
+                </framework:html-sanitizer>
+            </framework:config>
+        </container>
+
+    .. code-block:: php
+
+        // config/packages/framework.php
+        use Symfony\Config\FrameworkConfig;
+
+        return static function (FrameworkConfig $framework) {
+            $framework->htmlSanitizer()
+                ->sanitizer('app.post_sanitizer')
+                    // specifies the max input length. Inputs longer than this value will be
+                    // truncated (default: 20000)
+                    ->withMaxInputLength(20000)
+            ;
+        };
+
+    .. code-block:: php-standalone
+
+        use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+        use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+
+        $postSanitizer = new HtmlSanitizer(
+            (new HtmlSanitizerConfig())
+                // specifies the max input length. Inputs longer than this value will be
+                // truncated (default: 20000)
+                ->withMaxInputLength(20000)
+        );
+
 Custom Attribute Sanitizers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -931,11 +931,12 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
                 ->allowRelativeMedias()
         );
 
-Configure max input length
+Configure Max input length
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Using this option, you can change the default max input length of ``20000`` characters.
-Any input longer than this value will be truncated.
+To prevent DoS attacks, the HTML sanitizer limits the input length to ``20000`` by default.
+Using this option, you can change the max input length.
+Inputs longer than this value will be truncated.
 
 .. configuration-block::
 


### PR DESCRIPTION
Add missing documentation for https://symfony.com/doc/current/html_sanitizer.html#allow-elements

Related to the bug https://github.com/symfony/symfony/issues/49040
