### PR TITLE
Don't use double backquotes in the comments

### DIFF
--- a/components/cache/adapters/array_cache_adapter.rst
+++ b/components/cache/adapters/array_cache_adapter.rst
@@ -15,7 +15,7 @@ method::
         // until the current PHP process finishes)
         $defaultLifetime = 0,
 
-        // if ``true``, the values saved in the cache are serialized before storing them
+        // if true, the values saved in the cache are serialized before storing them
         $storeSerialized = true,
 
         // the maximum lifetime (in seconds) of the entire cache (after this time, the

--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -796,7 +796,7 @@ could listen to the ``mailer.post_send`` event and change the method's return va
         public function onMailerPostSend(AfterSendMailEvent $event)
         {
             $returnValue = $event->getReturnValue();
-            // modify the original ``$returnValue`` value
+            // modify the original $returnValue value
 
             $event->setReturnValue($returnValue);
         }

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -216,8 +216,8 @@ adding a service alias:
                 # ...
 
             # but this fixes it!
-            # the ``app.rot13.transformer`` service will be injected when
-            # an ``App\Util\Rot13Transformer`` type-hint is detected
+            # the "app.rot13.transformer" service will be injected when
+            # an App\Util\Rot13Transformer type-hint is detected
             App\Util\Rot13Transformer: '@app.rot13.transformer'
 
     .. code-block:: xml
@@ -251,8 +251,8 @@ adding a service alias:
                 ->autowire();
 
             // but this fixes it!
-            // the ``app.rot13.transformer`` service will be injected when
-            // an ``App\Util\Rot13Transformer`` type-hint is detected
+            // the "app.rot13.transformer" service will be injected when
+            // an App\Util\Rot13Transformer type-hint is detected
             $services->alias(Rot13Transformer::class, 'app.rot13.transformer');
         };
 
@@ -355,8 +355,8 @@ To fix that, add an :ref:`alias <service-autowiring-alias>`:
 
             $services->set(Rot13Transformer::class);
 
-            // the ``App\Util\Rot13Transformer`` service will be injected when
-            // an ``App\Util\TransformerInterface`` type-hint is detected
+            // the App\Util\Rot13Transformer service will be injected when
+            // an App\Util\TransformerInterface type-hint is detected
             $services->alias(TransformerInterface::class, Rot13Transformer::class);
         };
 
@@ -526,13 +526,13 @@ the injection::
             $services->set(Rot13Transformer::class)->autowire();
             $services->set(UppercaseTransformer::class)->autowire();
 
-            // the ``App\Util\UppercaseTransformer`` service will be
-            // injected when an ``App\Util\TransformerInterface``
-            // type-hint for a ``$shoutyTransformer`` argument is detected.
+            // the App\Util\UppercaseTransformer service will be
+            // injected when an App\Util\TransformerInterface
+            // type-hint for a $shoutyTransformer argument is detected.
             $services->alias(TransformerInterface::class.' $shoutyTransformer', UppercaseTransformer::class);
 
             // If the argument used for injection does not match, but the
-            // type-hint still matches, the ``App\Util\Rot13Transformer``
+            // type-hint still matches, the App\Util\Rot13Transformer
             // service will be injected.
             $services->alias(TransformerInterface::class, Rot13Transformer::class);
 

--- a/testing.rst
+++ b/testing.rst
@@ -566,11 +566,10 @@ In the above example, the test validates that the HTTP response was successful
 and the request body contains a ``<h1>`` tag with ``"Hello world"``.
 
 The ``request()`` method also returns a crawler, which you can use to
-create more complex assertions in your tests::
+create more complex assertions in your tests (e.g. to count the number of page
+elements that match a given CSS selector)::
 
     $crawler = $client->request('GET', '/post/hello-world');
-
-    // for instance, count the number of ``.comment`` elements on the page
     $this->assertCount(4, $crawler->filter('.comment'));
 
 You can learn more about the crawler in :doc:`/testing/dom_crawler`.


### PR DESCRIPTION
I was reading https://symfony.com/doc/current/service_container/autowiring.html and I saw that in some comments, we use double backticks to wrap code elements. I think it looks ugly:

![](https://user-images.githubusercontent.com/73419/232819951-ba815cff-229d-4875-90d5-b6a39a175069.png)

I found other occurrences in other articles, so let's remove all of them.