### PR TITLE
[DependencyInjection] Mark service as public with #[Autoconfigure] attribute

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -927,6 +927,26 @@ setting:
             ;
         };
 
+It is also possible to define a service as public thanks to the ``#[Autoconfigure]``
+attribute. This attribute must be used directly on the class of the service
+you want to configure::
+
+    // src/Service/PublicService.php
+    namespace App\Service;
+
+    use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+    #[Autoconfigure(public: true)]
+    class PublicService
+    {
+        // ...
+    }
+
+.. versionadded:: 5.3
+
+    The ``#[Autoconfigure]`` attribute was introduced in Symfony 5.3. PHP
+    attributes require at least PHP 8.0.
+
 .. deprecated:: 5.1
 
     As of Symfony 5.1, it is no longer possible to autowire the service

--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -62,6 +62,26 @@ You can also control the ``public`` option on a service-by-service basis:
                 ->public();
         };
 
+It is also possible to define a service as public thanks to the ``#[Autoconfigure]``
+attribute. This attribute must be used directly on the class of the service
+you want to configure::
+
+    // src/Service/Foo.php
+    namespace App\Service;
+
+    use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+    #[Autoconfigure(public: true)]
+    class Foo
+    {
+        // ...
+    }
+
+.. versionadded:: 5.3
+
+    The ``#[Autoconfigure]`` attribute was introduced in Symfony 5.3. PHP
+    attributes require at least PHP 8.0.
+
 .. _services-why-private:
 
 Private services are special because they allow the container to optimize whether


### PR DESCRIPTION
I wanted to mark a service as public with an attribute to avoid yaml configuration, but I could not find anything in the documentation. So I started digging and found out that the `#[Autoconfigure]` attribute allows to do that.

Also, the mention 

> PHP attributes require at least PHP 8.0.

is not needed in 6.0. Should I create an other PR (if this one is relevant) ?
