### PR TITLE
Update overview.rst

### DIFF
--- a/contributing/documentation/overview.rst
+++ b/contributing/documentation/overview.rst
@@ -113,16 +113,16 @@ memorable name for the new branch (if you are fixing a reported issue, use
 
 .. code-block:: terminal
 
-    $ git checkout -b improve_install_article upstream/5.4
+    $ git checkout -b improve_install_article upstream/6.4
 
 In this example, the name of the branch is ``improve_install_article`` and the
-``upstream/5.4`` value tells Git to create this branch based on the ``5.4``
+``upstream/6.4`` value tells Git to create this branch based on the ``6.4``
 branch of the ``upstream`` remote, which is the original Symfony Docs repository.
 
 Fixes should always be based on the **oldest maintained branch** which contains
-the error. Nowadays this is the ``5.4`` branch. If you are instead documenting a
+the error. Nowadays this is the ``6.4`` branch. If you are instead documenting a
 new feature, switch to the first Symfony version that included it, e.g.
-``upstream/6.2``.
+``upstream/7.2``.
 
 **Step 5.** Now make your changes in the documentation. Add, tweak, reword and
 even remove any content and do your best to comply with the
@@ -156,7 +156,7 @@ changes should be applied:
     :alt: The base branch select option on the GitHub page.
 
 In this example, the **base fork** should be ``symfony/symfony-docs`` and
-the **base** branch should be the ``5.4``, which is the branch that you selected
+the **base** branch should be the ``4.4``, which is the branch that you selected
 to base your changes on. The **head fork** should be your forked copy
 of ``symfony-docs`` and the **compare** branch should be ``improve_install_article``,
 which is the name of the branch you created and where you made your changes.
@@ -209,7 +209,7 @@ contribution to the Symfony docs:
     # create a new branch based on the oldest maintained version
     $ cd projects/symfony-docs/
     $ git fetch upstream
-    $ git checkout -b my_changes upstream/5.4
+    $ git checkout -b my_changes upstream/6.4
 
     # ... do your changes
 
@@ -258,8 +258,8 @@ into multiple branches, corresponding to the different versions of Symfony itsel
 The latest (e.g. ``5.x``) branch holds the documentation for the development branch of
 the code.
 
-Unless you're documenting a feature that was introduced after Symfony 5.4,
-your changes should always be based on the ``5.4`` branch. Documentation managers
+Unless you're documenting a feature that was introduced after Symfony 6.4,
+your changes should always be based on the ``6.4`` branch. Documentation managers
 will use the necessary Git-magic to also apply your changes to all the active
 branches of the documentation.
 


### PR DESCRIPTION
Update version numbers to currently last maintained version (According to overview in the Releases Page). Intent is to make it clearer and also easier for users using Copy-Paste for git commands.

Description in the github screenshot intentionally changed to 4.4 to avoid confusion between picture and description (replacing the screenshot seemed excessive)

