### PR TITLE
[Form] URLType : explain `null` value for `default_protocol`

### DIFF
--- a/reference/forms/types/url.rst
+++ b/reference/forms/types/url.rst
@@ -27,6 +27,8 @@ Field Options
 
 **type**: ``string`` **default**: ``http``
 
+Set the value as ``null`` to render the field as ``<input type="url"/>``.
+
 If a value is submitted that doesn't begin with some protocol (e.g. ``http://``,
 ``ftp://``, etc), this protocol will be prepended to the string when
 the data is submitted to the form.


### PR DESCRIPTION
Sources:

- https://github.com/symfony/symfony/issues/30635
- https://github.com/symfony/symfony/pull/50922