### PR TITLE
Update code sample with getSupportedTypes

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -48,6 +48,13 @@ to customize the normalized data. To do that, leverage the ``ObjectNormalizer``:
         {
             return $data instanceof Topic;
         }
+
+        public function getSupportedTypes(?string $format): array
+        {
+            return [
+                Topic::class => true,
+            ];
+        }·
     }
 
 .. deprecated:: 6.1


### PR DESCRIPTION
The getSupportedType method is now required after Symfony 6.3

