### PR TITLE
[configuration][override_dir_structure] autoload to autoload_runtime

### DIFF
--- a/configuration/override_dir_structure.rst
+++ b/configuration/override_dir_structure.rst
@@ -254,7 +254,7 @@ your ``index.php`` front controller. If you renamed the directory, you're fine.
 But if you moved it in some way, you may need to modify these paths inside those
 files::
 
-    require_once __DIR__.'/../path/to/vendor/autoload.php';
+    require_once __DIR__.'/../path/to/vendor/autoload_runtime.php';
 
 You also need to change the ``extra.public-dir`` option in the ``composer.json``
 file:


### PR DESCRIPTION
From Symfony 5.3 we use autoload_runtime instead of autoload

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
