### PR TITLE
[Cache] Small correction in the use of tags in the cache

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -572,7 +572,7 @@ Using Cache Tags
 In applications with many cache keys it could be useful to organize the data stored
 to be able to invalidate the cache more efficiently. One way to achieve that is to
 use cache tags. One or more tags could be added to the cache item. All items with
-the same key could be invalidated with one function call::
+the same tag could be invalidated with one function call::
 
     use Symfony\Contracts\Cache\ItemInterface;
     use Symfony\Contracts\Cache\TagAwareCacheInterface;


### PR DESCRIPTION
Replacement of the word key by tag in the description of the use of tags in the cache

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
