### PR TITLE
[Console] link Symfony default style doc page on coloring doc page

### DIFF
--- a/console/coloring.rst
+++ b/console/coloring.rst
@@ -102,6 +102,11 @@ you can click on the *"Symfony Homepage"* text to open its URL in your default
 browser. Otherwise, you'll see *"Symfony Homepage"* as regular text and the URL
 will be lost.
 
+.. tip::
+
+    If you need a standard yet complete style, you can leverage the :doc:`default
+    Symfony Style </console/style>`.
+
 .. _Cmder: https://github.com/cmderdev/cmder
 .. _ConEmu: https://conemu.github.io/
 .. _ANSICON: https://github.com/adoxa/ansicon/releases


### PR DESCRIPTION
I think it may help, wdyt?

the edited file appears on top of the TOC of the console page, where the linked page appears far at bottom
show casing that Symfony already has this done is relevant ([think of the abstract controller is documented when documenting controller](https://symfony.com/doc/current/controller.html#the-base-controller-class-services))