### PR TITLE
fix phpclass reference with namespaces

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -1388,12 +1388,12 @@ normalizers (in order of priority):
     want ``null`` instead, you can set the ``BackedEnumNormalizer::ALLOW_INVALID_VALUES`` option.
 
 :class:`Symfony\\Component\\Serializer\\Normalizer\\NumberNormalizer`
-    This normalizer converts between :phpclass:`BcMath\\Number` or :phpclass:`GMP` objects and
+    This normalizer converts between :phpclass:`BcMath\Number` or :phpclass:`GMP` objects and
     strings or integers.
 
-.. versionadded:: 7.2
+    .. versionadded:: 7.3
 
-    The ``NumberNormalizer`` was introduced in Symfony 7.2.
+        The ``NumberNormalizer`` was introduced in Symfony 7.3.
 
 :class:`Symfony\\Component\\Serializer\\Normalizer\\DataUriNormalizer`
     This normalizer converts between :phpclass:`SplFileInfo` objects and a


### PR DESCRIPTION
The link is currently broken (see https://symfony.com/doc/7.3/serializer.html).