### PR TITLE
Update security.rst

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1601,6 +1601,7 @@ and set the ``limiter`` option to its service ID:
                     $globalFactory: '@limiter.ip_login'
                     # localFactory is the limiter for username+IP
                     $localFactory: '@limiter.username_ip_login'
+                    $secret: '%kernel.secret%'
 
         security:
             firewalls:
@@ -1651,6 +1652,8 @@ and set the ``limiter`` option to its service ID:
                     <srv:argument type="service" id="limiter.ip_login"/>
                     <!-- 2nd argument is the limiter for username+IP -->
                     <srv:argument type="service" id="limiter.username_ip_login"/>
+                    <!-- 3rd argument is the app secret -->
+                    <srv:argument type="service" id="%kernel.secret%"/>
                 </srv:service>
             </srv:services>
 
@@ -1693,6 +1696,8 @@ and set the ``limiter`` option to its service ID:
                     new Reference('limiter.ip_login'),
                     // 2nd argument is the limiter for username+IP
                     new Reference('limiter.username_ip_login'),
+                    // 3rd argument is the app secret
+                    new Reference('kernel.secret'),
                 ]);
 
             $security->firewall('main')


### PR DESCRIPTION
Add third argument on example of config of DefaultLoginRateLimiter.

After migrate 6.2 to 6.4.1 i got an error : 
Too few arguments to function Symfony\Component\Security\Http\RateLimiter\DefaultLoginRateLimiter::__construct(), 2 passed in /var/www/html/var/cache/dev/ContainerJcwPZ89/getSecurity_Listener_LoginThrottling_MainService.php on line 41 and exactly 3 expected

in the class

```php
/**
 * @param non-empty-string $secret A secret to use for hashing the IP address and username
 */
public function __construct(RateLimiterFactory $globalFactory, RateLimiterFactory $localFactory, #[\SensitiveParameter] string $secret)
{
    if (!$secret) {
        throw new InvalidArgumentException('A non-empty secret is required.');
    }

    $this->globalFactory = $globalFactory;
    $this->localFactory = $localFactory;
    $this->secret = $secret;
}
```

So,  it will be nice to update these config example section !