### PR TITLE
[Security] use strings for chained user providers

### DIFF
--- a/security/user_providers.rst
+++ b/security/user_providers.rst
@@ -363,7 +363,7 @@ providers until the user is found:
             ;
 
             $allProviders = $security->provider('all_users')->chain()
-                ->providers([$backendProvider, $legacyProvider, $userProvider])
+                ->providers(['backend_users', 'legacy_users', 'users'])
             ;
         };
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
