### PR TITLE
[DependencyInjection] Mention `debug:autowiring` command with argument

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -694,6 +694,12 @@ But, you can control this and pass in a different logger:
 This tells the container that the ``$logger`` argument to ``__construct`` should use
 service whose id is ``monolog.logger.request``.
 
+For a list of possible logger services that can be used with autowiring, run:
+
+.. code-block:: terminal
+
+    $ php bin/console debug:autowiring logger
+
 .. _container-debug-container:
 
 For a full list of *all* possible services in the container, run:


### PR DESCRIPTION
The command is mentioned once at the top of the page, listing all autowiring types.
I think it deserves to shine in the "Choose a specific service" section, currently using `bin/console debug:container` is advised, which does not offer the same DX.
Here's a screenshot of the result when searching for loggers:
<img width="924" alt="Screenshot 2023-08-04 at 10 54 49 AM" src="https://github.com/symfony/symfony-docs/assets/10107633/77a79511-6860-4dd8-b235-5f27b2f88e2f">
