### PR TITLE
[Messenger][Process] add `fromShellCommandLine()` documentation

### DIFF
--- a/components/process.rst
+++ b/components/process.rst
@@ -114,6 +114,8 @@ You can configure the options passed to the ``other_options`` argument of
     and ``suppress_errors``) are only supported on Windows operating systems.
     Check out the `PHP documentation for proc_open()`_ before using them.
 
+.. _process-using-features-from-the-os-shell:
+
 Using Features From the OS Shell
 --------------------------------
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -2301,8 +2301,9 @@ will take care of creating a new process with the parameters you passed::
 
     class CleanUpService
     {
-        public function __construct(private readonly MessageBusInterface $bus)
-        {
+        public function __construct(
+            private readonly MessageBusInterface $bus,
+        ) {
         }
 
         public function cleanUp(): void
@@ -2312,6 +2313,34 @@ will take care of creating a new process with the parameters you passed::
             // ...
         }
     }
+
+A static factory :method:`Symfony\\Component\\Process\\Messenger\\RunProcessMessage::fromShellCommandline` is also
+available if you want to use features of your shell such as redirections or pipes::
+
+    use Symfony\Component\Messenger\MessageBusInterface;
+    use Symfony\Component\Process\Messenger\RunProcessMessage;
+
+    class CleanUpService
+    {
+        public function __construct(
+            private readonly MessageBusInterface $bus,
+        ) {
+        }
+
+        public function cleanUp(): void
+        {
+            $this->bus->dispatch(RunProcessMessage::fromShellCommandline('echo "Hello World" > var/log/hello.txt'));
+
+            // ...
+        }
+    }
+
+For more information, see the
+dedicated :ref:`Using Features From the OS Shell <process-using-features-from-the-os-shell>` documentation.
+
+.. versionadded:: 7.3
+
+    The ``RunProcessMessage::fromShellCommandline()`` method was introduced in Symfony 7.3.
 
 Once handled, the handler will return a
 :class:`Symfony\\Component\\Process\\Messenger\\RunProcessContext` which


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony-docs/issues/20655

The :method:`Symfony\\Component\\Process\\Messenger\\RunProcessMessage::fromShellCommandline` in my docs point to the 7.1 branch on my local build, any idea how to make it point to 7.3?