### PR TITLE
[OptionsResolver] [Options Resolver] Fix file reference method

### DIFF
--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -822,7 +822,7 @@ method::
 
     When using an option deprecated by you in your own library, you can pass
     ``false`` as the second argument of the
-    :method:`Symfony\\Component\\OptionsResolver\\Options::offsetGet` method
+    :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::offsetGet` method
     to not trigger the deprecation warning.
 
 .. note::


### PR DESCRIPTION
The documentation mentions offsetGet from OptionsResolver.php file but the current link targets Options.php