### PR TITLE
[Security] Add usage example for `#[IsCsrfTokenValid` attribute on controller classes

### DIFF
--- a/security/csrf.rst
+++ b/security/csrf.rst
@@ -281,6 +281,20 @@ Suppose you want a CSRF token per item, so in the template you have something li
         <button type="submit">Delete item</button>
     </form>
 
+In addition :class:`Symfony\\Component\\Security\\Http\\Attribute\\IsCsrfTokenValid`
+attribute can be applied to a controller class.
+This will cause the CSRF token validation to be executed for all routes defined within the controller::
+
+    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
+    // ...
+
+    #[IsCsrfTokenValid('controller')]
+    final class FooController extends AbstractController
+    {
+        // ...
+    }
+
 The :class:`Symfony\\Component\\Security\\Http\\Attribute\\IsCsrfTokenValid`
 attribute also accepts an :class:`Symfony\\Component\\ExpressionLanguage\\Expression`
 object evaluated to the id::


### PR DESCRIPTION
This PR updates the documentation to demonstrate how the `IsCsrfTokenValid` attribute can be applied directly to a controller class.

By applying this attribute at the class level, CSRF token validation will be automatically executed for all routes defined within the controller, ensuring consistent security across all actions without needing to annotate each method individually.

The example includes the appropriate use statements and a sample controller implementation for clarity.