### PR TITLE
[Security] Configuration logout target indicates route name instead of path

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -1800,8 +1800,8 @@ To enable logging out, activate the  ``logout`` config parameter under your fire
                     logout:
                         path: /logout
 
-                        # where to redirect after logout
-                        # target: app_any_route
+                        # where to redirect after logout (use path not route name)
+                        # target: /logout-redirect
 
     .. code-block:: xml
 


### PR DESCRIPTION
Doc indicates a route name instead of a path name. Route names did not success for me so i think this is a choice.

