### PR TITLE
[Dotenv] Fix non-working examples of `json` and `csv` env var processors

### DIFF
--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -262,9 +262,8 @@ Symfony provides the following env var processors:
 
             # config/packages/framework.yaml
             parameters:
-                env(TRUSTED_HOSTS): '["10.0.0.1", "10.0.0.2"]'
-            framework:
-                trusted_hosts: '%env(json:TRUSTED_HOSTS)%'
+                env(ALLOWED_LANGUAGES): '["en","de","es"]'
+                app_allowed_languages: '%env(json:ALLOWED_LANGUAGES)%'
 
         .. code-block:: xml
 
@@ -279,10 +278,9 @@ Symfony provides the following env var processors:
                     https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
                 <parameters>
-                    <parameter key="env(TRUSTED_HOSTS)">["10.0.0.1", "10.0.0.2"]</parameter>
+                    <parameter key="env(ALLOWED_LANGUAGES)">["en","de","es"]</parameter>
+                    <parameter key="app_allowed_languages">%env(json:ALLOWED_LANGUAGES)%</parameter>
                 </parameters>
-
-                <framework:config trusted-hosts="%env(json:TRUSTED_HOSTS)%"/>
             </container>
 
         .. code-block:: php
@@ -293,9 +291,9 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\FrameworkConfig;
 
-            return static function (ContainerBuilder $container, FrameworkConfig $framework) {
-                $container->setParameter('env(TRUSTED_HOSTS)', '["10.0.0.1", "10.0.0.2"]');
-                $framework->trustedHosts(env('TRUSTED_HOSTS')->json());
+            return static function (ContainerBuilder $container) {
+                $container->setParameter('env(ALLOWED_LANGUAGES)', '["en","de","es"]');
+                $container->setParameter('app_allowed_languages', '%env(json:ALLOWED_LANGUAGES)%');
             };
 
 ``env(resolve:FOO)``
@@ -348,9 +346,8 @@ Symfony provides the following env var processors:
 
             # config/packages/framework.yaml
             parameters:
-                env(TRUSTED_HOSTS): "10.0.0.1,10.0.0.2"
-            framework:
-               trusted_hosts: '%env(csv:TRUSTED_HOSTS)%'
+                env(ALLOWED_LANGUAGES): "en,de,es"
+                app_allowed_languages: '%env(csv:ALLOWED_LANGUAGES)%'
 
         .. code-block:: xml
 
@@ -365,10 +362,9 @@ Symfony provides the following env var processors:
                     https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
                 <parameters>
-                    <parameter key="env(TRUSTED_HOSTS)">10.0.0.1,10.0.0.2</parameter>
+                    <parameter key="env(ALLOWED_LANGUAGES)">en,de,es</parameter>
+                    <parameter key="app_allowed_languages">%env(csv:ALLOWED_LANGUAGES)%</parameter>
                 </parameters>
-
-                <framework:config trusted-hosts="%env(csv:TRUSTED_HOSTS)%"/>
             </container>
 
         .. code-block:: php
@@ -379,9 +375,9 @@ Symfony provides the following env var processors:
             use Symfony\Component\DependencyInjection\ContainerBuilder;
             use Symfony\Config\FrameworkConfig;
 
-            return static function (ContainerBuilder $container, FrameworkConfig $framework) {
-                $container->setParameter('env(TRUSTED_HOSTS)', '10.0.0.1,10.0.0.2');
-                $framework->trustedHosts(env('TRUSTED_HOSTS')->csv());
+            return static function (ContainerBuilder $container) {
+                $container->setParameter('env(ALLOWED_LANGUAGES)', 'en,de,es');
+                $container->setParameter('app_allowed_languages', '%env(csv:ALLOWED_LANGUAGES)%');
             };
 
 ``env(file:FOO)``


### PR DESCRIPTION
Changes the examples for `json` and `csv` env var processors. The previous examples were not working.

Closes https://github.com/symfony/symfony/issues/50341
