### PR TITLE
[Config] Update definition.rst

### DIFF
--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -870,3 +870,9 @@ Otherwise the result is a clean array of configuration values::
         $databaseConfiguration,
         $configs
     );
+
+.. caution::
+
+    When processing the configuration tree, the processor assumes the top level 
+    array key is already stripped off. If you want a root name, you should
+    add it to your tree builder as an array node.


### PR DESCRIPTION
Always acting as a trap for me : the configuration processor consider the root node (TreeBuilder "name") already stripped off. Always wanted to add documentation about it and never found out where to find this information.
