### PR TITLE
[Doctrine] Suggest reusable bundles use explicit `name` configurations for Doctrine entities

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -167,6 +167,13 @@ recommended to define their mapping using XML files stored in
 :doc:`standard Symfony mechanism to override bundle parts </bundles/override>`.
 This is not possible when using annotations/attributes to define the mapping.
 
+Also, include explicit ``name`` values in the configuration for database tables
+and columns, to make sure your code is independent of the Doctrine naming strategy
+in use. Otherwise, for example when referring to columns in plain SQL queries,
+using different naming strategies may break your code. This may mean that the
+database schema elements belonging to your bundle follow another convention than
+the rest of the project.
+
 .. caution::
 
     The recommended bundle structure was changed in Symfony 5, read the


### PR DESCRIPTION
This may be highly opinionated and not everyone's liking, but at least I wanted to bring this potential issue to attention.

The options are: 

a) Be explicit in the configuration for everything where ambiguity might be an issue
b) Do not use explicit `name` configurations at all, but then, at the same time, do not make any assumptions about e. g. column names, for example in Doctrine native queries.