### PR TITLE
Update deployment.rst: Adding alternative way to clear the cache

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -205,7 +205,7 @@ warm up the cache (so you should load your app afterwards):
 
 .. code-block:: terminal
 
-    $ APP_ENV=prod APP_DEBUG=0 rm -rf var/cache/prod/*
+    $ rm -rf var/cache/prod/*
 
 E) Other Things!
 ~~~~~~~~~~~~~~~~

--- a/deployment.rst
+++ b/deployment.rst
@@ -200,6 +200,13 @@ Make sure you clear and warm-up your Symfony cache:
 
     $ APP_ENV=prod APP_DEBUG=0 php bin/console cache:clear
 
+Alternatively, you can also delete the cache files manually. However, this does not
+warm up the cache (so you should load your app afterwards):
+
+.. code-block:: terminal
+
+    $ APP_ENV=prod APP_DEBUG=0 rm -rf var/cache/prod/*
+
 E) Other Things!
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Page: https://symfony.com/doc/5.x/deployment.html#d-clear-your-symfony-cache

Reason: I have an app which "suddenly" produces a memory overflow upon `cache:clear`, but otherwise runs fine. Searching around, I found out that many people encounter this problem, for various reasons. So I'm figuring it's not so easy to really fix this in the Symfony code. So, I guess it's a good idea to show people an alternative way. Cause when deploying, and `cache:clear` crashes, you probably need a solution *fast* ;-)