### PR TITLE
[Serializer] Remove `AdvancedNameConverterInterface`

### DIFF
--- a/serializer/custom_name_converter.rst
+++ b/serializer/custom_name_converter.rst
@@ -43,12 +43,6 @@ A custom name converter can handle such cases::
         }
     }
 
-.. note::
-
-    You can also implement
-    :class:`Symfony\\Component\\Serializer\\NameConverter\\AdvancedNameConverterInterface`
-    to access the current class name, format and context.
-
 Then, configure the serializer to use your name converter:
 
 .. configuration-block::


### PR DESCRIPTION
| Q | A
|-|-
| Feature PR | https://github.com/symfony/symfony/pull/60870
| PR author(s) | @mttsch
| Merged in | 8.0
