### PR TITLE
[Messenger] Remove remaining deprecations

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1718,12 +1718,6 @@ during a request::
         }
     }
 
-.. versionadded:: 6.3
-
-    The namespace of the ``InMemoryTransport`` class changed in Symfony 6.3 from
-    ``Symfony\Component\Messenger\Transport\InMemoryTransport`` to
-    ``Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport``.
-
 The transport has a number of options:
 
 ``serialize`` (boolean, default: ``false``)
@@ -2019,12 +2013,6 @@ A single handler class can handle multiple messages. For that add the
             // ...
         }
     }
-
-.. deprecated:: 6.2
-
-    Implementing the :class:`Symfony\\Component\\Messenger\\Handler\\MessageSubscriberInterface`
-    is another way to handle multiple messages with one handler class. This
-    interface was deprecated in Symfony 6.2.
 
 Binding Handlers to Different Transports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -133,9 +133,6 @@ you can restrict each handler to a specific bus using the ``messenger.message_ha
         services:
             App\MessageHandler\SomeCommandHandler:
                 tags: [{ name: messenger.message_handler, bus: command.bus }]
-                # prevent handlers from being registered twice (or you can remove
-                # the MessageHandlerInterface that autoconfigure uses to find handlers)
-                autoconfigure: false
 
     .. code-block:: xml
 


### PR DESCRIPTION
Part of https://github.com/symfony/symfony-docs/issues/18507#issuecomment-1621530573

Some Messenger removed deprecations doesn't appear in the doc (like `StopWorkerOnSigtermSignalListener `). So this should take care of what's remaining for this component 🙂 