### PR TITLE
[Security] Document "pass controller object argument by name" behavior for IsGranted attribute

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2548,6 +2548,25 @@ the ``ROLE_SUPER_ADMIN`` permission:
         }
     }
 
+You can pass any controller argument to the #[IsGranted()] attribute by name:
+
+.. code-block:: php-attributes
+
+    // src/Controller/PostController.php
+    // ...
+
+    use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+    class PostController extends AbstractController
+    {
+        #[Route('/posts/{id}/edit', name: 'post_edit')]
+        #[IsGranted('edit', 'post')]
+        public function edit(Post $post): Response
+        {
+            // ...
+        }
+    }
+
 If you want to use a custom status code instead of the default one (which
 is 403), this can be done by setting with the ``statusCode`` argument::
 

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -78,6 +78,7 @@ code like this:
         {
             #[Route('/posts/{id}', name: 'post_show')]
             // check for "view" access: calls all voters
+            // pass the Post entity by name
             #[IsGranted('view', 'post')]
             public function show(Post $post): Response
             {
@@ -86,6 +87,7 @@ code like this:
 
             #[Route('/posts/{id}/edit', name: 'post_edit')]
             // check for "edit" access: calls all voters
+            // pass the Post entity by name
             #[IsGranted('edit', 'post')]
             public function edit(Post $post): Response
             {


### PR DESCRIPTION
Fixes #19589.
I am unsure if this also applied to the `@IsGranted` annotation in 5.4.