### PR TITLE
[Form] Fix File Upload Example

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -206,9 +206,13 @@ You can use the following code to link to the PDF brochure of a product:
         use Symfony\Component\HttpFoundation\File\File;
         // ...
 
-        $product->setBrochureFilename(
-            new File($brochuresDirectory.DIRECTORY_SEPARATOR.$product->getBrochureFilename())
-        );
+        if (!$form->isSubmitted() && $product->getBrochureFilename()) {
+            $form->setData(['brochure' => new File($this->getParameter('brochures_directory').DIRECTORY_SEPARATOR.$product->getBrochureFilename())]);
+        }
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            // ...
+        }
 
 Creating an Uploader Service
 ----------------------------


### PR DESCRIPTION
Currently the example suggests to execute this code when doing edit
```php
$product->setBrochureFilename(
    new File($this->getParameter('brochures_directory').'/'.$product->getBrochureFilename())
);
```

this is wrong in couple of ways

First the `setBrochureFilename` method expects string and not a `File` instance. No error is thrown because the `File` instance can be casted to `string` and will return the full path, which is not what's needed. In the database field you need to store the filename only, and not the full path.

Second the form expects `File` instance and not the entity. This is why the form data needs to be changed and not the entity.

In the 4.4 branch it's the same.