### PR TITLE
[Scheduler] Add some pointers regarding worker processes deployment

### DIFF
--- a/scheduler.rst
+++ b/scheduler.rst
@@ -818,6 +818,14 @@ the Messenger component:
 .. image:: /_images/components/scheduler/generate_consume.png
     :alt: Symfony Scheduler - generate and consume
 
+.. tip::
+
+    Depending on your deployment scenario, instead of manually executing this
+    Messenger worker process, you might want to run it with cron, supervisor or systemd,
+    and ensure workers are running at all times. Check out the `Deploying to Production`_
+    section of the Messenger component documentation.
+
+
 Creating a Consumer Programmatically
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -981,6 +989,7 @@ helping you identify those messages when needed.
     to redispatched messages was introduced in Symfony 6.4.
 
 .. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
+.. _`Deploying to Production`: https://symfony.com/doc/current/messenger.html#deploying-to-production
 .. _`Memoizing`: https://en.wikipedia.org/wiki/Memoization
 .. _`cron command-line utility`: https://en.wikipedia.org/wiki/Cron
 .. _`crontab.guru website`: https://crontab.guru/


### PR DESCRIPTION
It took me quite some effort to figure this out...

https://stackoverflow.com/questions/79257466/how-does-symfony-scheduler-component-get-triggered/79257514

It's one of those things that are obvious _after_ you know them, and where you should be looking for them, but not before...

I think the specific mentions of "cron" in the text are valuable (because people will search for it), even though it's not the wisest option (when compared to supervisor etc). The link will take them to the best-practices.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
