### PR TITLE
Adopt Snake Case Naming for Route Paths and Names

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -214,8 +214,8 @@ Naming Conventions
 * Use `camelCase`_ for PHP variables, function and method names, arguments
   (e.g. ``$acceptableContentTypes``, ``hasSession()``);
 
-* Use `snake_case`_ for configuration parameters and Twig template variables
-  (e.g. ``framework.csrf_protection``, ``http_status_code``);
+Use `snake_case`_ for configuration parameters, route names and Twig template
+  variables (e.g. ``framework.csrf_protection``, ``http_status_code``);
 
 * Use SCREAMING_SNAKE_CASE for constants (e.g. ``InputArgument::IS_ARRAY``);
 


### PR DESCRIPTION
Hey everyone,

I’ve got a quick idea I’d love to share: let’s embrace snake_case for our routing in Symfony and make sure it’s included in the contribution docs.

**1. RFC Compliance**

First off, the [RFC 3986](https://www.rfc-editor.org/info/rfc3986) gives us the thumbs up for clear naming conventions. `snake_case` does just that—it's super readable and fits the bill perfectly.

**2. Practices of Other Languages**

Plus, many languages like Python and Ruby are already on the snake_case train. This makes it way easier for developers coming from other backgrounds.

**3.  Industry Practices**

And hey, check this out: major players like Google, Facebook, and Twitter use snake_case in their APIs. If it’s good enough for them, it’s definitely worth considering!
Conclusion

By adopting `snake_case` for route names and paths and adding this to our contribution docs, we’ll boost the consistency and clarity of Symfony.