### PR TITLE
[HttpFoundation] Add missing example for HeaderUtils class

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -287,6 +287,10 @@ this complexity and defines some methods for the most common tasks::
     HeaderUtils::parseQuery('foo[bar.baz]=qux');
     // => ['foo' => ['bar.baz' => 'qux']]
 
+    // Generates an HTTP "Content-Disposition" field-value, with fallback filename.
+    HeaderUtils::makeDisposition('attachment', 'utf8_filename.txt', 'ascii_fallback.txt'));
+    // => 'attachment; filename=ascii_fallback.txt; filename*=utf-8\'\'utf8_filename.txt'
+
 .. versionadded:: 5.2
 
     The ``parseQuery()`` method was introduced in Symfony 5.2.

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -288,7 +288,7 @@ this complexity and defines some methods for the most common tasks::
     // => ['foo' => ['bar.baz' => 'qux']]
 
     // Generates an HTTP "Content-Disposition" field-value, with fallback filename.
-    HeaderUtils::makeDisposition('attachment', 'utf8_filename.txt', 'ascii_fallback.txt'));
+    HeaderUtils::makeDisposition('attachment', 'utf8_filename.txt', 'ascii_fallback.txt');
     // => 'attachment; filename=ascii_fallback.txt; filename*=utf-8\'\'utf8_filename.txt'
 
 .. versionadded:: 5.2


### PR DESCRIPTION
Adds an example for `makeDisposition`  method, from `HeaderUtils` class, that missed for now.