### PR TITLE
[Console] Added Progress Indicator link to Console Helpers overview page.

### DIFF
--- a/components/console/helpers/map.rst.inc
+++ b/components/console/helpers/map.rst.inc
@@ -1,6 +1,7 @@
 * :doc:`/components/console/helpers/formatterhelper`
 * :doc:`/components/console/helpers/processhelper`
 * :doc:`/components/console/helpers/progressbar`
+* :doc:`/components/console/helpers/progressindicator`
 * :doc:`/components/console/helpers/questionhelper`
 * :doc:`/components/console/helpers/table`
 * :doc:`/components/console/helpers/debug_formatter`


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->

Added a missing page (https://symfony.com/doc/6.4/components/console/helpers/progressindicator.html) to the overview page (https://symfony.com/doc/6.4/components/console/helpers/index.html).