### PR TITLE
Add a note about updating phpdoc in a patch release

### DIFF
--- a/contributing/code/maintenance.rst
+++ b/contributing/code/maintenance.rst
@@ -67,6 +67,9 @@ issue):
 * **Adding new deprecations**: After a version reaches stability, new
   deprecations cannot be added anymore.
 
+* **Adding or updating annotations**: Adding or updating annotations (PHPDoc
+  annotations for instance) is not allowed; fixing them might be accepted.
+
 Anything not explicitly listed above should be done on the next minor or major
 version instead. For instance, the following changes are never accepted in a
 patch version:


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
