### PR TITLE
[Serializer] Remove unhelpful exposed "serializer alternative"

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -2575,7 +2575,6 @@ Going Further with the Serializer
 
     serializer/*
 
-.. _`JMS serializer`: https://github.com/schmittjoh/serializer
 .. _`API Platform`: https://api-platform.com
 .. _`JSON-LD`: https://json-ld.org
 .. _`Hydra Core Vocabulary`: https://www.hydra-cg.com/

--- a/serializer.rst
+++ b/serializer.rst
@@ -33,11 +33,6 @@ install the serializer :ref:`Symfony pack <symfony-packs>` before using it:
     ``symfony/serializer`` package and install optional dependencies if you
     need them.
 
-.. seealso::
-
-    A popular alternative to the Symfony Serializer component is the third-party
-    library, `JMS serializer`_.
-
 Serializing an Object
 ---------------------
 


### PR DESCRIPTION
Removed mention of JMS serializer as an alternative to Symfony Serializer.

It was pushed at the bottom of page in https://github.com/symfony/symfony-docs/pull/7043

Reintroduced in https://github.com/symfony/symfony-docs/pull/17783 during the big merge of the serializer docs (i guess because new structure had no more a natural good place in the end of the page)

---

To me, it does not feel necessary, and I'm betting create more confusion in readers mind that really helps anyone..

But my main point will be "why is this not done on other packages doc pages?" ... if we need to promote alternative, I can think of a few other Symfony packages where that kind of mention could be legit...

Well just a minor thing passing by :)

So I suggest we simply remove this mention.
