### PR TITLE
WIP: Fix security oidc_user_info

### DIFF
--- a/security/access_token.rst
+++ b/security/access_token.rst
@@ -381,8 +381,7 @@ and retrieve the user info:
                     access_token:
                         token_handler:
                             oidc_user_info:
-                                client:
-                                    base_uri: https://www.example.com/realms/demo/protocol/openid-connect/userinfo
+                                base_uri: https://www.example.com/realms/demo/protocol/openid-connect/userinfo
 
     .. code-block:: xml
 
@@ -439,8 +438,7 @@ identifier by default. To use another claim, specify it on the configuration:
                         token_handler:
                             oidc_user_info:
                                 claim: email
-                                client:
-                                    base_uri: https://www.example.com/realms/demo/protocol/openid-connect/userinfo
+                                base_uri: https://www.example.com/realms/demo/protocol/openid-connect/userinfo
 
     .. code-block:: xml
 


### PR DESCRIPTION
Thix PR is not yet finished but currently the blog post: 

https://symfony.com/blog/new-in-symfony-6-3-openid-connect-token-handler

And the documentation here:

https://symfony.com/doc/current/security/access_token.html

Ends in my case in:

![Bildschirmfoto 2023-07-04 um 13 31 48](https://github.com/symfony/symfony-docs/assets/1698337/814a733e-bde7-4b27-834d-3bcf1c404db8)

