### PR TITLE
[Messenger] Explain SQS message deduplication default

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1995,6 +1995,8 @@ The transport has a number of options:
     :class:`Symfony\\Component\\Messenger\\Bridge\\AmazonSqs\\MessageGroupAwareInterface`,
     the middleware will automatically set the ``Message group ID`` of the stamp.
 
+    ``Message deduplication ID`` defaults to a hash of the SQS message's headers and body.
+
     You can learn more about middlewares in
     :ref:`the dedicated section <messenger_middleware>`.
 


### PR DESCRIPTION
Explain how Symfony sets a default value:

https://github.com/symfony/symfony/blob/e96b2e55eccf8c57ae9cb08860d513d4adfcd280/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php#L405