### PR TITLE
[Routing] Rename variable to stay consistent

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -2671,11 +2671,11 @@ the :class:`Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface` class
 
     class SomeService
     {
-        private $router;
+        private $urlGenerator;
 
-        public function __construct(UrlGeneratorInterface $router)
+        public function __construct(UrlGeneratorInterface $urlGenerator)
         {
-            $this->router = $router;
+            $this->urlGenerator = $urlGenerator;
         }
 
         public function someMethod()
@@ -2683,20 +2683,20 @@ the :class:`Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface` class
             // ...
 
             // generate a URL with no route arguments
-            $signUpPage = $this->router->generate('sign_up');
+            $signUpPage = $this->urlGenerator->generate('sign_up');
 
             // generate a URL with route arguments
-            $userProfilePage = $this->router->generate('user_profile', [
+            $userProfilePage = $this->urlGenerator->generate('user_profile', [
                 'username' => $user->getUserIdentifier(),
             ]);
 
             // generated URLs are "absolute paths" by default. Pass a third optional
             // argument to generate different URLs (e.g. an "absolute URL")
-            $signUpPage = $this->router->generate('sign_up', [], UrlGeneratorInterface::ABSOLUTE_URL);
+            $signUpPage = $this->urlGenerator->generate('sign_up', [], UrlGeneratorInterface::ABSOLUTE_URL);
 
             // when a route is localized, Symfony uses by default the current request locale
             // pass a different '_locale' value if you want to set the locale explicitly
-            $signUpPageInDutch = $this->router->generate('sign_up', ['_locale' => 'nl']);
+            $signUpPageInDutch = $this->urlGenerator->generate('sign_up', ['_locale' => 'nl']);
         }
     }
 


### PR DESCRIPTION
Here we are using `$urlGenerator` 

* https://symfony.com/doc/6.4/routing.html#generating-urls-in-commands
* https://symfony.com/doc/6.4/security.html#customizing-logout
* https://symfony.com/doc/6.4/security.html#customizing-logout

cc @mvhirsch 