### PR TITLE
Fix a list item in object_mapper.rst

### DIFF
--- a/object_mapper.rst
+++ b/object_mapper.rst
@@ -149,7 +149,7 @@ You can apply the ``#[Map]`` attribute to properties to customize their mapping 
 
 * ``target``: Specifies the name of the property in the target object;
 * ``source``: Specifies the name of the property in the source object (useful
-    when mapping is defined on the target, see below);
+  when mapping is defined on the target, see below);
 * ``if``: Defines a condition for mapping the property;
 * ``transform``: Applies a transformation to the value before mapping.
 


### PR DESCRIPTION
I'm not sure if this is the correct fix, but I'm trying to fix this strange looking list item:
https://symfony.com/doc/7.3/object_mapper.html#configuring-property-mapping

![grafik](https://github.com/user-attachments/assets/9f6ed8ec-8c13-4915-b46e-f114ca8b8170)
