### PR TITLE
[Route][Attribute] Fix FileLocatorFileNotFoundException micro_kernel_…

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -55,6 +55,13 @@ Next, create an ``index.php`` file that defines the kernel class and runs it:
                 ]);
             }
 
+            protected function configureRoutes(RoutingConfigurator $routes): void
+            {
+                if (false !== ($fileName = (new \ReflectionObject($this))->getFileName())) {
+                    $routes->import($fileName, 'annotation');
+                }
+            }
+
             #[Route('/random/{limit}', name: 'random_number')]
             public function randomNumber(int $limit): JsonResponse
             {


### PR DESCRIPTION
…trait.rst fix

We don't have the config directory yet and in the configuredRoutes method we have imported routes from dir config that caused exception FileLocatorFileNotFoundException

To ignore this exception, either we create the config directory or override the configureRoutes method and take the statements only for load the route annotation.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
