### PR TITLE
[Validator] Bring precisions on Valid constraint's groups

### DIFF
--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -297,6 +297,13 @@ Options
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
+.. note::
+
+    Unlike other constraints, the ``Valid`` constraint does not use the ``Default``
+    group. This means that it will always be applied by default, **even** if you
+    specify a group when calling the validator. If you want to restrict the
+    constraint to a subset of groups, you have to define the ``groups`` option.
+
 .. include:: /reference/constraints/_payload-option.rst.inc
 
 ``traverse``


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/17338