### PR TITLE
[Setup] Update 7.2.x-dev to 7.2.x

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -48,10 +48,10 @@ application:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ symfony new my_project_directory --version="7.2.x-dev" --webapp
+    $ symfony new my_project_directory --version="7.2.x" --webapp
 
     # run this if you are building a microservice, console application or API
-    $ symfony new my_project_directory --version="7.2.x-dev"
+    $ symfony new my_project_directory --version="7.2.x"
 
 The only difference between these two commands is the number of packages
 installed by default. The ``--webapp`` option installs extra packages to give
@@ -63,12 +63,12 @@ Symfony application using Composer:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ composer create-project symfony/skeleton:"7.2.x-dev" my_project_directory
+    $ composer create-project symfony/skeleton:"7.2.x" my_project_directory
     $ cd my_project_directory
     $ composer require webapp
 
     # run this if you are building a microservice, console application or API
-    $ composer create-project symfony/skeleton:"7.2.x-dev" my_project_directory
+    $ composer create-project symfony/skeleton:"7.2.x" my_project_directory
 
 No matter which command you run to create the Symfony application. All of them
 will create a new ``my_project_directory/`` directory, download some dependencies


### PR DESCRIPTION
This is my very first contribution to open-source world, so I might be wrong.

Since version 7.2 was released in November 2024, we no longer need the `-dev` suffix for new installations.
I apologize in advance if this change doesn't make any sense or if it was already planned :/