### PR TITLE
 doc: remove uppercase in yaml.rst

### DIFF
--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -3,7 +3,7 @@ The Yaml Component
 
     The Yaml component loads and dumps YAML files.
 
-What is It?
+What is it?
 -----------
 
 The Symfony Yaml component parses YAML strings to convert them to PHP arrays.


### PR DESCRIPTION
It looks like an “l” and it's unnecessary:

> <img width="226" height="113" alt="image" src="https://github.com/user-attachments/assets/f1a36572-8252-492e-a2e1-b0e2812f82b7" />
