### PR TITLE
[Messenger] Add missing backticks for inline snippets

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1679,7 +1679,7 @@ redis_sentinel           support is disabled
 
 .. versionadded:: 7.1
 
-    The option `redis_sentinel` as an alias for `sentinel_master` was introduced
+    The option ``redis_sentinel`` as an alias for ``sentinel_master`` was introduced
     in Symfony 7.1.
 
 .. caution::


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
