### PR TITLE
Fix missing link

### DIFF
--- a/frontend/_ux-libraries.rst.inc
+++ b/frontend/_ux-libraries.rst.inc
@@ -38,6 +38,7 @@
 .. _`Chart.js`: https://www.chartjs.org/
 .. _`Swup`: https://swup.js.org/
 .. _`React`: https://reactjs.org/
+.. _`Svelte`: https://svelte.dev/
 .. _`Turbo Drive`: https://turbo.hotwired.dev/
 .. _`Typed`: https://github.com/mattboldt/typed.js/
 .. _`Vue`: https://vuejs.org/


### PR DESCRIPTION
Compilation broken by https://github.com/symfony/symfony-docs/commit/ac6b7f71a2e1019809f05e1d07a2118222376435