### PR TITLE
[Lock] Document what values to use to activate the Lock component NullStore and InMemoryStore

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -405,7 +405,8 @@ Store                                                       Scope   Blocking  Ex
 
     Symfony includes two other special stores that are mostly useful for testing:
     ``InMemoryStore``, which saves locks in memory during a process, and ``NullStore``,
-    which doesn't persist anything.
+    which doesn't persist anything. To activate either one, simply set the ``LOCK_DSN`` to
+    ``null`` or ``in-memory``.
 
 .. versionadded:: 7.2
 


### PR DESCRIPTION
Adds a clarification in the Lock component documentation about the the values to use for the env variable LOCK_DSN in order to activate the NullStore and the InMemoryStore.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
