### PR TITLE
[Mailer] Embedding images support custom cid

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -616,10 +616,26 @@ images inside the HTML contents::
         ->html('... <div background="cid:footer-signature"> ... </div> ...')
     ;
 
+You can also use :method:`DataPart::setContentId() <Symfony\\Component\\Mime\\Part\\DataPart::setContentId>` method to
+define value and use it as ``cid`` reference::
+
+    $part = new DataPart(new File('/path/to/images/signature.gif'));
+    $part->setContentId('footer-signature');
+
+    $email = (new Email())
+        // ...
+        ->addPart($part->asInline())
+        ->html('... <img src="cid:footer-signature"> ...')
+    ;
+
 .. versionadded:: 6.1
 
     The support of embedded images as HTML backgrounds was introduced in Symfony
     6.1.
+
+.. versionadded:: 6.3
+
+    The support of custom ``cid`` for embedded images was introduced in Symfony 6.3.
 
 .. _mailer-configure-email-globally:
 


### PR DESCRIPTION
Fix #17703 

It was complicated to me to understand well PR and use case, as it's very specific and can be considered as a bugfix, but it's was e feature.

Example of use case:

We send an Email with `Parts` and html with cid (human friendly name is replaced by generated cid). We want to forward this email, so we keep the same html (with generated cid) and `Parts` are rebuild with generated cid (setContentId).

Now it works (cid are kept), but before it was ko