### PR TITLE
Remove redundant parenthesis on attribute

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -421,7 +421,7 @@ return a ``Response``.
 
     There is a default listener inside the Symfony Framework for the ``kernel.view``
     event. If your controller action returns an array, and you apply the
-    :ref:`#[Template()] attribute <templates-template-attribute>` to that
+    :ref:`#[Template] attribute <templates-template-attribute>` to that
     controller action, then this listener renders a template, passes the array
     you returned from your controller to that template, and creates a ``Response``
     containing the returned content from that template.

--- a/controller.rst
+++ b/controller.rst
@@ -557,7 +557,7 @@ Make sure to install `phpstan/phpdoc-parser`_ and `phpdocumentor/type-resolver`_
 if you want to map a nested array of specific DTOs::
 
     public function dashboard(
-        #[MapRequestPayload()] EmployeesDto $employeesDto
+        #[MapRequestPayload] EmployeesDto $employeesDto
     ): Response
     {
         // ...

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -231,7 +231,7 @@ The *easiest* way to cache a response is by caching it for a specific amount of 
 
 .. versionadded:: 6.2
 
-    The ``#[Cache()]`` attribute was introduced in Symfony 6.2.
+    The ``#[Cache]`` attribute was introduced in Symfony 6.2.
 
 Thanks to this new code, your HTTP response will have the following header:
 
@@ -331,7 +331,7 @@ Additionally, most cache-related HTTP headers can be set via the single
 
 .. tip::
 
-    All these options are also available when using the ``#[Cache()]`` attribute.
+    All these options are also available when using the ``#[Cache]`` attribute.
 
 Cache Invalidation
 ------------------

--- a/http_cache/cache_vary.rst
+++ b/http_cache/cache_vary.rst
@@ -28,7 +28,7 @@ trigger a different representation of the requested resource:
     resource based on the URI and the value of the ``Accept-Encoding`` and
     ``User-Agent`` request header.
 
-Set the ``Vary`` header via the ``Response`` object methods or the ``#[Cache()]``
+Set the ``Vary`` header via the ``Response`` object methods or the ``#[Cache]``
 attribute::
 
 .. configuration-block::

--- a/http_cache/expiration.rst
+++ b/http_cache/expiration.rst
@@ -61,7 +61,7 @@ or disadvantage to either.
 
 According to the HTTP specification, "the ``Expires`` header field gives
 the date/time after which the response is considered stale." The ``Expires``
-header can be set with the ``expires`` option of the ``#[Cache()]`` attribute or
+header can be set with the ``expires`` option of the ``#[Cache]`` attribute or
 the ``setExpires()`` ``Response`` method::
 
 .. configuration-block::

--- a/security.rst
+++ b/security.rst
@@ -2525,7 +2525,7 @@ will happen:
 .. _security-securing-controller-annotations:
 .. _security-securing-controller-attributes:
 
-Another way to secure one or more controller actions is to use the ``#[IsGranted()]`` attribute.
+Another way to secure one or more controller actions is to use the ``#[IsGranted]`` attribute.
 In the following example, all controller actions will require the
 ``ROLE_ADMIN`` permission, except for ``adminDashboard()``, which will require
 the ``ROLE_SUPER_ADMIN`` permission:
@@ -2579,11 +2579,11 @@ that is thrown with the ``exceptionCode`` argument::
 
 .. versionadded:: 6.2
 
-    The ``#[IsGranted()]`` attribute was introduced in Symfony 6.2.
+    The ``#[IsGranted]`` attribute was introduced in Symfony 6.2.
 
 .. versionadded:: 6.3
 
-    The ``exceptionCode`` argument of the ``#[IsGranted()]`` attribute was
+    The ``exceptionCode`` argument of the ``#[IsGranted]`` attribute was
     introduced in Symfony 6.3.
 
 .. _security-template:

--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -7,7 +7,7 @@ Using Expressions in Security Access Controls
     the :doc:`Voter System </security/voters>`.
 
 In addition to security roles like ``ROLE_ADMIN``, the ``isGranted()`` method
-and ``#[IsGranted()]`` attribute also accept an
+and ``#[IsGranted]`` attribute also accept an
 :class:`Symfony\\Component\\ExpressionLanguage\\Expression` object:
 
 .. configuration-block::
@@ -71,7 +71,7 @@ and ``#[IsGranted()]`` attribute also accept an
 
 .. versionadded:: 6.2
 
-    The ``#[IsGranted()]`` attribute was introduced in Symfony 6.2.
+    The ``#[IsGranted]`` attribute was introduced in Symfony 6.2.
 
 In this example, if the current user has ``ROLE_ADMIN`` or if the current
 user object's ``isSuperAdmin()`` method returns ``true``, then access will
@@ -142,7 +142,7 @@ Additionally, you have access to a number of functions inside the expression:
     true if the user has actually logged in during this session (i.e. is
     full-fledged).
 
-In case of the ``#[IsGranted()]`` attribute, the subject can also be an
+In case of the ``#[IsGranted]`` attribute, the subject can also be an
 :class:`Symfony\\Component\\ExpressionLanguage\\Expression` object::
 
     // src/Controller/MyController.php

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -121,14 +121,14 @@ code like this:
             }
         }
 
-The ``#[IsGranted()]`` attribute or ``denyAccessUnlessGranted()`` method (and also the ``isGranted()`` method)
+The ``#[IsGranted]`` attribute or ``denyAccessUnlessGranted()`` method (and also the ``isGranted()`` method)
 calls out to the "voter" system. Right now, no voters will vote on whether or not
 the user can "view" or "edit" a ``Post``. But you can create your *own* voter that
 decides this using whatever logic you want.
 
 .. versionadded:: 6.2
 
-    The ``#[IsGranted()]`` attribute was introduced in Symfony 6.2.
+    The ``#[IsGranted]`` attribute was introduced in Symfony 6.2.
 
 Creating the custom Voter
 -------------------------

--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -131,7 +131,7 @@ laziness, and supports lazy-autowiring of union types::
 
 .. versionadded:: 6.3
 
-    The ``lazy`` argument of the ``#[Autowire()]`` attribute was introduced in
+    The ``lazy`` argument of the ``#[Autowire]`` attribute was introduced in
     Symfony 6.3.
 
 Interface Proxifying

--- a/templates.rst
+++ b/templates.rst
@@ -579,7 +579,7 @@ use the ``render()`` method of the ``twig`` service.
 
 .. _templates-template-attribute:
 
-Another option is to use the ``#[Template()]`` attribute on the controller method
+Another option is to use the ``#[Template]`` attribute on the controller method
 to define the template to render::
 
     // src/Controller/ProductController.php
@@ -596,7 +596,7 @@ to define the template to render::
         {
             // ...
 
-            // when using the #[Template()] attribute, you only need to return
+            // when using the #[Template] attribute, you only need to return
             // an array with the parameters to pass to the template (the attribute
             // is the one which will create and return the Response object).
             return [
@@ -608,7 +608,7 @@ to define the template to render::
 
 .. versionadded:: 6.2
 
-    The ``#[Template()]`` attribute was introduced in Symfony 6.2.
+    The ``#[Template]`` attribute was introduced in Symfony 6.2.
 
 The :ref:`base AbstractController <the-base-controller-classes-services>` also provides the
 :method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController::renderBlock`


### PR DESCRIPTION
Follow #19898 on, 6.4


> 
> In symfony codebase `#[Foo]` is used instead of `#[Foo()]`
> 
> Phpstorm like also without
> ![image](https://github.com/symfony/symfony-docs/assets/9253091/9a4902ef-4c6a-428d-9fae-7034aca17f19)
> 
> I've made also PR for 6.4, if you're agree with this rule I will made other PR.
> (And maybe a new doctor-rst rule)