### PR TITLE
[Security] fix getUser function link

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1097,7 +1097,7 @@ token (or whatever you need to return) and return the JSON response:
 
     The ``#[CurrentUser]`` can only be used in controller arguments to
     retrieve the authenticated user. In services, you would use
-    :method:`Symfony\\Component\\Security\\Core\\Security::getUser`.
+    :method:`Symfony\\Bundle\\SecurityBundle\\Security::getUser`.
 
 That's it! To summarize the process:
 


### PR DESCRIPTION

`Symfony\Component\Security\Core\Security` class has been deprecated since 6.2 and deleted in 7.0.

We should use `Symfony\Bundle\SecurityBundle\Security` instead.