### PR TITLE
fix expression language precedence cell grouping

### DIFF
--- a/reference/formats/expression_language.rst
+++ b/reference/formats/expression_language.rst
@@ -446,9 +446,9 @@ Operators                                                associativity
 ``~``                                                    left
 ``+``, ``-``                                             left
 ``..``                                                   left
-``==``, ``===``, ``!=``, ``!==``,                        left
-``<``, ``>``, ``>=``, ``<=``,
-``not in``, ``in``, ``contains``,
+``==``, ``===``, ``!=``, ``!==``, \                      left
+``<``, ``>``, ``>=``, ``<=``, \
+``not in``, ``in``, ``contains``, \
 ``starts with``, ``ends with``, ``matches``
 ``&``                                                    left
 ``^``                                                    left


### PR DESCRIPTION
Fix for https://github.com/symfony/symfony-docs/pull/19860#issuecomment-2115246828

I do not know how to test the changes as those were working with the doc builder previously.