### PR TITLE
[Validator] drop type-hints for properties where the ´Type´ constraint is used

### DIFF
--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -33,19 +33,19 @@ This will check if ``emailAddress`` is an instance of ``Symfony\Component\Mime\A
         class Author
         {
             #[Assert\Type(Address::class)]
-            protected Address $emailAddress;
+            protected $emailAddress;
 
             #[Assert\Type('string')]
-            protected string $firstName;
+            protected $firstName;
 
             #[Assert\Type(
                 type: 'integer',
                 message: 'The value {{ value }} is not a valid {{ type }}.',
             )]
-            protected int $age;
+            protected $age;
 
             #[Assert\Type(type: ['alpha', 'digit'])]
-            protected string $accessCode;
+            protected $accessCode;
         }
 
     .. code-block:: yaml


### PR DESCRIPTION
partially revert #18362 as having the native type-hints prevents the `Type` constraint to be applied in a meaningful way (if the types don't match, PHP will error before)