### PR TITLE
[DependencyInjection] Remove TaggedIterator and TaggedLocator attributes

### DIFF
--- a/reference/attributes.rst
+++ b/reference/attributes.rst
@@ -39,17 +39,9 @@ Dependency Injection
 * :ref:`AutowireServiceClosure <autowiring_closures>`
 * :ref:`Exclude <service-psr4-loader>`
 * :ref:`Lazy <lazy-services_configuration>`
-* :ref:`TaggedIterator <tags_reference-tagged-services>`
-* :ref:`TaggedLocator <service-subscribers-locators_defining-service-locator>`
 * :ref:`Target <autowiring-multiple-implementations-same-type>`
 * :ref:`When <service-container_limiting-to-env>`
 * :ref:`WhenNot <service-container_limiting-to-env>`
-
-.. deprecated:: 7.1
-
-    The :class:`Symfony\\Component\\DependencyInjection\\Attribute\\TaggedIterator`
-    and :class:`Symfony\\Component\\DependencyInjection\\Attribute\\TaggedLocator`
-    attributes were deprecated in Symfony 7.1.
 
 EventDispatcher
 ~~~~~~~~~~~~~~~

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -302,14 +302,6 @@ This is done by having ``getSubscribedServices()`` return an array of
         ];
     }
 
-.. deprecated:: 7.1
-
-    The :class:`Symfony\\Component\\DependencyInjection\\Attribute\\TaggedIterator`
-    and :class:`Symfony\\Component\\DependencyInjection\\Attribute\\TaggedLocator`
-    attributes were deprecated in Symfony 7.1 in favor of
-    :class:`Symfony\\Component\\DependencyInjection\\Attribute\\AutowireIterator`
-    and :class:`Symfony\\Component\\DependencyInjection\\Attribute\\AutowireLocator`.
-
 .. note::
 
     The above example requires using ``3.2`` version or newer of ``symfony/service-contracts``.


### PR DESCRIPTION
Fixes #21098.

In `service_container/tags.rst` there are some occurrences of a similar but different class:

```
use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
```

It's needed because i's used by the `tagged_iterator()` method (which is not deprecated).