### PR TITLE
[Proxy configuration] Add help for hidden SSL termination

### DIFF
--- a/deployment/proxies.rst
+++ b/deployment/proxies.rst
@@ -164,8 +164,31 @@ handling the request::
     // ...
     $response = $kernel->handle($request);
 
+Overriding configuration behind hidden SSL termination
+------------------------------------------------------
+
+Some cloud setups (like running a Docker container with the "Web App for Containers"
+in `Microsoft Azure`_) do SSL termination and contact your web server over http, but
+do not change the remote address nor set the ``X-Forwarded-*`` headers. This means
+the trusted proxy funcationality of Symfony can't help you.
+
+Once you made sure your server is only reachable through the cloud proxy over HTTPS
+and not through HTTP, you can override the information your web server sends to PHP.
+For Nginx, this could look like this:
+
+.. code-block:: nginx
+
+    location ~ ^/index\.php$ {
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi.conf;
+        # Lie to symfony about the protocol and port so that it generates the correct https URLs
+        fastcgi_param SERVER_PORT "443";
+        fastcgi_param HTTPS "on";
+    }
+
 .. _`security groups`: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-groups.html
 .. _`CloudFront`: https://en.wikipedia.org/wiki/Amazon_CloudFront
 .. _`CloudFront IP ranges`: https://ip-ranges.amazonaws.com/ip-ranges.json
 .. _`HTTP Host header attacks`: https://www.skeletonscribe.net/2013/05/practical-http-host-header-attacks.html
 .. _`nginx realip module`: https://nginx.org/en/docs/http/ngx_http_realip_module.html
+.. _`Microsoft Azure`: https://en.wikipedia.org/wiki/Microsoft_Azure


### PR DESCRIPTION
i struggled quite a bit trying to make links generated with https in azure. 

the ssl termination is done by azure, but they "hide" that it happens, there is no information in the HTTP headers about the proxy that does it.