### PR TITLE
[Security] Fix more heading levels in the security reference

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -38,86 +38,15 @@ separate articles:
 * `role_hierarchy`_
 
 access_denied_url
-~~~~~~~~~~~~~~~~~
+-----------------
 
 **type**: ``string`` **default**: ``null``
 
 Defines the URL where the user is redirected after a ``403`` HTTP error (unless
 you define a custom access denial handler). Example: ``/no-permission``
 
-delete_cookies
-~~~~~~~~~~~~~~
-
-**type**: ``array`` **default**: ``[]``
-
-Lists the names (and other optional features) of the cookies to delete when the
-user logs out::
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # config/packages/security.yaml
-        security:
-            # ...
-
-            firewalls:
-                main:
-                    # ...
-                    logout:
-                        delete_cookies:
-                            cookie1-name: null
-                            cookie2-name:
-                                path: '/'
-                            cookie3-name:
-                                path: null
-                                domain: example.com
-
-    .. code-block:: xml
-
-        <!-- config/packages/security.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <srv:container xmlns="http://symfony.com/schema/dic/security"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:srv="http://symfony.com/schema/dic/services"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd">
-
-            <config>
-                <!-- ... -->
-
-                <firewall name="main">
-                    <!-- ... -->
-                    <logout path="...">
-                        <delete-cookie name="cookie1-name"/>
-                        <delete-cookie name="cookie2-name" path="/"/>
-                        <delete-cookie name="cookie3-name" domain="example.com"/>
-                    </logout>
-                </firewall>
-            </config>
-        </srv:container>
-
-    .. code-block:: php
-
-        // config/packages/security.php
-
-        // ...
-
-        return static function (SecurityConfig $securityConfig): void {
-            // ...
-
-            $securityConfig->firewall('main')
-                ->logout()
-                    ->deleteCookie('cookie1-name')
-                    ->deleteCookie('cookie2-name')
-                        ->path('/')
-                    ->deleteCookie('cookie3-name')
-                        ->path(null)
-                        ->domain('example.com');
-        };
-
 erase_credentials
-~~~~~~~~~~~~~~~~~
+-----------------
 
 **type**: ``boolean`` **default**: ``true``
 
@@ -125,7 +54,7 @@ If ``true``, the ``eraseCredentials()`` method of the user object is called
 after authentication.
 
 hide_user_not_found
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 **type**: ``boolean`` **default**: ``true``
 
@@ -138,7 +67,7 @@ If ``false``, the exception thrown is of type
 and it includes the given not found user identifier.
 
 session_fixation_strategy
-~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 
 **type**: ``string`` **default**: ``SessionAuthenticationStrategy::MIGRATE``
 
@@ -157,7 +86,7 @@ The possible values of this option are:
   other session attributes are lost.
 
 access_control
-~~~~~~~~~~~~~~
+--------------
 
 Defines the security protection of the URLs of your application. It's used for
 example to trigger the user authentication when trying to access to the backend
@@ -166,7 +95,7 @@ and to allow unauthenticated users to the login form page.
 This option is explained in detail in :doc:`/security/access_control`.
 
 firewalls
-~~~~~~~~~
+---------
 
 This is arguably the most important option of the security config file. It
 defines the authentication mechanism used for each URL (or URL pattern) of your
@@ -427,7 +356,7 @@ delete_cookies
 **type**: ``array`` **default**: ``[]``
 
 Lists the names (and other optional features) of the cookies to delete when the
-user logs out::
+user logs out:
 
 .. configuration-block::
 


### PR DESCRIPTION
This does the remaining fixes for https://github.com/symfony/symfony-docs/issues/20716:

- ensure that firewall subkeys are indeed nested
- remove the documentation of `delete_cookies` as a `<h2>` (we already have the duplicate content in the appropriate location under `logout`)
- fix `providers` and `role_hierarchy` being rendered properly as h2 (this is actually fix by changing the delimiter used for h2, being consistent with the other documentation pages, keeping the `~~~` delimiter for elements that should become `h3`).
