### PR TITLE
[Scheduler] Emphasize `__toString()`

### DIFF
--- a/scheduler.rst
+++ b/scheduler.rst
@@ -189,6 +189,8 @@ For example, if you want to send customer reports daily except for holiday perio
 
         public function __toString(): string
         {
+            // give a nice displayable name to your trigger
+            // to ease debugging
             return $this->inner.' (except holidays)';
         }
 


### PR DESCRIPTION
Fix #18250 

The information is already present but we can emphasize the need to implement this option. What do you think?