### PR TITLE
Fix the parameter configuration in the file upload doc

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -175,16 +175,17 @@ Finally, you need to update the code of the controller that handles the form::
         }
     }
 
-Now, create the ``brochures_directory`` parameter that was used in the
-controller to specify the directory in which the brochures should be stored:
+Now, bind the ``$brochuresDirectory`` controller argument to its actual value
+using the service configuration:
 
 .. code-block:: yaml
 
     # config/services.yaml
-
-    # ...
-    parameters:
-        brochures_directory: '%kernel.project_dir%/public/uploads/brochures'
+    services:
+        _defaults:
+            # ...
+            bind:
+                $brochuresDirectory: '%kernel.project_dir%/public/uploads/brochures'
 
 There are some important things to consider in the code of the above controller:
 


### PR DESCRIPTION
Fixes #20039.

I propose to do this change in 5.4 ... but revert this and use `#[Autowire('%kernel.project_dir%/public/uploads/brochures')]` instead in 6.4 branch and up.