### PR TITLE
[String] `ByteString::fromRandom()` defaults to base58 characters

### DIFF
--- a/components/string.rst
+++ b/components/string.rst
@@ -125,7 +125,7 @@ There are also some specialized constructors::
 
     // ByteString can create a random string of the given length
     $foo = ByteString::fromRandom(12);
-    // by default, random strings use A-Za-z0-9 characters; you can restrict
+    // by default, random strings use base58 characters; you can set
     // the characters to use with the second optional argument
     $foo = ByteString::fromRandom(6, 'AEIOU0123456789');
     $foo = ByteString::fromRandom(10, 'qwertyuiop');


### PR DESCRIPTION
The ByteString::fromRandom() function defaults to the base58 characters if the second argument is not supplied.

The default was changed to base58 in:

https://github.com/symfony/symfony/commit/b36baa77bbdad4413e3e427675be0b45a9aeef75

This updates the documentation to reflect this change.