### PR TITLE
[Messenger] Incompatibility between pgsql LISTEN/NOTIFY and prioritized transports

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1605,6 +1605,11 @@ in the table.
 ``use_notify`` (default: ``true``)
     Whether to use LISTEN/NOTIFY.
 
+    .. note::
+
+        ``use_notify`` will work incorrectly if you use "Prioritized
+        Transports". Disable the LISTEN/NOTIFY feature in this case.
+
 ``check_delayed_interval`` (default: ``60000``)
     The interval to check for delayed messages, in milliseconds. Set to 0 to
     disable checks.


### PR DESCRIPTION
https://github.com/symfony/symfony/issues/58574

PostgreSQL LISTEN/NOTIFY feature should not be used with prioritized transports

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
