### PR TITLE
Fix an RST syntax issue of some missing headline

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -330,7 +330,7 @@ absolute URLs instead of relative URLs.
 .. _reference-twig-function-t:
 
 t
-~
+~~~
 
 .. code-block:: twig
 


### PR DESCRIPTION
Fixes #18289 as proposed by Wouter in https://github.com/symfony/symfony-docs/issues/18289#issuecomment-1542794221