### PR TITLE
Include php opening tag in sample code 

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -38,6 +38,11 @@ Suppose you want to create a page - ``/lucky/number`` - that generates a lucky (
 random) number and prints it. To do that, create a "Controller" class and a
 "controller" method inside of it::
 
+.. code-block:: php
+   :caption: src/Controller/LuckyController.php
+
+    <?php
+    declare(strict_types=1);
     // src/Controller/LuckyController.php
     namespace App\Controller;
 


### PR DESCRIPTION
The sample code looks like it should be copy-and-pasted into a new file, but the code doesn't include the php opening tag.
This change includes the opening tag and also use of strict types directive to help with debugging.
