### PR TITLE
[DependencyInjection] Fix xml example for defaut-index-name for tagged service provider

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -997,7 +997,7 @@ with the ``default_index_method`` attribute on the tagged argument:
                     <!-- use getIndex() instead of getDefaultIndexName() -->
                     <argument type="tagged_iterator"
                         tag="app.handler"
-                        default-index-method="someFunctionName"
+                        default-index-method="getIndex"
                     />
                 </service>
             </services>


### PR DESCRIPTION
Comment say it should be `getIndex` instead of `someFunctionName`.