### PR TITLE
[Security] use access decision manager to control which token to vote on

### DIFF
--- a/security/impersonating_user.rst
+++ b/security/impersonating_user.rst
@@ -309,17 +309,17 @@ logic you want::
     namespace App\Security\Voter;
 
     use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+    use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
     use Symfony\Component\Security\Core\Authorization\Voter\Voter;
-    use Symfony\Component\Security\Core\Security;
     use Symfony\Component\Security\Core\User\UserInterface;
 
     class SwitchToCustomerVoter extends Voter
     {
-        private $security;
+        private $accessDecisionManager;
 
-        public function __construct(Security $security)
+        public function __construct(AccessDecisionManager $accessDecisionManager)
         {
-            $this->security = $security;
+            $this->accessDecisionManager = $accessDecisionManager;
         }
 
         protected function supports($attribute, $subject): bool
@@ -337,12 +337,12 @@ logic you want::
             }
 
             // you can still check for ROLE_ALLOWED_TO_SWITCH
-            if ($this->security->isGranted('ROLE_ALLOWED_TO_SWITCH')) {
+            if ($this->accessDecisionManager->isGranted($token, ['ROLE_ALLOWED_TO_SWITCH'])) {
                 return true;
             }
 
             // check for any roles you want
-            if ($this->security->isGranted('ROLE_TECH_SUPPORT')) {
+            if ($this->accessDecisionManager->isGranted($token, ['ROLE_TECH_SUPPORT'])) {
                 return true;
             }
 

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -222,25 +222,25 @@ Checking for Roles inside a Voter
 ---------------------------------
 
 What if you want to call ``isGranted()`` from *inside* your voter - e.g. you want
-to see if the current user has ``ROLE_SUPER_ADMIN``. That's possible by injecting
-the :class:`Symfony\\Component\\Security\\Core\\Security`
-into your voter. You can use this to, for example, *always* allow access to a user
+to see if the current user has ``ROLE_SUPER_ADMIN``. That's possible by using an
+:class:`access decision manager <Symfony\\Component\\Security\\Core\\Authorization\\AccessDecisionManagerInterface>`
+inside your voter. You can use this to, for example, *always* allow access to a user
 with ``ROLE_SUPER_ADMIN``::
 
     // src/Security/PostVoter.php
 
     // ...
-    use Symfony\Component\Security\Core\Security;
+    use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 
     class PostVoter extends Voter
     {
         // ...
 
-        private $security;
+        private $accessDecisionManager;
 
-        public function __construct(Security $security)
+        public function __construct(AccessDecisionManagerInterface $accessDecisionManager)
         {
-            $this->security = $security;
+            $this->accessDecisionManager = $accessDecisionManager;
         }
 
         protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
@@ -248,7 +248,7 @@ with ``ROLE_SUPER_ADMIN``::
             // ...
 
             // ROLE_SUPER_ADMIN can do anything! The power!
-            if ($this->security->isGranted('ROLE_SUPER_ADMIN')) {
+            if ($this->accessDecisionManager->isGranted($token, ['ROLE_SUPER_ADMIN'])) {
                 return true;
             }
 


### PR DESCRIPTION
Following symfony/symfony#58754: calling. `Security::isGranted()` inside a voter has the drawback that we do not know if the checks performed here act on the same token that we have in our voter as the token inside the token storage might have change or may change in between.