### PR TITLE
Set request stateless only if the attribute is not defined

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -1006,7 +1006,8 @@ the session must not be used when authenticating users:
             // ...
         };
 
-Routes under this firewall will be :ref:`configured stateless <stateless-routing>`.
+Routes under this firewall will be :ref:`configured stateless <stateless-routing>`
+when they are not explicitly configured stateless or not.
 
 .. versionadded:: 6.3
 


### PR DESCRIPTION
https://github.com/symfony/symfony/pull/48044 added in 6.3 was updated in https://github.com/symfony/symfony/pull/49997.

This PR ajust behavior documentation