### PR TITLE
[Serializer] add nullable format to defaultContext circularReference handler to prevent normalize error

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -1500,7 +1500,7 @@ having unique identifiers::
 
     $encoder = new JsonEncoder();
     $defaultContext = [
-        AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => function (object $object, string $format, array $context): string {
+        AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => function (object $object, ?string $format, array $context): string {
             return $object->getName();
         },
     ];


### PR DESCRIPTION
add nullable $format parameter if this defaultContext is used with $serializer->normalize where $format can be nullable.

compress arguments with only seventh set.