### PR TITLE
Update templating.rst from "Create your own Framework"

### DIFF
--- a/create_framework/templating.rst
+++ b/create_framework/templating.rst
@@ -142,13 +142,14 @@ framework does not need to be modified in any way, create a new
 ``app.php`` file::
 
     // example.com/src/app.php
+    use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Routing;
 
     function is_leap_year($year = null)
     {
         if (null === $year) {
-            $year = date('Y');
+            $year = (int)date('Y');
         }
 
         return 0 === $year % 400 || (0 === $year % 4 && 0 !== $year % 100);


### PR DESCRIPTION
- parameter $year is typed with integer. date function returns string. Code works but casting to the right type feels better.
- added missing import to fix TypeError "Argument 1 ($request) must be of type Request"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
