### PR TITLE
Remove symfony 5.x version references

### DIFF
--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -277,7 +277,7 @@ You can also restrict the list to a specific bus by providing its name as an arg
 
 .. tip::
 
-    Since Symfony 5.1, the command will also show the PHPDoc description of
+    The command will also show the PHPDoc description of
     the message and handler classes.
 
 .. _article about CQRS: https://martinfowler.com/bliki/CQRS.html

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2332,7 +2332,7 @@ package:
 
     If you request an asset that is *not found* in the ``manifest.json`` file, the original -
     *unmodified* - asset path will be returned.
-    Since Symfony 5.4, you can set ``strict_mode`` to ``true`` to get an exception when an asset is *not found*.
+    You can set ``strict_mode`` to ``true`` to get an exception when an asset is *not found*.
 
 .. note::
 

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -331,7 +331,6 @@ For example, you may add the following transports as services:
             $services = $container->services();
 
             $services->set(\MailerSmtpTransport::class)
-                // the param() method was introduced in Symfony 5.2.
                 ->args([param('mailer_host')])
                 ->tag('app.mail_transport')
             ;
@@ -499,7 +498,6 @@ To answer this, change the service declaration:
             $services = $container->services();
 
             $services->set(\MailerSmtpTransport::class)
-                // the param() method was introduced in Symfony 5.2.
                 ->args([param('mailer_host')])
                 ->tag('app.mail_transport', ['alias' => 'smtp'])
             ;

--- a/translation.rst
+++ b/translation.rst
@@ -1069,7 +1069,7 @@ unused translation messages templates:
 
     The extractors can't find messages translated outside templates (like form
     labels or controllers) unless using :ref:`translatable-objects` or calling
-    the ``trans()`` method on a translator (since Symfony 5.3). Dynamic
+    the ``trans()`` method on a translator. Dynamic
     translations using variables or expressions in templates are not
     detected either:
 


### PR DESCRIPTION
I think they should have been in `versionadded` directive and not in sentences

I'm right ?

