### PR TITLE
[Intl] Remove warning about replacement layer

### DIFF
--- a/components/intl.rst
+++ b/components/intl.rst
@@ -3,13 +3,6 @@ The Intl Component
 
     This component provides access to the localization data of the `ICU library`_.
 
-.. caution::
-
-    The replacement layer is limited to the ``en`` locale. If you want to use
-    other locales, you should `install the intl extension`_. There is no conflict
-    between the two because, even if you use the extension, this package can still
-    be useful to access the ICU data.
-
 .. seealso::
 
     This article explains how to use the Intl features as an independent component
@@ -430,7 +423,6 @@ Learn more
     /reference/forms/types/locale
     /reference/forms/types/timezone
 
-.. _install the intl extension: https://www.php.net/manual/en/intl.setup.php
 .. _ICU library: https://icu.unicode.org/
 .. _`Unicode ISO 15924 Registry`: https://www.unicode.org/iso15924/iso15924-codes.html
 .. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2


### PR DESCRIPTION
The "replacement layer" mentionned in the first block on the page has been [deprecated in 5.3](https://github.com/symfony/symfony/commit/6ad0169c4feea4881b64dd5cb00acf5e9ecd11dd) (and [removed in 6.0](https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/Intl/CHANGELOG.md#60)).

(that's why i target 6.3+ and not 5.4 -- where it still makes sense to mention it)


```
.. caution::

    The replacement layer is limited to the ``en`` locale. If you want to use
    other locales, you should `install the intl extension`_. There is no conflict
    between the two because, even if you use the extension, this package can still
    be useful to access the ICU data.
```
