### PR TITLE
[FrameworkBundle] Update `cache_dir` config

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1511,6 +1511,19 @@ cache_dir
 The directory where routing information will be cached. Can be set to
 ``~`` (``null``) to disable route caching.
 
+.. deprecated:: 7.1
+
+    Setting the ``cache_dir`` option is deprecated since Symfony 7.1. The routes
+    are now always cached in the ``%kernel.build_dir%`` directory. If you want
+    to disable route caching, set the ``ignore_cache`` option to ``true``.
+
+ignore_cache
+............
+
+**type**: ``boolean`` **default**: ``false``
+
+When this option is set to ``true``, routing information will not be cached.
+
 secrets
 ~~~~~~~
 


### PR DESCRIPTION
Update the documentation on configuration of the FrameworkBundle to reflect the deprecation of `cache_dir` (done in symfony/symfony#52962) and the introduction of `ignore_cache` (from symfony/symfony#53059).

Fixes #19281

Ping @alexandre-daubois