### PR TITLE
[FrameworkBundle] Lower uppercase `must`

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3268,7 +3268,7 @@ settings from the base pool as defaults.
 
 .. note::
 
-    Your service MUST implement the ``Psr\Cache\CacheItemPoolInterface`` interface.
+    Your service **must** implement the ``Psr\Cache\CacheItemPoolInterface`` interface.
 
 public
 """"""


### PR DESCRIPTION
Just came across this one and it felt out of place. We tend to avoid "must". Even if I agree it is required in this situation, let's use bold instead of uppercase, feels less aggressive :slightly_smiling_face: 