### PR TITLE
[VarDumper] Add return to `VarDumper::setHandler()`

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -170,7 +170,7 @@ Outside a Symfony application, use the :class:`Symfony\\Component\\VarDumper\\Du
     ]);
 
     VarDumper::setHandler(function (mixed $var) use ($cloner, $dumper): ?string {
-        $dumper->dump($cloner->cloneVar($var));
+        return $dumper->dump($cloner->cloneVar($var));
     });
 
 .. note::


### PR DESCRIPTION
In the Documentation for the VarDumper component in the "The Dump server" section, the code for configuring the Dump Server outside of a symfony application has an error.

The "setHandler" callback has the return type "?string" but is missing a return statement. This results in the error "{closure}(): Return value must be of type ?string, none returned".