### PR TITLE
[Routing] Document `_query` parameter for URL generation

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -1151,6 +1151,17 @@ special parameters created by Symfony:
     This is used for such things as setting the ``Content-Type`` of the response
     (e.g. a ``json`` format translates into a ``Content-Type`` of ``application/json``).
 
+``_query``
+    Used to add query parameters to the generated URL.
+
+    .. versionadded:: 7.4
+
+        The ``_query`` parameter was introduced in Symfony 7.4.
+
+    .. deprecated:: 7.4
+
+        Passing a value other than an array as the ``_query`` parameter was deprecated in Symfony 7.4.
+
 ``_fragment``
     Used to set the fragment identifier, which is the optional last part of a URL that
     starts with a ``#`` character and is used to identify a portion of a document.


### PR DESCRIPTION
Fix #21055

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
