### PR TITLE
[Mime] Add `TemplatedEmail::locale()` to set the locale for the email rendering

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -791,12 +791,20 @@ for Twig templates::
         // path of the Twig template to render
         ->htmlTemplate('emails/signup.html.twig')
 
+        // change locale used in the template, e.g. to match user's locale
+        ->locale('de')
+
         // pass variables (name => value) to the template
         ->context([
             'expiration_date' => new \DateTime('+7 days'),
             'username' => 'foo',
         ])
     ;
+
+.. versionadded:: 6.4
+
+    The :method:`Symfony\\Bridge\\Twig\\Mime\\TemplatedEmail::locale` method
+    was introduced in Symfony 6.4.
 
 Then, create the template:
 


### PR DESCRIPTION
Fix
* https://github.com/symfony/symfony-docs/issues/18951