### PR TITLE
[Validator] Cannot validate svg image size

### DIFF
--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -530,5 +530,10 @@ options has been set.
 
 This message has no parameters.
 
+.. note::
+
+    SVG images sizes are not currently supported. Using size constraints with
+    these files will display this message.
+
 .. _`IANA website`: https://www.iana.org/assignments/media-types/media-types.xhtml
 .. _`PHP GD extension`: https://www.php.net/manual/en/book.image.php


### PR DESCRIPTION
As an addition of #20496 and considering what is described in related [code PR](https://github.com/symfony/symfony/pull/59265) I think it can be helpful to explicit mention this restriction for SVG images