### PR TITLE
[DependencyInjection] Remove references to `TaggedIterator` and `TaggedLocator` attributes

### DIFF
--- a/reference/attributes.rst
+++ b/reference/attributes.rst
@@ -39,17 +39,10 @@ Dependency Injection
 * :ref:`AutowireServiceClosure <autowiring_closures>`
 * :ref:`Exclude <service-psr4-loader>`
 * :ref:`Lazy <lazy-services_configuration>`
-* :ref:`TaggedIterator <tags_reference-tagged-services>`
-* :ref:`TaggedLocator <service-subscribers-locators_defining-service-locator>`
 * :ref:`Target <autowiring-multiple-implementations-same-type>`
 * :ref:`When <service-container_limiting-to-env>`
 * :ref:`WhenNot <service-container_limiting-to-env>`
 
-.. deprecated:: 7.1
-
-    The :class:`Symfony\\Component\\DependencyInjection\\Attribute\\TaggedIterator`
-    and :class:`Symfony\\Component\\DependencyInjection\\Attribute\\TaggedLocator`
-    attributes were deprecated in Symfony 7.1.
 
 EventDispatcher
 ~~~~~~~~~~~~~~~

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -307,14 +307,6 @@ This is done by having ``getSubscribedServices()`` return an array of
         ];
     }
 
-.. deprecated:: 7.1
-
-    The :class:`Symfony\\Component\\DependencyInjection\\Attribute\\TaggedIterator`
-    and :class:`Symfony\\Component\\DependencyInjection\\Attribute\\TaggedLocator`
-    attributes were deprecated in Symfony 7.1 in favor of
-    :class:`Symfony\\Component\\DependencyInjection\\Attribute\\AutowireIterator`
-    and :class:`Symfony\\Component\\DependencyInjection\\Attribute\\AutowireLocator`.
-
 .. note::
 
     The above example requires using ``3.2`` version or newer of ``symfony/service-contracts``.

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -1047,8 +1047,6 @@ you can define it in the configuration of the collecting service:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
-
         return function (ContainerConfigurator $container): void {
             $services = $container->services();
 
@@ -1138,7 +1136,6 @@ to index the services:
 
         use App\Handler\One;
         use App\Handler\Two;
-        use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 
         return function (ContainerConfigurator $container): void {
             $services = $container->services();
@@ -1242,7 +1239,6 @@ get the value used to index the services:
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
         use App\HandlerCollection;
-        use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 
         return function (ContainerConfigurator $container) {
             $services = $container->services();


### PR DESCRIPTION
Fix #21098

Also remove unused `use` use statement for `TaggedIteratorArgument` (may be backported?)