### PR TITLE
Update event_dispatcher.rst

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -317,7 +317,7 @@ of the event to dispatch::
     // creates the OrderPlacedEvent and dispatches it
     $event = new OrderPlacedEvent($order);
 
-    //The event name is now optional in the dispatch() method, so you can pass just the event object
+    // The event name is now optional in the dispatch() method, so you can pass just the event object
     $dispatcher->dispatch($event);
 
 Notice that the special ``OrderPlacedEvent`` object is created and passed to

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -316,7 +316,9 @@ of the event to dispatch::
 
     // creates the OrderPlacedEvent and dispatches it
     $event = new OrderPlacedEvent($order);
-    $dispatcher->dispatch($event, OrderPlacedEvent::NAME);
+
+    //The event name is now optional in the dispatch() method, so you can pass just the event object
+    $dispatcher->dispatch($event);
 
 Notice that the special ``OrderPlacedEvent`` object is created and passed to
 the ``dispatch()`` method. Now, any listener to the ``order.placed``


### PR DESCRIPTION
Related to this [documentation](https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching), the way to dispatch an event changed and unfortunately it's not updated in the component documentation.
