### PR TITLE
[Console][LockableTrait] Do not redeclare $lockFactory through constructor property promotion in the code example

### DIFF
--- a/console/lockable_trait.rst
+++ b/console/lockable_trait.rst
@@ -55,8 +55,11 @@ a ``$lockFactory`` property with your own lock factory::
     {
         use LockableTrait;
 
-        public function __construct(private LockFactory $lockFactory)
+        public function __construct(LockFactory $lockFactory)
         {
+            $this->lockFactory = $lockFactory;
+
+            parent::__construct();
         }
 
         // ...


### PR DESCRIPTION
Adding visibility on the constructor parameter results in constructor property promotion and in redeclaring the property in a way which is incompatible with the declaration from the trait, resulting in a fatal error if the example is used as is. For reference: https://www.php.net/manual/en/language.oop5.traits.php#language.oop5.traits.properties.example
Instead, I think the visibility should be removed in order to prevent redeclaration (and incompatibility with the property from the trait), and just use dependency injection and overwrite the default value so that the trait won't create a new instance for the $lockFactory.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
