### PR TITLE
[Validator] Add missing types and return types

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -39,7 +39,7 @@ Configuration
         class Author
         {
             #[Assert\Callback]
-            public function validate(ExecutionContextInterface $context, $payload): void
+            public function validate(ExecutionContextInterface $context, mixed $payload): void
             {
                 // ...
             }
@@ -80,7 +80,7 @@ Configuration
                 $metadata->addConstraint(new Assert\Callback('validate'));
             }
 
-            public function validate(ExecutionContextInterface $context, $payload): void
+            public function validate(ExecutionContextInterface $context, mixed $payload): void
             {
                 // ...
             }
@@ -101,7 +101,7 @@ field those errors should be attributed::
         // ...
         private string $firstName;
 
-        public function validate(ExecutionContextInterface $context, $payload)
+        public function validate(ExecutionContextInterface $context, mixed $payload): void
         {
             // somehow you have an array of "fake names"
             $fakeNames = [/* ... */];
@@ -121,13 +121,13 @@ Static Callbacks
 You can also use the constraint with static methods. Since static methods don't
 have access to the object instance, they receive the object as the first argument::
 
-    public static function validate($object, ExecutionContextInterface $context, $payload)
+    public static function validate(mixed $value, ExecutionContextInterface $context, mixed $payload): void
     {
         // somehow you have an array of "fake names"
         $fakeNames = [/* ... */];
 
         // check if the name is actually a fake name
-        if (in_array($object->getFirstName(), $fakeNames)) {
+        if (in_array($value->getFirstName(), $fakeNames)) {
             $context->buildViolation('This name sounds totally fake!')
                 ->atPath('firstName')
                 ->addViolation()
@@ -149,7 +149,7 @@ Suppose your validation function is ``Acme\Validator::validate()``::
 
     class Validator
     {
-        public static function validate($object, ExecutionContextInterface $context, $payload)
+        public static function validate(mixed $value, ExecutionContextInterface $context, mixed $payload): void
         {
             // ...
         }
@@ -206,7 +206,7 @@ You can then use the following configuration to invoke this validator:
 
         class Author
         {
-            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            public static function loadValidatorMetadata(ClassMetadata $metadata): void
             {
                 $metadata->addConstraint(new Assert\Callback([
                     Validator::class,
@@ -235,9 +235,9 @@ constructor of the Callback constraint::
 
     class Author
     {
-        public static function loadValidatorMetadata(ClassMetadata $metadata)
+        public static function loadValidatorMetadata(ClassMetadata $metadata): void
         {
-            $callback = function ($object, ExecutionContextInterface $context, $payload): void {
+            $callback = function (mixed $value, ExecutionContextInterface $context, mixed $payload): void {
                 // ...
             };
 

--- a/reference/constraints/DisableAutoMapping.rst
+++ b/reference/constraints/DisableAutoMapping.rst
@@ -76,7 +76,7 @@ metadata:
         {
             // ...
 
-            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            public static function loadValidatorMetadata(ClassMetadata $metadata): void
             {
                 $metadata->addConstraint(new Assert\DisableAutoMapping());
             }

--- a/reference/constraints/EnableAutoMapping.rst
+++ b/reference/constraints/EnableAutoMapping.rst
@@ -76,7 +76,7 @@ metadata:
         {
             // ...
 
-            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            public static function loadValidatorMetadata(ClassMetadata $metadata): void
             {
                 $metadata->addConstraint(new Assert\EnableAutoMapping());
             }

--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -88,7 +88,7 @@ The validator class only has one required method ``validate()``::
 
     class ContainsAlphanumericValidator extends ConstraintValidator
     {
-        public function validate($value, Constraint $constraint): void
+        public function validate(mixed $value, Constraint $constraint): void
         {
             if (!$constraint instanceof ContainsAlphanumeric) {
                 throw new UnexpectedTypeException($constraint, ContainsAlphanumeric::class);


### PR DESCRIPTION
Follow-up of https://github.com/symfony/symfony-docs/pull/18568

Also the first parameter of `ConstraintValidator::validate()` has been renamed to `$value` instead of `$object`, I updated the few places I could find it appears :slightly_smiling_face: 