### PR TITLE
Added docs on how to configure the reverse proxy for a subfolder & Documented the usage of X-Forwared-Prefix

### DIFF
--- a/deployment/proxies.rst
+++ b/deployment/proxies.rst
@@ -159,6 +159,29 @@ enough, as it will only trust the node sitting directly above your application
 ranges of any additional proxy (e.g. `CloudFront IP ranges`_) to the array of
 trusted proxies.
 
+Reverse proxy in a subpath / subfolder
+--------------------------------------
+
+If you a running a Symfony application behind a reverse proxy, where the application is served in a subpath / subfolder,
+you might encounter the problem that Symfony generates incorrect URLs, which ignore the subpath / subfolder of the reverse proxy.
+To fix this, you need to pass the subpath / subfolder route prefix of the reverse proxy to Symfony by
+setting the ``X-Forwarded-Prefix`` header. This is required for Symfony to generate the correct URLs. The header can normally be configured
+in your reverse proxy configuration. Configure ``X-Forwared-Prefix`` as trusted header to be able to use this feature.
+
+The ``X-Forwarded-Prefix`` is used by Symfony to prefix the base URL of request objects, which is
+used to generate absolute paths and URLs in Symfony applications. Without the header, the base URL would be only determined
+based on the configuration of the web server running Symfony, which leads to incorrect pathes/URLs, when the application
+is served under a subpath by a reverse proxy.
+
+For example if your symfony application is directly served under an URL like ``https://symfony.tld/``
+and you would like to use a reverse proxy to serve the application under ``https://public.tld/app/``, you would need
+to set the ``X-Forwarded-Prefix`` header to ``/app/`` in your reverse proxy configuration.
+Without the header, Symfony would generate URLs based on its servers base URL (e.g. ``/my/route``) instead of the correct
+``/app/my/route``, which is required to access the route via the reverse proxy.
+
+The header can be different for each reverse proxy, so that access via different reverse proxies served under different
+subpaths can be handled correctly.
+
 Custom Headers When Using a Reverse Proxy
 -----------------------------------------
 


### PR DESCRIPTION
If you want to put a symfony application behind a reverse proxy which is configured the application in a subfolder, then this is supported by setting the non-standard `X-Forwarded-Prefix HTTP header`. This was already [added in Symfony 5.2](https://github.com/symfony/http-foundation/commit/d3a250632a328c56aef3245611e536353ea88e61).  However, this is nowhere documented and no good solution on how to achieve this goal is found on the internet. This commit adds documentation on how to use this header.

This should apply to all Symfony versions (at least from 5.4 upwards)