### PR TITLE
[AssetMapper] Fix importmap code example with multiple entrypoints

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -1042,7 +1042,7 @@ both ``app`` and ``checkout``:
     {% block importmap %}
         {# do NOT call parent() #}
 
-        {{ importmap('app', 'checkout') }}
+        {{ importmap(['app', 'checkout']) }}
     {% endblock %}
 
 By passing both ``app`` and ``checkout``, the ``importmap()`` function will


### PR DESCRIPTION
Fix #19311

importmap twig extension method does indeed require an array or a string, and not a variadic : https://github.com/symfony/symfony/blob/6.4/src/Symfony/Bridge/Twig/Extension/ImportMapRuntime.php




