### PR TITLE
[Serializer] Fix classname comment in Create a Custom Encoders section

### DIFF
--- a/serializer/encoders.rst
+++ b/serializer/encoders.rst
@@ -271,7 +271,7 @@ Creating a Custom Encoder
 Imagine you want to serialize and deserialize `NEON`_. For that you'll have to
 create your own encoder::
 
-    // src/Serializer/YamlEncoder.php
+    // src/Serializer/NeonEncoder.php
     namespace App\Serializer;
 
     use Nette\Neon\Neon;


### PR DESCRIPTION
Fix classname comment in `Creating a Custom Encoder` section

