### PR TITLE
[HttpFoundation] [http-foundation] Check if ip is in cidr subnet

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -353,6 +353,27 @@ analysis purposes. Use the ``anonymize()`` method from the
     $anonymousIpv6 = IpUtils::anonymize($ipv6);
     // $anonymousIpv6 = '2a01:198:603:10::'
 
+
+Check if an IP belongs to a CIDR subnet
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you need to know if an IP address is included in a CIDR subnet, you can
+use the ``checkIp`` method from the
+:class:`Symfony\\Component\\HttpFoundation\\IpUtils` to do that::
+
+    use Symfony\Component\HttpFoundation\IpUtils;
+
+    $ipv4 = '192.168.1.56';
+    $CIDRv4 = '192.168.1.0/16';
+    $isIpInCIDRv4 = IpUtils::checkIp($ipv4, $CIDRv4);
+    // $isIpInCIDRv4 = true
+
+    $ipv6 = '2001:db8:abcd:1234::1';
+    $CIDRv6 = '2001:db8:abcd::/48';
+    $isIpInCIDRv6 = IpUtils::checkIp($ipv6, $CIDRv6);
+    // $isIpInCIDRv6 = true
+
+
 Accessing other Data
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
While I was searching a way to check if an IP is included in a CIDR subnet, I found this old stack overflow : https://stackoverflow.com/questions/594112/check-whether-or-not-a-cidr-subnet-contains-an-ip-address

This old question has of course an old answer but also has a "recent" one that might answer to 99% use cases of Symfony devs. And should be in the documentation.
