### PR TITLE
[Serializer] Deprecate `CacheableSupportsMethodInterface`

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -82,6 +82,12 @@ is called.
     All built-in :ref:`normalizers and denormalizers <component-serializer-normalizers>`
     as well the ones included in `API Platform`_ natively implement this interface.
 
+.. deprecated:: 6.3
+
+    The :class:`Symfony\\Component\\Serializer\\Normalizer\\CacheableSupportsMethodInterface`
+    interface is deprecated since Symfony 6.3. You should implement the
+    ``getSupportedTypes()`` method instead, as shown in the section below.
+
 Improving Performance of Normalizers/Denormalizers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Part of https://github.com/symfony/symfony-docs/issues/18471