### PR TITLE
fix warning for number constraints with PHP 7.x

### DIFF
--- a/reference/constraints/_php7-string-and-number.rst.inc
+++ b/reference/constraints/_php7-string-and-number.rst.inc
@@ -3,4 +3,4 @@
     When using PHP 7.x, if the value is a string (e.g. ``1234asd``), the validator
     will not trigger an error. In this case, you must also use the
     :doc:`Type constraint </reference/constraints/Type>` with
-    ``numeric``, ``integer`, etc. to reject strings.
+    ``numeric``, ``integer``, etc. to reject strings.


### PR DESCRIPTION
Fixes display issue on https://symfony.com/doc/5.x/reference/constraints/Positive.html

> ![image](https://github.com/symfony/symfony-docs/assets/2071331/1f38acb6-950f-4837-9ae5-0f9074d49b8f)

`integer` is not displayed as code.

- Follow-up of #19765