### PR TITLE
Add `must` usage in coding standards

### DIFF
--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -195,6 +195,9 @@ Structure
     - throw new \Exception(sprintf('Command "%s" failed.', $command::class));
     + throw new \Exception(sprintf('Command "%s" failed.', get_debug_type($command)));
 
+* User-oriented exception, error and deprecation messages must not use ``must``. Instead,
+  alternative phrasing should be used: ``should``, ``needs to``, ``has to``, etc.
+
 * Do not use ``else``, ``elseif``, ``break`` after ``if`` and ``case`` conditions
   which return or throw something;
 


### PR DESCRIPTION
A recurring topic in code PRs is the use of “must” in exception messages. As @chalasr points out in https://github.com/symfony/symfony/pull/59177#discussion_r1880433307, this does not appear to be a decision written into the code standards of the project.

I suggest we add a rule to the standard coding, indicating that “must” should never be used in messages intended for the user. Indeed, it is a feedback I had a few times on some of my PRs. I know that the docs repository tries to ban the use of "must", except in very rare occasions.

What do you think? Discussion is open 🙂 