### PR TITLE
Fix `doctrine/dbal` deprecation using `Statement::executeQuery`

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -998,8 +998,8 @@ In addition, you can query directly with SQL if you need to::
                 WHERE p.price > :price
                 ORDER BY p.price ASC
                 ';
-            $stmt = $conn->prepare($sql);
-            $resultSet = $stmt->executeQuery(['price' => $price]);
+
+            $resultSet = $conn->executeQuery($sql, ['price' => $price]);
 
             // returns an array of arrays (i.e. a raw data set)
             return $resultSet->fetchAllAssociative();


### PR DESCRIPTION
Deprecation warning when `doctrine/dbal >= 3.4.*`.

In Symfony docs,executeQuery() is mentionned here : [Querying with SQL](https://symfony.com/doc/current/doctrine.html#querying-with-sql).
 
But since `3.4.*` passing parameters to `Statement::execute*()` functions is deprecated by `doctrine/dbal` with this warning:
`User Deprecated: Passing $params to Statement::executeQuery() is deprecated. Bind parameters using Statement::bindParam() or Statement::bindValue() instead. (Statement.php:212 called by User.php:40, https://github.com/doctrine/dbal/pull/5556, package doctrine/dbal)`.

I've already ask in the [DBAL PR concerned](https://github.com/doctrine/dbal/pull/5556#issuecomment-1571489203) how to use `executeQuery` from now on. 

![image](https://github.com/symfony/symfony-docs/assets/46444652/e0b6938b-4f67-474a-a8f5-5f565b04e5b4)
[(in the same PR)](https://github.com/doctrine/dbal/pull/5556#issuecomment-1571617512)

So, after having tested it in a prod project, I propose an update of the doc in this sense.

Thanks again @derrabus 🙏