### PR TITLE
[Notifier] Fixes typo

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -944,7 +944,7 @@ The default behavior for browser channel notifications is to add a
 However, you might prefer to map the importance level of the notification to the
 type of flash message, so you can tweak their style.
 
-you can do that by overriding the default ``notifier.flash_message_importance_mapper``
+You can do that by overriding the default ``notifier.flash_message_importance_mapper``
 service with your own implementation of
 :class:`Symfony\\Component\\Notifier\\FlashMessage\\FlashMessageImportanceMapperInterface`
 where you can provide your own "importance" to "alert level" mapping.


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->

I'm targeting 6.1, because this introduced the typo.