### PR TITLE
Update micro_kernel_trait.rst

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -260,11 +260,11 @@ Now it looks like this::
 
         public function registerBundles(): iterable
         {
-            yield FrameworkBundle();
-            yield TwigBundle();
+            yield new FrameworkBundle();
+            yield new TwigBundle();
 
             if ('dev' === $this->getEnvironment()) {
-                yield WebProfilerBundle();
+                yield new WebProfilerBundle();
             }
         }
 
@@ -304,18 +304,6 @@ Now it looks like this::
             // load the routes defined as PHP attributes
             // (use 'annotation' as the second argument if you define routes as annotations)
             $routes->import(__DIR__.'/Controller/', 'attribute');
-        }
-
-        // optional, to use the standard Symfony cache directory
-        public function getCacheDir(): string
-        {
-            return __DIR__.'/../var/cache/'.$this->getEnvironment();
-        }
-
-        // optional, to use the standard Symfony logs directory
-        public function getLogDir(): string
-        {
-            return __DIR__.'/../var/log';
         }
     }
 


### PR DESCRIPTION
Yielded classes in registerBundles() function example code require "new" keyword to work.

Also removed getLogDir() and getCacheDir() functions in example code (these functions are already defined in an identical way by the parent class).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
