### PR TITLE
[Templating] Adding AssetMapper to `asset()` function

### DIFF
--- a/templates.rst
+++ b/templates.rst
@@ -312,8 +312,12 @@ You can now use the ``asset()`` function:
     {# the JS file lives at "public/bundles/acme/js/loader.js" #}
     <script src="{{ asset('bundles/acme/js/loader.js') }}"></script>
 
-The ``asset()`` function's main purpose is to make your application more portable.
-If your application lives at the root of your host (e.g. ``https://example.com``),
+Using the ``asset()`` function is recommended for two reasons:
+
+* It automatically takes care of versioning your assets with
+  :doc:`Symfony's AssetMapper </frontend>`
+
+* If your application lives at the root of your host (e.g. ``https://example.com``),
 then the rendered path should be ``/images/logo.png``. But if your application
 lives in a subdirectory (e.g. ``https://example.com/my_app``), each asset path
 should render with the subdirectory (e.g. ``/my_app/images/logo.png``). The


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/templates.html#linking-to-css-javascript-and-image-assets

There is another link to AssetMapper just one screen further down - maybe you want to merge them somehow: https://symfony.com/doc/6.4/templates.html#build-versioning-more-advanced-css-javascript-and-image-handling

My point here is that the main advantage of the `asset()` function IMO is not the subdirectory scenario, but rather: If you *later* switch to AssetMapper, it saves you a lot of time if you've already used `asset()` everywhere.