### PR TITLE
[RFC] chore: use assert instead of phpdoc

### DIFF
--- a/security/voters.rst
+++ b/security/voters.rst
@@ -172,9 +172,9 @@ would look like this::
                 return false;
             }
 
-            // you know $subject is a Post object, thanks to `supports()`
-            /** @var Post $post */
+            // $subject is a Post object, thanks to `supports()` above
             $post = $subject;
+            assert($post instanceof Post);
 
             return match($attribute) {
                 self::VIEW => $this->canView($post, $user),


### PR DESCRIPTION
hello
RFC on such change: with a codebase and langage being more and more type hinted and less with phpdoc
and with ppl copying/getting inspired with the official doc
wdyt of such changes? keep it or trash it ? can we replicate elsewhere?

thank you