### PR TITLE
[ExpressionLanguage] fix lint method description

### DIFF
--- a/components/expression_language.rst
+++ b/components/expression_language.rst
@@ -93,7 +93,7 @@ The :method:`Symfony\\Component\\ExpressionLanguage\\ExpressionLanguage::parse`
 method returns a :class:`Symfony\\Component\\ExpressionLanguage\\ParsedExpression`
 instance that can be used to inspect and manipulate the expression. The
 :method:`Symfony\\Component\\ExpressionLanguage\\ExpressionLanguage::lint`, on the
-other hand, returns a boolean indicating if the expression is valid or not::
+other hand, throws a :class:`Symfony\\Component\\ExpressionLanguage\\SyntaxError` if the expression is not valid::
 
     use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
@@ -103,7 +103,7 @@ other hand, returns a boolean indicating if the expression is valid or not::
     // displays the AST nodes of the expression which can be
     // inspected and manipulated
 
-    var_dump($expressionLanguage->lint('1 + 2', [])); // displays true
+    $expressionLanguage->lint('1 + 2', []); // doesn't throw anything
 
 Passing in Variables
 --------------------


### PR DESCRIPTION
At first, I made a fix pr [#58679](https://github.com/symfony/symfony/pull/58679), but someone suggested to make a doc fix.

I think it's pretty weird to have a linting method throwing exception as its task is to tell if the expression is valid or not. :thinking: 