### PR TITLE
Add links for the better nav in the format specification refs

### DIFF
--- a/reference/formats/expression_language.rst
+++ b/reference/formats/expression_language.rst
@@ -1,7 +1,7 @@
 The Expression Syntax
 =====================
 
-The ExpressionLanguage component uses a specific syntax which is based on the
+The :doc:`ExpressionLanguage component </components/expression_language>` uses a specific syntax which is based on the
 expression syntax of Twig. In this document, you can find all supported
 syntaxes.
 

--- a/reference/formats/message_format.rst
+++ b/reference/formats/message_format.rst
@@ -3,7 +3,7 @@ How to Translate Messages using the ICU MessageFormat
 
 Messages (i.e. strings) in applications are almost never completely static.
 They contain variables or other complex logic like pluralization. To
-handle this, the Translator component supports the `ICU MessageFormat`_ syntax.
+handle this, the :doc:`Translator component </translation>` supports the `ICU MessageFormat`_ syntax.
 
 .. tip::
 

--- a/reference/formats/yaml.rst
+++ b/reference/formats/yaml.rst
@@ -1,7 +1,7 @@
 The YAML Format
 ---------------
 
-The Symfony Yaml Component implements a selected subset of features defined in
+The Symfony :doc:`Yaml Component </components/yaml>` implements a selected subset of features defined in
 the `YAML 1.2 version specification`_.
 
 Scalars


### PR DESCRIPTION
Pages from the [Configuration Options](https://symfony.com/doc/current/reference/index.html#configuration-options) section (except framework) have a link in the first paragraph to the corresponding part of the [documentation](https://symfony.com/doc/current/index.html).
For better navigation, I also added such links in the [Format Specifications](https://symfony.com/doc/current/reference/index.html#format-specifications) section.
