### PR TITLE
[Messenger] fix comment

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -2283,8 +2283,8 @@ to your message::
 
     public function index(MessageBusInterface $bus)
     {
+        // wait 5 seconds before processing
         $bus->dispatch(new SmsNotification('...'), [
-            // wait 5 seconds before processing
             new DelayStamp(5000),
         ]);
 


### PR DESCRIPTION
comment "inside php code" render in wrong color
<img width="589" alt="Capture d’écran 2024-08-17 à 17 30 57" src="https://github.com/user-attachments/assets/f6d90b17-4ab4-47c2-b7a6-7ba724fc32f7">
