### PR TITLE
Mention the Symfony packages that don't follow the components versioning

### DIFF
--- a/setup/upgrade_major.rst
+++ b/setup/upgrade_major.rst
@@ -152,9 +152,10 @@ starting with ``symfony/`` to the new major version:
     +         "symfony/console": "6.0.*",
               "...": "...",
 
-              "...": "A few libraries starting with
-                      symfony/ follow their own versioning scheme. You
-                      do not need to update these versions: you can
+              "...": "A few libraries starting with symfony/ follow their own
+                      versioning scheme (e.g. symfony/polyfill-[...],
+                      symfony/ux-[...], symfony/[...]-bundle).
+                      You do not need to update these versions: you can
                       upgrade them independently whenever you want",
               "symfony/monolog-bundle": "^3.5",
           },


### PR DESCRIPTION
Fixes #16755.

This is not the exact fix asked in the related issue. But, I don't think it's a good idea to show an exhaustive list of all the Symfony packages that follow their own versioning (there are more than 200 Symfony packages!).

So, in this PR I propose to just show the three biggest package patterns that follow their own versioning.