### PR TITLE
 framework.rst: fixed `cookie_samesite` default value

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3040,7 +3040,7 @@ If not set, ``php.ini``'s `session.cookie_path`_ directive will be relied on.
 cookie_samesite
 ...............
 
-**type**: ``string`` or ``null`` **default**: ``null``
+**type**: ``string`` or ``null`` **default**: ``'lax'``
 
 It controls the way cookies are sent when the HTTP request did not originate
 from the same domain that is associated with the cookies. Setting this option is


### PR DESCRIPTION
It used to be `null`, but since 7.0 it is `'lax'`:

* https://github.com/symfony/symfony/blob/8c637721ffb5b1f239c31b13308cc92ba39701cb/UPGRADE-7.0.md?plain=1#L258
* https://github.com/symfony/symfony/blob/v7.3.2/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php#L705
