### PR TITLE
Update session.rst

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -541,7 +541,7 @@ a Symfony service for the connection to the Redis server:
 
             Redis:
                 # you can also use \RedisArray, \RedisCluster or \Predis\Client classes
-                class: Redis
+                class: \Redis
                 calls:
                     - connect:
                         - '%env(REDIS_HOST)%'


### PR DESCRIPTION
using Redis as class is in error, the class needs to be specified as \Redis as that is the correct namespace.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
