### PR TITLE
[Validator] Change return type from iterable to Generator

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -660,7 +660,7 @@ class to simplify writing unit tests for your custom constraints::
                 ->assertRaised();
         }
 
-        public function provideInvalidConstraints(): iterable
+        public function provideInvalidConstraints(): \Generator
         {
             yield [new ContainsAlphanumeric(message: 'myMessage')];
             // ...


### PR DESCRIPTION
As a Generator can introduce some specific code path and behavior, I recommend using this type to be clearer about the provider intent.