### PR TITLE
[Logger] Update link to Monolog Configuration class

### DIFF
--- a/logging.rst
+++ b/logging.rst
@@ -420,5 +420,5 @@ Learn more
 .. _`Monolog`: https://github.com/Seldaek/monolog
 .. _`LoggerInterface`: https://github.com/php-fig/log/blob/master/src/LoggerInterface.php
 .. _`logrotate`: https://github.com/logrotate/logrotate
-.. _`Monolog Configuration`: https://github.com/symfony/monolog-bundle/blob/master/DependencyInjection/Configuration.php#L25
+.. _`Monolog Configuration`: https://github.com/symfony/monolog-bundle/blob/3.x/src/DependencyInjection/Configuration.php
 .. _`STDERR PHP stream`: https://www.php.net/manual/en/features.commandline.io-streams.php

--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -30,4 +30,4 @@ in your application configuration.
     messages in the profiler. The profiler uses the name "debug" so it
     is reserved and cannot be used in the configuration.
 
-.. _`Monolog Configuration`: https://github.com/symfony/monolog-bundle/blob/master/DependencyInjection/Configuration.php
+.. _`Monolog Configuration`: https://github.com/symfony/monolog-bundle/blob/3.x/src/DependencyInjection/Configuration.php


### PR DESCRIPTION
- Branch renamed to `3.x`
- Class moved into `src/` directory: https://github.com/symfony/monolog-bundle/pull/516

Next, I'll open a PR on 7.4 to change to the branch `4.x` as this version of the MonologBundle will be released at the same time as Symfony 7.4.