### PR TITLE
[Console] Add `ProcessHelper` link to the list of helpers

### DIFF
--- a/components/console/helpers/processhelper.rst
+++ b/components/console/helpers/processhelper.rst
@@ -1,11 +1,12 @@
 Process Helper
 ==============
 
-The Process Helper shows processes as they're running and reports
-useful information about process status.
+The Process Helper shows processes as they're running and reports useful
+information about process status.
 
-To display process details, use the :class:`Symfony\\Component\\Console\\Helper\\ProcessHelper`
-and run your command with verbosity. For example, running the following code with
+To display process details, use the
+:class:`Symfony\\Component\\Console\\Helper\\ProcessHelper` and run your command
+with verbosity. For example, running the following code with
 a very verbose verbosity (e.g. ``-vv``)::
 
     use Symfony\Component\Process\Process;

--- a/console.rst
+++ b/console.rst
@@ -593,6 +593,7 @@ tools capable of helping you with different tasks:
 * :doc:`/components/console/helpers/table`: displays tabular data as a table
 * :doc:`/components/console/helpers/debug_formatter`: provides functions to
   output debug information when running an external program
+* :doc:`/components/console/helpers/processhelper`: allows to run processes using ``DebugProcessHelper``
 * :doc:`/components/console/helpers/cursor`: allows to manipulate the cursor in the terminal
 
 .. _`exit status`: https://en.wikipedia.org/wiki/Exit_status


### PR DESCRIPTION
The page documenting the helper already exists, but it was not listed among other helpers.
This PR fixes it.
