### PR TITLE
Mention Symfony CLI workers where applicable

### DIFF
--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -83,6 +83,13 @@ To build the assets, run the following if you use the Yarn package manager:
 All of these commands - e.g. ``dev`` or ``watch`` - are shortcuts that are defined
 in your ``package.json`` file.
 
+.. tip::
+
+    If you're using the Symfony CLI tool, you can configure workers to be
+    automatically run along with the webserver. You can find more information
+    in the :ref:`Symfony CLI Workers <symfony-server_configuring-workers>`
+    documentation.
+
 .. caution::
 
     Whenever you make changes in your ``webpack.config.js`` file, you must

--- a/messenger.rst
+++ b/messenger.rst
@@ -484,6 +484,13 @@ on your transport and handling them. This command is called your "worker".
 
 .. tip::
 
+    In a development environment and if you're using the Symfony CLI tool,
+    you can configure workers to be automatically run along with the webserver.
+    You can find more information in the
+    :ref:`Symfony CLI Workers <symfony-server_configuring-workers>` documentation.
+
+.. tip::
+
     To properly stop a worker, throw an instance of
     :class:`Symfony\\Component\\Messenger\\Exception\\StopWorkerException`.
 

--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -338,6 +338,8 @@ There are several options that you can set using a ``.symfony.local.yaml`` confi
     using the ``proxy:domain:attach`` command for the current project when you start
     the server.
 
+.. _symfony-server_configuring-workers:
+
 Configuring Workers
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
@kbond had the great idea to add Symfony CLI workers mentions where relevant. I didn't even know about this feature :smile: If any place come into your mind on where this should be added in the docs, I'll gladly take care of it :+1: 

:christmas_tree: 