### PR TITLE
[Serializer] (re)document PRESERVE_EMPTY_OBJECTS

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -1571,6 +1571,13 @@ to ``true``::
     ]);
     // $jsonContent contains {"name":"Jane Doe"}
 
+Preserving Empty Objetcs
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the Serializer will transform an empty array to `[]`.
+You can change this behavior by setting the ``AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS`` context option
+to ``true``, when the value is `\ArrayObject()` the serialization would be `{}`.
+
 Handling Uninitialized Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
👋🏻 
when implementing a web hook, I had to serialize en empty array as object, and found it was wrong (empty list not empty object)

```php
// json without flag
'data' => [],
"data":[],

// json with flag
'data' => new \ArrayObject(),
"data":{},

```
this PR (re)adds this feature as I thinks its useful to have it directly showcased in the main doc
weirdly it was present in v5.4 https://github.com/symfony/symfony-docs/pull/16977