### PR TITLE
Update security.rst

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -833,10 +833,10 @@ Finally, create or update the template:
 
         <form action="{{ path('app_login') }}" method="post">
             <label for="username">Email:</label>
-            <input type="text" id="username" name="_username" value="{{ last_username }}">
+            <input type="text" id="username" name="_username" value="{{ last_username }}" required>
 
             <label for="password">Password:</label>
-            <input type="password" id="password" name="_password">
+            <input type="password" id="password" name="_password" required>
 
             {# If you want to control the URL the user is redirected to on success
             <input type="hidden" name="_target_path" value="/account"> #}


### PR DESCRIPTION
If this form is submitted with an empty username or password, a 400 error will be thrown in a new page:  The key "_password" must be a non-empty string. By adding "required" the user will instead get a more helpful "Please fill in this field." error on screen next to the appropriate box which is a much better experience.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
