### PR TITLE
Update all references to Symfony CLI and web server

### DIFF
--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -130,8 +130,7 @@ Next, create an ``index.php`` file that defines the kernel class and runs it:
     ``config/`` in your project (even if it's empty because you define the configuration
     options inside the ``configureContainer()`` method).
 
-That's it! To test it, start the :doc:`Symfony Local Web Server
-</setup/symfony_cli>`:
+That's it! To test it, start the :ref:`Symfony local web server <symfony-cli-server>`:
 
 .. code-block:: terminal
 
@@ -469,8 +468,7 @@ this:
     ├─ composer.json
     └─ composer.lock
 
-As before you can use the :doc:`Symfony Local Web Server
-</setup/symfony_cli>`:
+As before you can use the :ref:`Symfony local web server <symfony-cli-server>`:
 
 .. code-block:: terminal
 

--- a/console.rst
+++ b/console.rst
@@ -108,12 +108,8 @@ completion (by default, by pressing the Tab key).
 
 .. tip::
 
-    If you are using the :doc:`Symfony local web server
-    </setup/symfony_cli>`, it is recommended to use the built-in completion
-    script that will ensure the right PHP version and configuration are used when
-    running the Console Completion. Run ``symfony completion --help`` for the
-    installation instructions for your shell. The Symfony CLI will provide
-    completion for the ``console`` and ``composer`` commands.
+    If you are using the :doc:`Symfony CLI </setup/symfony_cli>` tool, follow
+    :ref:`these instructions <symfony-cli-autocompletion>` to enable autocompletion.
 
 Creating a Command
 ------------------

--- a/contributing/code/reproducer.rst
+++ b/contributing/code/reproducer.rst
@@ -65,8 +65,8 @@ to a route definition. Then, after creating your project:
    of controllers, actions, etc. as in your original application.
 #. Create a small controller and add your routing definition that shows the bug.
 #. Don't create or modify any other file.
-#. Install the :doc:`local web server </setup/symfony_cli>` provided by Symfony
-   and use the ``symfony server:start`` command to browse to the new route and
+#. Install the :doc:`Symfony CLI </setup/symfony_cli>` tool and use the
+   ``symfony server:start`` command to browse to the new route and
    see if the bug appears or not.
 #. If you can see the bug, you're done and you can already share the code with us.
 #. If you can't see the bug, you must keep making small changes. For example, if

--- a/create_framework/front_controller.rst
+++ b/create_framework/front_controller.rst
@@ -154,7 +154,7 @@ Now, configure your web server root directory to point to ``web/`` and all
 other files will no longer be accessible from the client.
 
 To test your changes in a browser (``http://localhost:4321/hello?name=Fabien``),
-run the :doc:`Symfony Local Web Server </setup/symfony_cli>`:
+run the :ref:`Symfony local web server <symfony-cli-server>`:
 
 .. code-block:: terminal
 

--- a/create_framework/introduction.rst
+++ b/create_framework/introduction.rst
@@ -101,7 +101,7 @@ start with the simplest web application we can think of in PHP::
 
     printf('Hello %s', $name);
 
-You can use the :doc:`Symfony Local Web Server </setup/symfony_cli>` to test
+You can use the :ref:`Symfony local web server <symfony-cli-server>` to test
 this great application in a browser
 (``http://localhost:8000/index.php?name=Fabien``):
 

--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -53,9 +53,9 @@ method in your ``webpack.config.js`` file:
 Enabling HTTPS using the Symfony Web Server
 -------------------------------------------
 
-If you're using the :doc:`Symfony web server </setup/symfony_cli>` locally with HTTPS,
-you'll need to also tell the dev-server to use HTTPS. To do this, you can reuse the Symfony web
-server SSL certificate:
+If you're using the :ref:`Symfony local web server <symfony-cli-server>` locally
+with HTTPS, you'll need to also tell the dev-server to use HTTPS. To do this,
+you can reuse the Symfony web server SSL certificate:
 
 .. code-block:: diff
 

--- a/mailer.rst
+++ b/mailer.rst
@@ -1824,8 +1824,8 @@ Enabling an Email Catcher
 
 When developing locally, it is recommended to use an email catcher. If you have
 enabled Docker support via Symfony recipes, an email catcher is automatically
-configured. In addition, if you are using the :doc:`Symfony local web server
-</setup/symfony_cli>`, the mailer DSN is automatically exposed via the
+configured. In addition, if you are using the :doc:`Symfony CLI </setup/symfony_cli>`
+tool, the mailer DSN is automatically exposed via the
 :ref:`symfony binary Docker integration <symfony-server-docker>`.
 
 Sending Test Emails

--- a/mercure.rst
+++ b/mercure.rst
@@ -72,7 +72,7 @@ Thanks to :doc:`the Docker integration of Symfony </setup/docker>`,
 :ref:`Flex <symfony-flex>` proposes to install a Mercure hub for development.
 Run ``docker-compose up`` to start the hub if you have chosen this option.
 
-If you use the :doc:`Symfony Local Web Server </setup/symfony_cli>`,
+If you use the :ref:`Symfony local web server <symfony-cli-server>`,
 you must start it with the ``--no-tls`` option to prevent mixed content and
 invalid TLS certificate issues:
 

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -80,7 +80,7 @@ metadata to code):
           }
       }
 
-That's it! If you are using :doc:`the Symfony web server </setup/symfony_cli>`,
+That's it! If you are using :ref:`the Symfony web server <symfony-cli-server>`,
 try it out by going to: http://localhost:8000/lucky/number
 
 .. tip::

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -42,8 +42,8 @@ Symfony application:
 Can we already load the project in a browser? Yes! You can set up
 :doc:`Nginx or Apache </setup/web_server_configuration>` and configure their
 document root to be the ``public/`` directory. But, for development, it's better
-to :doc:`install the Symfony local web server </setup/symfony_cli>` and run
-it as follows:
+to install the :doc:`Symfony CLI </setup/symfony_cli>` tool and run its
+:ref:`local web server <symfony-cli-server>` as follows:
 
 .. code-block:: terminal
 

--- a/setup.rst
+++ b/setup.rst
@@ -121,8 +121,8 @@ development.
 .. _symfony-binary-web-server:
 
 However for local development, the most convenient way of running Symfony is by
-using the :doc:`local web server </setup/symfony_cli>` provided by the
-``symfony`` binary. This local server provides among other things support for
+using the :ref:`local web server <symfony-cli-server>` provided by the
+Symfony CLI tool. This local server provides among other things support for
 HTTP/2, concurrent requests, TLS/SSL and automatic generation of security
 certificates.
 

--- a/setup/symfony_cli.rst
+++ b/setup/symfony_cli.rst
@@ -21,6 +21,8 @@ The Symfony CLI is available as a standalone executable that supports Linux,
 macOS, and Windows. Download and install it following the instructions on
 `symfony.com/download`_.
 
+.. _symfony-cli-autocompletion:
+
 Shell Autocompletion
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -74,6 +76,8 @@ projects quickly:
 
     Pass the ``--cloud`` option to initialize a Symfony Cloud project at the same
     time the Symfony project is created.
+
+.. _symfony-cli-server:
 
 Running the Local Web Server
 ----------------------------

--- a/setup/web_server_configuration.rst
+++ b/setup/web_server_configuration.rst
@@ -2,7 +2,7 @@ Configuring a Web Server
 ========================
 
 The preferred way to develop your Symfony application is to use
-:doc:`Symfony Local Web Server </setup/symfony_cli>`.
+:ref:`Symfony local web server <symfony-cli-server>`.
 
 However, when running the application in the production environment, you'll need
 to use a fully-featured web server. This article describes how to use Symfony


### PR DESCRIPTION
After merging #21167, we need to revisit all links to that article because before it was only about the local web server but now it's about the Symfony CLI tool. This PR does that.