### PR TITLE
Fix typo in documentation: changed "controller" to "number" method

### DIFF
--- a/page_creation.rst
+++ b/page_creation.rst
@@ -36,7 +36,7 @@ Creating a Page: Route and Controller
 
 Suppose you want to create a page - ``/lucky/number`` - that generates a lucky (well,
 random) number and prints it. To do that, create a "Controller" class and a
-"controller" method inside of it::
+"number" method inside of it::
 
     <?php
     // src/Controller/LuckyController.php


### PR DESCRIPTION
Updated the line that incorrectly instructed to create a "controller" method.  Replaced it with "number" method to align with the actual example context.

Original:
To do that, create a "Controller" class and a "controller" method inside of it:

Updated:
To do that, create a "Controller" class and a "number" method inside of it:

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
