### PR TITLE
[MakerBundle] `make:migration` supports --formatted option

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -225,6 +225,11 @@ already installed:
 
     $ php bin/console make:migration
 
+.. tip::
+
+    Starting in `MakerBundle`_: v1.56.0 - Passing ``--formatted`` to ``make:migration``
+    generates a nice and tidy migration file.
+
 If everything worked, you should see something like this:
 
 .. code-block:: text
@@ -909,3 +914,4 @@ Learn more
 .. _`PDO`: https://www.php.net/pdo
 .. _`available Doctrine extensions`: https://github.com/doctrine-extensions/DoctrineExtensions
 .. _`StofDoctrineExtensionsBundle`: https://github.com/stof/StofDoctrineExtensionsBundle
+.. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html

--- a/security.rst
+++ b/security.rst
@@ -245,6 +245,11 @@ to create the tables by :ref:`creating and running a migration <doctrine-creatin
     $ php bin/console make:migration
     $ php bin/console doctrine:migrations:migrate
 
+.. tip::
+
+    Starting in `MakerBundle`_: v1.56.0 - Passing ``--formatted`` to ``make:migration``
+    generates a nice and tidy migration file.
+
 .. _where-do-users-come-from-user-providers:
 .. _security-user-providers:
 


### PR DESCRIPTION
Released in `v1.56.0`, passing `--formatted` will generate a "human friendly" migration file.

https://github.com/symfony/maker-bundle/releases/tag/v1.56.0