### PR TITLE
[WebLink] make use of avilable constant

### DIFF
--- a/web_link.rst
+++ b/web_link.rst
@@ -183,12 +183,12 @@ You can also add links to the HTTP response directly from controllers and servic
         public function index(Request $request): Response
         {
             // using the addLink() shortcut provided by AbstractController
-            $this->addLink($request, (new Link('preload', '/app.css'))->withAttribute('as', 'style'));
+            $this->addLink($request, (new Link(Link::REL_PRELOAD, '/app.css'))->withAttribute('as', 'style'));
 
             // alternative if you don't want to use the addLink() shortcut
             $linkProvider = $request->attributes->get('_links', new GenericLinkProvider());
             $request->attributes->set('_links', $linkProvider->withLink(
-                (new Link('preload', '/app.css'))->withAttribute('as', 'style')
+                (new Link(Link::REL_PRELOAD, '/app.css'))->withAttribute('as', 'style')
             ));
 
             return $this->render('...');


### PR DESCRIPTION
Should we show you can use constants for `preload` string with `Link::REL_PRELOAD`
