### PR TITLE
[Mailer] Updated webhook support in Mailer bridge overview for 6.4

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -112,7 +112,7 @@ Service               Install with                                    Webhook su
 `Mandrill`_           ``composer require symfony/mailchimp-mailer``
 `Postmark`_           ``composer require symfony/postmark-mailer``    yes
 `Scaleway`_           ``composer require symfony/scaleway-mailer``
-`SendGrid`_           ``composer require symfony/sendgrid-mailer``
+`SendGrid`_           ``composer require symfony/sendgrid-mailer``    yes
 ===================== =============================================== ===============
 
 .. versionadded:: 6.2


### PR DESCRIPTION
Followup of https://github.com/symfony/symfony-docs/pull/19263, as SendGrid webhook support was added in 6.4