### PR TITLE
[Messenger] Add a tip about using `make:messenger-middleware`

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -2920,6 +2920,11 @@ and a different instance will be created per bus.
             $bus->middleware()->id('App\Middleware\AnotherMiddleware');
         };
 
+.. tip::
+
+    If you have installed the Maker bundle, you can use the ``make:messenger-middleware`` command
+    to bootstrap the creation your own messenger middleware.
+
 .. _middleware-doctrine:
 
 Middleware for Doctrine


### PR DESCRIPTION
Add a tip about using make:messenger-middleware to create custom Middlewares, because it's easy to skip the importance of the "$stack->next()->handle($envelope, $stack)" line. Might save someone's time.
