### PR TITLE
[Routing] Fix documentation on router method option usage

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -442,9 +442,6 @@ evaluates them:
     $ php bin/console debug:router --method=GET
     $ php bin/console debug:router --method=ANY
 
-    # pass the option more than once to display the routes that match all the given methods
-    $ php bin/console debug:router --method=GET --method=PATCH
-
 .. versionadded:: 7.3
 
     The ``--method`` option was introduced in Symfony 7.3.


### PR DESCRIPTION
This update corrects the documentation to reflect the current behavior of the `--method` option in the router. The previous lines suggesting multiple `--method` options for displaying routes matching all given methods were incorrect. The system now only considers the last method passed. This fix removes the lines that caused confusion, clarifying that only the last method, such as PATCH, will be considered

Additionally, if it's considered a good idea, I can implement a new feature to allow multiple methods to be passed and match routes accordingly, enabling more flexibility in route debugging.