### PR TITLE
[HtmlSanitizer] Remove MastermindsParser

### DIFF
--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -29,13 +29,6 @@ You can install the HTML Sanitizer component with:
 
     $ composer require symfony/html-sanitizer
 
-.. versionadded:: 7.4
-
-    Starting in Symfony 7.4, applications running on PHP 8.4 or higher will use
-    the native HTML5 parser provided by PHP. All other applications will continue
-    to use the third-party ``masterminds/html5`` parser, which is installed
-    automatically when installing the HTML Sanitizer package.
-
 Basic Usage
 -----------
 


### PR DESCRIPTION
Fixes #21284.

No need to mention the addition of the `$context` argument in `parse()` method because we already explain the context argument in `sanitizeFor()` method, which is what users will really use.
