### PR TITLE
[UX-Bundle] Expose entrypoint

### DIFF
--- a/frontend/create_ux_bundle.rst
+++ b/frontend/create_ux_bundle.rst
@@ -224,7 +224,7 @@ or layouts, such as:
 * /dashboard
 
 To make your bundle's assets consumable, declare an *entrypoint* in your
-bundle’s `package.json`. This will tell to Symfony how to locate and render the
+bundle’s ``package.json``. This will tell to Symfony how to locate and render the
 associated compiled assets from either Webpack Encore or the modern AssetMapper
 with importmap.
 

--- a/frontend/create_ux_bundle.rst
+++ b/frontend/create_ux_bundle.rst
@@ -224,7 +224,7 @@ or layouts, such as:
 * /dashboard
 
 To make your bundle's assets consumable, declare an *entrypoint* in your
-bundle’s ``package.json``. This will tell to Symfony how to locate and render the
+bundle's ``package.json``. This will tell to Symfony how to locate and render the
 associated compiled assets from either Webpack Encore or the modern AssetMapper
 with importmap.
 

--- a/frontend/create_ux_bundle.rst
+++ b/frontend/create_ux_bundle.rst
@@ -209,19 +209,27 @@ to the container::
 Expose an entrypoint
 --------------------
 
-An entrypoint is a file that need to be always loaded, to usually start your application.
+An entrypoint is a JavaScript file that must be loaded
+whenever a specific part of the application is rendered. It typically
+initializes the frontend behavior for that area.
 
-It's usefull if your bundle have dedicated views, for example :
+In a standard Symfony application, this role is usually fulfilled by the
+``app`` entrypoint, loaded via Webpack Encore or importmap.
+
+Exposing an entrypoint is useful when your bundle provides dedicated sections
+or layouts, such as:
 
 * /admin
 * /translations
 * /dashboard
 
+To make your bundle's assets consumable, declare an *entrypoint* in your
+bundle’s `package.json`. This will tell to Symfony how to locate and render the
+associated compiled assets from either Webpack Encore or the modern AssetMapper
+with importmap.
 
-On a Standard symfony app, it's the ``app`` loaded by webpack encore or importmap.
-
-With Webpack Encore
-~~~~~~~~~~~~~~~~~~~
+Webpack Encore entrypoint
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the ``package.json`` file, define your entrypoint inside the ``symfony.entrypoints`` key:
 
@@ -266,8 +274,8 @@ In your templates, make sure to load that entry :
    It's mandatory to have stimulus-bundle and the ``.enableStimulusBridge('./assets/controllers.json')`` added to the webpack.config.js to be able to use the entrypoints.
 
 
-With Asset Mapper
-~~~~~~~~~~~~~~~~~
+AssetMapper + importmap entrypoint
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the ``package.json`` file, define your entrypoint inside the ``symfony.importmap`` key:
 

--- a/frontend/create_ux_bundle.rst
+++ b/frontend/create_ux_bundle.rst
@@ -248,7 +248,7 @@ That value will be copied inside the ``assets/controllers.json`` file after the 
 
 In your templates, make sure to load that entry :
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {# templates/my-bundle-base.html.twig #}
     ...
@@ -263,7 +263,7 @@ In your templates, make sure to load that entry :
 
 .. warning::
 
-   Is it mandatory to have stimulus-bundle and the ``.enableStimulusBridge('./assets/controllers.json')`` added to the webpack.config.js to be able to use the entrypoints.
+   It's mandatory to have stimulus-bundle and the ``.enableStimulusBridge('./assets/controllers.json')`` added to the webpack.config.js to be able to use the entrypoints.
 
 
 With Asset Mapper
@@ -287,9 +287,7 @@ In the ``package.json`` file, define your entrypoint inside the ``symfony.import
     The ``entrypoint`` keyword support was introduced in Symfony Flex 2.7.0
 
 
-After installation, the entry will be added to the ``importmap.php``:
-
-.. code-block:: php
+After installation, the entry will be added to the ``importmap.php``::
 
     // importmap.php
     return [
@@ -306,7 +304,7 @@ After installation, the entry will be added to the ``importmap.php``:
 
 In your templates, make sure to load that entry :
 
-.. code-block:: html+twig
+.. code-block:: twig
 
     {# templates/my-bundle-base.html.twig #}
     ...

--- a/frontend/create_ux_bundle.rst
+++ b/frontend/create_ux_bundle.rst
@@ -205,3 +205,111 @@ to the container::
             return is_file($bundlesMetadata['FrameworkBundle']['path'] . '/Resources/config/asset_mapper.php');
         }
     }
+
+Expose an entrypoint
+--------------------
+
+An entrypoint is a file that need to be always loaded, to usually start your application.
+
+It's usefull if your bundle have dedicated views, for example :
+
+* /admin
+* /translations
+* /dashboard
+
+
+On a Standard symfony app, it's the ``app`` loaded by webpack encore or importmap.
+
+With Webpack Encore
+~~~~~~~~~~~~~~~~~~~
+
+In the ``package.json`` file, define your entrypoint inside the ``symfony.entrypoints`` key:
+
+.. code-block:: json
+
+    {
+        "name": "@acme/feature",
+        "symfony": {
+            "entrypoints": {
+                "@acme/feature/entrypoint": "../node_modules/@acme/feature/entrypoint.js"
+            }
+        }
+    }
+
+
+The key is the entry that will be called in your templates, and the value is the path that webpack will use to load the file.
+
+.. note::
+
+    The path must be relative to ``assets`` folder of the symfony application.
+
+
+That value will be copied inside the ``assets/controllers.json`` file after the bundle installation.
+
+In your templates, make sure to load that entry :
+
+.. code-block:: html+twig
+
+    {# templates/my-bundle-base.html.twig #}
+    ...
+     {% block stylesheets %}
+        {{ encore_entry_link_tags('@acme/feature/entrypoint') }}
+    {% endblock %}
+
+    {% block javascripts %}
+        {{ encore_entry_script_tags('@acme/feature/entrypoint') }}
+    {% endblock %}
+
+
+.. warning::
+
+   Is it mandatory to have stimulus-bundle and the ``.enableStimulusBridge('./assets/controllers.json')`` added to the webpack.config.js to be able to use the entrypoints.
+
+
+With Asset Mapper
+~~~~~~~~~~~~~~~~~
+
+In the ``package.json`` file, define your entrypoint inside the ``symfony.importmap`` key:
+
+.. code-block:: json
+
+    {
+        "name": "@acme/feature",
+        "symfony": {
+            "importmap": {
+                "@acme/feature/entrypoint": "entrypoint:%PACKAGE%/entrypoint.js"
+            }
+        }
+    }
+
+.. versionadded:: 2.7.0
+
+    The ``entrypoint`` keyword support was introduced in Symfony Flex 2.7.0
+
+
+After installation, the entry will be added to the ``importmap.php``:
+
+.. code-block:: php
+
+    // importmap.php
+    return [
+        'app' => [
+            'path' => './assets/app.js',
+            'entrypoint' => true,
+        ],
+        // ...
+        '@acme/feature/entrypoint' => [
+            'path' => './vendor/acme/feature-bundle/assets/entrypoint.js',
+            'entrypoint' => true,
+        ],
+    ];
+
+In your templates, make sure to load that entry :
+
+.. code-block:: html+twig
+
+    {# templates/my-bundle-base.html.twig #}
+    ...
+    {% block javascripts %}
+        {% block importmap %}{{ importmap('@acme/feature/entrypoint') }}{% endblock %}
+    {% endblock %}


### PR DESCRIPTION
Fix #20991, this PR illustrate how to expose entrypoints for an UX bundle. 

The Webpack Encore part need to be double checked, I didn't find any information on it, but this is what I understood by digging the code

Note: I target 6.4 because it's compatible on it. I can change to other branch if needed

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
