### PR TITLE
[Validator] Mention how to disable validation translation in ConstraintViolationBuilderInterface

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -180,6 +180,16 @@ message as its argument and returns an instance of
 :class:`Symfony\\Component\\Validator\\Violation\\ConstraintViolationBuilderInterface`.
 The ``addViolation()`` method call finally adds the violation to the context.
 
+.. tip::
+
+    Validation error messages are automatically translated to the current application
+    locale. If your application doesn't use translations, you can disable this behavior
+    by calling the ``disableTranslation()`` method of ``ConstraintViolationBuilderInterface``.
+
+    .. versionadded:: 6.4
+
+        The ``disableTranslation()`` method was introduced in Symfony 6.4.
+
 Using the new Validator
 -----------------------
 


### PR DESCRIPTION
Fixes #18325.

When upmerging, add this phrase starting in 7.3 branch:

```rst
See also the :ref:`framework.validation.disable_translation option <reference-validation-disable_translation>`.
```
