### PR TITLE
[Cache] Fix redis adapter option type

### DIFF
--- a/components/cache/adapters/redis_adapter.rst
+++ b/components/cache/adapters/redis_adapter.rst
@@ -210,7 +210,7 @@ Available Options
     ``error``, ``distribute`` or ``slaves``.  For ``\Predis\ClientInterface`` valid options are ``slaves``
     or ``distribute``.
 
-``ssl`` (type: ``bool``, default: ``null``)
+``ssl`` (type: ``array``, default: ``null``)
     SSL context options. See `php.net/context.ssl`_ for more information.
 
 .. note::


### PR DESCRIPTION
Seems that those SSL options should be an array instead of a boolean value :slightly_smiling_face: 