### PR TITLE
[HttpClient] Symfony HTTP Client documentation

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1049,7 +1049,11 @@ If the server does respond with a gzipped response, it's decoded transparently.
 To disable HTTP compression, send an ``Accept-Encoding: identity`` HTTP header.
 
 Chunked transfer encoding is enabled automatically if both your PHP runtime and
-the remote server supports it.
+the remote server support it.
+
+.. caution::
+
+    If you set `Accept-Encoding` to e.g. `gzip`, you will need to handle the decompression yourself.
 
 HTTP/2 Support
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
notice about passing accept-encoding variable manually

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
