### PR TITLE
[Form] dynamic_form_modification - Update namespace related to EventSubscriber

### DIFF
--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -138,8 +138,8 @@ For better reusability or if there is some heavy logic in your event listener,
 you can also move the logic for creating the ``name`` field to an
 :ref:`event subscriber <event_dispatcher-using-event-subscribers>`::
 
-    // src/Form/EventListener/AddNameFieldSubscriber.php
-    namespace App\Form\EventListener;
+    // src/Form/EventSubscriber/AddNameFieldSubscriber.php
+    namespace App\Form\EventSubscriber;
 
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
     use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -172,7 +172,7 @@ Great! Now use that in your form class::
     namespace App\Form\Type;
 
     // ...
-    use App\Form\EventListener\AddNameFieldSubscriber;
+    use App\Form\EventSubscriber\AddNameFieldSubscriber;
 
     class ProductType extends AbstractType
     {


### PR DESCRIPTION
Update the namespace of the class to subscribe to events. Currently it points to \EventListener, but I find it more coherent to associate it with \EventSubscriber.

Link: https://symfony.com/doc/current/form/dynamic_form_modification.html#adding-an-event-subscriber-to-a-form-class

From:
<img width="612" alt="image" src="https://github.com/user-attachments/assets/aef1ef30-0fbf-4c5a-9b32-1fb4217e1ae0">

To:
<img width="612" alt="image" src="https://github.com/user-attachments/assets/9e7ab86c-d6fe-4a18-863d-dbc4329b38ae">
