### PR TITLE
[AssetMapper] Adding CSP details, recommending `script-src 'strict-dynamic'`

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -476,10 +476,14 @@ the page as ``link`` tags in the order they were imported.
 .. note::
 
     Importing a CSS file is *not* something that is natively supported by
-    JavaScript modules. AssetMapper makes this work by adding a special importmap
-    entry for each CSS file. These special entries are valid, but do nothing.
+    JavaScript modules. AssetMapper makes this work by adding an empty importmap
+    entry for each CSS file, e.g. ``"/assets/app.css": "data:application/javascript,",``.
+    These special entries are valid, but do nothing.
     AssetMapper adds a ``<link>`` tag for each CSS file, but when JavaScript
     executes the ``import`` statement, nothing additional happens.
+    When using a **Content-Security-Policy** with ``script-src 'self'``, this
+    will trigger an error because of the ``data:`` URL. You can either just
+    ignore the error, or lower the rule to ``script-src 'strict-dynamic'``.
 
 .. _asset-mapper-3rd-party-css:
 


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/frontend/asset_mapper.html#handling-css

I think there should be a clear recommendation for people using a Content-Security-Policy. Is `script-src 'strict-dynamic'` really the way to go? It's not possible for AssetMapper to just omit those empty CSS entries, is it? Or change them to `"/assets/app.css": ""`?

(The info is taken from https://github.com/symfony/symfony/issues/58416#issuecomment-2383265152)

