### PR TITLE
fix: typo in reverse proxy docs

### DIFF
--- a/deployment/proxies.rst
+++ b/deployment/proxies.rst
@@ -156,7 +156,7 @@ subpath/subfolder of the reverse proxy.
 To fix this, you need to pass the subpath/subfolder route prefix of the reverse
 proxy to Symfony by setting the ``X-Forwarded-Prefix`` header. The header can
 normally be configured in your reverse proxy configuration. Configure
-``X-Forwared-Prefix`` as trusted header to be able to use this feature.
+``X-Forwarded-Prefix`` as trusted header to be able to use this feature.
 
 The ``X-Forwarded-Prefix`` is used by Symfony to prefix the base URL of request
 objects, which is used to generate absolute paths and URLs in Symfony applications.


### PR DESCRIPTION
There was a typo in one of the `X-Forwarded-Prefix` mentions.
Exactly the one I copied so was stuck on the header not working 😅 
