### PR TITLE
[Form] Adding `callable` to `choices`

### DIFF
--- a/reference/forms/types/choice.rst
+++ b/reference/forms/types/choice.rst
@@ -147,7 +147,7 @@ Field Options
 choices
 ~~~~~~~
 
-**type**: ``array`` **default**: ``[]``
+**type**: ``array``, ``callable`` **default**: ``[]``
 
 This is the most basic way to specify the choices that should be used
 by this field. The ``choices`` option is an array, where the array key


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/reference/forms/types/choice.html#choices

Passing something like `MyEnum::myChoices()` to an `EnumType` works, so I guess it could be added here.

Secondly: The entire `choices` option is missing at https://symfony.com/doc/current/reference/forms/types/enum.html but IMO this is a viable alternative to `choice_filter` to limit the choices to only *some* of the enum's cases.

