### PR TITLE
[Mercure] fix service definition example in testing section

### DIFF
--- a/mercure.rst
+++ b/mercure.rst
@@ -673,8 +673,9 @@ sent:
 .. code-block:: yaml
 
     # config/services_test.yaml
-    mercure.hub.default:
-        class: App\Tests\Functional\Stub\HubStub
+    services:
+        mercure.hub.default:
+            class: App\Tests\Functional\Stub\HubStub
 
 As MercureBundle support multiple hubs, you may have to replace
 the other service definitions accordingly.


### PR DESCRIPTION
Tried to follow the example and noticed that this was wrong