### PR TITLE
[Cache] Fix PdoAdapter examples

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -143,7 +143,12 @@ Some of these adapters could be configured via shortcuts.
                 default_psr6_provider: 'app.my_psr6_service'
                 default_redis_provider: 'redis://localhost'
                 default_memcached_provider: 'memcached://localhost'
-                default_pdo_provider: 'pgsql:host=localhost'
+                default_pdo_provider: 'app.my_pdo_service'
+
+        services:
+            app.my_pdo_service:
+                class: \PDO
+                arguments: ['pgsql:host=localhost']
 
     .. code-block:: xml
 
@@ -164,17 +169,24 @@ Some of these adapters could be configured via shortcuts.
                     default-psr6-provider="app.my_psr6_service"
                     default-redis-provider="redis://localhost"
                     default-memcached-provider="memcached://localhost"
-                    default-pdo-provider="pgsql:host=localhost"
+                    default-pdo-provider="app.my_pdo_service"
                 />
             </framework:config>
+
+            <services>
+                <service id="app.my_pdo_service" class="\PDO">
+                    <argument>pgsql:host=localhost</argument>
+                </service>
+            </services>
         </container>
 
     .. code-block:: php
 
         // config/packages/cache.php
+        use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
         use Symfony\Config\FrameworkConfig;
 
-        return static function (FrameworkConfig $framework) {
+        return static function (FrameworkConfig $framework, ContainerConfigurator $container) {
             $framework->cache()
                 // Only used with cache.adapter.filesystem
                 ->directory('%kernel.cache_dir%/pools')
@@ -183,7 +195,12 @@ Some of these adapters could be configured via shortcuts.
                 ->defaultPsr6Provider('app.my_psr6_service')
                 ->defaultRedisProvider('redis://localhost')
                 ->defaultMemcachedProvider('memcached://localhost')
-                ->defaultPdoProvider('pgsql:host=localhost')
+                ->defaultPdoProvider('app.my_pdo_service')
+            ;
+
+            $container->services()
+                ->set('app.my_pdo_service', \PDO::class)
+                ->args(['pgsql:host=localhost'])
             ;
         };
 


### PR DESCRIPTION
As mentioned in https://github.com/symfony/symfony/issues/52460, using a DSN with the PdoAdapter is currently not supported, instead a service name should be provided, eg:

```yaml
app.my_pdo_service:
    class: \PDO
    arguments:
        - 'pgsql:host=localhost'
```

I haven't included the actual service definition since `app.my_psr6_service` isn't included either, but if you think I should, please let me know.