### PR TITLE
[Doctrine] Add missing `use` statement to databases & doctrine page

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -813,6 +813,7 @@ with any PHP model::
 
     use App\Entity\Product;
     use App\Repository\ProductRepository;
+    use Doctrine\ORM\EntityManagerInterface;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Routing\Annotation\Route;
     // ...


### PR DESCRIPTION
The example at https://symfony.com/doc/current/doctrine.html#updating-an-object is missing a `use` statement.