### PR TITLE
[Frontend] Removing toc tree, which duplicated links

### DIFF
--- a/frontend.rst
+++ b/frontend.rst
@@ -140,12 +140,6 @@ Other Front-End Articles
 * :doc:`/frontend/create_ux_bundle`
 * :doc:`/frontend/custom_version_strategy`
 
-.. toctree::
-    :maxdepth: 1
-    :glob:
-
-    frontend/*
-
 .. _`Webpack Encore`: https://www.npmjs.com/package/@symfony/webpack-encore
 .. _`Webpack`: https://webpack.js.org/
 .. _`Node.js`: https://nodejs.org/


### PR DESCRIPTION
@wouterj had mentioned that the `toctree` actually don't matter anymore internally. If that's true, I'm proposing we remove it from the frontend page. Right now, we have manual, organized links for every page... then the `toctree` duplicates all of them at the bottom.

Cheers!