### PR TITLE
Fix wording of code example blurb in lazy_services.rst

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -121,7 +121,7 @@ You can also configure laziness when your service is injected with the
     }
 
 This attribute also allows you to define the interfaces to proxy when using
-laziness, and supports lazy-autowiring of intersection types::
+laziness, and supports lazy-autowiring of union types::
 
     public function __construct(
         #[Autowire(service: 'foo', lazy: FooInterface::class)]


### PR DESCRIPTION
The code example shows how one member of a union type, and not an intersection type as stated, can be targeted with `#[Autowire(lazy: ...)]`.