### PR TITLE
[Form] Fix the default value for the constraints option of forms

### DIFF
--- a/reference/forms/types/options/constraints.rst.inc
+++ b/reference/forms/types/options/constraints.rst.inc
@@ -1,7 +1,7 @@
 ``constraints``
 ~~~~~~~~~~~~~~~
 
-**type**: ``array`` or :class:`Symfony\\Component\\Validator\\Constraint` **default**: ``null``
+**type**: ``array`` or :class:`Symfony\\Component\\Validator\\Constraint` **default**: ``[]``
 
 Allows you to attach one or more validation constraints to a specific field.
 For more information, see :ref:`Adding Validation <form-option-constraints>`.


### PR DESCRIPTION
`null` is not a valid value of this option.
