### PR TITLE
Fix Method 'getException' not found in ExceptionEvent

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -178,7 +178,7 @@ events directly from the kernel, again it will be registered automatically::
 
         public function onKernelException(ExceptionEvent $event): void
         {
-            if ($event->getException() instanceof Danger) {
+            if ($event->getThrowable() instanceof Danger) {
                 $event->setResponse(new Response('It\'s dangerous to go alone. Take this ⚔'));
             }
         }


### PR DESCRIPTION
The 'getException' method is not in ExceptionEvent and should be getThrowable.

<img width="1157" alt="image" src="https://github.com/symfony/symfony-docs/assets/24827501/9b91d44c-1723-4649-8a45-fe5918f483a2">

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
