### PR TITLE
fix: serializer includes only accessible attributes by default

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -471,7 +471,7 @@ As for groups, attributes can be selected during both the serialization and dese
 Ignoring Attributes
 -------------------
 
-All attributes are included by default when serializing objects. There are two
+All accessible attributes are included by default when serializing objects. There are two
 options to ignore some of those attributes.
 
 Option 1: Using ``@Ignore`` Annotation


### PR DESCRIPTION
Updates documentation based upon the discussion here: https://github.com/symfony/symfony/pull/52680