### PR TITLE
[Validator] Highlight `extensions` instead of `mimeTypes` for `File` constraint

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -77,11 +77,8 @@ so Symfony doesn't try to get/set its value from the related entity::
                     'constraints' => [
                         new File([
                             'maxSize' => '1024k',
-                            'mimeTypes' => [
-                                'application/pdf',
-                                'application/x-pdf',
-                            ],
-                            'mimeTypesMessage' => 'Please upload a valid PDF document',
+                            'extensions' => ['pdf'],
+                            'extensionsMessage' => 'Please upload a valid PDF document',
                         ])
                     ],
                 ])


### PR DESCRIPTION
You should always use the extensions option instead of mimeTypes except if you explicitly don't want to check that the extension of the file is consistent with its content (this can be a security issue).

By default, the extensions option also checks the media type of the file.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
