### PR TITLE
hint for mapping request payload error messages

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -502,6 +502,14 @@ payload formats::
         // ...
     }
 
+.. tip::
+
+    If you build a JSON API, make sure to declare your route as using the JSON
+    :ref:`format <routing-format-parameter>`. This will make the error handling
+    output a JSON response in case of validation errors, rather than an HTML page::
+
+        #[Route('/dashboard', name: 'dashboard', format: 'json')]
+
 Make sure to install `phpstan/phpdoc-parser`_ and `phpdocumentor/type-resolver`_
 if you want to map a nested array of specific DTOs::
 


### PR DESCRIPTION
The information is particularly important in the context of the `MapRequestPayload` but technically not related. It is about the behaviour of the symfony error handler. If there is more documentation about the error handler and output formats, i am happy to link to that if you point me to the right place.

I think it is valuable to mention this here though, as it will happen when using the feature. I almost gave up and set up some custom exception listener or whatnot to output json. Stackoverflow is full of answers proposing those to output errors as JSON.