### PR TITLE
minor : the process method from CompilerPassInterface should be public

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -651,7 +651,7 @@ to remove the ``kernel.reset`` tag from some services in your test environment::
 
         // ...
 
-        protected function process(ContainerBuilder $container): void
+        public function process(ContainerBuilder $container): void
         {
             if ('test' === $this->environment) {
                 // prevents the security token to be cleared


### PR DESCRIPTION
Since the method is defined in CompilerPassInterface as public, it should be defined as public in the Kernel.
