### PR TITLE
chore: add the request/response/exception flow diagram to showcase events

### DIFF
--- a/reference/events.rst
+++ b/reference/events.rst
@@ -7,6 +7,12 @@ application using the :doc:`HttpKernel component </components/http_kernel>`)
 dispatches some :doc:`events </event_dispatcher>` which you can use to modify
 how the request is handled and how the response is returned.
 
+.. raw:: html
+
+    <object data="../_images/components/http_kernel/http-workflow-exception.svg" type="image/svg+xml"
+        alt="The HTTP Kernel flow diagram showing events flow"
+    ></object>
+
 Kernel Events
 -------------
 


### PR DESCRIPTION
The diagram can be found deep in https://symfony.com/doc/current/components/http_kernel.html#handling-exceptions-the-kernel-exception-event

to me, it is very interesting to represent in the head/mind the flow, just before reading all the internals symfony events

wdyt?