### PR TITLE
[Routing] Changing `RouterInterface` => `UrlGeneratorInterface`

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -2772,37 +2772,32 @@ Now you'll get the expected results when generating URLs in your commands::
     use Symfony\Component\Console\Input\InputInterface;
     use Symfony\Component\Console\Output\OutputInterface;
     use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-    use Symfony\Component\Routing\RouterInterface;
     // ...
 
     class SomeCommand extends Command
     {
-        private $router;
-
-        public function __construct(RouterInterface $router)
+        public function __construct(private UrlGeneratorInterface $urlGenerator)
         {
             parent::__construct();
-
-            $this->router = $router;
         }
 
         protected function execute(InputInterface $input, OutputInterface $output): int
         {
             // generate a URL with no route arguments
-            $signUpPage = $this->router->generate('sign_up');
+            $signUpPage = $this->urlGenerator->generate('sign_up');
 
             // generate a URL with route arguments
-            $userProfilePage = $this->router->generate('user_profile', [
+            $userProfilePage = $this->urlGenerator->generate('user_profile', [
                 'username' => $user->getUserIdentifier(),
             ]);
 
-            // generated URLs are "absolute paths" by default. Pass a third optional
-            // argument to generate different URLs (e.g. an "absolute URL")
-            $signUpPage = $this->router->generate('sign_up', [], UrlGeneratorInterface::ABSOLUTE_URL);
+            // by default, generated URLs are "absolute paths". Pass a third optional
+            // argument to generate different URIs (e.g. an "absolute URL")
+            $signUpPage = $this->urlGenerator->generate('sign_up', [], UrlGeneratorInterface::ABSOLUTE_URL);
 
             // when a route is localized, Symfony uses by default the current request locale
             // pass a different '_locale' value if you want to set the locale explicitly
-            $signUpPageInDutch = $this->router->generate('sign_up', ['_locale' => 'nl']);
+            $signUpPageInDutch = $this->urlGenerator->generate('sign_up', ['_locale' => 'nl']);
 
             // ...
         }


### PR DESCRIPTION
Further up on the page it's advised to use `UrlGeneratorInterface` as typehint. I don't know what the difference is, but I'm guessing that it saves you from `use RouterInterface` (if you need the `UrlGeneratorInterface` for something else anyway, as in this example). Is this right?