### PR TITLE
Fix wrong attribute name

### DIFF
--- a/reference/attributes.rst
+++ b/reference/attributes.rst
@@ -110,7 +110,7 @@ Validator
 Each validation constraint comes with a PHP attribute. See
 :doc:`/reference/constraints` for a full list of validation constraints.
 
-* :doc:`HasNamedArgument </validation/custom_constraint>`
+* :doc:`HasNamedArguments </validation/custom_constraint>`
 
 .. _`AsEntityAutocompleteField`: https://symfony.com/bundles/ux-autocomplete/current/index.html#usage-in-a-form-with-ajax
 .. _`AsLiveComponent`: https://symfony.com/bundles/ux-live-component/current/index.html


### PR DESCRIPTION
The attribute is in fact called `HasNamedArgument*s*`

See https://github.com/symfony/validator/blob/6.3/Attribute/HasNamedArguments.php

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
