### PR TITLE
[Clock] Small typo, additional backtick

### DIFF
--- a/components/clock.rst
+++ b/components/clock.rst
@@ -17,7 +17,7 @@ for different use cases:
 :class:`Symfony\\Component\\Clock\\MockClock`
     Commonly used in tests as a replacement for the ``NativeClock`` to be able
     to freeze and change the current time using either ``sleep()`` or ``modify()``.
-:class:`Symfony\\Component\\Clock\\MonotonicClock``
+:class:`Symfony\\Component\\Clock\\MonotonicClock`
     Relies on ``hrtime()`` and provides a high resolution, monotonic clock,
     when you need a precise stopwatch.
 


### PR DESCRIPTION
Fix for additional ` behind MonotonicClock.

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/2707563/230044351-45f90d44-fa47-497f-a7fc-c66ee6c5a455.png">
