### PR TITLE
[Validator] Change `preg_match` condition on `ContainsAlphanumericValidator`

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -117,12 +117,14 @@ The validator class only has one required method ``validate()``::
                 // ...
             }
 
-            if (!preg_match('/^[a-zA-Z0-9]+$/', $value, $matches)) {
-                // the argument must be a string or an object implementing __toString()
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ string }}', $value)
-                    ->addViolation();
+            if (preg_match('/^[a-zA-Z0-9]+$/', $value, $matches)) {
+                return;
             }
+
+            // the argument must be a string or an object implementing __toString()
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ string }}', $value)
+                ->addViolation();
         }
     }
 
@@ -664,3 +666,4 @@ class to simplify writing unit tests for your custom constraints::
             // ...
         }
     }
+


### PR DESCRIPTION
Hello there ! ✋🏽 

I think following the Validator philosophy we prefer to check the regex this way, what do you think?
