### PR TITLE
[Console] Add upercases to match console output

### DIFF
--- a/components/console/usage.rst
+++ b/components/console/usage.rst
@@ -104,7 +104,7 @@ If you do not provide a console name then it will just output:
 
 .. code-block:: text
 
-    console tool
+    Console Tool
 
 You can force turning on ANSI output coloring with:
 


### PR DESCRIPTION
As per : https://github.com/symfony/symfony/blob/3a02e2103409c58b8ff45c15f44bb8d1f4b3e698/src/Symfony/Component/Console/Application.php#L484C17-L484C24
