### PR TITLE
[String] Reorganize String component contents

### DIFF
--- a/_build/redirection_map
+++ b/_build/redirection_map
@@ -529,7 +529,7 @@
 /components/serializer#component-serializer-attributes-groups-annotations /components/serializer#component-serializer-attributes-groups-attributes
 /logging/monolog_regex_based_excludes /logging/monolog_exclude_http_codes
 /security/named_encoders /security/named_hashers
-/components/inflector /components/string#inflector
+/components/inflector /string#inflector
 /security/experimental_authenticators /security
 /security/user_provider /security/user_providers
 /security/reset_password /security/passwords#reset-password
@@ -566,3 +566,4 @@
 /messenger/handler_results /messenger#messenger-getting-handler-results
 /messenger/dispatch_after_current_bus /messenger#messenger-transactional-messages
 /messenger/multiple_buses /messenger#messenger-multiple-buses
+/components/string /string

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -385,12 +385,9 @@ to catching the exception, you can also check if a given timezone ID is valid::
 Emoji Transliteration
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. note::
-
-    The ``EmojiTransliterator`` class provides a utility to translate emojis into
-    their textual representation in all languages based on the Unicode CLDR dataset.
-
-Discover all the available Emoji manipulations in the :ref:`component documentation <working-with-emojis>`.
+Symfony provides utilities to translate emojis into their textual representation
+in all languages. Read the documentation on :ref:`working with emojis in strings <string-emoji-transliteration>`
+to learn more about this feature.
 
 Disk space
 ----------

--- a/string.rst
+++ b/string.rst
@@ -1,11 +1,11 @@
-The String Component
-====================
+Creating and Manipulating Strings
+=================================
 
-    The String component provides a single object-oriented API to work with
-    three "unit systems" of strings: bytes, code points and grapheme clusters.
+Symfony provides an object-oriented API to work with Unicode strings (as bytes,
+code points and grapheme clusters). This API is available via the String component,
+which you must first install in your application:
 
-Installation
-------------
+.. _installation:
 
 .. code-block:: terminal
 
@@ -523,6 +523,8 @@ which you must first install in your application:
 .. code-block:: terminal
 
     $ composer require symfony/emoji
+
+.. include:: /components/require_autoload.rst.inc
 
 The data needed to store the transliteration of all emojis (~5,000) into all
 languages take a considerable disk space.


### PR DESCRIPTION
As mentioned in #19489, we want to move contents out from `components/`. This PR moves String to its own root-level article.