### PR TITLE
[FrameworkBundle] fix default value for the `collect_serializer_data` option

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2354,7 +2354,7 @@ Combine it with the ``collect`` option to enable/disable the profiler on demand:
 collect_serializer_data
 .......................
 
-**type**: ``boolean`` **default**: ``true``
+**type**: ``boolean`` **default**: ``false``
 
 When this option is ``true``, all normalizers and encoders are
 decorated by traceable implementations that collect profiling information about them.


### PR DESCRIPTION
If I don't miss anything, symfony/symfony#60069 didn't change the default value.