### PR TITLE
[Routing] correct environment-specific routing configuration examples

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -282,10 +282,10 @@ given value:
     .. code-block:: yaml
 
         # config/routes.yaml
-        tools:
-            path:       /tools
-            controller: App\Controller\DefaultController::developerTools
-            env:        dev
+        when@dev:
+            tools:
+                path: /tools
+                controller: App\Controller\DefaultController::developerTools
 
     .. code-block:: xml
 
@@ -296,9 +296,9 @@ given value:
             xsi:schemaLocation="http://symfony.com/schema/routing
                 https://symfony.com/schema/routing/routing-1.0.xsd">
 
-            <route id="tools" path="/tools" controller="App\Controller\DefaultController::developerTools">
-                <env>dev</env>
-            </route>
+            <when env="dev">
+                <route id="tools" path="/tools" controller="App\Controller\DefaultController::developerTools"/>
+            </when>
         </routes>
 
     .. code-block:: php
@@ -308,10 +308,11 @@ given value:
         use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
         return function (RoutingConfigurator $routes): void {
-            $routes->add('tools', '/tools')
-                ->controller([DefaultController::class, 'developerTools'])
-                ->env('dev')
-            ;
+            if('dev' === $routes->env()) {
+                $routes->add('tools', '/tools')
+                    ->controller([DefaultController::class, 'developerTools'])
+                ;
+            }
         };
 
 .. _routing-matching-expressions:


### PR DESCRIPTION
### Description

This PR updates the Symfony routing documentation examples to reflect the correct way to define environment-specific routes using `when@dev` (YAML), `<when env="dev">` (XML), and conditional logic in PHP.

### Changes Made

- **YAML**: Replaced  `env: dev` with `when@dev` syntax block.
- **XML**: Wrapped the `<route>` element in a `<when env="dev">` element.
- **PHP**: Added conditional logic using `$routes->env()` to only register the route in the `dev` environment.

### Why?

The previous examples used either unsupported keys or incorrect syntax for defining environment-specific routes (e.g. using env: dev directly inside a route definition). This update replaces those with the correct environment-based separation using when@dev blocks (YAML), <when env="dev"> wrappers (XML), and runtime conditionals in PHP. It ensures that environment-specific routes are properly scoped and configured according to Symfony's routing system.

### References
* [Allowed keys in YAML routing](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Routing/Loader/YamlFileLoader.php#L36-L38) — the env key is not permitted inside route definitions.
* [RoutingConfigurator::env() method](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php#L63-L69) — this method returns the current environment and does not accept an environment name as an argument for filtering.
* [RouteConfigurator class](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php#L19) — does not have an env() method.