### PR TITLE
Replaced `caution` directive by `warning`

### DIFF
--- a/components/type_info.rst
+++ b/components/type_info.rst
@@ -11,7 +11,7 @@ This component provides:
 * A way to get types from PHP elements such as properties, method arguments,
   return types, and raw strings.
 
-.. caution::
+.. warning::
 
     This component is :doc:`experimental </contributing/code/experimental>` and
     could be changed at any time without prior notice.

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -320,7 +320,7 @@ before, execute your migrations:
 
     $ php bin/console doctrine:migrations:migrate
 
-.. caution::
+.. warning::
 
     If you are using an SQLite database, you'll see the following error:
     *PDOException: SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL

--- a/mailer.rst
+++ b/mailer.rst
@@ -361,7 +361,7 @@ setting the ``auto_tls`` option to ``false`` in the DSN::
 
     $dsn = 'smtp://user:pass@10.0.0.25?auto_tls=false';
 
-.. caution::
+.. warning::
 
     It's not recommended to disable TLS while connecting to an SMTP server over
     the Internet, but it can be useful when both the application and the SMTP


### PR DESCRIPTION
Fixes #20371

#SymfonyHackday