### PR TITLE
[Config] Fix the XML configuration example for enums

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -232,7 +232,7 @@ reusable configuration value. By convention, parameters are defined under the
                 <parameter key="app.another_constant" type="constant">App\Entity\BlogPost::MAX_ITEMS</parameter>
 
                 <!-- Enum case as parameter values -->
-                <parameter key="app.some_enum" type="enum">App\Enum\PostState::Published</parameter>
+                <parameter key="app.some_enum" type="constant">App\Enum\PostState::Published</parameter>
             </parameters>
 
             <!-- ... -->


### PR DESCRIPTION
There is no `type="enum"` in the XML file loader.

The bad example was introduced in https://github.com/symfony/symfony-docs/pull/17910. However, the issue it was fixing was about a change in Symfony for **PHP** config files only. The Yaml and XML file loaders don't have any dedicated syntax for enums (but of course, the Yaml component itself does, which is what is used in the Yaml example)
