### PR TITLE
[Mailer] Minor reformating

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -572,8 +572,8 @@ header, etc.) but most of the times you'll set text headers::
 
     $email = (new Email())
         ->getHeaders()
-            // this non-standard header tells compliant autoresponders ("email holiday mode") to not
-            // reply to this message because it's an automated email
+            // this non-standard header tells compliant autoresponders ("email holiday mode")
+            // to not reply to this message because it's an automated email
             ->addTextHeader('X-Auto-Response-Suppress', 'OOF, DR, RN, NRN, AutoReply')
 
             // use an array if you want to add a header with multiple values


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/mailer.html#message-headers

Reason: Code block too wide by one word ;-)
