### PR TITLE
[Security] Explicit check route option for loginlink usage

### DIFF
--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -28,8 +28,8 @@ this is not yet the case.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The login link authenticator is configured using the ``login_link`` option
-under the firewall. You must configure a ``check_route`` and
-``signature_properties`` when enabling this authenticator:
+under the firewall. You must configure a ``check_route`` with a route name
+and ``signature_properties`` when enabling this authenticator:
 
 .. configuration-block::
 


### PR DESCRIPTION
After struggling with this option for a while when i tried to use route path as value for `check_route` option i suggest to explicitly say in documentation a route name is expected with this option