### PR TITLE
[HttpFoundation] Fix `IpsRequestMatcher` reference

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -407,7 +407,7 @@ address, it uses a certain HTTP method, etc.):
 * :class:`Symfony\\Component\\HttpFoundation\\RequestMatcher\\ExpressionRequestMatcher`
 * :class:`Symfony\\Component\\HttpFoundation\\RequestMatcher\\HostRequestMatcher`
 * :class:`Symfony\\Component\\HttpFoundation\\RequestMatcher\\IpsRequestMatcher`
-* :class:`Symfony\\Component\\HttpFoundation\\RequestMatcher\\IsJsonMatcher`
+* :class:`Symfony\\Component\\HttpFoundation\\RequestMatcher\\IsJsonRequestMatcher`
 * :class:`Symfony\\Component\\HttpFoundation\\RequestMatcher\\MethodRequestMatcher`
 * :class:`Symfony\\Component\\HttpFoundation\\RequestMatcher\\PathRequestMatcher`
 * :class:`Symfony\\Component\\HttpFoundation\\RequestMatcher\\PortRequestMatcher`


### PR DESCRIPTION
Valid link is

https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpFoundation/RequestMatcher/IsJsonRequestMatcher.php