### PR TITLE
[Testing] Fix nullable entitymanager in functional repository tests

### DIFF
--- a/testing/database.rst
+++ b/testing/database.rst
@@ -99,7 +99,7 @@ so, get the entity manager via the service container as follows::
 
     class ProductRepositoryTest extends KernelTestCase
     {
-        private EntityManager $entityManager;
+        private ?EntityManager $entityManager;
 
         protected function setUp(): void
         {


### PR DESCRIPTION
In Version 6.4 the a type was introduced to the $entityManager property in this example.
In the tearDown() method the entityManager is set to null (`$this->entityManager = null;`).

Docs (v5.x): https://symfony.com/doc/5.x/testing/database.html#functional-testing-of-a-doctrine-repository
Docs (v6.4): https://symfony.com/doc/6.4/testing/database.html#functional-testing-of-a-doctrine-repository

**Currently:**
```php
private EntityManager $entityManager;
```

**Change:**
```php
private ?EntityManager $entityManager;
```