### PR TITLE
[Validator] Fix `mb_detect_encoding` link in `Charset`

### DIFF
--- a/reference/constraints/Charset.rst
+++ b/reference/constraints/Charset.rst
@@ -89,7 +89,7 @@ Options
 An encoding or a set of encodings to check against. If you pass an array of
 encodings, the validator will check if the value is encoded in *any* of the
 encodings. This option accepts any value that can be passed to
-:phpfunction:`mb_detect_encoding()`.
+:phpfunction:`mb_detect_encoding`.
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 


### PR DESCRIPTION
Fix mb_detect_encoding link sending to 404 ( https://www.php.net/manual/en/function.mb-detect-encoding().php )

