### PR TITLE
[Scheduler] Remove incorrect mention of subtracting time from jitter

### DIFF
--- a/scheduler.rst
+++ b/scheduler.rst
@@ -153,7 +153,7 @@ the frequency of the message. Symfony provides different types of triggers:
 
 :class:`Symfony\\Component\\Scheduler\\Trigger\\JitterTrigger`
     A trigger that adds a random jitter to a given trigger. The jitter is some
-    time that it's added/subtracted to the original triggering date/time. This
+    time that is added to the original triggering date/time. This
     allows to distribute the load of the scheduled tasks instead of running them
     all at the exact same time.
 


### PR DESCRIPTION
As we can see in the [code](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Scheduler/Trigger/JitterTrigger.php)  we can only add time.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
