### PR TITLE
doc: Access Token Authentication - added a disambiguation on what the identifier is

### DIFF
--- a/security/access_token.rst
+++ b/security/access_token.rst
@@ -97,6 +97,7 @@ This handler must implement
             }
 
             // and return a UserBadge object containing the user identifier from the found token
+            // the user identifier being an email, a username and not necessarily an Id
             return new UserBadge($accessToken->getUserId());
         }
     }


### PR DESCRIPTION
Users could be confused seeing getUserId() and returning a user Id instead of the identifier defined in the app, such as an email.

Well I got stuck a fair amount of time on this, this comment might help others ? 

