### PR TITLE
Collect all deprecations with lint:twig command

### DIFF
--- a/templates.rst
+++ b/templates.rst
@@ -849,7 +849,8 @@ errors. It's useful to run it before deploying your application to production
     $ php bin/console lint:twig templates/email/
     $ php bin/console lint:twig templates/article/recent_list.html.twig
 
-    # you can also show the deprecated features used in your templates
+    # you can also show the first deprecated feature used in your templates
+    # as it shows only the first one found, you may need to run it until no more deprecations are found
     $ php bin/console lint:twig --show-deprecations templates/email/
 
 When running the linter inside `GitHub Actions`_, the output is automatically


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
This PR fix #20840 by tweaking the docs to precise only the first deprecation found will be outputed by the command.

_It's my first PR, I hope everything is fine, don't hesitate to notify me of any incorrect wording / style, or anything else. I'd be happy to learn how to contribute better for my future contributions!_

fixes #20840