### PR TITLE
[Cache] Document requirements for DoctrineDbalAdapter

### DIFF
--- a/components/cache/adapters/doctrine_dbal_adapter.rst
+++ b/components/cache/adapters/doctrine_dbal_adapter.rst
@@ -39,5 +39,22 @@ optional arguments::
     necessary to detect the database engine and version without opening the
     connection.
 
+The adapter uses SQL syntax that is optimized for database server that it is connected to.
+The following database servers are known to be compatible:
+
+* MySQL 5.7 and newer
+* MariaDB 10.2 and newer
+* Oracle 10g and newer
+* SQL Server 2012 and newer
+* SQLite 3.24 or later
+* PostgreSQL 9.5 or later
+
+.. note::
+
+    Newer releases of Doctrine DBAL might increase these minimal versions. Please check
+    the manual page on `Doctrine DBAL Platforms`_ if your database server is compatible
+    with the installed Doctrine DBAL version.
+
 .. _`Doctrine DBAL Connection`: https://github.com/doctrine/dbal/blob/master/src/Connection.php
-.. _`Doctrine DBAL URL`: https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+.. _`Doctrine DBAL URL`: https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/configuration.html#connecting-using-a-url
+.. _`Doctrine DBAL Platforms`: https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/platforms.html


### PR DESCRIPTION
Follows symfony/symfony#52720. I've added a block that documents the compatibility with various database engines.

* MySQL 5.7 is the oldest release supported by DBAL 3.
* MariaDB 10.2 is the oldest release supported by DBAL 3.
* The `MERGE` statement that the adapter uses requires Oracle 10g or newer.
* SQL Server 2012 is the oldest release supported by DBAL 3.
* The `INSERT OR REPLACE` statement that we use on SQLite requires PHP to be linked against libsqlite 3.24 or newer.
* The `ON CONFLICT` clause that we use on Postgres was introduced with version 9.5.