### PR TITLE
Remove redundant parenthesis on attribute

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -162,7 +162,7 @@ having to add any configuration in external files::
         }
     }
 
-You can add multiple ``#[AsEventListener()]`` attributes to configure different methods::
+You can add multiple ``#[AsEventListener]`` attributes to configure different methods::
 
     namespace App\EventListener;
 
@@ -198,7 +198,7 @@ can also be applied to methods directly::
 
     final class MyMultiListener
     {
-        #[AsEventListener()]
+        #[AsEventListener]
         public function onCustomEvent(CustomEvent $event): void
         {
             // ...


### PR DESCRIPTION
In symfony codebase `#[Foo]` is used instead of `#[Foo()]`

Phpstorm like also without
![image](https://github.com/symfony/symfony-docs/assets/9253091/9a4902ef-4c6a-428d-9fae-7034aca17f19)

I've made also PR for 6.4, if you're agree with this rule I will made other PR.
(And maybe a new doctor-rst rule)