### PR TITLE
[DependencyInjection] Mention autoconfiguration through attributes

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -60,7 +60,7 @@ so Symfony doesn't try to get/set its value from the related entity::
 
     class ProductType extends AbstractType
     {
-        public function buildForm(FormBuilderInterface $builder, array $options)
+        public function buildForm(FormBuilderInterface $builder, array $options): void
         {
             $builder
                 // ...

--- a/service_container.rst
+++ b/service_container.rst
@@ -948,6 +948,17 @@ you don't need to do *anything*: the service will be automatically loaded. Then,
 implements ``Twig\Extension\ExtensionInterface``. And thanks to ``autowire``, you can even add
 constructor arguments without any configuration.
 
+Autconfiguration also works with attributes. Some attributes like
+:class:`Symfony\\Component\\Messenger\\Attribute\\AsMessageHandler`,
+:class:`Symfony\\Component\\EventDispatcher\\Attribute\\AsEventListener` and
+:class:`Symfony\\Component\\Console\\Attribute\\AsCommand` are registered
+for autoconfiguration. Any class using these attributes will have tags applied
+to them.
+
+.. versionadded:: 5.3
+
+    Autoconfiguration through attributes was introduced in Symfony 5.3.
+
 Linting Service Definitions
 ---------------------------
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
