### PR TITLE
[HttpFoundation] Mention issues with generated URL hashes

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -2805,6 +2805,12 @@ service, which you can inject in your services or controllers::
     ``Symfony\Component\HttpKernel\UriSigner`` to
     ``Symfony\Component\HttpFoundation\UriSigner``.
 
+.. note::
+
+    The generated URI hashes may include the ``/`` and ``+`` characters, which
+    can cause issues with certain clients. If you encounter this problem, replace
+    them using the following: ``strtr($hash, ['/' => '_', '+' => '-'])``.
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
Related to #20481.

In #20508 we mention that "this problem no longer exist in 7.3". But, I think we should also mention that problem in all the branches before 7.3.