### PR TITLE
[Form] Deprecate using `UrlType` without setting `default_protocol`

### DIFF
--- a/reference/forms/types/url.rst
+++ b/reference/forms/types/url.rst
@@ -31,6 +31,11 @@ If a value is submitted that doesn't begin with some protocol (e.g. ``http://``,
 ``ftp://``, etc), this protocol will be prepended to the string when
 the data is submitted to the form.
 
+.. deprecated:: 7.1
+
+    Not setting the ``default_protocol`` option is deprecated since Symfony 7.1
+    and will default to ``null`` in Symfony 8.0.
+
 Overridden Options
 ------------------
 


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/19146