### PR TITLE
[AssetMapper] Minor

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -421,8 +421,8 @@ the page as ``link`` tags in the order they were imported.
 
     Importing a CSS file is *not* something that is natively supported by
     JavaScript modules. AssetMapper makes this work by adding a special importmap
-    entry for each CSS file. These special entries are valid valid, but do nothing.
-    AssetMapper adds a ``<link>`` tag for each CSS file, but when the JavaScript
+    entry for each CSS file. These special entries are valid, but do nothing.
+    AssetMapper adds a ``<link>`` tag for each CSS file, but when JavaScript
     executes the ``import`` statement, nothing additional happens.
 
 .. _asset-mapper-3rd-party-css:


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/frontend/asset_mapper.html#handling-css

This is indeed better than https://github.com/symfony/symfony-docs/pull/19453 was; and much better than before.

1. "valid" in which sense? Valid importmap syntax?
2. What about something like:
    > These special entries are valid importmap syntax, but ignored by JavaScript.

    Then the last sentence could be shortened.