### PR TITLE
Update upload_file.rst

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -286,7 +286,9 @@ Then, define a service for this class:
 
         # config/services.yaml
         services:
-            # ...
+            _defaults:
+                bind:
+                    string $targetDirectory: '%brochures_directory%'
 
             App\Service\FileUploader:
                 arguments:


### PR DESCRIPTION
Clarified that when injecting scalar parameters (like a string for the upload directory) into a service, it's necessary to use the bind configuration in services.yaml if autowiring alone is not sufficient. This helps avoid the "Cannot autowire service... string expected" error when following the tutorial.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
