### PR TITLE
Fixed typo in configuration.rst

### DIFF
--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -97,7 +97,7 @@ class, you can add all the logic related to processing the configuration in that
             // the "$config" variable is already merged and processed so you can
             // use it directly to configure the service container (when defining an
             // extension class, you also have to do this merging and processing)
-            $containerConfigurator->services()
+            $container->services()
                 ->get('acme_social.twitter_client')
                 ->arg(0, $config['twitter']['client_id'])
                 ->arg(1, $config['twitter']['client_secret'])


### PR DESCRIPTION
`$containerConfigurator` was renamed into `$container` in 6.4, but code example was not fully updated.
