### PR TITLE
[Form] Update FormEvents Data and Form Data description

### DIFF
--- a/form/events.rst
+++ b/form/events.rst
@@ -67,13 +67,14 @@ The method :method:`Form::setData() <Symfony\\Component\\Form\\Form::setData>`
 is locked since the event is dispatched from it and will throw an exception
 if called from a listener.
 
-===============  ========
-Data Type        Value
-===============  ========
-Model data       ``null``
-Normalized data  ``null``
-View data        ``null``
-===============  ========
+====================  ======================================
+Data Type             Value
+====================  ======================================
+Event data            Model data injected into ``setData()``
+Form model data       ``null``
+Form normalized data  ``null``
+Form view data        ``null``
+====================  ======================================
 
 .. seealso::
 
@@ -98,13 +99,14 @@ The ``FormEvents::POST_SET_DATA`` event is dispatched at the end of the
 method. This event can be used to modify a form depending on the populated data
 (adding or removing fields dynamically).
 
-===============  ====================================================
-Data Type        Value
-===============  ====================================================
-Model data       Model data injected into ``setData()``
-Normalized data  Model data transformed using a model transformer
-View data        Normalized data transformed using a view transformer
-===============  ====================================================
+====================  ====================================================
+Data Type             Value
+====================  ====================================================
+Event data            Model data injected into ``setData()``
+Form model data       Model data injected into ``setData()``
+Form normalized data  Model data transformed using a model transformer
+Form view data        Normalized data transformed using a view transformer
+====================  ====================================================
 
 .. seealso::
 
@@ -144,13 +146,14 @@ It can be used to:
 * Change data from the request, before submitting the data to the form;
 * Add or remove form fields, before submitting the data to the form.
 
-===============  ========================================
-Data Type        Value
-===============  ========================================
-Model data       Same as in ``FormEvents::POST_SET_DATA``
-Normalized data  Same as in ``FormEvents::POST_SET_DATA``
-View data        Same as in ``FormEvents::POST_SET_DATA``
-===============  ========================================
+====================  ========================================
+Data Type             Value
+====================  ========================================
+Event data            Data from the request
+Form model data       Same as in ``FormEvents::POST_SET_DATA``
+Form normalized data  Same as in ``FormEvents::POST_SET_DATA``
+Form view data        Same as in ``FormEvents::POST_SET_DATA``
+====================  ========================================
 
 .. seealso::
 
@@ -175,13 +178,14 @@ transforms back the normalized data to the model and view data.
 
 It can be used to change data from the normalized representation of the data.
 
-===============  ===================================================================================
-Data Type        Value
-===============  ===================================================================================
-Model data       Same as in ``FormEvents::POST_SET_DATA``
-Normalized data  Data from the request reverse-transformed from the request using a view transformer
-View data        Same as in ``FormEvents::POST_SET_DATA``
-===============  ===================================================================================
+====================  ===================================================================================
+Data Type             Value
+====================  ===================================================================================
+Event data            Data from the request reverse-transformed from the request using a view transformer
+Form model data       Same as in ``FormEvents::POST_SET_DATA``
+Form normalized data  Same as in ``FormEvents::POST_SET_DATA``
+Form view data        Same as in ``FormEvents::POST_SET_DATA``
+====================  ===================================================================================
 
 .. seealso::
 
@@ -207,13 +211,14 @@ model and view data have been denormalized.
 
 It can be used to fetch data after denormalization.
 
-===============  =============================================================
-Data Type        Value
-===============  =============================================================
-Model data       Normalized data reverse-transformed using a model transformer
-Normalized data  Same as in ``FormEvents::SUBMIT``
-View data        Normalized data transformed using a view transformer
-===============  =============================================================
+====================  ===================================================================================
+Data Type             Value
+====================  ===================================================================================
+Event data            Normalized data transformed using a view transformer
+Form model data       Normalized data reverse-transformed using a model transformer
+Form normalized data  Data from the request reverse-transformed from the request using a view transformer
+Form view data        Normalized data transformed using a view transformer
+====================  ===================================================================================
 
 .. seealso::
 


### PR DESCRIPTION
Fix #11193

[FormEvent](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Form/FormEvent.php) has 2 value: `data` and the `form` which has `modelData`, `normData` and `viewData`.

This PR document what is in `FormEvent->data` and fix `FormEvents::SUBMIT` description