### PR TITLE
[HttpClient] Document usage or user:pass@example.com for Basic Auth

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -489,6 +489,11 @@ each request (which overrides any global authentication):
 
 .. note::
 
+    Basic Authentication can be set by authority in the URL, like
+    http://user:pass@example.com/.
+
+.. note::
+
     The NTLM authentication mechanism requires using the cURL transport.
     By using ``HttpClient::createForBaseUri()``, we ensure that the auth credentials
     won't be sent to any other hosts than https://example.com/.


### PR DESCRIPTION
It is possible to use `username:password` in the current implementation. This behavior should be documented.