### PR TITLE
Duplicate a note useful for varnish

### DIFF
--- a/http_cache/varnish.rst
+++ b/http_cache/varnish.rst
@@ -44,6 +44,12 @@ header. In this case, you need to add the following configuration snippet:
         }
     }
 
+.. note::
+
+    Forcing HTTPS while using a reverse proxy or load balancer requires a proper
+    configuration to avoid infinite redirect loops; see :doc:`/deployment/proxies`
+    for more details.
+
 Cookies and Caching
 -------------------
 


### PR DESCRIPTION
Varnish talks with http to symfony.
So I suggest to duplicate the note regarding "https forcing" in the varnish doc.

Original note : https://symfony.com/doc/current/security/force_https.html
Varnish page:  https://symfony.com/doc/current/http_cache/varnish.htm

Spend the whole day with a redirect loop caused by some `requires_channel: https` so if it can helps :)