### PR TITLE
[TypeInfo] Fix PHP block

### DIFF
--- a/components/type_info.rst
+++ b/components/type_info.rst
@@ -141,7 +141,7 @@ Checking a **simple type**::
     $type->isIdentifiedBy(DummyParent::class);     // true
     $type->isIdentifiedBy(DummyInterface::class);  // true
 
-Using callables for **complex checks**:
+Using callables for **complex checks**::
 
     class Foo
     {


### PR DESCRIPTION
There is a missing `:` in TypeInfo documentation.
Here is a fix