### PR TITLE
Fix `:ref:` links

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -747,7 +747,7 @@ If you use the Redis Transport, note that each worker needs a unique consumer
 name to avoid the same message being handled by multiple workers. One way to
 achieve this is to set an environment variable in the Supervisor configuration
 file, which you can then refer to in ``messenger.yaml``
-(see the ref:`Redis section <messenger-redis-transport>` below):
+(see the :ref:`Redis section <messenger-redis-transport>` below):
 
 .. code-block:: ini
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
![image](https://github.com/user-attachments/assets/f427802c-36b8-433d-b9bc-e1c382941f4f)

AFAIK, this reference is also broken.
https://github.com/symfony/symfony-docs/blob/24076368c63d871ce07dd0b607fa539d6d79f6ea/components/expression_language.rst#L85
But I don't know how to point to the proper target. I've already tried with `:doc:`:
```diff
-    This content has been moved to the ref:`null coalescing operator <component-expression-null-coalescing-operator>`_
+    This content has been moved to the :doc:`null coalescing operator </reference/formats/expression_language#component-expression-null-coalescing-operator>`_
```


