### PR TITLE
[AssetMapper] Removing PostCSS

### DIFF
--- a/frontend.rst
+++ b/frontend.rst
@@ -35,7 +35,7 @@ Supports Sass/Tailwind            :ref:`yes <asset-mapper-tailwind>`  yes
 Supports React, Vue, Svelte?      yes :ref:`[1] <ux-note-1>`          yes
 Supports TypeScript               :ref:`yes <asset-mapper-ts>`        yes
 Removes comments from JavaScript  no                                  yes
-Removes comments from CSS         no :ref:`[2] <ux-note-2>`           no :ref:`[2] <ux-note-2>`
+Removes comments from CSS         no                                  no
 Versioned assets                  always                              optional
 ================================  ==================================  ==========
 
@@ -45,10 +45,6 @@ Versioned assets                  always                              optional
 need to use their native tools for pre-compilation. Also, some features (like
 Vue single-file components) cannot be compiled down to pure JavaScript that can
 be executed by a browser.
-
-.. _ux-note-2:
-
-**[2]** There are some `PostCSS`_ plugins available to remove comments from CSS files.
 
 .. _frontend-asset-mapper:
 


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/frontend.html

Sorry for the back-and-forth!
2 reasons for deleting it again:
* I was thinking that PostCSS is some de-facto standard, but it isn't.
* It's odd to "recommend" something for CSS, but nothing for JS.

I just suggested to integrate minifying into AssetMapper: https://github.com/symfony/symfony/issues/54070