### PR TITLE
[Workflow] Add PHP attributes to register listeners and guards

### DIFF
--- a/reference/attributes.rst
+++ b/reference/attributes.rst
@@ -117,6 +117,17 @@ Each validation constraint comes with a PHP attribute. See
 
 * :doc:`HasNamedArgument </validation/custom_constraint>`
 
+Workflow
+~~~~~~~~
+
+* :ref:`AsAnnounceListener <workflow_using-events>`
+* :ref:`AsCompletedListener <workflow_using-events>`
+* :ref:`AsEnterListener <workflow_using-events>`
+* :ref:`AsEnteredListener <workflow_using-events>`
+* :ref:`AsGuardListener <workflow_using-events>`
+* :ref:`AsLeaveListener <workflow_using-events>`
+* :ref:`AsTransitionListener <workflow_using-events>`
+
 .. _`AsEntityAutocompleteField`: https://symfony.com/bundles/ux-autocomplete/current/index.html#usage-in-a-form-with-ajax
 .. _`AsLiveComponent`: https://symfony.com/bundles/ux-live-component/current/index.html
 .. _`AsTwigComponent`: https://symfony.com/bundles/ux-twig-component/current/index.html

--- a/workflow.rst
+++ b/workflow.rst
@@ -361,6 +361,8 @@ name.
     You can find the list of available workflow services with the
     ``php bin/console debug:autowiring workflow`` command.
 
+.. _workflow_using-events:
+
 Using Events
 ------------
 
@@ -518,6 +520,40 @@ it via the marking::
 
     // contains the new value
     $marking->getContext();
+
+It is also possible to listen to these events by declaring event listeners
+with the following attributes:
+
+* :class:`Symfony\\Component\\Workflow\\Attribute\\AsAnnounceListener`
+* :class:`Symfony\\Component\\Workflow\\Attribute\\AsCompletedListener`
+* :class:`Symfony\\Component\\Workflow\\Attribute\\AsEnterListener`
+* :class:`Symfony\\Component\\Workflow\\Attribute\\AsEnteredListener`
+* :class:`Symfony\\Component\\Workflow\\Attribute\\AsGuardListener`
+* :class:`Symfony\\Component\\Workflow\\Attribute\\AsLeaveListener`
+* :class:`Symfony\\Component\\Workflow\\Attribute\\AsTransitionListener`
+
+These attributes do work like the
+:class:`Symfony\\Component\\EventDispatcher\\Attribute\\AsEventListener`
+attributes::
+
+    class ArticleWorkflowEventListener
+    {
+        #[AsTransitionListener(workflow: 'my-workflow', transition: 'published')]
+        public function onPublishedTransition(TransitionEvent $event): void
+        {
+            // ...
+        }
+
+        // ...
+    }
+
+You may refer to the documentation about
+:ref:`defining event listeners with PHP attributes <event-dispatcher_event-listener-attributes>`
+for further use.
+
+.. versionadded:: 6.4
+
+    The workflow event attributes were introduced in Symfony 6.4.
 
 .. _workflow-usage-guard-events:
 


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/18681
Is it OK to not put too many examples and refer to `AsEventListener` page? The explanation about workflow events is already pretty long

Friendly ping @lyrixx :slightly_smiling_face: