### PR TITLE
Update Docker page with instructions for Mac users

### DIFF
--- a/setup/docker.rst
+++ b/setup/docker.rst
@@ -51,4 +51,9 @@ If you're using the :ref:`symfony binary web server <symfony-local-web-server>` 
 then it can automatically detect your Docker services and expose them as environment
 variables. See :ref:`symfony-server-docker`.
 
+.. note::
+
+    Mac users need to explicitly allow the default Docker socket to be used for the Docker integration to work as explained in the `Docker documentation`_.
+
 .. _`https://github.com/dunglas/symfony-docker`: https://github.com/dunglas/symfony-docker
+.. _`Docker documentation`: https://docs.docker.com/desktop/mac/permission-requirements/


### PR DESCRIPTION
As explained in https://github.com/symfony-cli/symfony-cli/issues/350, Mac users need to grant specific permissions for the Docker integration of the Symfony CLI to work.