### PR TITLE
 Fix incorrect security configuration structure in testing documentation

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -735,10 +735,11 @@ configuration to ensure it exists and can be authenticated::
     # config/packages/security.yaml
     when@test:
         security:
-            users_in_memory:
-                memory:
-                    users:
-                        admin: { password: password, roles: ROLE_ADMIN }
+            providers:
+                users_in_memory:
+                    memory:
+                        users:
+                            admin: { password: password, roles: ROLE_ADMIN }
 
 To set a specific firewall (``main`` is set by default)::
 


### PR DESCRIPTION
Fixed the YAML configuration structure for defining in-memory users in the test environment. The previous configuration was missing the required providers key, which would result in a configuration error.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
