### PR TITLE
[DomCrawler] fixes typo `Form::getFields()` -> `Form::getFiles()`

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -917,7 +917,7 @@ The second optional argument is used to override the default form field values.
 
 If you need access to the :class:`Symfony\\Component\\DomCrawler\\Form` object
 that provides helpful methods specific to forms (such as ``getUri()``,
-``getValues()`` and ``getFields()``) use the ``Crawler::selectButton()`` method instead::
+``getValues()`` and ``getFiles()``) use the ``Crawler::selectButton()`` method instead::
 
     $client = static::createClient();
     $crawler = $client->request('GET', '/post/hello-world');


### PR DESCRIPTION
Looks like this method does not exist in `Form`: https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/DomCrawler/Form.php

I think it never did. Looking at v2.8 it does not exist, same's true for 3.4, 4.4, 5.4, 6.4, 7.0 ... 