### PR TITLE
[Messenger] Add mention of workers restarting with `supervisor`

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -726,6 +726,10 @@ Next, tell Supervisor to read your config and start your workers:
 
     $ sudo supervisorctl start messenger-consume:*
 
+    # If you deploy an update of your code, don't forget to restart your workers
+    # to run the new code
+    $ sudo supervisorctl restart messenger-consume:*
+
 See the `Supervisor docs`_ for more details.
 
 Graceful Shutdown


### PR DESCRIPTION
I think it may be a good thing to add this little line, so people doesn't think that calling `supervisorctl start` will update the worker code or whatsoever. I just came across a project where this confusion was made :slightly_smiling_face: 