### PR TITLE
[Lock] Update lock.rst

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -788,7 +788,7 @@ Using the above methods, a robust code would be::
             $lock->refresh();
         }
 
-        // Perform the task whose duration MUST be less than 5 minutes
+        // Perform the task whose duration MUST be less than 5 seconds
     }
 
 .. caution::


### PR DESCRIPTION
Incorrect assumption that $lock->getRemainingLifetime()'s unit was minutes instead of seconds

This typo is also present in versions 6.4 and 7.* of the documentation.
