### PR TITLE
[EventDispatcher] Fix the syntax of the Learn More list

### DIFF
--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -476,11 +476,7 @@ with some other dispatchers:
 Learn More
 ----------
 
-.. toctree::
-    :maxdepth: 1
-
-    /components/event_dispatcher/generic_event
-
+* :doc:`/components/event_dispatcher/generic_event`
 * :ref:`The kernel.event_listener tag <dic-tags-kernel-event-listener>`
 * :ref:`The kernel.event_subscriber tag <dic-tags-kernel-event-subscriber>`
 


### PR DESCRIPTION
Mixing the toctree with a normal list doesn't look good ... let's use a regular list instead.