### PR TITLE
[FrameworkBundle] Add support for union types on `#[AsEventListener]`

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -210,6 +210,12 @@ can also be applied to methods directly::
             // ...
         }
 
+        #[AsEventListener]
+        public function onMultipleCustomEvent(CustomEvent|AnotherCustomEvent $event): void
+        {
+            // ...
+        }
+
         #[AsEventListener(event: 'foo', priority: 42)]
         public function onFoo(): void
         {
@@ -227,6 +233,10 @@ can also be applied to methods directly::
 
     Note that the attribute doesn't require its ``event`` parameter to be set
     if the method already type-hints the expected event.
+
+.. versionadded:: 7.4
+
+    The support for union types in the method type-hints was introduced in Symfony 7.4.
 
 .. _events-subscriber:
 


### PR DESCRIPTION
Fix #21467
