### PR TITLE
[FrameworkBundle] Fix a minor syntax issue

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -482,7 +482,7 @@ instance), the host might have been manipulated by an attacker.
 
 .. seealso::
 
-    You can read "`HTTP Host header attacks`_" for more information about
+    You can read `HTTP Host header attacks`_ for more information about
     these kinds of attacks.
 
 The Symfony :method:`Request::getHost() <Symfony\\Component\\HttpFoundation\\Request::getHost>`


### PR DESCRIPTION
It's strange, but the quotes make it look like this when rendered:

![image](https://user-images.githubusercontent.com/73419/232813354-22aa0403-1459-4e06-8916-5678bdf19902.png)
