### PR TITLE
[Security] Remove mention of is_granted_ `$field` argument

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -160,14 +160,12 @@ is_granted
 
 .. code-block:: twig
 
-    {{ is_granted(role, object = null, field = null) }}
+    {{ is_granted(role, object = null) }}
 
 ``role``
     **type**: ``string``
 ``object`` *(optional)*
     **type**: ``object``
-``field`` *(optional)*
-    **type**: ``string``
 
 Returns ``true`` if the current user has the given role.
 
@@ -183,7 +181,7 @@ is_granted_for_user
 
 .. code-block:: twig
 
-    {{ is_granted_for_user(user, attribute, subject = null, field = null) }}
+    {{ is_granted_for_user(user, attribute, subject = null) }}
 
 ``user``
     **type**: ``object``
@@ -191,8 +189,6 @@ is_granted_for_user
     **type**: ``string``
 ``subject`` *(optional)*
     **type**: ``object``
-``field`` *(optional)*
-    **type**: ``string``
 
 Returns ``true`` if the user is authorized for the specified attribute.
 


### PR DESCRIPTION
The third argument of is_granted / is_granted_for_user is undocumented (except on this page) (neither on Symfony docs, code, nor on... Symfony ACL Bundle docs).

It must be kept and maintained for BC reasons. But it can be missleading/frustrating to show this argument to users, when they cannot use it with a standard/recommended Symfony installation.

And if they just test it, the error could lead them to believe the AclBundle needs to be installed to use the `is_granted` function(s).

As suggested in https://github.com/symfony/symfony/pull/59282#issuecomment-2569716817 I believe "not showing it" is the "best" solution here.

