### PR TITLE
[Serializer] Update reference to attribute in the section title

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -441,8 +441,8 @@ Ignoring Attributes
 All attributes are included by default when serializing objects. There are two
 options to ignore some of those attributes.
 
-Option 1: Using ``@Ignore`` Annotation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Option 1: Using ``#[Ignore]`` Attribute
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. configuration-block::
 


### PR DESCRIPTION
Symfony 6 uses attributes instead of annotations, but reference to the `@Ignore` annotation still remains in the section title.