### PR TITLE
[Messenger] Update messenger.rst

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -2644,7 +2644,7 @@ provided in order to ease the declaration of these special handlers::
         // of the trait to define your own batch size...
         private function shouldFlush(): bool
         {
-            return 100 <= \count($this->jobs);
+            return $this->getBatchSize() <= \count($this->jobs);
         }
 
         // ... or redefine the `getBatchSize()` method if the default


### PR DESCRIPTION
Was confused for a second because getBatchSize was introduced in 6.4 but according to the docs it wasn't used. It is according to the actual code so here's the fix.

See https://github.com/symfony/messenger/blob/6.4/Handler/BatchHandlerTrait.php#L58C9-L58C61