### PR TITLE
[Validator] docs: Add documentation about new constraint option `withSeconds`

### DIFF
--- a/reference/constraints/Time.rst
+++ b/reference/constraints/Time.rst
@@ -101,4 +101,18 @@ Parameter        Description
 ``{{ label }}``  Corresponding form field label
 ===============  ==============================================================
 
+``withSeconds``
+~~~~~~~~~~~~~~~
+
+**type**: ``boolean`` **default**: ``true``
+
+This option allows you to specify whether the time should include seconds.
+
+=========  ===============================  ==============  ================
+Option     Pattern                          Correct value   Incorrect value
+=========  ===============================  ==============  ================
+``true``   ``/^(\d{2}):(\d{2}):(\d{2})$/``  ``12:00:00``    ``12:00``
+``false``  ``/^(\d{2}):(\d{2})$/``          ``12:00``       ``12:00:00``
+=========  ===============================  ==============  ================
+
 .. include:: /reference/constraints/_payload-option.rst.inc


### PR DESCRIPTION
Issue: https://github.com/symfony/symfony-docs/issues/18669