### PR TITLE
Remove myself from active core members

### DIFF
--- a/contributing/code/core_team.rst
+++ b/contributing/code/core_team.rst
@@ -70,7 +70,6 @@ Active Core Members
   * **Alexander M. Turek** (`derrabus`_);
   * **Jérémy Derussé** (`jderusse`_);
   * **Oskar Stark** (`OskarStark`_);
-  * **Thomas Calvet** (`fancyweb`_);
   * **Mathieu Santostefano** (`welcomattic`_);
   * **Kevin Bond** (`kbond`_);
   * **Jérôme Tamarelle** (`gromnan`_).
@@ -114,7 +113,8 @@ Symfony contributions:
 * **Tobias Schultze** (`Tobion`_);
 * **Maxime Steinhausser** (`ogizanagi`_);
 * **Titouan Galopin** (`tgalopin`_);
-* **Michael Cullum** (`michaelcullum`_).
+* **Michael Cullum** (`michaelcullum`_);
+* **Thomas Calvet** (`fancyweb`_).
 
 Core Membership Application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As discussed on Slack, I have decided to step down from this role since I've been inactive for a while :smiling_face_with_tear: 