### PR TITLE
Add "frontend" as one of the topic to getting started

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -282,6 +282,7 @@ OK, time to finish mastering the fundamentals by reading these articles:
 * :doc:`/controller`
 * :doc:`/templates`
 * :doc:`/configuration`
+* :doc:`/frontend`
 
 Then, learn about other important topics like the
 :doc:`service container </service_container>`,


### PR DESCRIPTION
Hi!

Right here: https://symfony.com/doc/current/page_creation.html#what-s-next

I think adding a link to `frontend.rst` makes sense - it's title is `Front-end Tools: Handling CSS & JavaScript`. We are showing routes & controllers & templates, so making CSS/JS a main link I think makes sense.

Thanks!