### PR TITLE
[Cache] Update redis_adapter.rst

### DIFF
--- a/components/cache/adapters/redis_adapter.rst
+++ b/components/cache/adapters/redis_adapter.rst
@@ -220,19 +220,8 @@ Available Options
 
 .. _redis-tag-aware-adapter:
 
-Working with Tags
------------------
-
-In order to use tag-based invalidation, you can wrap your adapter in :class:`Symfony\\Component\\Cache\\Adapter\\TagAwareAdapter`, but when Redis is used as backend, it's often more interesting to use the dedicated :class:`Symfony\\Component\\Cache\\Adapter\\RedisTagAwareAdapter`. Since tag invalidation logic is implemented in Redis itself, this adapter offers better performance when using tag-based invalidation::
-
-    use Symfony\Component\Cache\Adapter\RedisAdapter;
-    use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
-
-    $client = RedisAdapter::createConnection('redis://localhost');
-    $cache = new RedisTagAwareAdapter($client);
-
 Configuring Redis
-~~~~~~~~~~~~~~~~~
+-----------------
 
 When using Redis as cache, you should configure the ``maxmemory`` and ``maxmemory-policy``
 settings. By setting ``maxmemory``, you limit how much memory Redis is allowed to consume.
@@ -246,6 +235,21 @@ try to add data when no memory is available. An example setting could look as fo
 
     maxmemory 100mb
     maxmemory-policy allkeys-lru
+
+Working with Tags
+-----------------
+
+In order to use tag-based invalidation, you can wrap your adapter in :class:`Symfony\\Component\\Cache\\Adapter\\TagAwareAdapter`, but when Redis is used as backend, it's often more interesting to use the dedicated :class:`Symfony\\Component\\Cache\\Adapter\\RedisTagAwareAdapter`. Since tag invalidation logic is implemented in Redis itself, this adapter offers better performance when using tag-based invalidation::
+
+    use Symfony\Component\Cache\Adapter\RedisAdapter;
+    use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
+
+    $client = RedisAdapter::createConnection('redis://localhost');
+    $cache = new RedisTagAwareAdapter($client);
+
+.. note::
+
+    When using RedisTagAwareAdapter, in order to maintain relationships between tags and cache items, you have to use either ``noeviction`` or ``volatile-*`` in the Redis ``maxmemory-policy`` eviction policy.
 
 Read more about this topic in the official `Redis LRU Cache Documentation`_.
 


### PR DESCRIPTION
Using RedisTagAwareAdapter, Redis maxmemory-policy has to be "noeviction" or "volatile-*"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
