### PR TITLE
[Security] Remove note about stateless firewalls marking routes as stateless

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -1075,13 +1075,6 @@ the session must not be used when authenticating users:
             // ...
         };
 
-Routes under this firewall will be :ref:`configured stateless <stateless-routing>`
-when they are not explicitly configured stateless or not.
-
-.. versionadded:: 6.3
-
-    Stateless firewall marking routes stateless was introduced in Symfony 6.3.
-
 User Checkers
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
Following https://github.com/symfony/symfony/pull/58017