### PR TITLE
[DomCrawler] Replace `parents()` by `ancestors()`

### DIFF
--- a/testing/dom_crawler.rst
+++ b/testing/dom_crawler.rst
@@ -10,11 +10,11 @@ Traversing
 
 Like jQuery, the Crawler has methods to traverse the DOM of an HTML/XML
 document. For example, the following finds all ``input[type=submit]`` elements,
-selects the last one on the page, and then selects its immediate parent element::
+selects the last one on the page, and then selects its immediate ancestor element::
 
     $newCrawler = $crawler->filter('input[type=submit]')
         ->last()
-        ->parents()
+        ->ancestors()
         ->first()
     ;
 
@@ -36,8 +36,8 @@ Many other methods are also available:
     All following siblings.
 ``previousAll()``
     All preceding siblings.
-``parents()``
-    Returns the parent nodes.
+``ancestors()``
+    Returns the ancestor nodes.
 ``children()``
     Returns children nodes.
 ``reduce($lambda)``


### PR DESCRIPTION

DomCrawler `parents()` method, has been replaced by  `ancestors()` in symfony 5.3 and removed in 6.0:

https://github.com/symfony/symfony/pull/39684