### PR TITLE
[Bundle] Best Practice: Add link for create ux-bundle

### DIFF
--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -559,6 +559,7 @@ Learn more
 
 * :doc:`/bundles/extension`
 * :doc:`/bundles/configuration`
+* :doc:`/frontend/create_ux_bundle`
 
 .. _`PSR-4`: https://www.php-fig.org/psr/psr-4/
 .. _`Symfony Flex recipe`: https://github.com/symfony/recipes


### PR DESCRIPTION
I always have trouble to find the ux-bundle page, let's add a link from best_practice page