### PR TITLE
Use "$container" consistently

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -2,8 +2,8 @@ rules:
     american_english: ~
     argument_variable_must_match_type:
         arguments:
-            - { type: 'ContainerBuilder', name: 'containerBuilder' }
-            - { type: 'ContainerConfigurator', name: 'containerConfigurator' }
+            - { type: 'ContainerBuilder', name: 'container' }
+            - { type: 'ContainerConfigurator', name: 'container' }
     avoid_repetetive_words: ~
     blank_line_after_anchor: ~
     blank_line_after_directive: ~

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -442,8 +442,8 @@ The end user can provide values in any configuration file:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->parameters()
+        return static function (ContainerConfigurator $container) {
+            $container->parameters()
                 ->set('acme_blog.author.email', 'fabien@example.com')
             ;
         };

--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -217,7 +217,7 @@ force validation (e.g. if an additional option was passed, an exception will be
 thrown)::
 
     // src/Acme/SocialBundle/DependencyInjection/AcmeSocialExtension.php
-    public function load(array $configs, ContainerBuilder $containerBuilder)
+    public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
 
@@ -259,15 +259,15 @@ In your extension, you can load this and dynamically set its arguments::
     use Symfony\Component\Config\FileLocator;
     use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
-    public function load(array $configs, ContainerBuilder $containerBuilder)
+    public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new XmlFileLoader($containerBuilder, new FileLocator(dirname(__DIR__).'/Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(dirname(__DIR__).'/Resources/config'));
         $loader->load('services.xml');
 
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $definition = $containerBuilder->getDefinition('acme.social.twitter_client');
+        $definition = $container->getDefinition('acme.social.twitter_client');
         $definition->replaceArgument(0, $config['twitter']['client_id']);
         $definition->replaceArgument(1, $config['twitter']['client_secret']);
     }
@@ -288,7 +288,7 @@ In your extension, you can load this and dynamically set its arguments::
         class AcmeHelloExtension extends ConfigurableExtension
         {
             // note that this method is called loadInternal and not load
-            protected function loadInternal(array $mergedConfig, ContainerBuilder $containerBuilder)
+            protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
             {
                 // ...
             }
@@ -304,7 +304,7 @@ In your extension, you can load this and dynamically set its arguments::
     (e.g. by overriding configurations and using :phpfunction:`isset` to check
     for the existence of a value). Be aware that it'll be very hard to support XML::
 
-        public function load(array $configs, ContainerBuilder $containerBuilder)
+        public function load(array $configs, ContainerBuilder $container)
         {
             $config = [];
             // let resources override the previous set value

--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -34,7 +34,7 @@ This is how the extension of an AcmeHelloBundle should look like::
 
     class AcmeHelloExtension extends Extension
     {
-        public function load(array $configs, ContainerBuilder $containerBuilder)
+        public function load(array $configs, ContainerBuilder $container)
         {
             // ... you'll load the files here later
         }
@@ -89,10 +89,10 @@ For instance, assume you have a file called ``services.xml`` in the
     use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
     // ...
-    public function load(array $configs, ContainerBuilder $containerBuilder)
+    public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader(
-            $containerBuilder,
+            $container,
             new FileLocator(__DIR__.'/../Resources/config')
         );
         $loader->load('services.xml');
@@ -115,7 +115,7 @@ they are compiled when generating the application cache to improve the overall
 performance. Define the list of annotated classes to compile in the
 ``addAnnotatedClassesToCompile()`` method::
 
-    public function load(array $configs, ContainerBuilder $containerBuilder)
+    public function load(array $configs, ContainerBuilder $container)
     {
         // ...
 

--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -31,7 +31,7 @@ To give an Extension the power to do this, it needs to implement
     {
         // ...
 
-        public function prepend(ContainerBuilder $containerBuilder)
+        public function prepend(ContainerBuilder $container)
         {
             // ...
         }
@@ -52,15 +52,15 @@ a configuration setting in multiple bundles as well as disable a flag in multipl
 in case a specific other bundle is not registered::
 
     // src/Acme/HelloBundle/DependencyInjection/AcmeHelloExtension.php
-    public function prepend(ContainerBuilder $containerBuilder)
+    public function prepend(ContainerBuilder $container)
     {
         // get all bundles
-        $bundles = $containerBuilder->getParameter('kernel.bundles');
+        $bundles = $container->getParameter('kernel.bundles');
         // determine if AcmeGoodbyeBundle is registered
         if (!isset($bundles['AcmeGoodbyeBundle'])) {
             // disable AcmeGoodbyeBundle in bundles
             $config = ['use_acme_goodbye' => false];
-            foreach ($containerBuilder->getExtensions() as $name => $extension) {
+            foreach ($container->getExtensions() as $name => $extension) {
                 switch ($name) {
                     case 'acme_something':
                     case 'acme_other':
@@ -70,21 +70,21 @@ in case a specific other bundle is not registered::
                         // note that if the user manually configured
                         // use_acme_goodbye to true in config/services.yaml
                         // then the setting would in the end be true and not false
-                        $containerBuilder->prependExtensionConfig($name, $config);
+                        $container->prependExtensionConfig($name, $config);
                         break;
                 }
             }
         }
 
         // get the configuration of AcmeHelloExtension (it's a list of configuration)
-        $configs = $containerBuilder->getExtensionConfig($this->getAlias());
+        $configs = $container->getExtensionConfig($this->getAlias());
 
         // iterate in reverse to preserve the original order after prepending the config
         foreach (array_reverse($configs) as $config) {
             // check if entity_manager_name is set in the "acme_hello" configuration
             if (isset($config['entity_manager_name'])) {
                 // prepend the acme_something settings with the entity_manager_name
-                $containerBuilder->prependExtensionConfig('acme_something', [
+                $container->prependExtensionConfig('acme_something', [
                     'entity_manager_name' => $config['entity_manager_name'],
                 ]);
             }
@@ -141,13 +141,13 @@ registered and the ``entity_manager_name`` setting for ``acme_hello`` is set to
         // config/packages/acme_something.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->extension('acme_something', [
+        return static function (ContainerConfigurator $container) {
+            $container->extension('acme_something', [
                 // ...
                 'use_acme_goodbye' => false,
                 'entity_manager_name' => 'non_default',
             ]);
-            $containerConfigurator->extension('acme_other', [
+            $container->extension('acme_other', [
                 // ...
                 'use_acme_goodbye' => false,
             ]);

--- a/cache.rst
+++ b/cache.rst
@@ -384,8 +384,8 @@ with either :class:`Symfony\\Contracts\\Cache\\CacheInterface` or
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return function(ContainerConfigurator $containerConfigurator) {
-                $containerConfigurator->services()
+            return function(ContainerConfigurator $container) {
+                $container->services()
                     // ...
 
                     ->set('app.cache.adapter.redis')
@@ -465,14 +465,14 @@ and use that when configuring the pool.
         use Symfony\Component\DependencyInjection\ContainerBuilder;
         use Symfony\Config\FrameworkConfig;
 
-        return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework) {
+        return static function (ContainerBuilder $container, FrameworkConfig $framework) {
             $framework->cache()
                 ->pool('cache.my_redis')
                     ->adapters(['cache.adapter.redis'])
                     ->provider('app.my_custom_redis_provider');
 
 
-            $containerBuilder->register('app.my_custom_redis_provider', \Redis::class)
+            $container->register('app.my_custom_redis_provider', \Redis::class)
                 ->setFactory([RedisAdapter::class, 'createConnection'])
                 ->addArgument('redis://localhost')
                 ->addArgument([

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -45,8 +45,8 @@ You can register this in the container as a service::
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-    $containerBuilder = new ContainerBuilder();
-    $containerBuilder->register('mailer', 'Mailer');
+    $container = new ContainerBuilder();
+    $container->register('mailer', 'Mailer');
 
 An improvement to the class to make it more flexible would be to allow
 the container to set the ``transport`` used. If you change the class
@@ -68,8 +68,8 @@ Then you can set the choice of transport in the container::
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-    $containerBuilder = new ContainerBuilder();
-    $containerBuilder
+    $container = new ContainerBuilder();
+    $container
         ->register('mailer', 'Mailer')
         ->addArgument('sendmail');
 
@@ -83,9 +83,9 @@ the ``Mailer`` service's constructor argument::
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-    $containerBuilder = new ContainerBuilder();
-    $containerBuilder->setParameter('mailer.transport', 'sendmail');
-    $containerBuilder
+    $container = new ContainerBuilder();
+    $container->setParameter('mailer.transport', 'sendmail');
+    $container
         ->register('mailer', 'Mailer')
         ->addArgument('%mailer.transport%');
 
@@ -112,14 +112,14 @@ not exist yet. Use the ``Reference`` class to tell the container to inject the
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Reference;
 
-    $containerBuilder = new ContainerBuilder();
+    $container = new ContainerBuilder();
 
-    $containerBuilder->setParameter('mailer.transport', 'sendmail');
-    $containerBuilder
+    $container->setParameter('mailer.transport', 'sendmail');
+    $container
         ->register('mailer', 'Mailer')
         ->addArgument('%mailer.transport%');
 
-    $containerBuilder
+    $container
         ->register('newsletter_manager', 'NewsletterManager')
         ->addArgument(new Reference('mailer'));
 
@@ -144,14 +144,14 @@ If you do want to though then the container can call the setter method::
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Reference;
 
-    $containerBuilder = new ContainerBuilder();
+    $container = new ContainerBuilder();
 
-    $containerBuilder->setParameter('mailer.transport', 'sendmail');
-    $containerBuilder
+    $container->setParameter('mailer.transport', 'sendmail');
+    $container
         ->register('mailer', 'Mailer')
         ->addArgument('%mailer.transport%');
 
-    $containerBuilder
+    $container
         ->register('newsletter_manager', 'NewsletterManager')
         ->addMethodCall('setMailer', [new Reference('mailer')]);
 
@@ -160,11 +160,11 @@ like this::
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-    $containerBuilder = new ContainerBuilder();
+    $container = new ContainerBuilder();
 
     // ...
 
-    $newsletterManager = $containerBuilder->get('newsletter_manager');
+    $newsletterManager = $container->get('newsletter_manager');
 
 Avoiding your Code Becoming Dependent on the Container
 ------------------------------------------------------
@@ -198,8 +198,8 @@ Loading an XML config file::
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
-    $containerBuilder = new ContainerBuilder();
-    $loader = new XmlFileLoader($containerBuilder, new FileLocator(__DIR__));
+    $container = new ContainerBuilder();
+    $loader = new XmlFileLoader($container, new FileLocator(__DIR__));
     $loader->load('services.xml');
 
 Loading a YAML config file::
@@ -208,8 +208,8 @@ Loading a YAML config file::
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-    $containerBuilder = new ContainerBuilder();
-    $loader = new YamlFileLoader($containerBuilder, new FileLocator(__DIR__));
+    $container = new ContainerBuilder();
+    $loader = new YamlFileLoader($container, new FileLocator(__DIR__));
     $loader->load('services.yaml');
 
 .. note::
@@ -233,8 +233,8 @@ into a separate config file and load it in a similar way::
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
-    $containerBuilder = new ContainerBuilder();
-    $loader = new PhpFileLoader($containerBuilder, new FileLocator(__DIR__));
+    $container = new ContainerBuilder();
+    $loader = new PhpFileLoader($container, new FileLocator(__DIR__));
     $loader->load('services.php');
 
 You can now set up the ``newsletter_manager`` and ``mailer`` services using
@@ -287,13 +287,13 @@ config files:
 
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->parameters()
+        return static function (ContainerConfigurator $container) {
+            $container->parameters()
                 // ...
                 ->set('mailer.transport', 'sendmail')
             ;
 
-            $services = $containerConfigurator->services();
+            $services = $container->services();
             $services->set('mailer', 'Mailer')
                 ->args(['%mailer.transport%'])
             ;

--- a/components/dependency_injection/_imports-parameters-note.rst.inc
+++ b/components/dependency_injection/_imports-parameters-note.rst.inc
@@ -31,6 +31,6 @@
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (ContainerConfigurator $containerConfigurator) {
-                $containerConfigurator->import('%kernel.project_dir%/somefile.yaml');
+            return static function (ContainerConfigurator $container) {
+                $container->import('%kernel.project_dir%/somefile.yaml');
             };

--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -61,10 +61,10 @@ A very simple extension may just load configuration files into the container::
 
     class AcmeDemoExtension implements ExtensionInterface
     {
-        public function load(array $configs, ContainerBuilder $containerBuilder)
+        public function load(array $configs, ContainerBuilder $container)
         {
             $loader = new XmlFileLoader(
-                $containerBuilder,
+                $container,
                 new FileLocator(__DIR__.'/../Resources/config')
             );
             $loader->load('services.xml');
@@ -114,14 +114,14 @@ are loaded::
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-    $containerBuilder = new ContainerBuilder();
-    $containerBuilder->registerExtension(new AcmeDemoExtension);
+    $container = new ContainerBuilder();
+    $container->registerExtension(new AcmeDemoExtension);
 
-    $loader = new YamlFileLoader($containerBuilder, new FileLocator(__DIR__));
+    $loader = new YamlFileLoader($container, new FileLocator(__DIR__));
     $loader->load('config.yaml');
 
     // ...
-    $containerBuilder->compile();
+    $container->compile();
 
 .. note::
 
@@ -132,7 +132,7 @@ are loaded::
 The values from those sections of the config files are passed into the first
 argument of the ``load()`` method of the extension::
 
-    public function load(array $configs, ContainerBuilder $containerBuilder)
+    public function load(array $configs, ContainerBuilder $container)
     {
         $foo = $configs[0]['foo']; //fooValue
         $bar = $configs[0]['bar']; //barValue
@@ -158,7 +158,7 @@ you could access the config value this way::
     use Symfony\Component\Config\Definition\Processor;
     // ...
 
-    public function load(array $configs, ContainerBuilder $containerBuilder)
+    public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
         $processor = new Processor();
@@ -219,13 +219,13 @@ The processed config value can now be added as container parameters as if
 it were listed in a ``parameters`` section of the config file but with the
 additional benefit of merging multiple files and validation of the configuration::
 
-    public function load(array $configs, ContainerBuilder $containerBuilder)
+    public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
         $processor = new Processor();
         $config = $processor->processConfiguration($configuration, $configs);
 
-        $containerBuilder->setParameter('acme_demo.FOO', $config['foo']);
+        $container->setParameter('acme_demo.FOO', $config['foo']);
 
         // ...
     }
@@ -234,14 +234,14 @@ More complex configuration requirements can be catered for in the Extension
 classes. For example, you may choose to load a main service configuration
 file but also load a secondary one only if a certain parameter is set::
 
-    public function load(array $configs, ContainerBuilder $containerBuilder)
+    public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
         $processor = new Processor();
         $config = $processor->processConfiguration($configuration, $configs);
 
         $loader = new XmlFileLoader(
-            $containerBuilder,
+            $container,
             new FileLocator(__DIR__.'/../Resources/config')
         );
         $loader->load('services.xml');
@@ -263,11 +263,11 @@ file but also load a secondary one only if a certain parameter is set::
 
         use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-        $containerBuilder = new ContainerBuilder();
+        $container = new ContainerBuilder();
         $extension = new AcmeDemoExtension();
-        $containerBuilder->registerExtension($extension);
-        $containerBuilder->loadFromExtension($extension->getAlias());
-        $containerBuilder->compile();
+        $container->registerExtension($extension);
+        $container->loadFromExtension($extension->getAlias());
+        $container->compile();
 
 .. note::
 
@@ -292,11 +292,11 @@ method is called by implementing
     {
         // ...
 
-        public function prepend(ContainerBuilder $containerBuilder)
+        public function prepend(ContainerBuilder $container)
         {
             // ...
 
-            $containerBuilder->prependExtensionConfig($name, $config);
+            $container->prependExtensionConfig($name, $config);
 
             // ...
         }
@@ -323,7 +323,7 @@ compilation::
 
     class AcmeDemoExtension implements ExtensionInterface, CompilerPassInterface
     {
-        public function process(ContainerBuilder $containerBuilder)
+        public function process(ContainerBuilder $container)
         {
             // ... do something during the compilation
         }
@@ -377,7 +377,7 @@ class implementing the ``CompilerPassInterface``::
 
     class CustomPass implements CompilerPassInterface
     {
-        public function process(ContainerBuilder $containerBuilder)
+        public function process(ContainerBuilder $container)
         {
             // ... do something during the compilation
         }
@@ -387,8 +387,8 @@ You then need to register your custom pass with the container::
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-    $containerBuilder = new ContainerBuilder();
-    $containerBuilder->addCompilerPass(new CustomPass());
+    $container = new ContainerBuilder();
+    $container->addCompilerPass(new CustomPass());
 
 .. note::
 
@@ -418,7 +418,7 @@ For example, to run your custom pass after the default removal passes have
 been run, use::
 
     // ...
-    $containerBuilder->addCompilerPass(
+    $container->addCompilerPass(
         new CustomPass(),
         PassConfig::TYPE_AFTER_REMOVING
     );
@@ -460,11 +460,11 @@ serves at dumping the compiled container::
         require_once $file;
         $container = new ProjectServiceContainer();
     } else {
-        $containerBuilder = new ContainerBuilder();
+        $container = new ContainerBuilder();
         // ...
-        $containerBuilder->compile();
+        $container->compile();
 
-        $dumper = new PhpDumper($containerBuilder);
+        $dumper = new PhpDumper($container);
         file_put_contents($file, $dumper->dump());
     }
 
@@ -487,11 +487,11 @@ dump it::
         require_once $file;
         $container = new MyCachedContainer();
     } else {
-        $containerBuilder = new ContainerBuilder();
+        $container = new ContainerBuilder();
         // ...
-        $containerBuilder->compile();
+        $container->compile();
 
-        $dumper = new PhpDumper($containerBuilder);
+        $dumper = new PhpDumper($container);
         file_put_contents(
             $file,
             $dumper->dump(['class' => 'MyCachedContainer'])
@@ -519,12 +519,12 @@ application::
         require_once $file;
         $container = new MyCachedContainer();
     } else {
-        $containerBuilder = new ContainerBuilder();
+        $container = new ContainerBuilder();
         // ...
-        $containerBuilder->compile();
+        $container->compile();
 
         if (!$isDebug) {
-            $dumper = new PhpDumper($containerBuilder);
+            $dumper = new PhpDumper($container);
             file_put_contents(
                 $file,
                 $dumper->dump(['class' => 'MyCachedContainer'])
@@ -554,14 +554,14 @@ for these resources and use them as metadata for the cache::
     $containerConfigCache = new ConfigCache($file, $isDebug);
 
     if (!$containerConfigCache->isFresh()) {
-        $containerBuilder = new ContainerBuilder();
+        $container = new ContainerBuilder();
         // ...
-        $containerBuilder->compile();
+        $container->compile();
 
-        $dumper = new PhpDumper($containerBuilder);
+        $dumper = new PhpDumper($container);
         $containerConfigCache->write(
             $dumper->dump(['class' => 'MyCachedContainer']),
-            $containerBuilder->getResources()
+            $container->getResources()
         );
     }
 

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -186,22 +186,22 @@ determine which instance is passed.
         use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
         use Symfony\Component\EventDispatcher\EventDispatcher;
 
-        $containerBuilder = new ContainerBuilder(new ParameterBag());
+        $container = new ContainerBuilder(new ParameterBag());
         // register the compiler pass that handles the 'kernel.event_listener'
         // and 'kernel.event_subscriber' service tags
-        $containerBuilder->addCompilerPass(new RegisterListenersPass());
+        $container->addCompilerPass(new RegisterListenersPass());
 
-        $containerBuilder->register('event_dispatcher', EventDispatcher::class);
+        $container->register('event_dispatcher', EventDispatcher::class);
 
         // registers an event listener
-        $containerBuilder->register('listener_service_id', \AcmeListener::class)
+        $container->register('listener_service_id', \AcmeListener::class)
             ->addTag('kernel.event_listener', [
                 'event' => 'acme.foo.action',
                 'method' => 'onFooAction',
             ]);
 
         // registers an event subscriber
-        $containerBuilder->register('subscriber_service_id', \AcmeSubscriber::class)
+        $container->register('subscriber_service_id', \AcmeSubscriber::class)
             ->addTag('kernel.event_subscriber');
 
     ``RegisterListenersPass`` resolves aliased class names which for instance
@@ -218,16 +218,16 @@ determine which instance is passed.
         use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
         use Symfony\Component\EventDispatcher\EventDispatcher;
 
-        $containerBuilder = new ContainerBuilder(new ParameterBag());
-        $containerBuilder->addCompilerPass(new AddEventAliasesPass([
+        $container = new ContainerBuilder(new ParameterBag());
+        $container->addCompilerPass(new AddEventAliasesPass([
             \AcmeFooActionEvent::class => 'acme.foo.action',
         ]));
-        $containerBuilder->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING);
 
-        $containerBuilder->register('event_dispatcher', EventDispatcher::class);
+        $container->register('event_dispatcher', EventDispatcher::class);
 
         // registers an event listener
-        $containerBuilder->register('listener_service_id', \AcmeListener::class)
+        $container->register('listener_service_id', \AcmeListener::class)
             ->addTag('kernel.event_listener', [
                 // will be translated to 'acme.foo.action' by RegisterListenersPass.
                 'event' => \AcmeFooActionEvent::class,

--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -998,8 +998,8 @@ faster alternative to the
 
         use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->services()
+        return static function (ContainerConfigurator $container) {
+            $container->services()
                 // ...
                 ->set('get_set_method_normalizer', GetSetMethodNormalizer::class)
                     ->tag('serializer.normalizer')

--- a/components/uid.rst
+++ b/components/uid.rst
@@ -126,13 +126,13 @@ configure the behavior of the factory using configuration files::
         // config/packages/uid.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $containerConfigurator): void {
-            $services = $containerConfigurator->services()
+        return static function (ContainerConfigurator $container): void {
+            $services = $container->services()
                 ->defaults()
                 ->autowire()
                 ->autoconfigure();
 
-            $containerConfigurator->extension('framework', [
+            $container->extension('framework', [
                 'uid' => [
                     'default_uuid_version' => 6,
                     'name_based_uuid_version' => 5,
@@ -568,7 +568,7 @@ configuration in your application before using these commands:
         use Symfony\Component\Uid\Command\InspectUlidCommand;
         use Symfony\Component\Uid\Command\InspectUuidCommand;
 
-        return static function (ContainerConfigurator $containerConfigurator): void {
+        return static function (ContainerConfigurator $container): void {
             // ...
 
             $services

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -144,8 +144,8 @@ the :ref:`dump_destination option <configuration-debug-dump_destination>` of the
         // config/packages/debug.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->extension('debug', [
+        return static function (ContainerConfigurator $container) {
+            $container->extension('debug', [
                 'dump_destination' => 'tcp://%env(VAR_DUMPER_SERVER)%',
             ]);
         };

--- a/configuration.rst
+++ b/configuration.rst
@@ -73,18 +73,18 @@ shown in these three formats.
         {
             // ...
 
-            private function configureContainer(ContainerConfigurator $containerConfigurator): void
+            private function configureContainer(ContainerConfigurator $container): void
             {
                 $configDir = $this->getConfigDir();
 
-                $containerConfigurator->import($configDir.'/{packages}/*.{yaml,php}');
-                $containerConfigurator->import($configDir.'/{packages}/'.$this->environment.'/*.{yaml,php}');
+                $container->import($configDir.'/{packages}/*.{yaml,php}');
+                $container->import($configDir.'/{packages}/'.$this->environment.'/*.{yaml,php}');
 
                 if (is_file($configDir.'/services.yaml')) {
-                    $containerConfigurator->import($configDir.'/services.yaml');
-                    $containerConfigurator->import($configDir.'/{services}_'.$this->environment.'.yaml');
+                    $container->import($configDir.'/services.yaml');
+                    $container->import($configDir.'/{services}_'.$this->environment.'.yaml');
                 } else {
-                    $containerConfigurator->import($configDir.'/{services}.php');
+                    $container->import($configDir.'/{services}.php');
                 }
             }
         }
@@ -158,17 +158,17 @@ configuration files, even if they use a different format:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->import('legacy_config.php');
+        return static function (ContainerConfigurator $container) {
+            $container->import('legacy_config.php');
 
             // glob expressions are also supported to load multiple files
-            $containerConfigurator->import('/etc/myapp/*.yaml');
+            $container->import('/etc/myapp/*.yaml');
 
             // the third optional argument of import() is 'ignore_errors'
             // 'ignore_errors' set to 'not_found' silently discards errors if the loaded file doesn't exist
-            $containerConfigurator->import('my_config_file.yaml', null, 'not_found');
+            $container->import('my_config_file.yaml', null, 'not_found');
             // 'ignore_errors' set to true silently discards all errors (including invalid code and not found)
-            $containerConfigurator->import('my_config_file.yaml', null, true);
+            $container->import('my_config_file.yaml', null, true);
         };
 
         // ...
@@ -257,8 +257,8 @@ reusable configuration value. By convention, parameters are defined under the
 
         use App\Entity\BlogPost;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->parameters()
+        return static function (ContainerConfigurator $container) {
+            $container->parameters()
                 // the parameter name is an arbitrary string (the 'app.' prefix is recommended
                 // to better differentiate your parameters from Symfony parameters).
                 ->set('app.admin_email', 'something@example.com')
@@ -329,8 +329,8 @@ configuration file using a special syntax: wrap the parameter name in two ``%``
         // config/packages/some_package.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->extension('some_package', [
+        return static function (ContainerConfigurator $container) {
+            $container->extension('some_package', [
                 // any string surrounded by two % is replaced by that parameter value
                 'email_address' => '%app.admin_email%',
 
@@ -366,8 +366,8 @@ configuration file using a special syntax: wrap the parameter name in two ``%``
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (ContainerConfigurator $containerConfigurator) {
-                $containerConfigurator->parameters()
+            return static function (ContainerConfigurator $container) {
+                $container->parameters()
                     ->set('url_pattern', 'http://symfony.com/?foo=%%s&amp;bar=%%d');
             };
 
@@ -502,7 +502,7 @@ files directly in the ``config/packages/`` directory.
             use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
             use Symfony\Config\WebpackEncoreConfig;
 
-            return static function (WebpackEncoreConfig $webpackEncore, ContainerConfigurator $containerConfigurator) {
+            return static function (WebpackEncoreConfig $webpackEncore, ContainerConfigurator $container) {
                 $webpackEncore
                     ->outputPath('%kernel.project_dir%/public/build')
                     ->strictMode(true)
@@ -510,12 +510,12 @@ files directly in the ``config/packages/`` directory.
                 ;
 
                 // cache is enabled only in the "prod" environment
-                if ('prod' === $containerConfigurator->env()) {
+                if ('prod' === $container->env()) {
                     $webpackEncore->cache(true);
                 }
 
                 // disable strict mode only in the "test" environment
-                if ('test' === $containerConfigurator->env()) {
+                if ('test' === $container->env()) {
                     $webpackEncore->strictMode(false);
                 }
             };
@@ -633,7 +633,7 @@ This example shows how you could configure the application secret using an env v
         // config/packages/framework.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
+        return static function (ContainerConfigurator $container) {
             $container->extension('framework', [
                 // by convention the env var names are always uppercase
                 'secret' => '%env(APP_SECRET)%',
@@ -989,8 +989,8 @@ doesn't work for parameters:
 
         use App\Service\MessageGenerator;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->parameters()
+        return static function (ContainerConfigurator $container) {
+            $container->parameters()
                 ->set('app.contents_dir', '...');
 
             $container->services()
@@ -1046,8 +1046,8 @@ whenever a service/controller defines a ``$projectDir`` argument, use this:
 
         use App\Controller\LuckyController;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->services()
+        return static function (ContainerConfigurator $container) {
+            $container->services()
                 ->defaults()
                     // pass this value to any $projectDir argument for any service
                     // that's created in this file (including controller arguments)

--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -104,8 +104,8 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\FrameworkConfig;
 
-            return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework) {
-                $containerBuilder->setParameter('env(SECRET)', 'some_secret');
+            return static function (ContainerBuilder $container, FrameworkConfig $framework) {
+                $container->setParameter('env(SECRET)', 'some_secret');
                 $framework->secret(env('SECRET')->string());
             };
 
@@ -150,8 +150,8 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\FrameworkConfig;
 
-            return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework) {
-                $containerBuilder->setParameter('env(HTTP_METHOD_OVERRIDE)', 'true');
+            return static function (ContainerBuilder $container, FrameworkConfig $framework) {
+                $container->setParameter('env(HTTP_METHOD_OVERRIDE)', 'true');
                 $framework->httpMethodOverride(env('HTTP_METHOD_OVERRIDE')->bool());
             };
 
@@ -242,8 +242,8 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\SecurityConfig;
 
-            return static function (ContainerBuilder $containerBuilder, SecurityConfig $security) {
-                $containerBuilder->setParameter('env(HEALTH_CHECK_METHOD)', 'Symfony\Component\HttpFoundation\Request::METHOD_HEAD');
+            return static function (ContainerBuilder $container, SecurityConfig $security) {
+                $container->setParameter('env(HEALTH_CHECK_METHOD)', 'Symfony\Component\HttpFoundation\Request::METHOD_HEAD');
                 $security->accessControl()
                     ->path('^/health-check$')
                     ->methods([env('HEALTH_CHECK_METHOD')->const()]);
@@ -293,8 +293,8 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\FrameworkConfig;
 
-            return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework) {
-                $containerBuilder->setParameter('env(TRUSTED_HOSTS)', '["10.0.0.1", "10.0.0.2"]');
+            return static function (ContainerBuilder $container, FrameworkConfig $framework) {
+                $container->setParameter('env(TRUSTED_HOSTS)', '["10.0.0.1", "10.0.0.2"]');
                 $framework->trustedHosts(env('TRUSTED_HOSTS')->json());
             };
 
@@ -379,8 +379,8 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\FrameworkConfig;
 
-            return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework) {
-                $containerBuilder->setParameter('env(TRUSTED_HOSTS)', '10.0.0.1,10.0.0.2');
+            return static function (ContainerBuilder $container, FrameworkConfig $framework) {
+                $container->setParameter('env(TRUSTED_HOSTS)', '10.0.0.1,10.0.0.2');
                 $framework->trustedHosts(env('TRUSTED_HOSTS')->csv());
             };
 

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -43,10 +43,10 @@ Next, create an ``index.php`` file that defines the kernel class and runs it::
             ];
         }
 
-        protected function configureContainer(ContainerConfigurator $containerConfigurator): void
+        protected function configureContainer(ContainerConfigurator $container): void
         {
             // PHP equivalent of config/packages/framework.yaml
-            $containerConfigurator->extension('framework', [
+            $container->extension('framework', [
                 'secret' => 'S0ME_SECRET'
             ]);
         }
@@ -88,7 +88,7 @@ that define your bundles, your services and your routes:
 **registerBundles()**
     This is the same ``registerBundles()`` that you see in a normal kernel.
 
-**configureContainer(ContainerConfigurator $containerConfigurator)**
+**configureContainer(ContainerConfigurator $container)**
     This method builds and configures the container. In practice, you will use
     ``extension()`` to configure different bundles (this is the equivalent
     of what you see in a normal ``config/packages/*`` file). You can also register
@@ -191,12 +191,12 @@ hold the kernel. Now it looks like this::
             return $bundles;
         }
 
-        protected function configureContainer(ContainerConfigurator $containerConfigurator): void
+        protected function configureContainer(ContainerConfigurator $container): void
         {
-            $containerConfigurator->import(__DIR__.'/../config/framework.yaml');
+            $container->import(__DIR__.'/../config/framework.yaml');
 
             // register all classes in /src/ as service
-            $containerConfigurator->services()
+            $container->services()
                 ->load('App\\', __DIR__.'/*')
                 ->autowire()
                 ->autoconfigure()
@@ -204,7 +204,7 @@ hold the kernel. Now it looks like this::
 
             // configure WebProfilerBundle only if the bundle is enabled
             if (isset($this->bundles['WebProfilerBundle'])) {
-                $containerConfigurator->extension('web_profiler', [
+                $container->extension('web_profiler', [
                     'toolbar' => true,
                     'intercept_redirects' => false,
                 ]);

--- a/configuration/multiple_kernels.rst
+++ b/configuration/multiple_kernels.rst
@@ -164,12 +164,12 @@ resources::
             return ($_SERVER['APP_LOG_DIR'] ?? $this->getProjectDir().'/var/log').'/'.$this->id;
         }
 
-        protected function configureContainer(ContainerConfigurator $containerConfigurator): void
+        protected function configureContainer(ContainerConfigurator $container): void
         {
             // load common config files, such as the framework.yaml, as well as
             // specific configs required exclusively for the app itself
-            $this->doConfigureContainer($containerConfigurator, $this->getSharedConfigDir());
-            $this->doConfigureContainer($containerConfigurator, $this->getAppConfigDir());
+            $this->doConfigureContainer($container, $this->getSharedConfigDir());
+            $this->doConfigureContainer($container, $this->getAppConfigDir());
         }
 
         protected function configureRoutes(RoutingConfigurator $routes): void
@@ -180,16 +180,16 @@ resources::
             $this->doConfigureRoutes($routes, $this->getAppConfigDir());
         }
 
-        private function doConfigureContainer(ContainerConfigurator $containerConfigurator, string $configDir): void
+        private function doConfigureContainer(ContainerConfigurator $container, string $configDir): void
         {
-            $containerConfigurator->import($configDir.'/{packages}/*.{php,yaml}');
-            $containerConfigurator->import($configDir.'/{packages}/'.$this->environment.'/*.{php,yaml}');
+            $container->import($configDir.'/{packages}/*.{php,yaml}');
+            $container->import($configDir.'/{packages}/'.$this->environment.'/*.{php,yaml}');
 
             if (is_file($configDir.'/services.yaml')) {
-                $containerConfigurator->import($configDir.'/services.yaml');
-                $containerConfigurator->import($configDir.'/{services}_'.$this->environment.'.yaml');
+                $container->import($configDir.'/services.yaml');
+                $container->import($configDir.'/{services}_'.$this->environment.'.yaml');
             } else {
-                $containerConfigurator->import($configDir.'/{services}.php');
+                $container->import($configDir.'/{services}.php');
             }
         }
 

--- a/configuration/using_parameters_in_dic.rst
+++ b/configuration/using_parameters_in_dic.rst
@@ -135,9 +135,9 @@ And set it in the constructor of ``Configuration`` via the ``Extension`` class::
     {
         // ...
 
-        public function getConfiguration(array $config, ContainerBuilder $containerBuilder)
+        public function getConfiguration(array $config, ContainerBuilder $container)
         {
-            return new Configuration($containerBuilder->getParameter('kernel.debug'));
+            return new Configuration($container->getParameter('kernel.debug'));
         }
     }
 

--- a/console/lazy_commands.rst
+++ b/console/lazy_commands.rst
@@ -68,13 +68,13 @@ with command names as keys and service identifiers as values::
     use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
     use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-    $containerBuilder = new ContainerBuilder();
-    $containerBuilder->register(FooCommand::class, FooCommand::class);
-    $containerBuilder->compile();
+    $container = new ContainerBuilder();
+    $container->register(FooCommand::class, FooCommand::class);
+    $container->compile();
 
-    $commandLoader = new ContainerCommandLoader($containerBuilder, [
+    $commandLoader = new ContainerCommandLoader($container, [
         'app:foo' => FooCommand::class,
     ]);
 
 Like this, executing the ``app:foo`` command will load the ``FooCommand`` service
-by calling ``$containerBuilder->get(FooCommand::class)``.
+by calling ``$container->get(FooCommand::class)``.

--- a/controller/argument_value_resolver.rst
+++ b/controller/argument_value_resolver.rst
@@ -230,8 +230,8 @@ and adding a priority.
 
         use App\ArgumentResolver\UserValueResolver;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return static function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(UserValueResolver::class)
                 ->tag('controller.argument_value_resolver', ['priority' => 50])

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -319,8 +319,8 @@ Then, define a service for this class:
 
         use App\Service\FileUploader;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return static function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(FileUploader::class)
                 ->arg('$targetDirectory', '%brochures_directory%')

--- a/create_framework/dependency_injection.rst
+++ b/create_framework/dependency_injection.rst
@@ -109,30 +109,30 @@ Create a new file to host the dependency injection container configuration::
     use Symfony\Component\HttpKernel;
     use Symfony\Component\Routing;
 
-    $containerBuilder = new DependencyInjection\ContainerBuilder();
-    $containerBuilder->register('context', Routing\RequestContext::class);
-    $containerBuilder->register('matcher', Routing\Matcher\UrlMatcher::class)
+    $container = new DependencyInjection\ContainerBuilder();
+    $container->register('context', Routing\RequestContext::class);
+    $container->register('matcher', Routing\Matcher\UrlMatcher::class)
         ->setArguments([$routes, new Reference('context')])
     ;
-    $containerBuilder->register('request_stack', HttpFoundation\RequestStack::class);
-    $containerBuilder->register('controller_resolver', HttpKernel\Controller\ControllerResolver::class);
-    $containerBuilder->register('argument_resolver', HttpKernel\Controller\ArgumentResolver::class);
+    $container->register('request_stack', HttpFoundation\RequestStack::class);
+    $container->register('controller_resolver', HttpKernel\Controller\ControllerResolver::class);
+    $container->register('argument_resolver', HttpKernel\Controller\ArgumentResolver::class);
 
-    $containerBuilder->register('listener.router', HttpKernel\EventListener\RouterListener::class)
+    $container->register('listener.router', HttpKernel\EventListener\RouterListener::class)
         ->setArguments([new Reference('matcher'), new Reference('request_stack')])
     ;
-    $containerBuilder->register('listener.response', HttpKernel\EventListener\ResponseListener::class)
+    $container->register('listener.response', HttpKernel\EventListener\ResponseListener::class)
         ->setArguments(['UTF-8'])
     ;
-    $containerBuilder->register('listener.exception', HttpKernel\EventListener\ErrorListener::class)
+    $container->register('listener.exception', HttpKernel\EventListener\ErrorListener::class)
         ->setArguments(['Calendar\Controller\ErrorController::exception'])
     ;
-    $containerBuilder->register('dispatcher', EventDispatcher\EventDispatcher::class)
+    $container->register('dispatcher', EventDispatcher\EventDispatcher::class)
         ->addMethodCall('addSubscriber', [new Reference('listener.router')])
         ->addMethodCall('addSubscriber', [new Reference('listener.response')])
         ->addMethodCall('addSubscriber', [new Reference('listener.exception')])
     ;
-    $containerBuilder->register('framework', Framework::class)
+    $container->register('framework', Framework::class)
         ->setArguments([
             new Reference('dispatcher'),
             new Reference('controller_resolver'),
@@ -141,7 +141,7 @@ Create a new file to host the dependency injection container configuration::
         ])
     ;
 
-    return $containerBuilder;
+    return $container;
 
 The goal of this file is to configure your objects and their dependencies.
 Nothing is instantiated during this configuration step. This is purely a

--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -224,8 +224,8 @@ with the ``doctrine.event_listener`` tag:
 
         use App\EventListener\SearchIndexer;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return static function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             // listeners are applied by default to all Doctrine connections
             $services->set(SearchIndexer::class)
@@ -357,8 +357,8 @@ with the ``doctrine.orm.entity_listener`` tag:
         use App\Entity\User;
         use App\EventListener\UserChangedNotifier;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return static function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(UserChangedNotifier::class)
                 ->tag('doctrine.orm.entity_listener', [
@@ -498,8 +498,8 @@ Doctrine connection to use) you must do that in the manual service configuration
 
         use App\EventListener\DatabaseActivitySubscriber;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return static function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(DatabaseActivitySubscriber::class)
                 ->tag('doctrine.event_subscriber'[

--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -91,8 +91,8 @@ notify Symfony that it is an event listener by using a special "tag":
 
         use App\EventListener\ExceptionListener;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(ExceptionListener::class)
                 ->tag('kernel.event_listener')
@@ -383,9 +383,9 @@ compiler pass ``AddEventAliasesPass``::
 
     class Kernel extends BaseKernel
     {
-        protected function build(ContainerBuilder $containerBuilder)
+        protected function build(ContainerBuilder $container)
         {
-            $containerBuilder->addCompilerPass(new AddEventAliasesPass([
+            $container->addCompilerPass(new AddEventAliasesPass([
                 MyCustomEvent::class => 'my_custom_event',
             ]));
         }

--- a/frontend/custom_version_strategy.rst
+++ b/frontend/custom_version_strategy.rst
@@ -141,8 +141,8 @@ After creating the strategy PHP class, register it as a Symfony service.
         use App\Asset\VersionStrategy\GulpBusterVersionStrategy;
         use Symfony\Component\DependencyInjection\Definition;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(GulpBusterVersionStrategy::class)
                 ->args(

--- a/http_cache/cache_invalidation.rst
+++ b/http_cache/cache_invalidation.rst
@@ -123,8 +123,8 @@ Then, register the class as a service that :doc:`decorates </service_container/s
 
         use App\CacheKernel;
 
-        return function (ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(CacheKernel::class)
                 ->decorate('http_cache')

--- a/mailer.rst
+++ b/mailer.rst
@@ -57,8 +57,8 @@ over SMTP by configuring the DSN in your ``.env`` file (the ``user``,
         use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
         use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-        return static function (ContainerConfigurator $containerConfigurator): void {
-            $containerConfigurator->extension('framework', [
+        return static function (ContainerConfigurator $container): void {
+            $container->extension('framework', [
                 'mailer' => [
                     'dsn' => env('MAILER_DSN'),
                 ],

--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -204,8 +204,8 @@ you can determine the message bus based on an implemented interface:
         use App\MessageHandler\CommandHandlerInterface;
         use App\MessageHandler\QueryHandlerInterface;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             // ...
 

--- a/profiler.rst
+++ b/profiler.rst
@@ -512,8 +512,8 @@ you'll need to configure the data collector explicitly:
 
         use App\DataCollector\RequestCollector;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(RequestCollector::class)
                 ->tag('data_collector', [

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -286,12 +286,12 @@ using the special ``when@`` keyword:
 
         use Symfony\Config\FrameworkConfig;
 
-        return static function (FrameworkConfig $framework, ContainerConfigurator $containerConfigurator) {
+        return static function (FrameworkConfig $framework, ContainerConfigurator $container) {
             $framework->router()
                 ->utf8(true)
             ;
 
-            if ('prod' === $containerConfigurator->env()) {
+            if ('prod' === $container->env()) {
                 $framework->router()
                     ->strictRequirements(null)
                 ;

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3356,8 +3356,8 @@ the `SMTP session`_. This value overrides any other recipient set in the code.
         // config/packages/mailer.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $containerConfigurator): void {
-            $containerConfigurator->extension('framework', [
+        return static function (ContainerConfigurator $container): void {
+            $container->extension('framework', [
                 'mailer' => [
                     'dsn' => 'smtp://localhost:25',
                     'envelope' => [

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -122,8 +122,8 @@ services:
         use App\Lock\PostgresqlLock;
         use App\Lock\SqliteLock;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set('app.mysql_lock', MysqlLock::class);
             $services->set('app.postgresql_lock', PostgresqlLock::class);
@@ -184,8 +184,8 @@ the generic ``app.lock`` service can be defined as follows:
         use App\Lock\PostgresqlLock;
         use App\Lock\SqliteLock;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set('app.mysql_lock', MysqlLock::class);
             $services->set('app.postgresql_lock', PostgresqlLock::class);

--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -328,8 +328,8 @@ Now define a service for the ``ExtraLoader``:
 
         use App\Routing\ExtraLoader;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return static function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(ExtraLoader::class)
                 ->tag('routing.loader')

--- a/security.rst
+++ b/security.rst
@@ -1572,7 +1572,7 @@ and set the ``limiter`` option to its service ID:
         use Symfony\Config\FrameworkConfig;
         use Symfony\Config\SecurityConfig;
 
-        return static function (ContainerBuilder $containerBuilder, FrameworkConfig $framework, SecurityConfig $security) {
+        return static function (ContainerBuilder $container, FrameworkConfig $framework, SecurityConfig $security) {
             $framework->rateLimiter()
                 ->limiter('username_ip_login')
                     ->policy('token_bucket')
@@ -1588,7 +1588,7 @@ and set the ``limiter`` option to its service ID:
                     ->interval('15 minutes')
             ;
 
-            $containerBuilder->register('app.login_rate_limiter', DefaultLoginRateLimiter::class)
+            $container->register('app.login_rate_limiter', DefaultLoginRateLimiter::class)
                 ->setArguments([
                     // 1st argument is the limiter for IP
                     new Reference('limiter.ip_login'),
@@ -2589,8 +2589,8 @@ for these events.
 
             use App\EventListener\LogoutSubscriber;
 
-            return function(ContainerConfigurator $containerConfigurator) {
-                $services = $containerConfigurator->services();
+            return function(ContainerConfigurator $container) {
+                $services = $container->services();
 
                 $services->set(LogoutSubscriber::class)
                     ->tag('kernel.event_subscriber', [

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -91,8 +91,8 @@ Take the following ``access_control`` entries as an example:
         use Symfony\Component\DependencyInjection\ContainerBuilder;
         use Symfony\Config\SecurityConfig;
 
-        return static function (ContainerBuilder $containerBuilder, SecurityConfig $security) {
-            $containerBuilder->setParameter('env(TRUSTED_IPS)', '10.0.0.1, 10.0.0.2');
+        return static function (ContainerBuilder $container, SecurityConfig $security) {
+            $container->setParameter('env(TRUSTED_IPS)', '10.0.0.1, 10.0.0.2');
             // ...
 
             $security->accessControl()

--- a/service_container.rst
+++ b/service_container.rst
@@ -205,9 +205,9 @@ each time you ask for it.
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return function(ContainerConfigurator $containerConfigurator) {
+            return function(ContainerConfigurator $container) {
                 // default configuration for services in *this* file
-                $services = $containerConfigurator->services()
+                $services = $container->services()
                     ->defaults()
                         ->autowire()      // Automatically injects dependencies in your services.
                         ->autoconfigure() // Automatically registers your services as commands, event subscribers, etc.
@@ -500,7 +500,7 @@ pass here. No problem! In your configuration, you can explicitly set this argume
 
         use App\Service\SiteUpdateManager;
 
-        return function(ContainerConfigurator $containerConfigurator) {
+        return function(ContainerConfigurator $container) {
             // ...
 
             // same as before
@@ -575,8 +575,8 @@ parameter and in PHP config use the ``service()`` function:
 
         use App\Service\MessageGenerator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(MessageGenerator::class)
                 // In versions earlier to Symfony 5.1 the service() function was called ref()
@@ -682,7 +682,7 @@ But, you can control this and pass in a different logger:
 
         use App\Service\MessageGenerator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
+        return function(ContainerConfigurator $container) {
             // ... same code as before
 
             // explicitly configure the service
@@ -783,8 +783,8 @@ You can also use the ``bind`` keyword to bind specific arguments by name or type
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\DependencyInjection\Reference;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services()
+        return function(ContainerConfigurator $container) {
+            $services = $container->services()
                 ->defaults()
                     // pass this value to any $adminEmail argument for any service
                     // that's defined in this file (including controller arguments)
@@ -918,7 +918,7 @@ setting:
 
         use App\Service\PublicService;
 
-        return function(ContainerConfigurator $containerConfigurator) {
+        return function(ContainerConfigurator $container) {
             // ... same as code before
 
             // explicitly configure the service
@@ -975,7 +975,7 @@ key. For example, the default Symfony configuration contains this:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
+        return function(ContainerConfigurator $container) {
             // ...
 
             // makes classes in src/ available to be used as services
@@ -1157,7 +1157,7 @@ admin email. In this case, each needs to have a unique service id:
         use App\Service\MessageGenerator;
         use App\Service\SiteUpdateManager;
 
-        return function(ContainerConfigurator $containerConfigurator) {
+        return function(ContainerConfigurator $container) {
             // ...
 
             // site_update_manager.superadmin is the service's id

--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -55,8 +55,8 @@ You can also control the ``public`` option on a service-by-service basis:
 
         use App\Service\Foo;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(Foo::class)
                 ->public();
@@ -127,8 +127,8 @@ services.
 
         use App\Mail\PhpMailer;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(PhpMailer::class)
                 ->private();
@@ -275,8 +275,8 @@ The following example shows how to inject an anonymous service into another serv
         use App\AnonymousBar;
         use App\Foo;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(Foo::class)
                 // In versions earlier to Symfony 5.1 the inline_service() function was called inline()
@@ -327,8 +327,8 @@ Using an anonymous service as a factory looks like this:
         use App\AnonymousBar;
         use App\Foo;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(Foo::class)
                 ->factory([inline_service(AnonymousBar::class), 'constructFoo']);
@@ -373,8 +373,8 @@ or you decided not to maintain it anymore), you can deprecate its definition:
 
         use App\Service\OldService;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(OldService::class)
                 ->deprecate(

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -104,8 +104,8 @@ both services:
     .. code-block:: php
 
         // config/services.php
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services()
+        return function(ContainerConfigurator $container) {
+            $services = $container->services()
                 ->defaults()
                     ->autowire()
                     ->autoconfigure()
@@ -243,7 +243,7 @@ adding a service alias:
 
         use App\Util\Rot13Transformer;
 
-        return function(ContainerConfigurator $containerConfigurator) {
+        return function(ContainerConfigurator $container) {
             // ...
 
             // the id is not a class, so it won't be used for autowiring
@@ -350,7 +350,7 @@ To fix that, add an :ref:`alias <service-autowiring-alias>`:
         use App\Util\Rot13Transformer;
         use App\Util\TransformerInterface;
 
-        return function(ContainerConfigurator $containerConfigurator) {
+        return function(ContainerConfigurator $container) {
             // ...
 
             $services->set(Rot13Transformer::class);
@@ -520,7 +520,7 @@ the injection::
         use App\Util\TransformerInterface;
         use App\Util\UppercaseTransformer;
 
-        return function(ContainerConfigurator $containerConfigurator) {
+        return function(ContainerConfigurator $container) {
             // ...
 
             $services->set(Rot13Transformer::class)->autowire();

--- a/service_container/calls.rst
+++ b/service_container/calls.rst
@@ -66,7 +66,7 @@ To configure the container to call the ``setLogger`` method, use the ``calls`` k
 
         use App\Service\MessageGenerator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
+        return function(ContainerConfigurator $container) {
             // ...
 
             $services->set(MessageGenerator::class)

--- a/service_container/compiler_passes.rst
+++ b/service_container/compiler_passes.rst
@@ -22,9 +22,9 @@ Compiler passes are registered in the ``build()`` method of the application kern
 
         // ...
 
-        protected function build(ContainerBuilder $containerBuilder): void
+        protected function build(ContainerBuilder $container): void
         {
-            $containerBuilder->addCompilerPass(new CustomPass());
+            $container->addCompilerPass(new CustomPass());
         }
     }
 
@@ -50,14 +50,14 @@ and process the services inside the ``process()`` method::
 
         // ...
 
-        public function process(ContainerBuilder $containerBuilder): void
+        public function process(ContainerBuilder $container): void
         {
             // in this method you can manipulate the service container:
             // for example, changing some container service:
-            $containerBuilder->getDefinition('app.some_private_service')->setPublic(true);
+            $container->getDefinition('app.some_private_service')->setPublic(true);
 
             // or processing tagged services:
-            foreach ($containerBuilder->findTaggedServiceIds('some_tag') as $id => $tags) {
+            foreach ($container->findTaggedServiceIds('some_tag') as $id => $tags) {
                 // ...
             }
         }
@@ -79,11 +79,11 @@ method in the extension)::
 
     class MyBundle extends Bundle
     {
-        public function build(ContainerBuilder $containerBuilder): void
+        public function build(ContainerBuilder $container): void
         {
-            parent::build($containerBuilder);
+            parent::build($container);
 
-            $containerBuilder->addCompilerPass(new CustomPass());
+            $container->addCompilerPass(new CustomPass());
         }
     }
 

--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -169,8 +169,8 @@ all the classes are already loaded as services. All you need to do is specify th
         use App\Mail\GreetingCardManager;
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             // Registers all 4 classes as services, including App\Mail\EmailConfigurator
             $services->load('App\\', '../src/*');
@@ -239,8 +239,8 @@ Services can be configured via invokable configurators (replacing the
         use App\Mail\GreetingCardManager;
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             // Registers all 4 classes as services, including App\Mail\EmailConfigurator
             $services->load('App\\', '../src/*');

--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -55,7 +55,7 @@ to another service: ``App\Mailer``. One way to do this is with an expression:
         use App\Mail\MailerConfiguration;
         use App\Mailer;
 
-        return function(ContainerConfigurator $containerConfigurator) {
+        return function(ContainerConfigurator $container) {
             // ...
 
             $services->set(MailerConfiguration::class);
@@ -110,8 +110,8 @@ via a ``container`` variable. Here's another example:
 
         use App\Mailer;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(Mailer::class)
                 ->args([expr("container.hasParameter('some_param') ? parameter('some_param') : 'default_value'")]);

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -74,8 +74,8 @@ create its object:
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerStaticFactory;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(NewsletterManager::class)
                 // the first argument is the class and the second argument is the static method
@@ -156,8 +156,8 @@ You can omit the class on the factory declaration:
 
         use App\Email\NewsletterManager;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             // Note that we are not using service()
             $services->set(NewsletterManager::class)
@@ -218,8 +218,8 @@ Configuration of the service container then looks like this:
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerFactory;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             // first, create a service for the factory
             $services->set(NewsletterManagerFactory::class);
@@ -297,8 +297,8 @@ method name:
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerFactory;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(NewsletterManager::class)
                 ->factory(service(InvokableNewsletterManagerFactory::class));
@@ -357,8 +357,8 @@ previous examples takes the ``templating`` service as an argument:
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerFactory;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(NewsletterManager::class)
                 ->factory([service(NewsletterManagerFactory::class), 'createNewsletterManager'])

--- a/service_container/import.rst
+++ b/service_container/import.rst
@@ -116,12 +116,12 @@ a relative or absolute path to the imported file:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->import('services/mailer.php');
+        return function(ContainerConfigurator $container) {
+            $container->import('services/mailer.php');
             // If you want to import a whole directory:
-            $containerConfigurator->import('services/');
+            $container->import('services/');
 
-            $services = $containerConfigurator->services()
+            $services = $container->services()
                 ->defaults()
                     ->autowire()
                     ->autoconfigure()

--- a/service_container/injection_types.rst
+++ b/service_container/injection_types.rst
@@ -71,8 +71,8 @@ service container configuration:
 
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(NewsletterManager::class)
                 // In versions earlier to Symfony 5.1 the service() function was called ref()
@@ -274,8 +274,8 @@ that accepts the dependency::
 
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(NewsletterManager::class)
                 ->call('setMailer', [service('mailer')]);
@@ -356,8 +356,8 @@ Another possibility is setting public fields of the class directly::
 
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set('app.newsletter_manager', NewsletterManager::class)
                 ->property('mailer', service('mailer'));

--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -76,8 +76,8 @@ You can mark the service as ``lazy`` by manipulating its definition:
 
         use App\Twig\AppExtension;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(AppExtension::class)->lazy();
         };
@@ -170,8 +170,8 @@ specific interfaces.
         use App\Twig\AppExtension;
         use Twig\Extension\ExtensionInterface;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(AppExtension::class)
                 ->lazy()

--- a/service_container/optional_dependencies.rst
+++ b/service_container/optional_dependencies.rst
@@ -38,8 +38,8 @@ if the service does not exist:
 
         use App\Newsletter\NewsletterManager;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(NewsletterManager::class)
                 // In versions earlier to Symfony 5.1 the service() function was called ref()
@@ -95,8 +95,8 @@ call if the service exists and remove the method call if it does not:
 
         use App\Newsletter\NewsletterManager;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(NewsletterManager::class)
                 ->call('setLogger', [service('logger')->ignoreOnInvalid()])

--- a/service_container/parent_services.rst
+++ b/service_container/parent_services.rst
@@ -119,8 +119,8 @@ avoid duplicated service definitions:
         use App\Repository\DoctrinePostRepository;
         use App\Repository\DoctrineUserRepository;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(BaseDoctrineRepository::class)
                 ->abstract()
@@ -229,8 +229,8 @@ the child class:
         use App\Repository\DoctrineUserRepository;
         // ...
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(BaseDoctrineRepository::class)
                 // ...

--- a/service_container/service_closures.rst
+++ b/service_container/service_closures.rst
@@ -77,8 +77,8 @@ argument of type ``service_closure``:
 
         use App\Service\MyService;
 
-        return function (ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(MyService::class)
                 ->args([service_closure('mailer')]);
@@ -104,7 +104,7 @@ a service closure by wrapping the service reference into an instance of
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Reference;
 
-    public function process(ContainerBuilder $containerBuilder): void
+    public function process(ContainerBuilder $container): void
     {
         // ...
 

--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -41,8 +41,8 @@ When overriding an existing definition, the original service is lost:
         use App\Mailer;
         use App\NewMailer;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(Mailer::class);
 
@@ -98,8 +98,8 @@ but keeps a reference of the old one as ``.inner``:
         use App\DecoratingMailer;
         use App\Mailer;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(Mailer::class);
 
@@ -161,8 +161,8 @@ automatically changed to ``'.inner'``):
         use App\DecoratingMailer;
         use App\Mailer;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(Mailer::class);
 
@@ -233,8 +233,8 @@ automatically changed to ``'.inner'``):
             use App\DecoratingMailer;
             use App\Mailer;
 
-            return function(ContainerConfigurator $containerConfigurator) {
-                $services = $containerConfigurator->services();
+            return function(ContainerConfigurator $container) {
+                $services = $container->services();
 
                 $services->set(Mailer::class);
 
@@ -295,8 +295,8 @@ the ``decoration_priority`` option. Its value is an integer that defaults to
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(\Foo::class);
 
@@ -382,8 +382,8 @@ ordered services, each one decorating the next:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->services()
+        return function(ContainerConfigurator $container) {
+            $container->services()
                 ->stack('decorated_foo_stack', [
                     inline_service(\Baz::class)->args([service('.inner')]),
                     inline_service(\Bar::class)->args([service('.inner')]),
@@ -465,8 +465,8 @@ advanced example of composition:
         use App\Decorated;
         use App\Decorator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->services()
+        return function(ContainerConfigurator $container) {
+            $container->services()
                 ->set('some_decorator', Decorator::class)
 
                 ->stack('embedded_stack', [
@@ -583,8 +583,8 @@ Three different behaviors are available:
 
         use Symfony\Component\DependencyInjection\ContainerInterface;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(Foo::class);
 

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -233,8 +233,8 @@ service type to a service.
 
         use App\CommandBus;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(CommandBus::class)
                 ->tag('container.service_subscriber', ['key' => 'logger', 'id' => 'monolog.logger.event']);
@@ -325,8 +325,8 @@ or directly via PHP attributes:
 
         use App\CommandBus;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(CommandBus::class)
                 ->args([service_locator([
@@ -409,8 +409,8 @@ other services. To do so, create a new service definition using the
 
         use Symfony\Component\DependencyInjection\ServiceLocator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set('app.command_handler_locator', ServiceLocator::class)
                 // In versions earlier to Symfony 5.1 the service() function was called ref()
@@ -471,8 +471,8 @@ Now you can inject the service locator in any other services:
 
         use App\CommandBus;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(CommandBus::class)
                 ->args([service('app.command_handler_locator')]);
@@ -490,7 +490,7 @@ will share identical locators among all the services referencing them::
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Reference;
 
-    public function process(ContainerBuilder $containerBuilder): void
+    public function process(ContainerBuilder $container): void
     {
         // ...
 
@@ -499,9 +499,9 @@ will share identical locators among all the services referencing them::
             'logger' => new Reference('logger'),
         ];
 
-        $myService = $containerBuilder->findDefinition(MyService::class);
+        $myService = $container->findDefinition(MyService::class);
 
-        $myService->addArgument(ServiceLocatorTagPass::register($containerBuilder, $locateableServices));
+        $myService->addArgument(ServiceLocatorTagPass::register($container, $locateableServices));
     }
 
 Indexing the Collection of Services
@@ -579,8 +579,8 @@ of the ``key`` tag attribute (as defined in the ``index_by`` locator option):
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(App\Handler\One::class)
                 ->tag('app.handler', ['key' => 'handler_one'])
@@ -686,8 +686,8 @@ attribute to the locator service defining the name of this custom method:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->services()
+        return function(ContainerConfigurator $container) {
+            $container->services()
                 ->set(App\HandlerCollection::class)
                     ->args([tagged_locator('app.handler', 'key', 'myOwnMethodName')])
             ;

--- a/service_container/shared.rst
+++ b/service_container/shared.rst
@@ -33,8 +33,8 @@ in your service definition:
 
         use App\SomeNonSharedService;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(SomeNonSharedService::class)
                 ->share(false);

--- a/service_container/synthetic_services.rst
+++ b/service_container/synthetic_services.rst
@@ -63,8 +63,8 @@ configuration:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             // synthetic services don't specify a class
             $services->set('app.synthetic_service')

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -37,8 +37,8 @@ example:
 
         use App\Twig\AppExtension;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(AppExtension::class)
                 ->tag('twig.extension');
@@ -103,8 +103,8 @@ If you want to apply tags automatically for your own services, use the
 
         use App\Security\CustomInterface;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             // this config only applies to the services created by this file
             $services
@@ -147,9 +147,9 @@ In a Symfony application, call this method in your kernel class::
     {
         // ...
 
-        protected function build(ContainerBuilder $containerBuilder): void
+        protected function build(ContainerBuilder $container): void
         {
-            $containerBuilder->registerForAutoconfiguration(CustomInterface::class)
+            $container->registerForAutoconfiguration(CustomInterface::class)
                 ->addTag('app.custom_tag')
             ;
         }
@@ -163,9 +163,9 @@ In a Symfony bundle, call this method in the ``load()`` method of the
     {
         // ...
 
-        public function load(array $configs, ContainerBuilder $containerBuilder): void
+        public function load(array $configs, ContainerBuilder $container): void
         {
-            $containerBuilder->registerForAutoconfiguration(CustomInterface::class)
+            $container->registerForAutoconfiguration(CustomInterface::class)
                 ->addTag('app.custom_tag')
             ;
         }
@@ -202,11 +202,11 @@ method::
     {
         // ...
 
-        protected function build(ContainerBuilder $containerBuilder): void
+        protected function build(ContainerBuilder $container): void
         {
             // ...
 
-            $containerBuilder->registerAttributeForAutoconfiguration(SensitiveElement::class, static function (ChildDefinition $definition, SensitiveElement $attribute, \ReflectionClass $reflector): void {
+            $container->registerAttributeForAutoconfiguration(SensitiveElement::class, static function (ChildDefinition $definition, SensitiveElement $attribute, \ReflectionClass $reflector): void {
                 // Apply the 'app.sensitive_element' tag to all classes with SensitiveElement
                 // attribute, and attach the token value to the tag
                 $definition->addTag('app.sensitive_element', ['token' => $attribute->getToken()]);
@@ -284,8 +284,8 @@ Then, define the chain as a service:
 
         use App\Mail\TransportChain;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(TransportChain::class);
         };
@@ -338,8 +338,8 @@ For example, you may add the following transports as services:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(\MailerSmtpTransport::class)
                 // the param() method was introduced in Symfony 5.2.
@@ -374,17 +374,17 @@ container for any services with the ``app.mail_transport`` tag::
 
     class MailTransportPass implements CompilerPassInterface
     {
-        public function process(ContainerBuilder $containerBuilder): void
+        public function process(ContainerBuilder $container): void
         {
             // always first check if the primary service is defined
-            if (!$containerBuilder->has(TransportChain::class)) {
+            if (!$container->has(TransportChain::class)) {
                 return;
             }
 
-            $definition = $containerBuilder->findDefinition(TransportChain::class);
+            $definition = $container->findDefinition(TransportChain::class);
 
             // find all service IDs with the app.mail_transport tag
-            $taggedServices = $containerBuilder->findTaggedServiceIds('app.mail_transport');
+            $taggedServices = $container->findTaggedServiceIds('app.mail_transport');
 
             foreach ($taggedServices as $id => $tags) {
                 // add the transport service to the TransportChain service
@@ -411,9 +411,9 @@ or from your kernel::
     {
         // ...
 
-        protected function build(ContainerBuilder $containerBuilder): void
+        protected function build(ContainerBuilder $container): void
         {
-            $containerBuilder->addCompilerPass(new MailTransportPass());
+            $container->addCompilerPass(new MailTransportPass());
         }
     }
 
@@ -501,8 +501,8 @@ To answer this, change the service declaration:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(\MailerSmtpTransport::class)
                 // the param() method was introduced in Symfony 5.2.
@@ -545,7 +545,7 @@ use this, update the compiler::
 
     class TransportCompilerPass implements CompilerPassInterface
     {
-        public function process(ContainerBuilder $containerBuilder): void
+        public function process(ContainerBuilder $container): void
         {
             // ...
 
@@ -655,8 +655,8 @@ directly via PHP attributes:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(App\Handler\One::class)
                 ->tag('app.handler')
@@ -720,8 +720,8 @@ the number, the earlier the tagged service will be located in the collection:
 
         use App\Handler\One;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function(ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(One::class)
                 ->tag('app.handler', ['priority' => 20])
@@ -796,8 +796,8 @@ you can define it in the configuration of the collecting service:
 
         use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 
-        return function (ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             // ...
 
@@ -884,8 +884,8 @@ indexed by the ``key`` attribute:
         use App\Handler\Two;
         use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 
-        return function (ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(One::class)
                 ->tag('app.handler', ['key' => 'handler_one']);
@@ -998,8 +998,8 @@ array element. For example, to retrieve the ``handler_two`` handler::
             use App\HandlerCollection;
             use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 
-            return function (ContainerConfigurator $containerConfigurator) {
-                $services = $containerConfigurator->services();
+            return function (ContainerConfigurator $container) {
+                $services = $container->services();
 
                 // ...
 

--- a/session.rst
+++ b/session.rst
@@ -723,8 +723,8 @@ To use it, first register a new handler service with your database credentials:
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
-        return static function (ContainerConfigurator $containerConfiguratorConfigurator) {
-            $services = $containerConfigurator->services();
+        return static function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(PdoSessionHandler::class)
                 ->args([
@@ -838,8 +838,8 @@ passed to the ``PdoSessionHandler`` service:
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
-        return static function (ContainerConfigurator $containerConfiguratorConfigurator) {
-            $services = $containerConfigurator->services();
+        return static function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(PdoSessionHandler::class)
                 ->args([
@@ -1011,8 +1011,8 @@ the MongoDB connection as argument:
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
 
-        return static function (ContainerConfigurator $containerConfiguratorConfigurator) {
-            $services = $containerConfigurator->services();
+        return static function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(MongoDbSessionHandler::class)
                 ->args([
@@ -1130,8 +1130,8 @@ configure these values with the second argument passed to the
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        return static function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             $services->set(MongoDbSessionHandler::class)
                 ->args([

--- a/testing.rst
+++ b/testing.rst
@@ -357,8 +357,8 @@ the ``test`` environment as follows:
         use App\Contracts\Repository\NewsRepositoryInterface;
         use App\Repository\NewsRepository;
 
-        return static function (ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->services()
+        return static function (ContainerConfigurator $container) {
+            $container->services()
                 // redefine the alias as it should be while making it public
                 ->alias(NewsRepositoryInterface::class, NewsRepository::class)
                     ->public()


### PR DESCRIPTION
Takes the other road from #17683 as discussed in #18295

Using `$containerBuilder` and `$containerConfigurator` is unnecessarily long, consuming horizontal space without adding any clarity.

This also aligns the name `$container` with existing practice in the code and in recipes.