### PR TITLE
[Scheduler] Add example about how to pass arguments to a Symfony command

### DIFF
--- a/scheduler.rst
+++ b/scheduler.rst
@@ -473,6 +473,20 @@ The attribute takes more parameters to customize the trigger::
     // defines the timezone to use
     #[AsCronTask('0 0 * * *', timezone: 'Africa/Malabo')]
 
+Arguments/options for Symfony commands are passed as plain string::
+
+    use Symfony\Component\Console\Command\Command;
+
+    #[AsCronTask('0 0 * * *', arguments: 'arg --my-option')]
+    class MyCommand extends Command
+    {
+        protected function configure(): void
+        {
+            $this->addArgument('my-arg');
+            $this->addOption('my-option');
+        }
+    }
+
 .. versionadded:: 6.4
 
     The :class:`Symfony\\Component\\Scheduler\\Attribute\\AsCronTask` attribute
@@ -519,6 +533,20 @@ The ``#[AsPeriodicTask]`` attribute takes many parameters to customize the trigg
         public function sendEmail(string $email): void
         {
             // ...
+        }
+    }
+
+Arguments/options for Symfony commands are passed as plain string::
+
+    use Symfony\Component\Console\Command\Command;
+
+    #[AsPeriodicTask(frequency: '1 day', arguments: 'arg --my-option')]
+    class MyCommand extends Command
+    {
+        protected function configure(): void
+        {
+            $this->addArgument('my-arg');
+            $this->addOption('my-option');
         }
     }
 


### PR DESCRIPTION
We recently wanted to pass arguments to a Symfony command which is configured for the scheduler component with the `#[AsPeriodicTask]` attribute.

The syntax mentioned in https://github.com/symfony/symfony/pull/51525#issuecomment-1702640214 worked.
This PR adds an example to the docs.
