### PR TITLE
[Tests] Update PHPUnit documentation links

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -463,4 +463,4 @@ you must set up a redirection.
 .. _`feature toggles`: https://en.wikipedia.org/wiki/Feature_toggle
 .. _`smoke testing`: https://en.wikipedia.org/wiki/Smoke_testing_(software)
 .. _`Webpack`: https://webpack.js.org/
-.. _`PHPUnit data providers`: https://docs.phpunit.de/en/9.5/writing-tests-for-phpunit.html#data-providers
+.. _`PHPUnit data providers`: https://docs.phpunit.de/en/9.6/writing-tests-for-phpunit.html#data-providers

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -1064,11 +1064,11 @@ not find the SUT:
 .. _`PHPUnit`: https://phpunit.de
 .. _`PHPUnit event listener`: https://docs.phpunit.de/en/10.0/extending-phpunit.html#phpunit-s-event-system
 .. _`ErrorHandler component`: https://github.com/symfony/error-handler
-.. _`PHPUnit's assertStringMatchesFormat()`: https://docs.phpunit.de/en/9.5/assertions.html#assertstringmatchesformat
+.. _`PHPUnit's assertStringMatchesFormat()`: https://docs.phpunit.de/en/9.6/assertions.html#assertstringmatchesformat
 .. _`PHP error handler`: https://www.php.net/manual/en/book.errorfunc.php
-.. _`environment variable`: https://docs.phpunit.de/en/9.5/configuration.html#the-env-element
+.. _`environment variable`: https://docs.phpunit.de/en/9.6/configuration.html#the-env-element
 .. _`@-silencing operator`: https://www.php.net/manual/en/language.operators.errorcontrol.php
 .. _`Travis CI`: https://travis-ci.org/
-.. _`test listener`: https://docs.phpunit.de/en/9.5/configuration.html#the-extensions-element
-.. _`@covers`: https://docs.phpunit.de/en/9.5/annotations.html#covers
+.. _`test listener`: https://docs.phpunit.de/en/9.6/configuration.html#the-extensions-element
+.. _`@covers`: https://docs.phpunit.de/en/9.6/annotations.html#covers
 .. _`PHP namespace resolutions rules`: https://www.php.net/manual/en/language.namespaces.rules.php

--- a/create_framework/unit_testing.rst
+++ b/create_framework/unit_testing.rst
@@ -220,6 +220,6 @@ Symfony code.
 Now that we are confident (again) about the code we have written, we can
 safely think about the next batch of features we want to add to our framework.
 
-.. _`PHPUnit`: https://docs.phpunit.de/en/9.5/
-.. _`test doubles`: https://docs.phpunit.de/en/9.5/test-doubles.html
+.. _`PHPUnit`: https://docs.phpunit.de/en/9.6/
+.. _`test doubles`: https://docs.phpunit.de/en/9.6/test-doubles.html
 .. _`XDebug`: https://xdebug.org/

--- a/form/unit_testing.rst
+++ b/form/unit_testing.rst
@@ -241,4 +241,4 @@ guessers using the :method:`Symfony\\Component\\Form\\Test\\FormIntegrationTestC
 and :method:`Symfony\\Component\\Form\\Test\\FormIntegrationTestCase::getTypeGuessers`
 methods.
 
-.. _`PHPUnit data providers`: https://docs.phpunit.de/en/9.5/writing-tests-for-phpunit.html#data-providers
+.. _`PHPUnit data providers`: https://docs.phpunit.de/en/9.6/writing-tests-for-phpunit.html#data-providers

--- a/testing.rst
+++ b/testing.rst
@@ -1116,12 +1116,12 @@ Learn more
 
 .. _`PHPUnit`: https://phpunit.de/
 .. _`documentation`: https://docs.phpunit.de/
-.. _`Writing Tests for PHPUnit`: https://docs.phpunit.de/en/9.5/writing-tests-for-phpunit.html
-.. _`PHPUnit documentation`: https://docs.phpunit.de/en/9.5/configuration.html
+.. _`Writing Tests for PHPUnit`: https://docs.phpunit.de/en/9.6/writing-tests-for-phpunit.html
+.. _`PHPUnit documentation`: https://docs.phpunit.de/en/9.6/configuration.html
 .. _`unit test`: https://en.wikipedia.org/wiki/Unit_testing
 .. _`DAMADoctrineTestBundle`: https://github.com/dmaicher/doctrine-test-bundle
 .. _`Doctrine data fixtures`: https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html
 .. _`DoctrineFixturesBundle documentation`: https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html
 .. _`SymfonyMakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
-.. _`PHPUnit Assertion`: https://docs.phpunit.de/en/9.5/assertions.html
+.. _`PHPUnit Assertion`: https://docs.phpunit.de/en/9.6/assertions.html
 .. _`section 4.1.18 of RFC 3875`: https://tools.ietf.org/html/rfc3875#section-4.1.18


### PR DESCRIPTION
All links to the phpunit documentation currently are 404s because documentation for version 9.5 is no longer available. Updated all links to 9.6.