### PR TITLE
[Routing] Add note on nuances of the Routing exclude config option

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -1439,7 +1439,7 @@ when importing the routes.
 
         # config/routes/attributes.yaml
         controllers:
-            resource: '../../src/Controller/'
+            resource: '../../src/Controller/**/*'
             type: attribute
             # this is added to the beginning of all imported route URLs
             prefix: '/blog'
@@ -1455,6 +1455,9 @@ when importing the routes.
 
             # you can optionally exclude some files/subdirectories when loading attributes
             # (the value must be a string or an array of PHP glob patterns)
+            # NOTE: For now, this will only work if you are using the string, glob notation for the
+            #       resource value.  The array notation containing `path` & `namespace` will not work,
+            #       and neither will using a non-glob string like `'../src/Controller'`.
             # exclude: '../../src/Controller/{Debug*Controller.php}'
 
     .. code-block:: xml


### PR DESCRIPTION
As per reported issue https://github.com/symfony/symfony/issues/39588,
currently the `exclude` option for attribute routing only works if the
`resource` value is a string, and is a glob pattern, so this updates the
example to use a glob pattern, and advise of this, current nuance.