### PR TITLE
[Serializer] Update serializer.rst - Use the right namespace for the Attribute

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -416,7 +416,7 @@ their paths using a :doc:`valid PropertyAccess syntax </components/property_acce
 
         namespace App\Model;
 
-        use Symfony\Component\Serializer\Annotation\SerializedPath;
+        use Symfony\Component\Serializer\Attribute\SerializedPath;
 
         class Person
         {


### PR DESCRIPTION
Use the right namespace for the Attribute

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
