### PR TITLE
[AssetMapper] Adding infos to be forwarded to package maintainers in case of error

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -188,6 +188,11 @@ to add any `npm package`_:
 
     $ php bin/console importmap:require bootstrap
 
+.. note::
+
+    If you're getting a 404 error, you can contact the package maintainer and ask them to
+    include `"main":` and `"module":` to the package's `package.json`.
+
 This adds the ``bootstrap`` package to your ``importmap.php`` file::
 
     // importmap.php
@@ -207,6 +212,8 @@ This adds the ``bootstrap`` package to your ``importmap.php`` file::
     such as ``@popperjs/core``. The ``importmap:require`` command will add both the
     main package *and* its dependencies. If a package includes a main CSS file,
     that will also be added (see :ref:`Handling 3rd-Party CSS <asset-mapper-3rd-party-css>`).
+    If the associated CSS file isn't added to the importmap, you can contact the package
+    maintainer and ask them to include `"style":` to the package's `package.json`.
 
 Now you can import the ``bootstrap`` package like usual:
 


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/frontend/asset_mapper.html#importing-3rd-party-javascript-packages

Closes https://github.com/symfony/symfony-docs/issues/19558

Thanks to @tofsjonas for figuring this out at https://github.com/tofsjonas/sortable/issues/68

You might say it's not the job of the Symfony docs to tell JavaScript package maintainers how to set up their packages.

But: With so many packages out there, I doubt that importing them will *always* work. So instead of leaving Symfony users back frustrated, I think it's better to tell them what they can do. And that it's not AssetMapper's fault that it didn't work out.