### PR TITLE
[Security] Improve `requires_channel` var naming

### DIFF
--- a/security/force_https.rst
+++ b/security/force_https.rst
@@ -74,8 +74,8 @@ access control:
             };
 
 To make life easier while developing, you can also use an environment variable,
-like ``requires_channel: '%env(SECURE_SCHEME)%'``. In your ``.env`` file, set
-``SECURE_SCHEME`` to ``http`` by default, but override it to ``https`` on production.
+like ``requires_channel: '%env(REQUIRED_SCHEME)%'``. In your ``.env`` file, set
+``REQUIRED_SCHEME`` to ``http`` by default, but override it to ``https`` on production.
 
 See :doc:`/security/access_control` for more details about ``access_control``
 in general.


### PR DESCRIPTION
When dealing with this part of the doc, I found confusing having a env var named `SECURE_SCHEME`. Indeed, as stated in the same section, this env var could take the `http` value when in dev environment which could lead to some confusion. I suggest to improve the naming of this env var in order to clarify the example.