### PR TITLE
Update mercure.rst

### DIFF
--- a/mercure.rst
+++ b/mercure.rst
@@ -46,7 +46,7 @@ Run this command to install the Mercure support:
 
 .. code-block:: terminal
 
-    $ composer require mercure
+    $ composer require symfony/mercure
 
 Running a Mercure Hub
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Ensure people install the correct bundle

When you follow the docs now:
```
composer require mercure
Could not find package mercure.
Pick one of these or leave empty to abort:
  [0] anik/mercure
  [1] symfony/mercure
  [2] freddie/mercure-x
  [3] bizley/yii2-mercure
  [4] symfony/ux-turbo
 > 1
```

This can also be considered a security issue, if someone publishes a mercure package that contains malicious code, this could lead to major problems...