### PR TITLE
[ExpressionLanguage] Fix uncaught ArgumentCountError

### DIFF
--- a/components/expression_language.rst
+++ b/components/expression_language.rst
@@ -99,11 +99,11 @@ other hand, returns a boolean indicating if the expression is valid or not::
 
     $expressionLanguage = new ExpressionLanguage();
 
-    var_dump($expressionLanguage->parse('1 + 2'));
+    var_dump($expressionLanguage->parse('1 + 2', []));
     // displays the AST nodes of the expression which can be
     // inspected and manipulated
 
-    var_dump($expressionLanguage->lint('1 + 2')); // displays true
+    var_dump($expressionLanguage->lint('1 + 2', [])); // displays true
 
 Passing in Variables
 --------------------


### PR DESCRIPTION
Set second argument with an empty array for the two instructions to get rid of the fatal error uncaught argumentError

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
