### PR TITLE
[DependencyInjection] Add support for `#[Autowire(lazy: class-string)]`

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -120,6 +120,15 @@ You can also configure laziness when your service is injected with the
         }
     }
 
+This attribute also allows you to define the interfaces to proxy when using
+laziness, and supports lazy-autowiring of intersection types::
+
+    public function __construct(
+        #[Autowire(service: 'foo', lazy: FooInterface::class)]
+        FooInterface|BarInterface $foo,
+    ) {
+    }
+
 .. versionadded:: 6.3
 
     The ``lazy`` argument of the ``#[Autowire()]`` attribute was introduced in


### PR DESCRIPTION
In addition to issue #18095 / pr #18106 to explicitly document https://github.com/symfony/symfony/pull/49836