### PR TITLE
[FrameworkBundle] Deprecate `terminate_on_cache_hit` option

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -171,6 +171,11 @@ bootstrap the Symfony framework on a cache hit.
 
     The ``terminate_on_cache_hit`` option was introduced in Symfony 6.2.
 
+.. deprecated:: 6.2
+
+    Setting the ``terminate_on_cache_hit`` option to ``true`` was deprecated in
+    Symfony 6.2 and the option will be removed in Symfony 7.0.
+
  .. _configuration-framework-http_method_override:
 
 http_method_override


### PR DESCRIPTION
It looks strange to add an option in 6.2 and deprecate it in the same version but:

https://github.com/nicolas-grekas/symfony/blob/19940ffcfe9bbae825ca951f1bb4c78a8a84f9ad/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php#L245

This is needed before working on #18491.