### PR TITLE
set empty_data to integers

### DIFF
--- a/form/data_mappers.rst
+++ b/form/data_mappers.rst
@@ -155,13 +155,13 @@ method::
                 ->add('red', IntegerType::class, [
                     // enforce the strictness of the type to ensure the constructor
                     // of the Color class doesn't break
-                    'empty_data' => '0',
+                    'empty_data' => 0,
                 ])
                 ->add('green', IntegerType::class, [
-                    'empty_data' => '0',
+                    'empty_data' => 0,
                 ])
                 ->add('blue', IntegerType::class, [
-                    'empty_data' => '0',
+                    'empty_data' => 0,
                 ])
                 // configure the data mapper for this FormType
                 ->setDataMapper($this)


### PR DESCRIPTION
Purely style, but to me it looks funny to set an IntegerType to a string, though of course it works as documented.

> enforce the strictness of the type to ensure the constructor

The constructor uses integers in the Color class.  