### PR TITLE
Fix translator cache_dir default value reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2508,7 +2508,7 @@ translator
 cache_dir
 .........
 
-**type**: ``string`` | ``null`` **default**: ``%kernel.cache_dir%/translations/``
+**type**: ``string`` | ``null`` **default**: ``%kernel.cache_dir%/translations``
 
 Defines the directory where the translation cache is stored. Use ``null`` to
 disable this cache.


### PR DESCRIPTION
According to https://github.com/symfony/symfony/blob/5.4/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php#L831 is the default value without a `/` at the end.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
