### PR TITLE
[Serializer] Fix `defaultContext` example 6.4

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -344,7 +344,7 @@ instance to disallow extra fields while deserializing:
 
         return static function (FrameworkConfig $framework): void {
             $framework->serializer()
-                ->defaultContext('', [
+                ->defaultContext([
                     'allow_extra_attributes' => false,
                 ])
             ;


### PR DESCRIPTION
Follow-up to #20767, this can now be merged into 6.4 cause of https://github.com/symfony/symfony/pull/59988.