### PR TITLE
[Notifier] Add SentMessage extra info

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -68,6 +68,7 @@ Service
 `AllMySms`_         **Install**: ``composer require symfony/all-my-sms-notifier`` \
                     **DSN**: ``allmysms://LOGIN:APIKEY@default?from=FROM`` \
                     **Webhook support**: No
+                    **SentMessage extra info**: `nbSms`, `balance`, `cost`
 `AmazonSns`_        **Install**: ``composer require symfony/amazon-sns-notifier`` \
                     **DSN**: ``sns://ACCESS_KEY:SECRET_KEY@default?region=REGION`` \
                     **Webhook support**: No
@@ -139,6 +140,7 @@ Service
 `OvhCloud`_         **Install**: ``composer require symfony/ovh-cloud-notifier`` \
                     **DSN**: ``ovhcloud://APPLICATION_KEY:APPLICATION_SECRET@default?consumer_key=CONSUMER_KEY&service_name=SERVICE_NAME`` \
                     **Webhook support**: No
+                    **SentMessage extra info**: `totalCreditsRemoved`
 `Plivo`_            **Install**: ``composer require symfony/plivo-notifier`` \
                     **DSN**: ``plivo://AUTH_ID:AUTH_TOKEN@default?from=FROM`` \
                     **Webhook support**: No


### PR DESCRIPTION
fixes https://github.com/symfony/symfony-docs/issues/20601

I'm not sure any doc should be added: the current sentence regarding the `SentMessage` object is: [The send() method returns a variable of type SentMessage which provides information such as the message ID and the original message contents](https://symfony.com/doc/7.3/notifier.html#sms-channel)