### PR TITLE
[BrowserKit] Add browser history assertions to docs

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -1047,6 +1047,10 @@ Browser Assertions
 ``assertBrowserCookieValueSame(string $name, string $expectedValue, string $path = '/', ?string $domain = null, string $message = '')``
     Asserts the given cookie in the test Client is set to the expected
     value.
+``assertBrowserHistoryIsOnFirstPage(string $message = '')``/``assertBrowserHistoryIsNotOnFirstPage(string $message = '')``
+    Asserts that the browser history is (not) on the first page.
+``assertBrowserHistoryIsOnLastPage(string $message = '')``/``assertBrowserHistoryIsNotOnLastPage(string $message = '')``
+    Asserts that the browser history is (not) on the last page.
 ``assertThatForClient(Constraint $constraint, string $message = '')``
     Asserts the given Constraint in the Client. Useful for using your custom asserts
     in the same way as built-in asserts (i.e. without passing the Client as argument)::
@@ -1056,6 +1060,10 @@ Browser Assertions
         {
             self::assertThatForClient(new SomeCustomConstraint());
         }
+
+.. versionadded:: 7.4
+
+    The ``assertBrowserHistoryIsOnFirstPage()`` and ``assertBrowserHistoryIsOnLastPage()`` assertions were introduced in Symfony 7.4.
 
 Crawler Assertions
 ..................


### PR DESCRIPTION
This PR adds documentation for the new `assertBrowserHistoryIsOnFirstPage` and `assertBrowserHistoryIsOnLastPage` assertions.