### PR TITLE
Fix incorrect placement of `is_empty_callback`

### DIFF
--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -61,6 +61,10 @@ The actual default value of this option depends on other field options:
 * If ``data_class`` is not set and ``compound`` is ``false``, then ``''``
   (empty string).
 
+.. include:: /reference/forms/types/options/empty_data_description.rst.inc
+
+.. _reference-form-option-error-bubbling:
+
 ``is_empty_callback``
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -68,9 +72,6 @@ The actual default value of this option depends on other field options:
 
 This callable takes form data and returns whether value is considered empty.
 
-.. include:: /reference/forms/types/options/empty_data_description.rst.inc
-
-.. _reference-form-option-error-bubbling:
 
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 


### PR DESCRIPTION
I think the `is_empty_callback` placement is wrong in [6.3 docs](https://symfony.com/doc/current/reference/forms/types/form.html#empty-data). This PR fixes it.

![image](https://github.com/symfony/symfony-docs/assets/5463371/88af4062-a8ee-4132-ac93-83d3fb154ac7)
