### PR TITLE
Update the docs-builder to 0.21

### DIFF
--- a/_build/composer.json
+++ b/_build/composer.json
@@ -17,6 +17,6 @@
         "php": ">=8.1",
         "symfony/console": "^6.2",
         "symfony/process": "^6.2",
-        "symfony-tools/docs-builder": "^0.20"
+        "symfony-tools/docs-builder": "^0.21"
     }
 }

--- a/_build/composer.lock
+++ b/_build/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c3437f0f5d5b44eb1a339dd720bbc38",
+    "content-hash": "8a771cef10c68c570bff7875e4bdece3",
     "packages": [
         {
             "name": "doctrine/deprecations",
@@ -466,16 +466,16 @@
         },
         {
             "name": "symfony-tools/docs-builder",
-            "version": "v0.20.5",
+            "version": "v0.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony-tools/docs-builder.git",
-                "reference": "11d9d81e3997e771ad1a57eabaa51fc22c500b35"
+                "reference": "7ab92db15e9be7d6af51b86db87c7e41a14ba18b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony-tools/docs-builder/zipball/11d9d81e3997e771ad1a57eabaa51fc22c500b35",
-                "reference": "11d9d81e3997e771ad1a57eabaa51fc22c500b35",
+                "url": "https://api.github.com/repos/symfony-tools/docs-builder/zipball/7ab92db15e9be7d6af51b86db87c7e41a14ba18b",
+                "reference": "7ab92db15e9be7d6af51b86db87c7e41a14ba18b",
                 "shasum": ""
             },
             "require": {
@@ -514,9 +514,9 @@
             "description": "The build system for Symfony's documentation",
             "support": {
                 "issues": "https://github.com/symfony-tools/docs-builder/issues",
-                "source": "https://github.com/symfony-tools/docs-builder/tree/v0.20.5"
+                "source": "https://github.com/symfony-tools/docs-builder/tree/v0.21.0"
             },
-            "time": "2023-04-28T09:41:45+00:00"
+            "time": "2023-07-11T15:21:07+00:00"
         },
         {
             "name": "symfony/console",


### PR DESCRIPTION
The website seems to be running docs-builder v0.21 or 0.20.6 (autoscrolling of `:method:` links works properly in Chromium-based browsers/Safari), but the repository still has v0.20.5.

Diff: https://github.com/symfony-tools/docs-builder/compare/v0.20.5...v0.21.0

The `tabs` directive is documented at https://symfony.com/doc/current/contributing/documentation/format.html#displaying-tabs, but is not yet used anywhere in the actual docs, so the build is not failing with current version of docs-builder, nonetheless the `:method:` links generated locally are incorrect.