### PR TITLE
[Console] Document the ability to set aliases and hidden status via command name

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -206,6 +206,33 @@ After configuring and registering the command, you can run it in the terminal:
 As you might expect, this command will do nothing as you didn't write any logic
 yet. Add your own logic inside the ``__invoke()`` method.
 
+Command Aliases
+~~~~~~~~~~~~~~~
+
+You can define alternative names (aliases) for a command directly in its name
+using a pipe (``|``) separator. The first name in the list becomes the actual
+command name; the others are aliases that can also be used to run the command::
+
+    // src/Command/CreateUserCommand.php
+    namespace App\Command;
+
+    use Symfony\Component\Console\Attribute\AsCommand;
+    use Symfony\Component\Console\Command\Command;
+
+    #[AsCommand(
+        name: 'app:create-user|app:add-user|app:new-user',
+        description: 'Creates a new user.',
+    )]
+    class CreateUserCommand extends Command
+    {
+        // ...
+    }
+
+.. versionadded:: 7.4
+
+    The ability to define aliases through the command name was introduced in
+    Symfony 7.4.
+
 Console Output
 --------------
 

--- a/console/hide_commands.rst
+++ b/console/hide_commands.rst
@@ -22,8 +22,28 @@ the ``hidden`` property of the ``AsCommand`` attribute::
         // ...
     }
 
-Hidden commands behave the same as normal commands but they are no longer displayed
-in command listings, so end-users are not aware of their existence.
+You can also define a command as hidden using the pipe (``|``) syntax in the
+command name::
+
+    // src/Command/LegacyCommand.php
+    namespace App\Command;
+
+    use Symfony\Component\Console\Attribute\AsCommand;
+    use Symfony\Component\Console\Command\Command;
+
+    #[AsCommand(name: '|app:legacy')]
+    class LegacyCommand extends Command
+    {
+        // ...
+    }
+
+.. versionadded:: 7.4
+
+    The ability to define a command as hidden using the pipe syntax in the
+    command name was introduced in Symfony 7.4.
+
+Hidden commands behave the same as normal commands but they are no longer
+displayed in command listings, so end-users are not aware of their existence.
 
 .. note::
 


### PR DESCRIPTION
- Add documentation for the pipe syntax to define command aliases
- Document how to make commands hidden using the `|` prefix
- Show examples for both #[AsCommand] attribute and constructor usage
- Include version annotation for Symfony 7.4

Fix https://github.com/symfony/symfony-docs/issues/21070