### PR TITLE
 Clarify renaming arguments isn't generally covered by the BC promise

### DIFF
--- a/contributing/code/bc.rst
+++ b/contributing/code/bc.rst
@@ -285,6 +285,7 @@ Make final                                                                No    
 Move to parent class                                                      Yes
 :ref:`Add argument without a default value <add-argument-public-method>`  No
 :ref:`Add argument with a default value <add-argument-public-method>`     No              :ref:`[7] <note-7>` :ref:`[8] <note-8>`
+Rename argument                                                           Yes             :ref:`[10] <note-10>`
 Remove argument                                                           No              :ref:`[3] <note-3>`
 Add default value to an argument                                          No              :ref:`[7] <note-7>` :ref:`[8] <note-8>`
 Remove default value of an argument                                       No
@@ -304,6 +305,7 @@ Make public                                                               No    
 Move to parent class                                                      Yes
 :ref:`Add argument without a default value <add-argument-public-method>`  No
 :ref:`Add argument with a default value <add-argument-public-method>`     No              :ref:`[7] <note-7>` :ref:`[8] <note-8>`
+Rename argument                                                           Yes             :ref:`[10] <note-10>`
 Remove argument                                                           No              :ref:`[3] <note-3>`
 Add default value to an argument                                          No              :ref:`[7] <note-7>` :ref:`[8] <note-8>`
 Remove default value of an argument                                       No              :ref:`[7] <note-7>`
@@ -320,6 +322,7 @@ Change name                                                               Yes
 Make public or protected                                                  Yes
 Add argument without a default value                                      Yes
 Add argument with a default value                                         Yes
+Rename argument                                                           Yes
 Remove argument                                                           Yes
 Add default value to an argument                                          Yes
 Remove default value of an argument                                       Yes


### PR DESCRIPTION
Based on a brief discussion in Slack, I believe it may be worth spelling out that argument names aren't covered by the BC promise. 