### PR TITLE
[Mailer] Remove unnecessary type checking for the method from SentMessageEvent

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1728,14 +1728,10 @@ which is useful for debugging errors::
 
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
     use Symfony\Component\Mailer\Event\SentMessageEvent;
-    use Symfony\Component\Mailer\SentMessage;
 
     public function onMessage(SentMessageEvent $event): void
     {
         $message = $event->getMessage();
-        if (!$message instanceof SentMessage) {
-            return;
-        }
 
         // do something with the message
     }


### PR DESCRIPTION
The getMessage method has been returning **only** SentMessage from the very [beginning](https://github.com/symfony/symfony/pull/47080/files#diff-19459911f97144033a370e7d86ae4e3bab9833c03cfe42e1eb3d71da90b15097R26).
