### PR TITLE
[Encore] Webpack Dev Server & Symfony CLI HTTPS: add note for Node 17+

### DIFF
--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -58,7 +58,6 @@ method in your ``webpack.config.js`` file:
         })
     ;
 
-
 Enabling HTTPS using the Symfony Web Server
 -------------------------------------------
 
@@ -83,6 +82,19 @@ server SSL certificate:
     +             }
     +         }
     +     })
+
+.. note::
+
+    If you are using Node.js 17 or newer, you have to run the ``dev-server`` command with the
+    ``--openssl-legacy-provider`` option:
+
+    .. code-block:: terminal
+
+        # if you use the Yarn package manager
+        $ NODE_OPTIONS=--openssl-legacy-provider yarn encore dev-server
+
+        # if you use the npm package manager
+        $ NODE_OPTIONS=--openssl-legacy-provider npm run dev-server
 
 CORS Issues
 -----------


### PR DESCRIPTION
A little note required to run Webpack Dev Server with Symfony CLI + its HTTPS certificate using Node.js 17+.

Related issue on Webpack Encore: https://github.com/symfony/webpack-encore/issues/1187

Credits to @fracsi for the "fix" :) 