### PR TITLE
 Escape user data in server-data.rst

### DIFF
--- a/frontend/server-data.rst
+++ b/frontend/server-data.rst
@@ -10,7 +10,7 @@ them later in JavaScript. For example:
 
     <div class="js-user-rating"
         data-is-authenticated="{{ app.user ? 'true' : 'false' }}"
-        data-user="{{ app.user|serialize(format = 'json') }}"
+        data-user="{{ app.user|serialize(format = 'json')|e('html_attr') }}"
     >
         <!-- ... -->
     </div>


### PR DESCRIPTION
Escape user data for HTML attributes to prevent XSS.

This is already done in the second code snippet below.

Twig playground demo:

https://twig.symfony.com/play?data=eyJ0ZW1wbGF0ZXMiOltbImluZGV4LnR3aWciLCI8ZGl2IGRhdGEtZm9vPVwiTm90IGVuY29kZWQge3sgbmFtZXxqc29uX2VuY29kZSB9fVwiPlxuXG48ZGl2IGRhdGEtZm9vPVwiRW5jb2RlZCB7eyBuYW1lfGpzb25fZW5jb2RlfGUoJ2h0bWxfYXR0cicpIH19XCI%2BIl1dLCJjb250ZXh0Ijp7Im5hbWUiOiJXb3JsZCJ9LCJ2ZXJzaW9uIjoiMy4yMS4xIiwib3B0aW9ucyI6eyJzdHJpY3RfdmFyaWFibGVzIjp0cnVlLCJjaGFyc2V0IjoiVVRGLTgiLCJhdXRvZXNjYXBlIjoiIn19