### PR TITLE
[Mailer] Add warning about custom SES headers

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -198,6 +198,11 @@ OhMySMTP             ohmysmtp+smtp://API_TOKEN@default                    n/a   
 
         The ``ping_threshold`` option for ``ses-smtp`` was introduced in Symfony 5.4.
 
+.. caution::
+
+    If you need to send custom headers to receive them later via webhook using the `Amazon SES` transport
+    be sure to use the ``ses+https`` provider since custom headers are not transmited otherwise. 
+
 .. note::
 
     When using SMTP, the default timeout for sending a message before throwing an


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony/issues/45168 by mentioning that the provider needs to be ses+https in order to transmit custom headers.