### PR TITLE
[Serializer] Use `NormalizerInterface` instead of `ObjectNormalizer`

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -48,6 +48,15 @@ to customize the normalized data. To do that, leverage the ``ObjectNormalizer``:
         }
     }
 
+.. deprecated:: 6.1
+
+    Injecting an ``ObjectNormalizer`` in your custom normalizer is deprecated
+    since Symfony 6.1. Implement the
+    :class:`Symfony\\Component\\Serializer\\Normalizer\\NormalizerAwareInterface`
+    and use the
+    :class:`Symfony\\Component\\Serializer\\Normalizer\\NormalizerAwareTrait` instead
+    to inject the ``$normalizer`` property.
+
 Registering it in your Application
 ----------------------------------
 


### PR DESCRIPTION
As mentioned in https://github.com/symfony/maker-bundle/issues/1252#issuecomment-1666470069, the documentation is telling to use a concrete implementation of the `NormalizerInteface`.
This is not the best in terms of OOP, and moreover doesn't work since Symfony 6.1 and the introduction of `TraceableNormalizer`.