### PR TITLE
[Validator] Improve type for the `mode` property of the `Bic` constraint

### DIFF
--- a/reference/constraints/Bic.rst
+++ b/reference/constraints/Bic.rst
@@ -124,18 +124,13 @@ Parameter        Description
 ``mode``
 ~~~~~~~~
 
-**type**: ``string`` **default**: ``strict``
+**type**: ``string`` **default**: ``BIC::VALIDATION_MODE_STRICT``
 
-This option defines how the BIC is validated:
+This option defines how the BIC is validated. Available constants are defined
+in the :class:`Symfony\\Component\\Validator\\Constraints\\BIC` class.
 
-* ``strict`` validates the given value without any modification;
-* ``case-insensitive`` converts the given value to uppercase before validating it.
-
-.. tip::
-
-    The possible values of this option are also defined as PHP constants of
-    :class:`Symfony\\Component\\Validator\\Constraints\\BIC`
-    (e.g. ``BIC::VALIDATION_MODE_CASE_INSENSITIVE``).
+* ``BIC::VALIDATION_MODE_STRICT`` validates the given value without any modification;
+* ``BIC::VALIDATION_MODE_CASE_INSENSITIVE`` converts the given value to uppercase before validating it.
 
 .. versionadded:: 7.2
 


### PR DESCRIPTION
Following [58810](https://github.com/symfony/symfony/pull/58810) in code