### PR TITLE
The #[IsCsrfTokenValid] attribute eliminates the need for a request parameter in your method.

### DIFF
--- a/security/csrf.rst
+++ b/security/csrf.rst
@@ -176,7 +176,7 @@ attribute on the controller action::
     // ...
 
     #[IsCsrfTokenValid('delete-item', tokenKey: 'token')]
-    public function delete(Request $request): Response
+    public function delete(): Response
     {
         // ... do something, like deleting an object
     }


### PR DESCRIPTION
#[IsCsrfTokenValid] attribute in Symfony 7.1 does not require you to  include a request parameter in the method itself. The attribute uses the request object internally to access the submitted data for validation.

for example
```php
    #[Route(path: '/admin/post/delete', name: 'admin_post_delete', methods: ['POST'])]
    #[IsCsrfTokenValid('delete-item')]
    public function adminPostDelete(): Response
    {
        dd('deleted');
    }
```