### PR TITLE
Update service_decoration.rst

### DIFF
--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -301,7 +301,8 @@ the ``decoration_priority`` option. Its value is an integer that defaults to
             class Bar
             {
                 public function __construct(
-                    private #[AutowireDecorated] $inner,
+                    #[AutowireDecorated]
+                    private $inner,
                 ) {
                 }
                 // ...
@@ -311,7 +312,8 @@ the ``decoration_priority`` option. Its value is an integer that defaults to
             class Baz
             {
                 public function __construct(
-                    private #[AutowireDecorated] $inner,
+                    #[AutowireDecorated]
+                    private $inner,
                 ) {
                 }
 


### PR DESCRIPTION
Fix code example to have attribute above property declaration.

You cannot have an attribute between the visibility and the name of the property

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
