### PR TITLE
[OptionsResolver] Minor typo

### DIFF
--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -51,7 +51,7 @@ check which options are set::
     }
 
 Also, the default values of the options are buried in the business logic of your
-code. Use the :phpfunction:`array_replace` to fix that::
+code. Use :phpfunction:`array_replace` to fix that::
 
     class Mailer
     {


### PR DESCRIPTION
Page: https://symfony.com/doc/5.4/components/options_resolver.html

The real issue is https://github.com/symfony/symfony-docs/issues/18271 - this here is just a by-product.