### PR TITLE
Add extra information on AsEventListener attribute usage

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -162,7 +162,9 @@ having to add any configuration in external files::
         }
     }
 
-You can add multiple ``#[AsEventListener]`` attributes to configure different methods::
+You can add multiple ``#[AsEventListener]`` attributes to configure different methods.
+In the below example, for ``foo`` event, ``onFoo`` method will be called
+implicitly if method attribute is not set::
 
     namespace App\EventListener;
 


### PR DESCRIPTION
The AsEventListener attribute has an implicit call to "on{Event}" if method attribute is not set.