### PR TITLE
[AssetMapper] Adding `{% block importmap %}` in v6.4

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -48,7 +48,7 @@ It also *updated* the ``templates/base.html.twig`` file:
 .. code-block:: diff
 
     {% block javascripts %}
-    +    {{ importmap('app') }}
+    +    {% block importmap %}{{ importmap('app') }}{% endblock %}
     {% endblock %}
 
 If you're not using Flex, you'll need to create & update these files manually. See


### PR DESCRIPTION
Same as https://github.com/symfony/symfony-docs/pull/19466 but now on the right branch :-)