### PR TITLE
[Form] `EnumType` Mentioning array keys of `choices`

### DIFF
--- a/reference/forms/types/enum.rst
+++ b/reference/forms/types/enum.rst
@@ -119,6 +119,13 @@ option to explicitly define which options to display::
         ],
     ]);
 
+You can add keys to the `choices` array, which will then be used as labels::
+
+    'choices' => [
+        'Align to the right' => TextAlign::Left,
+        'Align to the left' => TextAlign::Right,
+    ],
+
 .. include:: /reference/forms/types/options/choice_attr.rst.inc
 
 .. include:: /reference/forms/types/options/choice_filter.rst.inc


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/reference/forms/types/enum.html#choices

Feature is added in https://github.com/symfony/symfony/pull/61928 - so you probably want to merge this only when that PR has been released.