### PR TITLE
[Validator] Add docs for bridge twig validator #20836

### DIFF
--- a/bridge/twig/validation.rst
+++ b/bridge/twig/validation.rst
@@ -1,0 +1,63 @@
+Validating Twig Template Syntax
+===============================
+
+The Twig Bridge provides a custom `Twig` constraint that allows validating
+whether a given string contains valid Twig syntax.
+
+This is particularly useful when template content is user-generated or
+configurable, and you want to ensure it can be safely rendered by the Twig engine.
+
+Installation
+------------
+
+This constraint is part of the `symfony/twig-bridge` package. Make sure it's installed:
+
+.. code-block:: terminal
+
+    $ composer require symfony/twig-bridge
+
+Usage
+-----
+
+To use the `Twig` constraint, annotate the property that should contain a valid
+Twig template::
+
+    use Symfony\Bridge\Twig\Validator\Constraints\Twig;
+
+    class Template
+    {
+        #[Twig]
+        private string $templateCode;
+    }
+
+If the template contains a syntax error, a validation error will be thrown.
+
+Constraint Options
+------------------
+
+**message**
+Customize the default error message when the template is invalid::
+
+    // ...
+    class Template
+    {
+        #[Twig(message: 'Your template contains a syntax error.')]
+        private string $templateCode;
+    }
+
+**skipDeprecations**
+By default, this option is set to `true`, which means Twig deprecation warnings
+are ignored during validation.
+
+If you want validation to fail when deprecated features are used in the template,
+set this to `false`::
+
+    // ...
+    class Template
+    {
+        #[Twig(skipDeprecations: false)]
+        private string $templateCode;
+    }
+
+This can be helpful when enforcing stricter template rules or preparing for major
+Twig version upgrades.

--- a/index.rst
+++ b/index.rst
@@ -60,6 +60,7 @@ Topics
     web_link
     webhook
     workflow
+    twig_bridge
 
 Components
 ----------

--- a/twig_bridge.rst
+++ b/twig_bridge.rst
@@ -1,0 +1,9 @@
+Twig Bridge
+===========
+
+This bridge integrates Symfony with the Twig templating engine.
+
+.. toctree::
+   :maxdepth: 1
+
+   bridge/twig/validation


### PR DESCRIPTION

This pull request adds documentation for the new Twig Validator constraint introduced in the Twig Bridge.

Changes:
- Added a page to document the Twig validator constraint, including:
- Installation instructions for the symfony/twig-bridge package.
- Usage of the constraint in Symfony applications.
- Detailed options available, including `message` and `skipDeprecations`.
- Updated `index.rst` to include the new page under the "**Topics**" section for the **Twig Bridge.**

Related Issue:
[Issue #20836 - Add docs for Twig validator](https://github.com/symfony/symfony-docs/issues/20836)

Related PR:
[Symfony PR #58805](https://github.com/symfony/symfony/pull/58805) – Introduced the Twig validator constraint in the Twig Bridge.