### PR TITLE
[Messenger] Fix confusing wording about `redeliver_timeout` duration

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1601,7 +1601,7 @@ The transport has a number of options:
 
     .. note::
 
-        Set ``redeliver_timeout`` to a greater value than your slowest message
+        Set ``redeliver_timeout`` to a greater value than your longest message
         duration. Otherwise, some messages will start a second time while the
         first one is still being handled.
 


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/20963

Changed "slowest message duration" to "longest message duration" to clarify that redeliver_timeout should be greater than the maximum processing time of any message.