### PR TITLE
Update serializer.rst

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -1789,7 +1789,7 @@ identifier of the next nested object, instead of omitting the property::
     $child = new Person('Joe', $mother);
 
     // all callback parameters are optional (you can omit the ones you don't use)
-    $maxDepthHandler = function (object $innerObject, object $outerObject, string $attributeName, ?string $format = null, array $context = []): string {
+    $maxDepthHandler = function (object $innerObject, object $outerObject, string $attributeName, ?string $format = null, array $context = []): ?string {
         // return only the name of the next person in the tree
         return $innerObject instanceof Person ? $innerObject->getName() : null;
     };


### PR DESCRIPTION
The $maxDepthHandler function might return NULL, but the return type is set to : string, which causes a TypeError to be thrown.

This change allows the $maxDepthHandler function to return null, by changing the return type to : ?string for this example.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
