### PR TITLE
[FrameworkBundle][HttpFoundation] Deprecate `session.sid_length` and `session.sid_bits_per_character` config options

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1874,6 +1874,10 @@ session IDs are harder to guess.
 
 If not set, ``php.ini``'s `session.sid_length`_ directive will be relied on.
 
+.. deprecated:: 7.2
+
+    The ``sid_length`` option was deprecated in Symfony 7.2.
+
 sid_bits_per_character
 ......................
 
@@ -1885,6 +1889,10 @@ The more bits results in stronger session ID. ``5`` is recommended value for
 most environments.
 
 If not set, ``php.ini``'s `session.sid_bits_per_character`_ directive will be relied on.
+
+.. deprecated:: 7.2
+
+    The ``sid_bits_per_character`` option was deprecated in Symfony 7.2.
 
 save_path
 .........

--- a/session.rst
+++ b/session.rst
@@ -400,6 +400,11 @@ Check out the Symfony config reference to learn more about the other available
     ``session.auto_start = 1`` This directive should be turned off in
     ``php.ini``, in the web server directives or in ``.htaccess``.
 
+.. deprecated:: 7.2
+
+    The ``sid_length`` and ``sid_bits_per_character`` options were deprecated
+    in Symfony 7.2 and will be ignored in Symfony 8.0.
+
 The session cookie is also available in :ref:`the Response object <component-http-foundation-response>`.
 This is useful to get that cookie in the CLI context or when using PHP runners
 like Roadrunner or Swoole.


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/pull/57805

Fixes #20224