### PR TITLE
[DependencyInjection] Add readonly statement to the Lazy Services docs

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -23,7 +23,7 @@ until you interact with the proxy in some way.
 
 .. caution::
 
-    Lazy services do not support `final`_ classes, but you can use
+    Lazy services do not support `final`_ or `readonly` classes, but you can use
     `Interface Proxifying`_ to work around this limitation.
 
     In PHP versions prior to 8.0 lazy services do not support parameters with


### PR DESCRIPTION
The DI container cannot generate a lazy proxy for read-only services.

This will add the missing `readonly` statement to the [docs](https://symfony.com/doc/current/service_container/lazy_services.html) as the title describes.