### PR TITLE
[FrameworkBundle] Simplify usage of the `#[Target]` attribute

### DIFF
--- a/lock.rst
+++ b/lock.rst
@@ -319,7 +319,7 @@ For example, to inject the ``invoice`` package defined earlier::
 
 When :ref:`dealing with multiple implementations of the same type <autowiring-multiple-implementations-same-type>`
 the ``#[Target]`` attribute helps you select which one to inject. Symfony creates
-a target called "asset package name" + ``.lock.factory`` suffix.
+a target with the same name as the lock.
 
 For example, to select the ``invoice`` lock defined earlier::
 
@@ -329,8 +329,13 @@ For example, to select the ``invoice`` lock defined earlier::
     class SomeService
     {
         public function __construct(
-            #[Target('invoice.lock.factory')] private LockFactory $lockFactory
+            #[Target('invoice')] private LockFactory $lockFactory
         ): void {
             // ...
         }
     }
+
+.. versionadded:: 7.4
+
+    Before Symfony 7.4, the target name had to include the ``.lock.factory``
+    suffix (e.g. ``#[Target('invoice.lock.factory')]``).

--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -262,7 +262,7 @@ argument named ``$anonymousApiLimiter``::
 
 When :ref:`dealing with multiple implementations of the same type <autowiring-multiple-implementations-same-type>`
 the ``#[Target]`` attribute helps you select which one to inject. Symfony creates
-a target called "rate limiter name" + ``.limiter`` suffix.
+a target with the same name as the rate limiter.
 
 For example, to select the ``anonymous_api`` limiter defined earlier, use
 ``anonymous_api.limiter`` as the target::
@@ -273,7 +273,7 @@ For example, to select the ``anonymous_api`` limiter defined earlier, use
     class ApiController extends AbstractController
     {
         public function index(
-            #[Target('anonymous_api.limiter')] RateLimiterFactoryInterface $rateLimiter
+            #[Target('anonymous_api')] RateLimiterFactoryInterface $rateLimiter
         ): Response
         {
             // ...
@@ -285,6 +285,11 @@ For example, to select the ``anonymous_api`` limiter defined earlier, use
     :class:`Symfony\\Component\\RateLimiter\\RateLimiterFactoryInterface` was
     added and should now be used for autowiring instead of
     :class:`Symfony\\Component\\RateLimiter\\RateLimiterFactory`.
+
+.. versionadded:: 7.4
+
+    Before Symfony 7.4, the target name had to include the ``.limiter``
+    suffix (e.g. ``#[Target('anonymous_api.limiter')]``).
 
 Using the Rate Limiter Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -301,7 +301,7 @@ to inject the ``foo_package`` package defined earlier::
 
 When :ref:`dealing with multiple implementations of the same type <autowiring-multiple-implementations-same-type>`
 the ``#[Target]`` attribute helps you select which one to inject. Symfony creates
-a target called "asset package name" + ``.package`` suffix.
+a target with the same name as the asset package.
 
 For example, to select the ``foo_package`` package defined earlier::
 
@@ -311,11 +311,16 @@ For example, to select the ``foo_package`` package defined earlier::
     class SomeService
     {
         public function __construct(
-            #[Target('foo_package.package')] private PackageInterface $package
+            #[Target('foo_package')] private PackageInterface $package
         ): void {
             // ...
         }
     }
+
+.. versionadded:: 7.4
+
+    Before Symfony 7.4, the target name had to include the ``.package``
+    suffix (e.g. ``#[Target('foo_package.package')]``).
 
 .. _reference-framework-assets-packages:
 


### PR DESCRIPTION
This continues #21382 and fixes #21134.