### PR TITLE
Fix debug config reference dump_destination

### DIFF
--- a/reference/configuration/debug.rst
+++ b/reference/configuration/debug.rst
@@ -95,8 +95,13 @@ Typically, you would set this to ``php://stderr``:
     .. code-block:: php
 
         // config/packages/debug.php
-        $container->loadFromExtension('debug', [
-            'dump_destination' => 'php://stderr',
-        ]);
+        use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+        return static function (ContainerConfigurator $container): void {
+            $container->extension('debug', [
+                'dump_destination' => 'tcp://%env(VAR_DUMPER_SERVER)%',
+            ]);
+        };
+
 
 Configure it to ``"tcp://%env(VAR_DUMPER_SERVER)%"`` in order to use the :ref:`ServerDumper feature <var-dumper-dump-server>`.


### PR DESCRIPTION
The method `loadFromExtension` does not exist in the `Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;`

The only way to do this is to use the `extension` method, which then calls  `loadFromExtension `, as you can see in the class when using `CRTL+F` : 

![image](https://github.com/symfony/symfony-docs/assets/46444652/a330f98f-c7ba-42f2-baa5-672d50d3169e)

