### PR TITLE
[Console] Fix codeblock markup

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -585,7 +585,7 @@ call ``setAutoExit(false)`` on it to get the command result in ``CommandTester``
 When testing your commands, it could be useful to understand how your command
 reacts on different settings like the width and the height of the terminal.
 You have access to such information thanks to the
-:class:`Symfony\\Component\\Console\\Terminal` class:
+:class:`Symfony\\Component\\Console\\Terminal` class::
 
     use Symfony\Component\Console\Terminal;
 


### PR DESCRIPTION
Bug visible on `5.4` `6.2` `6.3` `6.4` & `7.0`

| 5.4 | 6.2 | 6.4 |
| - | - | - |
| ![a](https://github.com/symfony/symfony-docs/assets/1359581/58d7b403-bd63-4d02-ae0a-d666c5a39524) | ![b](https://github.com/symfony/symfony-docs/assets/1359581/bb692c0b-7235-435c-9e90-b4eee2c70d58) | ![c](https://github.com/symfony/symfony-docs/assets/1359581/9efb349a-3c10-4393-b3aa-d194f12db923) | 





