### PR TITLE
Added missing backtick character

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -220,7 +220,7 @@ method::
     }
 
 You can also make attributes usable on methods. To do so, update the previous
-example and add ``Attribute::TARGET_METHOD`::
+example and add ``Attribute::TARGET_METHOD``::
 
     // src/Attribute/SensitiveElement.php
     namespace App\Attribute;


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
