### PR TITLE
[PropertyInfo] Add `ConstructorExtractor` documentation for 6.2 (with CPP)

### DIFF
--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -438,6 +438,7 @@ information from annotations of properties and methods, such as ``@var``,
 
     // Extraction.php
     use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
+    use App\Domain\Foo;
 
     $phpStanExtractor = new PhpStanExtractor();
     $phpStanExtractor->getTypesFromConstructor(Foo::class, 'bar');
@@ -517,11 +518,9 @@ on the constructor arguments::
     // src/Domain/Foo.php
     class Foo
     {
-        private $bar;
-
-        public function __construct(string $bar)
-        {
-            $this->bar = $bar;
+        public function __construct(
+            private string $bar,
+        ) {
         }
     }
 


### PR DESCRIPTION
Follow-up of https://github.com/symfony/symfony-docs/pull/18161