### PR TITLE
[Console] Adding an example of command test using the ApplicationTester class

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -547,11 +547,6 @@ console::
 If you are using a :doc:`single-command application </components/console/single_command_tool>`,
 call ``setAutoExit(false)`` on it to get the command result in ``CommandTester``.
 
-.. tip::
-
-    You can also test a whole console application by using
-    :class:`Symfony\\Component\\Console\\Tester\\ApplicationTester`.
-
 .. warning::
 
     When testing commands using the ``CommandTester`` class, console events are
@@ -567,6 +562,51 @@ call ``setAutoExit(false)`` on it to get the command result in ``CommandTester``
         $application->setAutoExit(false);
 
         $tester = new ApplicationTester($application);
+
+.. tip::
+
+    You can also test a whole console application by using
+    :class:`Symfony\\Component\\Console\\Tester\\ApplicationTester`.
+
+    Here an example of a test using this class::
+
+        use Symfony\Bundle\FrameworkBundle\Console\Application;
+        use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+        use Symfony\Component\Console\Tester\ApplicationTester;
+        use Symfony\Component\Console\Tester\CommandTester;
+
+        class WelcomeCommandTest extends KernelTestCase
+        {
+            public function testPerson(): void
+            {
+                self::bootKernel();
+                $application = new Application(self::$kernel);
+                $application->setAutoExit(false);
+
+                $applicationTester = new ApplicationTester($application);
+
+                $input = [
+                    // Pass the command name
+                    'command' => 'app:welcome-person',
+
+                    // Pass the different arguments
+                    'firstName' => 'Michael',
+                    'lastName' => 'Jackson',
+                    'hobbies' => ['singing', 'dancing']
+                ];
+
+                // Call run to launch the application
+                $applicationTester->run($input);
+
+                $applicationTester->assertCommandIsSuccessful();
+
+                $output = $applicationTester->getDisplay();
+
+                // Here $output value is "The person is Michael Jackson and his hobbies are the following singing and dancing."
+                $this->assertStringContainsString('Michael Jackson', $output);
+                $this->assertStringContainsString('singing and dancing', $output);
+            }
+        }
 
 .. warning::
 


### PR DESCRIPTION
- Completing the tip by adding a simple example of a test using the ApplicationTester class. It gives a good basis to start testing with this class.
- A correction in the caution part concerning the disabling of the auto exit flag
