### PR TITLE
[Mailer] [Smtp] Add source_ip option

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -426,6 +426,27 @@ setting the ``auto_tls`` option to ``false`` in the DSN::
 
     This setting only works when the ``smtp://`` protocol is used.
 
+Binding to IPv4 or IPv6
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 7.3
+
+    The option to bind to IPv4 or IPv6 or a specific IP address was introduced in Symfony 7.3.
+
+By default, the underlying SocketStream will bind to IPv4 or IPv6 depending on the available
+interfaces. By specifying the ``source_ip`` option, binding to either IPv4 or IPv6 can be enforced,
+or even to a specific address. To bind to IPv4, use::
+
+    $dsn = 'smtp://smtp.example.com?source_ip=0.0.0.0';
+
+As per RFC2732, IPv6 addresses must be surrounded by square brackets. To bind to IPv6, use::
+
+    $dsn = 'smtp://smtp.example.com?source_ip=[::]';
+
+.. note::
+
+    This setting only works when the ``smtp://`` protocol is used.
+
 Overriding default SMTP authenticators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR documents the `source_ip` feature in this PR: https://github.com/symfony/symfony/pull/59482/files
