### PR TITLE
[AssetMapper] Changing the example file away from `.css`

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -14,9 +14,9 @@ is a light layer that helps serve your files directly to the browser.
 The component has two main features:
 
 * :ref:`Mapping & Versioning Assets <mapping-assets>`: All files inside of ``assets/``
-  are made available publicly and **versioned**. You can reference
-  ``assets/styles/app.css`` in a template with ``{{ asset('styles/app.css') }}``.
-  The final URL will include a version hash, like ``/assets/styles/app-3c16d9220694c0e56d8648f25e6035e9.css``.
+  are made available publicly and **versioned**. You can reference the file
+  ``assets/images/product.jpeg`` in a Twig template with ``{{ asset('images/product.jpeg') }}``.
+  The final URL will include a version hash, like ``/assets/images/product-3c16d9220694c0e56d8648f25e6035e9.jpeg``.
 
 * :ref:`Importmaps <importmaps-javascript>`: A native browser feature that makes it easier
   to use the JavaScript ``import`` statement (e.g. ``import { Modal } from 'bootstrap'``)


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/frontend/asset_mapper.html

Reason: `<link>` for CSS is included in `{{ importmap() }}`, so you usually don't have to call `{{ asset() }}` on a CSS.