### PR TITLE
[Config] Match Yaml configuration and Tree

### DIFF
--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -81,7 +81,7 @@ reflect the real structure of the configuration values::
                 ->defaultTrue()
             ->end()
             ->scalarNode('default_connection')
-                ->defaultValue('default')
+                ->defaultValue('mysql')
             ->end()
         ->end()
     ;


### PR DESCRIPTION
The documentation shows Yaml configuration using a mysql string as a default value for default_connection configuration.
It may be reflected into the Tree.
Even if this is not an error, it may help to remain consistent.