### PR TITLE
[Serializer] type: align with interface signature for denormalize methods

### DIFF
--- a/serializer/custom_context_builders.rst
+++ b/serializer/custom_context_builders.rst
@@ -31,7 +31,7 @@ value is ``0000-00-00``. To do that you'll first have to create your normalizer:
     {
         use DenormalizerAwareTrait;
 
-        public function denormalize($data, string $type, ?string $format = null, array $context = []): mixed
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
         {
             if ('0000-00-00' === $data) {
                 return null;
@@ -42,7 +42,7 @@ value is ``0000-00-00``. To do that you'll first have to create your normalizer:
             return $this->denormalizer->denormalize($data, $type, $format, $context);
         }
 
-        public function supportsDenormalization($data, string $type, ?string $format = null, array $context = []): bool
+        public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
         {
             return true === ($context['zero_datetime_to_null'] ?? false)
                 && is_a($type, \DateTimeInterface::class, true);


### PR DESCRIPTION
### Minor

Updated method signatures in ZeroDateTimeDenormalizer to use mixed type for $data, aligning with the [DenormalizerInterface](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php) definition in Symfony. No functional changes.
