### PR TITLE
[Validator] feat: add warning for number constraints with PHP 7.x

### DIFF
--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -12,6 +12,8 @@ Class       :class:`Symfony\\Component\\Validator\\Constraints\\GreaterThan`
 Validator   :class:`Symfony\\Component\\Validator\\Constraints\\GreaterThanValidator`
 ==========  ===================================================================
 
+.. include:: /reference/constraints/_php7-string-and-number.rst.inc
+
 Basic Usage
 -----------
 

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -11,6 +11,8 @@ Class       :class:`Symfony\\Component\\Validator\\Constraints\\GreaterThanOrEqu
 Validator   :class:`Symfony\\Component\\Validator\\Constraints\\GreaterThanOrEqualValidator`
 ==========  ===================================================================
 
+.. include:: /reference/constraints/_php7-string-and-number.rst.inc
+
 Basic Usage
 -----------
 

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -12,6 +12,8 @@ Class       :class:`Symfony\\Component\\Validator\\Constraints\\LessThan`
 Validator   :class:`Symfony\\Component\\Validator\\Constraints\\LessThanValidator`
 ==========  ===================================================================
 
+.. include:: /reference/constraints/_php7-string-and-number.rst.inc
+
 Basic Usage
 -----------
 

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -11,6 +11,8 @@ Class       :class:`Symfony\\Component\\Validator\\Constraints\\LessThanOrEqual`
 Validator   :class:`Symfony\\Component\\Validator\\Constraints\\LessThanOrEqualValidator`
 ==========  ===================================================================
 
+.. include:: /reference/constraints/_php7-string-and-number.rst.inc
+
 Basic Usage
 -----------
 

--- a/reference/constraints/Negative.rst
+++ b/reference/constraints/Negative.rst
@@ -11,6 +11,8 @@ Class       :class:`Symfony\\Component\\Validator\\Constraints\\Negative`
 Validator   :class:`Symfony\\Component\\Validator\\Constraints\\LessThanValidator`
 ==========  ===================================================================
 
+.. include:: /reference/constraints/_php7-string-and-number.rst.inc
+
 Basic Usage
 -----------
 

--- a/reference/constraints/NegativeOrZero.rst
+++ b/reference/constraints/NegativeOrZero.rst
@@ -10,6 +10,8 @@ Class       :class:`Symfony\\Component\\Validator\\Constraints\\NegativeOrZero`
 Validator   :class:`Symfony\\Component\\Validator\\Constraints\\LessThanOrEqualValidator`
 ==========  ===================================================================
 
+.. include:: /reference/constraints/_php7-string-and-number.rst.inc
+
 Basic Usage
 -----------
 

--- a/reference/constraints/Positive.rst
+++ b/reference/constraints/Positive.rst
@@ -11,6 +11,8 @@ Class       :class:`Symfony\\Component\\Validator\\Constraints\\Positive`
 Validator   :class:`Symfony\\Component\\Validator\\Constraints\\GreaterThanValidator`
 ==========  ===================================================================
 
+.. include:: /reference/constraints/_php7-string-and-number.rst.inc
+
 Basic Usage
 -----------
 

--- a/reference/constraints/PositiveOrZero.rst
+++ b/reference/constraints/PositiveOrZero.rst
@@ -10,6 +10,8 @@ Class       :class:`Symfony\\Component\\Validator\\Constraints\\PositiveOrZero`
 Validator   :class:`Symfony\\Component\\Validator\\Constraints\\GreaterThanOrEqualValidator`
 ==========  ===================================================================
 
+.. include:: /reference/constraints/_php7-string-and-number.rst.inc
+
 Basic Usage
 -----------
 

--- a/reference/constraints/_php7-string-and-number.rst.inc
+++ b/reference/constraints/_php7-string-and-number.rst.inc
@@ -1,0 +1,6 @@
+.. caution::
+
+    When using PHP 7.x, if the value is a string (e.g. ``1234asd``), the validator
+    will not trigger an error. In this case, you must also use the
+    :doc:`Type constraint </reference/constraints/Type>` with
+    ``numeric``, ``integer`, etc. to reject strings.


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony/issues/45710

See:
- https://github.com/symfony/symfony/issues/45710

Symfony 6.x requires PHP 8.x and it fixes this inconsistency, see https://github.com/symfony/symfony/issues/45710#issuecomment-1064929671

So this patch should be removed when merging `5.4` in `6.0` (or `6.4`).