### PR TITLE
[Security] Remove `is_anonymous` expesssion language function

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -818,7 +818,7 @@ transition. The value of this option is any valid expression created with the
                             from: draft
                             to:   reviewed
                         publish:
-                            # or "is_anonymous", "is_remember_me", "is_fully_authenticated", "is_granted", "is_valid"
+                            # or "is_remember_me", "is_fully_authenticated", "is_granted", "is_valid"
                             guard: "is_authenticated"
                             from: reviewed
                             to:   published
@@ -853,7 +853,7 @@ transition. The value of this option is any valid expression created with the
                     </framework:transition>
 
                     <framework:transition name="publish">
-                        <!-- or "is_anonymous", "is_remember_me", "is_fully_authenticated", "is_granted" -->
+                        <!-- or "is_remember_me", "is_fully_authenticated", "is_granted" -->
                         <framework:guard>is_authenticated</framework:guard>
                         <framework:from>reviewed</framework:from>
                         <framework:to>published</framework:to>
@@ -889,7 +889,7 @@ transition. The value of this option is any valid expression created with the
 
             $blogPublishing->transition()
                 ->name('publish')
-                    // or "is_anonymous", "is_remember_me", "is_fully_authenticated", "is_granted"
+                    // or "is_remember_me", "is_fully_authenticated", "is_granted"
                     ->guard('is_authenticated')
                     ->from(['reviewed'])
                     ->to(['published']);


### PR DESCRIPTION
`is_anonymous` has been deprecated in sf 5.4 and removed in 6.0

https://github.com/symfony/symfony/pull/42510/files#diff-788b1cc93ab32c347d892db378e262ca9970c5badf57627253e475e96cc02fdb