### PR TITLE
[Security] Add Oauth client package in doc

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -724,7 +724,7 @@ many other authenticators:
 
     If your application logs users in via a third-party service such as
     Google, Facebook or Twitter (social login), check out the `HWIOAuthBundle`_
-    community bundle.
+    community bundle or `Oauth2-client`_ package.
 
 .. _security-form-login:
 
@@ -3037,3 +3037,4 @@ Authorization (Denying Access)
 .. _`Login CSRF attacks`: https://en.wikipedia.org/wiki/Cross-site_request_forgery#Forging_login_requests
 .. _`PHP date relative formats`: https://www.php.net/manual/en/datetime.formats.php#datetime.formats.relative
 .. _`SensitiveParameter PHP attribute`: https://www.php.net/manual/en/class.sensitiveparameter.php
+.. _`Oauth2-client`: https://github.com/thephpleague/oauth2-client


### PR DESCRIPTION
Following #20492 

Add oauth2-client from thephpleague as a second option in documentation in addition to HWIOAuthBundle