### PR TITLE
Chore: Fix typo in multiple files

### DIFF
--- a/components/console/helpers/progressbar.rst
+++ b/components/console/helpers/progressbar.rst
@@ -5,7 +5,7 @@ When executing longer-running commands, it may be helpful to show progress
 information, which updates as your command runs:
 
 .. image:: /_images/components/console/progressbar.gif
-    :alt: Console output showing a progress bar advance to 100%, with the esimated time left, the memory usage and a special message that changes when the bar closes completion.
+    :alt: Console output showing a progress bar advance to 100%, with the estimated time left, the memory usage and a special message that changes when the bar closes completion.
 
 .. note::
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -1019,7 +1019,7 @@ implements :class:`Symfony\\Component\\DependencyInjection\\EnvVarLoaderInterfac
 .. note::
 
     If you're using the :ref:`default services.yaml configuration <service-container-services-load-example>`,
-    the autoconfiguration feature will enable and tag thise service automatically.
+    the autoconfiguration feature will enable and tag this service automatically.
     Otherwise, you need to register and :doc:`tag your service </service_container/tags>`
     with the ``container.env_var_loader`` tag.
 

--- a/reference/constraints/PasswordStrength.rst
+++ b/reference/constraints/PasswordStrength.rst
@@ -6,7 +6,7 @@ PasswordStrength
     The ``PasswordStrength`` constraint was introduced in Symfony 6.3.
 
 Validates that the given password has reached the minimum strength required by
-the constraint. The strengh of the password is not evaluated with a set of
+the constraint. The strength of the password is not evaluated with a set of
 predefined rules (include a number, use lowercase and uppercase characters,
 etc.) but by measuring the entropy of the password based on its length and the
 number of unique characters used.

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -161,7 +161,7 @@ Take the following ``access_control`` entries as an example:
                 ->requestMatcher('App\Security\RequestMatcher\MyRequestMatcher')
             ;
 
-            // require ROLE_ADMIN for 'admin' route. You can use the shortcut route('xxx') mehtod,
+            // require ROLE_ADMIN for 'admin' route. You can use the shortcut route('xxx') method,
             // instead of attributes(['_route' => 'xxx']) method
             $security->accessControl()
                 ->roles(['ROLE_ADMIN'])

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -658,10 +658,10 @@ Generate Closures With Autowiring
 ---------------------------------
 
 A **service closure** is an anonymous function that returns a service. This type
-of instanciation is handy when you are dealing with lazy-loading.  It is also
+of instantiation is handy when you are dealing with lazy-loading.  It is also
 useful for non-shared service dependencies.
 
-Automatically creating a closure encapsulating the service instanciation can be
+Automatically creating a closure encapsulating the service instantiation can be
 done with the
 :class:`Symfony\\Component\\DependencyInjection\\Attribute\\AutowireServiceClosure`
 attribute::

--- a/validation.rst
+++ b/validation.rst
@@ -649,7 +649,7 @@ properties even if the child properties override those constraints**. Symfony
 will always merge the parent constraints for each property.
 
 You can't change this behavior, but you can overcome it by defining the parent
-and the child contraints in different :doc:`validation groups </validation/groups>`
+and the child constraints in different :doc:`validation groups </validation/groups>`
 and then select the appropriate group when validating each object.
 
 Debugging the Constraints


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
This PR fix the typo seen in various files

```pseudo
esimated >estimated
strengh > strength
mehtod > method
contraints > constraints
instanciation > instantiation 
```