### PR TITLE
Fix different function signature for loadExtension function in docs and code

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -2,7 +2,6 @@ rules:
     american_english: ~
     argument_variable_must_match_type:
         arguments:
-            - { type: 'ContainerBuilder', name: 'container' }
             - { type: 'ContainerConfigurator', name: 'container' }
     avoid_repetetive_words: ~
     blank_line_after_anchor: ~

--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -357,7 +357,7 @@ logic to the bundle class directly::
         {
             // Contrary to the Extension class, the "$config" variable is already merged
             // and processed. You can use it directly to configure the service container.
-            $containerConfigurator->services()
+            $container->services()
                 ->get('acme.social.twitter_client')
                 ->arg(0, $config['twitter']['client_id'])
                 ->arg(1, $config['twitter']['client_secret'])

--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -353,7 +353,7 @@ logic to the bundle class directly::
             ;
         }
 
-        public function loadExtension(array $config, ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void
+        public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
         {
             // Contrary to the Extension class, the "$config" variable is already merged
             // and processed. You can use it directly to configure the service container.

--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -127,7 +127,7 @@ method::
 
     class AcmeHelloBundle extends AbstractBundle
     {
-        public function loadExtension(array $config, ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void
+        public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
         {
             // load an XML, PHP or Yaml file
             $containerConfigurator->import('../config/services.xml');

--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -130,15 +130,15 @@ method::
         public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
         {
             // load an XML, PHP or Yaml file
-            $containerConfigurator->import('../config/services.xml');
+            $container->import('../config/services.xml');
 
             // you can also add or replace parameters and services
-            $containerConfigurator->parameters()
+            $container->parameters()
                 ->set('acme_hello.phrase', $config['phrase'])
             ;
 
             if ($config['scream']) {
-                $containerConfigurator->services()
+                $container->services()
                     ->get('acme_hello.printer')
                         ->class(ScreamingPrinter::class)
                 ;

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -330,7 +330,7 @@ add a service conditionally based on the ``foo`` value::
                 ->end();
         }
 
-        public function loadExtension(array $config, ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void
+        public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
         {
             if ($config['foo']) {
                 $containerBuilder->register('foo_service', \stdClass::class);

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -333,7 +333,7 @@ add a service conditionally based on the ``foo`` value::
         public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
         {
             if ($config['foo']) {
-                $containerBuilder->register('foo_service', \stdClass::class);
+                $builder->register('foo_service', \stdClass::class);
             }
         }
     }


### PR DESCRIPTION
Fixed the argument names for loadExtension usages in the code examples and rewritten the function bodies to use the new names.

Closes #19668 
