### PR TITLE
Corrected missing property promotion.

### DIFF
--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -694,7 +694,7 @@ attribute::
     {
         public function __construct(
             #[AutowireServiceClosure('third_party.remote_message_formatter')]
-            \Closure $messageFormatterResolver
+            private \Closure $messageFormatterResolver
         ) {
         }
 


### PR DESCRIPTION
Fixes #18886 .

Promoted the constructor parameter to a private property to fix the example code.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
