### PR TITLE
[DoctrineBundle] Updated default configuration

### DIFF
--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -176,7 +176,7 @@ that the ORM resolves to:
 
     doctrine:
         orm:
-            auto_mapping: true
+            auto_mapping: false
             # the standard distribution overrides this to be true in debug, false otherwise
             auto_generate_proxy_classes: false
             proxy_namespace: Proxies


### PR DESCRIPTION
Default configuration of `auto_mapping` seems to be [set to false by default](https://github.com/doctrine/DoctrineBundle/blob/be90446a11efd00a1f48ed1857b5fadbce8f5481/src/DependencyInjection/Configuration.php#L654)
