### PR TITLE
[Console] Dispatch `ConsoleTerminateEvent` when exiting on signal

### DIFF
--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -152,6 +152,17 @@ Listeners receive a
     It is then dispatched just after the ``ConsoleEvents::ERROR`` event.
     The exit code received in this case is the exception code.
 
+    Additionally, the event is dispatched when the command is being exited on
+    a signal. You can learn more about signals in the
+    :ref:`the dedicated section <console-events_signal>`.
+
+    .. versionadded:: 6.4
+
+        The dispatching of the ``ConsoleEvents::TERMINATE`` event on exit
+        signal was introduced in Symfony 6.4.
+
+.. _console-events_signal:
+
 The ``ConsoleEvents::SIGNAL`` Event
 -----------------------------------
 

--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -158,7 +158,7 @@ Listeners receive a
 
     .. versionadded:: 6.4
 
-        The dispatching of the ``ConsoleEvents::TERMINATE`` event on exit
+        Dispatching the ``ConsoleEvents::TERMINATE`` event on exit
         signal was introduced in Symfony 6.4.
 
 .. _console-events_signal:


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/19016