### PR TITLE
[Security] : Redirect user to profile page

### DIFF
--- a/security/custom_authenticator.rst
+++ b/security/custom_authenticator.rst
@@ -163,7 +163,7 @@ can define what happens in these cases:
 ``onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response``
     If the user is authenticated, this method is called with the
     authenticated ``$token``. This method can return a response (e.g.
-    redirect the user to the homepage).
+    redirect the user to their profile page).
 
     If ``null`` is returned, the request continues like normal (i.e. the
     controller matching the login route is called). This is useful for API


### PR DESCRIPTION
Page: https://symfony.com/doc/5.x/security/custom_authenticator.html

The homepage is public. After login, you should redirect the user to some *protected* page.