### PR TITLE
[Lock] Add Redis Secure DSN example

### DIFF
--- a/lock.rst
+++ b/lock.rst
@@ -50,6 +50,7 @@ this behavior by using the ``lock`` key like:
             lock: ['memcached://m1.docker', 'memcached://m2.docker']
             lock: 'redis://r1.docker'
             lock: ['redis://r1.docker', 'redis://r2.docker']
+            lock: 'rediss://r1.docker?ssl[verify_peer]=1&ssl[cafile]=...'
             lock: 'zookeeper://z1.docker'
             lock: 'zookeeper://z1.docker,z2.docker'
             lock: 'sqlite:///%kernel.project_dir%/var/lock.db'


### PR DESCRIPTION
After hours of research today, I finally managed to make the Lock component work with a Redus Secure DSN. I think adding this simple little DSN example to the list could save future developers hours of vendor research. :smile: 