### PR TITLE
[Notifier] Error: Undefined Variable $texter

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -759,7 +759,7 @@ Now you can send notifications to your desktop as follows::
                 sprintf('%s is a new subscriber', $user->getFullName())
             );
 
-            $texter->send($message);
+            $this->texter->send($message);
         }
     }
 


### PR DESCRIPTION
The variable $texter is not defined inside the method, so PHP will throw an "Undefined variable" error.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
