### PR TITLE
[Forms] Use regular JavaScript functions in the examples

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -314,7 +314,7 @@ you'll replace with a unique, incrementing number (e.g. ``task[tags][3][name]``)
 
 .. code-block:: javascript
 
-    const addFormToCollection = (e) => {
+    function addFormToCollection(e) {
       const collectionHolder = document.querySelector('.' + e.currentTarget.dataset.collectionHolderClass);
 
       const item = document.createElement('li');
@@ -579,7 +579,8 @@ on the server. In order for this to work in an HTML form, you must remove
 the DOM element for the collection item to be removed, before submitting
 the form.
 
-First, add a "delete this tag" link to each tag form:
+In our JavaScript, we first need add a "delete" button to each existing tag on the page.
+Then, we append the "add delete button" method in the function that adds the new tags.
 
 .. code-block:: javascript
 
@@ -591,7 +592,7 @@ First, add a "delete this tag" link to each tag form:
 
     // ... the rest of the block from above
 
-    const addFormToCollection = (e) => {
+    function addFormToCollection(e) {
         // ...
 
         // add a delete link to the new form
@@ -602,7 +603,7 @@ The ``addTagFormDeleteLink()`` function will look something like this:
 
 .. code-block:: javascript
 
-    const addTagFormDeleteLink = (item) => {
+    function addTagFormDeleteLink(item) {
         const removeFormButton = document.createElement('button');
         removeFormButton.innerText = 'Delete this tag';
 


### PR DESCRIPTION
There is no real point to use `const` for functions. While it surely is an opinion, the arrow syntax should only be used for anonymous functions and it seems more confusing for newer people.

* To me and I would assume a new user `function (...) {` is instantly more clearer that we are working with a function instead of a variable
* Function has no name during debugging when using arrow syntax
* Its not shorter `function foo(e) {` vs `const foo = (e) => {`
* Hoisting is weird, specially for newer people (https://stackoverflow.com/a/33040926)

I also changed the introduction line to the delete button part to detail what the user is going to do in following code block which seemed a little unclear to me personally. If the writing is not ok, please change it.