### PR TITLE
FrankenPHP can perform action after the response has been send

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -497,8 +497,8 @@ as possible to the client (e.g. sending emails).
 .. warning::
 
     Internally, the HttpKernel makes use of the :phpfunction:`fastcgi_finish_request`
-    PHP function. This means that at the moment, only the `PHP FPM`_ server
-    API is able to send a response to the client while the server's PHP process
+    PHP function. This means that at the moment, only the `PHP FPM`_ and `FrankenPHP`_ servers
+    API are able to send a response to the client while the server's PHP process
     still performs some tasks. With all other server APIs, listeners to ``kernel.terminate``
     are still executed, but the response is not sent to the client until they
     are all completed.
@@ -770,3 +770,4 @@ Learn more
 .. _FOSRestBundle: https://github.com/friendsofsymfony/FOSRestBundle
 .. _`PHP FPM`: https://www.php.net/manual/en/install.fpm.php
 .. _variadic: https://www.php.net/manual/en/functions.arguments.php#functions.variable-arg-list
+.. _`FrankenPHP`: https://frankenphp.dev


### PR DESCRIPTION


Franken also implements fastcgi_finish_request PHP function. kernel.terminate event works well with franken.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
