### PR TITLE
[Process] :memo: process: `create_new_console` is only for windows

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -113,6 +113,11 @@ You can configure the options passed to the ``other_options`` argument of
     // this option allows a subprocess to continue running after the main script exited
     $process->setOptions(['create_new_console' => true]);
 
+.. note::
+
+    The ``create_new_console`` option is only available on Windows!
+
+
 Using Features From the OS Shell
 --------------------------------
 


### PR DESCRIPTION
cf: https://www.php.net/manual/en/function.proc-open.php

I find the current documentation a bit misleading because this option actually does nothing on non-Windows systems