### PR TITLE
[Security] Fixing PHP example for limiting login attempts with rate limiter

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1653,7 +1653,7 @@ and set the ``limiter`` option to its service ID:
                     <!-- 2nd argument is the limiter for username+IP -->
                     <srv:argument type="service" id="limiter.username_ip_login"/>
                     <!-- 3rd argument is the app secret -->
-                    <srv:argument type="service" id="%kernel.secret%"/>
+                    <srv:argument type="string">%kernel.secret%</srv:argument>
                 </srv:service>
             </srv:services>
 
@@ -1697,7 +1697,7 @@ and set the ``limiter`` option to its service ID:
                     // 2nd argument is the limiter for username+IP
                     new Reference('limiter.username_ip_login'),
                     // 3rd argument is the app secret
-                    new Reference('kernel.secret'),
+                    param('kernel.secret'),
                 ]);
 
             $security->firewall('main')


### PR DESCRIPTION
After struggling with the rate limiter on my app. 
I think the PHP example for « limiting login attempts » with a rate limiter has a bad copy/paste for the third option to pass to the container to register the `DefaultLoginRateLimiter::class`.

Using `new Reference('kernel.secret')` , I had an error telling me `No services 'kernel.secret' found`

Here is what I used and worked for me and so it is my proposal 🙏 