### PR TITLE
fix dump destination value in PHP config

### DIFF
--- a/reference/configuration/debug.rst
+++ b/reference/configuration/debug.rst
@@ -99,7 +99,7 @@ Typically, you would set this to ``php://stderr``:
 
         return static function (ContainerConfigurator $container): void {
             $container->extension('debug', [
-                'dump_destination' => 'tcp://%env(VAR_DUMPER_SERVER)%',
+                'dump_destination' => 'php://stderr',
             ]);
         };
 


### PR DESCRIPTION
Let the value be the same to what we configure with the YAML and XML examples.