### PR TITLE
[PropertyInfo] Fix PhpStanExtractor added version

### DIFF
--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -442,9 +442,9 @@ information from annotations of properties and methods, such as ``@var``,
     $phpStanExtractor = new PhpStanExtractor();
     $phpStanExtractor->getTypesFromConstructor(Foo::class, 'bar');
 
-.. versionadded:: 6.1
+.. versionadded:: 5.4
 
-    The ``PhpStanExtractor`` was introduced in Symfony 6.1.
+    The ``PhpStanExtractor`` was introduced in Symfony 5.4.
 
 SerializerExtractor
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`PhpStanExtractor` was actually added in 5.4: https://github.com/symfony/symfony/pull/40457#event-5543696578