### PR TITLE
[Security] Use attributes for entity example

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -125,32 +125,21 @@ from the `MakerBundle`_:
     use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
     use Symfony\Component\Security\Core\User\UserInterface;
 
-    /**
-     * @ORM\Entity(repositoryClass=UserRepository::class)
-     */
+    #[ORM\Entity(repositoryClass: UserRepository::class)]
     class User implements UserInterface, PasswordAuthenticatedUserInterface
     {
-        /**
-         * @ORM\Id
-         * @ORM\GeneratedValue
-         * @ORM\Column(type="integer")
-         */
+        #[ORM\Id]
+        #[ORM\GeneratedValue]
+        #[ORM\Column(type: 'integer')]
         private $id;
 
-        /**
-         * @ORM\Column(type="string", length=180, unique=true)
-         */
+        #[ORM\Column(type: 'string', length: 180, unique: true)]
         private $email;
 
-        /**
-         * @ORM\Column(type="json")
-         */
+        #[ORM\Column(type: 'json')]
         private $roles = [];
 
-        /**
-         * @var string The hashed password
-         * @ORM\Column(type="string")
-         */
+        #[ORM\Column(type: 'string')]
         private $password;
 
         public function getId(): ?int


### PR DESCRIPTION
Use attributes in place of annotations for consistency as we are using it for entity examples in some other pages or for routing further on security doc