### PR TITLE
[Mercure] Deleting forgotten(?) sentence

### DIFF
--- a/mercure.rst
+++ b/mercure.rst
@@ -684,8 +684,6 @@ Debugging
 
     The WebProfiler panel was introduced in MercureBundle 0.2.
 
-Enable the panel in your configuration, as follows:
-
 MercureBundle is shipped with a debug panel. Install the Debug pack to
 enable it::
 


### PR DESCRIPTION
Page: https://symfony.com/doc/5.x/mercure.html#debugging

Config instructions were added at https://github.com/symfony/symfony-docs/pull/12598 and later removed at https://github.com/symfony/symfony-docs/pull/15924

But I can't get the profiler to work. On which page am I supposed to open it? I guess on the one containing the JavaScript? (i.e. same page as I see the EventStrems in Chrome DevTools)? What do I have to do to get this to work?
On the profiler page, the "Mercure" entry is always greyed out.
