### PR TITLE
Fix yaml and xml example syntax error at `factories.rst`

### DIFF
--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -397,7 +397,7 @@ e.g. change the service based on a parameter:
 
             # you can use the arg() function to retrieve an argument from the definition
             App\Email\NewsletterManagerInterface:
-                factory: "@=arg(0).createNewsletterManager() ?: service("default_newsletter_manager")"
+                factory: '@=arg(0).createNewsletterManager() ?: service("default_newsletter_manager")'
                 arguments:
                     - '@App\Email\NewsletterManagerFactory'
 
@@ -418,7 +418,7 @@ e.g. change the service based on a parameter:
 
                 <!-- you can use the arg() function to retrieve an argument from the definition -->
                 <service id="App\Email\NewsletterManagerInterface">
-                    <factory expression="arg(0).createNewsletterManager() ?: service("default_newsletter_manager")"/>
+                    <factory expression="arg(0).createNewsletterManager() ?: service('default_newsletter_manager')"/>
                     <argument type="service" id="App\Email\NewsletterManagerFactory"/>
                 </service>
             </services>


### PR DESCRIPTION
Fix yaml and xml example syntax error at `factories.rst`