### PR TITLE
Fix return type on custom authenticators

### DIFF
--- a/security/custom_authenticator.rst
+++ b/security/custom_authenticator.rst
@@ -239,7 +239,7 @@ using :ref:`the user provider <security-user-providers>`::
                 // ...
 
                 return new Passport(
-                    new UserBadge($email, function (string $userIdentifier): ?User {
+                    new UserBadge($email, function (string $userIdentifier): ?UserInterface {
                         return $this->userRepository->findOneBy(['email' => $userIdentifier]);
                     }),
                     $credentials


### PR DESCRIPTION
The return type of this part of the documentation is giving a class that has been deprecated in Symfony 5.3
