### PR TITLE
fix: resolve confusing typo in php config example

### DIFF
--- a/logging/monolog_email.rst
+++ b/logging/monolog_email.rst
@@ -180,7 +180,7 @@ You can adjust the time period using the ``time`` option:
             // ...
 
             $monolog->handler('deduplicated')
-                ->type('deduplicated')
+                ->type('deduplication')
                 // the time in seconds during which duplicate entries are discarded (default: 60)
                 ->time(10)
                 ->handler('symfony_mailer')
@@ -304,7 +304,7 @@ get logged on the server as well as the emails being sent:
             ;
 
             $monolog->handler('deduplicated')
-                ->type('deduplicated')
+                ->type('deduplication')
                 ->handler('symfony_mailer')
             ;
 


### PR DESCRIPTION
Hey, looking at the documentation I noticed an inconsistency in the examples for configuration logging deduplication. 

After trying out the provided example using type `deduplicated`, I quickly found that it was not valid. Then I noticed the other config languages use the `deduplication` type. So we probably want to use the correct type in the example.
