### PR TITLE
[HttpFoundation] replace `$request->request` by `$request->getPayload()`

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -625,7 +625,7 @@ the ``Request`` class::
 
         // retrieves GET and POST variables respectively
         $request->query->get('page');
-        $request->request->get('page');
+        $request->getPayload()->get('page');
 
         // retrieves SERVER variables
         $request->server->get('HTTP_HOST');

--- a/create_framework/http_foundation.rst
+++ b/create_framework/http_foundation.rst
@@ -178,7 +178,7 @@ fingertips thanks to a nice and simple API::
 
     // retrieves GET and POST variables respectively
     $request->query->get('foo');
-    $request->request->get('bar', 'default value if bar does not exist');
+    $request->getPayload()->get('bar', 'default value if bar does not exist');
 
     // retrieves SERVER variables
     $request->server->get('HTTP_HOST');

--- a/form/direct_submit.rst
+++ b/form/direct_submit.rst
@@ -17,7 +17,7 @@ control over when exactly your form is submitted and what data is passed to it::
         $form = $this->createForm(TaskType::class, $task);
 
         if ($request->isMethod('POST')) {
-            $form->submit($request->request->all($form->getName()));
+            $form->submit($request->getPayload()->get($form->getName()));
 
             if ($form->isSubmitted() && $form->isValid()) {
                 // perform some action...
@@ -41,7 +41,7 @@ the fields defined by the form class. Otherwise, you'll see a form validation er
         if ($request->isMethod('POST')) {
             // '$json' represents payload data sent by React/Angular/Vue
             // the merge of parameters is needed to submit all form fields
-            $form->submit(array_merge($json, $request->request->all()));
+            $form->submit(array_merge($json, $request->getPayload()->all()));
 
             // ...
         }
@@ -73,4 +73,4 @@ the fields defined by the form class. Otherwise, you'll see a form validation er
     manually so that they are validated::
 
         // 'email' and 'username' are added manually to force their validation
-        $form->submit(array_merge(['email' => null, 'username' => null], $request->request->all()), false);
+        $form->submit(array_merge(['email' => null, 'username' => null], $request->getPayload()->all()), false);

--- a/form/without_class.rst
+++ b/form/without_class.rst
@@ -59,7 +59,7 @@ an array.
     You can also access POST values (in this case "name") directly through
     the request object, like so::
 
-        $request->request->get('name');
+        $request->getPayload()->get('name');
 
     Be advised, however, that in most cases using the ``getData()`` method is
     a better choice, since it returns the data (usually an object) after

--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -56,7 +56,7 @@ automatically when type-hinting for
         {
             public function createAction(HtmlSanitizerInterface $htmlSanitizer, Request $request): Response
             {
-                $unsafeContents = $request->request->get('post_contents');
+                $unsafeContents = $request->getPayload()->get('post_contents');
 
                 $safeContents = $htmlSanitizer->sanitize($unsafeContents);
                 // ... proceed using the safe HTML

--- a/introduction/http_fundamentals.rst
+++ b/introduction/http_fundamentals.rst
@@ -216,7 +216,7 @@ have all the request information at your fingertips::
 
     // retrieves $_GET and $_POST variables respectively
     $request->query->get('id');
-    $request->request->get('category', 'default category');
+    $request->getPayload()->get('category', 'default category');
 
     // retrieves $_SERVER variables
     $request->server->get('HTTP_HOST');

--- a/security/csrf.rst
+++ b/security/csrf.rst
@@ -156,7 +156,7 @@ method to check its validity::
 
     public function delete(Request $request): Response
     {
-        $submittedToken = $request->request->get('token');
+        $submittedToken = $request->getPayload()->get('token');
 
         // 'delete-item' is the same value used in the template to generate the token
         if ($this->isCsrfTokenValid('delete-item', $submittedToken)) {

--- a/security/custom_authenticator.rst
+++ b/security/custom_authenticator.rst
@@ -339,9 +339,9 @@ would initialize the passport like this::
     {
         public function authenticate(Request $request): Passport
         {
-            $password = $request->request->get('password');
-            $username = $request->request->get('username');
-            $csrfToken = $request->request->get('csrf_token');
+            $password = $request->getPayload()->get('password');
+            $username = $request->getPayload()->get('username');
+            $csrfToken = $request->getPayload()->get('csrf_token');
 
             // ... validate no parameter is empty
 

--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -159,7 +159,7 @@ this interface::
             // check if form is submitted
             if ($request->isMethod('POST')) {
                 // load the user in some way (e.g. using the form input)
-                $email = $request->request->get('email');
+                $email = $request->getPayload()->get('email');
                 $user = $userRepository->findOneBy(['email' => $email]);
 
                 // create a login link for $user this returns an instance
@@ -228,7 +228,7 @@ number::
         public function requestLoginLink(NotifierInterface $notifier, LoginLinkHandlerInterface $loginLinkHandler, UserRepository $userRepository, Request $request): Response
         {
             if ($request->isMethod('POST')) {
-                $email = $request->request->get('email');
+                $email = $request->getPayload()->get('email');
                 $user = $userRepository->findOneBy(['email' => $email]);
 
                 $loginLinkDetails = $loginLinkHandler->createLoginLink($user);


### PR DESCRIPTION
Considering new function getPayload added in [code #49614](https://github.com/symfony/symfony/pull/49614), what do you think about replace `$request->request` by `$request->getPayload` in documentation ? 