### PR TITLE
Replace `get_class()` calls by `::class`

### DIFF
--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -922,7 +922,7 @@ can change your code to do the configuration only once per class::
         public function __construct(array $options = [])
         {
             // What type of Mailer is this, a Mailer, a GoogleMailer, ... ?
-            $class = get_class($this);
+            $class = $this::class;
 
             // Was configureOptions() executed before for this class?
             if (!isset(self::$resolversByClass[$class])) {

--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -131,7 +131,7 @@ class exposes public methods to extract several types of information:
         $propertyInfo->getProperties($awesomeObject);
 
         // Good!
-        $propertyInfo->getProperties(get_class($awesomeObject));
+        $propertyInfo->getProperties($awesomeObject::class);
         $propertyInfo->getProperties('Example\Namespace\YourAwesomeClass');
         $propertyInfo->getProperties(YourAwesomeClass::class);
 

--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -296,7 +296,7 @@ You can make it convert to a ``DateTime`` instance by using the ``PARSE_DATETIME
 flag::
 
     $date = Yaml::parse('2016-05-27', Yaml::PARSE_DATETIME);
-    var_dump(get_class($date)); // DateTime
+    var_dump($date::class); // DateTime
 
 Dumping Multi-line Literal Blocks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/console/verbosity.rst
+++ b/console/verbosity.rst
@@ -60,7 +60,7 @@ level. For example::
 
             // available methods: ->isQuiet(), ->isVerbose(), ->isVeryVerbose(), ->isDebug()
             if ($output->isVerbose()) {
-                $output->writeln('User class: '.get_class($user));
+                $output->writeln('User class: '.$user::class);
             }
 
             // alternatively you can pass the verbosity level PHP constant to writeln()

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -447,7 +447,7 @@ by adding JOINs.
         $category = $product->getCategory();
 
         // prints "Proxies\AppEntityCategoryProxy"
-        dump(get_class($category));
+        dump($category::class);
         die();
 
     This proxy object extends the true ``Category`` object, and looks and

--- a/security/user_providers.rst
+++ b/security/user_providers.rst
@@ -425,7 +425,7 @@ command will generate a nice skeleton to get you started::
         public function refreshUser(UserInterface $user): UserInterface
         {
             if (!$user instanceof User) {
-                throw new UnsupportedUserException(sprintf('Invalid user class "%s".', get_class($user)));
+                throw new UnsupportedUserException(sprintf('Invalid user class "%s".', $user::class));
             }
 
             // Return a User object after making sure its data is "fresh".

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -36,7 +36,7 @@ to handle their respective command when it is asked for::
 
         public function handle(Command $command): mixed
         {
-            $commandClass = get_class($command);
+            $commandClass = $command::class;
 
             if (!$handler = $this->handlerMap[$commandClass] ?? null) {
                 return;
@@ -94,7 +94,7 @@ in the service subscriber::
 
         public function handle(Command $command): mixed
         {
-            $commandClass = get_class($command);
+            $commandClass = $command::class;
 
             if ($this->locator->has($commandClass)) {
                 $handler = $this->locator->get($commandClass);
@@ -328,7 +328,7 @@ attribute::
 
         public function handle(Command $command): mixed
         {
-            $commandClass = get_class($command);
+            $commandClass = $command::class;
 
             if ($this->handlers->has($commandClass)) {
                 $handler = $this->handlers->get($commandClass);


### PR DESCRIPTION
This change was made in symfony codebase in 2022 https://github.com/symfony/symfony/pull/47401.

I think we can use same rule in our examples