### PR TITLE
[Messenger] Add information about timeout semantics for redis option `timeout`

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1624,8 +1624,8 @@ persistent_id            String, if null connection is          null
 retry_interval           Int, value in milliseconds             ``0``
 read_timeout             Float, value in seconds                ``0``
                          default indicates unlimited
-timeout                  Float, value in seconds                ``0``
-                         default indicates unlimited
+timeout                  Connection timeout. Float, value in    ``0``
+                         seconds default indicates unlimited
 sentinel_master          String, if null or empty Sentinel      null
                          support is disabled
 =======================  =====================================  =================================


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->

Lowest branch with introduced `timeout` option - `6.1`