### PR TITLE
[HttpFoundation] Remove deprecated Request::get() in favor of using properties

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -639,7 +639,7 @@ else that can be used to create a working example::
     $routes->add('hello', new Route('/hello/{name}', [
         '_controller' => function (Request $request): Response {
             return new Response(
-                sprintf("Hello %s", $request->get('name'))
+                sprintf("Hello %s", $request->attributes->get('name'))
             );
         }]
     ));


### PR DESCRIPTION
Fix https://github.com/symfony/symfony-docs/issues/21463

`Request::get()` was not documented, so I think there is no deprecation directive to add ?