### PR TITLE
Remove PHPUnit 5.3 references

### DIFF
--- a/create_framework/unit_testing.rst
+++ b/create_framework/unit_testing.rst
@@ -99,8 +99,6 @@ We are now ready to write our first test::
         private function getFrameworkForException($exception)
         {
             $matcher = $this->createMock(Routing\Matcher\UrlMatcherInterface::class);
-            // use getMock() on PHPUnit 5.3 or below
-            // $matcher = $this->getMock(Routing\Matcher\UrlMatcherInterface::class);
 
             $matcher
                 ->expects($this->once())
@@ -159,8 +157,6 @@ Response::
     public function testControllerResponse()
     {
         $matcher = $this->createMock(Routing\Matcher\UrlMatcherInterface::class);
-        // use getMock() on PHPUnit 5.3 or below
-        // $matcher = $this->getMock(Routing\Matcher\UrlMatcherInterface::class);
 
         $matcher
             ->expects($this->once())

--- a/testing/database.rst
+++ b/testing/database.rst
@@ -61,8 +61,6 @@ constructor, you can pass a mock object within a test::
 
             // Now, mock the repository so it returns the mock of the employee
             $employeeRepository = $this->createMock(ObjectRepository::class);
-            // use getMock() on PHPUnit 5.3 or below
-            // $employeeRepository = $this->getMock(ObjectRepository::class);
             $employeeRepository->expects($this->any())
                 ->method('find')
                 ->willReturn($employee);
@@ -71,8 +69,6 @@ constructor, you can pass a mock object within a test::
             // (this is not needed if the class being tested injects the
             // repository it uses instead of the entire object manager)
             $objectManager = $this->createMock(ObjectManager::class);
-            // use getMock() on PHPUnit 5.3 or below
-            // $objectManager = $this->getMock(ObjectManager::class);
             $objectManager->expects($this->any())
                 ->method('getRepository')
                 ->willReturn($employeeRepository);


### PR DESCRIPTION
Symfony 6.0 require `php: >=8.0.2`, phpunit 5.3 require `php: ^5.6 || ^7.0`.

So they can't be used together, let's remove unnecessary documentation !

