### PR TITLE
[Security] : Removing duplicate sentence

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -575,7 +575,8 @@ Only one firewall is active on each request: Symfony uses the ``pattern`` key
 to find the first match (you can also
 :doc:`match by host or other things </security/firewall_restriction>`).
 Here, all real URLs are handled by the ``main`` firewall (no ``pattern`` key means
-it matches *all* URLs).
+it matches *all* URLs). A firewall can have many modes of authentication,
+in other words, it enables many ways to ask the question "Who are you?".
 
 The ``dev`` firewall is really a fake firewall: it makes sure that you
 don't accidentally block Symfony's dev tools - which live under URLs like
@@ -629,10 +630,6 @@ don't accidentally block Symfony's dev tools - which live under URLs like
     .. versionadded:: 6.4
 
         The feature to use an array of regex was introduced in Symfony 6.4.
-
-All *real* URLs are handled by the ``main`` firewall (no ``pattern`` key means
-it matches *all* URLs). A firewall can have many modes of authentication,
-in other words, it enables many ways to ask the question "Who are you?".
 
 Often, the user is unknown (i.e. not logged in) when they first visit your
 website. If you visit your homepage right now, you *will* have access and


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/security.html#the-firewall

Namely:
> Here, all real URLs are handled by the ``main`` firewall (no ``pattern`` key means
it matches *all* URLs).