### PR TITLE
Update symfony_server.rst - create new line for better readability

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -205,6 +205,7 @@ If this is the first time you run the proxy, you must configure it as follows:
    * `Proxy settings in Ubuntu`_.
 
 #. Set the following URL as the value of the **Automatic Proxy Configuration**:
+
    ``http://127.0.0.1:7080/proxy.pac``
 
 Now run this command to start the proxy:


### PR DESCRIPTION
With this change the configuration is not displayed in 2 lines.

I just copied the second line '127.0.0.1:7080/proxy.pac' into my config. And of couse proxy was not working.

Maybe this change help others to not waste time and copy the wrong config.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
