### PR TITLE
[Config] update enumClass to enumFqcn

### DIFF
--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -186,14 +186,14 @@ The configuration can now be written like this::
         ->end()
     ;
 
-You can also use the ``enumClass()`` method to pass the FQCN of an enum
+You can also use the ``enumFqcn()`` method to pass the FQCN of an enum
 class to the node. This will automatically set the values of the node to
 the cases of the enum::
 
     $rootNode
         ->children()
             ->enumNode('delivery')
-                ->enumClass(Delivery::class)
+                ->enumFqcn(Delivery::class)
             ->end()
         ->end()
     ;
@@ -203,7 +203,7 @@ to one of the enum cases if possible.
 
 .. versionadded:: 7.3
 
-    The ``enumClass()`` method was introduced in Symfony 7.3.
+    The ``enumFqcn()`` method was introduced in Symfony 7.3.
 
 Array Nodes
 ~~~~~~~~~~~


### PR DESCRIPTION
there is no `enumClass` method for `enumNode`, replaced to `enumFqcn`

https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Config/Definition/Builder/EnumNodeDefinition.php#L45-L54