### PR TITLE
[Console] Helpers updated to optimize the time formating

### DIFF
--- a/components/console/helpers/formatterhelper.rst
+++ b/components/console/helpers/formatterhelper.rst
@@ -119,3 +119,19 @@ If you don't want to use suffix at all, pass an empty string::
     $truncatedMessage = $formatter->truncate('test', 10);
     // result: test
     // because length of the "test..." string is shorter than 10
+
+Formatting Time
+~~~~~~~~~~~~~~~
+
+Sometimes you want to format seconds to time. This is possible with the
+:method:`Symfony\\Component\\Console\\Helper\\FormatterHelper::formatTime` method.
+The first argument is the seconds to format and the second argument is the
+precision (default ``1``) of the result::
+
+    $timeString = $formatter->truncate(42);        // 42 secs
+    $timeString = $formatter->truncate(125);       // 2 mins
+    $timeString = $formatter->truncate(125, 2);    // 2 mins, 5 secs
+    $timeString = $formatter->truncate(172799, 4); // 1 day, 23 hrs, 59 mins, 59 secs
+
+.. versionadded:: 6.4
+    The support for exact times were introduced in Symfony 6.4.

--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -243,10 +243,13 @@ current progress of the bar. Here is a list of the built-in placeholders:
 * ``memory``: The current memory usage;
 * ``message``: used to display arbitrary messages in the progress bar (as explained later).
 
+The time fields ``elapsed``, ``remaining`` and ``estimated`` are displayed with a precision of 2.
+That means `172799` seconds are displayed as ``1 day, 23 hrs`` instead of ``1 day, 23 hrs, 59 mins, 59 secs``.
+
 For instance, here is how you could set the format to be the same as the
 ``debug`` one::
 
-    $progressBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%');
+    $progressBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %elapsed:16s%/%estimated:-16s% %memory:6s%');
 
 Notice the ``:6s`` part added to some placeholders? That's how you can tweak
 the appearance of the bar (formatting and alignment). The part after the colon


### PR DESCRIPTION
This PR fixes #19008. Adding documentation for the Console Helper. This optimizes the format for times like ``elapsed``, ``remaining`` and ``estimated`` in the prohress bar.
It formats the e.g. 172799 seconds to 1 day, 23 hrs, 59 mins, 59 secs. In the ProgressBar it is shown in a precision 2, meaning in this example 1 day, 23 hrs. The abstract `Symfony\\Component\\Console\\Helper\\Helper::formatTime` allows to add a precision to the time format. The default is ``1``.
