### PR TITLE
Remove the warning marking the symfony server config file as experimental

### DIFF
--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -307,11 +307,6 @@ server provides a ``run`` command to wrap them as follows:
 Configuration file
 ------------------
 
-.. caution::
-
-    This feature is experimental and could change or be removed at any time
-    without prior notice.
-
 There are several options that you can set using a ``.symfony.local.yaml`` config file:
 
 .. code-block:: yaml


### PR DESCRIPTION
I validated with Fabien that this is not experimental anymore.