### PR TITLE
[Messenger] Fix instance variable declaration

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -2548,7 +2548,7 @@ using the ``DispatchAfterCurrentBusMiddleware`` and adding a
     {
         public function __construct(
             private MailerInterface $mailer,
-            EntityManagerInterface $em,
+            private EntityManagerInterface $em,
         ) {
         }
 


### PR DESCRIPTION
Add missing `private` keyword to use constructor property promotion. Otherwise, the call to `$this->em` in the `__invoke` method is invalid, as `$em` is considered a constructor parameter only.