### PR TITLE
[Cache] Make tag aware config examples consistent

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -603,6 +603,7 @@ to enable this feature. This could be added by using the following configuration
                 pools:
                     my_cache_pool:
                         adapter: cache.adapter.redis_tag_aware
+                        tags: true
 
     .. code-block:: xml
 
@@ -619,7 +620,7 @@ to enable this feature. This could be added by using the following configuration
             <framework:config>
                 <framework:cache>
                     <framework:pool name="my_cache_pool"
-                        adapter="cache.adapter.redis"
+                        adapter="cache.adapter.redis_tag_aware"
                         tags="true"
                     />
                 </framework:cache>
@@ -635,7 +636,7 @@ to enable this feature. This could be added by using the following configuration
             $framework->cache()
                 ->pool('my_cache_pool')
                     ->tags(true)
-                    ->adapters(['cache.adapter.redis'])
+                    ->adapters(['cache.adapter.redis_tag_aware'])
             ;
         };
 


### PR DESCRIPTION
The config examples for the tag aware cache config between formats wasn't consistent, so this PR gets them all to be roughly similar.