### PR TITLE
[Testing] Update a section heading to improve search results

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -745,8 +745,10 @@ a shortcut to make AJAX requests::
     // the required HTTP_X_REQUESTED_WITH header is added automatically
     $client->xmlHttpRequest('POST', '/submit', ['name' => 'Fabien']);
 
-Sending Custom Headers
-......................
+.. _sending-custom-headers:
+
+Sending Custom HTTP Headers
+...........................
 
 If your application behaves according to some HTTP headers, pass them as the
 second argument of ``createClient()``::


### PR DESCRIPTION
If you search for "testing HTTP headers" you don't get good results. Let's add `HTTP` explicitly to the heading of this section to try to improve this.