### PR TITLE
[Form] Fix custom form type docs

### DIFF
--- a/form/create_custom_field_type.rst
+++ b/form/create_custom_field_type.rst
@@ -362,9 +362,8 @@ fragments used to render the types:
 
     {# ... here you will add the Twig code ... #}
 
-Then, update the :ref:`form_themes option <reference-twig-tag-form-theme>` to
-add this new template at the beginning of the list (the first one overrides the
-rest of files):
+Then, update the :ref:`form_themes option <config-twig-form-themes>` to
+add this new template at the end of the list (each theme overrides all the previous ones):
 
 .. configuration-block::
 
@@ -373,8 +372,8 @@ rest of files):
         # config/packages/twig.yaml
         twig:
             form_themes:
-                - 'form/custom_types.html.twig'
                 - '...'
+                - 'form/custom_types.html.twig'
 
     .. code-block:: xml
 
@@ -389,8 +388,8 @@ rest of files):
                 https://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
             <twig:config>
-                <twig:form-theme>form/custom_types.html.twig</twig:form-theme>
                 <twig:form-theme>...</twig:form-theme>
+                <twig:form-theme>form/custom_types.html.twig</twig:form-theme>
             </twig:config>
         </container>
 
@@ -401,8 +400,8 @@ rest of files):
 
         return static function (TwigConfig $twig) {
             $twig->formThemes([
-                'form/custom_types.html.twig',
                 '...',
+                'form/custom_types.html.twig',
             ]);
         };
 


### PR DESCRIPTION
1. Fixes the link to the twig config reference
2. Fixes the priority of order of `twig.form_themes` see https://symfony.com/doc/current/reference/configuration/twig.html#form-themes