### PR TITLE
[Workflow] Remove `GuardEvent::getContext()` method without replacement

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -463,21 +463,6 @@ order:
 
         $workflow->apply($subject, $transitionName, [Workflow::DISABLE_ANNOUNCE_EVENT => true]);
 
-The context is accessible in all events except for the ``workflow.guard`` events::
-
-    // $context must be an array
-    $context = ['context_key' => 'context_value'];
-    $workflow->apply($subject, $transitionName, $context);
-
-    // in an event listener (workflow.guard events)
-    $context = $event->getContext(); // returns ['context']
-
-.. deprecated:: 6.4
-
-    Gathering events context is deprecated since Symfony 6.4 and the
-    :method:`Symfony\\Component\\Workflow\\Event::getContext` method will be
-    removed in Symfony 7.0.
-
 .. note::
 
     The leaving and entering events are triggered even for transitions that stay


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/18823