### PR TITLE
[DependencyInjection] Compiler pass bundle example does not implement `CompilerPassInterface`

### DIFF
--- a/service_container/compiler_passes.rst
+++ b/service_container/compiler_passes.rst
@@ -77,10 +77,11 @@ bundle class::
     namespace App\MyBundle;
 
     use App\DependencyInjection\Compiler\CustomPass;
+    use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
     use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 
-    class MyBundle extends AbstractBundle
+    class MyBundle extends AbstractBundle implements CompilerPassInterface
     {
         public function process(ContainerBuilder $container): void
         {


### PR DESCRIPTION
Not much more to add.

https://github.com/symfony/symfony-docs/blob/8b5773b8a66330cc6ddba546e5aabfc5d7645d51/service_container/compiler_passes.rst?plain=1#L70-L86

It adds the import/implements to this part.