### PR TITLE
[Security] remove `plaintext` password hasher usage

### DIFF
--- a/security/passwords.rst
+++ b/security/passwords.rst
@@ -124,25 +124,22 @@ Further in this article, you can find a
 
         .. code-block:: yaml
 
-            # config/packages/test/security.yaml
-            security:
-                # ...
+            # config/packages/security.yaml
+            when@test:
+                security:
+                    # ...
 
-                password_hashers:
-                    # Use your user class name here
-                    App\Entity\User:
-                        algorithm: plaintext # disable hashing (only do this in tests!)
-
-                    # or use the lowest possible values
-                    App\Entity\User:
-                        algorithm: auto # This should be the same value as in config/packages/security.yaml
-                        cost: 4 # Lowest possible value for bcrypt
-                        time_cost: 3 # Lowest possible value for argon
-                        memory_cost: 10 # Lowest possible value for argon
+                    password_hashers:
+                        # Use your user class name here
+                        App\Entity\User:
+                            algorithm: auto
+                            cost: 4 # Lowest possible value for bcrypt
+                            time_cost: 3 # Lowest possible value for argon
+                            memory_cost: 10 # Lowest possible value for argon
 
         .. code-block:: xml
 
-            <!-- config/packages/test/security.xml -->
+            <!-- config/packages/security.xml -->
             <?xml version="1.0" encoding="UTF-8"?>
             <srv:container xmlns="http://symfony.com/schema/dic/security"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -150,49 +147,42 @@ Further in this article, you can find a
                 xsi:schemaLocation="http://symfony.com/schema/dic/services
                     https://symfony.com/schema/dic/services/services-1.0.xsd">
 
-                <config>
-                    <!-- class: Use your user class name here -->
-                    <!-- algorithm: disable hashing (only do this in tests!) -->
-                    <security:password-hasher
-                        class="App\Entity\User"
-                        algorithm="plaintext"
-                    />
-
-                    <!-- or use the lowest possible values -->
-                    <!-- algorithm: This should be the same value as in config/packages/security.yaml -->
-                    <!-- cost: Lowest possible value for bcrypt -->
-                    <!-- time_cost: Lowest possible value for argon -->
-                    <!-- memory_cost: Lowest possible value for argon -->
-                    <security:password-hasher
-                        class="App\Entity\User"
-                        algorithm="auto"
-                        cost="4"
-                        time_cost="3"
-                        memory_cost="10"
-                    />
-                </config>
+                <when env="test">
+                    <config>
+                        <!-- class: Use your user class name here -->
+                        <!-- cost: Lowest possible value for bcrypt -->
+                        <!-- time_cost: Lowest possible value for argon -->
+                        <!-- memory_cost: Lowest possible value for argon -->
+                        <security:password-hasher
+                            class="App\Entity\User"
+                            algorithm="auto"
+                            cost="4"
+                            time_cost="3"
+                            memory_cost="10"
+                        />
+                    </config>
+                </when>
             </srv:container>
 
         .. code-block:: php
 
-            // config/packages/test/security.php
+            // config/packages/security.php
             use App\Entity\User;
+            use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
             use Symfony\Config\SecurityConfig;
 
-            return static function (SecurityConfig $security): void {
+            return static function (SecurityConfig $security, ContainerConfigurator $container): void {
                 // ...
 
-                // Use your user class name here
-                $security->passwordHasher(User::class)
-                    ->algorithm('plaintext'); // disable hashing (only do this in tests!)
-
-                // or use the lowest possible values
-                $security->passwordHasher(User::class)
-                    ->algorithm('auto') // This should be the same value as in config/packages/security.yaml
-                    ->cost(4) // Lowest possible value for bcrypt
-                    ->timeCost(2) // Lowest possible value for argon
-                    ->memoryCost(10) // Lowest possible value for argon
-                ;
+                if ('test' === $container->env()) {
+                    // Use your user class name here
+                    $security->passwordHasher(User::class)
+                        ->algorithm('auto') // This should be the same value as in config/packages/security.yaml
+                        ->cost(4) // Lowest possible value for bcrypt
+                        ->timeCost(2) // Lowest possible value for argon
+                        ->memoryCost(10) // Lowest possible value for argon
+                    ;
+                }
             };
 
 Hashing the Password


### PR DESCRIPTION
I think we shouldn't promote using the plaintext hasher at all.

Context:
- https://github.com/symfony/recipes/pull/1379
- https://github.com/symfony/recipes/pull/1026
- https://github.com/symfony/recipes/issues/1024
