### PR TITLE
Fix code example: replace request get() with all() method to support non-scalar types

### DIFF
--- a/form/direct_submit.rst
+++ b/form/direct_submit.rst
@@ -17,7 +17,7 @@ control over when exactly your form is submitted and what data is passed to it::
         $form = $this->createForm(TaskType::class, $task);
 
         if ($request->isMethod('POST')) {
-            $form->submit($request->request->get($form->getName()));
+            $form->submit($request->request->all($form->getName()));
 
             if ($form->isSubmitted() && $form->isValid()) {
                 // perform some action...


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->

Method `$request->request->get` does not support non-scalar types so it won't work with forms since they are received as an array type. 

Using `get` used to work in older Symfony versions but no longer does, now an exception is thrown.

IMO we should use `all` method instead in this example.
