### PR TITLE
Don't capitalize acronyms in class names

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -401,7 +401,7 @@ optional validation constraints::
 
     use Symfony\Component\Validator\Constraints as Assert;
 
-    class UserDTO
+    class UserDto
     {
         public function __construct(
             #[Assert\NotBlank]
@@ -419,14 +419,14 @@ optional validation constraints::
 You can then use the :class:`Symfony\\Component\\HttpKernel\\Attribute\\MapQueryString`
 attribute in your controller::
 
-    use App\Model\UserDTO;
+    use App\Model\UserDto;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 
     // ...
 
     public function dashboard(
-        #[MapQueryString] UserDTO $userDto
+        #[MapQueryString] UserDto $userDto
     ): Response
     {
         // ...
@@ -443,7 +443,7 @@ HTTP status to return if the validation fails::
         #[MapQueryString(
             validationGroups: ['strict', 'edit'],
             validationFailedStatusCode: Response::HTTP_UNPROCESSABLE_ENTITY
-        )] UserDTO $userDto
+        )] UserDto $userDto
     ): Response
     {
         // ...
@@ -454,14 +454,14 @@ The default status code returned if the validation fails is 404.
 If you need a valid DTO even when the request query string is empty, set a
 default value for your controller arguments::
 
-    use App\Model\UserDTO;
+    use App\Model\UserDto;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 
     // ...
 
     public function dashboard(
-        #[MapQueryString] UserDTO $userDto = new UserDTO()
+        #[MapQueryString] UserDto $userDto = new UserDto()
     ): Response
     {
         // ...
@@ -497,14 +497,14 @@ In this case, it is also possible to directly map this payload to your DTO by
 using the :class:`Symfony\\Component\\HttpKernel\\Attribute\\MapRequestPayload`
 attribute::
 
-    use App\Model\UserDTO;
+    use App\Model\UserDto;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 
     // ...
 
     public function dashboard(
-        #[MapRequestPayload] UserDTO $userDto
+        #[MapRequestPayload] UserDto $userDto
     ): Response
     {
         // ...
@@ -519,7 +519,7 @@ your DTO::
             serializationContext: ['...'],
             resolver: App\Resolver\UserDtoResolver
         )]
-        UserDTO $userDto
+        UserDto $userDto
     ): Response
     {
         // ...
@@ -537,7 +537,7 @@ the validation fails as well as supported payload formats::
             acceptFormat: 'json',
             validationGroups: ['strict', 'read'],
             validationFailedStatusCode: Response::HTTP_NOT_FOUND
-        )] UserDTO $userDto
+        )] UserDto $userDto
     ): Response
     {
         // ...
@@ -557,16 +557,16 @@ Make sure to install `phpstan/phpdoc-parser`_ and `phpdocumentor/type-resolver`_
 if you want to map a nested array of specific DTOs::
 
     public function dashboard(
-        #[MapRequestPayload()] EmployeesDTO $employeesDto
+        #[MapRequestPayload()] EmployeesDto $employeesDto
     ): Response
     {
         // ...
     }
 
-    final class EmployeesDTO
+    final class EmployeesDto
     {
         /**
-         * @param UserDTO[] $users
+         * @param UserDto[] $users
          */
         public function __construct(
             public readonly array $users = []

--- a/form/type_guesser.rst
+++ b/form/type_guesser.rst
@@ -44,14 +44,14 @@ This interface requires four methods:
 
 Start by creating the class and these methods. Next, you'll learn how to fill each in::
 
-    // src/Form/TypeGuesser/PHPDocTypeGuesser.php
+    // src/Form/TypeGuesser/PhpDocTypeGuesser.php
     namespace App\Form\TypeGuesser;
 
     use Symfony\Component\Form\FormTypeGuesserInterface;
     use Symfony\Component\Form\Guess\TypeGuess;
     use Symfony\Component\Form\Guess\ValueGuess;
 
-    class PHPDocTypeGuesser implements FormTypeGuesserInterface
+    class PhpDocTypeGuesser implements FormTypeGuesserInterface
     {
         public function guessType(string $class, string $property): ?TypeGuess
         {
@@ -90,9 +90,9 @@ The ``TypeGuess`` constructor requires three options:
   type with the highest confidence is used.
 
 With this knowledge, you can implement the ``guessType()`` method of the
-``PHPDocTypeGuesser``::
+``PhpDocTypeGuesser``::
 
-    // src/Form/TypeGuesser/PHPDocTypeGuesser.php
+    // src/Form/TypeGuesser/PhpDocTypeGuesser.php
     namespace App\Form\TypeGuesser;
 
     use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -102,7 +102,7 @@ With this knowledge, you can implement the ``guessType()`` method of the
     use Symfony\Component\Form\Guess\Guess;
     use Symfony\Component\Form\Guess\TypeGuess;
 
-    class PHPDocTypeGuesser implements FormTypeGuesserInterface
+    class PhpDocTypeGuesser implements FormTypeGuesserInterface
     {
         public function guessType(string $class, string $property): ?TypeGuess
         {
@@ -188,7 +188,7 @@ and tag it with ``form.type_guesser``:
         services:
             # ...
 
-            App\Form\TypeGuesser\PHPDocTypeGuesser:
+            App\Form\TypeGuesser\PhpDocTypeGuesser:
                 tags: [form.type_guesser]
 
     .. code-block:: xml
@@ -201,7 +201,7 @@ and tag it with ``form.type_guesser``:
                 https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <services>
-                <service id="App\Form\TypeGuesser\PHPDocTypeGuesser">
+                <service id="App\Form\TypeGuesser\PhpDocTypeGuesser">
                     <tag name="form.type_guesser"/>
                 </service>
             </services>
@@ -210,9 +210,9 @@ and tag it with ``form.type_guesser``:
     .. code-block:: php
 
         // config/services.php
-        use App\Form\TypeGuesser\PHPDocTypeGuesser;
+        use App\Form\TypeGuesser\PhpDocTypeGuesser;
 
-        $container->register(PHPDocTypeGuesser::class)
+        $container->register(PhpDocTypeGuesser::class)
             ->addTag('form.type_guesser')
         ;
 
@@ -223,12 +223,12 @@ and tag it with ``form.type_guesser``:
     :method:`Symfony\\Component\\Form\\FormFactoryBuilder::addTypeGuessers` of
     the ``FormFactoryBuilder`` to register new type guessers::
 
-        use App\Form\TypeGuesser\PHPDocTypeGuesser;
+        use App\Form\TypeGuesser\PhpDocTypeGuesser;
         use Symfony\Component\Form\Forms;
 
         $formFactory = Forms::createFormFactoryBuilder()
             // ...
-            ->addTypeGuesser(new PHPDocTypeGuesser())
+            ->addTypeGuesser(new PhpDocTypeGuesser())
             ->getFormFactory();
 
         // ...


### PR DESCRIPTION
PHP has approved a new policy banning the usage of capitalized acronyms in class names (https://wiki.php.net/rfc/class-naming-acronyms):

| Wrong | Correct
| ----- | -------
| `FooDTO` | `FooDto`
| `HTTPFoo` | `HttpFoo`
| `PDOFooPHP` | `PdoFooPhp`

So, I propose to use this same policy for Symfony Docs.

Note: we need to be careful because some class are defined by external projects and the use the "wrong" names (`ReactPHPRunner`, etc.)