### PR TITLE
[Scheduler][Webhook] add screencast links

### DIFF
--- a/scheduler.rst
+++ b/scheduler.rst
@@ -1,6 +1,11 @@
 Scheduler
 =========
 
+.. admonition:: Screencast
+    :class: screencast
+
+    Like video tutorials? Check out this `Scheduler quick-start screencast`_.
+
 The scheduler component manages task scheduling within your PHP application, like
 running a task each night at 3 AM, every two weeks except for holidays or any
 other custom schedule you might need.
@@ -1008,3 +1013,4 @@ helping you identify those messages when needed.
 .. _`cron command-line utility`: https://en.wikipedia.org/wiki/Cron
 .. _`crontab.guru website`: https://crontab.guru/
 .. _`relative formats`: https://www.php.net/manual/en/datetime.formats.php#datetime.formats.relative
+.. _`Scheduler quick-start screencast`: https://symfonycasts.com/screencast/mailtrap/bonus-symfony-scheduler

--- a/webhook.rst
+++ b/webhook.rst
@@ -15,6 +15,11 @@ Installation
 Usage in Combination with the Mailer Component
 ----------------------------------------------
 
+.. admonition:: Screencast
+    :class: screencast
+
+    Like video tutorials? Check out the `Webhook Component for Email Events screencast`_.
+
 When using a third-party mailer provider, you can use the Webhook component to
 receive webhook calls from this provider.
 
@@ -207,3 +212,4 @@ Creating a Custom Webhook
     Webhook.
 
 .. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
+.. _`Webhook Component for Email Events screencast`: https://symfonycasts.com/screencast/mailtrap/email-event-webhook


### PR DESCRIPTION
I'm of course biased but I think these short screencasts do a good job of showing the basics.

**Webhook**: shows installing, configuring an email remote event parser, and creating a consumer.

**Scheduler**: shows installing, creating, adding tasks, running the schedule.