### PR TITLE
Update serializer.rst

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -724,7 +724,7 @@ When serializing, you can set a callback to format a specific object property::
 
     // all callback parameters are optional (you can omit the ones you don't use)
     $dateCallback = function ($innerObject, $outerObject, string $attributeName, string $format = null, array $context = []) {
-        return $innerObject instanceof \DateTime ? $innerObject->format(\DateTime::ISO8601) : '';
+        return $innerObject instanceof \DateTime ? $innerObject->format(\DateTime::ATOM) : '';
     };
 
     $defaultContext = [


### PR DESCRIPTION
Constant 'ISO8601' is deprecated 

This format is not compatible with ISO-8601, but is left this way for backward compatibility reasons. Use DateTime::ATOM or DATE_ATOM for compatibility with ISO-8601 instead.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
