### PR TITLE
[EventDispatcher] Move note below and add examples

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -274,15 +274,6 @@ order. Start by creating this custom event class and documenting it::
 
 Each listener now has access to the order via the ``getOrder()`` method.
 
-.. note::
-
-    If you don't need to pass any additional data to the event listeners, you
-    can also use the default
-    :class:`Symfony\\Contracts\\EventDispatcher\\Event` class. In such case,
-    you can document the event and its name in a generic ``StoreEvents`` class,
-    similar to the :class:`Symfony\\Component\\HttpKernel\\KernelEvents`
-    class.
-
 Dispatch the Event
 ..................
 
@@ -305,6 +296,32 @@ of the event to dispatch::
 Notice that the special ``OrderPlacedEvent`` object is created and passed to
 the ``dispatch()`` method. Now, any listener to the ``OrderPlacedEvent::class``
 event will receive the ``OrderPlacedEvent``.
+
+.. note::
+
+    If you don't need to pass any additional data to the event listeners, you
+    can also use the default
+    :class:`Symfony\\Contracts\\EventDispatcher\\Event` class. In such case,
+    you can document the event and its name in a generic ``StoreEvents`` class,
+    similar to the :class:`Symfony\\Component\\HttpKernel\\KernelEvents`
+    class::
+
+        namespace App\Event;
+
+        class StoreEvents {
+
+            /**
+            * @Event("Symfony\Contracts\EventDispatcher\Event")
+            */
+            public const ORDER_PLACED = 'order.placed';
+        }
+
+    And use the :class:`Symfony\\Contracts\\EventDispatcher\\Event` class to
+    dispatch the event::
+
+        use Symfony\Contracts\EventDispatcher\Event;
+
+        $this->eventDispatcher->dispatch(new Event(), StoreEvents::ORDER_PLACED);
 
 .. _event_dispatcher-using-event-subscribers:
 


### PR DESCRIPTION
I find it more user-friendly to see examples when explaining alternative solutions. The note was also moved lower to give the reader first the context of how the Custom Event with arguments is created, before explaining the alternative solution without arguments.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
