### PR TITLE
[Testing] Response Assertions: add examples of headers

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -971,10 +971,10 @@ Response Assertions
     Asserts the response is a redirect response (optionally, you can check
     the target location and status code).
 ``assertResponseHasHeader(string $headerName, string $message = '')``/``assertResponseNotHasHeader(string $headerName, string $message = '')``
-    Asserts the given header is (not) available on the response.
+    Asserts the given header is (not) available on the response, e.g. ``assertResponseHasHeader('content-type');``.
 ``assertResponseHeaderSame(string $headerName, string $expectedValue, string $message = '')``/``assertResponseHeaderNotSame(string $headerName, string $expectedValue, string $message = '')``
     Asserts the given header does (not) contain the expected value on the
-    response.
+    response, e.g. ``assertResponseHeaderSame('content-type', 'application/octet-stream');``.
 ``assertResponseHasCookie(string $name, string $path = '/', string $domain = null, string $message = '')``/``assertResponseNotHasCookie(string $name, string $path = '/', string $domain = null, string $message = '')``
     Asserts the given cookie is present in the response (optionally
     checking for a specific cookie path or domain).


### PR DESCRIPTION
I didn't know if I had to write `contentType`, `CONTENT_TYPE`, etc.

So I checked and found the expected format.