### PR TITLE
Fix session lifetime index name in examples

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -966,7 +966,7 @@ MariaDB/MySQL
         `sess_data` BLOB NOT NULL,
         `sess_lifetime` INTEGER UNSIGNED NOT NULL,
         `sess_time` INTEGER UNSIGNED NOT NULL,
-        INDEX `sessions_sess_lifetime_idx` (`sess_lifetime`)
+        INDEX `sess_lifetime_idx` (`sess_lifetime`)
     ) COLLATE utf8mb4_bin, ENGINE = InnoDB;
 
 .. note::
@@ -987,7 +987,7 @@ PostgreSQL
         sess_lifetime INTEGER NOT NULL,
         sess_time INTEGER NOT NULL
     );
-    CREATE INDEX sessions_sess_lifetime_idx ON sessions (sess_lifetime);
+    CREATE INDEX sess_lifetime_idx ON sessions (sess_lifetime);
 
 Microsoft SQL Server
 ++++++++++++++++++++
@@ -999,7 +999,7 @@ Microsoft SQL Server
         sess_data NVARCHAR(MAX) NOT NULL,
         sess_lifetime INTEGER NOT NULL,
         sess_time INTEGER NOT NULL,
-        INDEX sessions_sess_lifetime_idx (sess_lifetime)
+        INDEX sess_lifetime_idx (sess_lifetime)
     );
 
 .. _session-database-mongodb:


### PR DESCRIPTION
Session index is generated using the lifetime column name.

https://github.com/symfony/symfony/commit/1a67728665332d39c1fc9cbbbde2da8b4cb90778#diff-fb1dcfa62129a037c11aebcf43264282a5c8e2da5d9409aa8f4f3281659b3dd1R263

However current the examples are prepending 'sessions_' to the generated index name.

This results in a migration being created to rename `sessions_sess_lifetime_idx` to `sess_lifetime_idx` after creating the table using the SQL in the docs.