### PR TITLE
Fix comma space

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1534,7 +1534,7 @@ that requires HTTPlug dependencies::
     }
 
 Because :class:`Symfony\\Component\\HttpClient\\HttplugClient` implements the
-three interfaces,you can use it this way::
+three interfaces, you can use it this way::
 
     use Symfony\Component\HttpClient\HttplugClient;
 


### PR DESCRIPTION
It's minor, but while reviewing https://github.com/symfony/symfony-docs/pull/18500 (6.2), I saw a missing space after comma

I checked all occurrences with `[a-zA-Z],[a-zA-Z]`, it's the only mistake on branch 5.4
