### PR TITLE
[Messenger] use a custom batch size

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -2644,7 +2644,7 @@ provided in order to ease the declaration of these special handlers::
         // of the trait to define your own batch size...
         private function shouldFlush(): bool
         {
-            return $this->getBatchSize() <= \count($this->jobs);
+            return 100 <= \count($this->jobs);
         }
 
         // ... or redefine the `getBatchSize()` method if the default


### PR DESCRIPTION
reverts #19953 so that the code matches the comment above the method