### PR TITLE
Changed text to mention one Product object instead of many

### DIFF
--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -501,7 +501,7 @@ following method to the ``ProductRepository`` class::
         }
     }
 
-This will *still* return an array of ``Product`` objects. But now, when you call
+This will *still* return a ``Product`` object. But now, when you call
 ``$product->getCategory()`` and use that data, no second query is made.
 
 Now, you can use this method in your controller to query for a ``Product``


### PR DESCRIPTION
The getOneOrNullResult will not return multiple results.
