### PR TITLE
Replace code block text with terminal where it was used incorrectly

### DIFF
--- a/components/console/helpers/table.rst
+++ b/components/console/helpers/table.rst
@@ -199,7 +199,7 @@ You can also set the style to ``box``::
 
 which outputs:
 
-.. code-block:: text
+.. code-block:: terminal
 
     ┌───────────────┬──────────────────────────┬──────────────────┐
     │ ISBN          │ Title                    │ Author           │
@@ -217,7 +217,7 @@ You can also set the style to ``box-double``::
 
 which outputs:
 
-.. code-block:: text
+.. code-block:: terminal
 
     ╔═══════════════╤══════════════════════════╤══════════════════╗
     ║ ISBN          │ Title                    │ Author           ║

--- a/contributing/community/reviews.rst
+++ b/contributing/community/reviews.rst
@@ -167,7 +167,7 @@ Pick a pull request from the `PRs in need of review`_ and follow these steps:
    PR by running the following Git commands. Insert the PR ID (that's the number
    after the ``#`` in the PR title) for the ``<ID>`` placeholders:
 
-   .. code-block:: text
+   .. code-block:: terminal
 
        $ cd vendor/symfony/symfony
        $ git fetch origin pull/<ID>/head:pr<ID>
@@ -175,7 +175,7 @@ Pick a pull request from the `PRs in need of review`_ and follow these steps:
 
    For example:
 
-   .. code-block:: text
+   .. code-block:: terminal
 
        $ git fetch origin pull/15723/head:pr15723
        $ git checkout pr15723


### PR DESCRIPTION
Console commands in section 5 https://symfony.com/doc/current/contributing/community/reviews.html
Not all console output is displayed as terminal https://symfony.com/doc/current/components/console/helpers/table.html

I have also checked Progress Bar, but the console output there is modified with comments.
