### PR TITLE
use PHP 8.2 for Symfony 7 builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
           - name: Set-up PHP
             uses: shivammathur/setup-php@v2
             with:
-                php-version: 8.1
+                php-version: 8.2
                 coverage: none
 
           - name: Fetch branch from where the PR started


### PR DESCRIPTION
We were actually never running our test application with Symfony 7.0/7.1 as our CI config prevented Symfony 7 components to be installed:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires symfony/asset * -> satisfiable by symfony/asset[7.1.x-dev].
    - symfony/asset 7.1.x-dev requires php >=8.2 -> your php version (8.1.27) does not satisfy that requirement.
```