### PR TITLE
Not add quote in default values

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -740,7 +740,7 @@ is disabled. This can be either a template name or the content itself.
 path
 ....
 
-**type**: ``string`` **default**: ``'/_fragment'``
+**type**: ``string`` **default**: ``/_fragment``
 
 The path prefix for fragments. The fragment listener will only be executed
 when the request starts with this path.
@@ -1357,7 +1357,7 @@ requests (and not on the subrequests).
 dsn
 ...
 
-**type**: ``string`` **default**: ``'file:%kernel.cache_dir%/profiler'``
+**type**: ``string`` **default**: ``file:%kernel.cache_dir%/profiler``
 
 The DSN where to store the profiling information.
 
@@ -1553,7 +1553,7 @@ session
 storage_factory_id
 ..................
 
-**type**: ``string`` **default**: ``'session.storage.factory.native'``
+**type**: ``string`` **default**: ``session.storage.factory.native``
 
 The service ID used for creating the ``SessionStorageInterface`` that stores
 the session. This service is available in the Symfony application via the
@@ -1574,7 +1574,7 @@ To see a list of all available storages, run:
 handler_id
 ..........
 
-**type**: ``string`` **default**: ``'session.handler.native_file'``
+**type**: ``string`` **default**: ``session.handler.native_file``
 
 The service id used for session storage. The default value ``'session.handler.native_file'``
 will let Symfony manage the sessions itself using files to store the session metadata.
@@ -1666,7 +1666,7 @@ to the cookie specification.
 cookie_samesite
 ...............
 
-**type**: ``string`` or ``null`` **default**: ``'lax'``
+**type**: ``string`` or ``null`` **default**: ``lax``
 
 It controls the way cookies are sent when the HTTP request did not originate
 from the same domain that is associated with the cookies. Setting this option is
@@ -1701,7 +1701,7 @@ The possible values for this option are:
 cookie_secure
 .............
 
-**type**: ``boolean`` or ``'auto'`` **default**: ``'auto'``
+**type**: ``boolean`` or ``'auto'`` **default**: ``auto``
 
 This determines whether cookies should only be sent over secure connections. In
 addition to ``true`` and ``false``, there's a special ``'auto'`` value that
@@ -2702,7 +2702,7 @@ annotations
 cache
 .....
 
-**type**: ``string`` **default**: ``'php_array'``
+**type**: ``string`` **default**: ``php_array``
 
 This option can be one of the following values:
 
@@ -2722,7 +2722,7 @@ a service id
 file_cache_dir
 ..............
 
-**type**: ``string`` **default**: ``'%kernel.cache_dir%/annotations'``
+**type**: ``string`` **default**: ``%kernel.cache_dir%/annotations``
 
 The directory to store cache files for annotations, in case
 ``annotations.cache`` is set to ``'file'``.
@@ -3493,7 +3493,7 @@ marking_store
 
 Each marking store can define any of these options:
 
-* ``property`` (**type**: ``string`` **default**: ``'marking'``)
+* ``property`` (**type**: ``string`` **default**: ``marking``)
 * ``service`` (**type**: ``string``)
 * ``type`` (**type**: ``string`` **allow value**: ``'method'``)
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -494,7 +494,7 @@ success_handler
     :class:`Symfony\\Component\\Security\\Http\\Event\\LogoutEvent`
     instead.
 
-**type**: ``string`` **default**: ``'security.logout.success_handler'``
+**type**: ``string`` **default**: ``security.logout.success_handler``
 
 The service ID used for handling a successful logout. The service must implement
 :class:`Symfony\\Component\\Security\\Http\\Logout\\LogoutSuccessHandlerInterface`.
@@ -506,7 +506,7 @@ If it is set, the logout ``target`` option will be ignored.
 csrf_parameter
 ..............
 
-**type**: ``string`` **default**: ``'_csrf_token'``
+**type**: ``string`` **default**: ``_csrf_token``
 
 The name of the parameter that stores the CSRF token value.
 
@@ -521,7 +521,7 @@ default service whose ID is ``security.csrf.token_manager``.
 csrf_token_id
 .............
 
-**type**: ``string`` **default**: ``'logout'``
+**type**: ``string`` **default**: ``logout``
 
 An arbitrary string used to identify the token (and check its validity afterwards).
 

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -36,7 +36,7 @@ compiled again automatically.
 autoescape
 ~~~~~~~~~~
 
-**type**: ``boolean`` or ``string`` **default**: ``'name'``
+**type**: ``boolean`` or ``string`` **default**: ``name``
 
 If set to ``false``, automatic escaping is disabled (you can still escape each content
 individually in the templates).
@@ -83,7 +83,7 @@ called to determine the default escaping applied to the template.
 base_template_class
 ~~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``'Twig\Template'``
+**type**: ``string`` **default**: ``Twig\Template``
 
 Twig templates are compiled into PHP classes before using them to render
 contents. This option defines the base class from which all the template classes
@@ -93,7 +93,7 @@ application harder to maintain.
 cache
 ~~~~~
 
-**type**: ``string`` | ``false`` **default**: ``'%kernel.cache_dir%/twig'``
+**type**: ``string`` | ``false`` **default**: ``%kernel.cache_dir%/twig``
 
 Before using the Twig templates to render some contents, they are compiled into
 regular PHP code. Compilation is a costly process, so the result is cached in
@@ -107,7 +107,7 @@ compiled again.
 charset
 ~~~~~~~
 
-**type**: ``string`` **default**: ``'%kernel.charset%'``
+**type**: ``string`` **default**: ``%kernel.charset%``
 
 The charset used by the template files. By default it's the same as the value of
 the :ref:`kernel.charset container parameter <configuration-kernel-charset>`,
@@ -160,7 +160,7 @@ If this option is ``false``, the ``dump()`` function doesn't output any contents
 default_path
 ~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``'%kernel.project_dir%/templates'``
+**type**: ``string`` **default**: ``%kernel.project_dir%/templates``
 
 The path to the directory where Symfony will look for the application Twig
 templates by default. If you store the templates in more than one directory, use

--- a/reference/configuration/web_profiler.rst
+++ b/reference/configuration/web_profiler.rst
@@ -30,7 +30,7 @@ Configuration
 excluded_ajax_paths
 ~~~~~~~~~~~~~~~~~~~
 
-**type**: ``string`` **default**: ``'^/((index|app(_[\w]+)?)\.php/)?_wdt'``
+**type**: ``string`` **default**: ``^/((index|app(_[\w]+)?)\.php/)?_wdt``
 
 When the toolbar logs AJAX requests, it matches their URLs against this regular
 expression. If the URL matches, the request is not displayed in the toolbar. This

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -198,7 +198,7 @@ type::
 entry_type
 ~~~~~~~~~~
 
-**type**: ``string`` **default**: ``'Symfony\Component\Form\Extension\Core\Type\TextType'``
+**type**: ``string`` **default**: ``Symfony\Component\Form\Extension\Core\Type\TextType``
 
 This is the field type for each item in this collection (e.g. ``TextType``,
 ``ChoiceType``, etc). For example, if you have an array of email addresses,


### PR DESCRIPTION
Default values are sometime without quotes and sometime with.

For example in this page https://symfony.com/doc/5.4/reference/configuration/security.html#logout

This PR always remove quotes (it seems to be the rule)

Regex `**default**: ``'`
