### PR TITLE
PostgreSQL setparameter() compatibility

### DIFF
--- a/components/uid.rst
+++ b/components/uid.rst
@@ -285,6 +285,7 @@ of the UUID parameters::
     // src/Repository/ProductRepository.php
 
     // ...
+    use Doctrine\DBAL\ParameterType;
     use Symfony\Bridge\Doctrine\Types\UuidType;
 
     class ProductRepository extends ServiceEntityRepository
@@ -300,7 +301,8 @@ of the UUID parameters::
 
                 // alternatively, you can convert it to a value compatible with
                 // the type inferred by Doctrine
-                ->setParameter('user', $user->getUuid()->toBinary())
+                // Note: ParameterType::BINARY is required to query PostgreSQL
+                ->setParameter('user', $user->getUuid()->toBinary(), ParameterType::BINARY)
             ;
 
             // ...


### PR DESCRIPTION
Using PostgreSQL, Doctrine will use UUID field type. If you don't specify the parameter type it will try to send a string instead of the binary content and fail with an error :

```
SQLSTATE[22021]: Character not in repertoire: 7 ERROR:  invalid byte sequence for encoding \"UTF8\": ...
CONTEXT:  unnamed portal parameter $1
```
