### PR TITLE
[Messenger] [Messenger ] Add explanation on how to set default messenger table name

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1445,6 +1445,14 @@ a table named ``messenger_messages``.
     The ability to automatically generate a migration for the ``messenger_messages``
     table was introduced in Symfony 5.1 and DoctrineBundle 2.1.
 
+If you would like to change the name of the default table you can pass it in the DSN
+settings by using the ``table_name`` option.
+
+.. code-block:: env
+
+    # .env
+    MESSENGER_TRANSPORT_DSN=doctrine://default?table_name=your_table_name
+
 Or, to create the table yourself, set the ``auto_setup`` option to ``false`` and
 :ref:`generate a migration <doctrine-creating-the-database-tables-schema>`.
 


### PR DESCRIPTION
Added explanation on how to set default messenger table name

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
