### PR TITLE
[Security] `make:security:custom`

### DIFF
--- a/security/custom_authenticator.rst
+++ b/security/custom_authenticator.rst
@@ -5,7 +5,8 @@ Symfony comes with :ref:`many authenticators <security-authenticators>` and
 third party bundles also implement more complex cases like JWT and oAuth
 2.0. However, sometimes you need to implement a custom authentication
 mechanism that doesn't exist yet or you need to customize one. In such
-cases, you must create and use your own authenticator.
+cases, you can use the ``make:security:custom`` command to create your own
+authenticator.
 
 Authenticators should implement the
 :class:`Symfony\\Component\\Security\\Http\\Authenticator\\AuthenticatorInterface`.


### PR DESCRIPTION
Since MakerBundle `v1.59.0` - you can call `make:security:custom` to generate a simple, no-frills, custom authenticator based off the example in the docs.

- [x] Maker PR: https://github.com/symfony/maker-bundle/pull/1522
- [x] Maker Release: `v1.59.0`