### PR TITLE
[DependencyInjection] Add mentions where to find configCache

### DIFF
--- a/components/dependency_injection/compilation.rst
+++ b/components/dependency_injection/compilation.rst
@@ -504,7 +504,8 @@ serves at dumping the compiled container::
     The ``file_put_contents()`` function is not atomic. That could cause issues
     in a production environment with multiple concurrent requests. Instead, use
     the :ref:`dumpFile() method <filesystem-dumpfile>` from Symfony Filesystem
-    component or other methods provided by Symfony (e.g. ``$containerConfigCache->write()``)
+    component or other methods provided by Symfony (e.g. ``$containerConfigCache->write()``
+    which is part of the :doc:`Config component </components/config>`)
     which are atomic.
 
 ``ProjectServiceContainer`` is the default name given to the dumped container


### PR DESCRIPTION
Added mention where to find ConfigCache class. To be used in  $containerCache->write()

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
