### PR TITLE
[HtmlSanitizer] Information about subdomains of allowed hosts (they also match)

### DIFF
--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -730,8 +730,8 @@ URLs of ``<a>`` elements:
                         allowed_link_schemes: ['http', 'https', 'mailto']
 
                         # specifies the allowed hosts, the attribute will be dropped if the
-                        # URL contains a different host
-                        allowed_link_hosts: ['symfony.com']
+                        # URL contains a different host which is not a subdomain of the allowed host
+                        allowed_link_hosts: ['symfony.com'] # also allows any subdomain (i.e. www.symfony.com)
 
                         # whether to allow relative links (i.e. URLs without scheme and host)
                         allow_relative_links: true
@@ -763,7 +763,8 @@ URLs of ``<a>`` elements:
                     <allowed-link-scheme>mailto</allowed-link-scheme>
 
                     <!-- specifies the allowed hosts, the attribute will be dropped if the
-                         URL contains a different host -->
+                         URL contains a different host which is not a subdomain of the allowed host
+                         Also allows any subdomain (i.e. www.symfony.com) -->
                     <allowed-link-host>symfony.com</allowed-link-host>
                 </framework:html-sanitizer>
             </framework:config>
@@ -786,8 +787,8 @@ URLs of ``<a>`` elements:
                     ->allowedLinkSchemes(['http', 'https', 'mailto'])
 
                     // specifies the allowed hosts, the attribute will be dropped if the
-                    // URL contains a different host
-                    ->allowedLinkHost('symfony.com')
+                    // URL contains a different host which is not a subdomain of the allowed host
+                    ->allowedLinkHost('symfony.com') // Also allows any subdomain (i.e. www.symfony.com)
 
                     // whether to allow relative links (i.e. URLs without scheme and host)
                     ->allowRelativeLinks(true)
@@ -810,8 +811,8 @@ URLs of ``<a>`` elements:
                 ->allowedLinkSchemes(['http', 'https', 'mailto'])
 
                 // specifies the allowed hosts, the attribute will be dropped if the
-                // URL contains a different host
-                ->allowedLinkHosts(['symfony.com'])
+                // URL contains a different host which is not a subdomain of the allowed host
+                ->allowedLinkHosts(['symfony.com']) // Also allows any subdomain (i.e. www.symfony.com)
 
                 // whether to allow relative links (i.e. URLs without scheme and host)
                 ->allowRelativeLinks()
@@ -844,8 +845,8 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
                         allowed_media_schemes: ['http', 'https', 'mailto']
 
                         # specifies the allowed hosts, the attribute will be dropped if the URL
-                        # contains a different host
-                        allowed_media_hosts: ['symfony.com']
+                        # contains a different host which is not a subdomain of the allowed host
+                        allowed_media_hosts: ['symfony.com'] # Also allows any subdomain (i.e. www.symfony.com)
 
                         # whether to allow relative URLs (i.e. URLs without scheme and host)
                         allow_relative_medias: true
@@ -877,7 +878,8 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
                     <allowed-media-scheme>mailto</allowed-media-scheme>
 
                     <!-- specifies the allowed hosts, the attribute will be dropped if the URL
-                         contains a different host -->
+                         contains a different host which is not a subdomain of the allowed host.
+                         Also allows any subdomain (i.e. www.symfony.com) -->
                     <allowed-media-host>symfony.com</allowed-media-host>
                 </framework:html-sanitizer>
             </framework:config>
@@ -900,8 +902,8 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
                     ->allowedMediaSchemes(['http', 'https', 'mailto'])
 
                     // specifies the allowed hosts, the attribute will be dropped if the URL
-                    // contains a different host
-                    ->allowedMediaHost('symfony.com')
+                    // contains a different host which is not a subdomain of the allowed host
+                    ->allowedMediaHost('symfony.com') // Also allows any subdomain (i.e. www.symfony.com)
 
                     // whether to allow relative URLs (i.e. URLs without scheme and host)
                     ->allowRelativeMedias(true)
@@ -924,8 +926,8 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
                 ->allowedMediaSchemes(['http', 'https', 'mailto'])
 
                 // specifies the allowed hosts, the attribute will be dropped if the URL
-                // contains a different host
-                ->allowedMediaHosts(['symfony.com'])
+                // contains a different host which is not a subdomain of the allowed host
+                ->allowedMediaHosts(['symfony.com']) // Also allows any subdomain (i.e. www.symfony.com)
 
                 // whether to allow relative URLs (i.e. URLs without scheme and host)
                 ->allowRelativeMedias()


### PR DESCRIPTION
As seen in the [code](https://github.com/symfony/html-sanitizer/blob/6.2/TextSanitizer/UrlSanitizer.php#L108-L135) the allowed hosts also match any subdomain.