### PR TITLE
[Doctrine] Replace serverVersion example values with full version numbers

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -41,7 +41,7 @@ The database connection information is stored as an environment variable called
     # .env (or override DATABASE_URL in .env.local to avoid committing your changes)
 
     # customize this line!
-    DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7"
+    DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=8.0.37"
 
     # to use mariadb:
     # Before doctrine/dbal < 3.7
@@ -53,7 +53,7 @@ The database connection information is stored as an environment variable called
     # DATABASE_URL="sqlite:///%kernel.project_dir%/var/app.db"
 
     # to use postgresql:
-    # DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
+    # DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=12.19 (Debian 12.19-1.pgdg120+1)&charset=utf8"
 
     # to use oracle:
     # DATABASE_URL="oci8://db_user:db_password@127.0.0.1:1521/db_name"
@@ -75,7 +75,7 @@ database for you:
     $ php bin/console doctrine:database:create
 
 There are more options in ``config/packages/doctrine.yaml`` that you can configure,
-including your ``server_version`` (e.g. 5.7 if you're using MySQL 5.7), which may
+including your ``server_version`` (e.g. 8.0.37 if you're using MySQL 8.0.37), which may
 affect how Doctrine functions.
 
 .. tip::

--- a/doctrine/dbal.rst
+++ b/doctrine/dbal.rst
@@ -32,7 +32,7 @@ Then configure the ``DATABASE_URL`` environment variable in ``.env``:
     # .env (or override DATABASE_URL in .env.local to avoid committing your changes)
 
     # customize this line!
-    DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7"
+    DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=8.0.37"
 
 Further things can be configured in ``config/packages/doctrine.yaml`` - see
 :ref:`reference-dbal-configuration`. Remove the ``orm`` key in that file

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -57,7 +57,7 @@ The following block shows all possible configuration keys:
                 charset:              utf8mb4
                 logging:              '%kernel.debug%'
                 platform_service:     App\DBAL\MyDatabasePlatformService
-                server_version:       '5.7'
+                server_version:       '8.0.37'
                 mapping_types:
                     enum: string
                 types:
@@ -91,7 +91,7 @@ The following block shows all possible configuration keys:
                     charset="utf8mb4"
                     logging="%kernel.debug%"
                     platform-service="App\DBAL\MyDatabasePlatformService"
-                    server-version="5.7">
+                    server-version="8.0.37">
 
                     <doctrine:option key="foo">bar</doctrine:option>
                     <doctrine:mapping-type name="enum">string</doctrine:mapping-type>
@@ -134,13 +134,13 @@ If you want to configure multiple connections in YAML, put them under the
                     user:             root
                     password:         null
                     host:             localhost
-                    server_version:   '5.6'
+                    server_version:   '8.0.37'
                 customer:
                     dbname:           customer
                     user:             root
                     password:         null
                     host:             localhost
-                    server_version:   '5.7'
+                    server_version:   '8.2.0'
 
 The ``database_connection`` service always refers to the *default* connection,
 which is the first one defined or the one configured via the

--- a/testing.rst
+++ b/testing.rst
@@ -225,7 +225,7 @@ need in your ``.env.test`` file:
     # .env.test
 
     # ...
-    DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name_test?serverVersion=5.7"
+    DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name_test?serverVersion=8.0.37"
 
 In the test environment, these env files are read (if vars are duplicated
 in them, files lower in the list override previous items):
@@ -381,7 +381,7 @@ env var:
 .. code-block:: env
 
     # .env.test.local
-    DATABASE_URL="mysql://USERNAME:PASSWORD@127.0.0.1:3306/DB_NAME?serverVersion=5.7"
+    DATABASE_URL="mysql://USERNAME:PASSWORD@127.0.0.1:3306/DB_NAME?serverVersion=8.0.37"
 
 This assumes that each developer/machine uses a different database for the
 tests. If the test set-up is the same on each machine, use the ``.env.test``


### PR DESCRIPTION
Doctrine DBAL 3.6.0 deprecated incomplete version numbers for the serverVersion value (for example 8 or 8.0 for MySQL). Instead, a full version number (8.0.37) is expected.
See https://www.doctrine-project.org/projects/doctrine-dbal/en/4.0/reference/configuration.html#automatic-platform-version-detection and https://github.com/doctrine/dbal/blob/4.0.x/UPGRADE.md#bc-break-disallowed-partial-version-numbers-in-serverversion.

This commit replaces partial version numbers with full version numbers. It also replaces examples with EOL database versions (such as MySQL 5.7 and PostgreSQL 11) with more modern, supported versions.

Fixes https://github.com/symfony/symfony-docs/issues/19876.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
