### PR TITLE
 Update asset_mapper.rst

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -1196,7 +1196,7 @@ both ``app`` and ``checkout``:
         Override an "importmap" block from base.html.twig.
         If you don't have that block, add it around the {{ importmap('app') }} call.
     #}
-    {% block importmap %}
+    {% block javascripts %}
         {# do NOT call parent() #}
 
         {{ importmap(['app', 'checkout']) }}
@@ -1209,7 +1209,7 @@ above, the ``app.js`` file *and* the ``checkout.js`` file).
 
 .. warning::
 
-    Do not call ``parent()`` inside the ``{% block importmap %}`` Twig block. Each
+    Do not call ``parent()`` inside the ``{% block javascripts %}`` Twig block. Each
     page can include only one import map, so ``importmap()`` must be called exactly once.
 
 If you want to execute *only* ``checkout.js`` (and not ``app.js``), call


### PR DESCRIPTION
I try with 
{% block importmap %}
    {{ importmap(['app', 'game']) }}
{% endblock %} 

but that works with
{% block javascripts %}
    {{ importmap(['app', 'game']) }}
{% endblock %}

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
