### PR TITLE
[ExpressionLanguage] Remove misleading warning

### DIFF
--- a/components/expression_language.rst
+++ b/components/expression_language.rst
@@ -112,13 +112,6 @@ expressions (e.g. the request, the current user, etc.):
 * :doc:`Variables available in service container expressions </service_container/expression_language>`;
 * :ref:`Variables available in routing expressions <routing-matching-expressions>`.
 
-.. caution::
-
-    When using variables in expressions, avoid passing untrusted data into the
-    array of variables. If you can't avoid that, sanitize non-alphanumeric
-    characters in untrusted data to prevent malicious users from injecting
-    control characters and altering the expression.
-
 .. _expression-language-caching:
 
 Caching


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony-docs/issues/17978 

The warning I am removing was created after https://github.com/symfony/symfony-docs/issues/8259 but the issue used an incorrect regex to show a potential problem which doesn't exist.

In my issue I show that it's not actually possible to inject control characters. I would still suggest for someone more involved in symfony development to investigate further, if the expression language is used in the security component this would need more than just a warning

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
