### PR TITLE
[Encore] [Frontend] Correct "Removes comments from CSS" comparison

### DIFF
--- a/frontend.rst
+++ b/frontend.rst
@@ -35,7 +35,7 @@ Supports Sass/Tailwind            :ref:`yes <asset-mapper-tailwind>`  yes
 Supports React, Vue, Svelte?      yes :ref:`[1] <ux-note-1>`          yes
 Supports TypeScript               :ref:`yes <asset-mapper-ts>`        yes
 Removes comments from JavaScript  no :ref:`[2] <ux-note-2>`           yes
-Removes comments from CSS         no :ref:`[2] <ux-note-2>`           no
+Removes comments from CSS         no :ref:`[2] <ux-note-2>`           yes :ref:`[4] <ux-note-4>`
 Versioned assets                  always                              optional
 Can update 3rd party packages     yes                                 no :ref:`[3] <ux-note-3>`
 ================================  ==================================  ==========
@@ -55,6 +55,10 @@ be executed by a browser.
 .. _ux-note-3:
 
 **[3]** If you use ``npm``, there are update checkers available (e.g. ``npm-check``).
+
+.. _ux-note-4:
+
+**[4]** Comments from CSS code can be removed with `CssMinimizerPlugin`_, configurable with ``Encore.configureCssMinimizerPlugin()``.
 
 .. _frontend-asset-mapper:
 
@@ -153,3 +157,4 @@ Other Front-End Articles
 .. _`SensioLabs Minify Bundle`: https://github.com/sensiolabs/minify-bundle
 .. _`AssetMapper screencast series`: https://symfonycasts.com/screencast/asset-mapper
 .. _`API Platform screencast series`: https://symfonycasts.com/screencast/api-platform
+.. _`CssMinimizerPlugin`: https://webpack.js.org/plugins/css-minimizer-webpack-plugin


### PR DESCRIPTION
Hey!

Following internal discussions about Encore, I came across [this page](https://symfony.com/doc/6.4/frontend.html#using-php-twig) and found incorrect information, Encore can remove comments from CSS by configuring the `CssMinimizerPlugin`, included with Encore.

On another note, I don't really understand the sentence `Can update 3rd party packages`. It looks like a comparaison between `importmap:require` and something that is not a Node.js package manager... right? isn't this comparison biased?

Thanks!