### PR TITLE
[Form] Explain `choice_label` option for enums

### DIFF
--- a/reference/forms/types/enum.rst
+++ b/reference/forms/types/enum.rst
@@ -80,6 +80,29 @@ implement ``TranslatableInterface`` to translate or display custom labels::
         }
     }
 
+Another way of controlling the label displayed in the ``<option>`` element is by 
+using the `choice_label`. In your `Enum` add a label method::
+
+    // src/Enum/TexAlign.php
+    // ...
+    
+    public function label(): string
+    {
+        return match ($this) {
+            self::Left => 'Left aligned',
+            self::Center => 'Center aligned',
+            self::Right => 'Right aligned',
+        }
+    }
+
+Then in your `EnumType` add the `choice_label`::
+
+    $builder->add('alignment', EnumType::class, [
+        'class' => TextAlign::class,
+        'choice_label' => fn (TextAlign $alignment) => $alignment->label(),
+    ]);
+
+
 Field Options
 -------------
 

--- a/reference/forms/types/enum.rst
+++ b/reference/forms/types/enum.rst
@@ -80,7 +80,7 @@ implement ``TranslatableInterface`` to translate or display custom labels::
         }
     }
 
-Another way of controlling the label displayed in the ``<option>`` element is by 
+Another way of controlling the label displayed in the ``<option>`` element is by
 using the `choice_label`. In your `Enum` add a label method::
 
     // src/Enum/TexAlign.php
@@ -92,7 +92,7 @@ using the `choice_label`. In your `Enum` add a label method::
             self::Left => 'Left aligned',
             self::Center => 'Center aligned',
             self::Right => 'Right aligned',
-        }
+        };
     }
 
 Then in your `EnumType` add the `choice_label`::


### PR DESCRIPTION
Adding an example of how to use the choice_label to control the label displayed in the select. I think this is a beter option then using the TranslaterInterface. Especially if you don't use translations.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
