### PR TITLE
[Translation] Give current locale to LocaleSwitcher::runWithLocale()'s callback

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -1069,9 +1069,24 @@ of:
 
             });
 
+            // you can optionally declare an argument in your callback to receive the
+            // injected locale
+            $this->localeSwitcher->runWithLocale('es', function(string $locale) {
+
+                // here, the $locale argument will be set to 'es'
+
+            });
+
             // ...
         }
     }
+
+.. versionadded:: 6.4
+
+    The support of declaring an argument in the callback to inject the locale
+    being used in the
+    :method:`Symfony\\Component\\Translation\\LocaleSwitcher::runWithLocale`
+    method was introduced in Symfony 6.4.
 
 When using :ref:`autowiring <services-autowire>`, type-hint any controller or
 service argument with the :class:`Symfony\\Component\\Translation\\LocaleSwitcher`


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/18902