### PR TITLE
Update kernel.rst: Adding example for `kernel.project_dir`

### DIFF
--- a/reference/configuration/kernel.rst
+++ b/reference/configuration/kernel.rst
@@ -261,11 +261,13 @@ method of the kernel class, which you can override to return a different value.
 ``kernel.project_dir``
 ----------------------
 
-**type**: ``string`` **default**: the directory of the project ``composer.json``
+**type**: ``string`` **default**: the directory of the project's ``composer.json``
 
 This parameter stores the absolute path of the root directory of your Symfony application,
 which is used by applications to perform operations with file paths relative to
 the project's root directory.
+
+Example: `/home/user/my_project`
 
 By default, its value is calculated automatically as the directory where the
 main ``composer.json`` file is stored. This value is also exposed via the


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/reference/configuration/kernel.html#kernel-project-dir

Reason: Showing there is no trailing slash in the path.