### PR TITLE
[FrameworkBundle][PropertyInfo] Enable the property-info constructor extractor by default

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2497,10 +2497,15 @@ enabled
 with_constructor_extractor
 ..........................
 
-**type**: ``boolean`` **default**: ``false``
+**type**: ``boolean`` **default**: ``true``
 
 Configures the ``property_info`` service to extract property information from the constructor arguments
 using the :ref:`ConstructorExtractor <components-property-information-constructor-extractor>`.
+
+.. versionadded:: 8.0
+
+    The default value of the ``with_constructor_extractor`` option was changed
+    to ``true`` in Symfony 8.0.
 
 rate_limiter
 ~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #21060.

No need to make other changes because in `components/property_info.rst` we assume that the "Constructor Extractor" is enabled by default.