### PR TITLE
[Contributing] Add documentation for rebasing when contributing to the docs

### DIFF
--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -136,6 +136,10 @@ even remove any content and do your best to comply with the
 
 **Step 6.** **Push** the changes to your forked repository:
 
+Before submitting your PR, you may have to update your branch as described in :doc:`the code contribution guide </contributing/code/pull_requests#rebase-your-pull-request>`.
+
+Then, you can push your changes:
+
 .. code-block:: terminal
 
     $ git push origin improve_install_article


### PR DESCRIPTION
Title pretty much says it all : I asked [on Slack](https://symfony-devs.slack.com/archives/C9HKZM8KY/p1713877557930869) about how to rebase my docs branch because I'm not used to rebasing.

We noticed there is no such documentation on the [Contributing to the Documentation](https://symfony.com/doc/current/contributing/documentation/overview.html#review-your-changes) page, whereas there is one in the [Proposing a Change](https://symfony.com/doc/current/contributing/code/pull_requests.html#rebase-your-pull-request).

So here is the PR to add such a section.

QUESTIONS :
- [x] Maybe the `Rebase your branch` title is too big ?