### PR TITLE
[FrameworkBundle] Update the http_method_override default value explanation

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -176,13 +176,20 @@ bootstrap the Symfony framework on a cache hit.
 http_method_override
 ~~~~~~~~~~~~~~~~~~~~
 
-**type**: ``boolean`` **default**: ``true``
+**type**: ``boolean`` **default**: (see explanation below)
 
 This determines whether the ``_method`` request parameter is used as the
 intended HTTP method on POST requests. If enabled, the
 :method:`Request::enableHttpMethodParameterOverride <Symfony\\Component\\HttpFoundation\\Request::enableHttpMethodParameterOverride>`
 method gets called automatically. It becomes the service container parameter
 named ``kernel.http_method_override``.
+
+The **default value** is:
+
+* ``true``, if you have an existing application that you've upgraded from an older
+  Symfony version without resyncing the :doc:`Symfony Flex </setup/flex>` recipes;
+* ``false``, if you've created a new Symfony application or updated the Symfony
+  Flex recipes. This is also the default value starting from Symfony 7.0.
 
 .. seealso::
 


### PR DESCRIPTION
Fixes #16923.

I reused the explanation made by @xabbuh in https://github.com/symfony/symfony-docs/issues/16923#issuecomment-1191159805