### PR TITLE
[Validator] Fix parameters list in Choice::$multipleMessage option

### DIFF
--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -304,6 +304,7 @@ Parameter          Description
 =================  ============================================================
 ``{{ choices }}``  A comma-separated list of available choices
 ``{{ value }}``    The current (invalid) value
+``{{ limit }}``    The maximum number of selectable choices
 =================  ============================================================
 
 match
@@ -362,6 +363,7 @@ Parameter          Description
 =================  ============================================================
 ``{{ choices }}``  A comma-separated list of available choices
 ``{{ value }}``    The current (invalid) value
+``{{ limit }}``    The minimum number of selectable choices
 =================  ============================================================
 
 ``multiple``
@@ -385,11 +387,11 @@ is not in the array of valid choices.
 
 You can use the following parameters in this message:
 
-===============  ==============================================================
-Parameter        Description
-===============  ==============================================================
-``{{ value }}``  The current (invalid) value
-``{{ label }}``  Corresponding form field label
-===============  ==============================================================
+=================  ============================================================
+Parameter          Description
+=================  ============================================================
+``{{ choices }}``  A comma-separated list of available choices
+``{{ value }}``    The current (invalid) value
+=================  ============================================================
 
 .. include:: /reference/constraints/_payload-option.rst.inc


### PR DESCRIPTION
Documentation says that `\Symfony\Component\Validator\Constraints\Choice::$multipleMessage` option can take parameters `{{ value }}` and `{{ label }}` in the message, but regarding `\Symfony\Component\Validator\Constraints\ChoiceValidator`, this is wrong. Just like for the other use-cass of `Choice` messaging options, it cannot take `{{ label }}` but `{{ choices }}` instead. 