### PR TITLE
[HttpKernel] Update micro_kernel_trait.rst

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -230,6 +230,7 @@ Now it looks like this::
 
     use App\DependencyInjection\AppExtension;
     use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
     use Symfony\Component\HttpKernel\Kernel as BaseKernel;
     use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;


### PR DESCRIPTION
ContainerBuilder class is missing in src/Kernel.php

`use Symfony\Component\DependencyInjection\ContainerBuilder;`
