### PR TITLE
[Serializer] Normalizer Callback params confusion: $innerObject should be called $attributeValue and $outerObject should be just $object

### DIFF
--- a/components/serializer.rst
+++ b/components/serializer.rst
@@ -799,8 +799,8 @@ When serializing, you can set a callback to format a specific object property::
     $encoder = new JsonEncoder();
 
     // all callback parameters are optional (you can omit the ones you don't use)
-    $dateCallback = function ($innerObject, $outerObject, string $attributeName, ?string $format = null, array $context = []) {
-        return $innerObject instanceof \DateTime ? $innerObject->format(\DateTime::ATOM) : '';
+    $dateCallback = function ($attributeValue, $object, string $attributeName, ?string $format = null, array $context = []) {
+        return $attributeValue instanceof \DateTime ? $attributeValue->format(\DateTime::ATOM) : '';
     };
 
     $defaultContext = [


### PR DESCRIPTION
Closes https://github.com/symfony/symfony-docs/issues/20080