### PR TITLE
[DependencyInjection] Ref for autowiring alias

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -1286,7 +1286,9 @@ admin email. In this case, each needs to have a unique service id:
 In this case, *two* services are registered: ``site_update_manager.superadmin``
 and ``site_update_manager.normal_users``. Thanks to the alias, if you type-hint
 ``SiteUpdateManager`` the first (``site_update_manager.superadmin``) will be passed.
-If you want to pass the second, you'll need to :ref:`manually wire the service <services-wire-specific-service>`.
+
+If you want to pass the second, you'll need to :ref:`manually wire the service <services-wire-specific-service>`
+or to create a named ref:`autowiring alias <autowiring-alias>`.
 
 .. caution::
 

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -423,6 +423,8 @@ Additionally, you can define several named autowiring aliases if you want to use
 one implementation in some cases, and another implementation in some
 other cases.
 
+.. _autowiring-alias:
+
 For instance, you may want to use the ``Rot13Transformer``
 implementation by default when the ``TransformerInterface`` interface is
 type hinted, but use the ``UppercaseTransformer`` implementation in some


### PR DESCRIPTION
Replaces
* https://github.com/symfony/symfony-docs/pull/17051

I had a lot of conflicts, because #17051 was against `4.4` branch, so I decided to recreate this PR.