### PR TITLE
Fix: external links to PHP docs are broken

### DIFF
--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -532,5 +532,5 @@ you can use a specific :ref:`named lock <lock-named-locks>` via the
 .. _`Apache mod_ratelimit`: https://httpd.apache.org/docs/current/mod/mod_ratelimit.html
 .. _`NGINX rate limiting`: https://www.nginx.com/blog/rate-limiting-nginx/
 .. _`token bucket algorithm`: https://en.wikipedia.org/wiki/Token_bucket
-.. _`PHP date relative formats`: https://www.php.net/datetime.formats.relative
+.. _`PHP date relative formats`: https://www.php.net/manual/en/datetime.formats.php#datetime.formats.relative
 .. _`Race conditions`: https://en.wikipedia.org/wiki/Race_condition

--- a/security.rst
+++ b/security.rst
@@ -2722,4 +2722,5 @@ Authorization (Denying Access)
 .. _`SymfonyCastsVerifyEmailBundle`: https://github.com/symfonycasts/verify-email-bundle
 .. _`HTTP Basic authentication`: https://en.wikipedia.org/wiki/Basic_access_authentication
 .. _`Login CSRF attacks`: https://en.wikipedia.org/wiki/Cross-site_request_forgery#Forging_login_requests
-.. _`PHP date relative formats`: https://www.php.net/datetime.formats.relative
+.. _`SensitiveParameter PHP attribute`: https://wiki.php.net/rfc/redact_parameters_in_back_traces
+.. _`PHP date relative formats`: https://www.php.net/manual/en/datetime.formats.php#datetime.formats.relative


### PR DESCRIPTION
Seems PHP.net recently changed their docs regarding relative time formats.

The old URL is gone and the content integrated at the new location:
https://www.php.net/manual/en/datetime.formats.php#datetime.formats.relative