### PR TITLE
[Security] Add post method attribute to json login

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1054,7 +1054,7 @@ token (or whatever you need to return) and return the JSON response:
 
       class ApiLoginController extends AbstractController
       {
-          #[Route('/api/login', name: 'api_login')]
+          #[Route('/api/login', name: 'api_login', methods: ['POST'])]
     -     public function index(): Response
     +     public function index(#[CurrentUser] ?User $user): Response
           {


### PR DESCRIPTION
With json login, restrict the api/login route to post method only.
