### PR TITLE
remove reference to removed erase_credentials option

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -22,7 +22,6 @@ key in your application configuration.
 **Basic Options**:
 
 * `access_denied_url`_
-* `erase_credentials`_
 * `expose_security_errors`_
 * `hide_user_not_found`_ (deprecated)
 * `session_fixation_strategy`_


### PR DESCRIPTION
see the current build failure: https://github.com/symfony/symfony-docs/actions/runs/15920742958/job/44906783074#step:7:13 (documentation for that option was removed in #21092)