### PR TITLE
[Security] [DOC] Update passwords.rst

### DIFF
--- a/security/passwords.rst
+++ b/security/passwords.rst
@@ -518,13 +518,13 @@ migration by returning ``true`` in the ``needsRehash()`` method::
     namespace App\Security;
 
     // ...
-    use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+    use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
-    class CustomPasswordHasher implements UserPasswordHasherInterface
+    class CustomPasswordHasher implements PasswordHasherInterface
     {
         // ...
 
-        public function needsRehash(string $hashed): bool
+        public function needsRehash(string $hashedPassword): bool
         {
             // check whether the current password is hashed using an outdated hasher
             $hashIsOutdated = ...;


### PR DESCRIPTION
The signature of the needsRehash method of the `SymfonyComponentPasswordHasher\Hasher\UserPasswordHasherInterface` interface is `public function needsRehash(PasswordAuthenticatedUserInterface $user): bool;`.

If we use the method `public function needsRehash(string $hashedPassword): bool;`, then the interface should be `Symfony\Component\PasswordHasher\PasswordHasherInterface`.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
