### PR TITLE
[Messenger] Clarify that RecoverableMessageHandlingException retryDelay is milliseconds

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1203,7 +1203,7 @@ and must be retried. If you throw
 :class:`Symfony\\Component\\Messenger\\Exception\\RecoverableMessageHandlingException`,
 the message will always be retried infinitely and ``max_retries`` setting will be ignored.
 
-You can define a custom retry delay (e.g., to use the value from the ``Retry-After``
+You can define a custom retry delay in milliseconds (e.g., to use the value from the ``Retry-After``
 header in an HTTP response) by setting the ``retryDelay`` argument in the
 constructor of the ``RecoverableMessageHandlingException``.
 


### PR DESCRIPTION


<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
