### PR TITLE
[DependencyInjection] Document `ServiceConfigurator` remove method

### DIFF
--- a/service_container/remove.rst
+++ b/service_container/remove.rst
@@ -1,0 +1,23 @@
+How to Remove a Service
+=======================
+
+A service can be removed from the service container if needed
+(for instance in the test or a specific environment):
+
+.. configuration-block::
+
+    .. code-block:: php
+
+        // config/services_test.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\RemovedService;
+
+        return function(ContainerConfigurator $containerConfigurator) {
+            $services = $containerConfigurator->services();
+
+            $services->remove(RemovedService::class);
+        };
+
+Now, the container will not contain the ``App\RemovedService``
+in the test environment.


### PR DESCRIPTION
Continue work started by @94noni in https://github.com/symfony/symfony-docs/pull/17098

Fix #14854