### PR TITLE
Add MapRequestPayload tips with built-in types

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -539,10 +539,18 @@ if you want to map a nested array of specific DTOs::
         ) {}
     }
 
-.. tip::
+.. caution::
 
-    If using typed properties with `MapRequestPayload`, it's recommanded to use built-in types (like `int`, `bool`, `string`...) for mapping. Using custom types can expose your application implementation outside with errors during denormalization.
-    Validating an Enum in your `#[MapRequestPayload]` class should look like this::
+    If you're using typed properties with ``MapRequestPayload```, it is 
+    recommended to use built-in types like ``int``, ``bool`` or ``string`` for 
+    mapping. Using custom types could expose your application implementation in 
+    errors during denormalization. For example, validating an enum when using
+    ``#[MapRequestPayload]`` could look like this::
+
+        // src/Controller/LuckyController.php
+        use App\Model\MyInput;
+        use Symfony\Component\HttpFoundation\Response;
+        use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 
         class LuckyController
         {
@@ -553,12 +561,14 @@ if you want to map a nested array of specific DTOs::
             }
         }
 
+        // src/Model/MyInput.php
         class MyInput
         {
             #[Assert\Choice(callback: [MyEnum::class, 'values'])]
             public string $myInputAttribute;
         }
 
+        // src/Model/MyEnum.php
         enum MyEnum: string
         {
             case FIRST_CASE = 'first_case';

--- a/controller.rst
+++ b/controller.rst
@@ -541,9 +541,9 @@ if you want to map a nested array of specific DTOs::
 
 .. caution::
 
-    If you're using typed properties with ``MapRequestPayload```, it is 
-    recommended to use built-in types like ``int``, ``bool`` or ``string`` for 
-    mapping. Using custom types could expose your application implementation in 
+    If you're using typed properties with ``MapRequestPayload```, it is
+    recommended to use built-in types like ``int``, ``bool`` or ``string`` for
+    mapping. Using custom types could expose your application implementation in
     errors during denormalization. For example, validating an enum when using
     ``#[MapRequestPayload]`` could look like this::
 

--- a/controller.rst
+++ b/controller.rst
@@ -539,6 +539,37 @@ if you want to map a nested array of specific DTOs::
         ) {}
     }
 
+.. tip::
+
+    If using typed properties with `MapRequestPayload`, it's recommanded to use built-in types (like `int`, `bool`, `string`...) for mapping. Using custom types can expose your application implementation outside with errors during denormalization.
+    Validating an Enum in your `#[MapRequestPayload]` class should look like this::
+
+        class LuckyController
+        {
+            #[Route('/lucky/number/{max}', name: 'app_lucky_number', methods: ['POST'])]
+            public function number(#[MapRequestPayload] MyInput $input, int $max): Response
+            {
+                // use it like this : $input->myInputAttribute;
+            }
+        }
+
+        class MyInput
+        {
+            #[Assert\Choice(callback: [MyEnum::class, 'values'])]
+            public string $myInputAttribute;
+        }
+
+        enum MyEnum: string
+        {
+            case FIRST_CASE = 'first_case';
+            case SECOND_CASE = 'second_case';
+
+            public static function values(): array
+            {
+                return array_column(self::cases(), 'value');
+            }
+        }
+
 Managing the Session
 --------------------
 


### PR DESCRIPTION
Added a tip for using built-in types only with `MapRequestPayload`, to avoid revealing the internal implementation of your applications 

Edit : I tried to target to 7.0 because feature is already available but lot of commits involved. Currently stay for 7.1, let you decide (or I can make a new PR to target 6.4 if you want)