### PR TITLE
[Security] Add `role_fetcher` option to LDAP security configuration

### DIFF
--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -256,6 +256,23 @@ This is the default role you wish to give to a user fetched from the LDAP
 server. If you do not configure this key, your users won't have any roles,
 and will not be considered as authenticated fully.
 
+role_fetcher
+............
+
+**type**: ``string`` **default**: ``null``
+
+When your LDAP service provides user roles, you can use this configuration option
+to define the role fetcher service. The role fetcher service must implement the
+``Component\Ldap\Security\RoleFetcherInterface`` interface.
+``default_roles`` is ignored when ``role_fetcher`` is set.
+
+``Symfony\Component\Ldap\Security\MemberOfRoles`` is a concrete implementation
+of the ``RoleFetcherInterface`` that fetches roles from the ``ismemberof`` attribute.
+
+.. versionadded:: 7.3
+
+    The configuration option ``role_fetcher`` was introduced in Symfony 7.3.
+
 uid_key
 .......
 


### PR DESCRIPTION
Fix #20640

The `role_fetcher` option allows defining a service to fetch user roles from the LDAP server by implementing `RoleFetcherInterface`. This option was introduced in Symfony 7.3, and it supersedes `default_roles` when set. The `MemberOfRoles` implementation can be used to retrieve roles from the `ismemberof` attribute.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
