### PR TITLE
Docs: Add APP_SECRET generation step for the demo application

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -293,6 +293,8 @@ Run this command to create a new project based on the Symfony Demo application:
 .. code-block:: terminal
 
     $ symfony new my_project_directory --demo
+    $ cd my_project_directory
+    $ php bin/console secrets:set APP_SECRET
 
 Start Coding!
 -------------


### PR DESCRIPTION
When following the [current documentation](https://symfony.com/doc/current/setup.html#the-symfony-demo-application) to set up the Symfony Demo application, an error occurs on startup because the APP_SECRET variable is not set in the .env file.

<img width="1372" height="780" alt="スクリーンショット 2025-07-20 14 39 46" src="https://github.com/user-attachments/assets/cb10a7b7-9cad-44bf-85ec-53ecf353830f" />

To fix this and allow the server to start, the following command must be run manually:

```bash
php bin/console secrets:set APP_SECRET
```

To resolve this issue, I propose adding the command to set APP_SECRET to the documentation:

```diff
symfony new my_project_directory --demo
+ cd my_project_directory
+ php bin/console secrets:set APP_SECRET
```

## How to Reproduce

1. Run the following commands as instructed by the documentation:

```
symfony new my_project_directory --demo
cd my_project_directory
symfony server:start
```

2. Open http://localhost:8000 (or the server's address) in a browser.

An error page is displayed, indicating that secret is missing.