### PR TITLE
[Security] Chain Providers: Fixing PHP code sample

### DIFF
--- a/security/user_providers.rst
+++ b/security/user_providers.rst
@@ -347,23 +347,23 @@ providers until the user is found:
         return static function (SecurityConfig $security): void {
             // ...
 
-            $backendProvider = $security->provider('backend_users')
+            $security->provider('backend_users')
                 ->ldap()
                 // ...
             ;
 
-            $legacyProvider = $security->provider('legacy_users')
+            $security->provider('legacy_users')
                 ->entity()
                 // ...
             ;
 
-            $userProvider = $security->provider('users')
+            $security->provider('users')
                 ->entity()
                 // ...
             ;
 
-            $allProviders = $security->provider('all_users')->chain()
-                ->providers([$backendProvider, $legacyProvider, $userProvider])
+            $security->provider('all_users')->chain()
+                ->providers(['backend_users', 'legacy_users', 'users'])
             ;
         };
 


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/security/user_providers.html#security-chain-user-provider

When passing in the variables, I got:
> Cannot use values of type "Symfony\Config\Security\ProviderConfig\EntityConfig" in service configuration files in .../config/packages/security.php (which is being imported from ".../src/Kernel.php").

So I deleted the variables altogether...