### PR TITLE
[Security] Fix wrong method call of the decision manager 

### DIFF
--- a/security/impersonating_user.rst
+++ b/security/impersonating_user.rst
@@ -337,12 +337,12 @@ logic you want::
             }
 
             // you can still check for ROLE_ALLOWED_TO_SWITCH
-            if ($this->accessDecisionManager->isGranted($token, ['ROLE_ALLOWED_TO_SWITCH'])) {
+            if ($this->accessDecisionManager->decide($token, ['ROLE_ALLOWED_TO_SWITCH'])) {
                 return true;
             }
 
             // check for any roles you want
-            if ($this->accessDecisionManager->isGranted($token, ['ROLE_TECH_SUPPORT'])) {
+            if ($this->accessDecisionManager->decide($token, ['ROLE_TECH_SUPPORT'])) {
                 return true;
             }
 

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -248,7 +248,7 @@ with ``ROLE_SUPER_ADMIN``::
             // ...
 
             // ROLE_SUPER_ADMIN can do anything! The power!
-            if ($this->accessDecisionManager->isGranted($token, ['ROLE_SUPER_ADMIN'])) {
+            if ($this->accessDecisionManager->decide($token, ['ROLE_SUPER_ADMIN'])) {
                 return true;
             }
 


### PR DESCRIPTION
@xabbuh  changed the use of “decision manage” in [PR-20388](https://github.com/symfony/symfony-docs/pull/20388)  However, the method is described differently in the [interface](https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php#L29).

It's not `isGranted` its `decide`