### PR TITLE
[Workflow] Add tip on how to add a WHERE constraint on a multi-state marking store

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -285,8 +285,11 @@ if you are using Doctrine, the matching column definition should use the type ``
 
 .. tip::
 
-    On a database level, you can check the current place as follows:
-    ``[WHERE] JSON_CONTAINS_PATH(item.currentPlaces, 'one', '$.draft')``
+    On a database level, querying or filtering for multiple state marking stores
+    requires special handling. When using Doctrine with MySQL, you can install
+    `scienta/doctrine-json-functions` and enable the `JSON_CONTAINS_PATH` doctrine
+    function. Then you can filter for a current place as follows:
+    ``$qb->andWhere("JSON_CONTAINS_PATH(item.currentPlaces, 'one', '$.draft') <> 0")``
     (where `draft` is the place to be checked)
 
 Accessing the Workflow in a Class

--- a/workflow.rst
+++ b/workflow.rst
@@ -283,6 +283,12 @@ if you are using Doctrine, the matching column definition should use the type ``
     this Doctrine type will store its value only as a string, resulting in the
     loss of the object's current place.
 
+.. tip::
+
+    On a database level, you can check the current place as follows:
+    ``[WHERE] JSON_CONTAINS_PATH(item.currentPlaces, 'one', '$.draft')``
+    (where `draft` is the place to be checked)
+
 Accessing the Workflow in a Class
 ---------------------------------
 


### PR DESCRIPTION
Filtering a single state marking store might be straightforward (i.e., `WHERE currentPlaces = :place`).

I found filtering on a multiple state marking store with JSON schema more challenging (because of the key-value structure as well).
Also, JSON functions are not default to Doctrine and not standardized among databases.