### PR TITLE
[Console] Corrected return type of anonymous functions

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -217,7 +217,7 @@ provide a callback function to dynamically generate suggestions::
             // where files and dirs can be found
             $foundFilesAndDirs = @scandir($inputPath) ?: [];
 
-            return array_map(function (string $dirOrFile) use ($inputPath): void {
+            return array_map(function (string $dirOrFile) use ($inputPath): string {
                 return $inputPath.$dirOrFile;
             }, $foundFilesAndDirs);
         };
@@ -462,7 +462,7 @@ You can also use a validator with a hidden question::
         $question->setNormalizer(function (?string $value): string {
             return $value ?? '';
         });
-        $question->setValidator(function (string $value): void {
+        $question->setValidator(function (string $value): string {
             if ('' === trim($value)) {
                 throw new \Exception('The password cannot be empty');
             }


### PR DESCRIPTION
Fixes wrong return type (void) for anonymous functions clearly returning a string value

When copying the current example from the docs it results in the following error;

```
Symfony\Component\ErrorHandler\Error\FatalError {#506
  #message: "Compile Error: A void function must not return a value"
  #code: 0
  #file: "./src/Command/ExampleCommand.php"
  #line: 58
  -error: array:4 [
    "type" => 64
    "message" => "A void function must not return a value"
    "file" => "../src/Command/Debug/OverrideUserCommand.php"
    "line" => 58
  ]
}
```
