### PR TITLE
[DomCrawler] Remove useless note about useHtml5Parser argument

### DIFF
--- a/components/dom_crawler.rst
+++ b/components/dom_crawler.rst
@@ -659,27 +659,8 @@ another given base URI::
     UriResolver::resolve('?a=b', 'http://localhost/bar#foo'); // http://localhost/bar?a=b
     UriResolver::resolve('../../', 'http://localhost/'); // http://localhost/
 
-Using a HTML5 Parser
-~~~~~~~~~~~~~~~~~~~~
-
-If you need the :class:`Symfony\\Component\\DomCrawler\\Crawler` to use an HTML5
-parser, set its ``useHtml5Parser`` constructor argument to ``true``::
-
-    use Symfony\Component\DomCrawler\Crawler;
-
-    $crawler = new Crawler(null, $uri, useHtml5Parser: true);
-
-By doing so, the crawler will use the HTML5 parser provided by the `masterminds/html5`_
-library to parse the documents.
-
-.. versionadded:: 6.3
-
-    The ``useHtml5Parser`` argument was introduced in Symfony 6.3.
-
 Learn more
 ----------
 
 * :doc:`/testing`
 * :doc:`/components/css_selector`
-
-.. _`masterminds/html5`: https://packagist.org/packages/masterminds/html5


### PR DESCRIPTION
useHtml5Parser defaults to true, so that this note is misleading and needless.
We're going to remove this argument in Symfony 8 anyway.