### PR TITLE
[Messenger] Clarify transport creation example

### DIFF
--- a/components/messenger.rst
+++ b/components/messenger.rst
@@ -302,17 +302,23 @@ do is to write your own CSV receiver::
     {
         private $serializer;
         private $filePath;
+        private $connection;
 
         public function __construct(SerializerInterface $serializer, string $filePath)
         {
             $this->serializer = $serializer;
             $this->filePath = $filePath;
+
+            // Available connection bundled with the Messenger component
+            // can be found in "Symfony\Component\Messenger\Bridge\*\Transport\Connection".
+            $this->connection = /* create your connection */;
         }
 
         public function get(): iterable
         {
             // Receive the envelope according to your transport ($yourEnvelope here),
             // in most cases, using a connection is the easiest solution.
+            $yourEnvelope = $this->connection->get();
             if (null === $yourEnvelope) {
                 return [];
             }
@@ -338,7 +344,9 @@ do is to write your own CSV receiver::
         public function reject(Envelope $envelope): void
         {
             // In the case of a custom connection
-            $this->connection->reject($this->findCustomStamp($envelope)->getId());
+            $id = /* get the message id thanks to information or stamps present in the envelope */;
+
+            $this->connection->reject($id);
         }
     }
 


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/12680

There are still a few "missing parts", but this is a advanced use case and I think people who needs to create their own receiver will be able to figure out missing lines :slightly_smiling_face: 