### PR TITLE
[AssetMapper] Shortening "Optimizing Performance"

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -635,8 +635,7 @@ which will automatically do most of these things for you:
 - **Compress your assets**: Your web server should compress (e.g. using gzip)
   your assets (JavaScript, CSS, images) before sending them to the browser. This
   is automatically enabled in Caddy and can be activated in Nginx and Apache.
-  Or, proxy your site through a service like Cloudflare, which will
-  automatically compress your assets for you. In Cloudflare, you can also
+  In Cloudflare, you can also
   enable `auto minify`_ to further compress your assets (e.g. removing
   whitespace and comments from JavaScript and CSS files).
 
@@ -658,7 +657,7 @@ Performance: Understanding Preloading
 
     Automatic preloading of JavaScript files was introduced in Symfony 6.4.
 
-One issue that LightHouse may report is:
+One issue that Lighthouse may report is:
 
     Avoid Chaining Critical Requests
 


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/frontend/asset_mapper.html#optimizing-performance

I agree with your care about newcomers in https://github.com/symfony/symfony-docs/pull/19609#issuecomment-1971023178

But those 3 paragraphs still sound like a Cloudflare commercial...

Please start reading at https://symfony.com/doc/6.4/frontend/asset_mapper.html#optimizing-performance
> To make your AssetMapper-powered site fly,...