### PR TITLE
[Serializer] Support preserving array keys with XmlEncoder

### DIFF
--- a/serializer/encoders.rst
+++ b/serializer/encoders.rst
@@ -211,6 +211,8 @@ These are the options available on the :ref:`serializer context <serializer-cont
     require it. Example: ``'/(firstname|lastname)/'``
 ``ignore_empty_attributes`` (default: ``false``)
     If set to true, ignores all attributes with empty values in the generated XML
+``preserve_numeric_keys`` (default: ``false``)
+    If set to true, it keeps numeric array indexes instead of collapsing them into ``<item>`` nodes.
 
 .. versionadded:: 7.1
 
@@ -223,6 +225,8 @@ These are the options available on the :ref:`serializer context <serializer-cont
 .. versionadded:: 7.4
 
     The ``cdata_wrapping_name_pattern`` option was introduced in Symfony 7.4.
+
+    The ``preserve_numeric_keys`` option was introduced in Symfony 7.4.
 
 Example with a custom ``context``::
 
@@ -253,6 +257,44 @@ Example with a custom ``context``::
     //   <id>IDHNQIItNyQ</id>
     //   <date>2019-10-24</date>
     // </track>
+
+Example with ``preserve_numeric_keys``::
+
+    use Symfony\Component\Serializer\Encoder\XmlEncoder;
+
+    $data = [
+        'person' => [
+            ['firstname' => 'Benjamin', 'lastname' => 'Alexandre'],
+            ['firstname' => 'Damien', 'lastname' => 'Clay'],
+        ],
+    ];
+
+    $xmlEncoder->encode($data, 'xml', ['preserve_numeric_keys' => false]);
+    // outputs:
+    //<response>
+    //  <person>
+    //    <firstname>Benjamin</firstname>
+    //    <lastname>Alexandre</lastname>
+    //  </person>
+    //  <person>
+    //    <firstname>Damien</firstname>
+    //    <lastname>Clay</lastname>
+    //  </person>
+    //</response>
+    $xmlEncoder->encode($data, 'xml', ['preserve_numeric_keys' => true]);
+    // outputs:
+    //<response>
+    //  <person>
+    //    <item key="0">
+    //        <firstname>Benjamin</firstname>
+    //        <lastname>Alexandre</lastname>
+    //    </item>
+    //      <item key="1">
+    //        <firstname>Damien</firstname>
+    //        <lastname>Clay</lastname>
+    //      </item>
+    //  </person>
+    //</response>
 
 The ``YamlEncoder``
 -------------------


### PR DESCRIPTION
This follows the issue #21388  which is related to the PR https://github.com/symfony/symfony/pull/60228
