### PR TITLE
[Yaml] Typo in yaml component

### DIFF
--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -41,7 +41,7 @@ compact block collections and multi-document files.
 Real Parser
 ~~~~~~~~~~~
 
-It sports a real parser and is able to parse a large subset of the YAML
+It supports a real parser and is able to parse a large subset of the YAML
 specification, for all your configuration needs. It also means that the parser
 is pretty robust, easy to understand, and simple enough to extend.
 


### PR DESCRIPTION
"**supports**" instead of "**sports**" in the Real Parser section

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
