### PR TITLE
[Notifier] Mention the extra info returned in Bluesky SentMessage

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -365,6 +365,7 @@ Service
                                          **DSN**: ``sns://ACCESS_KEY:SECRET_KEY@default?region=REGION``
 `Bluesky`_                               **Install**: ``composer require symfony/bluesky-notifier`` \
                                          **DSN**: ``bluesky://USERNAME:PASSWORD@default``
+                                         **Extra properties in SentMessage**:: ``cid``
 `Chatwork`_                              **Install**: ``composer require symfony/chatwork-notifier`` \
                                          **DSN**: ``chatwork://API_TOKEN@default?room_id=ID``
 `Discord`_                               **Install**: ``composer require symfony/discord-notifier`` \


### PR DESCRIPTION
Fixes #20662.

For these extra info parameters we don't add a versionadded directive to reduce the noise.