### PR TITLE
[Security] : Aligning CSRF `tokenId` with other code sample

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -958,9 +958,9 @@ First, you need to enable CSRF on the form login:
 
 .. _csrf-login-template:
 
-Then, use the ``csrf_token()`` function in the Twig template to generate a CSRF
-token and store it as a hidden field of the form. By default, the HTML field
-is called ``_csrf_token`` and takes an arbitrary string as argument ``tokenId``:
+Then, add a hidden field to the form. In order to work with the built-in ``FormLoginAuthenticator``,
+the HTML field must be called ``_csrf_token``, and the argument of Twig's ``csrf_token()`` function
+must be called ``authenticate``:
 
 .. code-block:: html+twig
 

--- a/security.rst
+++ b/security.rst
@@ -960,8 +960,7 @@ First, you need to enable CSRF on the form login:
 
 Then, use the ``csrf_token()`` function in the Twig template to generate a CSRF
 token and store it as a hidden field of the form. By default, the HTML field
-must be called ``_csrf_token`` and the string used to generate the value must
-be ``authenticate``:
+is called ``_csrf_token`` and takes an arbitrary string as argument ``tokenId``:
 
 .. code-block:: html+twig
 
@@ -971,7 +970,7 @@ be ``authenticate``:
     <form action="{{ path('app_login') }}" method="post">
         {# ... the login fields #}
 
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token('login') }}">
 
         <button type="submit">login</button>
     </form>

--- a/security/custom_authenticator.rst
+++ b/security/custom_authenticator.rst
@@ -349,9 +349,9 @@ would initialize the passport like this::
     {
         public function authenticate(Request $request): Passport
         {
-            $password = $request->request->get('password');
             $username = $request->request->get('username');
-            $csrfToken = $request->request->get('csrf_token');
+            $password = $request->request->get('password');
+            $csrfToken = $request->request->get('_csrf_token');
 
             // ... validate no parameter is empty
 


### PR DESCRIPTION
Page: https://symfony.com/doc/5.x/security.html

* I'm making this compatible with the `tokenId` used at https://symfony.com/doc/5.x/security/custom_authenticator.html#passport-badges
* Where what the info coming from that it "must" be called `authenticate`? The docblock of `CsrfTokenBadge` just says it's an "arbitrary string"

Second commit: Aligning CSRF token filed name at https://symfony.com/doc/5.x/security/custom_authenticator.html#passport-badges with https://symfony.com/doc/5.x/security.html#csrf-protection-in-login-forms

Question: I think the other names should be changed too (adding underscore): `_username` and `_password`