### PR TITLE
Fix lint major symfony version from 7 to 8

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -75,16 +75,16 @@ rules:
     yaml_instead_of_yml_suffix: ~
 
     versionadded_directive_major_version:
-        major_version: 7
+        major_version: 8
 
     versionadded_directive_min_version:
-        min_version: '7.0'
+        min_version: '8.0'
 
     deprecated_directive_major_version:
-        major_version: 7
+        major_version: 8
 
     deprecated_directive_min_version:
-        min_version: '7.0'
+        min_version: '8.0'
 
 exclude_rule_for_file:
     - path: configuration/multiple_kernels.rst


### PR DESCRIPTION
Solves failed pipelines for `8.0` branch.

Example: PR #21101 (job https://github.com/symfony/symfony-docs/actions/runs/15779150078/job/44480309482)