### PR TITLE
[Form] Add `input=date_point` to `DateTimeType`, `DateType` and `TimeType`

### DIFF
--- a/reference/forms/types/datetime.rst
+++ b/reference/forms/types/datetime.rst
@@ -110,6 +110,7 @@ on your underlying object. Valid values are:
 * ``string`` (e.g. ``2011-06-05 12:15:00``)
 * ``datetime`` (a ``DateTime`` object)
 * ``datetime_immutable`` (a ``DateTimeImmutable`` object)
+* ``date_point`` (a ``DatePoint`` object)
 * ``array`` (e.g. ``[2011, 06, 05, 12, 15, 0]``)
 * ``timestamp`` (e.g. ``1307276100``)
 

--- a/reference/forms/types/options/date_input.rst.inc
+++ b/reference/forms/types/options/date_input.rst.inc
@@ -9,6 +9,7 @@ on your underlying object. Valid values are:
 * ``string`` (e.g. ``2011-06-05``)
 * ``datetime`` (a ``DateTime`` object)
 * ``datetime_immutable`` (a ``DateTimeImmutable`` object)
+* ``date_point`` (a ``DatePoint`` object)
 * ``array`` (e.g. ``['year' => 2011, 'month' => 06, 'day' => 05]``)
 * ``timestamp`` (e.g. ``1307232000``)
 

--- a/reference/forms/types/time.rst
+++ b/reference/forms/types/time.rst
@@ -99,6 +99,7 @@ on your underlying object. Valid values are:
 * ``string`` (e.g. ``12:17:26``)
 * ``datetime`` (a ``DateTime`` object)
 * ``datetime_immutable`` (a ``DateTimeImmutable`` object)
+* ``date_point`` (a ``DatePoint`` object)
 * ``array`` (e.g. ``['hour' => 12, 'minute' => 17, 'second' => 26]``)
 * ``timestamp`` (e.g. ``1307232000``)
 


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/21022

```
use Symfony\Component\Form\Extension\Core\Type\DateType;
use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
use Symfony\Component\Form\Extension\Core\Type\TimeType;
use Symfony\Component\Form\Extension\Core\Type\BirthdayType;

$builder->add('from', DateType::class, [
    'input' => 'date_point',
]);
$builder->add('from', DateTimeType::class, [
    'input' => 'date_point',
]);
$builder->add('from', TimeType::class, [
    'input' => 'date_point',
]);
$builder->add('from', BirthdayType::class, [
    'input' => 'date_point',
]);