### PR TITLE
[Messenger] Update reference for `framework.cache.prefix_seed` config node

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -532,7 +532,7 @@ On production, there are a few important things to think about:
 
 **Use the Same Cache Between Deploys**
     If your deploy strategy involves the creation of new target directories, you
-    should set a value for the :ref:`cache.prefix.seed <reference-cache-prefix-seed>`
+    should set a value for the :ref:`cache.prefix_seed <reference-cache-prefix-seed>`
     configuration option in order to use the same cache namespace between deployments.
     Otherwise, the ``cache.app`` pool will use the value of the ``kernel.project_dir``
     parameter as base for the namespace, which will lead to different namespaces


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->

See:
* https://symfony.com/doc/current/reference/configuration/framework.html#prefix-seed;
* https://github.com/symfony/symfony/blob/6896976123a70cf56c9e2576773400486f30e80f/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php#L1071.
