### PR TITLE
[Validator] Fix typo

### DIFF
--- a/reference/constraints/Url.rst
+++ b/reference/constraints/Url.rst
@@ -323,7 +323,7 @@ also relative URLs that contain no protocol (e.g. ``//example.com``).
     and will default to ``true`` in Symfony 8.0.
 
 By default, URLs like ``https://aaa`` or ``https://foobar`` are considered valid
-because they are tecnically correct according to the `URL spec`_. If you set this option
+because they are technically correct according to the `URL spec`_. If you set this option
 to ``true``, the host part of the URL will have to include a TLD (top-level domain
 name): e.g. ``https://example.com`` will be valid but ``https://example`` won't.
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->

Just a small typo for the 7.2 + 7.3 branches in the description of `requireTld`.

(looks to be introduced in 7.1 but from my understanding of contributing notes, this is wholly unmaintained, hence pointing this at 7.2)