### PR TITLE
[Console] Minor tweak in the article introduction

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -18,14 +18,14 @@ the ``list`` command to view all available commands in the application:
     ...
 
     Available commands:
-      about                                      Display information about the current project
-      completion                                 Dump the shell completion script
-      help                                       Display help for a command
-      list                                       List commands
+      about             Display information about the current project
+      completion        Dump the shell completion script
+      help              Display help for a command
+      list              List commands
      assets
-      assets:install                             Install bundle's web assets under a public directory
+      assets:install    Install bundle's web assets under a public directory
      cache
-      cache:clear                                Clear the cache
+      cache:clear       Clear the cache
     ...
 
 .. note::


### PR DESCRIPTION
The first example shows a scroll because of the excessive white spaces:

![console-intro](https://github.com/user-attachments/assets/d4faa4ff-0267-4d73-b686-2b55d5705fcf)
