### PR TITLE
[HtmlSanitizer] corrected what `force_https_urls` actually does

### DIFF
--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -729,8 +729,9 @@ URLs of ``<a>`` elements:
                     app.post_sanitizer:
                         # ...
 
-                        # if `true`, all URLs will be forced using the `https://` scheme (instead
-                        # of e.g. `http://` or `mailto:`)
+                        # if `true`, all URLs using the `http://` scheme will be converted to
+                        # using the `https://` scheme instead. `http` still needs to be allowed
+                        # in `allowed_link_schemes`
                         force_https_urls: true
 
                         # specifies the allowed URL schemes. If the URL has a different scheme, the
@@ -756,8 +757,9 @@ URLs of ``<a>`` elements:
                 http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
             <framework:config>
-                <!-- force-https-urls: if `true`, all URLs will be forced using the `https://`
-                                       scheme (instead of e.g. `http://` or `mailto:`) -->
+                <!-- force-https-urls: if `true`, all URLs using the `http://` scheme will be
+                                       converted to using the `https://` scheme instead.
+                                       `http` still needs to be allowed in `allowed-link-scheme` -->
                 <!-- allow-relative-links: whether to allow relative links (i.e. URLs without
                                            scheme and host) -->
                 <framework:html-sanitizer
@@ -785,8 +787,9 @@ URLs of ``<a>`` elements:
         return static function (FrameworkConfig $framework) {
             $framework->htmlSanitizer()
                 ->sanitizer('app.post_sanitizer')
-                    // if `true`, all URLs will be forced using the `https://` scheme (instead
-                    // of e.g. `http://` or `mailto:`)
+                    // if `true`, all URLs using the `http://` scheme will be converted to
+                    // using the `https://` scheme instead. `http` still needs to be
+                    // allowed in `allowedLinkSchemes`
                     ->forceHttpsUrls(true)
 
                     // specifies the allowed URL schemes. If the URL has a different scheme, the
@@ -811,8 +814,9 @@ URLs of ``<a>`` elements:
 
         $postSanitizer = new HtmlSanitizer(
             (new HtmlSanitizerConfig())
-                // if `true`, all URLs will be forced using the `https://` scheme (instead
-                // of e.g. `http://` or `mailto:`)
+                // if `true`, all URLs using the `http://` scheme will be converted to
+                // using the `https://` scheme instead. `http` still needs to be
+                // allowed in `allowedLinkSchemes`
                 ->forceHttpsUrls()
 
                 // specifies the allowed URL schemes. If the URL has a different scheme, the
@@ -845,8 +849,9 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
                     app.post_sanitizer:
                         # ...
 
-                        # if `true`, all URLs will be forced using the `https://` scheme (instead
-                        # of e.g. `http://` or `data:`)
+                        # if `true`, all URLs using the `http://` scheme will be converted to
+                        # using the `https://` scheme instead. `http` still needs to be allowed
+                        # in `allowed_media_schemes`
                         force_https_urls: true
 
                         # specifies the allowed URL schemes. If the URL has a different scheme, the
@@ -872,8 +877,9 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
                 http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
             <framework:config>
-                <!-- force-https-urls: if `true`, all URLs will be forced using the `https://`
-                                       scheme (instead of e.g. `http://` or `data:`) -->
+                <!-- force-https-urls: if `true`, all URLs using the `http://` scheme will be
+                                       converted to using the `https://` scheme instead. `http`
+                                       still needs to be allowed in `allowed-media-scheme` -->
                 <!-- allow-relative-medias: whether to allow relative URLs (i.e. URLs without
                                            scheme and host) -->
                 <framework:html-sanitizer
@@ -901,8 +907,9 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
         return static function (FrameworkConfig $framework) {
             $framework->htmlSanitizer()
                 ->sanitizer('app.post_sanitizer')
-                    // if `true`, all URLs will be forced using the `https://` scheme (instead
-                    // of e.g. `http://` or `data:`)
+                    // if `true`, all URLs using the `http://` scheme will be converted to
+                    // using the `https://` scheme instead. `http` still needs to be
+                    // allowed in `allowedMediaSchemes`
                     ->forceHttpsUrls(true)
 
                     // specifies the allowed URL schemes. If the URL has a different scheme, the
@@ -927,8 +934,9 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
 
         $postSanitizer = new HtmlSanitizer(
             (new HtmlSanitizerConfig())
-                // if `true`, all URLs will be forced using the `https://` scheme (instead
-                // of e.g. `http://` or `data:`)
+                // if `true`, all URLs using the `http://` scheme will be converted to
+                // using the `https://` scheme instead. `http` still needs to be
+                // allowed in `allowedMediaSchemes`
                 ->forceHttpsUrls()
 
                 // specifies the allowed URL schemes. If the URL has a different scheme, the


### PR DESCRIPTION
As seen in the [code](https://github.com/symfony/html-sanitizer/blob/eae9b0a9ad7a2ed1963f819547d59ff99ad9e0fd/TextSanitizer/UrlSanitizer.php#L68-L71) this only converts `http://` to `https://` but does not change any other scheme.
