### PR TITLE
[Doctrine] Profiler bar only visible with at least  tags `<body></body>`

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -601,8 +601,12 @@ the :ref:`doctrine-queries` section.
     see the web debug toolbar, install the ``profiler`` :ref:`Symfony pack <symfony-packs>`
     by running this command: ``composer require --dev symfony/profiler-pack``.
 
+    For more information on ``profiler``, see :doc:`/profiler`.
+
 Automatically Fetching Objects (ParamConverter)
 -----------------------------------------------
+
+.. _doctrine-entity-value-resolver:
 
 In many cases, you can use the `SensioFrameworkExtraBundle`_ to do the query
 for you automatically! First, install the bundle in case you don't have it:


### PR DESCRIPTION
Hello,

I can't show my request until I do a `new Response('<body></body>');` another condition to see it.

Thanks for your work :pray: 