### PR TITLE
[AssetMapper] Recommending `Cache-Control` instead of `Expires` HTTP header

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -640,10 +640,10 @@ which will automatically do most of these things for you:
   enable `auto minify`_ to further compress your assets (e.g. removing
   whitespace and comments from JavaScript and CSS files).
 
-- **Set long-lived Expires headers**: Your web server should set long-lived
-  ``Expires`` HTTP headers on your assets. Because the AssetMapper component includes a version
-  hash in the filename of each asset, you can safely set the ``Expires`` header
-  to a very long time in the future (e.g. 1 year). This isn't automatic in
+- **Set long-lived cache expiry**: Your web server should set a long-lived
+  ``Cache-Control`` HTTP header on your assets. Because the AssetMapper component includes a version
+  hash in the filename of each asset, you can safely set ``max-age``
+  to a very long time (e.g. 1 year). This isn't automatic in
   any web server, but can be easily enabled.
 
 Once you've done these things, you can use a tool like `Lighthouse`_ to


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/frontend/asset_mapper.html#optimizing-performance

Closes https://github.com/symfony/symfony-docs/issues/19626