### PR TITLE
Fix the top-level key in the DebugBundle reference

### DIFF
--- a/reference/configuration/debug.rst
+++ b/reference/configuration/debug.rst
@@ -8,14 +8,14 @@ key in your application configuration.
 .. code-block:: terminal
 
     # displays the default config values defined by Symfony
-    $ php bin/console config:dump-reference framework
+    $ php bin/console config:dump-reference debug
 
     # displays the actual config values used by your application
-    $ php bin/console debug:config framework
+    $ php bin/console debug:config debug
 
     # displays the config values used by your application and replaces the
     # environment variables with their actual values
-    $ php bin/console debug:config --resolve-env framework
+    $ php bin/console debug:config --resolve-env debug
 
 .. versionadded:: 6.2
 


### PR DESCRIPTION
All our bundle reference pages have the snippet showing the commands to dump the reference and the actual values. However, the DebugBundle reference page copied the snippet from FrameworkBundle without replacing the bundle config namespace.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
