### PR TITLE
[Server] Fix typo in Symfony Local Web Server page

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -60,7 +60,7 @@ run the Symfony server in the background:
 
     On macOS, when starting the Symfony server you might see a warning dialog asking
     *"Do you want the application to accept incoming network connections?"*.
-    This happens when running unsigned appplications that are not listed in the
+    This happens when running unsigned applications that are not listed in the
     firewall list. The solution is to run this command that signs the Symfony binary:
 
     .. code-block:: terminal


### PR DESCRIPTION
Hello,

I found a small typo in the [Symfony Local Web Server](https://symfony.com/doc/current/setup/symfony_server.html) page.
Fixing it.

Thanks for the reviews 🙏 