### PR TITLE
Move Doctrine constraints out of Other constraints

### DIFF
--- a/reference/constraints/map.rst.inc
+++ b/reference/constraints/map.rst.inc
@@ -86,6 +86,13 @@ Financial and other Number Constraints
 * :doc:`Issn </reference/constraints/Issn>`
 * :doc:`Isin </reference/constraints/Isin>`
 
+Doctrine Constraints
+~~~~~~~~~~~~~~~~~~~~
+
+* :doc:`UniqueEntity </reference/constraints/UniqueEntity>`
+* :doc:`EnableAutoMapping </reference/constraints/EnableAutoMapping>`
+* :doc:`DisableAutoMapping </reference/constraints/DisableAutoMapping>`
+
 Other Constraints
 ~~~~~~~~~~~~~~~~~
 
@@ -100,6 +107,3 @@ Other Constraints
 * :doc:`Traverse </reference/constraints/Traverse>`
 * :doc:`Collection </reference/constraints/Collection>`
 * :doc:`Count </reference/constraints/Count>`
-* :doc:`UniqueEntity </reference/constraints/UniqueEntity>`
-* :doc:`EnableAutoMapping </reference/constraints/EnableAutoMapping>`
-* :doc:`DisableAutoMapping </reference/constraints/DisableAutoMapping>`


### PR DESCRIPTION
The "Other Constraints" category is very useful, I regularly find myself checking out each of them to find the best fit. As a user of DBAL only, the Doctrine constraints are not as generic as the other ones.

I suggest giving Doctrine constraints their own category, which may help people that use Doctrine, but also people that don't.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
