### PR TITLE
[Console] Update the hidden command doc when using the pipe syntax

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -206,6 +206,8 @@ After configuring and registering the command, you can run it in the terminal:
 As you might expect, this command will do nothing as you didn't write any logic
 yet. Add your own logic inside the ``__invoke()`` method.
 
+.. _command-aliases:
+
 Command Aliases
 ~~~~~~~~~~~~~~~
 

--- a/console/hide_commands.rst
+++ b/console/hide_commands.rst
@@ -22,8 +22,9 @@ the ``hidden`` property of the ``AsCommand`` attribute::
         // ...
     }
 
-You can also define a command as hidden using the pipe (``|``) syntax in the
-command name::
+You can also define a command as hidden using the pipe (``|``) syntax of
+:ref:`command aliases <command-aliases>`. To do this, use the command name as one
+of the aliases and leave the main command name (the part before the ``|``) empty::
 
     // src/Command/LegacyCommand.php
     namespace App\Command;
@@ -39,11 +40,7 @@ command name::
 
 .. versionadded:: 7.4
 
-    The ability to define a command as hidden using the pipe syntax in the
-    command name was introduced in Symfony 7.4.
-
-Hidden commands behave the same as normal commands but they are no longer
-displayed in command listings, so end-users are not aware of their existence.
+    Support for hidding commands using the pipe syntax was introduced in Symfony 7.4.
 
 .. note::
 


### PR DESCRIPTION
I propose these minor tweaks after merging #21166.

I removed the `Hidden commands behave the same as...` phrase because it's already explained at the beginning of the article.