### PR TITLE
Readd handling of fallback of bundles directory in Apache config

### DIFF
--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -91,6 +91,14 @@ directive to pass requests for PHP files to PHP FPM:
         #     Options FollowSymlinks
         # </Directory>
 
+        # optionally disable the fallback resource for the asset directories
+        # which will allow Apache to return a 404 error when files are
+        # not found instead of passing the request to Symfony
+        # <Directory /var/www/project/public/bundles>
+        #     DirectoryIndex disabled
+        #     FallbackResource disabled
+        # </Directory>
+
         ErrorLog /var/log/apache2/project_error.log
         CustomLog /var/log/apache2/project_access.log combined
     </VirtualHost>


### PR DESCRIPTION
In 035af33a a configuration for Apache was removed that would prevent URLs in the public `bundles` directory to be parsed from Symfony. Unfortunately, my question in https://github.com/symfony/symfony-docs/pull/17597#issuecomment-1919087852 if there was any reason for removing this part didn't get any answers. The similar directive for Nginx is still there: https://github.com/symfony/symfony-docs/blob/5.4/setup/web_server_configuration.rst?plain=1#L123-L128, so I assume it was just a mistake and to not handle the `bundles` directory not by Symfony is still a good idea.