### PR TITLE
Fix error_pages.rst setResponse()

### DIFF
--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -319,7 +319,7 @@ error pages.
 
 .. note::
 
-    If your listener calls ``setThrowable()`` on the
+    If your listener calls ``setResponse()`` on the
     :class:`Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent`
     event, propagation will be stopped and the response will be sent to
     the client.


### PR DESCRIPTION
I believe https://github.com/symfony/symfony-docs/pull/13877 should not have been merged because `setException` has been replaced by `setThrowable`, not `setResponse`.