### PR TITLE
[Yaml] Minor fix when using the format option in the lint command

### DIFF
--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -436,7 +436,7 @@ Add the ``--format`` option to get the output in JSON format:
 
 .. code-block:: terminal
 
-    $ php lint.php path/to/file.yaml --format json
+    $ php lint.php path/to/file.yaml --format=json
 
 .. tip::
 


### PR DESCRIPTION
While reviewing #19991 I found this and I think it's an error.