### PR TITLE
Mention that backward compatibility promise doesn't cover translations

### DIFF
--- a/contributing/code/bc.rst
+++ b/contributing/code/bc.rst
@@ -176,6 +176,13 @@ covered by our backward compatibility promise:
 | Use a public, protected or private method     | Yes                         |
 +-----------------------------------------------+-----------------------------+
 
+Using our Translations
+~~~~~~~~~~~~~~~~~~~~~~
+
+All translations provided by Symfony for security and validation errors are
+intended for internal use only. They may be changed or removed at any time.
+Symfony's Backward Compatibility Promise does not apply to internal translations.
+
 Working on Symfony Code
 -----------------------
 


### PR DESCRIPTION
Fix #20980.

Given that translations are not code, it felt weird to add a new row to one of the tables of the BC promise page. So, I propose to create a short new section.