### PR TITLE
[DependencyInjection] Fix a RST syntax issue

### DIFF
--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -180,16 +180,16 @@ You can override this behavior as follows::
 
 These are all the possible behaviors:
 
- * ``ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE``: throws an exception
-   at compile time (this is the **default** behavior);
- * ``ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE``: throws an
-   exception at runtime, when trying to access the missing service;
- * ``ContainerInterface::NULL_ON_INVALID_REFERENCE``: returns ``null``;
- * ``ContainerInterface::IGNORE_ON_INVALID_REFERENCE``: ignores the wrapping
-   command asking for the reference (for instance, ignore a setter if the service
-   does not exist);
- * ``ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE``: ignores/returns
-   ``null`` for uninitialized services or invalid references.
+* ``ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE``: throws an exception
+  at compile time (this is the **default** behavior);
+* ``ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE``: throws an
+  exception at runtime, when trying to access the missing service;
+* ``ContainerInterface::NULL_ON_INVALID_REFERENCE``: returns ``null``;
+* ``ContainerInterface::IGNORE_ON_INVALID_REFERENCE``: ignores the wrapping
+  command asking for the reference (for instance, ignore a setter if the service
+  does not exist);
+* ``ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE``: ignores/returns
+  ``null`` for uninitialized services or invalid references.
 
 Avoiding your Code Becoming Dependent on the Container
 ------------------------------------------------------


### PR DESCRIPTION
Line items cannot contain any space at the beginning.