### PR TITLE
[Console] Add Helper::formatMemory in the doc

### DIFF
--- a/components/console/helpers/formatterhelper.rst
+++ b/components/console/helpers/formatterhelper.rst
@@ -119,3 +119,28 @@ If you don't want to use suffix at all, pass an empty string::
     $truncatedMessage = $formatter->truncate('test', 10);
     // result: test
     // because length of the "test..." string is shorter than 10
+
+Formatting Time
+---------------
+
+Sometimes you want to format seconds to time. This is possible with the
+:method:`Symfony\\Component\\Console\\Helper\\Helper::formatTime` method.
+The first argument is the seconds to format and the second argument is the
+precision (default ``1``) of the result::
+
+    Helper::formatTime(42);        // 42 secs
+    Helper::formatTime(125);       // 2 mins
+    Helper::formatTime(125, 2);    // 2 mins, 5 secs
+    Helper::formatTime(172799, 4); // 1 day, 23 hrs, 59 mins, 59 secs
+
+Formatting Memory
+-----------------
+
+Sometimes you want to format memory to GiB, MiB, KiB and B. This is possible with the
+:method:`Symfony\\Component\\Console\\Helper\\Helper::formatMemory` method.
+The only argument is the memory size to format::
+
+    Helper::formatMemory(512);                // 512 B
+    Helper::formatMemory(1024);               // 1 KiB
+    Helper::formatMemory(1024 * 1024);        // 1.0 MiB
+    Helper::formatMemory(1024 * 1024 * 1024); // 1 GiB


### PR DESCRIPTION
just add few lines on formatMemory which was available in the code and not documented in the formaterHelper
