### PR TITLE
The wrong type is used for autowiring

### DIFF
--- a/security/impersonating_user.rst
+++ b/security/impersonating_user.rst
@@ -317,7 +317,7 @@ logic you want::
     {
         private $accessDecisionManager;
 
-        public function __construct(AccessDecisionManager $accessDecisionManager)
+        public function __construct(AccessDecisionManagerInterface $accessDecisionManager)
         {
             $this->accessDecisionManager = $accessDecisionManager;
         }


### PR DESCRIPTION
The wrong type is being used for autowiring. 
If you do not use the interface, the class is not loaded and the interface is also used for the use states. 

I hope 5.4 is the right targeted Version. 