### PR TITLE
[Security] Mention customizing successful and failed authentication

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1602,6 +1602,20 @@ and set the ``limiter`` option to its service ID:
             ;
         };
 
+Customize Successful and Failed Authentication Behavior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to customize the success or failure handling process, instead of
+overwriting the respective listeners globally, you can set custom success
+failure handlers by implementing the
+:class:`Symfony\\Component\\Security\\Http\\Authentication\\AuthenticationSuccessHandlerInterface`
+or the
+:class:`Symfony\\Component\\Security\\Http\\Authentication\\AuthenticationFailureHandlerInterface`.
+
+If you want more information about this, you can have a look at the section
+about
+:ref:`customizing your success handler <login-link_customize-success-handler>`.
+
 .. _security-logging-out:
 
 Logging Out

--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -693,6 +693,8 @@ from the first hash value and the ``kernel.secret`` container parameter. This
 allows Symfony to sign this final hash, which is contained in the login URL.
 The final hash is also a Base64 encoded SHA-256 hash.
 
+.. _login-link_customize-success-handler:
+
 Customizing the Success Handler
 -------------------------------
 


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/4258, part of https://github.com/symfony/symfony-docs/issues/15908