### PR TITLE
[Doctrine] Update doctrine.rst on ssl documentation

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -470,5 +470,62 @@ If the ``dir`` configuration is set and the ``is_bundle`` configuration
 is ``true``, the DoctrineBundle will prefix the ``dir`` configuration with
 the path of the bundle.
 
+SSL Connection with MySQL
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to configure a secure SSL connection to MySQL in your Symfony application using Doctrine, you need to set specific options for the SSL certificates. Here's how to configure the connection using environment variables for the certificate paths:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        doctrine:
+            dbal:
+                url: '%env(DATABASE_URL)%'
+                server_version: '8.0.31'
+                driver: 'pdo_mysql'
+                options:
+                    # SSL private key (PDO::MYSQL_ATTR_SSL_KEY)
+                    1007: '%env(MYSQL_SSL_KEY)%'
+                    # SSL certificate (PDO::MYSQL_ATTR_SSL_CERT)
+                    1008: '%env(MYSQL_SSL_CERT)%'
+                    # SSL CA authority (PDO::MYSQL_ATTR_SSL_CA)
+                    1009: '%env(MYSQL_SSL_CA)%'
+
+    .. code-block:: xml
+
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/doctrine
+                https://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
+
+            <doctrine:config>
+                <doctrine:dbal
+                    url="%env(DATABASE_URL)%"
+                    server-version="8.0.31"
+                    driver="pdo_mysql">
+
+                    <doctrine:option key="1007">%env(MYSQL_SSL_KEY)%</doctrine:option>
+                    <doctrine:option key="1008">%env(MYSQL_SSL_CERT)%</doctrine:option>
+                    <doctrine:option key="1009">%env(MYSQL_SSL_CA)%</doctrine:option>
+                </doctrine:dbal>
+            </doctrine:config>
+        </container>
+
+Make sure that your environment variables are correctly set in your ``.env.local`` or ``.env.local.php`` file as follows:
+
+.. code-block:: bash
+
+    MYSQL_SSL_KEY=/path/to/your/server-key.pem
+    MYSQL_SSL_CERT=/path/to/your/server-cert.pem
+    MYSQL_SSL_CA=/path/to/your/ca-cert.pem
+
+This configuration secures your MySQL connection with SSL by specifying the paths to the required certificates.
+
+
 .. _DBAL documentation: https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/configuration.html
 .. _`Doctrine Metadata Drivers`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/metadata-drivers.html


### PR DESCRIPTION
Added SSL configuration example for MySQL in Doctrine DBAL

- Included YAML and XML configuration examples for setting up an SSL connection with MySQL using Doctrine DBAL in Symfony.
- Explained how to use environment variables for specifying SSL certificate paths (`MYSQL_SSL_KEY`, `MYSQL_SSL_CERT`, `MYSQL_SSL_CA`).
- Added a note on configuring the `.env.local` or `.env.local.php` files with the appropriate certificate paths.