### PR TITLE
[Webhook] show `make:webhook`

### DIFF
--- a/webhook.rst
+++ b/webhook.rst
@@ -16,6 +16,11 @@ Installation
 
     $ composer require symfony/webhook
 
+.. tip::
+
+    Since MakerBundle ``v1.58.0`` - you can run ``php bin/console make:webhook``
+    to generate the files needed to use the Webhook component.
+
 Usage in Combination with the Mailer Component
 ----------------------------------------------
 


### PR DESCRIPTION
Since `v1.58.0` (https://github.com/symfony/maker-bundle/releases/tag/v1.58.0) - MakerBundle has a `make:webhook` command (https://github.com/symfony/maker-bundle/pull/1491) that generates a basic `ConsumerInterface` implementation.

- Milestone `7.1` is incorrect