### PR TITLE
[Mailer] [Amazon] Remove outdated warning

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -268,12 +268,6 @@ party provider:
     you need to add the ``ping_threshold`` parameter to your ``MAILER_DSN`` with
     a value lower than ``10``: ``ses+smtp://USERNAME:PASSWORD@default?ping_threshold=9``
 
-.. warning::
-
-    If you send custom headers when using the `Amazon SES`_ transport (to receive
-    them later via a webhook), make sure to use the ``ses+https`` provider because
-    it's the only one that supports them.
-
 .. note::
 
     When using SMTP, the default timeout for sending a message before throwing an


### PR DESCRIPTION
As per https://github.com/symfony/symfony/pull/58761, the warning about requiring the `ses+https` provider for custom headers is no longer relevant for 7.3 and has been removed. Fixes https://github.com/symfony/symfony-docs/issues/20512