### PR TITLE
[Routing] Add new tip to explain usage of --method option for filtering routes

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -456,6 +456,10 @@ route details:
     Use the ``--show-aliases`` option to show all available aliases for a given
     route.
 
+.. tip::
+
+    Use the ``--method`` option to filter routes by HTTP method. For example, to only show routes that use the ``GET`` method, add ``--method=GET``
+
 The other command is called ``router:match`` and it shows which route will match
 the given URL. It's useful to find out why some URL is not executing the
 controller action that you expect:


### PR DESCRIPTION
This PR updates the documentation for the debug:router command to include the new --method option, which allows developers to filter routes by HTTP method (such as GET, POST, PUT, DELETE, etc.). This enhances the debug:router command, making it easier to focus on specific routes based on their HTTP method, especially in large applications.

For more context, refer to the original issue: [Symfony Issue #59906](https://github.com/symfony/symfony/issues/59906).