### PR TITLE
[AssetMapper] Removing TODOs

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -993,10 +993,6 @@ rendered by the ``{{ importmap() }}`` Twig function:
 Page-Specific CSS & JavaScript
 ------------------------------
 
----> TODO HEre
----> need to add the entrypoint in the importmap.php file
-----> and should NOT call parent() in the javascript block
-
 Sometimes you may choose to include CSS or JavaScript files only on certain
 pages. For JavaScript, an easy way is to load the file with a `dynamic import`_:
 


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/frontend/asset_mapper.html#page-specific-css-javascript

Looks like @weaverryan just forgot to delete this after finishing https://github.com/symfony/symfony-docs/pull/19189 :-)