### PR TITLE
[PHPUnitBridge] Add a note to disable the locale forcing by the bridge

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -432,6 +432,9 @@ configuration file:
         </php>
     </phpunit>
 
+Finally, if you want to avoid the bridge to force any locale, you can set the
+``SYMFONY_PHPUNIT_LOCALE`` environment variable to ``0``.
+
 .. versionadded:: 6.4
 
     The support for the ``SYMFONY_PHPUNIT_LOCALE`` environment variable was


### PR DESCRIPTION
Following https://github.com/symfony/symfony-docs/pull/19089#issuecomment-1783242749, cc @VincentLanglet 🙂 