### PR TITLE
[Templating] use /templates instead of /Resources/views

### DIFF
--- a/templates.rst
+++ b/templates.rst
@@ -1294,7 +1294,7 @@ and leaves the repeated contents and HTML structure to some parent templates.
 
     .. code-block:: html+twig
 
-        {# app/Resources/views/blog/index.html.twig #}
+        {# app/templates/blog/index.html.twig #}
         {% extends 'base.html.twig' %}
 
         {# the line below is not captured by a "block" tag #}
@@ -1481,7 +1481,7 @@ templates under an automatic namespace created after the bundle name.
 
 For example, the templates of a bundle called ``AcmeBlogBundle`` are available
 under the ``AcmeBlog`` namespace. If this bundle includes the template
-``<your-project>/vendor/acme/blog-bundle/Resources/views/user/profile.html.twig``,
+``<your-project>/vendor/acme/blog-bundle/templates/user/profile.html.twig``,
 you can refer to it as ``@AcmeBlog/user/profile.html.twig``.
 
 .. tip::


### PR DESCRIPTION
The modern (and default) directory structure.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
