### PR TITLE
[Routing] Improving language, shortening twig code

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -1603,15 +1603,14 @@ information in a controller via the ``Request`` object::
         }
     }
 
-You can get this information in services too injecting the ``request_stack``
-service to :doc:`get the Request object in a service </service_container/request>`.
-In templates, use the :ref:`Twig global app variable <twig-app-variable>` to get
+To get this information in a service, see :doc:`/service_container/request`.
+In templates, you can use the :ref:`Twig global app variable <twig-app-variable>` to get
 the current route and its attributes:
 
 .. code-block:: twig
 
-    {% set route_name = app.current_route %}
-    {% set route_parameters = app.current_route_parameters %}
+    {% app.current_route %}
+    {% app.current_route_parameters %}
 
 .. versionadded:: 6.2
 


### PR DESCRIPTION
Page: https://symfony.com/doc/6.3/routing.html#getting-the-route-name-and-parameters

* The first sentence wasn't english.
* Defining a  Twig variable for this is quite useless nowadays - this looks like a leftover from previous versions where the syntax was lengthy: https://symfony.com/doc/5.4/routing.html#getting-the-route-name-and-parameters
