### PR TITLE
Updating the web_server_configuration.rst File

### DIFF
--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -195,7 +195,8 @@ directive to pass requests for PHP files to PHP FPM:
     If you are doing some quick tests with Apache, you can also run
     ``composer require symfony/apache-pack``. This package creates an ``.htaccess``
     file in the ``public/`` directory with the necessary rewrite rules needed to serve
-    the Symfony application. However, in production, it's recommended to move these
+    the Symfony application. Don't forget to change the Apache's ``AllowOverride None`` setting to
+    ``AllowOverride All``. However, in production, it's recommended to move these
     rules to the main Apache configuration file (as shown above) to improve performance.
 
 Caddy


### PR DESCRIPTION
In the documentation, it's being said that Symfony requires the `symfony/apache-pack`, which adds a `.htaccess` file to the `public/` directory.

However, it's nowhere specified to change the `AllowOverride` setting from `None` to `All`.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
