### PR TITLE
[Validator] Add min and max in both error messages of `LengthValidator`

### DIFF
--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -201,9 +201,15 @@ You can use the following parameters in this message:
 Parameter               Description
 ======================  ============================================================
 ``{{ limit }}``         The expected maximum length
+``{{ min }}``           The expected minimum length
+``{{ max }}``           The expected maximum length
 ``{{ value }}``         The current (invalid) value
 ``{{ value_length }}``  The current value's length
 ======================  ============================================================
+
+.. versionadded:: 7.4
+
+    The `{{ min }}` and `{{ max }}` parameters were introduced in Symfony 7.4.
 
 ``min``
 ~~~~~~~
@@ -233,9 +239,15 @@ You can use the following parameters in this message:
 Parameter               Description
 ======================  ============================================================
 ``{{ limit }}``         The expected minimum length
+``{{ min }}``           The expected minimum length
+``{{ max }}``           The expected maximum length
 ``{{ value }}``         The current (invalid) value
 ``{{ value_length }}``  The current value's length
 ======================  ============================================================
+
+.. versionadded:: 7.4
+
+    The `{{ min }}` and `{{ max }}` parameters were introduced in Symfony 7.4.
 
 .. include:: /reference/constraints/_normalizer-option.rst.inc
 


### PR DESCRIPTION
Closes https://github.com/symfony/symfony-docs/issues/21248