### PR TITLE
Extend AbstractBundle instead of Bundle

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -78,16 +78,22 @@ The following is the recommended directory structure of an AcmeBlogBundle:
     ├── LICENSE
     └── README.md
 
-This directory structure requires to configure the bundle path to its root
-directory as follows::
+.. note::
 
-    class AcmeBlogBundle extends Bundle
-    {
-        public function getPath(): string
+    This directory structure is used by default when your bundle class extends
+    the recommended :class:`Symfony\\Component\\HttpKernel\\Bundle\\AbstractBundle`.
+    If your bundle extends the :class:`Symfony\\Component\\HttpKernel\\Bundle\\Bundle`
+    class, you have to override the ``getPath()`` method as follows::
+
+        use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+        class AcmeBlogBundle extends Bundle
         {
-            return \dirname(__DIR__);
+            public function getPath(): string
+            {
+                return \dirname(__DIR__);
+            }
         }
-    }
 
 **The following files are mandatory**, because they ensure a structure convention
 that automated tools can rely on:

--- a/service_container/compiler_passes.rst
+++ b/service_container/compiler_passes.rst
@@ -75,9 +75,9 @@ method in the extension)::
 
     use App\DependencyInjection\Compiler\CustomPass;
     use Symfony\Component\DependencyInjection\ContainerBuilder;
-    use Symfony\Component\HttpKernel\Bundle\Bundle;
+    use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 
-    class MyBundle extends Bundle
+    class MyBundle extends AbstractBundle
     {
         public function build(ContainerBuilder $container): void
         {


### PR DESCRIPTION
Fixes #19838.

After this, we use `AbstractBundle` everywhere except for this example which explicitly shows the old way of doing things when extending `Bundle`: https://symfony.com/doc/current/bundles/extension.html#manually-registering-an-extension-class