### PR TITLE
[Ldap] feat: remove mention of FOSUserBundle in doc

### DIFF
--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -25,7 +25,7 @@ This means that the following scenarios will work:
   either the LDAP form login or LDAP HTTP Basic authentication providers.
 
 * Checking a user's password against an LDAP server while fetching user
-  information from another source (database using FOSUserBundle, for
+  information from another source like your main database for
   example).
 
 * Loading user information from an LDAP server, while using another


### PR DESCRIPTION
as per https://github.com/FriendsOfSymfony/FOSUserBundle?tab=readme-ov-file#maintenance-status
I think targeting the actual LTS make sens to remove such references in the doc, WDYT?