### PR TITLE
[Expression Language] Number of backslashes to escape a backslash

### DIFF
--- a/reference/formats/expression_language.rst
+++ b/reference/formats/expression_language.rst
@@ -20,8 +20,8 @@ The component supports:
 
 .. caution::
 
-    A backslash (``\``) must be escaped by 4 backslashes (``\\\\``) in a string
-    and 8 backslashes (``\\\\\\\\``) in a regex::
+    A backslash (``\``) must be escaped by 3 backslashes (``\\\\``) in a string
+    and 7 backslashes (``\\\\\\\\``) in a regex::
 
         echo $expressionLanguage->evaluate('"\\\\"'); // prints \
         $expressionLanguage->evaluate('"a\\\\b" matches "/^a\\\\\\\\b$/"'); // returns true


### PR DESCRIPTION
To escape a backslash in a string, we must use 3 backslashes before the backslash itself.
The documentation points out we need to escape by 4 backslashes the backslash. It could be confusing, the total would 5 backslashes.


