### PR TITLE
[Controller ] Update link to PHP docs for Validate filters/constants

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -846,6 +846,6 @@ Learn more about Controllers
 .. _`Early hints`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103
 .. _`SAPI`: https://www.php.net/manual/en/function.php-sapi-name.php
 .. _`FrankenPHP`: https://frankenphp.dev
-.. _`Validate Filters`: https://www.php.net/manual/en/filter.filters.validate.php
+.. _`Validate Filters`: https://www.php.net/manual/en/filter.constants.php
 .. _`phpstan/phpdoc-parser`: https://packagist.org/packages/phpstan/phpdoc-parser
 .. _`phpdocumentor/type-resolver`: https://packagist.org/packages/phpdocumentor/type-resolver


### PR DESCRIPTION
Strange one here on https://symfony.com/doc/current/controller.html#mapping-query-parameters-individually - 

![ScreenShot-2024-11-06-15 30 17](https://github.com/user-attachments/assets/7fef71be-671e-4708-8aaf-9078910129ec)

The link on Validate Filters is now a 404

The ENGLISH page https://www.php.net/manual/en/filter.filters.validate.php is now a 404
Its viewable in other languages (Ukraine for example) at https://www.php.net/manual/uk/filter.filters.validate.php

However ultimately I think it has moved to https://www.php.net/manual/en/filter.constants.php which contains the same kind of list - also available in other languages already, eg Ukraine https://www.php.net/manual/uk/filter.constants.php

Ultimately **the Symfony docs are linking to a 404**, and so either you accept this PR, or collectively we need to find and propose a different fix/url to fix the link to the 404 page. 