### PR TITLE
Remove semicolon marking previous end of statement

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -263,7 +263,7 @@ reusable configuration value. By convention, parameters are defined under the
 
                 // PHP constants as parameter values
                 ->set('app.some_constant', GLOBAL_CONSTANT)
-                ->set('app.another_constant', BlogPost::MAX_ITEMS);
+                ->set('app.another_constant', BlogPost::MAX_ITEMS)
 
                 // Enum case as parameter values
                 ->set('app.some_enum', PostState::Published);


### PR DESCRIPTION
It looks like another example was added at some point without removing the existing semicolon, causing a syntax error in the example.