### PR TITLE
[HttpKernel] Support Uid in `#[MapQueryParameter]`

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -371,6 +371,11 @@ The ``MapQueryParameter`` attribute supports the following argument types:
 * ``float``
 * ``int``
 * ``string``
+* Objects that extend :class:`Symfony\\Component\\Uid\\AbstractUid`
+
+.. versionadded:: 7.3
+
+    The support of ``AbstractUid`` was introduced in Symfony 7.3.
 
 ``#[MapQueryParameter]`` can take an optional argument called ``filter``. You can use the
 `Validate Filters`_ constants defined in PHP::


### PR DESCRIPTION
When https://github.com/symfony/symfony-docs/pull/20783 is merge we can document new supported type.

Fix #20626 