### PR TITLE
Removed some occurrences of explicitly talking about "PHP 8 attributes"

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -208,8 +208,7 @@ available in the ``configure()`` method::
 Registering the Command
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-In PHP 8 and newer versions, you can register the command by adding the
-``AsCommand`` attribute to it::
+You can register the command by adding the ``AsCommand`` attribute to it::
 
     // src/Command/CreateUserCommand.php
     namespace App\Command;

--- a/service_container.rst
+++ b/service_container.rst
@@ -238,8 +238,8 @@ each time you ask for it.
 Limiting Services to a specific Symfony Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you are using PHP 8.0 or later, you can use the ``#[When]`` PHP
-attribute to only register the class as a service in some environments::
+You can use the ``#[When]`` attribute to only register the class
+as a service in some environments::
 
     use Symfony\Component\DependencyInjection\Attribute\When;
 

--- a/service_container/calls.rst
+++ b/service_container/calls.rst
@@ -145,11 +145,8 @@ The configuration to tell the container it should do so would be like:
     If autowire is enabled, you can also use attributes; with the previous
     example it would be::
 
-        /**
-         * @return static
-         */
         #[Required]
-        public function withLogger(LoggerInterface $logger)
+        public function withLogger(LoggerInterface $logger): static
         {
             $new = clone $this;
             $new->logger = $logger;
@@ -157,8 +154,7 @@ The configuration to tell the container it should do so would be like:
             return $new;
         }
 
-    You can also leverage the PHP 8 ``static`` return type instead of the
-    ``@return static`` annotation. If you don't want a method with a
-    PHP 8 ``static`` return type and a ``#[Required]`` attribute to behave as
-    a wither, you can add a ``@return $this`` annotation to disable the
-    *returns clone* feature.
+    If you don't want a method with a ``static`` return type and
+    a ``#[Required]`` attribute to behave as a wither, you can
+    add a ``@return $this`` annotation to disable the *returns clone*
+    feature.

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -168,7 +168,7 @@ In a Symfony bundle, call this method in the ``load()`` method of the
     }
 
 Autoconfiguration registering is not limited to interfaces. It is possible
-to use PHP 8 attributes to autoconfigure services by using the
+to use PHP attributes to autoconfigure services by using the
 :method:`Symfony\\Component\\DependencyInjection\\ContainerBuilder::registerAttributeForAutoconfiguration`
 method::
 


### PR DESCRIPTION
Annotations usage is discouraged and I guess we can replace occurrences where we talk about "PHP 8 attributes", "PHP 8.0 and newer", etc as you must have PHP 8.0 to run Symfony 6.2. What do you think?