### PR TITLE
[Routing] Update page_creation.rst remove confusing unstyled diff symbol

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -104,7 +104,7 @@ You can now add your route directly *above* the controller:
         // src/Controller/LuckyController.php
 
         // ...
-        + use Symfony\Component\Routing\Annotation\Route;
+        use Symfony\Component\Routing\Annotation\Route;
 
         class LuckyController
         {


### PR DESCRIPTION
This is a left over from docs showing both annotation and attribute route methods.  The plus sign isn't handled because the code block is not a diff.  Issue was brought up by a confused user who thought that the plus sign was required syntax.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
