### PR TITLE
Add implements ProcessorInterface

### DIFF
--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -20,10 +20,11 @@ using a processor::
     namespace App\Logger;
 
     use Monolog\LogRecord;
+    use Monolog\Processor\ProcessorInterface;
     use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
     use Symfony\Component\HttpFoundation\RequestStack;
 
-    class SessionRequestProcessor
+    class SessionRequestProcessor implements ProcessorInterface
     {
         public function __construct(
             private RequestStack $requestStack


### PR DESCRIPTION
The code example is not wrong, but I believe it makes it more understandable if we implement the `ProcessorInterface` to show where the `__invoke` method comes from. 
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
