### PR TITLE
Update security.rst

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -23,6 +23,7 @@ creates a ``security.yaml`` configuration file for you:
 
     # config/packages/security.yaml
     security:
+        enable_authenticator_manager: true
         # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
         password_hashers:
             Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'


### PR DESCRIPTION
Without this line, I had this error after a cache clear: No authentication listener registered for firewall "main".

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
