### PR TITLE
Remove function getSalt() from security user class

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -194,17 +194,6 @@ from the `MakerBundle`_:
         }
 
         /**
-         * Returning a salt is only needed if you are not using a modern
-         * hashing algorithm (e.g. bcrypt or sodium) in your security.yaml.
-         *
-         * @see UserInterface
-         */
-        public function getSalt(): ?string
-        {
-            return null;
-        }
-
-        /**
          * @see UserInterface
          */
         public function eraseCredentials(): void


### PR DESCRIPTION
The method getSalt() is no longer part of the UserInterface