### PR TITLE
[Console] Remove invalid ProcessHelper specified usage

### DIFF
--- a/components/console/helpers/processhelper.rst
+++ b/components/console/helpers/processhelper.rst
@@ -42,12 +42,7 @@ In case the process fails, debugging is easier:
 Arguments
 ---------
 
-There are three ways to use the process helper:
-
-* Using a command line string::
-
-    // ...
-    $helper->run($output, 'figlet Symfony');
+There are two ways to use the process helper:
 
 * An array of arguments::
 


### PR DESCRIPTION
Since Symfony 6.0, the ProcessHelper have the `$cmd` argument from its two methods `run()` and `mustRun()` typed as `array|Process` [source](https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/Console/Helper/ProcessHelper.php).

When you try to run as described in the documentation with a string, PHP will throw a TypeError
```
Fatal error: Uncaught TypeError: Symfony\Component\Console\Helper\ProcessHelper::run(): Argument #2 ($cmd) must be of type Symfony\Component\Process\Process|array, string given, called in /app/src/FooCommand.php on line 22 and defined in /app/vendor/symfony/console/Helper/ProcessHelper.php:35
```

Documentation is invalid since 6.0 up to the latest version.