### PR TITLE
Revert "Fix the installation instructions of symfony/psr-http-message-bridge"

### DIFF
--- a/components/psr7.rst
+++ b/components/psr7.rst
@@ -10,7 +10,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/psr-http-message-bridge:^2.3
+    $ composer require symfony/psr-http-message-bridge
 
 .. include:: /components/require_autoload.rst.inc
 


### PR DESCRIPTION
Reverts symfony/symfony-docs#19022

Following the discussion on the original PR :slightly_smiling_face: 