### PR TITLE
[MakerBundle] document --with-uuid & --with-ulid

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -157,9 +157,16 @@ Whoa! You now have a new ``src/Entity/Product.php`` file::
         // ... getter and setter methods
     }
 
+.. tip::
+
+    Starting in `MakerBundle`_: v1.57.0 - You can pass either ``--with-uuid`` or
+    ``--with-ulid`` to ``make:entity``. Leveraging Symfony's :doc:`Uid Component </components/uid>`,
+    this generates an entity with the ``id`` type as :ref:`Uuid <uuid>`
+    or :ref:`Ulid <ulid>` instead of ``int``.
+
 .. note::
 
-    Starting in v1.44.0 - MakerBundle only supports entities using PHP attributes.
+    Starting in v1.44.0 - `MakerBundle`_: only supports entities using PHP attributes.
 
 .. note::
 
@@ -909,3 +916,4 @@ Learn more
 .. _`PDO`: https://www.php.net/pdo
 .. _`available Doctrine extensions`: https://github.com/doctrine-extensions/DoctrineExtensions
 .. _`StofDoctrineExtensionsBundle`: https://github.com/stof/StofDoctrineExtensionsBundle
+.. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -79,6 +79,13 @@ This will generate your new entity class::
         // ... getters and setters
     }
 
+.. tip::
+
+    Starting in `MakerBundle`_: v1.57.0 - You can pass either ``--with-uuid`` or
+    ``--with-ulid`` to ``make:entity``. Leveraging Symfony's :doc:`Uid Component </components/uid>`,
+    this generates an entity with the ``id`` type as :ref:`Uuid <uuid>`
+    or :ref:`Ulid <ulid>` instead of ``int``.
+
 Mapping the ManyToOne Relationship
 ----------------------------------
 
@@ -700,3 +707,4 @@ Doctrine's `Association Mapping Documentation`_.
 .. _`orphanRemoval`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/working-with-associations.html#orphan-removal
 .. _`Mastering Doctrine Relations`: https://symfonycasts.com/screencast/doctrine-relations
 .. _`ArrayCollection`: https://www.doctrine-project.org/projects/doctrine-collections/en/1.6/index.html
+.. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html

--- a/security.rst
+++ b/security.rst
@@ -232,6 +232,13 @@ from the `MakerBundle`_:
         }
     }
 
+.. tip::
+
+    Starting in `MakerBundle`_: v1.57.0 - You can pass either ``--with-uuid`` or
+    ``--with-ulid`` to ``make:user``. Leveraging Symfony's :doc:`Uid Component </components/uid>`,
+    this generates a ``User`` entity with the ``id`` type as :ref:`Uuid <uuid>`
+    or :ref:`Ulid <ulid>` instead of ``int``.
+
 .. versionadded:: 5.3
 
     The :class:`Symfony\\Component\\Security\\Core\\User\\PasswordAuthenticatedUserInterface`

--- a/security/passwords.rst
+++ b/security/passwords.rst
@@ -294,6 +294,13 @@ you'll see a success message and a list of any other steps you need to do.
 
     $ php bin/console make:reset-password
 
+.. tip::
+
+    Starting in `MakerBundle`_: v1.57.0 - You can pass either ``--with-uuid`` or
+    ``--with-ulid`` to ``make:reset-password``. Leveraging Symfony's :doc:`Uid Component </components/uid>`,
+    the entities will be generated with the ``id`` type as :ref:`Uuid <uuid>`
+    or :ref:`Ulid <ulid>` instead of ``int``.
+
 You can customize the reset password bundle's behavior by updating the
 ``reset_password.yaml`` file. For more information on the configuration,
 check out the `SymfonyCastsResetPasswordBundle`_  guide.


### PR DESCRIPTION
Introduced in MakerBundle `v1.57.0` passing `--with-uuid` || --with-ulid` to:

- `make:user`
- `make:entity`
- `make:reset-password`

Will generate the entities with either `Uuid`'s or `Ulid`'s for the entities `id` / primary key.

https://github.com/symfony/maker-bundle/releases/tag/v1.57.0

