### PR TITLE
[DependencyInjection] Fix XML tag array attribute example

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -481,8 +481,10 @@ To answer this, change the service declaration:
 
                 <service id="MailerSendmailTransport">
                     <tag name="app.mail_transport">
-                        <attribute>sendmail</attribute>
-                        <attribute>anotherAlias</attribute>
+                        <attribute name="alias">
+                            <attribute name="0">sendmail</attribute>
+                            <attribute name="1">anotherAlias</attribute>
+                        </attribute>
                     </tag>
                 </service>
             </services>


### PR DESCRIPTION
Fixes #17932 (and closes #17395)

Spotted in https://github.com/symfony/symfony/issues/50081#issuecomment-1517513302

The syntax is a bit awkward but it is how it works for now.