### PR TITLE
[HttpClient] Added a paragraph about HttpOptions object

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -149,6 +149,16 @@ method to retrieve a new instance of the client with new default options::
 
     The ``withOptions()`` method was introduced in Symfony 5.3.
 
+Alternatively, the :class:`Symfony\\Component\\HttpClient\\HttpOptions` class brings most of the available options with
+type-hinted getters and setters::
+
+    $this->client = $client->withOptions(
+        (new HttpOptions())
+            ->setBaseUri('https://...')
+            ->setHeaders(['header-name' => 'header-value'])
+            ->toArray()
+    );
+
 Some options are described in this guide:
 
 * `Authentication`_


### PR DESCRIPTION
Partial fix of #19236

A note will be added on the 7.1 branch after this gets merged to warn about the override behavior of ->setHeaders instead of newly added ->addHeader.