### PR TITLE
[OptionsResolver] Remove setDefault() method to set nested options

### DIFF
--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -686,12 +686,6 @@ default value::
         ],
     ]);
 
-.. deprecated:: 7.3
-
-    Defining nested options via :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::setDefault`
-    is deprecated since Symfony 7.3. Use the :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::setOptions`
-    method instead, which also allows defining default values for prototyped options.
-
 .. versionadded:: 7.3
 
     The ``setOptions()`` method was introduced in Symfony 7.3.


### PR DESCRIPTION
Fixes #21058.

Yonel did a great update in #21058 to make all code examples use the new method. So, we can just remove the `deprecated` directive and that's it.