### PR TITLE
[Form] Document using TranslatableMessage in form Fields

### DIFF
--- a/reference/forms/types/options/button_label.rst.inc
+++ b/reference/forms/types/options/button_label.rst.inc
@@ -1,7 +1,7 @@
 ``label``
 ~~~~~~~~~
 
-**type**: ``string`` **default**: The label is "guessed" from the field name
+**type**: ``string`` or ``TranslatableMessage`` **default**: The label is "guessed" from the field name
 
 Sets the label that will be displayed on the button. The label can also
 be directly set inside the template:

--- a/reference/forms/types/options/placeholder.rst.inc
+++ b/reference/forms/types/options/placeholder.rst.inc
@@ -1,7 +1,7 @@
 ``placeholder``
 ~~~~~~~~~~~~~~~
 
-**type**: ``string`` or ``boolean``
+**type**: ``string`` or ``TranslatableMessage`` or ``boolean``
 
 This option determines whether or not a special "empty" option (e.g. "Choose
 an option") will appear at the top of a select widget. This option only
@@ -14,6 +14,9 @@ applies if the ``multiple`` option is set to false.
 
     $builder->add('states', ChoiceType::class, [
         'placeholder' => 'Choose an option',
+
+        // or if you want to translate the text
+        'placeholder' => new TranslatableMessage('form.placeholder.select_option', [], 'form'),
     ]);
 
 * Guarantee that no "empty" value option is displayed::


### PR DESCRIPTION
Document using TranslatableMessage for button_label and placeholder like form help (https://github.com/symfony/symfony-docs/pull/15527)
#SymfonyHackday
