### PR TITLE
[HttpClient] Document `CachingHttpClient` compatible with RFC 9111

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1661,6 +1661,77 @@ If this option is a boolean value, the response is buffered when the value is
 returned value is ``true`` (the closure receives as argument an array with the
 response headers).
 
+caching
+.......
+
+**type**: ``array``
+
+This option configures the behavior of the HTTP client caching, including which
+types of requests to cache and how many times. The behavior is
+defined with the following options:
+
+* :ref:`cache_pool <reference-http-client-caching-cache-pool>`
+* :ref:`shared <reference-http-client-caching-shared>`
+* :ref:`max_ttl <reference-http-client-caching-max-ttl>`
+
+.. code-block:: yaml
+
+    # config/packages/framework.yaml
+    framework:
+        # ...
+        http_client:
+            # ...
+            default_options:
+                caching:
+                    cache_pool: cache.app
+                    shared: true
+                    max_ttl: 86400
+
+            scoped_clients:
+                my_api.client:
+                    # ...
+                    caching:
+                        cache_pool: my_taggable_pool
+
+.. versionadded:: 7.4
+
+    The ``caching`` option was introduced in Symfony 7.4.
+
+.. _reference-http-client-caching-cache-pool:
+
+cache_pool
+""""""""""
+
+**type**: ``string``
+
+The service ID of the cache pool used to store the cached responses. The service
+must implement the :class:`Symfony\\Contracts\\Cache\\TagAwareCacheInterface`.
+
+By default, it uses an instance of :class:`Symfony\\Component\\Cache\\Adapter\\TagAwareAdapter`
+wrapping the ``cache.app`` pool.
+
+.. _reference-http-client-caching-shared:
+
+shared
+"""""""
+
+**type**: ``boolean`` **default**: ``true``
+
+Whether the cache is shared or private. If ``true``, the cache
+is `shared <https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#shared_cache>`_
+(default), if ``false``, the cache is
+`private <https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#private_caches>`_.
+
+.. _reference-http-client-caching-max-ttl:
+
+max_ttl
+"""""""""
+
+**type**: ``integer`` **default**: ``null``
+
+The maximum time-to-live (in seconds) for cached responses. Server-provided TTLs
+are capped to this value if set.
+
 cafile
 ......
 


### PR DESCRIPTION
Closes https://github.com/symfony/symfony-docs/issues/21437
