### PR TITLE
[AssetMapper] Document how to make it work with a Content Security Policy

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -1061,6 +1061,27 @@ have *one* importmap, so ``importmap()`` must be called exactly once.
 If, for some reason, you want to execute *only* ``checkout.js``
 and *not* ``app.js``, pass only ``checkout`` to ``importmap()``.
 
+Using a Content Security Policy (CSP)
+-------------------------------------
+
+If you're using a `Content Security Policy`_ (CSP) to prevent cross-site
+scripting attacks, the inline ``<script>`` tags rendered by the ``importmap()``
+function will likely violate that policy and will not be executed by the browser.
+
+To allow these scripts to run without disabling the security provided by
+the CSP, you can generate a secure random string for every request (called
+a *nonce*) and include it in the CSP header and in a ``nonce`` attribute on
+the ``<script>`` tags.
+The ``importmap()`` function accepts an optional second argument that can be
+used to pass attributes to the rendered ``<script>`` tags.
+You can use the `NelmioSecurityBundle`_ to generate the nonce and include
+it in the CSP header, and then pass the same nonce to the Twig function:
+
+.. code-block:: twig
+
+    {# the csp_nonce() function is defined by the NelmioSecurityBundle #}
+    {{ importmap('app', {'nonce': csp_nonce('script')}) }}
+
 The AssetMapper Component Caching System in dev
 -----------------------------------------------
 
@@ -1143,3 +1164,5 @@ command as part of your CI to be warned anytime a new vulnerability is found.
 .. _`dist/css/bootstrap.min.css file`: https://www.jsdelivr.com/package/npm/bootstrap?tab=files&path=dist%2Fcss#tabRouteFiles
 .. _`dynamic import`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import
 .. _`package.json configuration file`: https://docs.npmjs.com/creating-a-package-json-file
+.. _Content Security Policy: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+.. _NelmioSecurityBundle: https://symfony.com/bundles/NelmioSecurityBundle/current/index.html#nonce-for-inline-script-handling


### PR DESCRIPTION
Last week I converted a website from classic Webpack (without Encore) to AssetMapper and so far I'm impressed with how it simplifies asset management! :tada: (thanks @weaverryan!)

One thing I had some difficulty with was to get it working with the website's [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). Before the switch I only used static assets hosted on the same domain, but the importmap functionality relies on inline scripts - which are blocked by default when a CSP is configured.

I managed to get it working using a nonce, with the help of [NelmioSecurityBundle](https://symfony.com/bundles/NelmioSecurityBundle/current/index.html#nonce-for-inline-script-handling). The nonce is inserted into the `<script>` tags by passing it to the second argument of the `importmap()` function. This functionality was introduced in Symfony 6.3 by https://github.com/symfony/symfony/pull/50456 for this exact use case, but has not been documented as far as I could find.