### PR TITLE
Update calling_commands.rst - call the command non interactively 

### DIFF
--- a/console/calling_commands.rst
+++ b/console/calling_commands.rst
@@ -36,6 +36,9 @@ method)::
                 '--yell'  => true,
             ]);
 
+            // disable interactive behavior for the greet command
+            $greetInput->setInteractive(false);
+
             $returnCode = $this->getApplication()->doRun($greetInput, $output);
 
             // ...


### PR DESCRIPTION
* https://github.com/symfony/symfony/issues/51339

I am not sure which branch to chose. It is not a bug, not a new feature.

https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Console/Input/Input.php#L83