### PR TITLE
Fix the installation instructions of symfony/psr-http-message-bridge

### DIFF
--- a/components/psr7.rst
+++ b/components/psr7.rst
@@ -10,7 +10,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/psr-http-message-bridge
+    $ composer require symfony/psr-http-message-bridge:^2.3
 
 .. include:: /components/require_autoload.rst.inc
 


### PR DESCRIPTION
Fixes #19018.

When upmerging to 6.3, we'll keep this change. In 6.4 and 7.0 we'll remove it.