### PR TITLE
[Console] Add more examples for lazy commands

### DIFF
--- a/console/commands_as_services.rst
+++ b/console/commands_as_services.rst
@@ -133,3 +133,5 @@ only when the ``app:sunshine`` command is actually called.
 .. caution::
 
     Calling the ``list`` command will instantiate all commands, including lazy commands.
+    However, if the command is a ``Symfony\Component\Console\Command\LazyCommand``, then
+    the underlying command factory will not be executed.


### PR DESCRIPTION
I think the current doc is a bit confusing regarding the laziness of commands:

- It does not mention `LazyCommand` which is quite important to make a command lazy in a way it still works with the `list` command which is used a lot.
- The `list` doc regarding instantiating the commands is a bit too absolute. Technically it is not wrong but there is also more subtleties to it. Indeed what it will really do is instantiate the command and then try to get the name and description. Which also means if the underlying command/factory can still not be instantiated (either by tweaking `Command` or using `LazyCommand`). This is unlike another command like the auto-complete or help which will try to get the input definition in which case even a `LazyCommand` will call its command factory. 

I am not sure which branch it should target however and I am sure there is a lot to say about the phrasing used.