### PR TITLE
[Messenger] [Mesenger] Mention that some option doesn't have docs

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1465,7 +1465,7 @@ The transport has a number of options:
     (no description available)
 
 ``sasl_method``
-
+    (no description available)
 
 ``connection_name``
     For custom connection names (requires at least version 1.10 of the PHP AMQP


### PR DESCRIPTION
I tried to find docs for this, but it's really hard. In the Symfony Code, the "docs" just point to this file: https://github.com/php-amqp/php-amqp/blob/latest/amqp_connection_resource.h

So, let's at least add the text saying that "there's no docs" so the page design doesn't break.

#SymfonyHackday