### PR TITLE
[Contributing] Document :ref: links

### DIFF
--- a/contributing/documentation/format.rst
+++ b/contributing/documentation/format.rst
@@ -190,6 +190,28 @@ If you want to modify that title, use this alternative syntax:
 
         :doc:`environments`
 
+It is also possible to link to a specific section, instead of a whole page.
+First, define a target above section you will link to:
+
+.. code-block:: rst
+
+    # /service_container/autowiring.rst
+
+    # Define the target
+    .. _autowiring-calls:
+
+    Autowiring other Methods (e.g. Setters and Public Typed Properties)
+    -------------------------------------------------------------------
+    [section content ...]
+
+Then create reference to link to that section from another file:
+
+.. code-block:: rst
+
+    # /reference/attributes.rst
+
+    :ref:`Required <autowiring-calls>`
+
 **Links to the API** follow a different syntax, where you must specify the type
 of the linked resource (``class`` or ``method``):
 


### PR DESCRIPTION
PR adds an example of using `:ref:` to link to sections from other files.