### PR TITLE
[Validator] [MacAddress] Add a missing value for `type` option

### DIFF
--- a/reference/constraints/MacAddress.rst
+++ b/reference/constraints/MacAddress.rst
@@ -132,6 +132,7 @@ Parameter                         Allowed MAC addresses
 ``multicast_no_broadcast``        Only multicast except broadcast
 ``unicast_all``                   Only unicast
 ``universal_all``                 Only universal
+``universal_unicast``             Only universal and unicast
 ``universal_multicast``           Only universal and multicast
 ================================  =========================================
 


### PR DESCRIPTION
It looks like a value accidentally disappeared during a commit to sort them in alphabetical order