### PR TITLE
[String] Remove confusing paragraph about `withEmoji('strip')`

### DIFF
--- a/components/intl.rst
+++ b/components/intl.rst
@@ -424,6 +424,15 @@ platforms::
     $transliterator->transliterate('Menus with 🥗 or 🧆');
     // => 'Menus with :green_salad: or :falafel:'
 
+Furthermore the ``EmojiTransliterator`` provides a special ``strip`` locale
+that removes all the emojis from a string::
+
+    use Symfony\Component\Intl\Transliterator\EmojiTransliterator;
+
+    $transliterator = EmojiTransliterator::create('strip');
+    $transliterator->transliterate('🎉Hey!🥳 🎁Happy Birthday!🎁');
+    // => 'Hey! Happy Birthday!'
+
 .. tip::
 
     Combine this emoji transliterator with the :ref:`Symfony String slugger <string-slugger-emoji>`

--- a/components/string.rst
+++ b/components/string.rst
@@ -589,16 +589,6 @@ from GitHub or Slack, use the first argument of ``withEmoji()`` method::
     $slug = $slugger->slug('a 😺, 🐈‍⬛, and a 🦁');
     // $slug = 'a-smiley-cat-black-cat-and-a-lion';
 
-If you want to strip emojis from slugs, use the special ``strip`` locale::
-
-    use Symfony\Component\String\Slugger\AsciiSlugger;
-
-    $slugger = new AsciiSlugger();
-    $slugger = $slugger->withEmoji('strip');
-
-    $slug = $slugger->slug('a 😺, 🐈‍⬛, and a 🦁');
-    // $slug = 'a-and-a';
-
 .. _string-inflector:
 
 Inflector


### PR DESCRIPTION
The AsciiSlugger does remove every emoji from a given string per default without any external component or package, as they are not... ASCII.

The paragraph added some confusion to the reader, implying that
* AsciiSlugger did not work with emoji per default
* the special locale + the Intl component was required

So i suggest to purely remove it.

