### PR TITLE
[Encore] [Documentation] Update *Using webpack-dev-server and HMR*

### DIFF
--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -34,7 +34,7 @@ You can set these options via command line options:
     $ yarn encore dev-server --port 9000
 
     # if you use the npm package manager
-    $ npm run dev-server -- --port 9000
+    $ npm run dev-server --port 9000
 
 You can also set these options using the ``Encore.configureDevServerOptions()``
 method in your ``webpack.config.js`` file:


### PR DESCRIPTION
### Description

This pull request addresses a syntax error in the documentation related to the usage of the development server command. The current documentation incorrectly states:

```bash
npm run dev-server -- --port 9000
```
The corrected command is:

```bash
npm run dev-server --port 9000
```
This fix ensures that users can accurately follow the instructions to run the development server with the specified port.