### PR TITLE
Fix initialization of configurable options for the attribute

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -41,7 +41,16 @@ First you need to create a Constraint class and extend :class:`Symfony\\Componen
         class ContainsAlphanumeric extends Constraint
         {
             public $message = 'The string "{{ string }}" contains an illegal character: it can only contain letters or numbers.';
-            public $mode = 'strict'; // If the constraint has configuration options, define them as public properties
+            public $mode = 'strict';
+
+            // all configurable options must be passed to the constructor
+            public function __construct(string $mode = null, string $message = null, array $groups = null, $payload = null)
+            {
+                parent::__construct([], $groups, $payload);
+
+                $this->mode = $mode ?? $this->mode;
+                $this->message = $message ?? $this->message;
+            }
         }
 
 Add ``@Annotation`` or ``#[\Attribute]`` to the constraint class if you want to


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony-docs/issues/18868

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
