### PR TITLE
[Process] Remove wrong note about `create_new_console` option

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -113,11 +113,6 @@ You can configure the options passed to the ``other_options`` argument of
     // this option allows a subprocess to continue running after the main script exited
     $process->setOptions(['create_new_console' => true]);
 
-.. note::
-
-    The ``create_new_console`` option is only available on Windows!
-
-
 Using Features From the OS Shell
 --------------------------------
 


### PR DESCRIPTION
Fix #18414 