### PR TITLE
[Reference] Fix assets links have wrong label

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -120,8 +120,10 @@ the application is installed (e.g. in case the project is accessed in a host
 subdirectory) and the optional asset package base path.
 
 Symfony provides various cache busting implementations via the
-:ref:`reference-framework-assets-version`, :ref:`reference-assets-version-strategy`,
-and :ref:`reference-assets-json-manifest-path` configuration options.
+:ref:`assets.version <reference-framework-assets-version>`, 
+:ref:`assets.version_strategy <reference-assets-version-strategy>`, 
+and :ref:`assets.json_manifest_path <reference-assets-json-manifest-path>` 
+configuration options.
 
 .. seealso::
 


### PR DESCRIPTION
Asset options shared the same label, making the reading of [this paragraph](https://symfony.com/doc/current/reference/configuration/framework.html#reference-framework-assets-version) a bit confusing.

I'm more _signaling_ you than fixing it with confidence, as i'm not sure how to use the syntax there with references pages. 

Targetting 5.4 as this "bug" (a strong word there) is on all current versions (5.4 -> 7.1)

<img width="890" alt="screenshot" src="https://github.com/symfony/symfony-docs/assets/1359581/ebca08f7-3f8c-444f-8d7a-24789aacd701">
