### PR TITLE
[DependencyInjection] Warns `instanceof` should be called before services registration

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -113,6 +113,11 @@ If you want to apply tags automatically for your own services, use the
                     ->tag('app.custom_tag');
         };
 
+.. caution::
+
+    If you're using PHP, you need to call ``instanceof`` before any service
+    registration to make sure tags are correctly applied.
+
 It is also possible to use the ``#[AutoconfigureTag]`` attribute directly on the
 base class or interface::
 


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony/issues/49988 and https://github.com/symfony/symfony/issues/50329

Order matters when configuring the service container using PHP.

Maybe we should warn about `defaults` too but I’m not sure where :thinking: 