### PR TITLE
[Serializer] Minor improvements

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -958,16 +958,22 @@ parameter::
     $jsonData = ...; // the serialized JSON data from the previous example
     $persons = $serializer->deserialize($JsonData, Person::class.'[]', 'json');
 
-For nested classes, you have to add a PHPDoc type to the property/setter::
+For nested classes, you have to add a PHPDoc type to the property, constructor or setter::
 
     // src/Model/UserGroup.php
     namespace App\Model;
 
     class UserGroup
     {
-        private array $members;
+        /**
+         * @param Person[] $members
+         */
+        public function __construct(
+            private array $members,
+        ) {
+        }
 
-        // ...
+        // or if you're using a setter
 
         /**
          * @param Person[] $members
@@ -976,6 +982,8 @@ For nested classes, you have to add a PHPDoc type to the property/setter::
         {
             $this->members = $members;
         }
+
+        // ...
     }
 
 .. tip::
@@ -1356,8 +1364,6 @@ normalizers (in order of priority):
 
     During denormalization, it supports using the constructor as well as
     the discovered methods.
-
-:ref:`serializer.encoder <reference-dic-tags-serializer-encoder>`
 
 .. danger::
 

--- a/serializer/encoders.rst
+++ b/serializer/encoders.rst
@@ -311,7 +311,8 @@ as a service in your app. If you're using the
 that's done automatically!
 
 If you're not using :ref:`autoconfigure <services-autoconfigure>`, make sure
-to register your class as a service and tag it with ``serializer.encoder``:
+to register your class as a service and tag it with
+:ref:`serializer.encoder <reference-dic-tags-serializer-encoder>`:
 
 .. configuration-block::
 


### PR DESCRIPTION
Fixes/improves two things:

1. as discussed with @wouterj on Slack, there seems to be a leftover link to `serializer.encoder`:
   ![image](https://github.com/user-attachments/assets/f6fe6647-311d-4e48-9d40-f6061e640910)
2. I've added an example of how to use nested classes with a constructor to make it clear that this works as well