### PR TITLE
Revert "match parameter names with AbstractBundle"

### DIFF
--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -127,18 +127,18 @@ method::
 
     class AcmeHelloBundle extends AbstractBundle
     {
-        public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+        public function loadExtension(array $config, ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void
         {
             // load an XML, PHP or Yaml file
-            $container->import('../config/services.xml');
+            $containerConfigurator->import('../config/services.xml');
 
             // you can also add or replace parameters and services
-            $container->parameters()
+            $containerConfigurator->parameters()
                 ->set('acme_hello.phrase', $config['phrase'])
             ;
 
             if ($config['scream']) {
-                $container->services()
+                $containerConfigurator->services()
                     ->get('acme_hello.printer')
                         ->class(ScreamingPrinter::class)
                 ;


### PR DESCRIPTION
This reverts commit 6896b7e44582dc9d986a8ed453c2dbcacf63e00a.

reverting #19321 to make the CI green again