### PR TITLE
Update controller.rst, fix use statement App\Model\UserDto

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -419,7 +419,7 @@ optional validation constraints::
 You can then use the :class:`Symfony\\Component\\HttpKernel\\Attribute\\MapQueryString`
 attribute in your controller::
 
-    use App\Model\UserDto;
+    use App\Model\UserDTO;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 
@@ -454,7 +454,7 @@ The default status code returned if the validation fails is 404.
 If you need a valid DTO even when the request query string is empty, set a
 default value for your controller arguments::
 
-    use App\Model\UserDto;
+    use App\Model\UserDTO;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 
@@ -497,7 +497,7 @@ In this case, it is also possible to directly map this payload to your DTO by
 using the :class:`Symfony\\Component\\HttpKernel\\Attribute\\MapRequestPayload`
 attribute::
 
-    use App\Model\UserDto;
+    use App\Model\UserDTO;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 


### PR DESCRIPTION
In use statement use wrong case, then this error happens 'Case mismatch between loaded and declared class names: "App\Model\UserDto" vs "App\Model\UserDTO". ',

https://stackoverflow.com/questions/78352633/controller-returning-500-could-not-denormalize-object-of-type/78420166

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
