### PR TITLE
[Flex] Remove PHP<8 section, remove flex reference

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -931,17 +931,6 @@ To improve performance, you can optionally run the ``dump-env`` Composer command
 
         # config/services.yaml
         services:
-            Symfony\Component\Dotenv\Command\DotenvDumpCommand:
-                - '%kernel.project_dir%/.env'
-                - '%kernel.environment%'
-
-    In PHP >= 8, you can remove the two arguments when autoconfiguration is enabled
-    (which is the default):
-
-    .. code-block:: yaml
-
-        # config/services.yaml
-        services:
             Symfony\Component\Dotenv\Command\DotenvDumpCommand: ~
 
     Then, run the command:


### PR DESCRIPTION
- symfony 6.x requires php > 8 so configuration section for pre 8 is irrelevant
- `dotenv:dump` has been implemented in 5.4 and reference to flex is no longer relevant https://github.com/symfony/symfony/commit/234c0b300d13f43abe871d99943e779e1b4051f6

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
