### PR TITLE
[Logger] Update link to Monolog Configuration class for v4

### DIFF
--- a/logging.rst
+++ b/logging.rst
@@ -420,5 +420,5 @@ Learn more
 .. _`Monolog`: https://github.com/Seldaek/monolog
 .. _`LoggerInterface`: https://github.com/php-fig/log/blob/master/src/LoggerInterface.php
 .. _`logrotate`: https://github.com/logrotate/logrotate
-.. _`Monolog Configuration`: https://github.com/symfony/monolog-bundle/blob/3.x/src/DependencyInjection/Configuration.php
+.. _`Monolog Configuration`: https://github.com/symfony/monolog-bundle/blob/4.x/src/DependencyInjection/Configuration.php
 .. _`STDERR PHP stream`: https://www.php.net/manual/en/features.commandline.io-streams.php

--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -30,4 +30,4 @@ in your application configuration.
     messages in the profiler. The profiler uses the name "debug" so it
     is reserved and cannot be used in the configuration.
 
-.. _`Monolog Configuration`: https://github.com/symfony/monolog-bundle/blob/3.x/src/DependencyInjection/Configuration.php
+.. _`Monolog Configuration`: https://github.com/symfony/monolog-bundle/blob/4.x/src/DependencyInjection/Configuration.php


### PR DESCRIPTION
Follows https://github.com/symfony/symfony-docs/pull/21416

`symfony/monolog-bundle: ^4` will be the only version supporting Symfony 8.
