### PR TITLE
bundles - add reason why they are not recommended

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -160,6 +160,8 @@ values is that it's complicated to redefine their values in your tests.
 Business Logic
 --------------
 
+.. _best-practice-no-application-bundles:
+
 Don't Create any Bundle to Organize your Application Logic
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/bundles.rst
+++ b/bundles.rst
@@ -6,7 +6,7 @@ The Bundle System
 .. caution::
 
     In Symfony versions prior to 4.0, it was recommended to organize your own
-    application code using bundles. This is no longer recommended and bundles
+    application code using bundles. This is :ref:`no longer recommended <best-practice-no-application-bundles>` and bundles
     should only be used to share code and features between multiple applications.
 
 A bundle is similar to a plugin in other software, but even better. The core


### PR DESCRIPTION
I was missing a link for reasoning why this was deprecated. Please add this missing context.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
