### PR TITLE
[VarExporter] Remove "lazyObjectId" from LazyGhostTrait because it doesn't seem to do anything

### DIFF
--- a/components/var_exporter.rst
+++ b/components/var_exporter.rst
@@ -210,9 +210,6 @@ initialized::
     class HashProcessor
     {
         use LazyGhostTrait;
-        // Because of how the LazyGhostTrait trait works internally, you
-        // must add this private property in your class
-        private int $lazyObjectId;
 
         // This property may require a heavy computation to have its value
         public readonly string $hash;


### PR DESCRIPTION
Hello,

If I didn't miss any hidden dynamic resolving black magic, the variable "lazyObjectId" doesn't seem to have any uses for LazyGhost to work, if that's the case, I made the modification to remove this potentially missleading part of the documentation