### PR TITLE
[Uid] Default versions in framework VS recipes

### DIFF
--- a/components/uid.rst
+++ b/components/uid.rst
@@ -94,10 +94,10 @@ configure the behavior of the factory using configuration files::
         # config/packages/uid.yaml
         framework:
             uid:
-                default_uuid_version: 7
+                default_uuid_version: 6
                 name_based_uuid_version: 5
                 name_based_uuid_namespace: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
-                time_based_uuid_version: 7
+                time_based_uuid_version: 6
                 time_based_uuid_node: 121212121212
 
     .. code-block:: xml
@@ -113,10 +113,10 @@ configure the behavior of the factory using configuration files::
 
             <framework:config>
                 <framework:uid
-                    default_uuid_version="7"
+                    default_uuid_version="6"
                     name_based_uuid_version="5"
                     name_based_uuid_namespace="6ba7b810-9dad-11d1-80b4-00c04fd430c8"
-                    time_based_uuid_version="7"
+                    time_based_uuid_version="6"
                     time_based_uuid_node="121212121212"
                 />
             </framework:config>
@@ -135,10 +135,10 @@ configure the behavior of the factory using configuration files::
 
             $container->extension('framework', [
                 'uid' => [
-                    'default_uuid_version' => 7,
+                    'default_uuid_version' => 6,
                     'name_based_uuid_version' => 5,
                     'name_based_uuid_namespace' => '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
-                    'time_based_uuid_version' => 7,
+                    'time_based_uuid_version' => 6,
                     'time_based_uuid_node' => 121212121212,
                 ],
             ]);
@@ -160,7 +160,7 @@ on the configuration you defined::
 
         public function generate(): void
         {
-            // This creates a UUID of the version given in the configuration file (v7 by default)
+            // This creates a UUID of the version given in the configuration file (v6 by default)
             $uuid = $this->uuidFactory->create();
 
             $nameBasedUuid = $this->uuidFactory->nameBased(/** ... */);


### PR DESCRIPTION
Really not sure if this is normal or not, and how it could be improved. 

In the framework DI/config, default UUID versions are 
* 6 5 6 in [Symfony 6.2 6.3 and 6.4](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php)
* 7 5 7 in [Symfony >= 7.0](https://github.com/symfony/symfony/blob/7.0/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php)

BUT

It seems the symfony/uid flex recipes did already use 7 5 7 in 6.4... 

So ... 🤷🏻‍♂️



