### PR TITLE
[Translation] Mention that `default_locale` is used as the default for `framework.translator.fallbacks`

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -943,6 +943,9 @@ the framework:
             $framework->defaultLocale('en');
         };
 
+This ``default_locale`` is also relevant for the translator, as we will see
+in the next section.
+
 .. _translation-fallback:
 
 Fallback Translation Locales
@@ -963,7 +966,8 @@ checks translation resources for several locales:
    (Spanish) translation resource (e.g. ``messages.es.yaml``);
 
 #. If the translation still isn't found, Symfony uses the ``fallbacks`` option,
-   which can be configured as follows:
+   which can be configured as follows. When this option is not defined, it
+   defaults to the ``default_locale`` setting mentioned in the previous section.
 
    .. configuration-block::
 


### PR DESCRIPTION
I consider this relevant, since the current wording suggests that `default_locale` is for setting the default `_locale` value in the `Request` only – but, in fact, this setting also makes its way into the translator configuration.