### PR TITLE
[PHPUnitBridge] Fix reference to `vendor/` dir

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -253,7 +253,7 @@ deprecations but:
 * forget to mark appropriate tests with the ``@group legacy`` annotations.
 
 By using ``SYMFONY_DEPRECATIONS_HELPER=max[self]=0``, deprecations that are
-triggered outside the ``vendors`` directory will be accounted for separately,
+triggered outside the ``vendor/`` directory will be accounted for separately,
 while deprecations triggered from a library inside it will not (unless you reach
 999999 of these), giving you the best of both worlds.
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
