### PR TITLE
[ExpressionLanguage] `in` and `not in` operators are using strict comparison

### DIFF
--- a/reference/formats/expression_language.rst
+++ b/reference/formats/expression_language.rst
@@ -352,12 +352,9 @@ For example::
 
 The ``$inGroup`` would evaluate to ``true``.
 
-.. deprecated:: 6.3
+.. note::
 
-    In Symfony versions previous to 6.3, ``in`` and ``not in`` operators
-    were using loose comparison. Using these operators with variables of
-    different types is now deprecated, and these operators will be using
-    strict comparison from Symfony 7.0.
+    The ``in`` and ``not in`` operators are using strict comparison.
 
 Numeric Operators
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/pull/50867