### PR TITLE
Use the same template across all examples

### DIFF
--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -277,7 +277,7 @@ number::
                 return $this->render('security/login_link_sent.html.twig');
             }
 
-            return $this->render('security/login.html.twig');
+            return $this->render('security/request_login_link.html.twig');
         }
 
         // ...
@@ -664,7 +664,7 @@ user create this POST request (e.g. by clicking a button)::
         <h2>Hi! You are about to login to ...</h2>
 
         <!-- for instance, use a form with hidden fields to
-             create the POST request --->
+             create the POST request -->
         <form action="{{ path('login_check') }}" method="POST">
             <input type="hidden" name="expires" value="{{ expires }}">
             <input type="hidden" name="user" value="{{ user }}">


### PR DESCRIPTION
The documentation is using `security/request_login_link.html.twig` in 2 of the 3 code snippets. This makes sure the docs are using the same link everywhere.
