### PR TITLE
[HttpFoundation] Fix call to an undefined method setContentDisposition()

### DIFF
--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -850,7 +850,7 @@ or change its ``Content-Disposition``::
 
     // ...
     $response->headers->set('Content-Type', 'text/plain');
-    $response->setContentDisposition(
+    $response->headers->set('Content-Disposition',
         ResponseHeaderBag::DISPOSITION_ATTACHMENT,
         'filename.txt'
     );


### PR DESCRIPTION
This commit fix the call to an undefined method  named "setContentDisposition" of class "Symfony\Component\HttpFoundation\Response".

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
