### PR TITLE
[AssetMapper] Adding `{% block importmap %}`

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -44,7 +44,7 @@ It also *updated* the ``templates/base.html.twig`` file:
 .. code-block:: diff
 
     {% block javascripts %}
-    +    {{ importmap('app') }}
+    +    {% block importmap %}{{ importmap('app') }}{% endblock %}
     {% endblock %}
 
 If you're not using Flex, you'll need to create & update these files manually. See


### PR DESCRIPTION
Looks like recent versions are adding it this way.