### PR TITLE
[Translation] Mention that you need to install the PHP extension

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -52,6 +52,12 @@ First, run this command to install the translator before using it:
 
     $ composer require symfony/translation
 
+Symfony includes several internationalization polyfills (``symfony/polyfill-intl-icu``,
+``symfony/polyfill-intl-messageformatter``, etc.) that allow you to use translation
+features even without the `PHP intl extension`_. However, these polyfills only
+support English translations, so you must install the PHP ``intl`` extension
+when translating into other languages.
+
 .. _translation-configuration:
 
 Configuration
@@ -1595,6 +1601,7 @@ Learn more
 .. _`ICU MessageFormat`: https://unicode-org.github.io/icu/userguide/format_parse/messages/
 .. _`ISO 3166-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes
 .. _`ISO 639-1`: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+.. _`PHP intl extension`: https://php.net/book.intl
 .. _`Translatable Extension`: https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/translatable.md
 .. _`Translatable Behavior`: https://github.com/KnpLabs/DoctrineBehaviors
 .. _`Custom Language Name setting`: https://docs.lokalise.com/en/articles/1400492-uploading-files#custom-language-codes


### PR DESCRIPTION
Related to #21285, I propose to mention that you must have the `intl` PHP extension for proper translation and localization.