### PR TITLE
[Routing] fix: remove quotes on routes

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -302,7 +302,7 @@ arbitrary matching logic:
         # config/routes.yaml
         contact:
             path:       /contact
-            controller: 'App\Controller\DefaultController::contact'
+            controller: App\Controller\DefaultController::contact
             condition:  "context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'"
             # expressions can also include configuration parameters:
             # condition: "request.headers.get('User-Agent') matches '%app.allowed_browsers%'"
@@ -311,7 +311,7 @@ arbitrary matching logic:
 
         post_show:
             path:       /posts/{id}
-            controller: 'App\Controller\DefaultController::showPost'
+            controller: App\Controller\DefaultController::showPost
             # expressions can retrieve route parameter values using the "params" variable
             condition:  "params['id'] < 1000"
 


### PR DESCRIPTION
On this section https://symfony.com/doc/6.4/routing.html#matching-http-methods and the next: `controller:` appears without and with quotes:

> ![image](https://github.com/user-attachments/assets/03d7d938-eb61-42a1-8078-ba978e0683c7)

I removed the quotes for consistency.

