### PR TITLE
Update custom_normalizer.rst: Fix incorrect variable in normalize() method example

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -38,14 +38,14 @@ normalization process::
 
         public function normalize(mixed $data, ?string $format = null, array $context = []): array
         {
-            $data = $this->normalizer->normalize($data, $format, $context);
+            $normalizedData = $this->normalizer->normalize($data, $format, $context);
 
             // Here, add, edit, or delete some data:
-            $data['href']['self'] = $this->router->generate('topic_show', [
-                'id' => $object->getId(),
+            $normalizedData['href']['self'] = $this->router->generate('topic_show', [
+                'id' => $data->getId(),
             ], UrlGeneratorInterface::ABSOLUTE_URL);
 
-            return $data;
+            return $normalizedData;
         }
 
         public function supportsNormalization($data, ?string $format = null, array $context = []): bool


### PR DESCRIPTION
The `normalize()` method in the documentation references an `$object` variable that is never defined. This can be confusing for developers trying to follow the example.

This merge request updates the example to use the correct `$data` variable, which holds the original object being normalized.