### PR TITLE
[Notifier] Add Smsbox Notifier doc

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -177,7 +177,7 @@ Service
                     **Webhook support**: No
 `Smsbox`_           **Install**: ``composer require symfony/smsbox-notifier`` \
                     **DSN**: ``smsbox://APIKEY@default?mode=MODE&strategy=STRATEGY&sender=SENDER`` \
-                    **Webhook support**: No
+                    **Webhook support**: Yes
 `SmsBiuras`_        **Install**: ``composer require symfony/sms-biuras-notifier`` \
                     **DSN**: ``smsbiuras://UID:API_KEY@default?from=FROM&test_mode=0`` \
                     **Webhook support**: No

--- a/webhook.rst
+++ b/webhook.rst
@@ -171,6 +171,7 @@ Currently, the following third-party SMS transports support webhooks:
 SMS service  Parser service name
 ============ ==========================================
 Twilio       ``notifier.webhook.request_parser.twilio``
+Smsbox       ``notifier.webhook.request_parser.smsbox``
 Sweego       ``notifier.webhook.request_parser.sweego``
 Vonage       ``notifier.webhook.request_parser.vonage``
 ============ ==========================================


### PR DESCRIPTION
Add support for Webhook to Smsbox Notifier
Event statuses come from Smsbox [documentation](https://en.smsbox.net/docs/doc-APIReceive-SMSBOX-EN.pdf).
