### PR TITLE
[Scheduler] Add runtime schedule modification feature to docs

### DIFF
--- a/scheduler.rst
+++ b/scheduler.rst
@@ -890,6 +890,46 @@ code::
     use the ``messenger:consume`` command as explained in the previous
     section.
 
+Modifying the Schedule at Runtime
+---------------------------------
+
+.. versionadded:: 6.4
+
+    Modifying the schedule at runtime and recalculating the heap was introduced in Symfony 6.4.
+
+When a recurring message is added to or removed from the schedule,
+the scheduler automatically restarts and recalculates the internal trigger heap.
+This allows dynamic control over scheduled tasks during runtime.
+code::
+
+    // src/Scheduler/DynamicScheduleProvider.php
+    namespace App\Scheduler;
+
+    #[AsSchedule('uptoyou')]
+    class DynamicScheduleProvider implements ScheduleProviderInterface
+    {
+        private ?Schedule $schedule = null;
+
+        public function getSchedule(): Schedule
+        {
+            return $this->schedule ??= (new Schedule())
+                ->with(
+                    // ...
+                )
+            ;
+        }
+
+        public function clearAndAddMessages(): void
+        {
+            // Clear the current schedule (if any) and add new recurring messages
+            $this->schedule?->clear();
+            $this->schedule?->add(
+                RecurringMessage::cron('@hourly', new DoActionMessage()),
+                RecurringMessage::cron('@daily', new DoAnotherActionMessage()),
+            );
+        }
+    }
+
 Debugging the Schedule
 ----------------------
 


### PR DESCRIPTION
This PR addresses #18929.

It documents the new feature introduced in Symfony 6.4 that allows schedules to be modified dynamically at runtime. 

Friendly ping @Jeroeny 👋