### PR TITLE
Upgrade the minimum PHP version requirement for Symfony 7.0

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -14,7 +14,7 @@ Technical Requirements
 
 Before creating your first Symfony application you must:
 
-* Install PHP 8.1 or higher and these PHP extensions (which are installed and
+* Install PHP 8.2 or higher and these PHP extensions (which are installed and
   enabled by default in most PHP 8 installations): `Ctype`_, `iconv`_,
   `PCRE`_, `Session`_, `SimpleXML`_, and `Tokenizer`_;
 * `Install Composer`_, which is used to install PHP packages.


### PR DESCRIPTION
Fixes #18340.

The first PR for Symfony 7 🥳 

@stof could you please check if it's still true that you must have all the following PHP extensions to run any Symfony app: `Ctype`, `iconv`, `PCRE`, `Session`, `SimpleXML`, and `Tokenizer`.

Thanks!