### PR TITLE
[DependencyInjection] Add support for generating lazy closures

### DIFF
--- a/reference/attributes.rst
+++ b/reference/attributes.rst
@@ -31,9 +31,9 @@ Dependency Injection
 * :ref:`Autoconfigure <lazy-services_configuration>`
 * :ref:`AutoconfigureTag <di-instanceof>`
 * :ref:`Autowire <autowire-attribute>`
-* :ref:`AutowireCallable <container_closure-as-argument>`
+* :ref:`AutowireCallable <autowiring_closures>`
 * :doc:`AutowireDecorated </service_container/service_decoration>`
-* :doc:`AutowireServiceClosure </service_container/service_closures>`
+* :ref:`AutowireServiceClosure <autowiring_closures>`
 * :ref:`Exclude <service-psr4-loader>`
 * :ref:`TaggedIterator <tags_reference-tagged-services>`
 * :ref:`TaggedLocator <service-subscribers-locators_defining-service-locator>`

--- a/service_container.rst
+++ b/service_container.rst
@@ -780,54 +780,14 @@ Our configuration looks like this:
             ;
         };
 
+.. seealso::
+
+    Closures can be injected :ref:`by using autowiring <autowiring_closures>`
+    and its dedicated attributes.
+
 .. versionadded:: 6.1
 
     The ``closure`` argument type was introduced in Symfony 6.1.
-
-It is also possible to convert a callable into an injected closure
-thanks to the
-:class:`Symfony\\Component\\DependencyInjection\\Attribute\\AutowireCallable`
-attribute. Let's say our ``MessageHashGenerator`` class now has a ``generate()``
-method::
-
-        // src/Hash/MessageHashGenerator.php
-        namespace App\Hash;
-
-        class MessageHashGenerator
-        {
-            public function generate(): string
-            {
-                // Compute and return a message hash
-            }
-        }
-
-We can inject the ``generate()`` method of the ``MessageHashGenerator``
-like this::
-
-    // src/Service/MessageGenerator.php
-    namespace App\Service;
-
-    use App\Hash\MessageHashGenerator;
-    use Psr\Log\LoggerInterface;
-    use Symfony\Component\DependencyInjection\Attribute\AutowireCallable;
-
-    class MessageGenerator
-    {
-        public function __construct(
-            private LoggerInterface $logger,
-            #[AutowireCallable(service: MessageHashGenerator::class, method: 'generate')]
-            private \Closure $generateMessageHash
-        ) {
-            // ...
-        }
-
-        // ...
-    }
-
-.. versionadded:: 6.3
-
-    The :class:`Symfony\\Component\\DependencyInjection\\Attribute\\AutowireCallable`
-    attribute was introduced in Symfony 6.3.
 
 .. _services-binding:
 

--- a/service_container/service_closures.rst
+++ b/service_container/service_closures.rst
@@ -92,45 +92,13 @@ argument of type ``service_closure``:
 
 .. seealso::
 
+    Service closures can be injected :ref:`by using autowiring <autowiring_closures>`
+    and its dedicated attributes.
+
+.. seealso::
+
     Another way to inject services lazily is via a
     :doc:`service locator </service_container/service_subscribers_locators>`.
-
-Thanks to the
-:class:`Symfony\\Component\\DependencyInjection\\Attribute\\AutowireServiceClosure`
-attribute, defining a service wrapped in a closure can directly be done
-in the service class, without further configuration::
-
-    // src/Service/MyService.php
-    namespace App\Service;
-
-    use Symfony\Component\DependencyInjection\Attribute\AutowireServiceClosure;
-    use Symfony\Component\Mailer\MailerInterface;
-
-    class MyService
-    {
-        public function __construct(
-            #[AutowireServiceClosure('mailer')]
-            private \Closure $mailer
-        ) {
-        }
-
-        public function doSomething(): void
-        {
-            // ...
-
-            $this->getMailer()->send($email);
-        }
-
-        private function getMailer(): MailerInterface
-        {
-            return ($this->mailer)();
-        }
-    }
-
-.. versionadded:: 6.3
-
-    The :class:`Symfony\\Component\\DependencyInjection\\Attribute\\AutowireServiceClosure`
-    attribute was introduced in Symfony 6.3.
 
 Using a Service Closure in a Compiler Pass
 ------------------------------------------


### PR DESCRIPTION
Resolves https://github.com/symfony/symfony-docs/issues/18090

I moved existing sections about those attributes and reworded them with (I hope) better examples. I followed what's been written [by Nicolas](https://github.com/symfony/symfony-docs/issues/18090#issuecomment-1562395459). I feel this makes more sense to group those attributes in the `Autowiring` page. I still left a few `See also` redirecting to this new section.