### PR TITLE
[Messenger] Clarify UnrecoverableMessageHandlingException message going to failure transport

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1044,6 +1044,12 @@ and should not be retried. If you throw
 :class:`Symfony\\Component\\Messenger\\Exception\\UnrecoverableMessageHandlingException`,
 the message will not be retried.
 
+.. note::
+
+    Messages that will not be retried, will still show up in the configured failure transport.
+    If you want to avoid that, consider handling the error yourself and let the handler
+    successfully end.
+
 Forcing Retrying
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Related to this issue / question: https://github.com/symfony/symfony/issues/53561