### PR TITLE
[HttpKernel] MapQueryParameter regex example correction

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -375,7 +375,7 @@ attribute, arguments of your controller's action can be automatically fulfilled:
     // ...
 
     public function dashboard(
-        #[MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => '/^\w++$/'])] string $firstName,
+        #[MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => '/^\w+$/'])] string $firstName,
         #[MapQueryParameter] string $lastName,
         #[MapQueryParameter(filter: \FILTER_VALIDATE_INT)] int $age,
     ): Response


### PR DESCRIPTION
Correction of the example using MapQueryParameter with the filter using a regex.
