### PR TITLE
Accept-Language return default_locale if no match

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -997,8 +997,7 @@ preferences. This is achieved with the ``getPreferredLanguage()`` method of the
 
 Symfony finds the best possible language based on the locales passed as argument
 and the value of the ``Accept-Language`` HTTP header. If it can't find a perfect
-match between them, this method returns the first locale passed as argument
-(that's why the order of the passed locales is important).
+match between them, this method returns ``default_locale``.
 
 .. _translation-fallback:
 


### PR DESCRIPTION
This pull request goes in pair with a pull request I submitted on Symfony here : https://github.com/symfony/symfony/pull/54703

It is about using `default_locale` instead of the first value of `enabled_locales` when `Accept-Language` doesn't match with any 'enabled_locales'.
