### PR TITLE
[HttpFoundation] Clarify behavior of session access via RequestStack to avoid auto-starting sessions

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -107,11 +107,6 @@ By default, session attributes are key-value pairs managed with the
 :class:`Symfony\\Component\\HttpFoundation\\Session\\Attribute\\AttributeBag`
 class.
 
-Sessions are automatically started whenever you read, write or even check for
-the existence of data in the session. This may hurt your application performance
-because all users will receive a session cookie. In order to prevent starting
-sessions for anonymous users, you must *completely* avoid accessing the session.
-
 .. note::
 
     Sessions will also be started when using features that rely on them internally,


### PR DESCRIPTION
Symfony’s documentation states that sessions are automatically started when they are accessed (read, written, or even just checked), and it recommends avoiding session access for anonymous users to prevent unnecessary session cookies.

However, calling `Request::getSession()` or `RequestStack::getSession()` can throw a `SessionNotFoundException` if the session has not yet been started. This behavior contradicts the suggestion to "simply avoid accessing the session," since accessing it directly may cause an exception rather than just lazily starting the session as in previous versions where the session was injected via `SessionInterface`.

For this reason, I believe it makes sense to remove the following line from the documentation:

"Sessions are automatically started whenever you read, write or even check for the existence of data in the session. This may hurt your application performance because all users will receive a session cookie. In order to prevent starting sessions for anonymous users, you must completely avoid accessing the session."

This guidance may no longer reflect the actual behavior, where trying to access a session that doesn't exist now results in an exception, not an automatic creation.

It’s possible that I’m misunderstanding the intended behavior. If that’s the case, I apologize and will be happy to close this pull request. I just wanted to raise the concern in case it helps clarify the documentation.