### PR TITLE
[Security] add the `$token` argument to `checkPostAuth()`

### DIFF
--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -40,7 +40,7 @@ displayed to the user::
             }
         }
 
-        public function checkPostAuth(UserInterface $user): void
+        public function checkPostAuth(UserInterface $user, TokenInterface $token): void
         {
             if (!$user instanceof AppUser) {
                 return;


### PR DESCRIPTION
fixes #20062