### PR TITLE
Remove all 6.x deprecations on 7.0

### DIFF
--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -255,16 +255,6 @@ handle all signals e.g. to do some tasks before terminating the command.
         The :class:`Symfony\\Component\\Console\\SignalRegistry\\SignalMap` class was
         introduced in Symfony 6.4.
 
-.. deprecated:: 6.3
-
-    In Symfony versions previous to 6.3, all signals (except ``SIGUSR1`` and
-    ``SIGUSR2``) would terminate the script by calling ``exit(0)``. Starting
-    from Symfony 6.3, no more signal is automatically calling ``exit(0)``.
-
-.. deprecated:: 6.3
-
-    Not returning a value in ``handleSignal()`` is deprecated since Symfony 6.3.
-
 .. _`reserved exit codes`: https://www.tldp.org/LDP/abs/html/exitcodes.html
 .. _`Signals`: https://en.wikipedia.org/wiki/Signal_(IPC)
 .. _`constants of the PCNTL PHP extension`: https://www.php.net/manual/en/pcntl.constants.php

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -152,13 +152,10 @@ has some methods to filter the input values:
 
 :method:`Symfony\\Component\\HttpFoundation\\ParameterBag::filter`
     Filters the parameter by using the PHP :phpfunction:`filter_var` function.
-
-    .. deprecated:: 6.3
-
-        Ignoring invalid values when using ``filter()`` is deprecated and will throw
-        a :class:`Symfony\\Component\\HttpKernel\\Exception\\BadRequestHttpException`
-        in Symfony 7.0. You can use the ``FILTER_NULL_ON_FAILURE`` flag to keep
-        ignoring them.
+    If invalid values are found, a
+    :class:`Symfony\\Component\\HttpKernel\\Exception\\BadRequestHttpException`
+    is thrown. The ``FILTER_NULL_ON_FAILURE`` flag can be used to ignore invalid
+    values.
 
 All getters take up to two arguments: the first one is the parameter name
 and the second one is the default value to return if the parameter does not

--- a/components/validator/resources.rst
+++ b/components/validator/resources.rst
@@ -114,10 +114,6 @@ If you use annotations instead of attributes, it's also required to call
         ->addDefaultDoctrineAnnotationReader() // add this only when using annotations
         ->getValidator();
 
-.. deprecated:: 6.4
-
-    Annotations are deprecated since Symfony 6.4, use attributes instead.
-
 To disable the annotation loader after it was enabled, call
 :method:`Symfony\\Component\\Validator\\ValidatorBuilder::disableAnnotationMapping`.
 

--- a/console.rst
+++ b/console.rst
@@ -171,12 +171,6 @@ You can optionally define a description, help message and the
     ``setDescription()`` method instead of the attribute to define the command
     description.
 
-.. deprecated:: 6.1
-
-    The static property ``$defaultDescription`` was deprecated in Symfony 6.1.
-    Instead, use the ``#[AsCommand]`` attribute to define the optional command
-    description.
-
 The ``configure()`` method is called automatically at the end of the command
 constructor. If your command defines its own constructor, set the properties
 first and then call to the parent constructor, to make those properties
@@ -237,11 +231,6 @@ If you can't use PHP attributes, register the command as a service and
 :doc:`tag it </service_container/tags>` with the ``console.command`` tag. If you're using the
 :ref:`default services.yaml configuration <service-container-services-load-example>`,
 this is already done for you, thanks to :ref:`autoconfiguration <services-autoconfigure>`.
-
-.. deprecated:: 6.1
-
-    The static property ``$defaultName`` was deprecated in Symfony 6.1.
-    Define your command name with the ``#[AsCommand]`` attribute instead.
 
 Running the Command
 ~~~~~~~~~~~~~~~~~~~

--- a/contributing/documentation/format.rst
+++ b/contributing/documentation/format.rst
@@ -216,7 +216,7 @@ If you are documenting a brand new feature, a change or a deprecation that's
 been made in Symfony, you should precede your description of the change with
 the corresponding directive and a short description:
 
-For a new feature or a behavior change use the ``.. versionadded:: 6.x``
+For a new feature or a behavior change use the ``.. versionadded:: 7.x``
 directive:
 
 .. code-block:: rst
@@ -243,12 +243,12 @@ For a deprecation use the ``.. deprecated:: 6.x`` directive:
 
         ... ... ... was deprecated in Symfony 6.2.
 
-Whenever a new major version of Symfony is released (e.g. 6.0, 7.0, etc), a new
+Whenever a new major version of Symfony is released (e.g. 7.0, 8.0, etc), a new
 branch of the documentation is created from the ``x.4`` branch of the previous
 major version. At this point, all the ``versionadded`` and ``deprecated`` tags
 for Symfony versions that have a lower major version will be removed. For
-example, if Symfony 6.0 were released today, 5.0 to 5.4 ``versionadded`` and
-``deprecated`` tags would be removed from the new ``6.0`` branch.
+example, if Symfony 7.0 were released today, 6.0 to 6.4 ``versionadded`` and
+``deprecated`` tags would be removed from the new ``7.0`` branch.
 
 .. _reStructuredText: https://docutils.sourceforge.io/rst.html
 .. _Sphinx: https://www.sphinx-doc.org/

--- a/mailer.rst
+++ b/mailer.rst
@@ -581,12 +581,6 @@ Alternatively you can attach contents from a stream by passing it directly to th
         ->addPart(new DataPart(fopen('/path/to/documents/contract.doc', 'r')))
     ;
 
-.. deprecated:: 6.2
-
-    In Symfony versions previous to 6.2, the methods ``attachFromPath()`` and
-    ``attach()`` could be used to add attachments. These methods have been
-    deprecated and replaced with ``addPart()``.
-
 Embedding Images
 ~~~~~~~~~~~~~~~~
 
@@ -627,12 +621,6 @@ images inside the HTML contents::
 .. versionadded:: 6.1
 
     The support of embedded images as HTML backgrounds was introduced in Symfony 6.1.
-
-.. deprecated:: 6.2
-
-    In Symfony versions previous to 6.2, the methods ``embedFromPath()`` and
-    ``embed()`` could be used to embed images. These methods have been deprecated
-    and replaced with ``addPart()`` together with inline ``DataPart`` objects.
 
 .. _mailer-configure-email-globally:
 
@@ -1561,7 +1549,7 @@ Here's an example of making one available to download::
         {
             $message = (new DraftEmail())
                 ->html($this->renderView(/* ... */))
-                ->attach(/* ... */)
+                ->addPart(/* ... */)
             ;
 
             $response = new Response($message->toString());

--- a/messenger.rst
+++ b/messenger.rst
@@ -889,12 +889,6 @@ properties in the ``reset()`` method.
 If you don't want to reset the container, add the ``--no-reset`` option when
 running the ``messenger:consume`` command.
 
-.. deprecated:: 6.1
-
-    In Symfony versions previous to 6.1, the service container didn't reset
-    automatically between messages and you had to set the
-    ``framework.messenger.reset_on_message`` option to ``true``.
-
 .. _messenger-retries-failures:
 
 Retries & Failures

--- a/reference/attributes.rst
+++ b/reference/attributes.rst
@@ -5,11 +5,6 @@ Attributes are the successor of annotations since PHP 8. Attributes are native
 to the language and Symfony takes full advantage of them across the framework
 and its different components.
 
-.. deprecated:: 6.4
-
-    Annotations across the framework are deprecated since Symfony 6.4, you must
-    only use attributes instead.
-
 Doctrine Bridge
 ~~~~~~~~~~~~~~~
 

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -270,13 +270,9 @@ you can control. The following configuration options exist for a mapping:
 ``type``
 ........
 
-One of ``annotation`` (for PHP annotations; it's the default value),
-``attribute`` (for PHP attributes), ``xml``, ``yml``, ``php`` or
-``staticphp``. This specifies which type of metadata type your mapping uses.
-
-.. deprecated:: 6.4
-
-    Annotations are deprecated since Symfony 6.4, use attributes instead.
+One of ``attribute`` (for PHP attributes; it's the default value),
+``xml``, ``yml``, ``php`` or ``staticphp``. This specifies which
+type of metadata type your mapping uses.
 
 See `Doctrine Metadata Drivers`_ for more information about this option.
 

--- a/reference/formats/expression_language.rst
+++ b/reference/formats/expression_language.rst
@@ -333,7 +333,7 @@ Array Operators
 * ``in`` (contain)
 * ``not in`` (does not contain)
 
-For example::
+These operators are using strict comparison. For example::
 
     class User
     {

--- a/reference/forms/types/options/date_widget_description.rst.inc
+++ b/reference/forms/types/options/date_widget_description.rst.inc
@@ -10,8 +10,3 @@ following:
 
 * ``single_text``: renders a single input of type ``date``. User's input
   is validated based on the `format`_ option.
-
-.. deprecated:: 6.3
-
-    Not setting a value explicitly for this option is deprecated since Symfony 6.3
-    because the default value will change to ``single_text`` in Symfony 7.0.

--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -58,15 +58,6 @@ normalization process::
         }
     }
 
-.. deprecated:: 6.4
-
-    Injecting an ``ObjectNormalizer`` in your custom normalizer is deprecated
-    since Symfony 6.4. Implement the
-    :class:`Symfony\\Component\\Serializer\\Normalizer\\NormalizerAwareInterface`
-    and use the
-    :class:`Symfony\\Component\\Serializer\\Normalizer\\NormalizerAwareTrait` instead
-    to inject the ``$normalizer`` property.
-
 Registering it in your Application
 ----------------------------------
 

--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -211,12 +211,6 @@ automatically changed to ``'.inner'``):
                 ->args([service('.inner')]);
         };
 
-.. deprecated:: 6.3
-
-    The ``#[MapDecorated]`` attribute is deprecated since Symfony 6.3.
-    Instead, use the
-    :class:`#[AutowireDecorated] <Symfony\\Component\\DependencyInjection\\Attribute\\AutowireDecorated>` attribute.
-
 .. tip::
 
     The visibility of the decorated ``App\Mailer`` service (which is an alias


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
