### PR TITLE
[EventDispatcher][Event Listeners] Update event_dispatcher.rst : fix return type

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -728,7 +728,7 @@ this::
             return $this->subject;
         }
 
-        public function setSubject(string $subject): string
+        public function setSubject(string $subject): void
         {
             $this->subject = $subject;
         }


### PR DESCRIPTION
Fixed return type for a setter in the example `BeforeSendMailEvent` class. From `string` to `void`.