### PR TITLE
[Validator] avoid broken rendering of inline types in `UniqueEntity`

### DIFF
--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -277,7 +277,7 @@ each with a single field.
 ``ignoreNull``
 ~~~~~~~~~~~~~~
 
-**type**: ``boolean`` | ``string`` | ``array`` **default**: ``true``
+**type**: ``boolean``, ``string`` or ``array`` **default**: ``true``
 
 If this option is set to ``true``, then the constraint will allow multiple
 entities to have a ``null`` value for a field without failing validation.


### PR DESCRIPTION
This PR fixes a documentation issue where inline type annotations like `| string |` were not rendering correctly. This happened because reStructuredText interprets text enclosed in | (e.g., `|string|`) as a [substitution](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#substitutions) reference, which requires a corresponding definition elsewhere in the document.

Changes
Replaced ambiguous expressions like `| string |` with clearer wording such as: boolean, string, or array.

Ensures consistent rendering across Sphinx and other reStructuredText parsers.

Why this matters
This change improves the readability of inline documentation and avoids confusion by using a format that renders correctly and doesn't unintentionally trigger reStructuredText substitution rules.