### PR TITLE
[Mailer] Update mailer.rst

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -108,7 +108,7 @@ Service               Install with
 `Mailgun`_            ``composer require symfony/mailgun-mailer``
 `Mailjet`_            ``composer require symfony/mailjet-mailer``
 `MailPace`_           ``composer require symfony/mail-pace-mailer``
-`MailerSend`_         ``composer require symfony/mailersend-mailer``
+`MailerSend`_         ``composer require symfony/mailer-send-mailer``
 `Postmark`_           ``composer require symfony/postmark-mailer``
 `SendGrid`_           ``composer require symfony/sendgrid-mailer``
 `Sendinblue`_         ``composer require symfony/sendinblue-mailer``


### PR DESCRIPTION
wrong composer packagename

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
