### PR TITLE
[FrameworkBundle] Configuration : Fix !php/const syntax in yaml

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2915,21 +2915,21 @@ This option also accepts a map of PHP errors to log levels:
         framework:
             php_errors:
                 log:
-                    '!php/const \E_DEPRECATED': !php/const Psr\Log\LogLevel::ERROR
-                    '!php/const \E_USER_DEPRECATED': !php/const Psr\Log\LogLevel::ERROR
-                    '!php/const \E_NOTICE': !php/const Psr\Log\LogLevel::ERROR
-                    '!php/const \E_USER_NOTICE': !php/const Psr\Log\LogLevel::ERROR
-                    '!php/const \E_STRICT': !php/const Psr\Log\LogLevel::ERROR
-                    '!php/const \E_WARNING': !php/const Psr\Log\LogLevel::ERROR
-                    '!php/const \E_USER_WARNING': !php/const Psr\Log\LogLevel::ERROR
-                    '!php/const \E_COMPILE_WARNING': !php/const Psr\Log\LogLevel::ERROR
-                    '!php/const \E_CORE_WARNING': !php/const Psr\Log\LogLevel::ERROR
-                    '!php/const \E_USER_ERROR': !php/const Psr\Log\LogLevel::CRITICAL
-                    '!php/const \E_RECOVERABLE_ERROR': !php/const Psr\Log\LogLevel::CRITICAL
-                    '!php/const \E_COMPILE_ERROR': !php/const Psr\Log\LogLevel::CRITICAL
-                    '!php/const \E_PARSE': !php/const Psr\Log\LogLevel::CRITICAL
-                    '!php/const \E_ERROR': !php/const Psr\Log\LogLevel::CRITICAL
-                    '!php/const \E_CORE_ERROR': !php/const Psr\Log\LogLevel::CRITICAL
+                    !php/const \E_DEPRECATED: !php/const Psr\Log\LogLevel::ERROR
+                    !php/const \E_USER_DEPRECATED: !php/const Psr\Log\LogLevel::ERROR
+                    !php/const \E_NOTICE: !php/const Psr\Log\LogLevel::ERROR
+                    !php/const \E_USER_NOTICE: !php/const Psr\Log\LogLevel::ERROR
+                    !php/const \E_STRICT: !php/const Psr\Log\LogLevel::ERROR
+                    !php/const \E_WARNING: !php/const Psr\Log\LogLevel::ERROR
+                    !php/const \E_USER_WARNING: !php/const Psr\Log\LogLevel::ERROR
+                    !php/const \E_COMPILE_WARNING: !php/const Psr\Log\LogLevel::ERROR
+                    !php/const \E_CORE_WARNING: !php/const Psr\Log\LogLevel::ERROR
+                    !php/const \E_USER_ERROR: !php/const Psr\Log\LogLevel::CRITICAL
+                    !php/const \E_RECOVERABLE_ERROR: !php/const Psr\Log\LogLevel::CRITICAL
+                    !php/const \E_COMPILE_ERROR: !php/const Psr\Log\LogLevel::CRITICAL
+                    !php/const \E_PARSE: !php/const Psr\Log\LogLevel::CRITICAL
+                    !php/const \E_ERROR: !php/const Psr\Log\LogLevel::CRITICAL
+                    !php/const \E_CORE_ERROR: !php/const Psr\Log\LogLevel::CRITICAL
 
     .. code-block:: xml
 


### PR DESCRIPTION
Hello,

I would like to suggest a correction for the FrameworkBundle configuration documentation. In a configuration example, the Yaml syntax to use the value of a PHP constant as a key is incorrect. Indeed, in Symfony's Yaml parser source code, only unquoted scalars are evaluated. Therefore, the configuration key should not be enclosed in quotes for the example to work.

Please feel free to question me if you need any further information.