### PR TITLE
Update without_class.rst

### DIFF
--- a/form/without_class.rst
+++ b/form/without_class.rst
@@ -99,7 +99,8 @@ but here's a short example::
                 'constraints' => new Length(['min' => 3]),
             ])
             ->add('lastName', TextType::class, [
-                'constraints' => [
+// the following configuration triggers an error `An error has occurred resolving the options of the form "Symfony\Component\Form\Extension\Core\Type\FormType": The option "constraints" with value array is expected to be of type "Symfony\Component\Validator\Constraint" or "Symfony\Component\Validator\Constraint[]", but one of the elements is of type "array".`
+                'constraints' => [  
                     new NotBlank(),
                     new Length(['min' => 3]),
                 ],
@@ -165,6 +166,9 @@ This can be done by setting the ``constraints`` option in the
 
 This means you can also do this when using the ``createFormBuilder()`` method
 in your controller::
+
+// the following configuration triggers an error `An error has occurred resolving the options of the form "Symfony\Component\Form\Extension\Core\Type\FormType": The option "constraints" with value array is expected to be of type "Symfony\Component\Validator\Constraint" or "Symfony\Component\Validator\Constraint[]", but one of the elements is of type "array".`
+
 
     $form = $this->createFormBuilder($defaultData, [
             'constraints' => [

--- a/form/without_class.rst
+++ b/form/without_class.rst
@@ -99,7 +99,7 @@ but here's a short example::
                 'constraints' => new Length(['min' => 3]),
             ])
             ->add('lastName', TextType::class, [
-// the following configuration triggers an error `An error has occurred resolving the options of the form "Symfony\Component\Form\Extension\Core\Type\FormType": The option "constraints" with value array is expected to be of type "Symfony\Component\Validator\Constraint" or "Symfony\Component\Validator\Constraint[]", but one of the elements is of type "array".`
+.. the following configuration triggers an error `An error has occurred resolving the options of the form "Symfony\Component\Form\Extension\Core\Type\FormType": The option "constraints" with value array is expected to be of type "Symfony\Component\Validator\Constraint" or "Symfony\Component\Validator\Constraint[]", but one of the elements is of type "array".` ..
                 'constraints' => [  
                     new NotBlank(),
                     new Length(['min' => 3]),
@@ -167,7 +167,7 @@ This can be done by setting the ``constraints`` option in the
 This means you can also do this when using the ``createFormBuilder()`` method
 in your controller::
 
-// the following configuration triggers an error `An error has occurred resolving the options of the form "Symfony\Component\Form\Extension\Core\Type\FormType": The option "constraints" with value array is expected to be of type "Symfony\Component\Validator\Constraint" or "Symfony\Component\Validator\Constraint[]", but one of the elements is of type "array".`
+.. the following configuration triggers an error `An error has occurred resolving the options of the form "Symfony\Component\Form\Extension\Core\Type\FormType": The option "constraints" with value array is expected to be of type "Symfony\Component\Validator\Constraint" or "Symfony\Component\Validator\Constraint[]", but one of the elements is of type "array".` ..
 
 
     $form = $this->createFormBuilder($defaultData, [


### PR DESCRIPTION
hello

when trying to add several validation constraints (setup an array of constraints for a given form field) in the `Constraints At Class Level`, an error is raised as described in  the following screenshot :

![image](https://github.com/user-attachments/assets/3bb636d7-3674-426b-9084-7079f502d505)


Symfony version : 7.2.1
PHP version :  8.2.20

Steps to reproduce the bug: 

**Step 1**

create a controller like described in the doc 

![image](https://github.com/user-attachments/assets/ba23719a-bc3a-4ebc-ae21-f95fe724ff74)


**Step 2**

render the form 

![image](https://github.com/user-attachments/assets/3ff63fd3-8071-4818-b17a-1d30fa5b10c9)


**Step 3**

Go to the page http://localhost/contact 

the error is raised 

![image](https://github.com/user-attachments/assets/8601c54b-b197-47df-8145-f0f714658284)

to make sure that the problem is coming from the 

```
'lastName' => [
    new NotBlank(),
    new Length(['min' => 3]),
],
```

change this configuration by either remove the entire config or just do 

```
'lastName' =>new NotBlank(),
```

(use Constraint instead of an array)

and the result is as follows

![image](https://github.com/user-attachments/assets/cfa3eed8-724b-4b6b-8647-68b8b5f404f3)

the form is rendered with no problems


thanks in advance,
