### PR TITLE
[5.4] add note about newer version on the “upgrade major” guide

### DIFF
--- a/setup/upgrade_major.rst
+++ b/setup/upgrade_major.rst
@@ -176,6 +176,12 @@ this one. For instance, update it to ``6.0.*`` to upgrade to Symfony 6.0:
           }
       }
 
+
+.. tip::
+
+    If a more recent minor version is available, e.g. ``6.4``, you can use this version directly
+    and skip the older releases, like ``6.0``. Check the `available versions`_.
+
 Next, use Composer to download new versions of the libraries:
 
 .. code-block:: terminal
@@ -335,3 +341,4 @@ Classes in the ``vendor/`` directory are always ignored.
 
 .. _`PHP CS Fixer`: https://github.com/friendsofphp/php-cs-fixer
 .. _`Rector`: https://github.com/rectorphp/rector
+.. _`available versions`: https://symfony.com/releases


### PR DESCRIPTION
Suggestion for https://symfony.com/doc/5.x/setup/upgrade_major.html#2-update-to-the-new-major-version-via-composer

It looks like this page is useful when a major version has just been released, but I think that it can be misleading once a newer version has been released.

So I added a note so that users don't follow the guide blindly and install `6.0`, but use a newer version when it's applicable.
