### PR TITLE
[Security] Document `InteractiveLoginEvent`

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2654,6 +2654,12 @@ Authentication Events
 Other Events
 ~~~~~~~~~~~~
 
+:class:`Symfony\\Component\\Security\\Http\\Event\\InteractiveLoginEvent`
+    Dispatched after authentication was fully successful only when the authenticator
+    implements :class:`Symfony\\Component\\Security\\Http\\Authenticator\\InteractiveAuthenticatorInterface`,
+    which indicates login requires explicit user action (e.g. a login form).
+    Listeners to this event can modify the response sent back to the user.
+
 :class:`Symfony\\Component\\Security\\Http\\Event\\LogoutEvent`
     Dispatched just before a user logs out of your application. See
     :ref:`security-logging-out`.


### PR DESCRIPTION
`InteractiveLoginEvent` was not documented

Found it while reviewing #17595