### PR TITLE
Document Symfony CLI autocompletion

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -103,6 +103,15 @@ options by pressing the Tab key.
 
         $ php vendor/bin/phpstan completion bash | sudo tee /etc/bash_completion.d/phpstan
 
+.. tip::
+
+    If you are using the :doc:`Symfony local web server
+    </setup/symfony_server>`, it is recommended to use the builtin completion
+    script that will ensure the right PHP version and configuration is used when
+    running the Console Completion. Run ``symfony completion --help`` for the
+    installation instructions for your shell. The Symfony CLI will provide
+    completion for the ``console`` and ``composer`` commands.
+
 Creating a Command
 ------------------
 

--- a/setup/symfony_server.rst
+++ b/setup/symfony_server.rst
@@ -17,6 +17,17 @@ Installation
 The Symfony server is part of the ``symfony`` binary created when you
 `install Symfony`_ and has support for Linux, macOS and Windows.
 
+.. tip::
+
+    The Symfony CLI supports auto completion for Bash, Zsh or Fish shells. You
+    have to install the completion script *once*. Run ``symfony completion
+    --help`` for the installation instructions for your shell. After installing
+    and restarting your terminal, you're all set to use completion (by default,
+    by pressing the Tab key).
+
+    The Symfony CLI will also provide completion for the ``composer`` command
+    and for the ``console`` command if it detects a Symfony project.
+
 .. note::
 
    You can view and contribute to the Symfony CLI source in the


### PR DESCRIPTION
I recently implemented autocompletion for any tools based on [symfony-cli/console](https://github.com/symfony-cli/console) including Symfony CLI (see https://github.com/symfony-cli/console/pull/11).
I also added completion forwarding for `composer` and `console` (see https://github.com/symfony-cli/symfony-cli/pull/493).

This means that you can have the autocompletion for the 3 tools by following `symfony completion --help` instructions and that it will automatically use the right configuration (ie. PHP version, `php.ini`, etc) when running it.

Note: I opened the PR against `7.1` but technically this is not related to any `Symfony version`, let me know if you want me to change the target version.