### PR TITLE
[Serializer] Fix recursive custom normalizer

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -12,8 +12,8 @@ Creating a New Normalizer
 Imagine you want add, modify, or remove some properties during the serialization
 process. For that you'll have to create your own normalizer. But it's usually
 preferable to let Symfony normalize the object, then hook into the normalization
-to customize the normalized data. To do that, leverage the
-``NormalizerAwareInterface`` and the ``NormalizerAwareTrait``. This will give
+to customize the normalized data. To do that, you can inject a
+``NormalizerInterface`` and wire it to Symfony's object normalizer. This will give
 you access to a ``$normalizer`` property which takes care of most of the
 normalization process::
 
@@ -21,16 +21,16 @@ normalization process::
     namespace App\Serializer;
 
     use App\Entity\Topic;
+    use Symfony\Component\DependencyInjection\Attribute\Autowire;
     use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-    use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
-    use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
     use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-    class TopicNormalizer implements NormalizerInterface, NormalizerAwareInterface
+    class TopicNormalizer implements NormalizerInterface
     {
-        use NormalizerAwareTrait;
-
         public function __construct(
+            #[Autowire(service: 'serializer.normalizer.object')]
+            private readonly NormalizerInterface $normalizer,
+
             private UrlGeneratorInterface $router,
         ) {
         }


### PR DESCRIPTION
As mentioned in the following issue: https://github.com/symfony/symfony/issues/53708, the example showing how to create a custom normalizer leads to an infinite recursion.

I could have been fixed like that:
```diff
class TopicNormalizer implements NormalizerInterface, NormalizerAwareInterface
{
    use NormalizerAwareTrait;

+    private const ALREADY_CALLED = self::class.'_already_called';
+
    public function __construct(
        private UrlGeneratorInterface $router,
    ) {
    }

    public function normalize($topic, string $format = null, array $context = []): array
    {
+       $context[self::ALREADY_CALLED] = true;
+
        $data = $this->normalizer->normalize($topic, $format, $context);

        // Here, add, edit, or delete some data:
        $data['href']['self'] = $this->router->generate('topic_show', [
            'id' => $topic->getId(),
        ], UrlGeneratorInterface::ABSOLUTE_URL);

        return $data;
    }

    public function supportsNormalization($data, string $format = null, array $context = []): bool
    {
+        if ($context[self::ALREADY_CALLED] ?? false) {
+            return false;
+        }
+
        return $data instanceof Topic;
    }

    public function getSupportedTypes(?string $format): array
    {
        return [
-             Topic::class => true,
+             Topic::class => false,
        ];
    }
}
```

But this will prevent the normalizer to be cacheable (because it depends on the context).

Instead, I dropped the use of `NormalizerAwareInterface` and `NormalizerAwareTrait` and used an explicit constructor injection instead.

WDYT?