### PR TITLE
[Security] [Best practices] Remove mention of `anonymous`

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -362,10 +362,6 @@ Unless you have two legitimately different authentication systems and users
 (e.g. form login for the main site and a token system for your API only), it's
 recommended to have only one firewall to keep things simple.
 
-Additionally, you should use the ``anonymous`` key under your firewall. If you
-require users to be logged in for different sections of your site, use the
-:doc:`access_control </security/access_control>` option.
-
 Use the ``auto`` Password Hasher
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
As far as I know, the `anonymous` key does not exist any more.