### PR TITLE
[Security] fix: use correct function and parameter name

### DIFF
--- a/security/voters.rst
+++ b/security/voters.rst
@@ -331,7 +331,7 @@ Then, override one or both of the following methods::
 
         // this method returns true if the voter applies to the given object class/type;
         // if it returns false, Symfony won't call it again for that type of object
-        public function supportsType(string subjectType): bool
+        public function supportsType(string $subjectType): bool
         {
             // you can't use a simple Post::class === $subjectType comparison
             // because the subject type might be a Doctrine proxy class

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -331,7 +331,7 @@ Then, override one or both of the following methods::
 
         // this method returns true if the voter applies to the given object class/type;
         // if it returns false, Symfony won't call it again for that type of object
-        public function supportsAttribute(string $attribute): bool
+        public function supportsType(string subjectType): bool
         {
             // you can't use a simple Post::class === $subjectType comparison
             // because the subject type might be a Doctrine proxy class


### PR DESCRIPTION
https://github.com/symfony/symfony-docs/pull/21040

while merging this, the same function name was used 2 times. 