### PR TITLE
[FrameworkBundle] Add note for `prefix_seed` about container compilation

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3184,6 +3184,12 @@ It's also useful when using `blue/green deployment`_ strategies and more
 generally, when you need to abstract out the actual deployment directory (for
 example, when warming caches offline).
 
+.. note::
+
+    The ``prefix_seed`` option is used at compile time. This means
+    that any change made to this value after container's compilation
+    will have no effect.
+
 .. versionadded:: 5.2
 
     Starting from Symfony 5.2, the ``%kernel.container_class%`` parameter is no


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/18609