### PR TITLE
Remove non-existent password_strength setting from the reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2840,14 +2840,6 @@ metadata of the class. You can define an array of strings with the names of
 several methods. In that case, all of them will be called in that order to load
 the metadata.
 
-.. _reference-validation-password-strength:
-
-password_strength
-.................
-
-The :doc:`PasswordStrength </reference/constraints/PasswordStrength>`
-constraint verifies the submitted string entropy is matching the minimum entropy score.
-
 .. _reference-validation-email_validation_mode:
 
 email_validation_mode


### PR DESCRIPTION
This was added in https://github.com/symfony/symfony-docs/pull/18124 when documenting the new constraint, but the implementation does not have a configuration setting for that in the FrameworkBundle configuration.

I spotted this when I saw it being in the reference without the usual info about the type of values and wanting to fix it.
