### PR TITLE
Fixed typo in "Symfony CLI" section

### DIFF
--- a/setup/symfony_cli.rst
+++ b/setup/symfony_cli.rst
@@ -10,7 +10,7 @@ to boost your productivity with smart features like:
 
 * **Web server** optimized for development, with **HTTPS support**
 * **Docker** integration and automatic environment variable management
-* Management of muktiple **PHP versions**
+* Management of multiple **PHP versions**
 * Support for background **workers**
 * Seamless integration with **Symfony Cloud**
 


### PR DESCRIPTION
Fixed typo in "Symfony CLI" section

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
