### PR TITLE
Clearer difference with max and quiet options

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -325,6 +325,10 @@ It's also possible to change verbosity per deprecation type. For example, using
 ``quiet[]=indirect&quiet[]=other`` will hide details for deprecations of types
 "indirect" and "other".
 
+Note that `quiet` hides details for the specified deprecation types, but will
+not change the outcome in terms of exit code. That's what :ref:`max <making-tests-fail>` is for, and both
+settings are orthogonal.
+
 .. versionadded:: 5.1
 
     The ``quiet`` option was introduced in Symfony 5.1.


### PR DESCRIPTION
Hello,

First contribution here so I hope that I didn't made a mistake. Let me know if I need to change or point a process I missed.

As discussed on the symfony/symfony#46497, the difference between `quiet` and `max` may be unclear. In addition the behavior existing before 5.4 might have been erroneous. As the change is hard to retrieve and impossible to fix now, we come to the conclusion that a doc update may help to fix end user issue with this change.

Let me know if the added paragraph needs to be clearer or at another place or if it needs to be rephrased as English is not my first language. I also wanted to make a link to the section which talk about `max` and making tests fail. I hope this is the right way.

Thanks for reading. :-)