### PR TITLE
[Notifier][Webhook] Updated Webhook-supported Notifier bridges for 6.4

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -99,7 +99,7 @@ Service             Package                                DSN                  
 `Telnyx`_           ``symfony/telnyx-notifier``            ``telnyx://API_KEY@default?from=FROM&messaging_profile_id=MESSAGING_PROFILE_ID``
 `TurboSms`_         ``symfony/turbo-sms-notifier``         ``turbosms://AUTH_TOKEN@default?from=FROM``
 `Twilio`_           ``symfony/twilio-notifier``            ``twilio://SID:TOKEN@default?from=FROM``                                                                                  yes
-`Vonage`_           ``symfony/vonage-notifier``            ``vonage://KEY:SECRET@default?from=FROM``
+`Vonage`_           ``symfony/vonage-notifier``            ``vonage://KEY:SECRET@default?from=FROM``                                                                                 yes
 `Yunpian`_          ``symfony/yunpian-notifier``           ``yunpian://APIKEY@default``
 ==================  =====================================  ========================================================================================================================= ===============
 

--- a/webhook.rst
+++ b/webhook.rst
@@ -79,16 +79,15 @@ The Webhook component routing needs to be defined:
 
 Currently, the following third-party services support webhooks:
 
-======== ==========================================
-Service  Parser service name
-======== ==========================================
-Brevo    ``mailer.webhook.request_parser.brevo``
-Mailgun  ``mailer.webhook.request_parser.mailgun``
-Mailjet  ``mailer.webhook.request_parser.mailjet``
-Postmark ``mailer.webhook.request_parser.postmark``
-Sendgrid ``mailer.webhook.request_parser.sendgrid``
-Vonage   ``notifier.webhook.request_parser.vonage``
-======== ==========================================
+============== ==========================================
+Mailer Service Parser service name
+============== ==========================================
+Brevo          ``mailer.webhook.request_parser.brevo``
+Mailgun        ``mailer.webhook.request_parser.mailgun``
+Mailjet        ``mailer.webhook.request_parser.mailjet``
+Postmark       ``mailer.webhook.request_parser.postmark``
+Sendgrid       ``mailer.webhook.request_parser.sendgrid``
+============== ==========================================
 
 .. versionadded:: 6.3
 
@@ -96,8 +95,7 @@ Vonage   ``notifier.webhook.request_parser.vonage``
 
 .. versionadded:: 6.4
 
-    The support for Brevo, Mailjet, Sendgrid and Vonage was introduced in
-    Symfony 6.4.
+    The support for Brevo, Mailjet and Sendgrid was introduced in Symfony 6.4.
 
 Set up the webhook in the third-party mailer. For Mailgun, you can do this
 in the control panel. As URL, make sure to use the ``/webhook/mailer_mailgun``
@@ -156,11 +154,16 @@ Currently, the following third-party sms transports support webhooks:
 SMS service  Parser service name
 ============ ==========================================
 Twilio       ``notifier.webhook.request_parser.twilio``
+Vonage       ``notifier.webhook.request_parser.vonage``
 ============ ==========================================
 
 .. versionadded:: 6.3
 
     The support for Twilio was introduced in Symfony 6.3.
+
+.. versionadded:: 6.4
+
+    The support for Vonage was introduced in Symfony 6.4.
 
 For SMS transports, an additional ``SmsEvent`` is available in the RemoteEvent
 consumer::


### PR DESCRIPTION
Moved Vonage to the Notifier bit of the Webhook docs.