### PR TITLE
[Serializer] Better example for date denormalization

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -243,7 +243,7 @@ Use the options to specify context specific to normalization or denormalization:
     {
         #[Context(
             normalizationContext: [DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'],
-            denormalizationContext: [DateTimeNormalizer::FORMAT_KEY => \DateTime::RFC3339],
+            denormalizationContext: [DateTimeNormalizer::FORMAT_KEY => '!Y-m-d'], // To prevent to have the time from the moment of denormalization
         )]
         public $createdAt;
 


### PR DESCRIPTION
Hi,

When we use the `DateTimeNormalizer` to denormalize a date without time, using the same format `Y-m-d` does not seem a good example because the object `DateTimeImmutable` has the time from the moment of denormalization.

Example:
```php
$dateTimeFormat = 'Y-m-d'; // From `$context[self::FORMAT_KEY]`

$result = DateTimeImmutable::createFromFormat($dateTimeFormat, '2024-01-31');

var_dump($result);
```

Output:
```
object(DateTimeImmutable)symfony#1 (3) {
  ["date"]=>
  string(26) "2024-01-31 17:14:23.000000"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(16) "Europe/Amsterdam"
}
```

It seems better to differentiate the normalization and the denormalization like:
```php
#[Context(
    normalizationContext: [DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'],
    denormalizationContext: [DateTimeNormalizer::FORMAT_KEY => '!Y-m-d'],
)]
```

The format `!Y-m-d` prevents to have a time and weird behavior.
```php
$dateTimeFormat = '!Y-m-d'; // From `$context[self::FORMAT_KEY]`

$result = DateTimeImmutable::createFromFormat($dateTimeFormat, '2024-01-31');

var_dump($result);
```

Output:
```
object(DateTimeImmutable)symfony#1 (3) {
  ["date"]=>
  string(26) "2024-01-31 00:00:00.000000"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(16) "Europe/Amsterdam"
}
```

WDYT?

Mickaël