### PR TITLE
example function param 1 requires string

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -627,7 +627,7 @@ For example, to get a dump as a string in a variable, you can do::
 
     $dumper->dump(
         $cloner->cloneVar($variable),
-        function (int $line, int $depth) use (&$output): void {
+        function (string $line, int $depth) use (&$output): void {
             // A negative depth means "end of dump"
             if ($depth >= 0) {
                 // Adds a two spaces indentation to the line


### PR DESCRIPTION
An int causes a PHP error

argument symfony#1 ($line) must be of type int, string given,
