### PR TITLE
[micro_kernel] Fix deleted feature AnnotationRegistry::registerLoader

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -328,12 +328,9 @@ Finally, you need a front controller to boot and run the application. Create a
 
     // public/index.php
     use App\Kernel;
-    use Doctrine\Common\Annotations\AnnotationRegistry;
     use Symfony\Component\HttpFoundation\Request;
 
-    $loader = require __DIR__.'/../vendor/autoload.php';
-    // auto-load annotations
-    AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+    require __DIR__.'/../vendor/autoload.php';
 
     $kernel = new Kernel('dev', true);
     $request = Request::createFromGlobals();


### PR DESCRIPTION
[Dropping AnnotationRegistry completely, relying on native autoloading instead](https://github.com/doctrine/annotations/pull/205) v2.0.0

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
