### PR TITLE
Add missing default value in the Twig reference

### DIFF
--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -315,7 +315,7 @@ mailer
 html_to_text_converter
 ......................
 
-**type**: ``string`` **default**: ````
+**type**: ``string`` **default**: ``null``
 
 .. versionadded:: 6.2
 


### PR DESCRIPTION
This also fixes the rendering, because empty literals are not valid in rST so this was displaying 4 backticks:

![image](https://github.com/user-attachments/assets/47ea8b1a-823e-4426-aa74-cc3430c44ebd)

