### PR TITLE
[Translation] Fix param name for lint:translations

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -1405,7 +1405,7 @@ to check that the translation contents are also correct:
         $ php bin/console lint:translations
 
         # checks the contents of the translation catalogues for Italian (it) and Japanese (ja) locales
-        $ php bin/console lint:translations --locales=it --locales=ja
+        $ php bin/console lint:translations --locale=it --locale=ja
 
 .. versionadded:: 7.2
 


### PR DESCRIPTION
For code [PR 57650](https://github.com/symfony/symfony/pull/57650)