### PR TITLE
[Testing] PHPUnit Version update

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -397,6 +397,8 @@ Now, enable it as a PHPUnit extension:
 
         <extensions>
             <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
+            <!-- Greater than PHPunit v10 -->
+            <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
         </extensions>
     </phpunit>
 


### PR DESCRIPTION
PHPUnit V10 uses `bootstrap` instead of `extension`.

- Element 'extension': This element is not expected. Expected is ( bootstrap ).