### PR TITLE
[Cache] Fix "Marshalling (Serializing) Data" code rendering issue

### DIFF
--- a/components/cache.rst
+++ b/components/cache.rst
@@ -209,11 +209,11 @@ the cache items before storing them.
 
 The :class:`Symfony\\Component\\Cache\\Marshaller\\DefaultMarshaller` uses PHP's
 ``serialize()`` function by default, but you can optionally use the ``igbinary_serialize()``
-function from the `Igbinary extension`_:
+function from the `Igbinary extension`_::
 
     use Symfony\Component\Cache\Adapter\RedisAdapter;
-    use Symfony\Component\Cache\DefaultMarshaller;
-    use Symfony\Component\Cache\DeflateMarshaller;
+    use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
+    use Symfony\Component\Cache\Marshaller\DeflateMarshaller;
 
     $marshaller = new DeflateMarshaller(new DefaultMarshaller());
     // you can optionally use the Igbinary extension if you have it installed


### PR DESCRIPTION
The code block is not correctly rendered on https://symfony.com/doc/current/components/cache.html#marshalling-serializing-data, see 
![image](https://github.com/user-attachments/assets/83666e3c-ca0e-48b5-96c7-18ebc7b9a5fa)
