### PR TITLE
Tweak reference documents

### DIFF
--- a/reference/configuration/debug.rst
+++ b/reference/configuration/debug.rst
@@ -27,9 +27,6 @@ key in your application configuration.
     namespace and the related XSD schema is available at:
     ``https://symfony.com/schema/dic/debug/debug-1.0.xsd``
 
-Configuration
--------------
-
 max_items
 ~~~~~~~~~
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -19,9 +19,6 @@ configured under the ``framework`` key in your application configuration.
     namespace and the related XSD schema is available at:
     ``https://symfony.com/schema/dic/symfony/symfony-1.0.xsd``
 
-Configuration
--------------
-
 .. _configuration-framework-secret:
 
 secret

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -19,9 +19,6 @@ key in your application configuration.
     namespace and the related XSD schema is available at:
     ``https://symfony.com/schema/dic/services/services-1.0.xsd``
 
-Configuration
--------------
-
 **Basic Options**:
 
 * `access_denied_url`_

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -19,9 +19,6 @@ under the ``twig`` key in your application configuration.
     namespace and the related XSD schema is available at:
     ``https://symfony.com/schema/dic/twig/twig-1.0.xsd``
 
-Configuration
--------------
-
 auto_reload
 ~~~~~~~~~~~
 

--- a/reference/configuration/web_profiler.rst
+++ b/reference/configuration/web_profiler.rst
@@ -24,9 +24,6 @@ under the ``web_profiler`` key in your application configuration.
 
     The web debug toolbar is not available for responses of type ``StreamedResponse``.
 
-Configuration
--------------
-
 excluded_ajax_paths
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
As reported by @stof, there's a problem with some Configuration Reference documents.

**Problem**

`h4` and `h5` headings are styled the same on symfony.com

This makes hard to understand options like this: https://symfony.com/doc/current/reference/configuration/framework.html#not-compromised-password

`enabled` and `endpoint` are sub-keys of `not_compromised_password` while `static_method` is a sibling. Very confusing.

**Solution**

I don't want to make `h5` even smaller or different in any way. I think that needing to use `h5` reveals a complexity problem in your page.

So, let's fix this differently. And I think there could be a very simple solution.

Look at the page TOC:

![imagen](https://github.com/user-attachments/assets/350f8567-fd4e-45ef-9f47-10d8fb7002c5)

The "useless" `Configuration` title adds a heading level in the entire page, pushing some elements to `h5` level. If we remove it, all the sub-headings go up one level automatically. This will probably be enough.

Note that the perfect solution would be to remove `Configuration` heading and update ALL the other headings to use the same heading markers (`---`, `~~~`, etc.) as the rest of Symfony Docs.

Doing this would be a merge conflict nightmare. Luckily, reStructuredText format doesn't care about the specific markers used. The first one it finds is h2, the second one is h3 and so on. So, I think it's fine to use different markers just on these reference pages.

what do you think?