### PR TITLE
[Messenger] Clarify keepalive implementation for each transport

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1729,6 +1729,13 @@ The transport has a number of options:
     The message time to run before it is put back in the ready queue - in
     seconds.
 
+The Beanstalkd transport supports the ``--keepalive`` option by using Beanstalkd's
+``touch`` command to periodically reset the job's ``ttr``.
+
+.. versionadded:: 7.2
+
+    Keepalive support was introduced in Symfony 7.2.
+
 .. _messenger-redis-transport:
 
 Redis Transport
@@ -2050,6 +2057,13 @@ The transport has a number of options:
 
     FIFO queues don't support setting a delay per message, a value of ``delay: 0``
     is required in the retry strategy settings.
+
+The SQS transport supports the ``--keepalive`` option by using the ``ChangeMessageVisibility``
+action to periodically update the ``VisibilityTimeout`` of the message.
+
+.. versionadded:: 7.2
+
+    Keepalive support was introduced in Symfony 7.2.
 
 Serializing Messages
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As discussed with @OskarStark in #20721, this PR clarifies how the keepalive mechanism is implemented for each transport.