### PR TITLE
fix: Add missing ContainerBuilder use statement in Bundle documentation

### DIFF
--- a/bundles/extension.rst
+++ b/bundles/extension.rst
@@ -29,6 +29,7 @@ class, you can define the :method:`Symfony\\Component\\HttpKernel\\Bundle\\Abstr
 method to load service definitions from configuration files::
 
     // ...
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
     use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 


### PR DESCRIPTION
Add missing ContainerBuilder use statement in the "How to Load Service Configuration inside a Bundle" documentation