### PR TITLE
[Security] document current user attribute in the main security doc entry

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2106,6 +2106,11 @@ accessed via the ``getUser()`` shortcut in the
         {
             // $user is an instance of \App\Entity\User
         }
+
+        public function profile(#[CurrentUser] ?User $user): Response
+        {
+            // $user is an instance of \App\Entity\User or null as unauthenticated
+        }
     }
 
 Fetching the User from a Service

--- a/security.rst
+++ b/security.rst
@@ -2082,6 +2082,7 @@ accessed via the ``getUser()`` shortcut in the
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
     class ProfileController extends AbstractController
     {
@@ -2099,6 +2100,11 @@ accessed via the ``getUser()`` shortcut in the
             // Call whatever methods you've added to your User class
             // For example, if you added a getFirstName() method, you can use that.
             return new Response('Well hi there '.$user->getFirstName());
+        }
+
+        public function me(#[CurrentUser] User $user): Response
+        {
+            // $user is an instance of \App\Entity\User
         }
     }
 


### PR DESCRIPTION
I know its documented rapidly (via a code diff example) on top of this file
but here on a controller I thinks its more usefull rather than using the getUser of the abstract controller 
wdyt?

also unrelated but, would it be possible to display the class name here ?
seeing only `getUser` can be misleading, what about `Security::getUser`
because getUser is globally generic in the codebase 
<img width="828" alt="Capture d’écran 2025-04-07 à 09 38 21" src="https://github.com/user-attachments/assets/aca86841-1a06-4ee3-97a7-096d5f4b7211" />
