### PR TITLE
[AssetMapper] Add docs for `importmap:install` command

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -233,8 +233,11 @@ If you want to download the package locally, use the ``--download`` option:
     $ php bin/console importmap:require bootstrap --download
 
 This will download the package into an ``assets/vendor/`` directory and update
-the ``importmap.php`` file to point to it. You *should* commit this file to
-your repository.
+the ``importmap.php`` file to point to it. You can either commit this directory
+to your repository, or ignore the directory in your ``.gitignore`` config file.
+If the directory is ignored, you can run the
+``php bin/console importmap:install`` command to download the files on other
+computers if some files are missing.
 
 .. note::
 


### PR DESCRIPTION
Hi, this PR adds docs for the new `importmap:install` command added by symfony/symfony#51351.