### PR TITLE
[Form] Task object instead of id as param

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -598,12 +598,8 @@ the relationship between the removed ``Tag`` and ``Task`` object.
 
         class TaskController extends AbstractController
         {
-            public function edit($id, Request $request, EntityManagerInterface $entityManager): Response
+            public function edit(Task $task, Request $request, EntityManagerInterface $entityManager): Response
             {
-                if (null === $task = $entityManager->getRepository(Task::class)->find($id)) {
-                    throw $this->createNotFoundException('No task found for id '.$id);
-                }
-
                 $originalTags = new ArrayCollection();
 
                 // Create an ArrayCollection of the current Tag objects in the database


### PR DESCRIPTION
Thanks to Paramconverter we can get Task object  directly instead of putting the $id and we can throw automatically an exception if the task was not found

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
