### PR TITLE
[Uid] Use ::class to reference id generator services

### DIFF
--- a/components/uid.rst
+++ b/components/uid.rst
@@ -257,6 +257,7 @@ entity primary keys::
     namespace App\Entity;
 
     use Doctrine\ORM\Mapping as ORM;
+    use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
     use Symfony\Bridge\Doctrine\Types\UuidType;
     use Symfony\Component\Uid\Uuid;
 
@@ -265,7 +266,7 @@ entity primary keys::
         #[ORM\Id]
         #[ORM\Column(type: UuidType::NAME, unique: true)]
         #[ORM\GeneratedValue(strategy: 'CUSTOM')]
-        #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+        #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
         private ?Uuid $id;
 
         public function getId(): ?Uuid
@@ -444,6 +445,7 @@ entity primary keys::
     namespace App\Entity;
 
     use Doctrine\ORM\Mapping as ORM;
+    use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
     use Symfony\Bridge\Doctrine\Types\UlidType;
     use Symfony\Component\Uid\Ulid;
 
@@ -452,7 +454,7 @@ entity primary keys::
         #[ORM\Id]
         #[ORM\Column(type: UlidType::NAME, unique: true)]
         #[ORM\GeneratedValue(strategy: 'CUSTOM')]
-        #[ORM\CustomIdGenerator(class: 'doctrine.ulid_generator')]
+        #[ORM\CustomIdGenerator(class: UlidGenerator::class)]
         private ?Ulid $id;
 
         public function getId(): ?Ulid


### PR DESCRIPTION
Might prevents people to run into issues like https://github.com/phpstan/phpstan-doctrine/issues/297 and seems to be cleaner. Thanks @NMe84 for pointing it out in the aforementioned issue.