### PR TITLE
 Update setup.rst to mention about Intl extension

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -15,7 +15,7 @@ Technical Requirements
 Before creating your first Symfony application you must:
 
 * Install PHP 8.2 or higher and these PHP extensions (which are installed and
-  enabled by default in most PHP 8 installations): `Ctype`_, `iconv`_,
+  enabled by default in most PHP 8 installations): `Intl`_, `Ctype`_, `iconv`_,
   `PCRE`_, `Session`_, `SimpleXML`_, and `Tokenizer`_;
 * `Install Composer`_, which is used to install PHP packages.
 


### PR DESCRIPTION
Without the Intl extension, `composer install` will face a PHP fatal error

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
