### PR TITLE
[Security] Fix role to detect logged-in user

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2648,7 +2648,7 @@ you have the following two options.
 
 Firstly, if you've given *every* user ``ROLE_USER``, you can check for that role.
 
-Secondly, you can use the special "attribute" ``IS_AUTHENTICATED_FULLY`` in place of a role::
+Secondly, you can use the special "attribute" ``IS_AUTHENTICATED`` in place of a role::
 
     // ...
 


### PR DESCRIPTION
An error has been introduced since 6.2  when checking to see if a user is logged-in