### PR TITLE
[HttpKernel] Document supported types `#[MapQueryParameter]`

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -367,6 +367,16 @@ attribute, arguments of your controller's action can be automatically fulfilled:
         // ...
     }
 
+:class:`Symfony\\Component\\HttpKernel\\Attribute\\MapQueryParameter` support
+arguments of type:
+
+- ``string``
+- ``int``
+- ``float``
+- ``bool``
+- ``array``
+- ``\BackedEnum``
+
 ``#[MapQueryParameter]`` can take an optional argument called ``filter``. You can use the
 `Validate Filters`_ constants defined in PHP::
 


### PR DESCRIPTION
Before doing #20626 I think we need to document already supported types by `#[MapQueryParameter]` attribute

https://github.com/symfony/symfony/blob/5a9a3515b78f1a499e8e5f86636cbdc205067e24/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/QueryParameterValueResolver.php#L22