### PR TITLE
[Doctrine][Messenger] Document middleware to log when transaction has been left open

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -2441,6 +2441,10 @@ may want to use:
                             # in any handler will cause a rollback
                             - doctrine_transaction
 
+                            # Log an error when a Doctrine transaction was opened but
+                            # did not closed
+                            - doctrine_open_transaction_logger
+
                             # or pass a different entity manager to any
                             #- doctrine_transaction: ['custom']
 
@@ -2462,6 +2466,7 @@ may want to use:
                         <framework:middleware id="doctrine_transaction"/>
                         <framework:middleware id="doctrine_ping_connection"/>
                         <framework:middleware id="doctrine_close_connection"/>
+                        <framework:middleware id="doctrine_open_transaction_logger"/>
 
                         <!-- or pass a different entity manager to any -->
                         <!--
@@ -2486,6 +2491,7 @@ may want to use:
             $bus->middleware()->id('doctrine_transaction');
             $bus->middleware()->id('doctrine_ping_connection');
             $bus->middleware()->id('doctrine_close_connection');
+            $bus->middleware()->id('doctrine_open_transaction_logger');
             // Using another entity manager
             $bus->middleware()->id('doctrine_transaction')
                 ->arguments(['custom']);


### PR DESCRIPTION
Fix #15892