### PR TITLE
[Validator] Update Url for changing the default value of the requireTld option

### DIFF
--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -317,6 +317,11 @@ also relative URLs that contain no protocol (e.g. ``//example.com``).
 
     The ``requiredTld`` option was introduced in Symfony 7.1.
 
+.. deprecated:: 7.1
+
+    Not setting the ``requireTld`` option is deprecated since Symfony 7.1
+    and will default to ``true`` in Symfony 8.0.
+
 By default, URLs like ``https://aaa`` or ``https://foobar`` are considered valid
 because they are tecnically correct according to the `URL spec`_. If you set this option
 to ``true``, the host part of the URL will have to include a TLD (top-level domain


### PR DESCRIPTION
I find it weird to indicate depreciation in the same version as the introduction of this option but I did not have other idea. WDYT? 

Related to https://github.com/symfony/symfony/pull/54588
