### PR TITLE
Fix the toctree syntax of some content

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -85,4 +85,7 @@ Create your Own Framework
 
 Want to create your own framework based on Symfony?
 
-.. include:: /create_framework/map.rst.inc
+.. toctree::
+   :maxdepth: 2
+
+   create_framework/index


### PR DESCRIPTION
This tries to fix the missing Prev/Next link in the "Create your own framework" docs.

See https://github.com/symfony-tools/docs-builder/issues/164#issuecomment-1890965891