### PR TITLE
[Form] Re-adding `choice_label` to EnumType

### DIFF
--- a/reference/forms/types/enum.rst
+++ b/reference/forms/types/enum.rst
@@ -100,6 +100,8 @@ Inherited Options
 
 These options inherit from the :doc:`ChoiceType </reference/forms/types/choice>`:
 
+.. include:: /reference/forms/types/options/choice_label.rst.inc
+
 .. include:: /reference/forms/types/options/error_bubbling.rst.inc
 
 .. include:: /reference/forms/types/options/error_mapping.rst.inc


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/reference/forms/types/enum.html

All `choice*` options are missing (e.g. `choice`, `choice_attr`, etc.).

I don't know if this is the way to bring them back - just wanted to make you aware :-)