### PR TITLE
[DependencyInjection] Deprecate `getNamespace()` and `getXsdValidationBasePath()` methods

### DIFF
--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -477,6 +477,14 @@ the extension. You might want to change this to a more professional URL::
         }
     }
 
+.. deprecated:: 7.4
+
+    The ``getNamespace()`` method, together with XML support, is deprecated
+    since Symfony 7.4 and will be removed in Symfony 8.0.
+
+    If your bundle needs to remain compatible with older Symfony versions that
+    still support XML, keep this method and add the ``@deprecated`` annotation to it.
+
 Providing an XML Schema
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -509,6 +517,14 @@ can place it anywhere you like. You should return this path as the base path::
             return __DIR__.'/../config/schema';
         }
     }
+
+.. deprecated:: 7.4
+
+    The ``getXsdValidationBasePath()`` method, together with XML support, is
+    deprecated since Symfony 7.4 and will be removed in Symfony 8.0.
+
+    If your bundle needs to remain compatible with older Symfony versions that
+    still support XML, keep this method and add the ``@deprecated`` annotation to it.
 
 Assuming the XSD file is called ``hello-1.0.xsd``, the schema location will be
 ``https://acme_company.com/schema/dic/hello/hello-1.0.xsd``:


### PR DESCRIPTION
Fixes #21454.

Most of the changes will be needed in 8.0 branch, where we'll have to keep some of the existing doc and mention that it's deprecated (but still can be used to support old Symfony versions).

But, we won't do that when upmerging this PR. We take care of `.. deprecated` directives separately when working on 8.0 branch.