### PR TITLE
Clarify Lazy Services usage with `final` & `readonly` classes

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -23,8 +23,8 @@ until you interact with the proxy in some way.
 
 .. warning::
 
-    Lazy services do not support `final`_ or ``readonly`` classes, but you can use
-    `Interface Proxifying`_ to work around this limitation.
+    Lazy services support for `final`_ or ``readonly`` classes was introduced in Symfony 7.3, and
+    requires PHP 8.4 or newer. You can use `Interface Proxifying`_ to work around this limitation.
 
 .. _lazy-services_configuration:
 
@@ -145,9 +145,9 @@ It defines an optional parameter used to define interfaces for proxy and interse
 Interface Proxifying
 --------------------
 
-Under the hood, proxies generated to lazily load services inherit from the class
-used by the service. However, sometimes this is not possible at all (e.g. because
-the class is `final`_ and can not be extended) or not convenient.
+Under the hood, lazy services leverage `lazy objects`_ since PHP 8.4 and Symfony 7.3. In earlier version,
+proxy objects inheriting from the service's class are generated. One of the limitations of proxy objects
+is inability to extend `final`_ or ``readonly`` classes.
 
 To workaround this limitation, you can configure a proxy to only implement
 specific interfaces.
@@ -231,4 +231,5 @@ implement multiple interfaces by adding new "proxy" tags.
 
 .. _`ghost object`: https://en.wikipedia.org/wiki/Lazy_loading#Ghost
 .. _`final`: https://www.php.net/manual/en/language.oop5.final.php
+.. _`lazy objects`: https://www.php.net/manual/en/language.oop5.lazy-objects.php
 .. _`proxy`: https://en.wikipedia.org/wiki/Proxy_pattern


### PR DESCRIPTION
Since Symfony 7.3 lazy services support `final` and `readonly` objects:

```
% grep TaskGroups src/UseCase/CreateUser.php 
final class TaskGroups extends YamlConfig
% bin/console debug:container 'App\UseCase\CreateUser' 2>/dev/null | grep Lazy
  Lazy             yes
```

This works since [PHP 8.4 allows for native lazy ghosts](https://3v4l.org/DW2lp) that don't need to extend the class:
```php
final readonly class TestObject {
    public function __construct(public int $number) {
        echo "Constructor called\n";
    }

    public function getLucky(): void {
        echo "Your lucky number: $this->number\n";
    }
}

$lazy = new ReflectionClass(TestObject::class)->newLazyGhost(function (TestObject $object) {
    $object->__construct(\random_int(0, 100));
});
echo "Object created\n";
$lazy->getLucky();
```

The support for this feature was introduced in https://github.com/symfony/symfony/commit/ed695a64df11f30610479c1c7555b75bd795ea3d (precisely [here](https://github.com/symfony/symfony/commit/ed695a64df11f30610479c1c7555b75bd795ea3d#diff-2c52d04e798a26ab373d67eaa071cf85741e4e7f679e544df3e65a96fef6db2d)). However, documentation still points users to use Interface Proxifying, regardless of the frameworks or PHP version.