### PR TITLE
Fix php example syntax error at `mailer.rst`

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1765,7 +1765,7 @@ the HTTP calls made by the HTTP transports, which is useful for debugging errors
 
     public function onMessage(SentMessageEvent $event): void
     {
-        $message $event->getMessage();
+        $message = $event->getMessage();
 
         // do something with the message (e.g. get its id)
     }


### PR DESCRIPTION
Fixes syntax error at php example at `mailer.rst`
