### PR TITLE
[Deployment] - More accurate local .env file recommendation

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -134,14 +134,13 @@ B) Configure your Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Most Symfony applications read their configuration from environment variables.
-While developing locally, you'll usually store these in ``.env`` and ``.env.local``
-(for local overrides). On production, you have two options:
+While developing locally, you'll usually store these in :ref:`.env files <configuration-env-var-in-dev>`. On production, you have two options:
 
 1. Create "real" environment variables. How you set environment variables, depends
    on your setup: they can be set at the command line, in your Nginx configuration,
    or via other methods provided by your hosting service;
 
-2. Or, create a ``.env.local`` file like your local development.
+2. Or, create a ``.env.prod.local`` file containing values specific to your production environment.
 
 There is no significant advantage to either of the two options: use whatever is
 most natural in your hosting environment.


### PR DESCRIPTION
Updated file recommended for use when using .env files to manage environment variables for the application. 

Previously, the recommended file was `.env.local`, but if values added here would be overridden by `.env.prod` if present. It might be uncommon that someone would use a combination of `.env` and `.env.prod`, but it can't be assumed that it isn't the case. Using `.env.prod.local` is always going to be the last file processed by the dotenv component by default.

It might be even better to not reference "prod" directly in `.env.prod.local` and instead say `.env.<env>.local`, but prod is explicitly referenced elsewhere in this section/page. So I left the explicit reference.
