### PR TITLE
[Serializer] Fix `defaultContext` example

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -344,7 +344,7 @@ instance to disallow extra fields while deserializing:
 
         return static function (FrameworkConfig $framework): void {
             $framework->serializer()
-                ->defaultContext('', [
+                ->defaultContext([
                     'allow_extra_attributes' => false,
                 ])
             ;


### PR DESCRIPTION
The current example has a mistake.