### PR TITLE
[FrameworkBundle] Add reference to `framework.session.storage_id` option

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1602,7 +1602,7 @@ To see a list of all available storages, run:
 
 .. versionadded:: 5.3
 
-    The ``storage_factory_id`` option was introduced in Symfony 5.3.
+    The ``storage_factory_id`` option was introduced in Symfony 5.3 deprecating the ``storage_id`` option.
 
 .. _config-framework-session-handler-id:
 


### PR DESCRIPTION
Relates to https://github.com/symfony/symfony-docs/issues/14979

I appreciate this is a low effort fix. I've been trying to work out why my app breaks when removing the  `framework.session.storage_id` option which I had assumed was unused based on the fact it is not in the documentation. I figured it was a left over from a previous Symfony upgrade - hopefully this hint helps somebody else in the same boat. 