### PR TITLE
chore: replace `workflow` by `flow` and add more context

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -15,8 +15,8 @@ Installation
 
 .. include:: /components/require_autoload.rst.inc
 
-The Workflow of a Request
--------------------------
+The Full Flow of a Request-Response lifecycle
+---------------------------------------------
 
 .. seealso::
 
@@ -29,7 +29,7 @@ The Workflow of a Request
 Every HTTP web interaction begins with a request and ends with a response.
 Your job as a developer is to create PHP code that reads the request information
 (e.g. the URL) and creates and returns a response (e.g. an HTML page or JSON string).
-This is a simplified overview of the request workflow in Symfony applications:
+This is a simplified overview of the request to response flow in Symfony applications:
 
 #. The **user** asks for a **resource** in a **browser**;
 #. The **browser** sends a **request** to the **server**;
@@ -66,7 +66,7 @@ that system::
 
 Internally, :method:`HttpKernel::handle() <Symfony\\Component\\HttpKernel\\HttpKernel::handle>` -
 the concrete implementation of :method:`HttpKernelInterface::handle() <Symfony\\Component\\HttpKernel\\HttpKernelInterface::handle>` -
-defines a workflow that starts with a :class:`Symfony\\Component\\HttpFoundation\\Request`
+defines a process flow that starts with a :class:`Symfony\\Component\\HttpFoundation\\Request`
 and ends with a :class:`Symfony\\Component\\HttpFoundation\\Response`.
 
 .. raw:: html
@@ -75,7 +75,7 @@ and ends with a :class:`Symfony\\Component\\HttpFoundation\\Response`.
         alt="A flow diagram showing all HTTP Kernel events in the Request-Response lifecycle. Each event is numbered 1 to 8 and described in detail in the following subsections."
     ></object>
 
-The exact details of this workflow are the key to understanding how the kernel
+The exact details of this flow are the key to understanding how the kernel
 (and the Symfony Framework or any other library that uses the kernel) works.
 
 HttpKernel: Driven by Events


### PR DESCRIPTION
idea:
add more context that its a request/response logic (actually we read more request than response)
swap the word workflow to flow (ref https://github.com/symfony/symfony-docs/pull/19603 and the kernel flow)
