### PR TITLE
Add `CacheableVoterInterface` into voters docs

### DIFF
--- a/security/voters.rst
+++ b/security/voters.rst
@@ -51,7 +51,7 @@ which makes creating a voter even easier::
 
 The Cacheable Voter Interface
 -----------------------------
-When Symfony calls the isGranted() method during runtime, it checks each voter
+When Symfony calls the ``isGranted()`` method during runtime, it checks each voter
 until it meets the access decision strategy set by the configuration.
 While this generally works well, it can slow down performance in some cases.
 
@@ -59,8 +59,8 @@ Imagine a backend displaying 20 items, each with 6 properties and 3 actions
 (like edit, show, delete). Checking permissions for all these requires 180 calls
 to each voter. With 5 voters, that's 900 calls.
 
-Usually, voters only need to focus on a specific permission (e.g., EDIT_BLOG_POST)
-or object type (e.g., User). This focus makes voters cacheable, so Symfony 5.4 introduces a
+Usually, voters only need to focus on a specific permission (e.g., ``EDIT_BLOG_POST``)
+or object type (e.g., ``User``). This focus makes voters cacheable, so Symfony 5.4 introduces a
 :class:`Symfony\\Component\\Security\\Core\\Authorization\\Voter\\CacheableVoterInterface`
 
     namespace Symfony\Component\Security\Core\Authorization\Voter;
@@ -69,7 +69,7 @@ or object type (e.g., User). This focus makes voters cacheable, so Symfony 5.4 i
     {
         public function supportsAttribute(string $attribute): bool;
     
-        // $subjectType is the value returned by `get_class($subject)` or `get_debug_type($subject)`
+        // $subjectType is the value returned by get_class($subject) or get_debug_type($subject)
         public function supportsType(string $subjectType): bool;
     }
 
@@ -77,10 +77,10 @@ If your voter returns false for these methods, it will cache this result,
 and your voter won't be called again for that attribute or type.
 
 If you extend from the abstract Voter class, you don't need to implement
-the interface directly—just override supportsAttribute() and/or supportsType().
+the interface directly - just override ``supportsAttribute()`` and/or ``supportsType()``.
 
 For instance, if your voter handles multiple object types but all permissions
-are prefixed with `APPROVE_`, do this:
+are prefixed with ``APPROVE_``, do this:
 
     namespace App\Security;
     

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -116,22 +116,6 @@ If your voter handles various permissions for a specific type, do this:
         // ...
     }
 
-You can also combine the logic and avoid code repetition by implementing the `supports()` function like this:
-
-    namespace App\Security;
-    
-    use Symfony\Component\Security\Core\Authorization\Voter\Voter;
-    
-    class MyVoter extends Voter
-    {
-        public function supports(string $attribute, mixed $subject): bool
-        {
-            $this->supportsAttribute($attribute) && $this->supportsType(get_debug_type($subject));
-        }
-    
-        // ...
-    }
-
 .. _how-to-use-the-voter-in-a-controller:
 
 Setup: Checking for Access in a Controller

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -51,16 +51,16 @@ which makes creating a voter even easier::
 
 The Cacheable Voter Interface
 -----------------------------
-When Symfony calls the isGranted() method during runtime, it checks each voter 
-until it meets the access decision strategy set by the configuration. 
+When Symfony calls the isGranted() method during runtime, it checks each voter
+until it meets the access decision strategy set by the configuration.
 While this generally works well, it can slow down performance in some cases.
 
-Imagine a backend displaying 20 items, each with 6 properties and 3 actions 
-(like edit, show, delete). Checking permissions for all these requires 180 calls 
+Imagine a backend displaying 20 items, each with 6 properties and 3 actions
+(like edit, show, delete). Checking permissions for all these requires 180 calls
 to each voter. With 5 voters, that's 900 calls.
 
-Usually, voters only need to focus on a specific permission (e.g., EDIT_BLOG_POST) 
-or object type (e.g., User). This focus makes voters cacheable, so Symfony 5.4 introduces a 
+Usually, voters only need to focus on a specific permission (e.g., EDIT_BLOG_POST)
+or object type (e.g., User). This focus makes voters cacheable, so Symfony 5.4 introduces a
 :class:`Symfony\\Component\\Security\\Core\\Authorization\\Voter\\CacheableVoterInterface`
 
     namespace Symfony\Component\Security\Core\Authorization\Voter;
@@ -73,14 +73,14 @@ or object type (e.g., User). This focus makes voters cacheable, so Symfony 5.4 i
         public function supportsType(string $subjectType): bool;
     }
 
-If your voter returns false for these methods, it will cache this result, 
+If your voter returns false for these methods, it will cache this result,
 and your voter won't be called again for that attribute or type.
 
-If you extend from the abstract Voter class, you don't need to implement 
+If you extend from the abstract Voter class, you don't need to implement
 the interface directly—just override supportsAttribute() and/or supportsType().
 
-For instance, if your voter handles multiple object types but all permissions 
-are prefixed with APPROVE_, do this:
+For instance, if your voter handles multiple object types but all permissions
+are prefixed with `APPROVE_`, do this:
 
     namespace App\Security;
     

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -48,15 +48,91 @@ which makes creating a voter even easier::
         abstract protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool;
     }
 
+
+The Cacheable Voter Interface
+-----------------------------
+When Symfony calls the isGranted() method during runtime, it checks each voter 
+until it meets the access decision strategy set by the configuration. 
+While this generally works well, it can slow down performance in some cases.
+
+Imagine a backend displaying 20 items, each with 6 properties and 3 actions 
+(like edit, show, delete). Checking permissions for all these requires 180 calls 
+to each voter. With 5 voters, that's 900 calls.
+
+Usually, voters only need to focus on a specific permission (e.g., EDIT_BLOG_POST) 
+or object type (e.g., User). This focus makes voters cacheable, so Symfony 5.4 introduces a 
+:class:`Symfony\\Component\\Security\\Core\\Authorization\\Voter\\CacheableVoterInterface`
+
+    namespace Symfony\Component\Security\Core\Authorization\Voter;
+    
+    interface CacheableVoterInterface extends VoterInterface
+    {
+        public function supportsAttribute(string $attribute): bool;
+    
+        // $subjectType is the value returned by `get_class($subject)` or `get_debug_type($subject)`
+        public function supportsType(string $subjectType): bool;
+    }
+
+If your voter returns false for these methods, it will cache this result, 
+and your voter won't be called again for that attribute or type.
+
+If you extend from the abstract Voter class, you don't need to implement 
+the interface directly—just override supportsAttribute() and/or supportsType().
+
+For instance, if your voter handles multiple object types but all permissions 
+are prefixed with APPROVE_, do this:
+
+    namespace App\Security;
+    
+    use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+    
+    class MyVoter extends Voter
+    {
+        public function supportsAttribute(string $attribute): bool
+        {
+            return str_starts_with($attribute, 'APPROVE_');
+        }
+    
+        // ...
+    }
+
+If your voter handles various permissions for a specific type, do this:
+
+    namespace App\Security;
+    
+    use App\Entity\BlogPost;
+    use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+    
+    class MyVoter extends Voter
+    {
+        public function supportsType(string $subjectType): bool
+        {
+            // you can't use a simple BlogPost::class === $subjectType comparison
+            // here because the given subject type could be the proxy class used
+            // by Doctrine when creating the entity object
+            return is_a($subjectType, BlogPost::class, true);
+        }
+    
+        // ...
+    }
+
+You can also combine the logic and avoid code repetition by implementing the `supports()` function like this:
+
+    namespace App\Security;
+    
+    use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+    
+    class MyVoter extends Voter
+    {
+        public function supports(string $attribute, mixed $subject): bool
+        {
+            $this->supportsAttribute($attribute) && $this->supportsType(get_debug_type($subject));
+        }
+    
+        // ...
+    }
+
 .. _how-to-use-the-voter-in-a-controller:
-
-.. tip::
-
-    Checking each voter several times can be time consuming for applications
-    that perform a lot of permission checks. To improve performance in those cases,
-    you can make your voters implement the :class:`Symfony\\Component\\Security\\Core\\Authorization\\Voter\\CacheableVoterInterface`.
-    This allows the access decision manager to remember the attribute and type
-    of subject supported by the voter, to only call the needed voters each time.
 
 Setup: Checking for Access in a Controller
 ------------------------------------------


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->

I came across https://symfony.com/blog/new-in-symfony-5-4-faster-security-voters and I think this should be documented in our docs.