### PR TITLE
[Validator] Image Constraint - `minPixels` and `maxPixels` should be float

### DIFF
--- a/reference/constraints/Image.rst
+++ b/reference/constraints/Image.rst
@@ -341,7 +341,7 @@ Parameter             Description
 ``maxPixels``
 ~~~~~~~~~~~~~
 
-**type**: ``integer``
+**type**: ``integer`` | ``float``
 
 If set, the amount of pixels of the image file must be less than or equal to this
 value.
@@ -368,7 +368,7 @@ Parameter             Description
 ``maxRatio``
 ~~~~~~~~~~~~
 
-**type**: ``float``
+**type**: ``integer`` | ``float``
 
 If set, the aspect ratio (``width / height``) of the image file must be less
 than or equal to this value.
@@ -465,7 +465,7 @@ Parameter             Description
 ``minPixels``
 ~~~~~~~~~~~~~
 
-**type**: ``integer``
+**type**: ``integer`` | ``float``
 
 If set, the amount of pixels of the image file must be greater than or equal to this
 value.
@@ -492,7 +492,7 @@ Parameter             Description
 ``minRatio``
 ~~~~~~~~~~~~
 
-**type**: ``float``
+**type**: ``integer`` | ``float``
 
 If set, the aspect ratio (``width / height``) of the image file must be greater
 than or equal to this value.


### PR DESCRIPTION
Related to [issue](https://github.com/symfony/symfony/issues/61980#issuecomment-3384839990).