### PR TITLE
AssetMapper 6.4 docs

### DIFF
--- a/frontend.rst
+++ b/frontend.rst
@@ -8,33 +8,44 @@ more advanced - like scaffolding your front-end with a tool like Next.js.
 However, Symfony *does* come with two powerful options to help you build a modern,
 fast frontend, *and* enjoy the process:
 
-* :ref:`Webpack Encore <frontend-webpack-encore>` is a powerful tool built with `Node.js`_
-  on top of `Webpack`_ that allows you to write modern CSS & JavaScript and handle
-  things like JSX (React), Vue or TypeScript.
+* :ref:`AssetMapper <frontend-asset-mapper>` (recommended for new projects) runs
+  entirely in PHP, doesn't require any build step and leverages modern web standards.
 
-* :ref:`AssetMapper <frontend-asset-mapper>`, is a production-ready simpler alternative
-  to Webpack Encore that runs entirely in PHP.
+* :ref:`Webpack Encore <frontend-webpack-encore>` is built with `Node.js`_
+  on top of `Webpack`_.
 
-================================  =================  ======================================================
-                                  Encore             AssetMapper
-================================  =================  ======================================================
-Production Ready?                 yes                yes
-Stable?                           yes                yes
-Requirements                      Node.js            none: pure PHP
-Requires a build step?            yes                no
-Works in all browsers?            yes                yes
-Supports `Stimulus/UX`_           yes                yes
-Supports Sass/Tailwind            yes                :ref:`yes <asset-mapper-tailwind>`
-Supports React, Vue, Svelte?      yes                yes :ref:`[1] <ux-note-1>`
-Supports TypeScript               yes                no :ref:`[1] <ux-note-1>`
-================================  =================  ======================================================
+================================  ==================================  ==========
+                                  AssetMapper                         Encore
+================================  ==================================  ==========
+Production Ready?                 yes                                 yes
+Stable?                           yes                                 yes
+Requirements                      none                                Node.js
+Requires a build step?            no                                  yes
+Works in all browsers?            yes                                 yes
+Supports `Stimulus/UX`_           yes                                 yes
+Supports Sass/Tailwind            :ref:`yes <asset-mapper-tailwind>`  yes
+Supports React, Vue, Svelte?      yes :ref:`[1] <ux-note-1>`          yes
+Supports TypeScript               :ref:`yes <asset-mapper-ts>`        yes
+================================  ==================================  ==========
 
 .. _ux-note-1:
 
-**[1]** Using JSX (React), Vue or TypeScript with AssetMapper is possible, but you'll
+**[1]** Using JSX (React), Vue, etc with AssetMapper is possible, but you'll
 need to use their native tools for pre-compilation. Also, some features (like
 Vue single-file components) cannot be compiled down to pure JavaScript that can
 be executed by a browser.
+
+.. _frontend-asset-mapper:
+
+AssetMapper (Recommended)
+-------------------------
+
+AssetMapper is the recommended system for handling your assets. It runs entirely
+in PHP with *no* complex build step or dependencies. It does this by leveraging
+the ``importmap`` feature of your browser, which is available in all browsers thanks
+to a polyfill.
+
+:doc:`Read the AssetMapper Documentation </frontend/asset_mapper>`
 
 .. _frontend-webpack-encore:
 
@@ -50,82 +61,14 @@ It *wraps* Webpack, giving you a clean & powerful API for bundling JavaScript mo
 pre-processing CSS & JS and compiling and minifying assets. Encore gives you a professional
 asset system that's a *delight* to use.
 
-Encore is inspired by `Webpacker`_ and `Mix`_, but stays in the spirit of Webpack:
-using its features, concepts and naming conventions for a familiar feel. It aims
-to solve the most common Webpack use cases.
-
-.. tip::
-
-    Encore is made by `Symfony`_ and works *beautifully* in Symfony applications.
-    But it can be used in any PHP application and even with other server-side
-    programming languages!
-
-.. _encore-toc:
-
-Encore Documentation
---------------------
-
-Getting Started
-...............
-
-* :doc:`Installation </frontend/encore/installation>`
-* :doc:`Using Webpack Encore </frontend/encore/simple-example>`
-
-Adding more Features
-....................
-
-* :doc:`CSS Preprocessors: Sass, LESS, etc. </frontend/encore/css-preprocessors>`
-* :doc:`PostCSS and autoprefixing </frontend/encore/postcss>`
-* :doc:`Enabling React.js </frontend/encore/reactjs>`
-* :doc:`Enabling Vue.js (vue-loader) </frontend/encore/vuejs>`
-* :doc:`/frontend/encore/copy-files`
-* :doc:`Configuring Babel </frontend/encore/babel>`
-* :doc:`Source maps </frontend/encore/sourcemaps>`
-* :doc:`Enabling TypeScript (ts-loader) </frontend/encore/typescript>`
-
-Optimizing
-..........
-
-* :doc:`Versioning (and the entrypoints.json/manifest.json files) </frontend/encore/versioning>`
-* :doc:`Using a CDN </frontend/encore/cdn>`
-* :doc:`/frontend/encore/code-splitting`
-* :doc:`/frontend/encore/split-chunks`
-* :doc:`/frontend/encore/url-loader`
-
-Guides
-......
-
-* :doc:`Using Bootstrap CSS & JS </frontend/encore/bootstrap>`
-* :doc:`jQuery and Legacy Applications </frontend/encore/legacy-applications>`
-* :doc:`Passing Information from Twig to JavaScript </frontend/encore/server-data>`
-* :doc:`webpack-dev-server and Hot Module Replacement (HMR) </frontend/encore/dev-server>`
-* :doc:`Adding custom loaders & plugins </frontend/encore/custom-loaders-plugins>`
-* :doc:`Advanced Webpack Configuration </frontend/encore/advanced-config>`
-* :doc:`Using Encore in a Virtual Machine </frontend/encore/virtual-machine>`
-
-Issues & Questions
-..................
-
-* :doc:`FAQ & Common Issues </frontend/encore/faq>`
-
-Full API
-........
-
-* `Full API`_
-
-.. _frontend-asset-mapper:
-
-AssetMapper
------------
-
-AssetMapper is an alternative to Webpack Encore that runs entirely in PHP
-without any complex build steps. It leverages the ``importmap`` feature of
-your browser, which is available in all browsers thanks to a polyfill.
-
-:doc:`Read the AssetMapper Documentation </frontend/asset_mapper>`
+:doc:`Read the Encore Documentation </frontend/encore/index>`
 
 Stimulus & Symfony UX Components
 --------------------------------
+
+Once you've installed AssetMapper or Encore, it's time to start building your
+front-end. You can write your JavaScript however you want, but we recommend
+using `Stimulus`_, `Turbo`_ and a set of tools called `Symfony UX`_.
 
 To learn about Stimulus & the UX Components, see:
 the `StimulusBundle Documentation`_
@@ -139,10 +82,9 @@ Other Front-End Articles
 .. _`Webpack Encore`: https://www.npmjs.com/package/@symfony/webpack-encore
 .. _`Webpack`: https://webpack.js.org/
 .. _`Node.js`: https://nodejs.org/
-.. _`Webpacker`: https://github.com/rails/webpacker
-.. _`Mix`: https://laravel.com/docs/mix
-.. _`Symfony`: https://symfony.com/
-.. _`Full API`: https://github.com/symfony/webpack-encore/blob/master/index.js
 .. _`Webpack Encore screencast series`: https://symfonycasts.com/screencast/webpack-encore
 .. _StimulusBundle Documentation: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _Stimulus/UX: https://symfony.com/bundles/StimulusBundle/current/index.html
+.. _Stimulus: https://stimulus.hotwired.dev/
+.. _Turbo: https://turbo.hotwired.dev/
+.. _Symfony UX: https://ux.symfony.com

--- a/frontend/encore/babel.rst
+++ b/frontend/encore/babel.rst
@@ -1,5 +1,5 @@
-Configuring Babel
-=================
+Configuring Babel with Encore
+=============================
 
 `Babel`_ is automatically configured for all ``.js`` and ``.jsx`` files via the
 ``babel-loader`` with sensible defaults (e.g. with the ``@babel/preset-env`` and

--- a/frontend/encore/bootstrap.rst
+++ b/frontend/encore/bootstrap.rst
@@ -1,5 +1,5 @@
-Using Bootstrap CSS & JS
-========================
+Using Bootstrap CSS & JS with Webpack Encore
+============================================
 
 This article explains how to install and integrate the `Bootstrap CSS framework`_
 in your Symfony application using :doc:`Webpack Encore </frontend>`.

--- a/frontend/encore/cdn.rst
+++ b/frontend/encore/cdn.rst
@@ -1,5 +1,5 @@
-Using a CDN
-===========
+Using a CDN with Webpack Encore
+===============================
 
 Are you deploying to a CDN? That's awesome :) Once you've made sure that your
 built files are uploaded to the CDN, configure it in Encore:

--- a/frontend/encore/code-splitting.rst
+++ b/frontend/encore/code-splitting.rst
@@ -1,5 +1,5 @@
-Async Code Splitting
-====================
+Async Code Splitting with Webpack Encore
+========================================
 
 When you require/import a JavaScript or CSS module, Webpack compiles that code into
 the final JavaScript or CSS file. Usually, that's exactly what you want. But what

--- a/frontend/encore/copy-files.rst
+++ b/frontend/encore/copy-files.rst
@@ -1,5 +1,5 @@
-Copying & Referencing Images
-============================
+Copying & Referencing Images with Webpack Encore
+================================================
 
 Need to reference a static file - like the path to an image for an ``img`` tag?
 That can be tricky if you store your assets outside of the public document root.

--- a/frontend/encore/css-preprocessors.rst
+++ b/frontend/encore/css-preprocessors.rst
@@ -1,5 +1,5 @@
-CSS Preprocessors: Sass, LESS, Stylus, etc.
-===========================================
+CSS Preprocessors: Sass, etc. with Webpack Encore
+=================================================
 
 To use the Sass, LESS or Stylus pre-processors, enable the one you want in ``webpack.config.js``:
 

--- a/frontend/encore/custom-loaders-plugins.rst
+++ b/frontend/encore/custom-loaders-plugins.rst
@@ -1,5 +1,5 @@
-Adding Custom Loaders & Plugins
-===============================
+Adding Custom Loaders & Plugins with Webpack Encore
+===================================================
 
 Adding Custom Loaders
 ---------------------

--- a/frontend/encore/faq.rst
+++ b/frontend/encore/faq.rst
@@ -1,5 +1,5 @@
-FAQ and Common Issues
-=====================
+WebpackEncore: FAQ and Common Issues
+====================================
 
 .. _how-do-i-deploy-my-encore-assets:
 

--- a/frontend/encore/index.rst
+++ b/frontend/encore/index.rst
@@ -1,0 +1,54 @@
+.. _encore-toc:
+
+Webpack Encore Documentation
+----------------------------
+
+Getting Started
+...............
+
+* :doc:`Installation </frontend/encore/installation>`
+* :doc:`Using Webpack Encore </frontend/encore/simple-example>`
+
+Adding more Features
+....................
+
+* :doc:`CSS Preprocessors: Sass, LESS, etc. </frontend/encore/css-preprocessors>`
+* :doc:`PostCSS and autoprefixing </frontend/encore/postcss>`
+* :doc:`Enabling React.js </frontend/encore/reactjs>`
+* :doc:`Enabling Vue.js (vue-loader) </frontend/encore/vuejs>`
+* :doc:`/frontend/encore/copy-files`
+* :doc:`Configuring Babel </frontend/encore/babel>`
+* :doc:`Source maps </frontend/encore/sourcemaps>`
+* :doc:`Enabling TypeScript (ts-loader) </frontend/encore/typescript>`
+
+Optimizing
+..........
+
+* :doc:`Versioning (and the entrypoints.json/manifest.json files) </frontend/encore/versioning>`
+* :doc:`Using a CDN </frontend/encore/cdn>`
+* :doc:`/frontend/encore/code-splitting`
+* :doc:`/frontend/encore/split-chunks`
+* :doc:`/frontend/encore/url-loader`
+
+Guides
+......
+
+* :doc:`Using Bootstrap CSS & JS </frontend/encore/bootstrap>`
+* :doc:`jQuery and Legacy Applications </frontend/encore/legacy-applications>`
+* :doc:`Passing Information from Twig to JavaScript </frontend/encore/server-data>`
+* :doc:`webpack-dev-server and Hot Module Replacement (HMR) </frontend/encore/dev-server>`
+* :doc:`Adding custom loaders & plugins </frontend/encore/custom-loaders-plugins>`
+* :doc:`Advanced Webpack Configuration </frontend/encore/advanced-config>`
+* :doc:`Using Encore in a Virtual Machine </frontend/encore/virtual-machine>`
+
+Issues & Questions
+..................
+
+* :doc:`FAQ & Common Issues </frontend/encore/faq>`
+
+Full API
+........
+
+* `Full API`_
+
+.. _`Full API`: https://github.com/symfony/webpack-encore/blob/master/index.js

--- a/frontend/encore/legacy-applications.rst
+++ b/frontend/encore/legacy-applications.rst
@@ -1,5 +1,5 @@
-jQuery Plugins and Legacy Applications
-======================================
+jQuery Plugins and Legacy Applications with Webpack Encore
+==========================================================
 
 Inside Webpack, when you require a module, it does *not* (usually) set a global variable.
 Instead, it just returns a value:

--- a/frontend/encore/postcss.rst
+++ b/frontend/encore/postcss.rst
@@ -1,5 +1,5 @@
-PostCSS and autoprefixing (postcss-loader)
-==========================================
+PostCSS and autoprefixing (postcss-loader) with Webpack Encore
+==============================================================
 
 `PostCSS`_ is a CSS post-processing tool that can transform your CSS in a lot
 of cool ways, like `autoprefixing`_, `linting`_ and more!

--- a/frontend/encore/reactjs.rst
+++ b/frontend/encore/reactjs.rst
@@ -1,5 +1,5 @@
-Enabling React.js
-=================
+Enabling React.js with Webpack Encore
+=====================================
 
 .. admonition:: Screencast
     :class: screencast
@@ -9,7 +9,7 @@ Enabling React.js
 .. tip::
 
     Check out live demos of Symfony UX React component at `https://ux.symfony.com/react`_!
-    
+
 Using React? First add some dependencies with Yarn:
 
 .. code-block:: terminal

--- a/frontend/encore/server-data.rst
+++ b/frontend/encore/server-data.rst
@@ -1,5 +1,5 @@
-Passing Information from Twig to JavaScript
-===========================================
+Passing Information from Twig to JavaScript with Webpack Encore
+===============================================================
 
 In Symfony applications, you may find that you need to pass some dynamic data
 (e.g. user information) from Twig to your JavaScript code. One great way to pass

--- a/frontend/encore/sourcemaps.rst
+++ b/frontend/encore/sourcemaps.rst
@@ -1,5 +1,5 @@
-Enabling Source Maps
-====================
+Enabling Source Maps with Webpack Encore
+========================================
 
 `Source maps`_ allow browsers to access the original code related to some
 asset (e.g. the Sass code that was compiled to CSS or the TypeScript code that

--- a/frontend/encore/split-chunks.rst
+++ b/frontend/encore/split-chunks.rst
@@ -1,4 +1,4 @@
-Preventing Duplication by "Splitting" Shared Code into Separate Files
+Preventing Duplication by "Splitting" Shared Code with Webpack Encore
 =====================================================================
 
 Suppose you have multiple entry files and *each* requires ``jquery``. In this

--- a/frontend/encore/typescript.rst
+++ b/frontend/encore/typescript.rst
@@ -1,5 +1,5 @@
-Enabling TypeScript (ts-loader)
-===============================
+Enabling TypeScript (ts-loader) with Webpack Encore
+===================================================
 
 Want to use `TypeScript`_? No problem! First, enable it:
 

--- a/frontend/encore/url-loader.rst
+++ b/frontend/encore/url-loader.rst
@@ -1,5 +1,5 @@
-Inlining Images & Fonts in CSS
-==============================
+Inlining Images & Fonts in CSS with Webpack Encore
+==================================================
 
 A simple technique to improve the performance of web applications is to reduce
 the number of HTTP requests inlining small files as base64 encoded URLs in the

--- a/frontend/encore/versioning.rst
+++ b/frontend/encore/versioning.rst
@@ -1,5 +1,5 @@
-Asset Versioning
-================
+Asset Versioning with Webpack Encore
+====================================
 
 .. _encore-long-term-caching:
 

--- a/frontend/encore/vuejs.rst
+++ b/frontend/encore/vuejs.rst
@@ -1,5 +1,5 @@
-Enabling Vue.js (``vue-loader``)
-================================
+Enabling Vue.js (``vue-loader``) with Webpack Encore
+====================================================
 
 .. admonition:: Screencast
     :class: screencast
@@ -9,7 +9,7 @@ Enabling Vue.js (``vue-loader``)
 .. tip::
 
     Check out live demos of Symfony UX Vue.js component at `https://ux.symfony.com/vue`_!
-    
+
 Want to use `Vue.js`_? No problem! First enable it in ``webpack.config.js``:
 
 .. code-block:: diff


### PR DESCRIPTION
Hi!

A few notable things:

A) Of course, AssetMapper docs were updated for 6.4. Many features were already done - thank you for the community for doing that! 

B) I set AssetMapper as the recommended assets solution for 6.4.

C) I Added "Encore" to many of the Encore documentation pages for clarity. I also moved the Encore TOC to its own page. This makes the frontend page short and focused: a landing point to go elsewhere.

Cheers!