### PR TITLE
[Reference] Form empty data option - Update repetitive text

### DIFF
--- a/reference/forms/types/options/empty_data_description.rst.inc
+++ b/reference/forms/types/options/empty_data_description.rst.inc
@@ -15,14 +15,12 @@ This will still render an empty text box, but upon submission the ``John Doe``
 value will be set. Use the ``data`` or ``placeholder`` options to show this
 initial value in the rendered form.
 
-If a form is compound, you can set ``empty_data`` as an array, object or
-closure. See the :doc:`/form/use_empty_data` article for more details about
-these options.
-
 .. note::
 
-    If you want to set the ``empty_data`` option for your entire form class,
-    see the :doc:`/form/use_empty_data` article.
+    If a form is compound, you can set ``empty_data`` as an array, object or
+    closure. This option can be set for your entire form class, see the
+    :doc:`/form/use_empty_data` article for more details about these
+    options.
 
 .. caution::
 


### PR DESCRIPTION
When I read this part of the documentation, I found these two paragraphs repetitive, so I made a small change to try make it clearer.