### PR TITLE
[FrameworkBundle] Remove ``--show-arguments`` option for ``debug:container``

### DIFF
--- a/controller/value_resolver.rst
+++ b/controller/value_resolver.rst
@@ -396,7 +396,7 @@ command to see which argument resolvers are present and in which order they run:
 
 .. code-block:: terminal
 
-    $ php bin/console debug:container debug.argument_resolver.inner --show-arguments
+    $ php bin/console debug:container debug.argument_resolver.inner
 
 You can also configure the name passed to the ``ValueResolver`` attribute to target
 your resolver. Otherwise it will default to the service's id.

--- a/service_container/debug.rst
+++ b/service_container/debug.rst
@@ -51,6 +51,3 @@ its id:
 .. code-block:: terminal
 
     $ php bin/console debug:container App\Service\Mailer
-
-    # to show the service arguments:
-    $ php bin/console debug:container App\Service\Mailer --show-arguments


### PR DESCRIPTION
Fixes #20542 

Here I don't think it's relevant to inform readers with an versionadded block / deprecated block version of the changes made, what do you think?