### PR TITLE
[Doctrine] Automapping validation example seems broken

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -448,12 +448,6 @@ Consider the following controller code::
         public function createProduct(ValidatorInterface $validator): Response
         {
             $product = new Product();
-            // This will trigger an error: the column isn't nullable in the database
-            $product->setName(null);
-            // This will trigger a type mismatch error: an integer is expected
-            $product->setPrice('1999');
-
-            // ...
 
             $errors = $validator->validate($product);
             if (count($errors) > 0) {


### PR DESCRIPTION
As the type hinting from setter is available, this example will not work (and not nullable in that case, it is not possible to run this example with the doc context)

Even without `declare(strict_types=1);` string which could be convert to integer will work but with it, impossible to run this example, as we will have the error "int" expected.
