### PR TITLE
fix: Change translation domain name for bundle translation and add an example

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -397,9 +397,13 @@ Translation Files
 -----------------
 
 If a bundle provides message translations, they must be defined in the XLIFF
-format; the domain should be named after the bundle name (``acme_blog``).
+format; the domain should be named after the bundle name (``AcmeBlog``).
 
 A bundle must not override existing messages from another bundle.
+
+The translation domain must match the translation file names. For example,
+if the translation domain is ``AcmeBlog``, the English translation file name
+should be ``AcmeBlog.en.xlf``.
 
 Configuration
 -------------


### PR DESCRIPTION
The documentation was misleading regarding the bundle translations.

While the page [Symfony Bundles Documentation](https://symfony.com/doc/current/bundles.html) mentions that translation file names should use PascalCase — as shown in the example `AcmeBlogBundle.en.xlf` — the [Best Practices for Bundles](https://symfony.com/doc/current/bundles/best_practices.html#translation-files) suggest that the translation domain should be `acme_blog`.

This inconsistency led me to believe that there might be some mechanism that automatically converts the snake_case domain into PascalCase, but that isn’t the case.

I reviewed several bundles by core Symfony developers (such as EasyAdmin and bundles from SymfonyCasts), and they do indeed appear to use PascalCase translation domain names.