### PR TITLE
[Validator] clarify how to disable client-side validation using the Regex constraint

### DIFF
--- a/reference/constraints/Regex.rst
+++ b/reference/constraints/Regex.rst
@@ -193,7 +193,7 @@ Options
 ``htmlPattern``
 ~~~~~~~~~~~~~~~
 
-**type**: ``string|boolean`` **default**: ``null``
+**type**: ``string|null`` **default**: ``null``
 
 This option specifies the pattern to use in the HTML5 ``pattern`` attribute.
 You usually don't need to specify this option because by default, the constraint
@@ -289,7 +289,7 @@ need to specify the HTML5 compatible pattern in the ``htmlPattern`` option:
             }
         }
 
-Setting ``htmlPattern`` to false will disable client side validation.
+Setting ``htmlPattern`` to the empty string will disable client side validation.
 
 ``match``
 ~~~~~~~~~


### PR DESCRIPTION
fixes symfony/symfony#53807