### PR TITLE
[Frontend] Create a UX bundle: fix code block indentation

### DIFF
--- a/frontend/create_ux_bundle.rst
+++ b/frontend/create_ux_bundle.rst
@@ -70,22 +70,22 @@ In this case, the file located at ``[assets directory]/dist/controller.js`` will
 
     1. Add the following to your ``package.json`` file:
 
-    .. code-block:: json
+       .. code-block:: json
 
-        {
-            "scripts": {
-                "build": "babel src --extensions .ts -d dist"
-            },
-            "devDependencies": {
-                "@babel/cli": "^7.20.7",
-                "@babel/core": "^7.20.12",
-                "@babel/plugin-proposal-class-properties": "^7.18.6",
-                "@babel/preset-env": "^7.20.2",
-                "@babel/preset-typescript": "^7.18.6",
-                "@hotwired/stimulus": "^3.2.1",
-                "typescript": "^4.9.5"
-            }
-        }
+           {
+               "scripts": {
+                   "build": "babel src --extensions .ts -d dist"
+               },
+               "devDependencies": {
+                   "@babel/cli": "^7.20.7",
+                   "@babel/core": "^7.20.12",
+                   "@babel/plugin-proposal-class-properties": "^7.18.6",
+                   "@babel/preset-env": "^7.20.2",
+                   "@babel/preset-typescript": "^7.18.6",
+                   "@hotwired/stimulus": "^3.2.1",
+                   "typescript": "^4.9.5"
+               }
+           }
 
     2. Run either ``npm install`` or ``yarn install`` to install the new dependencies.
 


### PR DESCRIPTION
Fixes an indentation issue that makes the ordered list "restart" at 1 after the code block.

See this issue live here: https://symfony.com/doc/5.4/frontend/create_ux_bundle.html#package-json-file