### PR TITLE
[FrameworkBundle][Routing] Update the `enabled_locales` description

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -428,9 +428,11 @@ performance a bit:
             $framework->enabledLocales(['en', 'es']);
         };
 
-If some user makes requests with a locale not included in this option, the
-application won't display any error because Symfony will display contents using
-the fallback locale.
+An added bonus of defining the enabled locales is that they are automatically
+added as a requirement of the :ref:`special _locale parameter <routing-locale-parameter>`.
+For example, if you define this value as ``['ar', 'he', 'ja', 'zh']``, the
+``_locale`` routing parameter will have an ``ar|he|ja|zh`` requirement. If some
+user makes requests with a locale not included in this option, they'll see an error.
 
 set_content_language_from_locale
 ................................


### PR DESCRIPTION
While working on https://github.com/symfony/demo/pull/1511 I found this feature, which works since Symfony 5.4. See:

https://github.com/symfony/symfony/blob/184597db05288c68c9eb11dff55239768268f646/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1083-L1086