### PR TITLE
Fix wrong link for https_proxy in lowercase explanation

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -530,5 +530,5 @@ help debug any issues.
 .. _`Proxy settings in Windows`: https://www.dummies.com/computers/operating-systems/windows-10/how-to-set-up-a-proxy-in-windows-10/
 .. _`Proxy settings in macOS`: https://support.apple.com/guide/mac-help/enter-proxy-server-settings-on-mac-mchlp2591/mac
 .. _`Proxy settings in Ubuntu`: https://help.ubuntu.com/stable/ubuntu-help/net-proxy.html.en
-.. _`is treated differently`: https://ec.haxx.se/usingcurl/usingcurl-proxies#http_proxy-in-lower-case-only
+.. _`is treated differently`: https://superuser.com/a/1799209
 .. _`Docker compose CLI env var reference`: https://docs.docker.com/compose/reference/envvars/


### PR DESCRIPTION
I saw this link was wrong besides the explanation is interesting. Here is a screen of the original content:
<img width="770" alt="image" src="https://github.com/symfony/symfony-docs/assets/972456/95ee9957-0801-405f-bf1d-5796c341eb40">

I was searching for some explanation that is not going to disappear so I decided to suggest a superuser link.