### PR TITLE
[Messenger] Make a list unordered

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -142,26 +142,26 @@ through the transport layer, use the ``SerializerStamp`` stamp::
 
 Here are some important envelope stamps that are shipped with the Symfony Messenger:
 
-#. :class:`Symfony\\Component\\Messenger\\Stamp\\DelayStamp`,
-   to delay handling of an asynchronous message.
-#. :class:`Symfony\\Component\\Messenger\\Stamp\\DispatchAfterCurrentBusStamp`,
-   to make the message be handled after the current bus has executed. Read more
-   at :doc:`/messenger/dispatch_after_current_bus`.
-#. :class:`Symfony\\Component\\Messenger\\Stamp\\HandledStamp`,
-   a stamp that marks the message as handled by a specific handler.
-   Allows accessing the handler returned value and the handler name.
-#. :class:`Symfony\\Component\\Messenger\\Stamp\\ReceivedStamp`,
-   an internal stamp that marks the message as received from a transport.
-#. :class:`Symfony\\Component\\Messenger\\Stamp\\SentStamp`,
-   a stamp that marks the message as sent by a specific sender.
-   Allows accessing the sender FQCN and the alias if available from the
-   :class:`Symfony\\Component\\Messenger\\Transport\\Sender\\SendersLocator`.
-#. :class:`Symfony\\Component\\Messenger\\Stamp\\SerializerStamp`,
-   to configure the serialization groups used by the transport.
-#. :class:`Symfony\\Component\\Messenger\\Stamp\\ValidationStamp`,
-   to configure the validation groups used when the validation middleware is enabled.
-#. :class:`Symfony\\Component\\Messenger\\Stamp\\ErrorDetailsStamp`,
-   an internal stamp when a message fails due to an exception in the handler.
+* :class:`Symfony\\Component\\Messenger\\Stamp\\DelayStamp`,
+  to delay handling of an asynchronous message.
+* :class:`Symfony\\Component\\Messenger\\Stamp\\DispatchAfterCurrentBusStamp`,
+  to make the message be handled after the current bus has executed. Read more
+  at :doc:`/messenger/dispatch_after_current_bus`.
+* :class:`Symfony\\Component\\Messenger\\Stamp\\HandledStamp`,
+  a stamp that marks the message as handled by a specific handler.
+  Allows accessing the handler returned value and the handler name.
+* :class:`Symfony\\Component\\Messenger\\Stamp\\ReceivedStamp`,
+  an internal stamp that marks the message as received from a transport.
+* :class:`Symfony\\Component\\Messenger\\Stamp\\SentStamp`,
+  a stamp that marks the message as sent by a specific sender.
+  Allows accessing the sender FQCN and the alias if available from the
+  :class:`Symfony\\Component\\Messenger\\Transport\\Sender\\SendersLocator`.
+* :class:`Symfony\\Component\\Messenger\\Stamp\\SerializerStamp`,
+  to configure the serialization groups used by the transport.
+* :class:`Symfony\\Component\\Messenger\\Stamp\\ValidationStamp`,
+  to configure the validation groups used when the validation middleware is enabled.
+* :class:`Symfony\\Component\\Messenger\\Stamp\\ErrorDetailsStamp`,
+  an internal stamp when a message fails due to an exception in the handler.
 
 .. note::
 


### PR DESCRIPTION
Unless there's a good reason to make it ordered, I think this list should be unordered:

<img width="659" alt="" src="https://github.com/symfony/symfony-docs/assets/73419/008e91bc-1714-4390-ab4e-2c88fe90f3aa">
