### PR TITLE
[TypeInfo] Refer ``TypeFactoryTrait`` to file

### DIFF
--- a/components/type_info.rst
+++ b/components/type_info.rst
@@ -37,8 +37,8 @@ to the :class:`Symfony\\Component\\TypeInfo\\Type` static methods as following::
     Type::list(Type::bool());
     Type::intersection(Type::object(\Stringable::class), Type::object(\Iterator::class));
 
-    // Many others are available and can be
-    // found in Symfony\Component\TypeInfo\TypeFactoryTrait
+Many others methods are available and can be found
+in :class:`Symfony\\Component\\TypeInfo\\TypeFactoryTrait`.
 
 Resolvers
 ~~~~~~~~~


### PR DESCRIPTION
IMO it's easier to access the class this way but `:class:` is not available in codeblock 
Did I miss any particular reason to mention it in comment ? 