### PR TITLE
remove reference to Travis CI (no longer free)

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -195,8 +195,7 @@ Continuous Integration
 
 Testing bundle code continuously, including all its commits and pull requests,
 is a good practice called Continuous Integration. There are several services
-providing this feature for free for open source projects, like `GitHub Actions`_
-and `Travis CI`_.
+providing this feature for free for open source projects, like `GitHub Actions`_.
 
 A bundle should at least test:
 


### PR DESCRIPTION
On a related note, the test matrix is old, referencing Symfony 4.  But I'm not sure of the best way to rework this.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
