### PR TITLE
[Cache] Fix redis adapter config to work with tags

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -618,8 +618,7 @@ to enable this feature. This could be added by using the following configuration
             cache:
                 pools:
                     my_cache_pool:
-                        adapter: cache.adapter.redis
-                        tags: true
+                        adapter: cache.adapter.redis_tag_aware
 
     .. code-block:: xml
 


### PR DESCRIPTION
I found that to work with redis and tags using this config was not working (tag not set and invalidation not working):

```
 'adapter' => 'cache.adapter.redis',
 'tags' => true,
```

While with this one all was working fine:

```
adapter' => 'cache.adapter.redis_tag_aware',
```

Up to you if you think that it makes sense :)