### PR TITLE
[Security] Fix type in `upgradePassword`

### DIFF
--- a/security/passwords.rst
+++ b/security/passwords.rst
@@ -500,13 +500,14 @@ the user provider::
     namespace App\Security;
 
     // ...
+    use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
     use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 
     class UserProvider implements UserProviderInterface, PasswordUpgraderInterface
     {
         // ...
 
-        public function upgradePassword(UserInterface $user, string $newHashedPassword): void
+        public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
         {
             // set the new hashed password on the User object
             $user->setPassword($newHashedPassword);


### PR DESCRIPTION
Fix the wrong type for the method `upgradePassword` according to `PasswordUpgraderInterface`.

It is wrong since the 6.0, the signature has changed from `PasswordAuthenticatedUserInterface|UserInterface` to `PasswordAuthenticatedUserInterface` in `PasswordUpgraderInterface`.

Commit: https://github.com/symfony/symfony/commit/30e2c008b4cfd6eefdb278fb11e67945730db057#diff-b31195679b81d7a86cf868774ef3bf74a79e8e059250db399531b989b4919bdeL17

Prevents PHP Error : 

```
Compile Error: Declaration of App\Services\Security\EmailUserProvider::upgradePassword(Symfony\Component\Security\Core\User\UserInterface $user, string $newHashedPassword): void must be compatible with Symfony\Component\Security\Core\User\PasswordUpgraderInterface::upgradePassword(Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
```