### PR TITLE
[FrameworkBundle] Replace session.storage service

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -1843,8 +1843,8 @@ the example below:
                 https://symfony.com/schema/dic/services/services-1.0.xsd">
 
             <framework:config>
-                <framework:session storage-id="session.storage.php_bridge"
-                    handler-id="session.storage.native_file"
+                <framework:session storage-id="session.storage.factory.php_bridge"
+                    handler-id="session.handler.native_file"
                 />
             </framework:config>
         </container>
@@ -1857,7 +1857,7 @@ the example below:
         return static function (FrameworkConfig $framework): void {
             $framework->session()
                 ->storageFactoryId('session.storage.factory.php_bridge')
-                ->handlerId('session.storage.native_file')
+                ->handlerId('session.handler.native_file')
             ;
         };
 


### PR DESCRIPTION
UPGRADE-5.3.md:

Deprecate the `session.storage` alias and `session.storage.*` services, use the `session.storage.factory` alias and `session.storage.factory.*` services instead

https://github.com/symfony/symfony/pull/40048/

Yaml code block use "good services".
This PR replace  xml and php code block to use same ids
