### PR TITLE
[Config] Typo in cache dir env var explanation

### DIFF
--- a/configuration/override_dir_structure.rst
+++ b/configuration/override_dir_structure.rst
@@ -67,7 +67,7 @@ Console script::
 Web front-controller::
 
     // public/index.php
-    
+
     // ...
     $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path'] = 'another/custom/path/to/.env';
 
@@ -109,8 +109,8 @@ In this code, ``$this->environment`` is the current environment (i.e. ``dev``).
 In this case you have changed the location of the cache directory to
 ``var/{environment}/cache/``.
 
-You can also change the cache directory defining an environment variable named
-``APP_CACHE_DIR`` whose value is the full path of the cache folder.
+You can also change the cache directory by defining an environment variable
+named ``APP_CACHE_DIR`` whose value is the full path of the cache folder.
 
 .. caution::
 


### PR DESCRIPTION
I'm not 100% sure that it is a typo, maybe it's correct english. But it felt weird when I came across this one :smile: 