### PR TITLE
fix path to Panther web server router file

### DIFF
--- a/testing/end_to_end.rst
+++ b/testing/end_to_end.rst
@@ -878,7 +878,7 @@ Then declare it as a router for Panther server in ``phpunit.xml.dist`` using the
         <!-- ... -->
         <php>
             <!-- ... -->
-            <server name="PANTHER_WEB_SERVER_ROUTER" value="./tests/router.php"/>
+            <server name="PANTHER_WEB_SERVER_ROUTER" value="../tests/router.php"/>
         </php>
     </phpunit>
 


### PR DESCRIPTION
The path is used as an argument for the `php` binary which treats it
relative to the document root directory that is passed with the `-t`
option (in a typical Symfony application the document root directory
is `public` which is located in the same parent directory as the `tests`
directory).