### PR TITLE
[Console] [Command] Helpers uses `stderr` by default

### DIFF
--- a/components/console/helpers/processhelper.rst
+++ b/components/console/helpers/processhelper.rst
@@ -31,6 +31,14 @@ In case the process fails, debugging is easier:
 .. image:: /_images/components/console/process-helper-error-debug.png
     :alt: The last line shows "RES 127 Command dit not run successfully", and the output lines show more the error information from the command.
 
+.. note::
+
+    By default, the process helper uses the error output (``stderr``) as
+    its default output. This behavior can be changed by passing an instance of
+    :class:`Symfony\\Component\\Console\\Output\\StreamOutput` to the
+    :method:`Symfony\\Component\\Console\\Helper\\ProcessHelper::run`
+    method.
+
 Arguments
 ---------
 

--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -44,6 +44,14 @@ number of units, and advance the progress as the command executes::
     ``$progress->advance()`` with a negative value. For example, if you call
     ``$progress->advance(-2)`` then it will regress the progress bar 2 steps.
 
+.. note::
+
+    By default, the progress bar helper uses the error output (``stderr``) as
+    its default output. This behavior can be changed by passing an instance of
+    :class:`Symfony\\Component\\Console\\Output\\StreamOutput` to the
+    :class:`Symfony\\Component\\Console\\Helper\\ProgressBar`
+    constructor.
+
 Instead of advancing the bar by a number of steps (with the
 :method:`Symfony\\Component\\Console\\Helper\\ProgressBar::advance` method),
 you can also set the current progress by calling the

--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -72,6 +72,14 @@ the second argument is not provided, ``true`` is assumed.
 
     The regex defaults to ``/^y/i``.
 
+.. note::
+
+    By default, the question helper uses the error output (``stderr``) as
+    its default output. This behavior can be changed by passing an instance of
+    :class:`Symfony\\Component\\Console\\Output\\StreamOutput` to the
+    :method:`Symfony\\Component\\Console\\Helper\\QuestionHelper::ask`
+    method.
+
 Asking the User for Information
 -------------------------------
 


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/18177