### PR TITLE
[Testing] Mention the `KernelBrowser::disableReboot` method

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -622,6 +622,7 @@ This allows you to create all types of requests you can think of:
     Also, it means that entities loaded by Doctrine repositories will
     be "detached", so they will need to be refreshed by the manager or
     queried again from a repository.
+    You can disable this behavior by calling the :method:`disableReboot() <Symfony\\Bundle\\FrameworkBundle\\KernelBrowser::disableReboot>` method.
 
 Browsing the Site
 .................


### PR DESCRIPTION
It would have been helpful to me to know about the `disableReboot` method while reading this caution block, so I think it will also be useful for others. :blush: 