### PR TITLE
Update web_server_configuration.rst: Moving nginx above Apache

### DIFF
--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -49,60 +49,6 @@ listen on. Each pool can also be run under a different UID and GID:
     ; or listen on a TCP connection
     ; listen = 127.0.0.1:9000
 
-Apache
-------
-
-If you are running Apache 2.4+, you can use ``mod_proxy_fcgi`` to pass
-incoming requests to PHP-FPM. Install the Apache2 FastCGI mod
-(``libapache2-mod-fastcgi`` on Debian), enable ``mod_proxy`` and
-``mod_proxy_fcgi`` in your Apache configuration, and use the ``SetHandler``
-directive to pass requests for PHP files to PHP FPM:
-
-.. code-block:: apache
-
-    # /etc/apache2/conf.d/example.com.conf
-    <VirtualHost *:80>
-        ServerName example.com
-        ServerAlias www.example.com
-
-        # Uncomment the following line to force Apache to pass the Authorization
-        # header to PHP: required for "basic_auth" under PHP-FPM and FastCGI
-        #
-        # SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
-
-        <FilesMatch \.php$>
-            # when using PHP-FPM as a unix socket
-            SetHandler proxy:unix:/var/run/php/php8.3-fpm.sock|fcgi://dummy
-
-            # when PHP-FPM is configured to use TCP
-            # SetHandler proxy:fcgi://127.0.0.1:9000
-        </FilesMatch>
-
-        DocumentRoot /var/www/project/public
-        <Directory /var/www/project/public>
-            AllowOverride None
-            Require all granted
-            FallbackResource /index.php
-        </Directory>
-
-        # uncomment the following lines if you install assets as symlinks
-        # or run into problems when compiling LESS/Sass/CoffeeScript assets
-        # <Directory /var/www/project>
-        #     Options FollowSymlinks
-        # </Directory>
-
-        ErrorLog /var/log/apache2/project_error.log
-        CustomLog /var/log/apache2/project_access.log combined
-    </VirtualHost>
-
-.. note::
-
-    If you are doing some quick tests with Apache, you can also run
-    ``composer require symfony/apache-pack``. This package creates an ``.htaccess``
-    file in the ``public/`` directory with the necessary rewrite rules needed to serve
-    the Symfony application. However, in production, it's recommended to move these
-    rules to the main Apache configuration file (as shown above) to improve performance.
-
 Nginx
 -----
 
@@ -189,6 +135,60 @@ The **minimum configuration** to get your application running under Nginx is:
     script (i.e. ``http://example.com/index.php``).
 
 For advanced Nginx configuration options, read the official `Nginx documentation`_.
+
+Apache
+------
+
+If you are running Apache 2.4+, you can use ``mod_proxy_fcgi`` to pass
+incoming requests to PHP-FPM. Install the Apache2 FastCGI mod
+(``libapache2-mod-fastcgi`` on Debian), enable ``mod_proxy`` and
+``mod_proxy_fcgi`` in your Apache configuration, and use the ``SetHandler``
+directive to pass requests for PHP files to PHP FPM:
+
+.. code-block:: apache
+
+    # /etc/apache2/conf.d/example.com.conf
+    <VirtualHost *:80>
+        ServerName example.com
+        ServerAlias www.example.com
+
+        # Uncomment the following line to force Apache to pass the Authorization
+        # header to PHP: required for "basic_auth" under PHP-FPM and FastCGI
+        #
+        # SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
+
+        <FilesMatch \.php$>
+            # when using PHP-FPM as a unix socket
+            SetHandler proxy:unix:/var/run/php/php8.3-fpm.sock|fcgi://dummy
+
+            # when PHP-FPM is configured to use TCP
+            # SetHandler proxy:fcgi://127.0.0.1:9000
+        </FilesMatch>
+
+        DocumentRoot /var/www/project/public
+        <Directory /var/www/project/public>
+            AllowOverride None
+            Require all granted
+            FallbackResource /index.php
+        </Directory>
+
+        # uncomment the following lines if you install assets as symlinks
+        # or run into problems when compiling LESS/Sass/CoffeeScript assets
+        # <Directory /var/www/project>
+        #     Options FollowSymlinks
+        # </Directory>
+
+        ErrorLog /var/log/apache2/project_error.log
+        CustomLog /var/log/apache2/project_access.log combined
+    </VirtualHost>
+
+.. note::
+
+    If you are doing some quick tests with Apache, you can also run
+    ``composer require symfony/apache-pack``. This package creates an ``.htaccess``
+    file in the ``public/`` directory with the necessary rewrite rules needed to serve
+    the Symfony application. However, in production, it's recommended to move these
+    rules to the main Apache configuration file (as shown above) to improve performance.
 
 Caddy
 -----


### PR DESCRIPTION
Page: https://symfony.com/doc/current/setup/web_server_configuration.html

Reason: IMO nginx is more widely used nowadays.