### PR TITLE
[Templating] [Templates] Replace Webpack with AssetMapper (minor)

### DIFF
--- a/templates.rst
+++ b/templates.rst
@@ -330,7 +330,7 @@ Build, Versioning & More Advanced CSS, JavaScript and Image Handling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For help building, versioning and minifying your JavaScript and
-CSS assets in a modern way, read about :doc:`Symfony's Webpack Encore </frontend>`.
+CSS assets in a modern way, read about :doc:`Symfony's Asset Mapper </frontend>`.
 
 .. _twig-app-variable:
 


### PR DESCRIPTION
Feature AM (as the "recommanded" choice) in this small note in the [Templating](https://symfony.com/doc/7.1/templates.html#build-versioning-more-advanced-css-javascript-and-image-handling) page.

(No need to change the link URL: it targets the shared "[frontend](https://symfony.com/doc/7.1/frontend.html)" page that present both solutions)