### PR TITLE
 Replace the fluent PHP config format by the array-shape one

### DIFF
--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -23,11 +23,13 @@ as integration of other related components:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->form()->enabled(true);
-        };
+        return App::config([
+            'framework' => [
+                'form' => true,
+            ],
+        ]);
 
 There are two different ways of creating friendly configuration for a bundle:
 
@@ -148,13 +150,16 @@ can add some configuration that looks like this:
     .. code-block:: php
 
         // config/packages/acme_social.php
-        use Symfony\Config\AcmeSocialConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (AcmeSocialConfig $acmeSocial): void {
-            $acmeSocial->twitter()
-                ->clientId(123)
-                ->clientSecret('your_secret');
-        };
+        return App::config([
+            'acme_social' => [
+                'twitter' => [
+                    'client_id' => 123,
+                    'client_secret' => 'your_secret',
+                ],
+            ],
+        ]);
 
 The basic idea is that instead of having the user override individual
 parameters, you let the user configure just a few, specifically created,

--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -100,12 +100,10 @@ registered and the ``entity_manager_name`` setting for ``acme_hello`` is set to
 
         # config/packages/acme_something.yaml
         acme_something:
-            # ...
             use_acme_goodbye: false
             entity_manager_name: non_default
 
         acme_other:
-            # ...
             use_acme_goodbye: false
 
     .. code-block:: php
@@ -113,17 +111,15 @@ registered and the ``entity_manager_name`` setting for ``acme_hello`` is set to
         // config/packages/acme_something.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container): void {
-            $container->extension('acme_something', [
-                // ...
+        return App::config([
+            'acme_something' => [
                 'use_acme_goodbye' => false,
                 'entity_manager_name' => 'non_default',
-            ]);
-            $container->extension('acme_other', [
-                // ...
+            ],
+            'acme_other' => [
                 'use_acme_goodbye' => false,
-            ]);
-        };
+            ],
+        ]);
 
 Prepending Extension in the Bundle Class
 ----------------------------------------

--- a/cache.rst
+++ b/cache.rst
@@ -64,14 +64,16 @@ adapter (template) they use by using the ``app`` and ``system`` key like:
     .. code-block:: php
 
         // config/packages/cache.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->cache()
-                ->app('cache.adapter.filesystem')
-                ->system('cache.adapter.system')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'app' => 'cache.adapter.filesystem',
+                    'system' => 'cache.adapter.system',
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -117,20 +119,20 @@ Some of these adapters could be configured via shortcuts.
     .. code-block:: php
 
         // config/packages/cache.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->cache()
-                // Only used with cache.adapter.filesystem
-                ->directory('%kernel.cache_dir%/pools')
-
-                ->defaultDoctrineDbalProvider('doctrine.dbal.default_connection')
-                ->defaultPsr6Provider('app.my_psr6_service')
-                ->defaultRedisProvider('redis://localhost')
-                ->defaultMemcachedProvider('memcached://localhost')
-                ->defaultPdoProvider('pgsql:host=localhost')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'directory' => '%kernel.cache_dir%/pools', // Only used with cache.adapter.filesystem
+                    'default_doctrine_dbal_provider' => 'doctrine.dbal.default_connection',
+                    'default_psr6_provider' => 'app.my_psr6_service',
+                    'default_redis_provider' => 'redis://localhost',
+                    'default_memcached_provider' => 'memcached://localhost',
+                    'default_pdo_provider' => 'pgsql:host=localhost',
+                ],
+            ],
+        ]);
 
 .. _cache-create-pools:
 
@@ -178,36 +180,43 @@ You can also create more customized pools:
     .. code-block:: php
 
         // config/packages/cache.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $cache = $framework->cache();
-            $cache->defaultMemcachedProvider('memcached://localhost');
-
-            // creates a "custom_thing.cache" service
-            // autowireable via "CacheInterface $customThingCache"
-            // uses the "app" cache configuration
-            $cache->pool('custom_thing.cache')
-                ->adapters(['cache.app']);
-
-            // creates a "my_cache_pool" service
-            // autowireable via "CacheInterface $myCachePool"
-            $cache->pool('my_cache_pool')
-                ->adapters(['cache.adapter.filesystem']);
-
-            // uses the default_memcached_provider from above
-            $cache->pool('acme.cache')
-                ->adapters(['cache.adapter.memcached']);
-
-             // control adapter's configuration
-            $cache->pool('foobar.cache')
-                ->adapters(['cache.adapter.memcached'])
-                ->provider('memcached://user:password@example.com');
-
-            $cache->pool('short_cache')
-                ->adapters(['foobar.cache'])
-                ->defaultLifetime(60);
-        };
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'default_memcached_provider' => 'memcached://localhost',
+                    'pools' => [
+                        // creates a "custom_thing.cache" service
+                        // autowireable via "CacheInterface $customThingCache"
+                        // uses the "app" cache configuration
+                        'custom_thing.cache' => [
+                            'adapter' => 'cache.app',
+                        ],
+                        // creates a "my_cache_pool" service
+                        // autowireable via "CacheInterface $myCachePool"
+                        'my_cache_pool' => [
+                            'adapter' => 'cache.adapter.filesystem',
+                        ],
+                        // uses the default_memcached_provider from above
+                        'acme.cache' => [
+                            'adapter' => 'cache.adapter.memcached',
+                        ],
+                        // control adapter's configuration
+                        'foobar.cache' => [
+                            'adapter' => 'cache.adapter.memcached',
+                            'provider' => 'memcached://user:password@example.com',
+                        ],
+                        // uses the "foobar.cache" pool as its backend but controls
+                        // the lifetime and (like all pools) has a separate cache namespace
+                        'short_cache' => [
+                            'adapter' => 'foobar.cache',
+                            'default_lifetime' => 60,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Each pool manages a set of independent cache keys: keys from different pools
 *never* collide, even if they share the same backend. This is achieved by prefixing
@@ -292,24 +301,26 @@ and use that when configuring the pool.
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
         use Symfony\Component\Cache\Adapter\RedisAdapter;
-        use Symfony\Component\DependencyInjection\ContainerBuilder;
-        use Symfony\Config\FrameworkConfig;
 
-        return static function (ContainerBuilder $container, FrameworkConfig $framework): void {
-            $framework->cache()
-                ->pool('cache.my_redis')
-                    ->adapters(['cache.adapter.redis'])
-                    ->provider('app.my_custom_redis_provider');
-
-            $container->register('app.my_custom_redis_provider', \Redis::class)
-                ->setFactory([RedisAdapter::class, 'createConnection'])
-                ->addArgument('redis://localhost')
-                ->addArgument([
-                    'retry_interval' => 2,
-                    'timeout' => 10
-                ])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'pools' => [
+                        'cache.my_redis' => [
+                            'adapter' => 'cache.adapter.redis',
+                            'provider' => 'app.my_custom_redis_provider',
+                        ],
+                    ],
+                ],
+            ],
+            'services' => [
+                'app.my_custom_redis_provider' => [
+                    'class' => \Redis::class,
+                    'factory' => [RedisAdapter::class, 'createConnection'],
+                    'arguments' => ['redis://localhost', ['retry_interval' => 2, 'timeout' => 10]],
+                ],
+            ],
+        ]);
 
 Creating a Cache Chain
 ----------------------
@@ -348,19 +359,24 @@ Symfony stores the item automatically in all the missing pools.
     .. code-block:: php
 
         // config/packages/cache.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->cache()
-                ->pool('my_cache_pool')
-                    ->defaultLifetime(31536000) // One year
-                    ->adapters([
-                        'cache.adapter.array',
-                        'cache.adapter.apcu',
-                        ['name' => 'cache.adapter.redis', 'provider' => 'redis://user:password@example.com'],
-                    ])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'pools' => [
+                        'my_cache_pool' => [
+                            'default_lifetime' => 31536000, // One year
+                            'adapters' => [
+                                'cache.adapter.array',
+                                'cache.adapter.apcu',
+                                ['name' => 'cache.adapter.redis', 'provider' => 'redis://user:password@example.com'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _cache-using-cache-tags:
 
@@ -420,15 +436,20 @@ to enable this feature. This could be added by using the following configuration
     .. code-block:: php
 
         // config/packages/cache.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->cache()
-                ->pool('my_cache_pool')
-                    ->tags(true)
-                    ->adapters(['cache.adapter.redis_tag_aware'])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'pools' => [
+                        'my_cache_pool' => [
+                            'adapter' => 'cache.adapter.redis_tag_aware',
+                            'tags' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Tags are stored in the same pool by default. This is good in most scenarios. But
 sometimes it might be better to store the tags in a different pool. That could be
@@ -451,20 +472,23 @@ achieved by specifying the adapter.
     .. code-block:: php
 
         // config/packages/cache.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->cache()
-                ->pool('my_cache_pool')
-                    ->tags('tag_pool')
-                    ->adapters(['cache.adapter.redis'])
-            ;
-
-            $framework->cache()
-                ->pool('tag_pool')
-                    ->adapters(['cache.adapter.apcu'])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'pools' => [
+                        'my_cache_pool' => [
+                            'adapter' => 'cache.adapter.redis',
+                            'tags' => 'tag_pool',
+                        ],
+                        'tag_pool' => [
+                            'adapter' => 'cache.adapter.apcu',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -573,16 +597,23 @@ Then, register the ``SodiumMarshaller`` service using this key:
     .. code-block:: php
 
         // config/packages/cache.php
-        use Symfony\Component\Cache\Marshaller\SodiumMarshaller;
-        use Symfony\Component\DependencyInjection\ChildDefinition;
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-        $container->setDefinition(SodiumMarshaller::class, new ChildDefinition('cache.default_marshaller'))
-            ->addArgument(['env(base64:CACHE_DECRYPTION_KEY)'])
-            // use multiple keys in order to rotate them
-            //->addArgument(['env(base64:CACHE_DECRYPTION_KEY)', 'env(base64:OLD_CACHE_DECRYPTION_KEY)'])
-            ->addArgument(new Reference('.inner'));
+        use Symfony\Component\Cache\Marshaller\SodiumMarshaller;
+
+        return App::config([
+            'services' => [
+                SodiumMarshaller::class => [
+                    'decorates' => 'cache.default_marshaller',
+                    'arguments' => [
+                        [env('CACHE_DECRYPTION_KEY')->base64()],
+                        // use multiple keys in order to rotate them
+                        // [env('CACHE_DECRYPTION_KEY')->base64(), env('OLD_CACHE_DECRYPTION_KEY')->base64()]
+                        service('.inner'),
+                    ],
+                ],
+            ],
+        ]);
 
 .. danger::
 
@@ -679,21 +710,29 @@ a message bus to compute values in a worker:
     .. code-block:: php
 
         // config/framework/framework.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Symfony\Component\Cache\Messenger\EarlyExpirationMessage;
-        use Symfony\Config\FrameworkConfig;
-        use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->cache()
-                ->pool('async.cache')
-                    ->earlyExpirationMessageBus('messenger.default_bus');
-
-            $framework->messenger()
-                ->transport('async_bus')
-                    ->dsn(env('MESSENGER_TRANSPORT_DSN'))
-                ->routing(EarlyExpirationMessage::class)
-                    ->senders(['async_bus']);
-        };
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'pools' => [
+                        'async.cache' => [
+                            'early_expiration_message_bus' => 'messenger.default_bus',
+                        ],
+                    ],
+                ],
+                'messenger' => [
+                    'transports' => [
+                        'async_bus' => env('MESSENGER_TRANSPORT_DSN'),
+                    ],
+                    'routing' => [
+                        EarlyExpirationMessage::class => 'async_bus',
+                    ],
+                ],
+            ],
+        ]);
 
 You can now start the consumer:
 

--- a/components/dependency_injection.rst
+++ b/components/dependency_injection.rst
@@ -260,6 +260,7 @@ config files:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         parameters:
             # ...
             mailer.transport: sendmail
@@ -275,27 +276,30 @@ config files:
 
     .. code-block:: php
 
+        // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container): void {
-            $container->parameters()
+        use App\Mailer;
+        use App\NewsletterManager;
+
+        return App::config([
+            'parameters' => [
                 // ...
-                ->set('mailer.transport', 'sendmail')
-            ;
-
-            $services = $container->services();
-            $services->set('mailer', 'Mailer')
-                ->args(['%mailer.transport%'])
-            ;
-
-            $services->set('mailer', 'Mailer')
-                ->args([param('mailer.transport')])
-            ;
-
-            $services->set('newsletter_manager', 'NewsletterManager')
-                ->call('setMailer', [service('mailer')])
-            ;
-        };
+                'mailer.transport' => 'sendmail',
+            ],
+            'services' => [
+                'mailer' => [
+                    'class' => Mailer::class,
+                    'arguments' => [param('mailer.transport')],
+                ],
+                'newsletter_manager' => [
+                    'class' => NewsletterManager::class,
+                    'calls' => [
+                        'setMailer' => [service('mailer')],
+                    ],
+                ],
+            ],
+        ]);
 
 Learn More
 ----------

--- a/components/dependency_injection/_imports-parameters-note.rst.inc
+++ b/components/dependency_injection/_imports-parameters-note.rst.inc
@@ -17,6 +17,8 @@
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (ContainerConfigurator $container): void {
-                $container->import('%kernel.project_dir%/somefile.yaml');
-            };
+            return [
+                'imports' => [
+                    ['resource => '%kernel.project_dir%/somefile.yaml'],
+                ],
+            ];

--- a/components/uid.rst
+++ b/components/uid.rst
@@ -209,13 +209,8 @@ You can configure these default values::
         // config/packages/uid.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container): void {
-            $services = $container->services()
-                ->defaults()
-                ->autowire()
-                ->autoconfigure();
-
-            $container->extension('framework', [
+        return App::config([
+            'framework' => [
                 'uid' => [
                     'default_uuid_version' => 6,
                     'name_based_uuid_version' => 3,
@@ -223,8 +218,8 @@ You can configure these default values::
                     'time_based_uuid_version' => 6,
                     'time_based_uuid_node' => 121212121212,
                 ],
-            ]);
-        };
+            ],
+        ]);
 
 Converting UUIDs
 ~~~~~~~~~~~~~~~~
@@ -672,15 +667,15 @@ configuration in your application before using these commands:
         use Symfony\Component\Uid\Command\InspectUlidCommand;
         use Symfony\Component\Uid\Command\InspectUuidCommand;
 
-        return static function (ContainerConfigurator $container): void {
-            // ...
-
-            $services
-                ->set(GenerateUlidCommand::class)
-                ->set(GenerateUuidCommand::class)
-                ->set(InspectUlidCommand::class)
-                ->set(InspectUuidCommand::class);
-        };
+        return App::config([
+            'services' => [
+                // ...
+                GenerateUlidCommand::class => null,
+                GenerateUuidCommand::class => null,
+                InspectUlidCommand::class => null,
+                InspectUuidCommand::class => null,
+            ],
+        ]);
 
 Now you can generate UUIDs/ULIDs as follows (add the ``--help`` option to the
 commands to learn about all their options):

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -129,11 +129,11 @@ the :ref:`dump_destination option <configuration-debug-dump_destination>` of the
         // config/packages/debug.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container): void {
-            $container->extension('debug', [
+        return App::config([
+            'debug' => [
                 'dump_destination' => 'tcp://%env(VAR_DUMPER_SERVER)%',
-            ]);
-        };
+            ],
+        ]);
 
 Outside a Symfony application, use the :class:`Symfony\\Component\\VarDumper\\Dumper\\ServerDumper` class::
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -100,20 +100,20 @@ configuration files, even if they use a different format:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container): void {
-            $container->import('legacy_config.php');
+        return App::config([
+            'imports' => [
+                ['resource' => 'legacy_config.php'],
 
-            // glob expressions are also supported to load multiple files
-            $container->import('/etc/myapp/*.yaml');
+                // glob expressions are also supported to load multiple files
+                ['resource' => '/etc/myapp/*.yaml'],
 
-            // the third optional argument of import() is 'ignore_errors'
-            // 'ignore_errors' set to 'not_found' silently discards errors if the loaded file doesn't exist
-            $container->import('my_config_file.yaml', null, 'not_found');
-            // 'ignore_errors' set to true silently discards all errors (including invalid code and not found)
-            $container->import('my_config_file.yaml', null, true);
-        };
+                // ignore_errors: not_found silently discards errors if the loaded file doesn't exist
+                ['resource' => 'my_config_file.xml', 'ignore_errors' => 'not_found'],
 
-        // ...
+                // ignore_errors: true silently discards all errors (including invalid code and not found)
+                ['resource' => 'my_other_config_file.xml', 'ignore_errors' => true],
+            ],
+        ]);
 
 .. _config-parameter-intro:
 .. _config-parameters-yml:
@@ -125,7 +125,7 @@ Configuration Parameters
 Sometimes the same configuration value is used in several configuration files.
 Instead of repeating it, you can define it as a "parameter", which is like a
 reusable configuration value. By convention, parameters are defined under the
-``parameters`` key in the ``config/services.yaml`` file:
+``parameters`` key:
 
 .. configuration-block::
 
@@ -163,30 +163,29 @@ reusable configuration value. By convention, parameters are defined under the
         use App\Entity\BlogPost;
         use App\Enum\PostState;
 
-        return static function (ContainerConfigurator $container): void {
-            $container->parameters()
+        return App::config([
+            'parameters' => [
                 // the parameter name is an arbitrary string (the 'app.' prefix is recommended
                 // to better differentiate your parameters from Symfony parameters).
-                ->set('app.admin_email', 'something@example.com')
+                'app.admin_email' => 'something@example.com',
 
                 // boolean parameters
-                ->set('app.enable_v2_protocol', true)
+                'app.enable_v2_protocol' => true,
 
                 // array/collection parameters
-                ->set('app.supported_locales', ['en', 'es', 'fr'])
+                'app.supported_locales' => ['en', 'es', 'fr'],
 
-                // binary content parameters (use the PHP escape sequences)
-                ->set('app.some_parameter', 'This is a Bell char: \x07')
+                // binary content parameters (encode the contents with base64_encode())
+                'app.some_parameter' => base64_decode('VGhpcyBpcyBhIEJlbGwgY2hhciAA'),
 
                 // PHP constants as parameter values
-                ->set('app.some_constant', GLOBAL_CONSTANT)
-                ->set('app.another_constant', BlogPost::MAX_ITEMS)
+                'app.some_constant' => GLOBAL_CONSTANT,
+                'app.another_constant' => BlogPost::MAX_ITEMS,
 
                 // Enum case as parameter values
-                ->set('app.some_enum', PostState::Published);
-        };
-
-        // ...
+                'app.some_enum' => PostState::Published,
+            ],
+        ]);
 
 Once defined, you can reference this parameter value from any other
 configuration file using a special syntax: wrap the parameter name in two ``%``
@@ -205,10 +204,9 @@ configuration file using a special syntax: wrap the parameter name in two ``%``
 
         // config/packages/some_package.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
-        use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 
-        return static function (ContainerConfigurator $container): void {
-            $container->extension('some_package', [
+        return App::config([
+            'some_package' => [
                 // when using the param() function, you only have to pass the parameter name...
                 'email_address' => param('app.admin_email'),
 
@@ -216,8 +214,8 @@ configuration file using a special syntax: wrap the parameter name in two ``%``
                 // surrounded by two % (same as in YAML format) and Symfony will
                 // replace it by that parameter value
                 'email_address' => '%app.admin_email%',
-            ]);
-        };
+            ],
+        ]);
 
 .. note::
 
@@ -239,10 +237,11 @@ configuration file using a special syntax: wrap the parameter name in two ``%``
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (ContainerConfigurator $container): void {
-                $container->parameters()
-                    ->set('url_pattern', 'http://symfony.com/?foo=%%s&amp;bar=%%d');
-            };
+            return App::config([
+                'parameters' => [
+                    'url_pattern' => 'http://symfony.com/?foo=%%s&amp;bar=%%d',
+                ],
+            ]);
 
 .. include:: /components/dependency_injection/_imports-parameters-note.rst.inc
 
@@ -356,27 +355,30 @@ files directly in the ``config/packages/`` directory.
 
         .. code-block:: php
 
-            // config/packages/framework.php
-            use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-            use Symfony\Config\WebpackEncoreConfig;
+            // config/packages/webpack_encore.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (WebpackEncoreConfig $webpackEncore, ContainerConfigurator $container): void {
-                $webpackEncore
-                    ->outputPath('%kernel.project_dir%/public/build')
-                    ->strictMode(true)
-                    ->cache(false)
-                ;
+            return [
+                'webpack_encore' => [
+                    'output_path' => '%kernel.project_dir%/public/build',
+                    'strict_mode' => true,
+                    'cache' => false,
+                ],
 
                 // cache is enabled only in the "prod" environment
-                if ('prod' === $container->env()) {
-                    $webpackEncore->cache(true);
-                }
+                'when@prod' => [
+                    'webpack_encore' => [
+                        'cache' => true,
+                    ],
+                ],
 
                 // disable strict mode only in the "test" environment
-                if ('test' === $container->env()) {
-                    $webpackEncore->strictMode(false);
-                }
-            };
+                'when@test' => [
+                    'webpack_encore' => [
+                        'strict_mode' => false,
+                    ],
+                ],
+            ],
 
 .. seealso::
 
@@ -479,12 +481,12 @@ This example shows how you could configure the application secret using an env v
         // config/packages/framework.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container): void {
-            $container->extension('framework', [
+        return App::config([
+            'framework' => [
                 // by convention the env var names are always uppercase
-                'secret' => '%env(APP_SECRET)%',
-            ]);
-        };
+                'secret' => env('APP_SECRET'),
+            ],
+        ]);
 
 .. note::
 
@@ -517,7 +519,7 @@ To do so, define a parameter with the same name as the env var using this syntax
 
     .. code-block:: yaml
 
-        # config/packages/framework.yaml
+        # config/services.yaml
         parameters:
             # if the SECRET env var value is not defined anywhere, Symfony uses this value
             env(SECRET): 'some_secret'
@@ -526,22 +528,18 @@ To do so, define a parameter with the same name as the env var using this syntax
 
     .. code-block:: php
 
-        // config/packages/framework.php
+        // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        use Symfony\Component\DependencyInjection\ContainerBuilder;
-        use Symfony\Config\FrameworkConfig;
-
-        return static function (ContainerBuilder $container, FrameworkConfig $framework) {
-            // if the SECRET env var value is not defined anywhere, Symfony uses this value
-            $container->setParameter('env(SECRET)', 'some_secret');
-
-            // ...
-        };
+        return App::config([
+            'parameters' => [
+                'env(SECRET)' => 'some_secret',
+            ],
+        ]);
 
 .. tip::
 
-    Some hosts - like Upsun - offer easy `utilities to manage env vars`_
+    Some hosts - like Upsun.com - offer easy `utilities to manage env vars`_
     in production.
 
 .. note::
@@ -987,14 +985,18 @@ doesn't work for parameters:
 
         use App\Service\MessageGenerator;
 
-        return static function (ContainerConfigurator $container): void {
-            $container->parameters()
-                ->set('app.contents_dir', '...');
-
-            $container->services()
-                ->get(MessageGenerator::class)
-                    ->arg('$contentsDir', '%app.contents_dir%');
-        };
+        return App::config([
+            'parameters' => [
+                'app.contents_dir' => '...',
+            ],
+            'services' => [
+                MessageGenerator::class => [
+                    'arguments' => [
+                        '$contentsDir' => param('app.contents_dir'),
+                    ],
+                ],
+            ],
+        ]);
 
 If you inject the same parameters over and over again, use the
 ``services._defaults.bind`` option instead. The arguments defined in that option are
@@ -1022,15 +1024,17 @@ whenever a service/controller defines a ``$projectDir`` argument, use this:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container): void {
-            $container->services()
-                ->defaults()
-                    // pass this value to any $projectDir argument for any service
-                    // that's created in this file (including controller arguments)
-                    ->bind('$projectDir', '%kernel.project_dir%');
-
-            // ...
-        };
+        return App::config([
+            'services' => [
+                '_defaults' => [
+                    'bind' => [
+                        // pass this value to any $projectDir argument for any service
+                        // that's created in this file (including controller arguments)
+                        '$projectDir' => param('kernel.project_dir'),
+                    ],
+                ],
+            ],
+        ]);
 
 .. seealso::
 

--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -26,15 +26,13 @@ processor to turn the value of the ``HTTP_PORT`` env var into an integer:
         // config/packages/framework.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        use Symfony\Config\FrameworkConfig;
-
-        return static function (FrameworkConfig $framework): void {
-            $framework->router()
-                ->httpPort('%env(int:HTTP_PORT)%')
-                // or
-                ->httpPort(env('HTTP_PORT')->int())
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'router' => [
+                    'http_port' => env('HTTP_PORT')->int(),
+                ],
+            ],
+        ]);
 
 Built-In Environment Variable Processors
 ----------------------------------------
@@ -59,13 +57,14 @@ Symfony provides the following env var processors:
             // config/packages/framework.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            use Symfony\Component\DependencyInjection\ContainerBuilder;
-            use Symfony\Config\FrameworkConfig;
-
-            return static function (ContainerBuilder $container, FrameworkConfig $framework): void {
-                $container->setParameter('env(SECRET)', 'some_secret');
-                $framework->secret(env('SECRET')->string());
-            };
+            return App::config([
+                'parameters' => [
+                    'env(SECRET)' => 'some_secret',
+                ],
+                'framework' => [
+                    'secret' => env('SECRET')->string(),
+                ],
+            ]);
 
 ``env(bool:FOO)``
     Casts ``FOO`` to a bool (``true`` values are ``'true'``, ``'on'``, ``'yes'``,
@@ -87,13 +86,14 @@ Symfony provides the following env var processors:
             // config/packages/framework.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            use Symfony\Component\DependencyInjection\ContainerBuilder;
-            use Symfony\Config\FrameworkConfig;
-
-            return static function (ContainerBuilder $container, FrameworkConfig $framework): void {
-                $container->setParameter('env(HTTP_METHOD_OVERRIDE)', 'true');
-                $framework->httpMethodOverride(env('HTTP_METHOD_OVERRIDE')->bool());
-            };
+            return App::config([
+                'parameters' => [
+                    'env(HTTP_METHOD_OVERRIDE)' => 'true',
+                ],
+                'framework' => [
+                    'http_method_override' => env('HTTP_METHOD_OVERRIDE')->bool(),
+                ],
+            ]);
 
 ``env(not:FOO)``
     Casts ``FOO`` to a bool (just as ``env(bool:...)`` does) except it returns the inverted value
@@ -110,7 +110,13 @@ Symfony provides the following env var processors:
         .. code-block:: php
 
             // config/services.php
-            $container->setParameter('safe_for_production', '%env(not:APP_DEBUG)%');
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return App::config([
+                'parameters' => [
+                    'safe_for_production' => env('APP_DEBUG')->not(),
+                ],
+            ]);
 
 ``env(int:FOO)``
     Casts ``FOO`` to an int.
@@ -135,15 +141,18 @@ Symfony provides the following env var processors:
         .. code-block:: php
 
             // config/packages/security.php
-            use Symfony\Component\DependencyInjection\ContainerBuilder;
-            use Symfony\Config\SecurityConfig;
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (ContainerBuilder $container, SecurityConfig $security): void {
-                $container->setParameter('env(HEALTH_CHECK_METHOD)', 'Symfony\Component\HttpFoundation\Request::METHOD_HEAD');
-                $security->accessControl()
-                    ->path('^/health-check$')
-                    ->methods([env('HEALTH_CHECK_METHOD')->const()]);
-            };
+            return App::config([
+                'parameters' => [
+                    'env(HEALTH_CHECK_METHOD)' => 'Symfony\Component\HttpFoundation\Request::METHOD_HEAD',
+                ],
+                'security' => [
+                    'access_control' => [
+                        ['path' => '^/health-check$', 'methods' => env('HEALTH_CHECK_METHOD')->const()],
+                    ],
+                ],
+            ]);
 
 ``env(base64:FOO)``
     Decodes the content of ``FOO``, which is a base64 encoded string.
@@ -156,23 +165,22 @@ Symfony provides the following env var processors:
 
         .. code-block:: yaml
 
-            # config/packages/framework.yaml
+            # config/services.yaml
             parameters:
                 env(ALLOWED_LANGUAGES): '["en","de","es"]'
                 app_allowed_languages: '%env(json:ALLOWED_LANGUAGES)%'
 
         .. code-block:: php
 
-            // config/packages/framework.php
+            // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            use Symfony\Component\DependencyInjection\ContainerBuilder;
-            use Symfony\Config\FrameworkConfig;
-
-            return static function (ContainerBuilder $container): void {
-                $container->setParameter('env(ALLOWED_LANGUAGES)', '["en","de","es"]');
-                $container->setParameter('app_allowed_languages', '%env(json:ALLOWED_LANGUAGES)%');
-            };
+            return App::config([
+                'parameters' => [
+                    'env(ALLOWED_LANGUAGES)' => '["en","de","es"]',
+                    'app_allowed_languages' => env('ALLOWED_LANGUAGES')->json(),
+                ],
+            ]);
 
 ``env(resolve:FOO)``
     If the content of ``FOO`` includes container parameters (with the syntax
@@ -192,10 +200,16 @@ Symfony provides the following env var processors:
         .. code-block:: php
 
             // config/packages/sentry.php
-            $container->setParameter('sentry_host', '10.0.0.1');
-            $container->setParameter('env(SENTRY_DSN)', 'http://%sentry_host%/project');
-            $container->loadFromExtension('sentry', [
-                'dsn' => '%env(resolve:SENTRY_DSN)%',
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return App::config([
+                'parameters' => [
+                    'sentry_host' => '10.0.0.1',
+                    'env(SENTRY_DSN)' => 'http://%sentry_host%/project',
+                ],
+                'sentry' => [
+                    'dsn' => env('SENTRY_DSN')->resolve(),
+                ],
             ]);
 
 ``env(csv:FOO)``
@@ -205,23 +219,22 @@ Symfony provides the following env var processors:
 
         .. code-block:: yaml
 
-            # config/packages/framework.yaml
+            # config/services.yaml
             parameters:
                 env(ALLOWED_LANGUAGES): "en,de,es"
                 app_allowed_languages: '%env(csv:ALLOWED_LANGUAGES)%'
 
         .. code-block:: php
 
-            // config/packages/framework.php
+            // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            use Symfony\Component\DependencyInjection\ContainerBuilder;
-            use Symfony\Config\FrameworkConfig;
-
-            return static function (ContainerBuilder $container): void {
-                $container->setParameter('env(ALLOWED_LANGUAGES)', 'en,de,es');
-                $container->setParameter('app_allowed_languages', '%env(csv:ALLOWED_LANGUAGES)%');
-            };
+            return App::config([
+                'parameters' => [
+                    'env(ALLOWED_LANGUAGES)' => 'en,de,es',
+                    'app_allowed_languages' => env('ALLOWED_LANGUAGES')->csv(),
+                ],
+            ]);
 
 ``env(shuffle:FOO)``
     Randomly shuffles values of the ``FOO`` env var, which must be an array.
@@ -230,7 +243,7 @@ Symfony provides the following env var processors:
 
         .. code-block:: yaml
 
-            # config/packages/framework.yaml
+            # config/services.yaml
             parameters:
                 env(REDIS_NODES): "127.0.0.1:6380,127.0.0.1:6381"
             services:
@@ -241,12 +254,19 @@ Symfony provides the following env var processors:
         .. code-block:: php
 
             // config/services.php
-            use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (ContainerConfigurator $containerConfigurator): void {
-                $container = $containerConfigurator->services()
-                    ->set(\RedisCluster::class, \RedisCluster::class)->args([null, '%env(shuffle:csv:REDIS_NODES)%']);
-            };
+            return App::config([
+                'parameters' => [
+                    'env(REDIS_NODES)' => '127.0.0.1:6380,127.0.0.1:6381',
+                ],
+                'services' => [
+                    \RedisCluster::class => [
+                        'class' => \RedisCluster::class,
+                        'arguments' => [null, env('REDIS_NODES')->csv()->shuffle()],
+                    ],
+                ],
+            ]);
 
 ``env(file:FOO)``
     Returns the contents of a file whose path is the value of the ``FOO`` env var:
@@ -255,7 +275,7 @@ Symfony provides the following env var processors:
 
         .. code-block:: yaml
 
-            # config/packages/framework.yaml
+            # config/packages/google.yaml
             parameters:
                 env(AUTH_FILE): '%kernel.project_dir%/config/auth.json'
             google:
@@ -263,10 +283,16 @@ Symfony provides the following env var processors:
 
         .. code-block:: php
 
-            // config/packages/framework.php
-            $container->setParameter('env(AUTH_FILE)', '../config/auth.json');
-            $container->loadFromExtension('google', [
-                'auth' => '%env(file:AUTH_FILE)%',
+            // config/packages/google.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return App::config([
+                'parameters' => [
+                    'env(AUTH_FILE)' => '../config/auth.json',
+                ],
+                'google' => [
+                    'auth' => env('AUTH_FILE')->file(),
+                ],
             ]);
 
 ``env(require:FOO)``
@@ -277,18 +303,24 @@ Symfony provides the following env var processors:
 
         .. code-block:: yaml
 
-            # config/packages/framework.yaml
+            # config/packages/google.yaml
             parameters:
                 env(PHP_FILE): '%kernel.project_dir%/config/.runtime-evaluated.php'
-            app:
+            google:
                 auth: '%env(require:PHP_FILE)%'
 
         .. code-block:: php
 
-            // config/packages/framework.php
-            $container->setParameter('env(PHP_FILE)', '../config/.runtime-evaluated.php');
-            $container->loadFromExtension('app', [
-                'auth' => '%env(require:PHP_FILE)%',
+            // config/packages/google.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return App::config([
+                'parameters' => [
+                    'env(PHP_FILE)' => '../config/.runtime-evaluated.php',
+                ],
+                'google' => [
+                    'auth' => env('PHP_FILE')->require(),
+                ],
             ]);
 
 ``env(trim:FOO)``
@@ -300,7 +332,7 @@ Symfony provides the following env var processors:
 
         .. code-block:: yaml
 
-            # config/packages/framework.yaml
+            # config/packages/google.yaml
             parameters:
                 env(AUTH_FILE): '%kernel.project_dir%/config/auth.json'
             google:
@@ -308,10 +340,16 @@ Symfony provides the following env var processors:
 
         .. code-block:: php
 
-            // config/packages/framework.php
-            $container->setParameter('env(AUTH_FILE)', '../config/auth.json');
-            $container->loadFromExtension('google', [
-                'auth' => '%env(trim:file:AUTH_FILE)%',
+            // config/packages/google.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return App::config([
+                'parameters' => [
+                    'env(AUTH_FILE)' => '../config/auth.json',
+                ],
+                'google' => [
+                    'auth' => env('AUTH_FILE')->file()->trim(),
+                ],
             ]);
 
 ``env(key:FOO:BAR)``
@@ -331,8 +369,15 @@ Symfony provides the following env var processors:
         .. code-block:: php
 
             // config/services.php
-            $container->setParameter('env(SECRETS_FILE)', '/opt/application/.secrets.json');
-            $container->setParameter('database_password', '%env(key:database_password:json:file:SECRETS_FILE)%');
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return App::config([
+                'parameters' => [
+                    'env(SECRETS_FILE)' => '/opt/application/.secrets.json',
+                    'database_password' => env('SECRETS_FILE')->file()->json()->key('database_password'),
+                    // if SECRETS_FILE contents are: {"database_password": "secret"} it returns "secret"
+                ],
+            ]);
 
 ``env(default:fallback_param:BAR)``
     Retrieves the value of the parameter ``fallback_param`` when the ``BAR`` env
@@ -351,10 +396,15 @@ Symfony provides the following env var processors:
         .. code-block:: php
 
             // config/services.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            // if PRIVATE_KEY is not a valid file path, the content of raw_key is returned
-            $container->setParameter('private_key', '%env(default:raw_key:file:PRIVATE_KEY)%');
-            $container->setParameter('raw_key', '%env(PRIVATE_KEY)%');
+            return App::config([
+                'parameters' => [
+                    // if PRIVATE_KEY is not a valid file path, the content of raw_key is returned
+                    'private_key' => env('PRIVATE_KEY')->file()->default('raw_key'),
+                    'raw_key' => env('PRIVATE_KEY'),
+                ],
+            ]);
 
     When the fallback parameter is omitted (e.g. ``env(default::API_KEY)``), then the
     returned value is ``null``.
@@ -371,34 +421,44 @@ Symfony provides the following env var processors:
 
         .. code-block:: yaml
 
-            # config/services.yaml
-            services:
-                # ...
-
-                some_service:
-                    arguments:
-                        $host: '%env(string:key:host:url:DATABASE_URL)%'
-                        $port: '%env(int:key:port:url:DATABASE_URL)%'
-                        $username: '%env(string:key:user:url:DATABASE_URL)%'
-                        $password: '%env(string:key:pass:url:DATABASE_URL)%'
-                        $database_name: '%env(key:path:url:DATABASE_URL)%'
+            # config/packages/doctrine_mongodb.yaml
+            doctrine_mongodb:
+                clients:
+                    default:
+                        hosts:
+                            - { host: '%env(string:key:host:url:MONGODB_URL)%', port: '%env(int:key:port:url:MONGODB_URL)%' }
+                        username: '%env(string:key:user:url:MONGODB_URL)%'
+                        password: '%env(string:key:pass:url:MONGODB_URL)%'
+                connections:
+                    default:
+                        database_name: '%env(key:path:url:MONGODB_URL)%'
 
         .. code-block:: php
 
-            // config/services.php
+            // config/packages/doctrine_mongodb.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return function(ContainerConfigurator $container): void {
-                // ...
-
-                $services->set(SomeService::class)
-                    ->arg('$host', '%env(string:key:host:url:DATABASE_URL)%')
-                    ->arg('$port', '%env(int:key:port:url:DATABASE_URL)%')
-                    ->arg('$username', '%env(string:key:user:url:DATABASE_URL)%')
-                    ->arg('$password', '%env(string:key:pass:url:DATABASE_URL)%')
-                    ->arg('$database_name', '%env(key:path:url:DATABASE_URL)%')
-                ;
-            };
+            return App::config([
+                'doctrine_mongodb' => [
+                    'clients' => [
+                        'default' => [
+                            'hosts' => [
+                                [
+                                    'host' => env('MONGODB_URL')->url()->key('host')->string(),
+                                    'port' => env('MONGODB_URL')->url()->key('port')->int(),
+                                ],
+                            ],
+                            'username' => env('MONGODB_URL')->url()->key('user')->string(),
+                            'password' => env('MONGODB_URL')->url()->key('pass')->string(),
+                        ],
+                    ],
+                    'connections' => [
+                        'default' => [
+                            'database_name' => env('MONGODB_URL')->url()->key('path'),
+                        ],
+                    ],
+                ],
+            ]);
 
     .. warning::
 
@@ -418,28 +478,28 @@ Symfony provides the following env var processors:
 
         .. code-block:: yaml
 
-            # config/services.yaml
-            services:
-                # ...
-
-                some_service:
-                    arguments:
-                        $serverVersion: '%env(string:key:serverVersion:query_string:DATABASE_URL)%'
-                        $charset: '%env(string:key:charset:query_string:DATABASE_URL)%'
+            # config/packages/doctrine_mongodb.yaml
+            doctrine_mongodb:
+                clients:
+                    default:
+                        # ...
+                        connectTimeoutMS: '%env(int:key:timeout:query_string:MONGODB_URL)%'
 
         .. code-block:: php
 
-            // config/services.php
+            // config/packages/doctrine_mongodb.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return function(ContainerConfigurator $container): void {
-                // ...
-
-                $services->set(SomeService::class)
-                    ->arg('$serverVersion', '%env(string:key:serverVersion:query_string:DATABASE_URL)%')
-                    ->arg('$charset', '%env(int:string:charset:query_string:DATABASE_URL)%')
-                ;
-            };
+            return App::config([
+                'doctrine_mongodb' => [
+                    'clients' => [
+                        'default' => [
+                            // ...
+                            'connectTimeoutMS' => env('MONGODB_URL')->queryString()->key('timeout')->int(),
+                        ],
+                    ],
+                ],
+            ]);
 
 ``env(enum:FooEnum:BAR)``
     Tries to convert an environment variable to an actual ``\BackedEnum`` value.
@@ -465,7 +525,15 @@ Symfony provides the following env var processors:
         .. code-block:: php
 
             // config/services.php
-            $container->setParameter('suit', '%env(enum:App\Enum\Suit:CARD_SUIT)%');
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            use App\Enum\Suit;
+
+            return App::config([
+                'parameters' => [
+                    'suit' => env('CARD_SUIT')->enum(Suit::class),
+                ],
+            ]);
 
     The value stored in the ``CARD_SUIT`` env var would be a string (e.g. ``'spades'``)
     but the application will use the enum value (e.g. ``Suit::Spades``).
@@ -485,7 +553,13 @@ Symfony provides the following env var processors:
         .. code-block:: php
 
             // config/services.php
-            $container->setParameter('typed_env', '%env(defined:FOO)%');
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return App::config([
+                'parameters' => [
+                    'typed_env' => env('FOO')->defined(),
+                ],
+            ]);
 
 .. _urlencode_environment_variable_processor:
 
@@ -498,23 +572,22 @@ Symfony provides the following env var processors:
 
         .. code-block:: yaml
 
-            # config/packages/framework.yaml
+            # config/services.yaml
             parameters:
                 env(DATABASE_URL): 'mysql://db_user:foo@b$r@127.0.0.1:3306/db_name'
                 encoded_database_url: '%env(urlencode:DATABASE_URL)%'
 
         .. code-block:: php
 
-            // config/packages/framework.php
+            // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            use Symfony\Component\DependencyInjection\ContainerBuilder;
-            use Symfony\Config\FrameworkConfig;
-
-            return static function (ContainerBuilder $container): void {
-                $container->setParameter('env(DATABASE_URL)', 'mysql://db_user:foo@b$r@127.0.0.1:3306/db_name');
-                $container->setParameter('encoded_database_url', '%env(urlencode:DATABASE_URL)%');
-            };
+            return App::config([
+                'parameters' => [
+                    'env(DATABASE_URL)' => 'mysql://db_user:foo@b$r@127.0.0.1:3306/db_name',
+                    'encoded_database_url' => env('DATABASE_URL')->urlencode(),
+                ],
+            ]);
 
 It is also possible to combine any number of processors:
 
@@ -522,7 +595,7 @@ It is also possible to combine any number of processors:
 
     .. code-block:: yaml
 
-        # config/packages/framework.yaml
+        # config/packages/google.yaml
         parameters:
             env(AUTH_FILE): "%kernel.project_dir%/config/auth.json"
         google:
@@ -534,14 +607,20 @@ It is also possible to combine any number of processors:
 
     .. code-block:: php
 
-        // config/packages/framework.php
-        $container->setParameter('env(AUTH_FILE)', '%kernel.project_dir%/config/auth.json');
-        // 1. gets the value of the AUTH_FILE env var
-        // 2. replaces the values of any config param to get the config path
-        // 3. gets the content of the file stored in that path
-        // 4. JSON-decodes the content of the file and returns it
-        $container->loadFromExtension('google', [
-            'auth' => '%env(json:file:resolve:AUTH_FILE)%',
+        // config/packages/google.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'parameters' => [
+                'env(AUTH_FILE)' => '%kernel.project_dir%/config/auth.json',
+            ],
+            'google' => [
+                // 1. gets the value of the AUTH_FILE env var
+                // 2. replaces the values of any config param to get the config path
+                // 3. gets the content of the file stored in that path
+                // 4. JSON-decodes the content of the file and returns it
+                'auth' => env('AUTH_FILE')->resolve()->file()->json(),
+            ],
         ]);
 
 Custom Environment Variable Processors
@@ -564,9 +643,9 @@ create a class that implements
 
         public static function getProvidedTypes(): array
         {
-            return [
+            return App::config([
                 'lowercase' => 'string',
-            ];
+            ]);
         }
     }
 

--- a/configuration/front_controllers_and_kernel.rst
+++ b/configuration/front_controllers_and_kernel.rst
@@ -169,12 +169,13 @@ parameter used, for example, to turn Twig's debug mode on:
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            // ...
-            $twig->debug('%kernel.debug%');
-        };
+        return App::config([
+            'twig' => [
+                'debug' => '%kernel.debug%',
+            ],
+        ]);
 
 The Environments
 ----------------

--- a/configuration/micro_kernel_trait.rst
+++ b/configuration/micro_kernel_trait.rst
@@ -360,15 +360,14 @@ because the configuration started to get bigger:
     .. code-block:: php
 
         // config/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework
-                ->secret('SOME_SECRET')
-                ->profiler()
-                    ->onlyExceptions(false)
-            ;
-        };
+        return App::config([
+            'framework' => [
+            'secret' => 'SOME_SECRET',
+                'profiler' => ['only_exceptions' => false],
+            ],
+        ]);
 
 This also loads attribute routes from an ``src/Controller/`` directory, which
 has one file in it::

--- a/configuration/override_dir_structure.rst
+++ b/configuration/override_dir_structure.rst
@@ -170,17 +170,18 @@ for multiple directories):
 
         # config/packages/twig.yaml
         twig:
-            # ...
             default_path: "%kernel.project_dir%/resources/views"
 
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            $twig->defaultPath('%kernel.project_dir%/resources/views');
-        };
+        return App::config([
+            'twig' => [
+                'default_path' => '%kernel.project_dir%/resources/views',
+            ],
+        ]);
 
 Override the Translations Directory
 -----------------------------------
@@ -202,13 +203,15 @@ configuration option to define your own translations directory (use :ref:`framew
     .. code-block:: php
 
         // config/packages/translation.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->translator()
-                ->defaultPath('%kernel.project_dir%/i18n')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'translator' => [
+                    'default_path' => '%kernel.project_dir%/i18n',
+                ],
+            ],
+        ]);
 
 .. _override-web-dir:
 .. _override-the-web-directory:

--- a/configuration/secrets.rst
+++ b/configuration/secrets.rst
@@ -111,20 +111,19 @@ If you stored a ``DATABASE_PASSWORD`` secret, you can reference it by:
         doctrine:
             dbal:
                 password: '%env(DATABASE_PASSWORD)%'
-                # ...
-            # ...
 
     .. code-block:: php
 
         // config/packages/doctrine.php
-        use Symfony\Config\DoctrineConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (DoctrineConfig $doctrine): void {
-            $doctrine->dbal()
-                ->connection('default')
-                    ->password(env('DATABASE_PASSWORD'))
-            ;
-        };
+        return App::config([
+            'doctrine' => [
+                'dbal' => [
+                    'password' => env('DATABASE_PASSWORD'),
+                ],
+            ],
+        ]);
 
 The actual value will be resolved at runtime: container compilation and cache
 warmup don't need the **decryption key**.
@@ -280,12 +279,14 @@ The secrets system is enabled by default and some of its behavior can be configu
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->secrets()
-                // ->vaultDirectory('%kernel.project_dir%/config/secrets/%kernel.environment%')
-                // ->localDotenvFile('%kernel.project_dir%/.env.%kernel.environment%.local')
-                // ->decryptionEnvVar('base64:default::SYMFONY_DECRYPTION_SECRET')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'secrets' => [
+                    // 'vault_directory' => '%kernel.project_dir%/config/secrets/%kernel.environment%',
+                    // 'local_dotenv_file' => '%kernel.project_dir%/.env.%kernel.environment%.local',
+                    // 'decryption_env_var' => 'base64:default::SYMFONY_DECRYPTION_SECRET',
+                ],
+            ],
+        ]);

--- a/console/commands_as_services.rst
+++ b/console/commands_as_services.rst
@@ -81,12 +81,19 @@ Or set the ``command`` attribute on the ``console.command`` tag in your service 
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Command\SunshineCommand;
 
-        // ...
-        $container->register(SunshineCommand::class)
-            ->addTag('console.command', ['command' => 'app:sunshine'])
-        ;
+        return App::config([
+            'services' => [
+                SunshineCommand::class => [
+                    'tags' => [
+                        ['console.command' => ['command' => 'app:sunshine']],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 

--- a/controller/error_pages.rst
+++ b/controller/error_pages.rst
@@ -161,15 +161,17 @@ automatically when installing ``symfony/framework-bundle``):
     .. code-block:: php
 
         // config/routes/framework.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return function (RoutingConfigurator $routes): void {
-            if ('dev' === $routes->env()) {
-                $routes->import('@FrameworkBundle/Resources/config/routing/errors.php', 'php')
-                    ->prefix('/_error')
-                ;
-            }
-        };
+        return Routes::config([
+            'when@dev' => [
+                '_errors' => [
+                    'resource' => '@FrameworkBundle/Resources/config/routing/errors.php',
+                    'type' => 'php',
+                    'prefix' => '/_error',
+                ],
+            ],
+        ]);
 
 With this route added, you can use URLs like these to preview the *error* page
 for a given status code as HTML or for a given status code and format (you might
@@ -245,12 +247,15 @@ configuration option to point to it:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->errorController('App\Controller\ErrorController::show');
-        };
+        use App\Controller\ErrorController;
+
+        return App::config([
+            'framework' => [
+                'error_controller' => [ErrorController::class, 'show'],
+            ],
+        ]);
 
 The :class:`Symfony\\Component\\HttpKernel\\EventListener\\ErrorListener`
 class used by the FrameworkBundle as a listener of the ``kernel.exception`` event creates

--- a/controller/service.rst
+++ b/controller/service.rst
@@ -146,15 +146,17 @@ a service like: ``App\Controller\HelloController::index``:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\HelloController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return function (RoutingConfigurator $routes): void {
-            $routes->add('hello', '/hello')
-                ->controller([HelloController::class, 'index'])
-                ->methods(['GET'])
-            ;
-        };
+        use App\Controller\HelloController;
+
+        return Routes::config([
+            'hello' => [
+                'path' => '/hello',
+                'controller' => [HelloController::class, 'index'],
+                'methods' => ['GET'],
+            ],
+        ]);
 
 .. _controller-service-invoke:
 
@@ -193,12 +195,17 @@ which is a common practice when following the `ADR pattern`_
 
     .. code-block:: php
 
+        // config/routes.php
+        namespace Symfony\Component\Routing\Loader\Configurator;
+
         use App\Controller\HelloController;
 
-        // app/config/routing.php
-        $collection->add('hello', new Route('/hello', [
-            '_controller' => HelloController::class,
-        ]));
+        return Routes::config([
+            'hello' => [
+                'path' => '/hello/{name}',
+                'controller' => [HelloController::class, 'index'],
+            ],
+        ]);
 
 Alternatives to base Controller Methods
 ---------------------------------------

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -292,13 +292,15 @@ Then, define a service for this class:
 
         use App\Service\FileUploader;
 
-        return static function (ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(FileUploader::class)
-                ->arg('$targetDirectory', '%brochures_directory%')
-            ;
-        };
+        return App::config([
+            'services' => [
+                FileUploader::class => [
+                    'arguments' => [
+                        '$targetDirectory' => param('brochures_directory'),
+                    ],
+                ],
+            ],
+        ]);
 
 Now you're ready to use this service in the controller::
 

--- a/controller/value_resolver.rst
+++ b/controller/value_resolver.rst
@@ -369,13 +369,16 @@ but you can set it yourself to change its ``priority`` or ``name`` attributes.
 
         use App\ValueResolver\BookingIdValueResolver;
 
-        return static function (ContainerConfigurator $containerConfigurator): void {
-            $services = $containerConfigurator->services();
-
-            $services->set(BookingIdValueResolver::class)
-                ->tag('controller.argument_value_resolver', ['name' => 'booking_id', 'priority' => 150])
-            ;
-        };
+        return App::config([
+            'services' => [
+                // ...
+                BookingIdValueResolver::class => [
+                    'tags' => [
+                        ['controller.argument_value_resolver' => ['name' => 'booking_id', 'priority' => 150]],
+                    ],
+                ],
+            ],
+        ]);
 
 While adding a priority is optional, it's recommended to add one to make sure
 the expected value is injected. The built-in ``RequestAttributeValueResolver``,

--- a/deployment/proxies.rst
+++ b/deployment/proxies.rst
@@ -47,20 +47,20 @@ using the following configuration options:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework
+        return App::config([
+            'framework' => [
                 // the IP address (or range) of your proxy
-                ->trustedProxies('192.0.0.1,10.0.0.0/8')
+                'trusted_proxies' => ['192.0.0.1,10.0.0.0/8', 'private_ranges'],
                 // shortcut for private IP address ranges of your proxy
-                ->trustedProxies('private_ranges')
-                // trust *all* "X-Forwarded-*" headers (the ! prefix means to not trust those headers)
-                ->trustedHeaders(['x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port', 'x-forwarded-prefix'])
+                'trusted_proxies' => 'private_ranges',
+                // trust *all* "X-Forwarded-*" headers
+                'trusted_headers' => ['x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port', 'x-forwarded-prefix'],
                 // or, if your proxy instead uses the "Forwarded" header
-                ->trustedHeaders(['forwarded'])
-            ;
-        };
+                'trusted_headers' => ['forwarded'],
+            ],
+        ]);
 
 .. danger::
 

--- a/doctrine/custom_dql_functions.rst
+++ b/doctrine/custom_dql_functions.rst
@@ -26,23 +26,31 @@ In Symfony, you can register your custom DQL functions as follows:
     .. code-block:: php
 
         // config/packages/doctrine.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\DQL\DatetimeFunction;
         use App\DQL\NumericFunction;
         use App\DQL\SecondStringFunction;
         use App\DQL\StringFunction;
-        use Symfony\Config\DoctrineConfig;
 
-        return static function (DoctrineConfig $doctrine): void {
-            $defaultDql = $doctrine->orm()
-                ->entityManager('default')
-                    // ...
-                    ->dql();
-
-            $defaultDql->stringFunction('test_string', StringFunction::class);
-            $defaultDql->stringFunction('second_string', SecondStringFunction::class);
-            $defaultDql->numericFunction('test_numeric', NumericFunction::class);
-            $defaultDql->datetimeFunction('test_datetime', DatetimeFunction::class);
-        };
+        return App::config([
+            'doctrine' => [
+                'orm' => [
+                    'dql' => [
+                        'string_functions' => [
+                            'test_string' => StringFunction::class,
+                            'second_string' => SecondStringFunction::class,
+                        ],
+                        'numeric_functions' => [
+                            'test_numeric' => NumericFunction::class,
+                        ],
+                        'datetime_functions' => [
+                            'test_datetime' => DatetimeFunction::class,
+                            ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -68,17 +76,26 @@ In Symfony, you can register your custom DQL functions as follows:
         .. code-block:: php
 
             // config/packages/doctrine.php
-            use App\DQL\DatetimeFunction;
-            use Symfony\Config\DoctrineConfig;
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (DoctrineConfig $doctrine): void {
-                $doctrine->orm()
-                    // ...
-                    ->entityManager('example_manager')
-                        // place your functions here
-                        ->dql()
-                            ->datetimeFunction('test_datetime', DatetimeFunction::class);
-            };
+            use App\DQL\DatetimeFunction;
+
+            return App::config([
+                'doctrine' => [
+                    'orm' => [
+                        'entity_managers' => [
+                            'example_manager' => [
+                                // Place your functions here
+                                'dql' => [
+                                    'datetime_functions' => [
+                                        'test_datetime' => DatetimeFunction::class,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
 
 .. warning::
 

--- a/doctrine/dbal.rst
+++ b/doctrine/dbal.rst
@@ -81,15 +81,21 @@ mapping types, read Doctrine's `Custom Mapping Types`_ section of their document
     .. code-block:: php
 
         // config/packages/doctrine.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Type\CustomFirst;
         use App\Type\CustomSecond;
-        use Symfony\Config\DoctrineConfig;
 
-        return static function (DoctrineConfig $doctrine): void {
-            $dbal = $doctrine->dbal();
-            $dbal->type('custom_first')->class(CustomFirst::class);
-            $dbal->type('custom_second')->class(CustomSecond::class);
-        };
+        return App::config([
+            'doctrine' => [
+                'dbal' => [
+                    'types' => [
+                        'custom_first' => CustomFirst::class,
+                        'custom_second' => CustomSecond::class,
+                    ],
+                ],
+            ],
+        ]);
 
 Registering custom Mapping Types in the SchemaTool
 --------------------------------------------------
@@ -114,13 +120,17 @@ mapping type:
     .. code-block:: php
 
         // config/packages/doctrine.php
-        use Symfony\Config\DoctrineConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (DoctrineConfig $doctrine): void {
-            $dbalDefault = $doctrine->dbal()
-                ->connection('default');
-            $dbalDefault->mappingType('enum', 'string');
-        };
+        return App::config([
+            'doctrine' => [
+            'dbal' => [
+                    'mapping_types' => [
+                        'enum' => 'string',
+                    ],
+                ],
+            ],
+        ]);
 
 .. _`PDO`: https://www.php.net/pdo
 .. _`Doctrine`: https://www.doctrine-project.org/

--- a/doctrine/events.rst
+++ b/doctrine/events.rst
@@ -185,30 +185,33 @@ with the ``doctrine.orm.entity_listener`` tag as follows:
         use App\Entity\User;
         use App\EventListener\UserChangedNotifier;
 
-        return static function (ContainerConfigurator $container): void {
-            $services = $container->services();
+        return App::config([
+            'services' => [
+                UserChangedNotifier::class => [
+                    'tags' => [
+                        [
+                            'doctrine.orm.entity_listener' => [
+                                // these are the options required to define the entity listener
+                                'event' => 'postUpdate',
+                                'entity' => User::class,
 
-            $services->set(UserChangedNotifier::class)
-                ->tag('doctrine.orm.entity_listener', [
-                    // These are the options required to define the entity listener:
-                    'event' => 'postUpdate',
-                    'entity' => User::class,
+                                // these are other options that you may define if needed
+                                // set the 'lazy' option to TRUE to only instantiate listeners when they are used
+                                // 'lazy' => true
 
-                    // These are other options that you may define if needed:
+                                // set the 'entity_manager' option if the listener is not associated to the default manager
+                                // 'entity_manager' => 'custom'
 
-                    // set the 'lazy' option to TRUE to only instantiate listeners when they are used
-                    // 'lazy' => true,
-
-                    // set the 'entity_manager' option if the listener is not associated to the default manager
-                    // 'entity_manager' => 'custom',
-
-                    // by default, Symfony looks for a method called after the event (e.g. postUpdate())
-                    // if it doesn't exist, it tries to execute the '__invoke()' method, but you can
-                    // configure a custom method name with the 'method' option
-                    // 'method' => 'checkUserChanges',
-                ])
-            ;
-        };
+                                // by default, Symfony looks for a method called after the event (e.g. postUpdate())
+                                // if it doesn't exist, it tries to execute the '__invoke()' method, but you can
+                                // configure a custom method name with the 'method' option
+                                // 'method' => 'checkUserChanges'
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _doctrine-lifecycle-listener:
 
@@ -298,24 +301,27 @@ listener in the Symfony application by creating a new service for it and
 
         use App\EventListener\SearchIndexer;
 
-        return static function (ContainerConfigurator $container): void {
-            $services = $container->services();
+        return App::config([
+            'services' => [
+                SearchIndexer::class => [
+                    'tags' => [
+                        [
+                            'doctrine.event_listener' => [
+                                // this is the only required option for the lifecycle listener tag
+                                'event' => 'postPersist',
 
-            // listeners are applied by default to all Doctrine connections
-            $services->set(SearchIndexer::class)
-                ->tag('doctrine.event_listener', [
-                    // this is the only required option for the lifecycle listener tag
-                    'event' => 'postPersist',
+                                // listeners can define their priority in case multiple listeners are associated
+                                // to the same event (default priority = 0; higher numbers = listener is run earlier)
+                                'priority' => 500,
 
-                    // listeners can define their priority in case multiple listeners are associated
-                    // to the same event (default priority = 0; higher numbers = listener is run earlier)
-                    'priority' => 500,
-
-                    # you can also restrict listeners to a specific Doctrine connection
-                    'connection' => 'default',
-                ])
-            ;
-        };
+                                // you can also restrict listeners to a specific Doctrine connection
+                                'connection' => 'default',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. versionadded:: 2.8.0
 

--- a/doctrine/multiple_entity_managers.rst
+++ b/doctrine/multiple_entity_managers.rst
@@ -58,36 +58,50 @@ The following configuration code shows how you can configure two entity managers
     .. code-block:: php
 
         // config/packages/doctrine.php
-        use Symfony\Config\DoctrineConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (DoctrineConfig $doctrine): void {
-            // Connections:
-            $doctrine->dbal()
-                ->connection('default')
-                ->url(env('DATABASE_URL')->resolve());
-            $doctrine->dbal()
-                ->connection('customer')
-                ->url(env('CUSTOMER_DATABASE_URL')->resolve());
-            $doctrine->dbal()->defaultConnection('default');
-
-            // Entity Managers:
-            $doctrine->orm()->defaultEntityManager('default');
-            $defaultEntityManager = $doctrine->orm()->entityManager('default');
-            $defaultEntityManager->connection('default');
-            $defaultEntityManager->mapping('Main')
-                ->isBundle(false)
-                ->dir('%kernel.project_dir%/src/Entity/Main')
-                ->prefix('App\Entity\Main')
-                ->alias('Main');
-            $customerEntityManager = $doctrine->orm()->entityManager('customer');
-            $customerEntityManager->connection('customer');
-            $customerEntityManager->mapping('Customer')
-                ->isBundle(false)
-                ->dir('%kernel.project_dir%/src/Entity/Customer')
-                ->prefix('App\Entity\Customer')
-                ->alias('Customer')
-            ;
-        };
+        return App::config([
+            'doctrine' => [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'url' => env('DATABASE_URL')->resolve(),
+                        ],
+                        'customer' => [
+                            'url' => env('CUSTOMER_DATABASE_URL')->resolve(),
+                        ],
+                    ],
+                    'default_connection' => 'default',
+                ],
+                'orm' => [
+                    'default_entity_manager' => 'default',
+                    'entity_managers' => [
+                        'default' => [
+                            'connection' => 'default',
+                            'mappings' => [
+                                'Main' => [
+                                    'is_bundle' => false,
+                                    'dir' => '%kernel.project_dir%/src/Entity/Main',
+                                    'prefix' => 'App\Entity\Main',
+                                    'alias' => 'Main',
+                                ],
+                            ],
+                        ],
+                        'customer' => [
+                            'connection' => 'customer',
+                            'mappings' => [
+                                'Customer' => [
+                                    'is_bundle' => false,
+                                    'dir' => '%kernel.project_dir%/src/Entity/Customer',
+                                    'prefix' => 'App\Entity\Customer',
+                                    'alias' => 'Customer',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 In this case, you've defined two entity managers and called them ``default``
 and ``customer``. The ``default`` entity manager manages entities in the

--- a/doctrine/resolve_target_entity.rst
+++ b/doctrine/resolve_target_entity.rst
@@ -105,15 +105,20 @@ how to replace the interface with the concrete class:
     .. code-block:: php
 
         // config/packages/doctrine.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Entity\Customer;
         use App\Model\InvoiceSubjectInterface;
-        use Symfony\Config\DoctrineConfig;
 
-        return static function (DoctrineConfig $doctrine): void {
-            $orm = $doctrine->orm();
-            // ...
-            $orm->resolveTargetEntity(InvoiceSubjectInterface::class, Customer::class);
-        };
+        return App::config([
+            'doctrine' => [
+                'orm' => [
+                    'resolve_target_entities' => [
+                        InvoiceSubjectInterface::class => Customer::class,
+                    ],
+                ],
+            ],
+        ]);
 
 Final Thoughts
 --------------

--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -78,13 +78,13 @@ notify Symfony that it is an event listener by using a special "tag":
 
         use App\EventListener\ExceptionListener;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(ExceptionListener::class)
-                ->tag('kernel.event_listener')
-            ;
-        };
+        return App::config([
+            'services' => [
+                ExceptionListener::class => [
+                    'tags' => ['kernel.event_listener'],
+                ],
+            ],
+        ]);
 
 Symfony follows this logic to decide which method to call inside the event
 listener class:
@@ -250,13 +250,13 @@ via its ``ExceptionEvent`` class::
         public static function getSubscribedEvents(): array
         {
             // return the subscribed events, their methods and priorities
-            return [
+            return App::config([
                 ExceptionEvent::class => [
                     ['processException', 10],
                     ['logException', 0],
                     ['notifyException', -10],
                 ],
-            ];
+            ]);
         }
 
         public function processException(ExceptionEvent $event): void
@@ -348,9 +348,9 @@ name (FQCN) of the corresponding event class::
     {
         public static function getSubscribedEvents(): array
         {
-            return [
+            return App::config([
                 RequestEvent::class => 'onKernelRequest',
-            ];
+            ]);
         }
 
         public function onKernelRequest(RequestEvent $event): void
@@ -470,9 +470,15 @@ First, define some token configuration as parameters:
     .. code-block:: php
 
         // config/services.php
-        $container->setParameter('tokens', [
-            'client1' => 'pass1',
-            'client2' => 'pass2',
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'parameters' => [
+                'tokens' => [
+                    'client1' => 'pass1',
+                    'client2' => 'pass2',
+                ],
+            ],
         ]);
 
 Tag Controllers to Be Checked
@@ -552,9 +558,9 @@ event subscribers, you can learn more about :ref:`how to use them <events-subscr
 
         public static function getSubscribedEvents(): array
         {
-            return [
+            return App::config([
                 KernelEvents::CONTROLLER => 'onKernelController',
-            ];
+            ]);
         }
     }
 
@@ -627,10 +633,10 @@ header on the response if it's found::
 
     public static function getSubscribedEvents(): array
     {
-        return [
+        return App::config([
             KernelEvents::CONTROLLER => 'onKernelController',
             KernelEvents::RESPONSE => 'onKernelResponse',
-        ];
+        ]);
     }
 
 That's it! The ``TokenSubscriber`` is now notified before every controller is
@@ -766,9 +772,9 @@ could listen to the ``mailer.post_send`` event and change the method's return va
 
         public static function getSubscribedEvents(): array
         {
-            return [
+            return App::config([
                 'mailer.post_send' => 'onMailerPostSend',
-            ];
+            ]);
         }
     }
 

--- a/form/bootstrap4.rst
+++ b/form/bootstrap4.rst
@@ -37,13 +37,13 @@ configuration:
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            $twig->formThemes(['bootstrap_4_layout.html.twig']);
-
-            // ...
-        };
+        return App::config([
+            'twig' => [
+                'form_themes' => ['bootstrap_4_layout.html.twig'],
+            ],
+        ]);
 
 If you prefer to apply the Bootstrap styles on a form to form basis, include the
 ``form_theme`` tag in the templates where those forms are used:

--- a/form/bootstrap5.rst
+++ b/form/bootstrap5.rst
@@ -37,13 +37,13 @@ configuration:
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function(TwigConfig $twig): void {
-            $twig->formThemes(['bootstrap_5_layout.html.twig']);
-
-            // ...
-        };
+        return App::config([
+            'twig' => [
+                'form_themes' => ['bootstrap_5_layout.html.twig'],
+            ],
+        ]);
 
 If you prefer to apply the Bootstrap styles on a form to form basis, include the
 ``form_theme`` tag in the templates where those forms are used:

--- a/form/create_custom_field_type.rst
+++ b/form/create_custom_field_type.rst
@@ -379,14 +379,16 @@ add this new template at the end of the list (each theme overrides all the previ
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            $twig->formThemes([
-                '...',
-                'form/custom_types.html.twig',
-            ]);
-        };
+        return App::config([
+            'twig' => [
+                'form_themes' => [
+                    '...',
+                    'form/custom_types.html.twig',
+                ],
+            ],
+        ]);
 
 The last step is to create the actual Twig template that will render the type.
 The template contents depend on which HTML, CSS and JavaScript frameworks and

--- a/form/form_themes.rst
+++ b/form/form_themes.rst
@@ -70,15 +70,13 @@ want to use another theme for all the forms of your app, configure it in the
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            $twig->formThemes([
-                'bootstrap_5_horizontal_layout.html.twig',
-            ]);
-
-            // ...
-        };
+        return App::config([
+            'twig' => [
+                'form_themes' => ['bootstrap_5_horizontal_layout.html.twig'],
+            ],
+        ]);
 
 You can pass multiple themes to this option because sometimes form themes only
 redefine a few elements. This way, if some theme doesn't override some element,
@@ -480,15 +478,13 @@ you want to apply the theme globally to all forms, define the
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            $twig->formThemes([
-                'form/my_theme.html.twig',
-            ]);
-
-            // ...
-        };
+        return App::config([
+            'twig' => [
+                'form_themes' => ['form/my_theme.html.twig'],
+            ],
+        ]);
 
 If you only want to apply it to some specific forms, use the ``form_theme`` tag:
 

--- a/form/type_guesser.rst
+++ b/form/type_guesser.rst
@@ -194,11 +194,17 @@ and tag it with ``form.type_guesser``:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Form\TypeGuesser\PhpDocTypeGuesser;
 
-        $container->register(PhpDocTypeGuesser::class)
-            ->addTag('form.type_guesser')
-        ;
+        return App::config([
+            'services' => [
+                PhpDocTypeGuesser::class => [
+                    'tags' => ['form.type_guesser'],
+                ],
+            ],
+        ]);
 
 .. sidebar:: Registering a Type Guesser in the Component
 

--- a/forms.rst
+++ b/forms.rst
@@ -342,13 +342,13 @@ can set this option to generate forms compatible with the Bootstrap 5 CSS framew
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            $twig->formThemes(['bootstrap_5_layout.html.twig']);
-
-            // ...
-        };
+        return App::config([
+            'twig' => [
+                'form_themes' => ['bootstrap_5_layout.html.twig'],
+            ],
+        ]);
 
 The :ref:`built-in Symfony form themes <symfony-builtin-forms>` include
 Bootstrap 3, 4 and 5, Foundation 5 and 6, as well as Tailwind 2. You can also

--- a/frontend/custom_version_strategy.rst
+++ b/frontend/custom_version_strategy.rst
@@ -112,17 +112,16 @@ After creating the strategy PHP class, register it as a Symfony service.
 
         use App\Asset\VersionStrategy\GulpBusterVersionStrategy;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(GulpBusterVersionStrategy::class)
-                ->args(
-                    [
+        return App::config([
+            'services' => [
+                GulpBusterVersionStrategy::class => [
+                    'arguments' => [
                         '%kernel.project_dir%/busters.json',
                         '%%s?version=%%s',
-                    ]
-                );
-        };
+                    ],
+                ],
+            ],
+        ]);
 
 Finally, enable the new asset versioning for all the application assets or just
 for some :ref:`asset package <reference-framework-assets-packages>` thanks to
@@ -141,14 +140,16 @@ the :ref:`version_strategy <reference-assets-version-strategy>` option:
     .. code-block:: php
 
         // config/packages/framework.php
-        use App\Asset\VersionStrategy\GulpBusterVersionStrategy;
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->assets()
-                ->versionStrategy(GulpBusterVersionStrategy::class)
-            ;
-        };
+        use App\Asset\VersionStrategy\GulpBusterVersionStrategy;
+
+        return App::config([
+            'framework' => [
+                'assets' => [
+                    'version_strategy' => GulpBusterVersionStrategy::class,
+                ],
+            ],
+        ]);
 
 .. _`gulp-buster`: https://www.npmjs.com/package/gulp-buster

--- a/frontend/encore/faq.rst
+++ b/frontend/encore/faq.rst
@@ -186,10 +186,24 @@ functions to trigger exceptions when there's no ``entrypoints.json`` file):
 
 .. code-block:: yaml
 
-    # config/packages/test/webpack_encore.yaml
-    webpack_encore:
-        strict_mode: false
-        # ...
+    # config/packages/webpack_encore.yaml
+    when@test:
+        webpack_encore:
+            strict_mode: false
+            # ...
+
+.. code-block:: php
+
+    // config/packages/webpack_encore.php
+    namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+    return App::config([
+        'when@test' => [
+            'webpack_encore' => [
+                'strict_mode' => false,
+            ],
+        ],
+    ]);
 
 .. _`rsync`: https://rsync.samba.org/
 .. _`Webpack integration in PhpStorm`: https://www.jetbrains.com/help/phpstorm/using-webpack.html

--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -171,14 +171,19 @@ You can do this by defining a new HTML sanitizer in the configuration:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->htmlSanitizer()
-                ->sanitizer('app.post_sanitizer')
-                    ->blockElement('h1')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'html_sanitizer' => [
+                    'sanitizers' => [
+                        'app.post_sanitizer' => [
+                            'block_elements' => ['h1'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -264,16 +269,21 @@ Safe elements
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->htmlSanitizer()
-                ->sanitizer('app.post_sanitizer')
-                    // enable either of these
-                    ->allowSafeElements(true)
-                    ->allowStaticElements(true)
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'html_sanitizer' => [
+                    'sanitizers' => [
+                        'app.post_sanitizer' => [
+                            // enable either of these
+                            'allow_safe_elements' => true,
+                            'allow_static_elements' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -317,24 +327,28 @@ attributes from the `W3C Standard Proposal`_ are allowed.
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->htmlSanitizer()
-                ->sanitizer('app.post_sanitizer')
-                    // allow the <article> element and 2 attributes
-                    ->allowElement('article', ['class', 'data-attr'])
-
-                    // allow the <img> element and preserve the src attribute
-                    ->allowElement('img', 'src')
-
-                    // allow the <h1> element with all safe attributes
-                    ->allowElement('h1', '*')
-
-                    // allow the <div> element with no attributes
-                    ->allowElement('div', [])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'html_sanitizer' => [
+                    'sanitizers' => [
+                        'app.post_sanitizer' => [
+                            'allow_elements' => [
+                                // allow the <article> element and 2 attributes
+                                'article' => ['class', 'data-attr'],
+                                // allow the <img> element and preserve the src attribute
+                                'img' => 'src',
+                                // allow the <h1> element with all safe attributes
+                                'h1' => '*',
+                                // allow the <div> element with no attributes
+                                'div' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -384,17 +398,22 @@ This can also be used to remove elements from the allow list.
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->htmlSanitizer()
-                ->sanitizer('app.post_sanitizer')
-                    // remove <div>, but process the children
-                    ->blockElement('div')
-                    // remove <figure> and its children
-                    ->dropElement('figure')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'html_sanitizer' => [
+                    'sanitizers' => [
+                        'app.post_sanitizer' => [
+                            // remove <div>, but process the children
+                            'block_elements' => ['div'],
+                            // remove <figure> and its children
+                            'drop_elements' => ['figure'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -436,18 +455,24 @@ on all elements allowed *before this setting*.
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->htmlSanitizer()
-                ->sanitizer('app.post_sanitizer')
-                    // allow "src' on <iframe> elements
-                    ->allowAttribute('src', ['iframe'])
-
-                    // allow "data-attr" on all elements currently allowed
-                    ->allowAttribute('data-attr', '*')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'html_sanitizer' => [
+                    'sanitizers' => [
+                        'app.post_sanitizer' => [
+                            'allow_attributes' => [
+                                // allow "src' on <iframe> elements
+                                'src' => ['iframe'],
+                                // allow "data-attr" on all elements currently allowed
+                                'data-attr' => '*',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -491,21 +516,28 @@ This option allows you to disallow attributes that were allowed before.
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->htmlSanitizer()
-                ->sanitizer('app.post_sanitizer')
-                    // allow the "data-attr" on all safe elements...
-                    ->allowAttribute('data-attr', '*')
-
-                    // ...except for the <section> element
-                    ->dropAttribute('data-attr', ['section'])
-
-                    // disallows "style' on any allowed element
-                    ->dropAttribute('style', '*')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'html_sanitizer' => [
+                    'sanitizers' => [
+                        'app.post_sanitizer' => [
+                            'allow_attributes' => [
+                                // allow the "data-attr" on all safe elements...
+                                'data-attr' => '*',
+                            ],
+                            'drop_attributes' => [
+                                // ... except for the <section> element
+                                'data-attr' => ['section'],
+                                // disallows "style" on any allowed element
+                                'style' => '*',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -548,14 +580,23 @@ element (even if the original one didn't contain a ``rel`` attribute):
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->htmlSanitizer()
-                ->sanitizer('app.post_sanitizer')
-                    ->forceAttribute('a', ['rel' => 'noopener noreferrer'])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'html_sanitizer' => [
+                    'sanitizers' => [
+                        'app.post_sanitizer' => [
+                            'force_attributes' => [
+                                'a' => [
+                                    'rel' => 'noopener noreferrer',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -606,29 +647,32 @@ URLs of ``<a>`` elements:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+        return App::config([
+            'framework' => [
+                'html_sanitizer' => [
+                    'sanitizers' => [
+                        'app.post_sanitizer' => [
+                            // if `true`, all URLs using the `http://` scheme will be converted to
+                            // use the `https://` scheme instead. `http` still needs to be
+                            // allowed in `allowed_link_schemes`
+                            'force_https_urls' => true,
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->htmlSanitizer()
-                ->sanitizer('app.post_sanitizer')
-                    // if `true`, all URLs using the `http://` scheme will be converted to
-                    // use the `https://` scheme instead. `http` still needs to be
-                    // allowed in `allowedLinkSchemes`
-                    ->forceHttpsUrls(true)
+                            // specifies the allowed URL schemes. If the URL has a different scheme, the
+                            // attribute will be dropped
+                            'allowed_link_schemes' => ['http', 'https', 'mailto'],
 
-                    // specifies the allowed URL schemes. If the URL has a different scheme, the
-                    // attribute will be dropped
-                    ->allowedLinkSchemes(['http', 'https', 'mailto'])
+                            // specifies the allowed hosts, the attribute will be dropped if the
+                            // URL contains a different host which is not a subdomain of the allowed host
+                            'allowed_link_hosts' => ['symfony.com'],
 
-                    // specifies the allowed hosts, the attribute will be dropped if the
-                    // URL contains a different host. Subdomains are allowed: e.g. the following
-                    // config would also allow 'www.symfony.com', 'live.symfony.com', etc.
-                    ->allowedLinkHosts(['symfony.com'])
-
-                    // whether to allow relative links (i.e. URLs without scheme and host)
-                    ->allowRelativeLinks(true)
-            ;
-        };
+                            // whether to allow relative links (i.e. URLs without scheme and host)
+                            'allow_relative_links' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -691,28 +735,33 @@ the HTML sanitizer: ``src``, ``href``, ``lowsrc``, ``background`` and ``ping``.
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->htmlSanitizer()
-                ->sanitizer('app.post_sanitizer')
-                    // if `true`, all URLs using the `http://` scheme will be converted to
-                    // use the `https://` scheme instead. `http` still needs to be
-                    // allowed in `allowedMediaSchemes`
-                    ->forceHttpsUrls(true)
+        return App::config([
+            'framework' => [
+                'html_sanitizer' => [
+                    'sanitizers' => [
+                        'app.post_sanitizer' => [
+                            // if `true`, all URLs using the `http://` scheme will be converted to
+                            // use the `https://` scheme instead. `http` still needs to be
+                            // allowed in `allowed_media_schemes`
+                            'force_https_urls' => true,
 
-                    // specifies the allowed URL schemes. If the URL has a different scheme, the
-                    // attribute will be dropped
-                    ->allowedMediaSchemes(['http', 'https', 'mailto'])
+                            // specifies the allowed URL schemes. If the URL has a different scheme, the
+                            // attribute will be dropped
+                            'allowed_media_schemes' => ['http', 'https', 'mailto'],
 
-                    // specifies the allowed hosts, the attribute will be dropped if the URL
-                    // contains a different host which is not a subdomain of the allowed host
-                    ->allowedMediaHosts(['symfony.com']) // Also allows any subdomain (i.e. www.symfony.com)
+                            // specifies the allowed hosts, the attribute will be dropped if the URL
+                            // contains a different host which is not a subdomain of the allowed host
+                            'allowed_media_hosts' => ['symfony.com'],
 
-                    // whether to allow relative URLs (i.e. URLs without scheme and host)
-                    ->allowRelativeMedias(true)
-            ;
-        };
+                            // whether to allow relative URLs (i.e. URLs without scheme and host)
+                            'allow_relative_medias' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -763,15 +812,20 @@ increase or decrease this limit:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->htmlSanitizer()
-                ->sanitizer('app.post_sanitizer')
-                    // inputs longer (in characters) than this value will be truncated (default: 20000)
-                    ->withMaxInputLength(20000)
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'html_sanitizer' => [
+                    'sanitizers' => [
+                        'app.post_sanitizer' => [
+                            // inputs longer (in characters) than this value will be truncated
+                            'max_input_length' => 30000, // default: 20000
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -818,18 +872,27 @@ to enable it for an HTML sanitizer:
     .. code-block:: php
 
         // config/packages/framework.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Sanitizer\CustomAttributeSanitizer;
-        use Symfony\Config\FrameworkConfig;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->htmlSanitizer()
-                ->sanitizer('app.post_sanitizer')
-                    ->withAttributeSanitizer(CustomAttributeSanitizer::class)
-
-                    // you can also disable previously enabled attribute sanitizers
-                    //->withoutAttributeSanitizer(CustomAttributeSanitizer::class)
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'html_sanitizer' => [
+                    'sanitizers' => [
+                        'app.post_sanitizer' => [
+                            'with_attribute_sanitizers' => [
+                                CustomAttributeSanitizer::class,
+                            ],
+                            // you can also disable previously enabled custom attribute sanitizers
+                            // 'without_attribute_sanitizers' => [
+                            //    CustomAttributeSanitizer::class,
+                            // ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 

--- a/http_cache.rst
+++ b/http_cache.rst
@@ -82,13 +82,15 @@ Use the ``framework.http_cache`` option to enable the proxy for the
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework, string $env): void {
-            if ('prod' === $env) {
-                $framework->httpCache()->enabled(true);
-            }
-        };
+        return App::config([
+            'framework' => [
+                'http_cache' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]);
 
 The kernel will immediately act as a reverse proxy: caching responses
 from your application and returning them to the client.

--- a/http_cache/cache_invalidation.rst
+++ b/http_cache/cache_invalidation.rst
@@ -121,18 +121,18 @@ Then, register the class as a service that :doc:`decorates </service_container/s
 
         use App\CacheKernel;
 
-        return function (ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(CacheKernel::class)
-                ->decorate('http_cache')
-                ->args([
-                    service('kernel'),
-                    service('http_cache.store'),
-                    service('esi')->nullOnInvalid(),
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                CacheKernel::class => [
+                    'decorates' => 'http_cache',
+                    'arguments' => [
+                        service('kernel'),
+                        service('http_cache.store'),
+                        service('esi')->nullOnInvalid(),
+                    ],
+                ],
+            ],
+        ]);
 
 .. danger::
 

--- a/http_cache/esi.rst
+++ b/http_cache/esi.rst
@@ -66,13 +66,15 @@ First, to use ESI, be sure to enable it in your application configuration:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->esi()
-                ->enabled(true)
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'esi' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]);
 
 Now, suppose you have a page that is relatively static, except for a news
 ticker at the bottom of the content. With ESI, you can cache the news ticker
@@ -210,14 +212,15 @@ that must be enabled in your configuration:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->fragments()
-                ->path('/_fragment')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'fragments' => [
+                    'path' => '/_fragment',
+                ],
+            ],
+        ]);
 
 One great advantage of the ESI renderer is that you can make your application
 as dynamic as needed and at the same time, hit the application as little as

--- a/http_cache/ssi.rst
+++ b/http_cache/ssi.rst
@@ -55,13 +55,15 @@ First, to use SSI, be sure to enable it in your application configuration:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->ssi()
-                ->enabled(true)
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'ssi' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]);
 
 Suppose you have a page with private content like a Profile page and you want
 to cache a static GDPR content block. With SSI, you can add some expiration

--- a/http_client.rst
+++ b/http_client.rst
@@ -102,14 +102,17 @@ You can configure the global options using the ``default_options`` option:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->httpClient()
-                ->defaultOptions()
-                    ->maxRedirects(7)
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'http_client' => [
+                    'default_options' => [
+                        'max_redirects' => 7,
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -169,14 +172,15 @@ This option cannot be overridden per request:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->httpClient()
-                ->maxHostConnections(10)
-                // ...
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'http_client' => [
+                    'max_host_connections' => 10,
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -219,26 +223,34 @@ autoconfigure the HTTP client based on the requested URL:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // only requests matching scope will use these options
-            $framework->httpClient()->scopedClient('github.client')
-                ->scope('https://api\.github\.com')
-                ->header('Accept', 'application/vnd.github.v3+json')
-                ->header('Authorization', 'token %env(GITHUB_API_TOKEN)%')
-                // ...
-            ;
+        return App::config([
+            'framework' => [
+                'http_client' => [
+                    'scoped_clients' => [
+                        // only requests matching scope will use these options
+                        'github.client' => [
+                            'scope' => 'https://api\.github\.com',
+                            'headers' => [
+                                'Accept' => 'application/vnd.github.v3+json',
+                                'Authorization' => 'token %env(GITHUB_API_TOKEN)%',
+                            ],
+                        ],
 
-            // using base_url, relative URLs (e.g. request("GET", "/repos/symfony/symfony-docs"))
-            // will default to these options
-            $framework->httpClient()->scopedClient('github.client')
-                ->baseUri('https://api.github.com')
-                ->header('Accept', 'application/vnd.github.v3+json')
-                ->header('Authorization', 'token %env(GITHUB_API_TOKEN)%')
-                // ...
-            ;
-        };
+                        // using base_uri, relative URLs (e.g. request("GET", "/repos/symfony/symfony-docs"))
+                        // will default to these options
+                        'github.client' => [
+                            'base_uri' => 'https://api.github.com',
+                            'headers' => [
+                                'Accept' => 'application/vnd.github.v3+json',
+                                'Authorization' => 'token %env(GITHUB_API_TOKEN)%',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -356,21 +368,28 @@ each request (which overrides any global authentication):
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->httpClient()->scopedClient('example_api')
-                ->baseUri('https://example.com/')
-                // HTTP Basic authentication
-                ->authBasic('the-username:the-password')
+        return App::config([
+            'framework' => [
+                'http_client' => [
+                    'scoped_clients' => [
+                        'example_api' => [
+                            'base_uri' => 'https://example.com/',
 
-                // HTTP Bearer authentication (also called token authentication)
-                ->authBearer('the-bearer-token')
+                            // HTTP Basic authentication
+                            'auth_basic' => 'the-username:the-password',
 
-                // Microsoft NTLM authentication
-                ->authNtlm('the-username:the-password')
-            ;
-        };
+                            // HTTP Bearer authentication (also called token authentication)
+                            'auth_bearer' => 'the-bearer-token',
+
+                            // Microsoft NTLM authentication
+                            'auth_ntlm' => 'the-username:the-password',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -443,14 +462,19 @@ Use the ``headers`` option to define the default headers added to all requests:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->httpClient()
-                ->defaultOptions()
-                    ->header('User-Agent', 'My Fancy App')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'http_client' => [
+                    'default_options' => [
+                        'headers' => [
+                            'User-Agent' => 'My Fancy App',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -840,14 +864,19 @@ of your application:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework) {
-            $framework->httpClient()
-                ->defaultOptions()
-                    ->vars(['secret' => 'secret-token'])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'http_client' => [
+                    'default_options' => [
+                        'vars' => [
+                            'secret' => 'secret-token',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 If you want to define your own logic to handle variables of URI templates, you
 can do so by redefining the ``http_client.uri_template_expander`` alias. Your
@@ -976,14 +1005,17 @@ To force HTTP/2 for ``http`` URLs, you need to enable it explicitly via the
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->httpClient()
-                ->defaultOptions()
-                    ->httpVersion('2.0')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'http_client' => [
+                    'default_options' => [
+                        'http_version' => '2.0',
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -1473,25 +1505,28 @@ installed in your application::
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->httpClient()->scopedClient('example.client')
-                ->baseUri('https://example.com')
-                ->rateLimiter('http_example_limiter');
-                // ...
-            ;
-
-            $framework->rateLimiter()
-                // Don't send more than 10 requests in 5 seconds
-                ->limiter('http_example_limiter')
-                    ->policy('token_bucket')
-                    ->limit(10)
-                    ->rate()
-                        ->interval('5 seconds')
-                        ->amount(10)
-                ;
-        };
+        return App::config([
+            'framework' => [
+                'http_client' => [
+                    'scoped_clients' => [
+                        'example.client' => [
+                            'base_uri' => 'https://example.com',
+                            'rate_limiter' => 'http_example_limiter',
+                        ],
+                    ],
+                    'rate_limiter' => [
+                        // Don't send more than 10 requests in 5 seconds
+                        'http_example_limiter' => [
+                            'policy' => 'token_bucket',
+                            'limit' => 10,
+                            'rate' => ['interval' => '5 seconds', 'amount' => 10],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -2085,26 +2120,26 @@ Then configure Symfony to use your callback:
 
     .. code-block:: yaml
 
-        # config/services_test.yaml
-        services:
-            # ...
-            App\Tests\MockClientCallback: ~
-
-        # config/packages/test/framework.yaml
-        framework:
-            http_client:
-                mock_response_factory: App\Tests\MockClientCallback
+        # config/packages/framework.yaml
+        when@test:
+            framework:
+                http_client:
+                    mock_response_factory: App\Tests\MockClientCallback
 
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->httpClient()
-                ->mockResponseFactory(MockClientCallback::class)
-            ;
-        };
+        use App\Tests\MockClientCallback;
+
+        return App::config([
+            'when@test' => 'framework' => [
+                'http_client' => [
+                    'mock_response_factory' => MockClientCallback::class,
+                ],
+            ],
+        ]);
 
 To return json, you would normally do::
 

--- a/lock.rst
+++ b/lock.rst
@@ -74,38 +74,40 @@ this behavior by using the ``lock`` key like:
     .. code-block:: php
 
         // config/packages/lock.php
-        use Symfony\Config\FrameworkConfig;
-        use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->lock()
-                ->resource('default', ['flock'])
-                ->resource('default', ['flock:///path/to/file'])
-                ->resource('default', ['semaphore'])
-                ->resource('default', ['memcached://m1.docker'])
-                ->resource('default', ['memcached://m1.docker', 'memcached://m2.docker'])
-                ->resource('default', ['redis://r1.docker'])
-                ->resource('default', ['redis://r1.docker', 'redis://r2.docker'])
-                ->resource('default', ['zookeeper://z1.docker'])
-                ->resource('default', ['zookeeper://z1.docker,z2.docker'])
-                ->resource('default', ['zookeeper://localhost01,localhost02:2181'])
-                ->resource('default', ['sqlite:///%kernel.project_dir%/var/lock.db'])
-                ->resource('default', ['mysql:host=127.0.0.1;dbname=app'])
-                ->resource('default', ['pgsql:host=127.0.0.1;dbname=app'])
-                ->resource('default', ['pgsql+advisory:host=127.0.0.1;dbname=app'])
-                ->resource('default', ['sqlsrv:server=127.0.0.1;Database=app'])
-                ->resource('default', ['oci:host=127.0.0.1;dbname=app'])
-                ->resource('default', ['mongodb://127.0.0.1/app?collection=lock'])
-                ->resource('default', ['dynamodb://127.0.0.1/lock'])
-                ->resource('default', [env('LOCK_DSN')])
+        return App::config([
+            'framework' => [
+                'lock' => null,
+                'lock' => 'flock',
+                'lock' => 'flock:///path/to/file',
+                'lock' => 'semaphore',
+                'lock' => 'memcached://m1.docker',
+                'lock' => 'memcached://m1.docker,memcached://m2.docker',
+                'lock' => 'redis://r1.docker',
+                'lock' => 'redis://r1.docker,redis://r2.docker',
+                'lock' => 'rediss://r1.docker?ssl[verify_peer]=1&ssl[cafile]=...',
+                'lock' => 'zookeeper://z1.docker',
+                'lock' => 'zookeeper://z1.docker,z2.docker',
+                'lock' => 'zookeeper://localhost01,localhost02:2181',
+                'lock' => 'sqlite:///%kernel.project_dir%/var/lock.db',
+                'lock' => 'mysql:host=127.0.0.1;dbname=app',
+                'lock' => 'pgsql:host=127.0.0.1;dbname=app',
+                'lock' => 'pgsql+advisory:host=127.0.0.1;dbname=app',
+                'lock' => 'sqlsrv:server=127.0.0.1;Database=app',
+                'lock' => 'oci:host=127.0.0.1;dbname=app',
+                'lock' => 'mongodb://127.0.0.1/app?collection=lock',
+                'lock' => 'dynamodb://127.0.0.1/lock',
+                'lock' => env('LOCK_DSN'),
                 // using an existing service
-                ->resource('default', ['snc_redis.default'])
-
+                'lock' => 'snc_redis.default',
                 // named locks
-                ->resource('invoice', ['semaphore', 'redis://r2.docker'])
-                ->resource('report', ['semaphore'])
-            ;
-        };
+                'lock' => [
+                    'invoice' => ['semaphore', 'redis://r2.docker'],
+                    'report' => 'semaphore',
+                ],
+            ],
+        ]);
 
 Locking a Resource
 ------------------
@@ -198,14 +200,16 @@ provides :ref:`named lock <reference-lock-resources-name>`:
     .. code-block:: php
 
         // config/packages/lock.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->lock()
-                ->resource('invoice', ['semaphore', 'redis://r2.docker'])
-                ->resource('report', ['semaphore']);
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'lock' => [
+                    'invoice' => ['semaphore', 'redis://r2.docker'],
+                    'report' => 'semaphore',
+                ],
+            ],
+        ]);
 
 After having configured one or more named locks, you have two ways of injecting
 them in any service or controller:

--- a/logging.rst
+++ b/logging.rst
@@ -136,23 +136,28 @@ to write logs using the :phpfunction:`syslog` function:
     .. code-block:: php
 
         // config/packages/prod/monolog.php
-        use Psr\Log\LogLevel;
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            // this "file_log" key could be anything
-            $monolog->handler('file_log')
-                ->type('stream')
-                // log to var/logs/(environment).log
-                ->path('%kernel.logs_dir%/%kernel.environment%.log')
-                // log *all* messages (LogLevel::DEBUG is lowest level)
-                ->level(LogLevel::DEBUG);
-
-            $monolog->handler('syslog_handler')
-                ->type('syslog')
-                // log error-level messages and higher
-                ->level(LogLevel::ERROR);
-        };
+        return App::config([
+            'monolog' => [
+                // this "file_log" key could be anything
+                'handlers' => [
+                    // this "file_log" key could be anything
+                    'file_log' => [
+                        'type' => 'stream',
+                        // log to var/logs/(environment).log
+                        'path' => '%kernel.logs_dir%/%kernel.environment%.log',
+                        // log *all* messages (LogLevel::DEBUG is lowest level)
+                        'level' => 'debug',
+                    ],
+                    'syslog_handler' => [
+                        'type' => 'syslog',
+                        // log error-level messages and higher
+                        'level' => 'error',
+                    ],
+                ],
+            ],
+        ]);
 
 This defines a stack of handlers. Each handler can define a ``priority``
 (default ``0``) to control its position in the stack. Handlers with a higher
@@ -177,20 +182,22 @@ which they are defined:
     .. code-block:: php
 
         // config/packages/prod/monolog.php
-        use Psr\Log\LogLevel;
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $monolog->handler('file_log')
-                ->type('stream')
-                ->path('%kernel.logs_dir%/%kernel.environment%.log')
-            ;
-
-            $monolog->handler('syslog_handler')
-                ->type('syslog')
-                ->priority(10) // called first
-            ;
-        };
+        return App::config([
+            'monolog' => [
+                'handlers' => [
+                    'file_log' => [
+                        'type' => 'stream',
+                        'path' => '%kernel.logs_dir%/%kernel.environment%.log',
+                    ],
+                    'syslog_handler' => [
+                        'type' => 'syslog',
+                        'priority' => 10, // called first
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -234,30 +241,30 @@ one of the messages reaches an ``action_level``. Take this example:
     .. code-block:: php
 
         // config/packages/prod/monolog.php
-        use Psr\Log\LogLevel;
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $monolog->handler('filter_for_errors')
-                ->type('fingers_crossed')
-                // if *one* log is error or higher, pass *all* to file_log
-                ->actionLevel(LogLevel::ERROR)
-                ->handler('file_log')
-            ;
-
-            // now passed *all* logs, but only if one log is error or higher
-            $monolog->handler('file_log')
-                ->type('stream')
-                ->path('%kernel.logs_dir%/%kernel.environment%.log')
-                ->level(LogLevel::DEBUG)
-            ;
-
-            // still passed *all* logs, and still only logs error or higher
-            $monolog->handler('syslog_handler')
-                ->type('syslog')
-                ->level(LogLevel::ERROR)
-            ;
-        };
+        return App::config([
+            'monolog' => [
+                'handlers' => [
+                    'filter_for_errors' => [
+                        'type' => 'fingers_crossed',
+                        // if *one* log is error or higher, pass *all* to file_log
+                        'action_level' => 'error',
+                        'handler' => 'file_log',
+                    ],
+                    // now passed *all* logs, but only if one log is error or higher
+                    'file_log' => [
+                        'type' => 'stream',
+                        'path' => '%kernel.logs_dir%/%kernel.environment%.log',
+                    ],
+                    // still passed *all* logs, and still only logs error or higher
+                    'syslog_handler' => [
+                        'type' => 'syslog',
+                        'level' => 'error',
+                    ],
+                ],
+            ],
+        ]);
 
 Now, if even one log entry has an ``LogLevel::ERROR`` level or higher, then *all* log entries
 for that request are saved to a file via the ``file_log`` handler. That means that
@@ -306,18 +313,22 @@ option of your handler to ``rotating_file``:
     .. code-block:: php
 
         // config/packages/prod/monolog.php
-        use Psr\Log\LogLevel;
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $monolog->handler('main')
-                ->type('rotating_file')
-                ->path('%kernel.logs_dir%/%kernel.environment%.log')
-                ->level(LogLevel::DEBUG)
-                // max number of log files to keep
-                // defaults to zero, which means infinite files
-                ->maxFiles(10);
-        };
+        return App::config([
+            'monolog' => [
+                'handlers' => [
+                    'main' => [
+                        'type' => 'rotating_file',
+                        'path' => '%kernel.logs_dir%/%kernel.environment%.log',
+                        'level' => 'debug',
+                        // max number of log files to keep
+                        // defaults to zero, which means infinite files
+                        'max_files' => 10,
+                    ],
+                ],
+            ],
+        ]);
 
 Using a Logger inside a Service
 -------------------------------

--- a/logging/channels_handlers.rst
+++ b/logging/channels_handlers.rst
@@ -47,23 +47,28 @@ from the ``security`` channel. The following example does that only in the
 
     .. code-block:: php
 
-        // config/packages/prod/monolog.php
-        use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-        use Symfony\Config\MonologConfig;
+        // config/packages/monolog.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog, ContainerConfigurator $container) {
-            if ('prod' === $container->env()) {
-                $monolog->handler('security')
-                    ->type('stream')
-                    ->path(param('kernel.logs_dir') . \DIRECTORY_SEPARATOR . 'security.log')
-                    ->channels()->elements(['security']);
-
-                $monolog->handler('main')
-                     // ...
-
-                    ->channels()->elements(['!security']);
-            }
-        };
+        return App::config([
+            'when@prod' => [
+                'monolog' => [
+                    'handlers' => [
+                        'security' => [
+                            // log all messages (since debug is the lowest level)
+                            'level' => 'debug',
+                            'type' => 'stream',
+                            'path' => '%kernel.logs_dir%/security.log',
+                            'channels' => ['security'],
+                        ],
+                        // an example of *not* logging security channel messages for this handler
+                        'main' => [
+                            // 'channels' => ['!security'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. warning::
 
@@ -114,11 +119,13 @@ You can also configure additional channels without the need to tag your services
     .. code-block:: php
 
         // config/packages/monolog.php
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $monolog->channels(['foo', 'bar', 'foo_bar']);
-        };
+        return App::config([
+            'monolog' => [
+                'channels' => ['foo', 'bar', 'foo_bar'],
+            ],
+        ]);
 
 Symfony automatically registers one service per channel (in this example, the
 channel ``foo`` creates a service called ``monolog.logger.foo``). In order to

--- a/logging/formatter.rst
+++ b/logging/formatter.rst
@@ -6,33 +6,40 @@ it. All Monolog handlers use an instance of
 ``Monolog\Formatter\LineFormatter`` by default but you can replace it.
 Your formatter must implement ``Monolog\Formatter\FormatterInterface``.
 
-For example, to use the built-in ``JsonFormatter``, register it as a service then
-configure your handler to use it:
+For example, to use the built-in ``JsonFormatter`` only in the ``prod`` environment,
+register it as a service then configure your handler to use it:
 
 .. configuration-block::
 
     .. code-block:: yaml
 
-        # config/packages/prod/monolog.yaml (and/or config/packages/dev/monolog.yaml)
-        monolog:
-            handlers:
-                file:
-                    type: stream
-                    level: debug
-                    formatter: 'monolog.formatter.json'
+        # config/packages/monolog.yaml
+        when@prod:
+            monolog:
+                handlers:
+                    file:
+                        type: stream
+                        level: debug
+                        formatter: 'monolog.formatter.json'
 
     .. code-block:: php
 
-        // config/packages/prod/monolog.php (and/or config/packages/dev/monolog.php)
-        use Symfony\Config\MonologConfig;
+        // config/packages/monolog.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $monolog->handler('file')
-                ->type('stream')
-                ->level('debug')
-                ->formatter('monolog.formatter.json')
-            ;
-        };
+        return App::config([
+            'when@prod' => [
+                'monolog' => [
+                    'handlers' => [
+                        'file' => [
+                            'type' => 'stream',
+                            'level' => 'debug',
+                            'formatter' => 'monolog.formatter.json',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Many built-in formatters are available in Monolog. A lot of them are declared as services
 and can be used in the ``formatter`` option:

--- a/logging/handlers.rst
+++ b/logging/handlers.rst
@@ -31,22 +31,28 @@ To use it, declare it as a service:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Monolog\Level;
         use Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler;
 
-        $container->register(ElasticsearchLogstashHandler::class);
+        return App::config([
+            'services' => [
+                ElasticsearchLogstashHandler::class => null,
 
-        // optionally, configure the handler using the constructor arguments (shown values are default)
-        $container->register(ElasticsearchLogstashHandler::class)
-            ->setArguments([
-                '$endpoint' => "http://127.0.0.1:9200",
-                '$index' => "monolog",
-                '$client' => null,
-                '$level' => Level::Debug,
-                '$bubble' => true,
-                '$elasticsearchVersion' => '1.0.0',
-            ])
-        ;
+                // optionally, configure the handler using the constructor arguments (shown values are default)
+                ElasticsearchLogstashHandler::class => [
+                    'arguments' => [
+                        '$endpoint' => "http://127.0.0.1:9200",
+                        '$index' => "monolog",
+                        '$client' => null,
+                        '$level' => Level::Debug,
+                        '$bubble' => true,
+                        '$elasticsearchVersion' => '1.0.0',
+                    ],
+                ],
+            ],
+        ]);
 
 Then reference it in the Monolog configuration.
 
@@ -67,15 +73,20 @@ each log, an HTTP request will be made to push the log to Elasticsearch:
     .. code-block:: php
 
         // config/packages/prod/monolog.php
-        use Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler;
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $monolog->handler('es')
-                ->type('service')
-                ->id(ElasticsearchLogstashHandler::class)
-            ;
-        };
+        use Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler;
+
+        return App::config([
+            'monolog' => [
+                'handlers' => [
+                    'es' => [
+                        'type' => 'service',
+                        'id' => ElasticsearchLogstashHandler::class,
+                    ],
+                ],
+            ],
+        ]);
 
 In a production environment, it's highly recommended to wrap this handler in a
 handler with buffering capabilities (like the `FingersCrossedHandler`_ or
@@ -100,19 +111,24 @@ even better performance and fault tolerance, a proper `ELK stack`_ is recommende
     .. code-block:: php
 
         // config/packages/prod/monolog.php
-        use Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler;
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $monolog->handler('main')
-                ->type('fingers_crossed')
-                ->handler('es')
-            ;
-            $monolog->handler('es')
-                ->type('service')
-                ->id(ElasticsearchLogstashHandler::class)
-            ;
-        };
+        use Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler;
+
+        return App::config([
+            'monolog' => [
+                'handlers' => [
+                    'main' => [
+                        'type' => 'fingers_crossed',
+                        'handler' => 'es',
+                    ],
+                    'es' => [
+                        'type' => 'service',
+                        'id' => ElasticsearchLogstashHandler::class,
+                    ],
+                ],
+            ],
+        ]);
 
 .. _`BufferHandler`: https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/BufferHandler.php
 .. _`ELK stack`: https://www.elastic.co/what-is/elk-stack

--- a/logging/monolog_console.rst
+++ b/logging/monolog_console.rst
@@ -79,31 +79,43 @@ The Monolog console handler is enabled by default:
 
     .. code-block:: yaml
 
-        # config/packages/dev/monolog.yaml
-        monolog:
-            handlers:
-                # ...
-                console:
-                    type:   console
-                    process_psr_3_messages: false
-                    channels: ['!event', '!doctrine', '!console']
+        # config/packages/monolog.yaml
+        when@dev:
+            monolog:
+                handlers:
+                    # ...
+                    console:
+                        type:   console
+                        process_psr_3_messages: false
+                        channels: ['!event', '!doctrine', '!console']
 
-                    # optionally configure the mapping between verbosity levels and log levels
-                    # verbosity_levels:
-                    #     VERBOSITY_NORMAL: NOTICE
+                        # optionally configure the mapping between verbosity levels and log levels
+                        # verbosity_levels:
+                        #     VERBOSITY_NORMAL: NOTICE
 
     .. code-block:: php
 
-        // config/packages/dev/monolog.php
-        use Symfony\Config\MonologConfig;
+        // config/packages/monolog.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $monolog->handler('console')
-                ->type('console')
-                ->processPsr3Messages(false)
-                ->channels()->elements(['!event', '!doctrine', '!console'])
-            ;
-        };
+        return App::config([
+            'when@dev' => [
+                'monolog' => [
+                    'handlers' => [
+                        'console' => [
+                            'type' => 'console',
+                            'process_psr_3_messages' => false,
+                            'channels' => ['!event', '!doctrine', '!console'],
+
+                            // optionally configure the mapping between verbosity levels and log levels
+                            // 'verbosity_levels' => [
+                            //     'VERBOSITY_NORMAL' => 'NOTICE',
+                            // ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Now, log messages will be shown on the console based on the log levels and verbosity.
 By default (normal verbosity level), warnings and higher will be shown. But in

--- a/logging/monolog_email.rst
+++ b/logging/monolog_email.rst
@@ -44,37 +44,38 @@ it is broken down.
     .. code-block:: php
 
         // config/packages/prod/monolog.php
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $mainHandler = $monolog->handler('main')
-                ->type('fingers_crossed')
-                // 500 errors are logged at the critical level
-                ->actionLevel('critical')
-                // to also log 400 level errors:
-                // ->actionLevel('error')
-                ->handler('deduplicated')
-            ;
-
-            // add this to exclude 404 errors
-            // $mainHandler->excludedHttpCode()->code(404);
-
-            $monolog->handler('deduplicated')
-                ->type('deduplication')
-                ->handler('symfony_mailer');
-
-            $monolog->handler('symfony_mailer')
-                ->type('symfony_mailer')
-                ->fromEmail('error@example.com')
-                ->toEmail(['error@example.com'])
-                // or a list of recipients
-                // ->toEmail(['dev1@example.com', 'dev2@example.com', ...])
-                ->subject('An Error Occurred! %%message%%')
-                ->level('debug')
-                ->formatter('monolog.formatter.html')
-                ->contentType('text/html')
-            ;
-        };
+        return App::config([
+            'monolog' => [
+                'handlers' => [
+                    'main' => [
+                        'type' => 'fingers_crossed',
+                        // 500 errors are logged at the critical level
+                        'action_level' => 'critical',
+                        // to also log 400 level errors:
+                        // 'action_level' => 'error',
+                        // excluded_http_codes: [404]
+                        'handler' => 'deduplicated',
+                    ],
+                    'deduplicated' => [
+                        'type' => 'deduplication',
+                        'handler' => 'symfony_mailer',
+                    ],
+                    'symfony_mailer' => [
+                        'type' => 'symfony_mailer',
+                        'from_email' => 'error@example.com',
+                        'to_email' => ['error@example.com'],
+                        // or list of recipients
+                        // 'to_email' => ['dev1@example.com', 'dev2@example.com', ...]
+                        'subject' => 'An Error Occurred! %%message%%',
+                        'level' => 'debug',
+                        'formatter' => 'monolog.formatter.html',
+                        'content_type' => 'text/html',
+                    ],
+                ],
+            ],
+        ]);
 
 The ``main`` handler is a ``fingers_crossed`` handler which means that
 it is only triggered when the action level, in this case ``critical`` is reached.
@@ -113,18 +114,21 @@ You can adjust the time period using the ``time`` option:
     .. code-block:: php
 
         // config/packages/prod/monolog.php
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            // ...
-
-            $monolog->handler('deduplicated')
-                ->type('deduplication')
-                // the time in seconds during which duplicate entries are discarded (default: 60)
-                ->time(10)
-                ->handler('symfony_mailer')
-            ;
-        };
+        return App::config([
+            'monolog' => [
+                'handlers' => [
+                    // ...
+                    'deduplicated' => [
+                        'type' => 'deduplication',
+                        // the time in seconds during which duplicate entries are discarded (default: 60)
+                        'time' => 10,
+                        'handler' => 'symfony_mailer',
+                    ],
+                ],
+            ],
+        ]);
 
 The messages are then passed to the ``symfony_mailer`` handler. This is the handler that
 actually deals with emailing you the error. The settings for this are
@@ -167,44 +171,41 @@ get logged on the server as well as the emails being sent:
     .. code-block:: php
 
         // config/packages/prod/monolog.php
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $monolog->handler('main')
-                ->type('fingers_crossed')
-                ->actionLevel('critical')
-                ->handler('grouped')
-            ;
-
-            $monolog->handler('grouped')
-                ->type('group')
-                ->members(['streamed', 'deduplicated'])
-            ;
-
-            $monolog->handler('streamed')
-                ->type('stream')
-                ->path('%kernel.logs_dir%/%kernel.environment%.log')
-                ->level('debug')
-            ;
-
-            $monolog->handler('deduplicated')
-                ->type('deduplication')
-                ->handler('symfony_mailer')
-            ;
-
-            // still passed *all* logs, and still only logs error or higher
-            $monolog->handler('symfony_mailer')
-                ->type('symfony_mailer')
-                ->fromEmail('error@example.com')
-                ->toEmail(['error@example.com'])
-                // or a list of recipients
-                // ->toEmail(['dev1@example.com', 'dev2@example.com', ...])
-                ->subject('An Error Occurred! %%message%%')
-                ->level('debug')
-                ->formatter('monolog.formatter.html')
-                ->contentType('text/html')
-            ;
-        };
+        return App::config([
+            'monolog' => [
+                'handlers' => [
+                    'main' => [
+                        'type' => 'fingers_crossed',
+                        'action_level' => 'critical',
+                        'handler' => 'grouped',
+                    ],
+                    'grouped' => [
+                        'type' => 'group',
+                        'members' => ['streamed', 'deduplicated'],
+                    ],
+                    'streamed' => [
+                        'type' => 'stream',
+                        'path' => '%kernel.logs_dir%/%kernel.environment%.log',
+                        'level' => 'debug',
+                    ],
+                    'deduplicated' => [
+                        'type' => 'deduplication',
+                        'handler' => 'symfony_mailer',
+                    ],
+                    'symfony_mailer' => [
+                        'type' => 'symfony_mailer',
+                        'from_email' => 'error@example.com',
+                        'to_email' => ['error@example.com'],
+                        'subject' => 'An Error Occurred! %%message%%',
+                        'level' => 'debug',
+                        'formatter' => 'monolog.formatter.html',
+                        'content_type' => 'text/html',
+                    ],
+                ],
+            ],
+        ]);
 
 This uses the ``grouped`` handler to send the messages to the two
 group members, the ``deduplicated`` and the ``stream`` handlers. The messages will

--- a/logging/monolog_exclude_http_codes.rst
+++ b/logging/monolog_exclude_http_codes.rst
@@ -21,18 +21,20 @@ logging these HTTP codes based on the MonologBundle configuration:
     .. code-block:: php
 
         // config/packages/prod/monolog.php
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $mainHandler = $monolog->handler('main')
-                // ...
-                ->type('fingers_crossed')
-                ->handler('...')
-            ;
-
-            $mainHandler->excludedHttpCode()->code(403);
-            $mainHandler->excludedHttpCode()->code(404);
-        };
+        return App::config([
+            'monolog' => [
+                'handlers' => [
+                    'main' => [
+                        // ...
+                        'type' => 'fingers_crossed',
+                        'handler' => ...,
+                        'excluded_http_codes' => [403, 404, ['400' => ['^/foo', '^/bar']]],
+                    ],
+                ],
+            ],
+        ]);
 
 .. warning::
 

--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -72,16 +72,24 @@ information:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Logger\SessionRequestProcessor;
         use Monolog\Formatter\LineFormatter;
 
-        $container
-            ->register('monolog.formatter.session_request', LineFormatter::class)
-            ->addArgument('[%%datetime%%] [%%extra.token%%] %%channel%%.%%level_name%%: %%message%% %%context%% %%extra%%\n');
-
-        $container
-            ->register(SessionRequestProcessor::class)
-            ->addTag('monolog.processor');
+        return App::config([
+            'services' => [
+                'monolog.formatter.session_request' => [
+                    'class' => LineFormatter::class,
+                    'arguments' => [
+                        "[%%datetime%%] [%%extra.token%%] %%channel%%.%%level_name%%: %%message%% %%context%% %%extra%%\n",
+                    ],
+                ],
+                SessionRequestProcessor::class => [
+                    'tags' => ['monolog.processor'],
+                ],
+            ],
+        ]);
 
 Finally, set the formatter to be used on whatever handler you want:
 
@@ -101,16 +109,20 @@ Finally, set the formatter to be used on whatever handler you want:
     .. code-block:: php
 
         // config/packages/prod/monolog.php
-        use Symfony\Config\MonologConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (MonologConfig $monolog): void {
-            $monolog->handler('main')
-                ->type('stream')
-                ->path('%kernel.logs_dir%/%kernel.environment%.log')
-                ->level('debug')
-                ->formatter('monolog.formatter.session_request')
-            ;
-        };
+        return App::config([
+            'monolog' => [
+                'handlers' => [
+                    'main' => [
+                        'type' => 'stream',
+                        'path' => '%kernel.logs_dir%/%kernel.environment%.log',
+                        'level' => 'debug',
+                        'formatter' => 'monolog.formatter.session_request',
+                    ],
+                ],
+            ],
+        ]);
 
 If you use several handlers, you can also register a processor at the
 handler level or at the channel level instead of registering it globally
@@ -190,11 +202,19 @@ the ``monolog.processor`` tag:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-        $container
-            ->register(SessionRequestProcessor::class)
-            ->addTag('monolog.processor', ['handler' => 'main']);
+        use App\Logger\SessionRequestProcessor;
+
+        return App::config([
+            'services' => [
+                SessionRequestProcessor::class => [
+                    'tags' => [
+                        ['monolog.processor' => ['handler' => 'main']],
+                    ],
+                ],
+            ],
+        ]);
 
 Registering Processors per Channel
 ----------------------------------
@@ -215,11 +235,19 @@ to the ``monolog.processor`` tag to only apply a processor for the given channel
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-        $container
-            ->register(SessionRequestProcessor::class)
-            ->addTag('monolog.processor', ['channel' => 'app']);
+        use App\Logger\SessionRequestProcessor;
+
+        return App::config([
+            'services' => [
+                SessionRequestProcessor::class => [
+                    'tags' => [
+                        ['monolog.processor' => ['channel' => 'app']],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _`Monolog`: https://github.com/Seldaek/monolog
 .. _`built-in Monolog processors`: https://github.com/Seldaek/monolog/tree/main/src/Monolog/Processor

--- a/mailer.rst
+++ b/mailer.rst
@@ -38,12 +38,15 @@ over SMTP by configuring the DSN in your ``.env`` file (the ``user``,
     .. code-block:: php
 
         // config/packages/mailer.php
-        use Symfony\Config\FrameworkConfig;
-        use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->mailer()->dsn(env('MAILER_DSN'));
-        };
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'dsn' => env('MAILER_DSN'),
+                ],
+            ],
+        ]);
 
 .. warning::
 
@@ -777,20 +780,23 @@ and headers.
     .. code-block:: php
 
         // config/packages/mailer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $mailer = $framework->mailer();
-            $mailer
-                ->envelope()
-                    ->sender('fabien@example.com')
-                    ->recipients(['foo@example.com', 'bar@example.com'])
-            ;
-
-            $mailer->header('From')->value('Fabien <fabien@example.com>');
-            $mailer->header('Bcc')->value('baz@example.com');
-            $mailer->header('X-Custom-Header')->value('foobar');
-        };
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'envelope' => [
+                        'sender' => 'fabien@example.com',
+                        'recipients' => ['foo@example.com', 'bar@example.com'],
+                    ],
+                    'headers' => [
+                        'From' => 'Fabien <fabien@example.com>',
+                        'Bcc' => 'baz@example.com',
+                        'X-Custom-Header' => 'foobar',
+                    ],
+                ],
+            ],
+        ]);
 
 .. warning::
 
@@ -1006,14 +1012,17 @@ image files as usual. First, to simplify things, define a Twig namespace called
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            // ...
-
-            // point this wherever your images live
-            $twig->path('%kernel.project_dir%/assets/images', 'images');
-        };
+        return App::config([
+            'twig' => [
+                // ...
+                'paths' => [
+                    // point this wherever your images live
+                    '%kernel.project_dir%/assets/images' => 'images',
+                ],
+            ],
+        ]);
 
 Now, use the special ``email.image()`` Twig helper to embed the images inside
 the email contents:
@@ -1105,14 +1114,17 @@ called ``styles`` that points to the directory where ``email.css`` lives:
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            // ...
-
-            // point this wherever your css files live
-            $twig->path('%kernel.project_dir%/assets/styles', 'styles');
-        };
+        return App::config([
+            'twig' => [
+                // ...
+                'paths' => [
+                    // point this wherever your css files live
+                    '%kernel.project_dir%/assets/styles' => 'styles',
+                ],
+            ],
+        ]);
 
 .. _mailer-markdown:
 
@@ -1344,22 +1356,24 @@ minimizes repetition and centralizes your configuration for DKIM and S/MIME sign
     .. code-block:: php
 
         // config/packages/mailer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $mailer = $framework->mailer();
-            $mailer->dsn('%env(MAILER_DSN)%');
-            $mailer->dkimSigner()
-                    ->key('file://%kernel.project_dir%/var/certificates/dkim.pem')
-                    ->domain('symfony.com')
-                    ->select('s1');
-
-            $mailer->smimeSigner()
-                    ->key('%kernel.project_dir%/var/certificates/smime.key')
-                    ->certificate('%kernel.project_dir%/var/certificates/smime.crt')
-                    ->passphrase('')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'dkim_signer' => [
+                        'key' => 'file://%kernel.project_dir%/var/certificates/dkim.pem',
+                        'domain' => 'symfony.com',
+                        'select' => 's1',
+                    ],
+                    'smime_signer' => [
+                        'key' => '%kernel.project_dir%/var/certificates/smime.key',
+                        'certificate' => '%kernel.project_dir%/var/certificates/smime.crt',
+                        'passphrase' => '',
+                    ],
+                ],
+            ],
+        ]);
 
 Encrypting Messages
 ~~~~~~~~~~~~~~~~~~~
@@ -1421,15 +1435,19 @@ encrypter that automatically applies to all outgoing messages:
     .. code-block:: php
 
         // config/packages/mailer.php
-        use App\Security\LocalFileCertificateRepository;
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $mailer = $framework->mailer();
-            $mailer->smimeEncrypter()
-                    ->repository(LocalFileCertificateRepository::class)
-            ;
-        };
+        use App\Security\LocalFileCertificateRepository;
+
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'smime_encrypter' => [
+                        'repository' => LocalFileCertificateRepository::class,
+                    ],
+                ],
+            ],
+        ]);
 
 The ``repository`` option is the ID of a service that implements
 :class:`Symfony\\Component\\Mailer\\EventListener\\SmimeCertificateRepositoryInterface`.
@@ -1480,15 +1498,18 @@ This can be configured by replacing the ``dsn`` configuration entry with a
     .. code-block:: php
 
         // config/packages/mailer.php
-        use Symfony\Config\FrameworkConfig;
-        use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->mailer()
-                ->transport('main', env('MAILER_DSN'))
-                ->transport('alternative', env('MAILER_DSN_IMPORTANT'))
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'transports' => [
+                        'main' => env('MAILER_DSN'),
+                        'alternative' => env('MAILER_DSN_IMPORTANT'),
+                    ],
+                ],
+            ],
+        ]);
 
 By default the first transport is used. The other transports can be selected by
 adding an ``X-Transport`` header (which Mailer will remove automatically from
@@ -1532,16 +1553,22 @@ you have a transport called ``async``, you can route the message there:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->messenger()
-                ->transport('async')->dsn(env('MESSENGER_TRANSPORT_DSN'));
+        use Symfony\Component\Mailer\Messenger\SendEmailMessage;
 
-            $framework->messenger()
-                ->routing('Symfony\Component\Mailer\Messenger\SendEmailMessage')
-                ->senders(['async']);
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'transports' => [
+                        'async' => env('MESSENGER_TRANSPORT_DSN'),
+                    ],
+                    'routing' => [
+                        SendEmailMessage::class => 'async',
+                    ],
+                ],
+            ],
+        ]);
 
 Thanks to this, instead of being delivered immediately, messages will be sent
 to the transport to be handled later (see :ref:`messenger-worker`). Note that
@@ -1587,12 +1614,15 @@ disable asynchronous delivery.
     .. code-block:: php
 
         // config/packages/mailer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->mailer()
-                ->messageBus('app.another_bus');
-        };
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'message_bus' => 'app.another_bus',
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -1855,13 +1885,15 @@ the mailer configuration file (e.g. in the ``dev`` or ``test`` environments):
     .. code-block:: php
 
         // config/packages/mailer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->mailer()
-                ->dsn('null://null');
-        };
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'dsn' => 'null://null',
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -1888,15 +1920,17 @@ a specific address, instead of the *real* address:
     .. code-block:: php
 
         // config/packages/mailer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->mailer()
-                ->envelope()
-                    ->recipients(['youremail@example.com'])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'envelope' => [
+                        'recipients' => ['youremail@example.com'],
+                    ],
+                ],
+            ],
+        ]);
 
 Use the ``allowed_recipients`` option to define specific addresses that should
 still receive their original emails. These messages will also be sent to the
@@ -1920,20 +1954,22 @@ address(es) defined in ``recipients``, as with all other emails:
     .. code-block:: php
 
         // config/packages/mailer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->mailer()
-                ->envelope()
-                    ->recipients(['youremail@example.com'])
-                    ->allowedRecipients([
-                        'internal@example.com',
-                        // you can also use regular expression to define allowed recipients
-                        'internal-.*@example.(com|fr)',
-                    ])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'envelope' => [
+                        'recipients' => ['youremail@example.com'],
+                        'allowed_recipients' => [
+                            'internal@example.com',
+                            // you can also use regular expression to define allowed recipients
+                            'internal-.*@example.(com|fr)',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 With this configuration, all emails will be sent to ``youremail@example.com``.
 Additionally, emails sent to ``internal@example.com``, ``internal-monitoring@example.fr``,

--- a/mercure.rst
+++ b/mercure.rst
@@ -131,10 +131,10 @@ MercureBundle provides a more advanced configuration:
         mercure:
             hubs:
                 default:
-                    url: '%env(string:MERCURE_URL)%'
-                    public_url: '%env(string:MERCURE_PUBLIC_URL)%'
+                    url: '%env(MERCURE_URL)%'
+                    public_url: '%env(MERCURE_PUBLIC_URL)%'
                     jwt:
-                        secret: '%env(string:MERCURE_JWT_SECRET)%'
+                        secret: '%env(MERCURE_JWT_SECRET)%'
                         publish: ['https://example.com/foo1', 'https://example.com/foo2']
                         subscribe: ['https://example.com/bar1', 'https://example.com/bar2']
                         algorithm: 'hmac.sha256'
@@ -145,19 +145,26 @@ MercureBundle provides a more advanced configuration:
     .. code-block:: php
 
         // config/packages/mercure.php
-        $container->loadFromExtension('mercure', [
-            'hubs' => [
-                'default' => [
-                    'url' => '%env(string:MERCURE_URL)%',
-                    'public_url' => '%env(string:MERCURE_PUBLIC_URL)%',
-                    'jwt' => [
-                        'secret' => '%env(string:MERCURE_JWT_SECRET)%',
-                        'publish' => ['https://example.com/foo1', 'https://example.com/foo2'],
-                        'subscribe' => ['https://example.com/bar1', 'https://example.com/bar2'],
-                        'algorithm' => 'hmac.sha256',
-                        'provider' => 'My\Provider',
-                        'factory' => 'My\Factory',
-                        'value' => 'my.jwt',
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\Mercure\MyFactory;
+        use App\Mercure\MyProvider;
+
+        return App::config([
+            'mercure' => [
+                'hubs' => [
+                    'default' => [
+                        'url' => env('MERCURE_URL'),
+                        'public_url' => env('MERCURE_PUBLIC_URL'),
+                        'jwt' => [
+                            'secret' => env('MERCURE_JWT_SECRET'),
+                            'publish' => ['https://example.com/foo1', 'https://example.com/foo2'],
+                            'subscribe' => ['https://example.com/bar1', 'https://example.com/bar2'],
+                            'algorithm' => 'hmac.sha256',
+                            'provider' => MyProvider::class,
+                            'factory' => MyFactory::class,
+                            'value' => 'my.jwt',
+                        ],
                     ],
                 ],
             ],
@@ -530,14 +537,18 @@ Then, reference this service in the bundle configuration:
     .. code-block:: php
 
         // config/packages/mercure.php
-        use App\Mercure\MyJwtProvider;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        $container->loadFromExtension('mercure', [
-            'hubs' => [
-                'default' => [
-                    'url' => 'https://mercure-hub.example.com/.well-known/mercure',
-                    'jwt' => [
-                        'provider' => MyJwtProvider::class,
+        use App\Mercure\MyTokenProvider;
+
+        return App::config([
+            'mercure' => [
+                'hubs' => [
+                    'default' => [
+                        'url' => 'https://mercure-hub.example.com/.well-known/mercure',
+                        'jwt' => [
+                            'provider' => MyTokenProvider::class,
+                        ],
                     ],
                 ],
             ],

--- a/messenger.rst
+++ b/messenger.rst
@@ -154,20 +154,23 @@ that uses this configuration:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->messenger()
-                ->transport('async')
-                    ->dsn(env('MESSENGER_TRANSPORT_DSN'))
-            ;
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'transports' => [
+                        'async' => env('MESSENGER_TRANSPORT_DSN'),
 
-            $framework->messenger()
-                ->transport('async')
-                    ->dsn(env('MESSENGER_TRANSPORT_DSN'))
-                    ->options([])
-            ;
-        };
+                        // or expanded to configure more options
+                        // 'async' => [
+                        //    'dsn' => env('MESSENGER_TRANSPORT_DSN'),
+                        //    'options' => [],
+                        // ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _messenger-routing:
 
@@ -209,14 +212,20 @@ you can configure them to be sent to a transport:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->messenger()
-                // async is whatever name you gave your transport above
-                ->routing('App\Message\SmsNotification')->senders(['async'])
-            ;
-        };
+        use App\Message\SmsNotification;
+
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'routing' => [
+                        // async is whatever name you gave your transport above
+                        SmsNotification::class => 'async',
+                    ],
+                ],
+            ],
+        ]);
 
 Thanks to this, the ``App\Message\SmsNotification`` will be sent to the ``async``
 transport and its handler(s) will *not* be called immediately. Any messages not
@@ -285,15 +294,24 @@ to multiple transports:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
-            // route all messages that extend this example base class or interface
-            $messenger->routing('App\Message\AbstractAsyncMessage')->senders(['async']);
-            $messenger->routing('App\Message\AsyncMessageInterface')->senders(['async']);
-            $messenger->routing('My\Message\ToBeSentToTwoSenders')->senders(['async', 'audit']);
-        };
+        use App\Message\AbstractAsyncMessage;
+        use App\Message\AsyncMessageInterface;
+        use My\Message\ToBeSentToTwoSenders;
+
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'routing' => [
+                        // route all messages that extend this example base class or interface
+                        AbstractAsyncMessage::class => 'async',
+                        AsyncMessageInterface::class => 'async',
+                        ToBeSentToTwoSenders::class => ['async', 'audit'],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -390,16 +408,22 @@ transport and "sending" messages there to be handled immediately:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
+        use App\Message\SmsNotification;
 
-            // ... other transports
-
-            $messenger->transport('sync')->dsn('sync://');
-            $messenger->routing('App\Message\SmsNotification')->senders(['sync']);
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'transports' => [
+                        'sync' => 'sync://',
+                    ],
+                    'routing' => [
+                        SmsNotification::class => 'sync',
+                    ],
+                ],
+            ],
+        ]);
 
 Creating your Own Transport
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -549,22 +573,45 @@ different messages to them. For example:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
+        use App\Message\NewUserWelcomeEmail;
+        use App\Message\SmsNotification;
 
-            $messenger->transport('async_priority_high')
-                ->dsn(env('MESSENGER_TRANSPORT_DSN'))
-                ->options(['queue_name' => 'high']);
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'transports' => [
+                        'async_priority_high' => [
+                            'dsn' => env('MESSENGER_TRANSPORT_DSN'),
+                            'options' => [
+                                // queue_name is specific to the doctrine transport
+                                'queue_name' => 'high',
 
-            $messenger->transport('async_priority_low')
-                ->dsn(env('MESSENGER_TRANSPORT_DSN'))
-                ->options(['queue_name' => 'low']);
-
-            $messenger->routing('App\Message\SmsNotification')->senders(['async_priority_low']);
-            $messenger->routing('App\Message\NewUserWelcomeEmail')->senders(['async_priority_high']);
-        };
+                                // for AMQP send to a separate exchange then queue
+                                // 'exchange' => [
+                                //    'name' => 'high',
+                                // ],
+                                // 'queues' => [
+                                //    'messages_high' => null,
+                                // ],
+                                // for redis try "group"
+                            ],
+                        ],
+                        'async_priority_low' => [
+                            'dsn' => env('MESSENGER_TRANSPORT_DSN'),
+                            'options' => [
+                                'queue_name' => 'low',
+                            ],
+                        ],
+                    ],
+                    'routing' => [
+                        SmsNotification::class => 'async_priority_low',
+                        NewUserWelcomeEmail::class => 'async_priority_high',
+                    ],
+                ],
+            ],
+        ]);
 
 You can then run individual workers for each transport or instruct one worker
 to handle messages in a priority order:
@@ -725,12 +772,19 @@ configuration option:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->messenger()
-                ->stopWorkerOnSignals(['SIGTERM', 'SIGINT', 'SIGUSR1']);
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'stop_worker_on_signals' => [
+                        'SIGTERM',
+                        'SIGINT',
+                        'SIGUSR1',
+                    ],
+                ],
+            ],
+        ]);
 
 In some cases the ``SIGTERM`` signal is sent by Supervisor itself (e.g. stopping
 a Docker container having Supervisor as its entrypoint). In these cases you
@@ -876,14 +930,19 @@ by setting its ``rate_limiter`` option:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework) {
-            $framework->messenger()
-                ->transport('async')
-                    ->options(['rate_limiter' => 'your_rate_limiter_name'])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'transports' => [
+                        'async' => [
+                            'rate_limiter' => 'your_rate_limiter_name',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. warning::
 
@@ -931,30 +990,34 @@ this is configurable for each transport:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
-
-            $messenger->transport('async_priority_high')
-                ->dsn(env('MESSENGER_TRANSPORT_DSN'))
-                // default configuration
-                ->retryStrategy()
-                    ->maxRetries(3)
-                    // milliseconds delay
-                    ->delay(1000)
-                    // causes the delay to be higher before each retry
-                    // e.g. 1 second delay, 2 seconds, 4 seconds
-                    ->multiplier(2)
-                    ->maxDelay(0)
-                    // applies randomness to the delay that can prevent the thundering herd effect
-                    // the value (between 0 and 1.0) is the percentage of 'delay' that will be added/subtracted
-                    ->jitter(0.1)
-                    // override all of this with a service that
-                    // implements Symfony\Component\Messenger\Retry\RetryStrategyInterface
-                    ->service(null)
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'transports' => [
+                        'async_priority_high' => [
+                            'dsn' => env('MESSENGER_TRANSPORT_DSN'),
+                        ],
+                        'retry_strategy' => [
+                            'max_retries' => 3,
+                            // milliseconds delay
+                            'delay' => 1000,
+                            // causes the delay to be higher before each retry
+                            // e.g. 1 second delay, 2 seconds, 4 seconds
+                            'multiplier' => 2,
+                            'max_delay' => 0,
+                            // applies randomness to the delay that can prevent the thundering herd effect
+                            // the value (between 0 and 1.0) is the percentage of 'delay' that will be added/subtracted
+                            'jitter' => 0.1,
+                            // override all of this with a service that
+                            // implements Symfony\Component\Messenger\Retry\RetryStrategyInterface
+                            // 'service' => null,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -1019,19 +1082,21 @@ be discarded. To avoid this happening, you can instead configure a ``failure_tra
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    // after retrying, messages will be sent to the "failed" transport
+                    'failure_transport' => 'failed',
 
-            // after retrying, messages will be sent to the "failed" transport
-            $messenger->failureTransport('failed');
-
-            // ... other transports
-
-            $messenger->transport('failed')
-                ->dsn('doctrine://default?queue_name=failed');
-        };
+                    'transports' => [
+                        // ... other transports
+                        'failed' => 'doctrine://default?queue_name=failed',
+                    ],
+                ],
+            ],
+        ]);
 
 In this example, if handling a message fails 3 times (default ``max_retries``),
 it will then be sent to the ``failed`` transport. While you *can* use
@@ -1112,30 +1177,31 @@ override the failure transport for only specific transports:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    // after retrying, messages will be sent to the "failed" transport
+                    // by default if no "failure_transport" is configured inside a transport
+                    'failure_transport' => 'failed_default',
 
-            // after retrying, messages will be sent to the "failed" transport
-            // by default if no "failure_transport" is configured inside a transport
-            $messenger->failureTransport('failed_default');
-
-            $messenger->transport('async_priority_high')
-                ->dsn(env('MESSENGER_TRANSPORT_DSN'))
-                ->failureTransport('failed_high_priority');
-
-            // since no failed transport is configured, the one used will be
-            // the global failure_transport set
-           $messenger->transport('async_priority_low')
-                ->dsn('doctrine://default?queue_name=async_priority_low');
-
-           $messenger->transport('failed_default')
-                ->dsn('doctrine://default?queue_name=failed_default');
-
-           $messenger->transport('failed_high_priority')
-                ->dsn('doctrine://default?queue_name=failed_high_priority');
-        };
+                    'transports' => [
+                        'async_priority_high' => [
+                            'dsn' => env('MESSENGER_TRANSPORT_DSN'),
+                            'failure_transport' => 'failed_high_priority',
+                        ],
+                        // since no failed transport is configured, the one used will be
+                        // the global "failure_transport" set
+                        'async_priority_low' => [
+                            'dsn' => 'doctrine://default?queue_name=async_priority_low',
+                        ],
+                        'failed_default' => 'doctrine://default?queue_name=failed_default',
+                        'failed_high_priority' => 'doctrine://default?queue_name=failed_high_priority',
+                    ],
+                ],
+            ],
+        ]);
 
 If there is no ``failure_transport`` defined globally or on the transport level,
 the messages will be discarded after the number of retries.
@@ -1183,15 +1249,20 @@ options. Options can be passed to the transport via a DSN string or configuratio
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
-
-            $messenger->transport('my_transport')
-                ->dsn(env('MESSENGER_TRANSPORT_DSN'))
-                ->options(['auto_setup' => false]);
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'transports' => [
+                        'my_transport' => [
+                            'dsn' => env('MESSENGER_TRANSPORT_DSN'),
+                            'options' => ['auto_setup' => false],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Options defined under ``options`` take precedence over ones defined in the DSN.
 
@@ -1618,21 +1689,52 @@ under the transport in ``messenger.yaml``:
 
     .. code-block:: yaml
 
-        # config/packages/test/messenger.yaml
+        # config/packages/messenger.yaml
         framework:
-            messenger:
-                transports:
-                    redis:
-                        dsn: "rediss://localhost"
-                        options:
-                            ssl:
-                                allow_self_signed: true
-                                capture_peer_cert: true
-                                capture_peer_cert_chain: true
-                                disable_compression: true
-                                SNI_enabled: true
-                                verify_peer: true
-                                verify_peer_name: true
+            when@test:
+                messenger:
+                    transports:
+                        redis:
+                            dsn: "rediss://localhost"
+                            options:
+                                ssl:
+                                    allow_self_signed: true
+                                    capture_peer_cert: true
+                                    capture_peer_cert_chain: true
+                                    disable_compression: true
+                                    SNI_enabled: true
+                                    verify_peer: true
+                                    verify_peer_name: true
+
+    .. code-block:: php
+
+        // config/packages/messenger.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'when@test' => [
+                'framework' => [
+                    'messenger' => [
+                        'transports' => [
+                            'redis' => [
+                                'dsn' => "rediss://localhost",
+                                'options' => [
+                                    'ssl' => [
+                                        'allow_self_signed' => true,
+                                        'capture_peer_cert' => true,
+                                        'capture_peer_cert_chain' => true,
+                                        'disable_compression' => true,
+                                        'SNI_enabled' => true,
+                                        'verify_peer' => true,
+                                        'verify_peer_name' => true,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. warning::
 
@@ -1667,23 +1769,29 @@ override it in the ``test`` environment to use this transport:
 
     .. code-block:: yaml
 
-        # config/packages/test/messenger.yaml
-        framework:
-            messenger:
-                transports:
-                    async_priority_normal: 'in-memory://'
+        # config/packages/messenger.yaml
+        when@test:
+            framework:
+                messenger:
+                    transports:
+                        async_priority_normal: 'in-memory://'
 
     .. code-block:: php
 
-        // config/packages/test/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        // config/packages/messenger.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
-
-            $messenger->transport('async_priority_normal')
-                ->dsn('in-memory://');
-        };
+        return App::config([
+            'when@test' => [
+                'framework' => [
+                    'messenger' => [
+                        'transports' => [
+                            'async_priority_normal' => 'in-memory://',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Then, while testing, messages will *not* be delivered to the real transport.
 Even better, in a test, you can check that exactly one message was sent
@@ -1871,21 +1979,27 @@ this globally (or for each transport) to a service that implements
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
-
-            $messenger->serializer()
-                ->defaultSerializer('messenger.transport.symfony_serializer')
-                ->symfonySerializer()
-                    ->format('json')
-                    ->context('foo', 'bar');
-
-            $messenger->transport('async_priority_normal')
-                ->dsn('...')
-                ->serializer('messenger.transport.symfony_serializer');
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'serializer' => [
+                        'default_serializer' => 'messenger.transport.symfony_serializer',
+                        'symfony_serializer' => [
+                            'format' => 'json',
+                            'context' => [],
+                        ],
+                    ],
+                    'transports' => [
+                        'async_priority_normal' => [
+                            'dsn' => // ...,
+                            'serializer' => 'messenger.transport.symfony_serializer',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 The ``messenger.transport.symfony_serializer`` is a built-in service that uses
 the :doc:`Serializer component </serializer>` and can be configured in a few ways.
@@ -2266,14 +2380,28 @@ with ``messenger.message_handler``.
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Message\SmsNotification;
         use App\MessageHandler\SmsNotificationHandler;
 
-        $container->register(SmsNotificationHandler::class)
-            ->addTag('messenger.message_handler', [
-                // only needed if can't be guessed by type-hint
-                'handles' => SmsNotification::class,
-            ]);
+        return App::config([
+            'services' => [
+                SmsNotificationHandler::class => [
+                    'tags' => ['messenger.message_handler'],
+
+                    // or configure with options
+                    'tags' => [
+                        [
+                            'messenger.message_handler' => [
+                                // only needed if can't be guessed by type-hint
+                                'handles' => SmsNotification::class,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Possible options to configure with tags are:
 
@@ -2521,17 +2649,21 @@ Then, make sure to "route" your message to *both* transports:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
-
-            $messenger->transport('async_priority_normal')->dsn('...');
-            $messenger->transport('image_transport')->dsn('...');
-
-            $messenger->routing('App\Message\UploadedImage')
-                ->senders(['image_transport', 'async_priority_normal']);
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'transports' => [
+                        'async_priority_normal' => // ...,
+                        'image_transport' => // ...,
+                    ],
+                    'routing' => [
+                        'App\Message\UploadedImage' => ['image_transport', 'async_priority_normal'],
+                    ],
+                ],
+            ],
+        ]);
 
 That's it! You can now consume each transport:
 
@@ -2705,21 +2837,27 @@ and a different instance will be created per bus.
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'buses' => [
+                        'messenger.bus.default' => [
+                            'default_middleware' => false,
+                            'middleware' => [
+                                // use and configure parts of the default middleware you want
+                                'add_bus_name_stamp_middleware' => ['messenger.bus.default'],
 
-            $bus = $messenger->bus('messenger.bus.default')
-                ->defaultMiddleware(false); // disable the default middleware
-
-            // use and configure parts of the default middleware you want
-            $bus->middleware()->id('add_bus_name_stamp_middleware')->arguments(['messenger.bus.default']);
-
-            // add your own services that implement Symfony\Component\Messenger\Middleware\MiddlewareInterface
-            $bus->middleware()->id('App\Middleware\MyMiddleware');
-            $bus->middleware()->id('App\Middleware\AnotherMiddleware');
-        };
+                                // add your own services that implement Symfony\Component\Messenger\Middleware\MiddlewareInterface
+                                'App\Middleware\MyMiddleware',
+                                'App\Middleware\AnotherMiddleware',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -2769,20 +2907,41 @@ may want to use:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'buses' => [
+                        'command_bus' => [
+                            'middleware' => [
+                                // each time a message is handled, the Doctrine connection
+                                // is "pinged" and reconnected if it's closed. Useful
+                                // if your workers run for a long time and the database
+                                // connection is sometimes lost
+                                'doctrine_ping_connection',
 
-            $bus = $messenger->bus('command_bus');
-            $bus->middleware()->id('doctrine_transaction');
-            $bus->middleware()->id('doctrine_ping_connection');
-            $bus->middleware()->id('doctrine_close_connection');
-            $bus->middleware()->id('doctrine_open_transaction_logger');
-            // Using another entity manager
-            $bus->middleware()->id('doctrine_transaction')
-                ->arguments(['custom']);
-        };
+                                // After handling, the Doctrine connection is closed,
+                                // which can free up database connections in a worker,
+                                // instead of keeping them open forever
+                                'doctrine_close_connection',
+
+                                // logs an error when a Doctrine transaction was opened but not closed
+                                'doctrine_open_transaction_logger',
+
+                                // wraps all handlers in a single Doctrine transaction
+                                // handlers do not need to call flush() and an error
+                                // in any handler will cause a rollback
+                                'doctrine_transaction',
+
+                                // or pass a different entity manager to any
+                                // 'doctrine_transaction' => ['custom'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Other Middlewares
 ~~~~~~~~~~~~~~~~~
@@ -2814,15 +2973,22 @@ to configure the validation groups.
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
-
-            $bus = $messenger->bus('command_bus');
-            $bus->middleware()->id('router_context');
-            $bus->middleware()->id('validation');
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'buses' => [
+                        'command_bus' => [
+                            'middleware' => [
+                                'router_context',
+                                'validation',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Messenger Events
 ~~~~~~~~~~~~~~~~
@@ -2955,16 +3121,22 @@ transports:
     .. code-block:: php
 
         // config/packages/messenger.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Messenger\Serializer\MessageWithTokenDecoder;
-        use Symfony\Config\FrameworkConfig;
 
-        return static function (FrameworkConfig $framework): void {
-            $messenger = $framework->messenger();
-
-            $messenger->transport('my_transport')
-                ->dsn('%env(MY_TRANSPORT_DSN)%')
-                ->serializer(MessageWithTokenDecoder::class);
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'transports' => [
+                        'my_transport' => [
+                            'dsn' => env('MY_TRANSPORT_DSN'),
+                            'serializer' => MessageWithTokenDecoder::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _messenger-multiple-buses:
 
@@ -3019,31 +3191,43 @@ an **event bus**. The event bus could have zero or more subscribers.
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // The bus that is going to be injected when injecting MessageBusInterface
-            $framework->messenger()->defaultBus('command.bus');
-
-            $commandBus = $framework->messenger()->bus('command.bus');
-            $commandBus->middleware()->id('validation');
-            $commandBus->middleware()->id('doctrine_transaction');
-
-            $queryBus = $framework->messenger()->bus('query.bus');
-            $queryBus->middleware()->id('validation');
-
-            $eventBus = $framework->messenger()->bus('event.bus');
-            $eventBus->defaultMiddleware()
-                ->enabled(true)
-                // set "allowNoHandlers" to true (default is false) to allow having
-                // no handler configured for this bus without throwing an exception
-                ->allowNoHandlers(false)
-                // set "allowNoSenders" to false (default is true) to throw an exception
-                // if no sender is configured for this bus
-                ->allowNoSenders(true)
-            ;
-            $eventBus->middleware()->id('validation');
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    // The bus that is going to be injected when injecting MessageBusInterface
+                    'default_bus' => 'command.bus',
+                    'buses' => [
+                        'command.bus' => [
+                            'middleware' => [
+                                'validation',
+                                'doctrine_transaction',
+                            ],
+                        ],
+                        'query.bus' => [
+                            'middleware' => [
+                                'validation',
+                            ],
+                        ],
+                        'event.bus' => [
+                            'default_middleware' => [
+                                'enabled' => true,
+                                // set "allow_no_handlers" to true (default is false) to allow having
+                                // no handler configured for this bus without throwing an exception
+                                'allow_no_handlers' => false,
+                                // set "allow_no_senders" to true (default is false) to allow having
+                                // no sender configured for this bus without throwing an exception
+                                'allow_no_senders' => true,
+                            ],
+                            'middleware' => [
+                                'validation',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 This will create three new services:
 
@@ -3073,9 +3257,19 @@ you can restrict each handler to a specific bus using the ``messenger.message_ha
     .. code-block:: php
 
         // config/services.php
-        $container->services()
-            ->set(App\MessageHandler\SomeCommandHandler::class)
-            ->tag('messenger.message_handler', ['bus' => 'command.bus']);
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\MessageHandler\SomeCommandHandler;
+
+        return App::config([
+            'services' => [
+                SomeCommandHandler::class => [
+                    'tags' => [
+                        ['messenger.message_handler' => ['bus' => 'command.bus']],
+                    ],
+                ],
+            ],
+        ]);
 
 This way, the ``App\MessageHandler\SomeCommandHandler`` handler will only be
 known by the ``command.bus`` bus.
@@ -3113,21 +3307,26 @@ you can determine the message bus based on an implemented interface:
         use App\MessageHandler\CommandHandlerInterface;
         use App\MessageHandler\QueryHandlerInterface;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            // ...
-
-            // all services implementing the CommandHandlerInterface
-            // will be registered on the command.bus bus
-            $services->instanceof(CommandHandlerInterface::class)
-                ->tag('messenger.message_handler', ['bus' => 'command.bus']);
-
-            // while those implementing QueryHandlerInterface will be
-            // registered on the query.bus bus
-            $services->instanceof(QueryHandlerInterface::class)
-                ->tag('messenger.message_handler', ['bus' => 'query.bus']);
-        };
+        return App::config([
+            'services' => [
+                'instanceof' => [
+                    // all services implementing the CommandHandlerInterface
+                    // will be registered on the command.bus bus
+                    CommandHandlerInterface::class => [
+                        'tags' => [
+                            ['messenger.message_handler' => ['bus' => 'command.bus']],
+                        ],
+                    ],
+                    // while those implementing QueryHandlerInterface will be
+                    // registered on the query.bus bus
+                    QueryHandlerInterface::class => [
+                        'tags' => [
+                            ['messenger.message_handler' => ['bus' => 'query.bus']],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Debugging the Buses
 ~~~~~~~~~~~~~~~~~~~

--- a/messenger/custom-transport.rst
+++ b/messenger/custom-transport.rst
@@ -149,10 +149,17 @@ Otherwise, add the following:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Your\Transport\YourTransportFactory;
 
-        $container->register(YourTransportFactory::class)
-            ->setTags(['messenger.transport_factory']);
+        return App::config([
+            'services' => [
+                YourTransportFactory::class => [
+                    'tags' => ['messenger.transport_factory'],
+                ],
+            ],
+        ]);
 
 Use your Transport
 ------------------
@@ -173,14 +180,17 @@ named transport using your own DSN:
     .. code-block:: php
 
         // config/packages/messenger.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->messenger()
-                ->transport('yours')
-                    ->dsn('my-transport://...')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'transports' => [
+                        'yours' => 'my-transport://...',
+                    ],
+                ],
+            ],
+        ]);
 
 In addition of being able to route your messages to the ``yours`` sender, this
 will give you access to the following services:

--- a/notifier.rst
+++ b/notifier.rst
@@ -243,13 +243,17 @@ configure the ``texter_transports``:
     .. code-block:: php
 
         // config/packages/notifier.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->notifier()
-                ->texterTransport('twilio', env('TWILIO_DSN'))
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'notifier' => [
+                    'texter_transports' => [
+                        'twilio' => env('TWILIO_DSN'),
+                    ],
+                ],
+            ],
+        ]);
 
 .. _sending-sms:
 
@@ -394,13 +398,17 @@ Chatters are configured using the ``chatter_transports`` setting:
     .. code-block:: php
 
         // config/packages/notifier.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->notifier()
-                ->chatterTransport('slack', env('SLACK_DSN'))
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'notifier' => [
+                    'chatter_transports' => [
+                        'slack' => env('SLACK_DSN'),
+                    ],
+                ],
+            ],
+        ]);
 
 .. _sending-chat-messages:
 
@@ -469,15 +477,18 @@ notification emails:
     .. code-block:: php
 
         // config/packages/mailer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->mailer()
-                ->dsn(env('MAILER_DSN'))
-                ->envelope()
-                    ->sender('notifications@example.com')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'dsn' => env('MAILER_DSN'),
+                    'envelope' => [
+                        'sender' => 'notifications@example.com',
+                    ],
+                ],
+            ],
+        ]);
 
 .. _notifier-push-channel:
 
@@ -537,13 +548,17 @@ configure the ``texter_transports``:
     .. code-block:: php
 
         // config/packages/notifier.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->notifier()
-                ->texterTransport('expo', env('EXPO_DSN'))
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'notifier' => [
+                    'texter_transports' => [
+                        'expo' => env('EXPO_DSN'),
+                    ],
+                ],
+            ],
+        ]);
 
 .. _notifier-desktop-channel:
 
@@ -586,13 +601,17 @@ need to add the following manually:
     .. code-block:: php
 
         // config/packages/notifier.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->notifier()
-                ->texterTransport('jolinotif', env('JOLINOTIF'))
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'notifier' => [
+                    'texter_transports' => [
+                        'jolinotif' => env('JOLINOTIF'),
+                    ],
+                ],
+            ],
+        ]);
 
 Now you can send notifications to your desktop as follows::
 
@@ -663,18 +682,22 @@ transport:
     .. code-block:: php
 
         // config/packages/notifier.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->notifier()
-                // Send notifications to Slack and use Telegram if
-                // Slack errored
-                ->chatterTransport('main', env('SLACK_DSN').' || '.env('TELEGRAM_DSN'))
+        return App::config([
+            'framework' => [
+                'notifier' => [
+                    'chatter_transports' => [
+                        // Send notifications to Slack and use Telegram if
+                        // Slack errored
+                        'main' => env('SLACK_DSN').' || '.env('TELEGRAM_DSN'),
 
-                // Send notifications to the next scheduled transport calculated by round robin
-                ->chatterTransport('roundrobin', env('SLACK_DSN').' && '.env('TELEGRAM_DSN'))
-            ;
-        };
+                        // Send notifications to the next scheduled transport calculated by round robin
+                        'roundrobin' => env('SLACK_DSN').' && '.env('TELEGRAM_DSN'),
+                    ],
+                ],
+            ]
+        ]);
 
 Creating & Sending Notifications
 --------------------------------
@@ -768,20 +791,26 @@ specify what channels should be used for specific levels (using
     .. code-block:: php
 
         // config/packages/notifier.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->notifier()
-                // Use SMS, Slack and email for urgent notifications
-                ->channelPolicy('urgent', ['sms', 'chat/slack', 'email'])
-                // Use Slack for highly important notifications
-                ->channelPolicy('high', ['chat/slack'])
-                // Use browser for medium and low notifications
-                ->channelPolicy('medium', ['browser'])
-                ->channelPolicy('low', ['browser'])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'notifier' => [
+                    // ...
+                    'channel_policy' => [
+                        // Use SMS, Slack and email for urgent notifications
+                        'urgent' => ['sms', 'chat/slack', 'email'],
+
+                        // Use Slack for highly important notifications
+                        'high' => ['chat/slack'],
+
+                        // Use browser for medium and low notifications
+                        'medium' => ['browser'],
+                        'low' => ['browser'],
+                    ],
+                ],
+            ],
+        ]);
 
 Now, whenever the notification's importance is set to "high", it will be
 sent using the Slack transport::
@@ -918,11 +947,13 @@ typical alert levels, which you can implement immediately using:
 
         use Symfony\Component\Notifier\FlashMessage\BootstrapFlashMessageImportanceMapper;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $containerConfigurator->services()
-                ->set('notifier.flash_message_importance_mapper', BootstrapFlashMessageImportanceMapper::class)
-            ;
-        };
+        return App::config([
+            'services' => [
+                'flash_message_importance_mapper' => [
+                    'class' => BootstrapFlashMessageImportanceMapper::class,
+                ],
+            ],
+        ]);
 
 Testing Notifier
 ----------------
@@ -944,13 +975,34 @@ all configured texter and chatter transports only in the ``dev`` (and/or
 
 .. code-block:: yaml
 
-    # config/packages/dev/notifier.yaml
-    framework:
-        notifier:
-            texter_transports:
-                twilio: 'null://null'
-            chatter_transports:
-                slack: 'null://null'
+    # config/packages/notifier.yaml
+    when@dev:
+        framework:
+            notifier:
+                texter_transports:
+                    twilio: 'null://null'
+                chatter_transports:
+                    slack: 'null://null'
+
+.. code-block:: php
+
+    // config/packages/notifier.php
+    namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+    return App::config([
+        'when@dev' => [
+            'framework' => [
+                'notifier' => [
+                    'texter_transports' => [
+                        'twilio' => 'null://null',
+                    ],
+                    'chatter_transports' => [
+                        'slack' => 'null://null',
+                    ],
+                ],
+            ],
+        ],
+    ]);
 
 .. _notifier-events:
 

--- a/performance.rst
+++ b/performance.rst
@@ -56,9 +56,11 @@ container into a single file, which could improve performance when using
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $container->parameters()->set('.container.dumper.inline_factories', true);
-        };
+        return App::config([
+            'parameters' => [
+                '.container.dumper.inline_factories' => true,
+            ],
+        ]);
 
 .. _performance-use-opcache:
 
@@ -220,9 +222,13 @@ in performance, you can stop generating the file as follows:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-        $container->parameters()->set('debug.container.dump', false);
+        return App::config([
+            'parameters' => [
+                'debug.container.dump' => false,
+            ],
+        ]);
 
 .. _profiling-applications:
 

--- a/profiler.rst
+++ b/profiler.rst
@@ -159,16 +159,25 @@ create an alias pointing to the existing ``profiler`` service:
 
     .. code-block:: yaml
 
-        # config/services_dev.yaml
-        services:
-            Symfony\Component\HttpKernel\Profiler\Profiler: '@profiler'
+        # config/services.yaml
+        when@dev:
+            services:
+                Symfony\Component\HttpKernel\Profiler\Profiler: '@profiler'
 
     .. code-block:: php
 
-        // config/services_dev.php
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Symfony\Component\HttpKernel\Profiler\Profiler;
 
-        $container->setAlias(Profiler::class, 'profiler');
+        return App::config([
+            'when@dev' => 'services' => [
+                Profiler::class => [
+                    'alias' => 'profiler',
+                ],
+            ],
+        ]);
 
 .. _enabling-the-profiler-conditionally:
 
@@ -181,11 +190,28 @@ parameter is included in the URL):
 
 .. code-block:: yaml
 
-    # config/packages/dev/web_profiler.yaml
+    # config/packages/web_profiler.yaml
+    when@dev:
         framework:
             profiler:
                 collect: false
                 collect_parameter: 'profile'
+
+.. code-block:: php
+
+    // config/packages/web_profiler.php
+    namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+    return App::config([
+        'when@dev' => [
+            'framework' => [
+                'profiler' => [
+                    'collect' => false,
+                    'collect_parameter' => 'profile',
+                ],
+            ],
+        ],
+    ]);
 
 This configuration disables the profiler by default (``collect: false``) to
 improve the application performance; but enables it for requests that include a
@@ -219,12 +245,15 @@ toolbar to be refreshed after each AJAX request by enabling ``ajax_replace`` in 
     .. code-block:: php
 
         // config/packages/web_profiler.php
-        use Symfony\Config\WebProfilerConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (WebProfilerConfig $profiler): void {
-            $profiler->toolbar()
-                ->ajaxReplace(true);
-        };
+        return App::config([
+            'web_profiler' => [
+                'toolbar' => [
+                    'ajax_replace' => true,
+                ],
+            ],
+        ]);
 
 If you need a more sophisticated solution, you can set the
 ``Symfony-Debug-Toolbar-Replace`` header to a value of ``'1'`` in the response
@@ -538,18 +567,24 @@ you'll need to configure the data collector explicitly:
 
         use App\DataCollector\RequestCollector;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(RequestCollector::class)
-                ->tag('data_collector', [
-                    'id' => RequestCollector::class,
-                    // optional template (it has more priority than the value returned by getTemplate())
-                    'template' => 'data_collector/template.html.twig',
-                    // optional priority (positive or negative integer; default = 0)
-                    // 'priority' => 300,
-                ]);
-        };
+        return App::config([
+            'services' => [
+                RequestCollector::class => [
+                    'tags' => [
+                        [
+                            'data_collector' => [
+                                // must match the value returned by the getName() method
+                                'id' => RequestCollector::class,
+                                // optional template (it has more priority than the value returned by getTemplate())
+                                'template' => 'data_collector/template.html.twig',
+                                // optional priority (positive or negative integer; default = 0)
+                                // 'priority' => 300,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _`Single-page applications`: https://en.wikipedia.org/wiki/Single-page_application
 .. _`Blackfire`: https://blackfire.io/docs/introduction?utm_source=symfony&utm_medium=symfonycom_docs&utm_campaign=profiler

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -248,19 +248,18 @@ using the special ``when@`` keyword:
         // config/packages/framework.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        use Symfony\Config\FrameworkConfig;
-
-        return static function (FrameworkConfig $framework, ContainerConfigurator $container): void {
-            $framework->router()
-                ->utf8(true)
-            ;
-
-            if ('prod' === $container->env()) {
-                $framework->router()
-                    ->strictRequirements(null)
-                ;
-            }
-        };
+        return App::config([
+            'framework' => [
+                'router' => [
+                    'utf8' => true,
+                ],
+            ],
+            'when@prod' => 'framework' => [
+                'router' => [
+                    'strict_requirements' => null,
+                ],
+            ],
+        ]);
 
 This is a *powerful* idea: by changing one piece of configuration (the environment),
 your app is transformed from a debugging-friendly experience to one that's optimized

--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -146,26 +146,25 @@ enforce different levels of service (free or paid):
     .. code-block:: php
 
         // config/packages/rate_limiter.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->rateLimiter()
-                ->limiter('anonymous_api')
-                    // use 'sliding_window' if you prefer that policy
-                    ->policy('fixed_window')
-                    ->limit(100)
-                    ->interval('60 minutes')
-                ;
-
-            $framework->rateLimiter()
-                ->limiter('authenticated_api')
-                    ->policy('token_bucket')
-                    ->limit(5000)
-                    ->rate()
-                        ->interval('15 minutes')
-                        ->amount(500)
-                ;
-        };
+        return App::config([
+            'framework' => [
+                'rate_limiter' => [
+                    'anonymous_api' => [
+                        // use 'sliding_window' if you prefer that policy
+                        'policy' => 'fixed_window',
+                        'limit' => 100,
+                        'interval' => '60 minutes',
+                    ],
+                ],
+                'authenticated_api' => [
+                    'policy' => 'token_bucket',
+                    'limit' => 5000,
+                    'rate' => ['interval' => '15 minutes', 'amount' => 500],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -421,17 +420,18 @@ You can use the ``cache_pool`` option to override the cache used by a specific l
     .. code-block:: php
 
         // config/packages/rate_limiter.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->rateLimiter()
-                ->limiter('anonymous_api')
-                    // ...
-
-                    // use the "cache.anonymous_rate_limiter" cache pool
-                    ->cachePool('cache.anonymous_rate_limiter')
-                ;
-        };
+        return App::config([
+            'framework' => [
+                'rate_limiter' => [
+                    'anonymous_api' => [
+                        // use the "cache.anonymous_rate_limiter" cache pool
+                        'cache_pool' => 'cache.anonymous_rate_limiter',
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -473,20 +473,21 @@ at all):
     .. code-block:: php
 
         // config/packages/rate_limiter.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->rateLimiter()
-                ->limiter('anonymous_api')
-                    // ...
+        return App::config([
+            'framework' => [
+                'rate_limiter' => [
+                    'anonymous_api' => [
+                        // use the "lock.rate_limiter.factory" for this limiter
+                        'lock_factory' => 'lock.rate_limiter.factory',
 
-                    // use the "lock.rate_limiter.factory" for this limiter
-                    ->lockFactory('lock.rate_limiter.factory')
-
-                    // or don't use any lock mechanism
-                    ->lockFactory(null)
-                ;
-        };
+                        // or don't use any lock mechanism
+                        'lock_factory' => null,
+                    ],
+                ],
+            ],
+        ]);
 
 Compound Rate Limiter
 ---------------------
@@ -515,29 +516,28 @@ You can configure multiple rate limiters to work together:
     .. code-block:: php
 
         // config/packages/rate_limiter.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->rateLimiter()
-                ->limiter('two_per_minute')
-                    ->policy('fixed_window')
-                    ->limit(2)
-                    ->interval('1 minute')
-                ;
-
-            $framework->rateLimiter()
-                ->limiter('five_per_hour')
-                    ->policy('fixed_window')
-                    ->limit(5)
-                    ->interval('1 hour')
-                ;
-
-            $framework->rateLimiter()
-                ->limiter('contact_form')
-                    ->policy('compound')
-                    ->limiters(['two_per_minute', 'five_per_hour'])
-                ;
-        };
+        return App::config([
+            'framework' => [
+                'rate_limiter' => [
+                    'two_per_minute' => [
+                        'policy' => 'fixed_window',
+                        'limit' => 2,
+                        'interval' => '1 minute',
+                    ],
+                    'five_per_hour' => [
+                        'policy' => 'fixed_window',
+                        'limit' => 5,
+                        'interval' => '1 hour',
+                    ],
+                    'contact_form' => [
+                        'policy' => 'compound',
+                        'limiters' => ['two_per_minute', 'five_per_hour'],
+                    ],
+                ],
+            ],
+        ]);
 
 Then, inject and use as normal::
 

--- a/reference/configuration/debug.rst
+++ b/reference/configuration/debug.rst
@@ -44,11 +44,11 @@ Typically, you would set this to ``php://stderr``:
         // config/packages/debug.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container): void {
-            $container->extension('debug', [
+        return App::config([
+            'debug' => [
                 'dump_destination' => 'php://stderr',
-            ]);
-        };
+            ],
+        ]);
 
 
 Configure it to ``"tcp://%env(VAR_DUMPER_SERVER)%"`` in order to use the :ref:`ServerDumper feature <var-dumper-dump-server>`.

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -28,6 +28,7 @@ The following block shows all possible configuration keys:
 
     .. code-block:: yaml
 
+        # config/packages/doctrine.yaml
         doctrine:
             dbal:
                 dbname:               database
@@ -59,33 +60,53 @@ The following block shows all possible configuration keys:
 
     .. code-block:: php
 
-        use Symfony\Config\DoctrineConfig;
+        // config/packages/doctrine.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (DoctrineConfig $doctrine): void {
-            $dbal = $doctrine->dbal();
+        use App\DBAL\MyConnectionWrapper;
+        use App\DBAL\MyCustomType;
+        use App\DBAL\MyDatabaseDriver;
+        use App\DBAL\MyDatabasePlatformService;
 
-            $dbal = $dbal
-                ->connection('default')
-                    ->dbname('database')
-                    ->host('localhost')
-                    ->port(1234)
-                    ->user('user')
-                    ->password('secret')
-                    ->driver('pdo_mysql')
-                    ->url('mysql://db_user:db_password@127.0.0.1:3306/db_name') // if the url option is specified, it will override the above config
-                    ->driverClass(App\DBAL\MyDatabaseDriver::class) // the DBAL driverClass option
-                    ->option('foo', 'bar') // the DBAL driverOptions option
-                    ->path('%kernel.project_dir%/var/data/data.sqlite')
-                    ->memory(true)
-                    ->unixSocket('/tmp/mysql.sock')
-                    ->wrapperClass(App\DBAL\MyConnectionWrapper::class) // the DBAL wrapperClass option
-                    ->charset('utf8mb4')
-                    ->logging('%kernel.debug%')
-                    ->platformService(App\DBAL\MyDatabasePlatformService::class)
-                    ->serverVersion('8.0.37')
-                    ->mappingType('enum', 'string')
-                    ->type('custom', App\DBAL\MyCustomType::class);
-        };
+        return App::config([
+            'doctrine' => [
+                'dbal' => [
+                    'connection' => [
+                        'default' => [
+                            'dbname' => 'database',
+                            'host' => 'localhost',
+                            'port' => 1234,
+                            'user' => 'user',
+                            'password' => 'secret',
+                            'driver' => 'pdo_mysql',
+                            // if the url option is specified, it will override the above config
+                            'url' => 'mysql://db_user:db_password@127.0.0.1:3306/db_name',
+                            // the DBAL driverClass option
+                            'driver_class' => MyDatabaseDriver::class,
+                            // the DBAL driverOptions option
+                            'options' => [
+                                'foo' => 'bar',
+                            ],
+                            'path' => '%kernel.project_dir%/var/data/data.sqlite',
+                            'memory' => true,
+                            'unix_socket' => '/tmp/mysql.sock',
+                            // the DBAL wrapperClass option
+                            'wrapper_class' => MyConnectionWrapper::class,
+                            'charset' => 'utf8mb4',
+                            'logging' => '%kernel.debug%',
+                            'platform_service' => MyDatabasePlatformService::class,
+                            'server_version' => '8.0.37',
+                            'mapping_types' => [
+                                'enum' => 'string',
+                            ],
+                            'types' => [
+                                'custom' => MyCustomType::class,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -116,6 +137,7 @@ If you want to configure multiple connections in YAML, put them under the
 
     .. code-block:: yaml
 
+        # config/packages/doctrine.yaml
         doctrine:
             dbal:
                 default_connection:       default
@@ -135,26 +157,37 @@ If you want to configure multiple connections in YAML, put them under the
 
     .. code-block:: php
 
-        use Symfony\Config\DoctrineConfig;
+        // config/packages/doctrine.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (DoctrineConfig $doctrine): void {
-            $dbal = $doctrine->dbal();
-            $dbal->defaultConnection('default');
+        use App\DBAL\MyConnectionWrapper;
+        use App\DBAL\MyCustomType;
+        use App\DBAL\MyDatabaseDriver;
+        use App\DBAL\MyDatabasePlatformService;
 
-            $dbal->connection('default')
-                ->dbname('Symfony')
-                ->user('root')
-                ->password('null')
-                ->host('localhost')
-                ->serverVersion('8.0.37');
-
-            $dbal->connection('customer')
-                ->dbname('customer')
-                ->user('root')
-                ->password('null')
-                ->host('localhost')
-                ->serverVersion('8.2.0');
-        };
+        return App::config([
+            'doctrine' => [
+                'dbal' => [
+                    'default_connection' => 'default',
+                    'connections' => [
+                        'default' => [
+                            'dbname' => 'Symfony',
+                            'user' => 'root',
+                            'password' => 'null',
+                            'host' => 'localhost',
+                            'server_version' => '8.0.37',
+                        ],
+                        'customer' => [
+                            'dbname' => 'customer',
+                            'user' => 'root',
+                            'password' => 'null',
+                            'host' => 'localhost',
+                            'server_version' => '8.2.0',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 The ``database_connection`` service always refers to the *default* connection,
 which is the first one defined or the one configured via the
@@ -194,6 +227,7 @@ Here's how to disable autocommit mode in DBAL:
 
     .. code-block:: yaml
 
+        # config/packages/doctrine.yaml
         doctrine:
             dbal:
                 connections:
@@ -205,28 +239,27 @@ Here's how to disable autocommit mode in DBAL:
                     # this option disables auto-commit at the DBAL level:
                     auto_commit: false
 
-    .. code-block:: xml
+    .. code-block:: php
 
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xmlns:doctrine="http://symfony.com/schema/dic/doctrine"
-           xmlns="http://symfony.com/schema/dic/services"
-           xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/doctrine
-                https://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
-        
-            <doctrine:config>
-                <doctrine:dbal
-                   auto-commit="false"
-                 >
-                     <!-- add this only if you are using DBAL with PDO -->
-                     <doctrine:connection name="default">
-                         <doctrine:option key-type="constant" key="PDO::ATTR_AUTOCOMMIT">false</doctrine:option>
-                     </doctrine:connection>
-              </doctrine:dbal>
-          </doctrine:config>
-        </container>
+        // config/packages/doctrine.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'doctrine' => [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'options' => [
+                                // add this only if you're using DBAL with PDO:
+                                \PDO::ATTR_AUTOCOMMIT => false,
+                            ],
+                        ],
+                        // this option disables auto-commit at the DBAL level:
+                        'auto_commit' => false,
+                    ],
+                ],
+            ],
+        ]);
 
 When using the `Doctrine Migrations Bundle`_, you need to register an additional
 listener to ensure that the final migration is committed properly:
@@ -242,22 +275,6 @@ listener to ensure that the final migration is committed properly:
                     - name: doctrine.event_listener
                       event: onMigrationsMigrated
 
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd">
-        
-            <services>
-                <service id="Doctrine\Migrations\Event\Listeners\AutoCommitListener">
-                    <tag name="doctrine.event_listener" event="onMigrationsMigrated"/>
-                </service>
-            </services>
-        </container>
-
     .. code-block:: php
     
         // config/services.php
@@ -266,15 +283,15 @@ listener to ensure that the final migration is committed properly:
         use Doctrine\Migrations\Event\Listeners\AutoCommitListener;
         use Doctrine\Migrations\Events;
         
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-            
-            $services->set(AutoCommitListener::class)
-                ->tag('doctrine.event_listener', [
-                    'event' => Events::onMigrationsMigrated
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                AutoCommitListener::class => [
+                    'tags' => [
+                        ['doctrine.event_listener' => ['event' => Events::onMigrationsMigrated]],
+                    ],
+                ],
+            ],
+        ]);
 
 Doctrine ORM Configuration
 --------------------------
@@ -286,6 +303,7 @@ that the ORM resolves to:
 
     .. code-block:: yaml
 
+        # config/packages/doctrine.yaml
         doctrine:
             orm:
                 auto_mapping: false
@@ -301,26 +319,25 @@ that the ORM resolves to:
 
     .. code-block:: php
 
-        use Symfony\Config\DoctrineConfig;
+        // config/packages/doctrine.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (DoctrineConfig $doctrine): void {
-            $orm = $doctrine->orm();
-
-            $orm
-                ->entityManager('default')
-                ->connection('default')
-                ->autoMapping(true)
-                ->metadataCacheDriver()->type('array')
-                ->queryCacheDriver()->type('array')
-                ->resultCacheDriver()->type('array')
-                ->namingStrategy('doctrine.orm.naming_strategy.default');
-
-            $orm
-                ->autoGenerateProxyClasses(false)
-                ->proxyNamespace('Proxies')
-                ->proxyDir('%kernel.cache_dir%/doctrine/orm/Proxies')
-                ->defaultEntityManager('default');
-        };
+        return App::config([
+            'doctrine' => [
+                'orm' => [
+                    'auto_mapping' => false,
+                    // the standard distribution overrides this to be true in debug, false otherwise
+                    'auto_generate_proxy_classes' => false,
+                    'proxy_namespace' => 'Proxies',
+                    'proxy_dir' => '%kernel.cache_dir%/doctrine/orm/Proxies',
+                    'default_entity_manager' => 'default',
+                    'metadata_cache_driver' => 'array',
+                    'query_cache_driver' => 'array',
+                    'result_cache_driver' => 'array',
+                    'naming_strategy' => 'doctrine.orm.naming_strategy.default',
+                ],
+            ],
+        ]);
 
 There are lots of other configuration options that you can use to overwrite
 certain classes, but those are for very advanced use-cases only.
@@ -399,36 +416,46 @@ to cache each of Doctrine ORM elements (queries, results, etc.):
 
     .. code-block:: php
 
-        use Symfony\Config\DoctrineConfig;
-        use Symfony\Config\FrameworkConfig;
+        // config/packages/prod/doctrine.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework, DoctrineConfig $doctrine): void {
-            $framework
-                ->cache()
-                    ->pool('doctrine.result_cache_pool')
-                        ->adapters('cache.app')
-                    ->pool('doctrine.system_cache_pool')
-                        ->adapters('cache.system');
-
-            $doctrine->orm()
-                // ...
-                ->entityManager('default')
-                ->metadataCacheDriver()
-                    ->type('pool')
-                    ->pool('doctrine.system_cache_pool')
-                ->queryCacheDriver()
-                    ->type('pool')
-                    ->pool('doctrine.system_cache_pool')
-                ->resultCacheDriver()
-                    ->type('pool')
-                    ->pool('doctrine.result_cache_pool')
-
-                // in addition to Symfony cache pools, you can also use the
-                // 'type: service' option to use any service as a cache pool
-                ->queryCacheDriver()
-                    ->type('service')
-                    ->id(App\ORM\MyCacheService::class);
-        };
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'pools' => [
+                        'doctrine.result_cache_pool' => [
+                            'adapter' => 'cache.app',
+                        ],
+                        'doctrine.system_cache_pool' => [
+                            'adapter' => 'cache.system',
+                        ],
+                    ],
+                ],
+            ],
+            'doctrine' => [
+                'orm' => [
+                    // ...
+                    'metadata_cache_driver' => [
+                        'type' => 'pool',
+                        'pool' => 'doctrine.system_cache_pool',
+                    ],
+                    'query_cache_driver' => [
+                        'type' => 'pool',
+                        'pool' => 'doctrine.system_cache_pool',
+                    ],
+                    'result_cache_driver' => [
+                        'type' => 'pool',
+                        'pool' => 'doctrine.result_cache_pool',
+                    ],
+                    // in addition to Symfony cache pools, you can also use the
+                    // 'type: service' option to use any service as a cache pool
+                    'query_cache_driver' => [
+                        'type' => 'service',
+                        'id' => App\ORM\MyCacheService::class,
+                    ],
+                ],
+            ],
+        ]);
 
 Mapping Configuration
 ~~~~~~~~~~~~~~~~~~~~~
@@ -500,6 +527,7 @@ directory instead:
 
     .. code-block:: yaml
 
+        # config/packages/doctrine.yaml
         doctrine:
             # ...
             orm:
@@ -513,17 +541,22 @@ directory instead:
 
     .. code-block:: php
 
-        use Symfony\Config\DoctrineConfig;
+        // config/packages/doctrine.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (DoctrineConfig $doctrine): void {
-            $emDefault = $doctrine->orm()->entityManager('default');
-
-            $emDefault->autoMapping(true);
-            $emDefault->mapping('AppBundle')
-                ->type('xml')
-                ->dir('SomeResources/config/doctrine')
-            ;
-        };
+        return App::config([
+            'doctrine' => [
+                'orm' => [
+                    'auto_mapping' => true,
+                    'mappings' => [
+                        'AppBundle' => [
+                            'type' => 'xml',
+                            'dir' => 'SomeResources/config/doctrine',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Mapping Entities Outside of a Bundle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -536,6 +569,7 @@ namespace in the ``src/Entity`` directory and gives them an ``App`` alias
 
     .. code-block:: yaml
 
+        # config/packages/doctrine.yaml
         doctrine:
                 # ...
                 orm:
@@ -551,20 +585,24 @@ namespace in the ``src/Entity`` directory and gives them an ``App`` alias
 
     .. code-block:: php
 
-        use Symfony\Config\DoctrineConfig;
+        // config/packages/doctrine.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (DoctrineConfig $doctrine): void {
-            $emDefault = $doctrine->orm()->entityManager('default');
-
-            $emDefault->autoMapping(true);
-            $emDefault->mapping('SomeEntityNamespace')
-                ->type('attribute')
-                ->dir('%kernel.project_dir%/src/Entity')
-                ->isBundle(false)
-                ->prefix('App\Entity')
-                ->alias('App')
-            ;
-        };
+        return App::config([
+            'doctrine' => [
+                'orm' => [
+                    'mappings' => [
+                        'SomeEntityNamespace' => [
+                            'type' => 'attribute',
+                            'dir' => '%kernel.project_dir%/src/Entity',
+                            'is_bundle' => false,
+                            'prefix' => 'App\Entity',
+                            'alias' => 'App',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Detecting a Mapping Configuration Format
 ........................................
@@ -609,9 +647,10 @@ set up the connection using environment variables for the certificate paths:
 
     .. code-block:: yaml
 
+        # config/packages/doctrine.yaml
         doctrine:
             dbal:
-                url: '%env(DATABASE_URL)%'
+                url: '%env(resolve:DATABASE_URL)%'
                 server_version: '8.0.31'
                 driver: 'pdo_mysql'
                 options:
@@ -625,21 +664,25 @@ set up the connection using environment variables for the certificate paths:
     .. code-block:: php
 
         // config/packages/doctrine.php
-        use Symfony\Config\DoctrineConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (DoctrineConfig $doctrine): void {
-            $doctrine->dbal()
-                ->connection('default')
-                ->url(env('DATABASE_URL')->resolve())
-                ->serverVersion('8.0.31')
-                ->driver('pdo_mysql');
-
-            $doctrine->dbal()->defaultConnection('default');
-
-            $doctrine->dbal()->option(\PDO::MYSQL_ATTR_SSL_KEY, '%env(MYSQL_SSL_KEY)%');
-            $doctrine->dbal()->option(\PDO::MYSQL_SSL_CERT, '%env(MYSQL_ATTR_SSL_CERT)%');
-            $doctrine->dbal()->option(\PDO::MYSQL_SSL_CA, '%env(MYSQL_ATTR_SSL_CA)%');
-        };
+        return App::config([
+            'doctrine' => [
+                'dbal' => [
+                    'url' => env('DATABASE_URL')->resolve(),
+                    'server_version' => '8.0.31',
+                    'driver' => 'pdo_mysql',
+                    'options' => [
+                        // SSL private key
+                        \PDO::MYSQL_ATTR_SSL_KEY => env('MYSQL_SSL_KEY'),
+                        // SSL certificate
+                        \PDO::MYSQL_ATTR_SSL_CERT => env('MYSQL_SSL_CERT'),
+                        // SSL CA authority
+                        \PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_SSL_CA'),
+                    ],
+                ],
+            ],
+        ]);
 
 Ensure your environment variables are correctly set in the ``.env.local`` or
 ``.env.local.php`` file as follows:

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -43,13 +43,15 @@ This option allows you to prepend a base path to the URLs generated for assets:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->assets()
-                ->basePath('/images');
-        };
+        return App::config([
+            'framework' => [
+                'assets' => [
+                    'base_path' => '/images',
+                ],
+            ],
+        ]);
 
 With this configuration, a call to ``asset('logo.png')`` will generate
 ``/images/logo.png`` instead of ``/logo.png``.
@@ -75,18 +77,20 @@ collection each time it generates an asset's path:
             # ...
             assets:
                 base_urls:
-                    - 'http://cdn.example.com/'
+                    - 'https://cdn.example.com/'
 
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->assets()
-                ->baseUrls(['http://cdn.example.com/']);
-        };
+        return App::config([
+            'framework' => [
+                'assets' => [
+                    'base_urls' => ['https://cdn.example.com/'],
+                ],
+            ],
+        ]);
 
 .. _reference-assets-json-manifest-path:
 .. _reference-templating-json-manifest-path:
@@ -136,26 +140,30 @@ package:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->assets()
-                // this manifest is applied to every asset (including packages)
-                ->jsonManifestPath('%kernel.project_dir%/public/build/manifest.json');
-
-            // you can use absolute URLs too and Symfony will download them automatically
-            // 'json_manifest_path' => 'https://cdn.example.com/manifest.json',
-            $framework->assets()->package('foo_package')
-                // this package uses its own manifest (the default file is ignored)
-                ->jsonManifestPath('%kernel.project_dir%/public/build/a_different_manifest.json')
-                // Throws an exception when an asset is not found in the manifest
-                ->setStrictMode('%kernel.debug%');
-
-            $framework->assets()->package('bar_package')
-                // this package uses the global manifest (the default file is used)
-                ->basePath('/images');
-        };
+        return App::config([
+            'framework' => [
+                'assets' => [
+                    // this manifest is applied to every asset (including packages)
+                    'json_manifest_path' => '%kernel.project_dir%/public/build/manifest.json',
+                    // you can use absolute URLs too and Symfony will download them automatically
+                    // 'json_manifest_path' => 'https://cdn.example.com/manifest.json',
+                    'packages' => [
+                        'foo_package' => [
+                            // this package uses its own manifest (the default file is ignored)
+                            'json_manifest_path' => '%kernel.project_dir%/public/build/a_different_manifest.json',
+                            // Throws an exception when an asset is not found in the manifest
+                            'strict_mode' => param('kernel.debug'),
+                        ],
+                        'bar_package' => [
+                            // this package uses the global manifest (the default file is used)
+                            'base_path' => '/images',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -230,19 +238,25 @@ You can group assets into packages, to specify different base URLs for them:
             assets:
                 packages:
                     avatars:
-                        base_urls: 'http://static_cdn.example.com/avatars'
+                        base_urls: 'https://static_cdn.example.com/avatars'
 
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->assets()
-                ->package('avatars')
-                    ->baseUrls(['http://static_cdn.example.com/avatars']);
-        };
+        return App::config([
+            'framework' => [
+                // ...
+                'assets' => [
+                    'packages' => [
+                        'avatars' => [
+                            'base_urls' => ['https://static_cdn.example.com/avatars'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Now you can use the ``avatars`` package in your templates:
 
@@ -306,13 +320,15 @@ Now, activate the ``version`` option:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->assets()
-                ->version('v2');
-        };
+        return App::config([
+            'framework' => [
+                'assets' => [
+                    'version' => 'v2',
+                ],
+            ],
+        ]);
 
 Now, the same asset will be rendered as ``/images/logo.png?v2`` If you use
 this feature, you **must** manually increment the ``version`` value
@@ -406,25 +422,30 @@ individually for each asset package:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->assets()
-                ->versionStrategy('app.asset.my_versioning_strategy');
-
-            $framework->assets()->package('foo_package')
-                // this package removes any versioning (its assets won't be versioned)
-                ->version(null);
-
-            $framework->assets()->package('bar_package')
-                // this package uses its own strategy (the default strategy is ignored)
-                ->versionStrategy('app.asset.another_version_strategy');
-
-            $framework->assets()->package('baz_package')
-                // this package inherits the default strategy
-                ->basePath('/images');
-        };
+        return App::config([
+            'framework' => [
+                'assets' => [
+                    // this strategy is applied to every asset (including packages)
+                    'version_strategy' => 'app.asset.my_versioning_strategy',
+                    'packages' => [
+                        'foo_package' => [
+                            // this package removes any versioning (its assets won't be versioned)
+                            'version' => null,
+                        ],
+                        'bar_package' => [
+                            // this package uses its own strategy (the default strategy is ignored)
+                            'version_strategy' => 'app.asset.another_version_strategy',
+                        ],
+                        'baz_package' => [
+                            // this package inherits the default strategy
+                            'base_path' => '/images',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -536,14 +557,20 @@ To configure a Redis cache pool with a default lifetime of 1 hour, do the follow
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->cache()
-                ->pool('cache.mycache')
-                    ->adapters(['cache.adapter.redis'])
-                    ->defaultLifetime(3600);
-        };
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'pools' => [
+                        'cache.mycache' => [
+                            'adapter' => 'cache.adapter.redis',
+                            'default_lifetime' => 3600,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 adapter
 """""""
@@ -682,12 +709,13 @@ can also :ref:`disable CSRF protection on individual forms <form-csrf-customizat
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
-        return static function (FrameworkConfig $framework): void {
-            $framework->csrfProtection()
-                ->enabled(true)
-            ;
-        };
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'csrf_protection' => true,
+            ],
+        ]);
 
 If you're using forms, but want to avoid starting your session (e.g. using
 forms in an API-only website), ``csrf_protection`` will need to be set to
@@ -760,11 +788,13 @@ performance a bit:
     .. code-block:: php
 
         // config/packages/translation.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->enabledLocales(['en', 'es']);
-        };
+        return App::config([
+            'framework' => [
+                'enabled_locales' => ['en', 'es'],
+            ],
+        ]);
 
 An added bonus of defining the enabled locales is that they are automatically
 added as a requirement of the :ref:`special _locale parameter <routing-locale-parameter>`.
@@ -844,11 +874,15 @@ You can also set ``esi`` to ``true`` to enable it:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->esi()->enabled(true);
-        };
+        return App::config([
+            'framework' => [
+                'esi' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]);
 
 .. _framework_exceptions:
 
@@ -875,16 +909,21 @@ and HTTP status code applied to the exceptions that match the given exception cl
     .. code-block:: php
 
         // config/packages/exceptions.php
-        use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->exception(BadRequestHttpException::class)
-                ->logLevel('debug')
-                ->statusCode(422)
-                ->logChannel('custom_channel')
-            ;
-        };
+        use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+        return App::config([
+            'framework' => [
+                'exceptions' => [
+                    BadRequestHttpException::class => [
+                        'log_level' => 'debug',
+                        'status_code' => 422,
+                        'log_channel' => 'custom_channel',
+                    ],
+                ],
+            ],
+        ]);
 
 The order in which you configure exceptions is important because Symfony will
 use the configuration of the first exception that matches ``instanceof``:
@@ -1184,14 +1223,16 @@ This service can be configured using ``framework.http_client.default_options``:
     .. code-block:: php
 
         // config/packages/framework.php
-        $container->loadFromExtension('framework', [
-            'http_client' => [
-                'max_host_connections' => 10,
-                'default_options' => [
-                    'headers' => [
-                        'X-Powered-By' => 'ACME App',
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'http_client' => [
+                    'max_host_connections' => 10,
+                    'default_options' => [
+                        'headers' => ['X-Powered-By' => 'ACME App'],
+                        'max_redirects' => 7,
                     ],
-                    'max_redirects' => 7,
                 ],
             ],
         ]);
@@ -1199,9 +1240,7 @@ This service can be configured using ``framework.http_client.default_options``:
     .. code-block:: php-standalone
 
         $client = HttpClient::create([
-            'headers' => [
-                'X-Powered-By' => 'ACME App',
-            ],
+            'headers' => ['X-Powered-By' => 'ACME App'],
             'max_redirects' => 7,
         ], 10);
 
@@ -1228,12 +1267,16 @@ these options and can define a few others:
     .. code-block:: php
 
         // config/packages/framework.php
-        $container->loadFromExtension('framework', [
-            'http_client' => [
-                'scoped_clients' => [
-                    'my_api.client' => [
-                        'auth_bearer' => 'secret_bearer_token',
-                        // ...
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'http_client' => [
+                    'scoped_clients' => [
+                        'my_api.client' => [
+                            'auth_bearer' => 'secret_bearer_token',
+                            // ...
+                        ],
                     ],
                 ],
             ],
@@ -1865,11 +1908,13 @@ doubling them to prevent Symfony from interpreting them as container parameters)
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->ide('myide://open?url=file://%%f&line=%%l');
-        };
+        return App::config([
+            'framework' => [
+                'ide' => 'myide://open?url=file://%%f&line=%%l',
+            ],
+        ]);
 
 Since every developer uses a different IDE, the recommended way to enable this
 feature is to configure it on a system level. First, you can define this option
@@ -1960,12 +2005,17 @@ the name as key and DSN or service id as value:
     .. code-block:: php
 
         // config/packages/lock.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->lock()
-                ->resource('default', [env('LOCK_DSN')]);
-        };
+        return App::config([
+            'framework' => [
+                'lock' => [
+                    'resource' => [
+                        'default' => [env('LOCK_DSN')],
+                    ],
+                ],
+            ],
+        ]);
 
 .. seealso::
 
@@ -2020,19 +2070,16 @@ the `SMTP session`_. This value overrides any other recipient set in the code.
         // config/packages/mailer.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerConfigurator $container): void {
-            $container->extension('framework', [
+        return App::config([
+            'framework' => [
                 'mailer' => [
                     'dsn' => 'smtp://localhost:25',
                     'envelope' => [
-                        'recipients' => [
-                            'admin@symfony.com',
-                            'lead@symfony.com',
-                        ],
+                        'recipients' => ['admin@symfony.com', 'lead@symfony.com'],
                     ],
                 ],
-            ]);
-        };
+            ],
+        ]);
 
 sender
 """"""
@@ -2132,14 +2179,32 @@ This option also accepts a map of PHP errors to log levels:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Psr\Log\LogLevel;
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->phpErrors()->log(\E_DEPRECATED, LogLevel::ERROR);
-            $framework->phpErrors()->log(\E_USER_DEPRECATED, LogLevel::ERROR);
-            // ...
-        };
+        use Psr\Log\LogLevel;
+
+        return App::config([
+            'framework' => [
+                'php_errors' => [
+                    'log' => [
+                        \E_DEPRECATED => LogLevel::ERROR,
+                        \E_USER_DEPRECATED => LogLevel::ERROR,
+                        \E_NOTICE => LogLevel::ERROR,
+                        \E_USER_NOTICE => LogLevel::ERROR,
+                        \E_STRICT => LogLevel::ERROR,
+                        \E_WARNING => LogLevel::ERROR,
+                        \E_USER_WARNING => LogLevel::ERROR,
+                        \E_COMPILE_WARNING => LogLevel::ERROR,
+                        \E_CORE_WARNING => LogLevel::ERROR,
+                        \E_USER_ERROR => LogLevel::CRITICAL,
+                        \E_COMPILE_ERROR => LogLevel::CRITICAL,
+                        \E_PARSE => LogLevel::CRITICAL,
+                        \E_ERROR => LogLevel::CRITICAL,
+                        \E_CORE_ERROR => LogLevel::CRITICAL,
+                    ],
+                ],
+            ],
+        ]);
 
 throw
 .....
@@ -2355,12 +2420,17 @@ To configure a ``jsonp`` format:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->request()
-                ->format('jsonp', 'application/javascript');
-        };
+        return App::config([
+            'framework' => [
+                'request' => [
+                    'formats' => [
+                        'jsonp' => 'application/javascript',
+                    ],
+                ],
+            ],
+        ]);
 
 router
 ~~~~~~
@@ -2545,13 +2615,13 @@ the name as key and DSN or service id as value:
     .. code-block:: php
 
         // config/packages/semaphore.php
-        use Symfony\Config\FrameworkConfig;
-        use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->semaphore()
-                ->resource('default', [env('SEMAPHORE_DSN')]);
-        };
+        return App::config([
+            'framework' => [
+                'semaphore' => env('SEMAPHORE_DSN'),
+            ],
+        ]);
 
 .. _reference-semaphore-resources-name:
 
@@ -2676,8 +2746,14 @@ Unlike the other session options, ``cache_limiter`` is set as a regular
     .. code-block:: php
 
         // config/services.php
-        $container->setParameter('session.storage.options', [
-            'cache_limiter' => 0,
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'parameters' => [
+                'session.storage.options' => [
+                    'cache_limiter' => 0,
+                ],
+            ],
         ]);
 
 Be aware that if you configure it, you'll have to set other session-related options
@@ -2783,12 +2859,15 @@ Whether to enable the session support in the framework.
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->session()
-                ->enabled(true);
-        };
+        return App::config([
+            'framework' => [
+                'session' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]);
 
 gc_divisor
 ..........
@@ -2854,19 +2933,19 @@ and also to configure the session handler with a DSN:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
-        use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-
-            $framework->session()
-                // a few possible examples
-                ->handlerId('redis://localhost')
-                ->handlerId(env('REDIS_URL'))
-                ->handlerId(env('DATABASE_URL'))
-                ->handlerId('file://%kernel.project_dir%/var/sessions');
-        };
+        return App::config([
+            'framework' => [
+                'session' => [
+                    // a few possible examples
+                    'handler_id' => 'redis://localhost',
+                    'handler_id' => env('REDIS_URL'),
+                    'handler_id' => env('DATABASE_URL'),
+                    'handler_id' => 'file://%kernel.project_dir%/var/sessions',
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -2931,12 +3010,15 @@ If ``null``, ``php.ini``'s `session.save_path`_ directive will be relied on:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->session()
-                ->savePath(null);
-        };
+        return App::config([
+            'framework' => [
+                'session' => [
+                    'save_path' => null,
+                ],
+            ],
+        ]);
 
 .. _storage_id:
 
@@ -3142,11 +3224,13 @@ the application won't respond and the user will receive a 400 response.
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->trustedHosts(['^example\.com$', '^example\.org$']);
-        };
+        return App::config([
+            'framework' => [
+                'trusted_hosts' => ['^example\.com$', '^example\.org$'],
+            ],
+        ]);
 
 Hosts can also be configured to respond to any subdomain, via
 ``^(.+\.)?example\.com$`` for instance.
@@ -3203,16 +3287,21 @@ Defines the Doctrine entities that will be introspected to add
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->validation()
-                ->autoMapping()
-                    ->paths([
-                        'App\\Entity\\' => [],
-                        'Foo\\' => ['Foo\\Some\\Entity', 'Foo\\Another\\Entity'],
-                    ]);
-        };
+        use App\Entity\AnotherEntity;
+        use App\Entity\SomeEntity;
+
+        return App::config([
+            'framework' => [
+                'auto_mapping' => [
+                    // an empty array means that all entities that belong to that
+                    // namespace will add automatic validation
+                    'App\\Entity\\' => [],
+                    'Foo\\' => [SomeEntity::class, AnotherEntity::class],
+                ],
+            ],
+        ]);
 
 .. _reference-validation-disable_translation:
 
@@ -3286,13 +3375,17 @@ the component will look for additional validation files:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->validation()
-                ->mapping()
-                    ->paths(['%kernel.project_dir%/config/validation/']);
-        };
+        return App::config([
+            'framework' => [
+                'validation' => [
+                    'mapping' => [
+                        'paths' => ['%kernel.project_dir%/config/validation/'],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _reference-validation-not-compromised-password:
 
@@ -3380,14 +3473,17 @@ A list of workflows to be created by the framework extension:
     .. code-block:: php
 
         // config/packages/workflow.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->workflows()
-                ->workflows('my_workflow')
-                    // ...
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'workflows' => [
+                    'my_workflow' => [
+                        // ...
+                    ],
+                ],
+            ],
+        ]);
 
 .. seealso::
 

--- a/reference/configuration/kernel.rst
+++ b/reference/configuration/kernel.rst
@@ -141,9 +141,13 @@ achieve a strict reproducible build:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-        $container->setParameter('kernel.container_build_time', '1234567890');
+        return App::config([
+            'parameters' => [
+                'kernel.container_build_time' => '1234567890',
+            ],
+        ]);
 
 ``kernel.container_class``
 --------------------------

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -111,20 +111,24 @@ application:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            // 'main' is the name of the firewall (can be chosen freely)
-            $security->firewall('main')
-                // 'pattern' is a regular expression matched against the incoming
-                // request URL. If there's a match, authentication is triggered
-                ->pattern('^/admin')
-                // the rest of options depend on the authentication mechanism
+        return App::config([
+            'security' => [
                 // ...
-            ;
-        };
+
+                // 'main' is the name of the firewall (can be chosen freely)
+                'firewalls' => [
+                    'main' => [
+                        // 'pattern' is a regular expression matched against the incoming
+                        // request URL. If there's a match, authentication is triggered
+                        'pattern' => '^/admin',
+                        // the rest of options depend on the authentication mechanism
+                        // ...
+                    ],
+                ],
+            ],
+        ]);
 
 .. seealso::
 
@@ -348,21 +352,28 @@ user logs out:
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-
-        return static function (SecurityConfig $securityConfig): void {
-            // ...
-
-            $securityConfig->firewall('main')
-                ->logout()
-                    ->deleteCookie('cookie1-name')
-                    ->deleteCookie('cookie2-name')
-                        ->path('/')
-                    ->deleteCookie('cookie3-name')
-                        ->path(null)
-                        ->domain('example.com');
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'logout' => [
+                            'delete_cookies' => [
+                                'cookie1-name' => null,
+                                'cookie2-name' => [
+                                    'path' => '/',
+                                ],
+                                'cookie3-name' => [
+                                    'path' => null,
+                                    'domain' => 'example.com',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 clear_site_data
 ...............
@@ -395,16 +406,19 @@ It's also possible to use ``*`` as a wildcard for all directives:
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-
-        return static function (SecurityConfig $securityConfig): void {
-            // ...
-
-            $securityConfig->firewall('main')
-                ->logout()
-                    ->clearSiteData(['cookies', 'storage']);
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'logout' => [
+                            'clear_site_data' => ['cookies', 'storage'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 invalidate_session
 ..................
@@ -525,17 +539,22 @@ The security configuration should be:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall->lazy(true);
-            $mainFirewall->jsonLogin()
-                ->checkPath('/login')
-                ->usernamePath('security.credentials.login')
-                ->passwordPath('security.credentials.password')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'lazy' => true,
+                        'json_login' => [
+                            'check_path' => '/login',
+                            'username_path' => 'security.credentials.login',
+                            'password_path' => 'security.credentials.password',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 password_path
 .............
@@ -626,17 +645,22 @@ X.509 Authentication
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall->x509()
-                ->provider('your_user_provider')
-                ->user('SSL_CLIENT_S_DN_Email')
-                ->credentials('SSL_CLIENT_S_DN')
-                ->userIdentifier('emailAddress')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'x509' => [
+                            'provider' => 'your_user_provider',
+                            'user' => 'SSL_CLIENT_S_DN_Email',
+                            'credentials' => 'SSL_CLIENT_S_DN',
+                            'user_identifier' => 'emailAddress',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 user
 ....
@@ -691,15 +715,20 @@ Remote User Authentication
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall->remoteUser()
-                ->provider('your_user_provider')
-                ->user('REMOTE_USER')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'remote_user' => [
+                            'provider' => 'your_user_provider',
+                            'user' => 'REMOTE_USER',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 provider
 ........
@@ -750,19 +779,20 @@ multiple firewalls, the "context" could actually be shared:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('somename')
-                // ...
-                ->context('my_context')
-            ;
-
-            $security->firewall('othername')
-                // ...
-                ->context('my_context')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'somename' => [
+                        'context' => 'my_context',
+                    ],
+                    'othername' => [
+                        'context' => 'my_context',
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -795,13 +825,17 @@ the session must not be used when authenticating users:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall->stateless(true);
-            // ...
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'stateless' => true,
+                    ],
+                ],
+            ],
+        ]);
 
 .. _reference-security-lazy:
 
@@ -828,13 +862,17 @@ session only if the application actually accesses the User object, (e.g. calling
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->lazy(true);
-            // ...
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'lazy' => true,
+                    ],
+                ],
+            ],
+        ]);
 
 User Checkers
 ~~~~~~~~~~~~~
@@ -866,13 +904,17 @@ Firewalls can configure a list of required badges that must be present on the au
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall->requiredBadges(['CsrfTokenBadge', 'My\Badge']);
-            // ...
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'required_badges' => ['CsrfTokenBadge', 'My\Badge'],
+                    ],
+                ],
+            ],
+        ]);
 
 providers
 ---------

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -160,16 +160,13 @@ The value of this option can be a regular expression, a glob, or a string:
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            $twig->fileNamePattern([
-                '*.twig',
-                'specific_file.html',
-            ]);
-
-            // ...
-        };
+        return App::config([
+            'twig' => [
+                'file_name_pattern' => ['*.twig', 'specific_file.html'],
+            ],
+        ]);
 
 .. _config-twig-form-themes:
 
@@ -193,16 +190,13 @@ all the forms of the application:
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            $twig->formThemes([
-                'bootstrap_5_layout.html.twig',
-                'form/my_theme.html.twig',
-            ]);
-
-            // ...
-        };
+        return App::config([
+            'twig' => [
+                'form_themes' => ['bootstrap_5_layout.html.twig', 'form/my_theme.html.twig'],
+            ],
+        ]);
 
 The order in which themes are defined is important because each theme overrides
 all the previous one. When rendering a form field whose block is not defined in
@@ -307,14 +301,16 @@ the directory defined in the :ref:`default_path option <config-twig-default-path
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            // ...
-
-            $twig->path('email/default/templates', null);
-            $twig->path('backend/templates', 'admin');
-        };
+        return App::config([
+            'twig' => [
+                'paths' => [
+                    'email/default/templates' => null,
+                    'backend/templates' => 'admin',
+                ],
+            ],
+        ]);
 
 Read more about :ref:`template directories and namespaces <templates-namespaces>`.
 

--- a/reference/constraints/PasswordStrength.rst
+++ b/reference/constraints/PasswordStrength.rst
@@ -181,13 +181,14 @@ service to use your own estimator:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+        use App\Validator\CustomPasswordStrengthEstimator;
         use Symfony\Component\Validator\Constraints\PasswordStrengthValidator;
 
-        return function (ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set('custom_password_strength_estimator', CustomPasswordStrengthEstimator::class);
-
-            $services->set(PasswordStrengthValidator::class)
-                ->args([closure('custom_password_strength_estimator')]);
-        };
+        return App::config([
+            'services' => [
+                'custom_password_strength_estimator' => CustomPasswordStrengthEstimator::class,
+                PasswordStrengthValidator::class => [
+                    'arguments' => [closure(service('custom_password_strength_estimator'))],
+                ],
+            ],
+        ]);

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -36,6 +36,7 @@ The name of the package is set in this order:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Assets\AvatarPackage:
                 tags:
@@ -43,12 +44,20 @@ The name of the package is set in this order:
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Assets\AvatarPackage;
 
-        $container
-            ->register(AvatarPackage::class)
-            ->addTag('assets.package', ['package' => 'avatars'])
-        ;
+        return App::config([
+            'services' => [
+                AvatarPackage::class => [
+                    'tags' => [
+                        ['assets.package' => ['package' => 'avatars']],
+                    ],
+                ],
+            ],
+        ]);
 
 Now you can use the ``avatars`` package in your templates:
 
@@ -68,6 +77,7 @@ services:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             app.mysql_lock:
                 class: App\Lock\MysqlLock
@@ -85,13 +95,19 @@ services:
         use App\Lock\PostgresqlLock;
         use App\Lock\SqliteLock;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set('app.mysql_lock', MysqlLock::class);
-            $services->set('app.postgresql_lock', PostgresqlLock::class);
-            $services->set('app.sqlite_lock', SqliteLock::class);
-        };
+        return App::config([
+            'services' => [
+                'app.mysql_lock' => [
+                    'class' => MysqlLock::class,
+                ],
+                'app.postgresql_lock' => [
+                    'class' => PostgresqlLock::class,
+                ],
+                'app.sqlite_lock' => [
+                    'class' => SqliteLock::class,
+                ],
+            ],
+        ]);
 
 Instead of dealing with these three services, your application needs a generic
 ``app.lock`` service that will be an alias to one of these services, depending on
@@ -105,13 +121,9 @@ the generic ``app.lock`` service can be defined as follows:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
-            app.mysql_lock:
-                # ...
-            app.postgresql_lock:
-                # ...
-            app.sqlite_lock:
-                # ...
+            # ...
             app.lock:
                 tags:
                     - { name: auto_alias, format: "app.%database_type%_lock" }
@@ -121,21 +133,18 @@ the generic ``app.lock`` service can be defined as follows:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        use App\Lock\MysqlLock;
-        use App\Lock\PostgresqlLock;
-        use App\Lock\SqliteLock;
+        // ...
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set('app.mysql_lock', MysqlLock::class);
-            $services->set('app.postgresql_lock', PostgresqlLock::class);
-            $services->set('app.sqlite_lock', SqliteLock::class);
-
-            $services->set('app.lock')
-                ->tag('auto_alias', ['format' => 'app.%database_type%_lock'])
-            ;
-        };
+        return App::config([
+            'services' => [
+                // ...
+                'app.lock' => [
+                    'tags' => [
+                        ['auto_alias' => ['format' => 'app.%database_type%_lock']],
+                    ],
+                ],
+            ],
+        ]);
 
 The ``format`` option defines the expression used to construct the name of the service
 to alias. This expression can use any container parameter (as usual,
@@ -187,18 +196,25 @@ Add this tag to a service and its class won't be preloaded when using
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\SomeNamespace\SomeService:
                 tags: ['container.no_preload']
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\SomeNamespace\SomeService;
 
-        $container
-            ->register(SomeService::class)
-            ->addTag('container.no_preload')
-        ;
+        return App::config([
+            'services' => [
+                SomeService::class => [
+                    'tags' => ['container.no_preload'],
+                ],
+            ],
+        ]);
 
 If you add some service tagged with ``container.no_preload`` as an argument of
 another service, the ``container.no_preload`` tag is applied automatically to
@@ -220,6 +236,7 @@ is restarted):
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\SomeNamespace\SomeService:
                 tags:
@@ -229,16 +246,23 @@ is restarted):
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Some\OtherClass;
         use App\SomeClass;
         use App\SomeNamespace\SomeService;
 
-        $container
-            ->register(SomeService::class)
-            ->addTag('container.preload', ['class' => SomeClass::class])
-            ->addTag('container.preload', ['class' => OtherClass::class])
-            // ...
-        ;
+        return App::config([
+            'services' => [
+                SomeService::class => [
+                    'tags' => [
+                        ['container.preload' => ['class' => SomeClass::class]],
+                        ['container.preload' => ['class' => OtherClass::class]],
+                    ],
+                ],
+            ],
+        ]);
 
 controller.argument_value_resolver
 ----------------------------------
@@ -343,18 +367,25 @@ can also register it manually:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Cache\MyClearer:
                 tags: [kernel.cache_clearer]
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Cache\MyClearer;
 
-        $container
-            ->register(MyClearer::class)
-            ->addTag('kernel.cache_clearer')
-        ;
+        return App::config([
+            'services' => [
+                MyClearer::class => [
+                    'tags' => ['kernel.cache_clearer'],
+                ],
+            ],
+        ]);
 
 kernel.cache_warmer
 -------------------
@@ -423,6 +454,7 @@ can also register it manually:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Cache\MyCustomWarmer:
                 tags:
@@ -430,12 +462,20 @@ can also register it manually:
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Cache\MyCustomWarmer;
 
-        $container
-            ->register(MyCustomWarmer::class)
-            ->addTag('kernel.cache_warmer', ['priority' => 0])
-        ;
+        return App::config([
+            'services' => [
+                MyCustomWarmer::class => [
+                    'tags' => [
+                        ['kernel.cache_warmer' => ['priority' => 0]],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -539,18 +579,25 @@ can also register it manually:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Locale\MyCustomLocaleHandler:
                 tags: [kernel.locale_aware]
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Locale\MyCustomLocaleHandler;
 
-        $container
-            ->register(LocaleHandler::class)
-            ->addTag('kernel.locale_aware')
-        ;
+        return App::config([
+            'services' => [
+                MyCustomLocaleHandler::class => [
+                    'tags' => ['kernel.locale_aware'],
+                ],
+            ],
+        ]);
 
 kernel.reset
 ------------
@@ -593,6 +640,7 @@ channel when injecting the logger in a service.
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Log\CustomLogger:
                 arguments: ['@logger']
@@ -601,12 +649,21 @@ channel when injecting the logger in a service.
 
     .. code-block:: php
 
-        use App\Log\CustomLogger;
-        use Symfony\Component\DependencyInjection\Reference;
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        $container->register(CustomLogger::class)
-            ->addArgument(new Reference('logger'))
-            ->addTag('monolog.logger', ['channel' => 'app']);
+        use App\Log\CustomLogger;
+
+        return App::config([
+            'services' => [
+                CustomLogger::class => [
+                    'arguments' => [service('logger')],
+                    'tags' => [
+                        ['monolog.logger' => ['channel' => 'app']],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -634,18 +691,25 @@ You can add a processor globally:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             Monolog\Processor\IntrospectionProcessor:
                 tags: [monolog.processor]
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Monolog\Processor\IntrospectionProcessor;
 
-        $container
-            ->register(IntrospectionProcessor::class)
-            ->addTag('monolog.processor')
-        ;
+        return App::config([
+            'services' => [
+                IntrospectionProcessor::class => [
+                    'tags' => ['monolog.processor'],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -659,6 +723,7 @@ attribute:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             Monolog\Processor\IntrospectionProcessor:
                 tags:
@@ -666,12 +731,20 @@ attribute:
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Monolog\Processor\IntrospectionProcessor;
 
-        $container
-            ->register(IntrospectionProcessor::class)
-            ->addTag('monolog.processor', ['handler' => 'firephp'])
-        ;
+        return App::config([
+            'services' => [
+                IntrospectionProcessor::class => [
+                    'tags' => [
+                        ['monolog.processor' => ['handler' => 'firephp']],
+                    ],
+                ],
+            ],
+        ]);
 
 You can also add a processor for a specific logging channel by using the
 ``channel`` attribute. This will register the processor only for the
@@ -681,6 +754,7 @@ You can also add a processor for a specific logging channel by using the
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             Monolog\Processor\IntrospectionProcessor:
                 tags:
@@ -688,12 +762,20 @@ You can also add a processor for a specific logging channel by using the
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Monolog\Processor\IntrospectionProcessor;
 
-        $container
-            ->register(IntrospectionProcessor::class)
-            ->addTag('monolog.processor', ['channel' => 'security'])
-        ;
+        return App::config([
+            'services' => [
+                IntrospectionProcessor::class => [
+                    'tags' => [
+                        ['monolog.processor' => ['channel' => 'security']],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -712,18 +794,25 @@ of your configuration and tag it with ``routing.loader``:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Routing\CustomLoader:
                 tags: [routing.loader]
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Routing\CustomLoader;
 
-        $container
-            ->register(CustomLoader::class)
-            ->addTag('routing.loader')
-        ;
+        return App::config([
+            'services' => [
+                CustomLoader::class => [
+                    'tags' => ['routing.loader'],
+                ],
+            ],
+        ]);
 
 For more information, see :doc:`/routing/custom_route_loader`.
 
@@ -804,6 +893,7 @@ Now, register your loader as a service and tag it with ``translation.loader``:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Translation\MyCustomLoader:
                 tags:
@@ -811,12 +901,20 @@ Now, register your loader as a service and tag it with ``translation.loader``:
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Translation\MyCustomLoader;
 
-        $container
-            ->register(MyCustomLoader::class)
-            ->addTag('translation.loader', ['alias' => 'bin'])
-        ;
+        return App::config([
+            'services' => [
+                MyCustomLoader::class => [
+                    'tags' => [
+                        ['translation.loader' => ['alias' => 'bin']],
+                    ],
+                ],
+            ],
+        ]);
 
 The ``alias`` option is required and very important: it defines the file
 "suffix" that will be used for the resource files that use this loader.
@@ -889,6 +987,7 @@ required option: ``alias``, which defines the name of the extractor::
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Translation\CustomExtractor:
                 tags:
@@ -896,10 +995,20 @@ required option: ``alias``, which defines the name of the extractor::
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Translation\CustomExtractor;
 
-        $container->register(CustomExtractor::class)
-            ->addTag('translation.extractor', ['alias' => 'foo']);
+        return App::config([
+            'services' => [
+                CustomExtractor::class => [
+                    'tags' => [
+                        ['translation.extractor' => ['alias' => 'foo']],
+                    ],
+                ],
+            ],
+        ]);
 
 translation.dumper
 ------------------
@@ -931,6 +1040,7 @@ This is the name that's used to determine which dumper should be used.
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Translation\JsonFileDumper:
                 tags:
@@ -938,10 +1048,20 @@ This is the name that's used to determine which dumper should be used.
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Translation\JsonFileDumper;
 
-        $container->register(JsonFileDumper::class)
-            ->addTag('translation.dumper', ['alias' => 'json']);
+        return App::config([
+            'services' => [
+                JsonFileDumper::class => [
+                    'tags' => [
+                        ['translation.dumper' => ['alias' => 'json']],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _reference-dic-tags-translation-provider-factory:
 
@@ -957,6 +1077,7 @@ must register your factory as a service and tag it with ``translation.provider_f
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Translation\CustomProviderFactory:
                 tags:
@@ -964,12 +1085,18 @@ must register your factory as a service and tag it with ``translation.provider_f
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Translation\CustomProviderFactory;
 
-        $container
-            ->register(CustomProviderFactory::class)
-            ->addTag('translation.provider_factory')
-        ;
+        return App::config([
+            'services' => [
+                CustomProviderFactory::class => [
+                    'tags' => ['translation.provider_factory'],
+                ],
+            ],
+        ]);
 
 .. _reference-dic-tags-twig-extension:
 
@@ -987,6 +1114,7 @@ the service is auto-registered and auto-tagged. But, you can also register it ma
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Twig\AppExtension:
                 tags: [twig.extension]
@@ -999,17 +1127,28 @@ the service is auto-registered and auto-tagged. But, you can also register it ma
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Twig\AnotherExtension;
         use App\Twig\AppExtension;
 
-        $container
-            ->register(AppExtension::class)
-            ->addTag('twig.extension')
-        ;
-        $container
-            ->register(AnotherExtension::class)
-            ->addTag('twig.extension', ['priority' => -100])
-        ;
+        return App::config([
+            'services' => [
+                AppExtension::class => [
+                    'tags' => ['twig.extension'],
+                ],
+
+                // optionally you can define the priority of the extension (default = 0).
+                // Extensions with higher priorities are registered earlier. This is mostly
+                // useful to register late extensions that override other extensions.
+                AnotherExtension::class => [
+                    'tags' => [
+                        ['twig.extension' => ['priority' => -100]],
+                    ],
+                ],
+            ],
+        ]);
 
 For information on how to create the actual Twig Extension class, see
 `Twig's documentation`_ on the topic or read the
@@ -1032,6 +1171,7 @@ also register it manually:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Twig\CustomLoader:
                 tags:
@@ -1039,12 +1179,20 @@ also register it manually:
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Twig\CustomLoader;
 
-        $container
-            ->register(CustomLoader::class)
-            ->addTag('twig.loader', ['priority' => 0])
-        ;
+        return App::config([
+            'services' => [
+                CustomLoader::class => [
+                    'tags' => [
+                        ['twig.loader' => ['priority' => 0]],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -1067,18 +1215,25 @@ the service is auto-registered and auto-tagged. But, you can also register it ma
 
     .. code-block:: yaml
 
+        # config/services.yaml
         services:
             App\Twig\AppExtension:
                 tags: [twig.runtime]
 
     .. code-block:: php
 
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Twig\AppExtension;
 
-        $container
-            ->register(AppExtension::class)
-            ->addTag('twig.runtime')
-        ;
+        return App::config([
+            'services' => [
+                AppExtension::class => [
+                    'tags' => ['twig.runtime'],
+                ],
+            ],
+        ]);
 
 validator.constraint_validator
 ------------------------------

--- a/routing.rst
+++ b/routing.rst
@@ -119,19 +119,21 @@ the ``BlogController``:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\BlogController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return function (RoutingConfigurator $routes): void {
-            $routes->add('blog_list', '/blog')
+        use App\Controller\BlogController;
+
+        return Routes::config([
+            'blog_list' => [
+                'path' => '/blog',
                 // the controller value has the format [controller_class, method_name]
-                ->controller([BlogController::class, 'list'])
+                'controller' => [BlogController::class, 'list'],
 
                 // if the action is implemented as the __invoke() method of the
                 // controller class, you can skip the 'method_name' part:
-                // ->controller(BlogController::class)
-            ;
-        };
+                // 'controller' => BlogController::class,
+            ],
+        ]);
 
 .. _routing-matching-http-methods:
 
@@ -183,19 +185,22 @@ Use the ``methods`` option to restrict the verbs each route should respond to:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\BlogApiController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return function (RoutingConfigurator $routes): void {
-            $routes->add('api_post_show', '/api/posts/{id}')
-                ->controller([BlogApiController::class, 'show'])
-                ->methods(['GET', 'HEAD'])
-            ;
-            $routes->add('api_post_edit', '/api/posts/{id}')
-                ->controller([BlogApiController::class, 'edit'])
-                ->methods(['PUT'])
-            ;
-        };
+        use App\Controller\BlogApiController;
+
+        return Routes::config([
+            'api_post_show' => [
+                'path' => '/api/posts/{id}',
+                'controller' => [BlogApiController::class, 'show'],
+                'methods' => ['GET', 'HEAD'],
+            ],
+            'api_post_edit' => [
+                'path' => '/api/posts/{id}',
+                'controller' => [BlogApiController::class, 'edit'],
+                'methods' => ['PUT'],
+            ],
+        ]);
 
 .. tip::
 
@@ -255,16 +260,18 @@ given value:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\DefaultController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return function (RoutingConfigurator $routes): void {
-            if('dev' === $routes->env()) {
-                $routes->add('tools', '/tools')
-                    ->controller([DefaultController::class, 'developerTools'])
-                ;
-            }
-        };
+        use App\Controller\DefaultController;
+
+        return Routes::config([
+            'when@dev' => [
+                'tools' => [
+                    'path' => '/tools',
+                    'controller' => [DefaultController::class, 'developerTools'],
+                ],
+            ],
+        ]);
 
 .. _routing-matching-expressions:
 
@@ -332,24 +339,27 @@ arbitrary matching logic:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\DefaultController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return function (RoutingConfigurator $routes): void {
-            $routes->add('contact', '/contact')
-                ->controller([DefaultController::class, 'contact'])
-                ->condition('context.getMethod() in ["GET", "HEAD"] and request.headers.get("User-Agent") matches "/firefox/i"')
+        use App\Controller\DefaultController;
+
+        return Routes::config([
+            'contact' => [
+                'path' => '/contact',
+                'controller' => [DefaultController::class, 'contact'],
+                'condition' => 'context.getMethod() in ["GET", "HEAD"] and request.headers.get("User-Agent") matches "/firefox/i"',
                 // expressions can also include configuration parameters:
-                // ->condition('request.headers.get("User-Agent") matches "%app.allowed_browsers%"')
+                // 'condition' => 'request.headers.get("User-Agent") matches "%app.allowed_browsers%"',
                 // expressions can even use environment variables:
-                // ->condition('context.getHost() == env("APP_MAIN_HOST")')
-            ;
-            $routes->add('post_show', '/posts/{id}')
-                ->controller([DefaultController::class, 'showPost'])
+                // 'condition' => 'context.getHost() == env("APP_MAIN_HOST")',
+            ],
+            'post_show' => [
+                'path' => '/posts/{id}',
+                'controller' => [DefaultController::class, 'showPost'],
                 // expressions can retrieve route parameter values using the "params" variable
-                ->condition('params["id"] < 1000')
-            ;
-        };
+                'condition' => 'params["id"] < 1000',
+            ],
+        ]);
 
 The value of the ``condition`` option is an expression using any valid
 :doc:`expression language syntax </reference/formats/expression_language>` and
@@ -515,14 +525,16 @@ For example, the route to display the blog post contents is defined as ``/blog/{
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\BlogController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return function (RoutingConfigurator $routes): void {
-            $routes->add('blog_show', '/blog/{slug}')
-                ->controller([BlogController::class, 'show'])
-            ;
-        };
+        use App\Controller\BlogController;
+
+        return Routes::config([
+            'blog_show' => [
+                'path' => '/blog/{slug}',
+                'controller' => [BlogController::class, 'show'],
+            ],
+        ]);
 
 The name of the variable part (``{slug}`` in this example) is used to create a
 PHP variable where that route content is stored and passed to the controller.
@@ -588,20 +600,21 @@ the ``{page}`` parameter using the ``requirements`` option:
     .. code-block:: php
 
         // config/routes.php
+        namespace Symfony\Component\Routing\Loader\Configurator;
+
         use App\Controller\BlogController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('blog_list', '/blog/{page}')
-                ->controller([BlogController::class, 'list'])
-                ->requirements(['page' => '\d+'])
-            ;
-
-            $routes->add('blog_show', '/blog/{slug}')
-                ->controller([BlogController::class, 'show'])
-            ;
-            // ...
-        };
+        return Routes::config([
+            'blog_list' => [
+                'path' => '/blog/{page}',
+                'controller' => [BlogController::class, 'list'],
+                'requirements' => ['page' => '\d+'],
+            ],
+            'blog_show' => [
+                'path' => '/blog/{slug}',
+                'controller' => [BlogController::class, 'show'],
+            ],
+        ]);
 
 The ``requirements`` option defines the `PHP regular expressions`_ that route
 parameters must match for the entire route to match. In this example, ``\d+`` is
@@ -653,17 +666,18 @@ URL                       Route          Parameters
         .. code-block:: php
 
             // config/routes.php
+            namespace Symfony\Component\Routing\Loader\Configurator;
+
             use App\Controller\BlogController;
-            use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
             use Symfony\Component\Routing\Requirement\Requirement;
 
-            return static function (RoutingConfigurator $routes): void {
-                $routes->add('blog_list', '/blog/{page}')
-                    ->controller([BlogController::class, 'list'])
-                    ->requirements(['page' => Requirement::DIGITS])
-                ;
-                // ...
-            };
+            return Routes::config([
+                'blog_list' => [
+                    'path' => '/blog/{page}',
+                    'controller' => [BlogController::class, 'list'],
+                    'requirements' => ['page' => Requirement::DIGITS],
+                ],
+            ]);
 
 .. tip::
 
@@ -712,15 +726,16 @@ concise, but it can decrease route readability when requirements are complex:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\BlogController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('blog_list', '/blog/{page<\d+>}')
-                ->controller([BlogController::class, 'list'])
-            ;
-            // ...
-        };
+        use App\Controller\BlogController;
+
+        return Routes::config([
+            'blog_list' => [
+                'path' => '/blog/{page<\d+>}',
+                'controller' => [BlogController::class, 'list'],
+            ],
+        ]);
 
 Optional Parameters
 ~~~~~~~~~~~~~~~~~~~
@@ -771,16 +786,21 @@ other configuration formats they are defined with the ``defaults`` option:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\BlogController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('blog_list', '/blog/{page}')
-                ->controller([BlogController::class, 'list'])
-                ->defaults(['page' => 1])
-                ->requirements(['page' => '\d+'])
-            ;
-        };
+        use App\Controller\BlogController;
+
+        return Routes::config([
+            'blog_list' => [
+                'path' => '/blog/{page}',
+                'controller' => [BlogController::class, 'list'],
+                'defaults' => ['page' => 1],
+                'requirements' => ['page' => '\d+'],
+            ],
+            'blog_show' => [
+                // ...
+            ],
+        ]);
 
 Now, when the user visits ``/blog``, the ``blog_list`` route will match and
 ``$page`` will default to a value of ``1``.
@@ -835,14 +855,16 @@ parameter:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\BlogController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('blog_list', '/blog/{page<\d+>?1}')
-                ->controller([BlogController::class, 'list'])
-            ;
-        };
+        use App\Controller\BlogController;
+
+        return Routes::config([
+            'blog_list' => [
+                'path' => '/blog/{page<\d+>?1}',
+                'controller' => [BlogController::class, 'list'],
+            ],
+        ]);
 
 .. tip::
 
@@ -1060,18 +1082,16 @@ and in route imports. Symfony defines some special attributes with the same name
 
         use App\Controller\ArticleController;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('article_show', '/articles/{_locale}/search.{_format}')
-                ->controller([ArticleController::class, 'search'])
-                ->locale('en')
-                ->format('html')
-                ->query(['page' => 1])
-                ->requirements([
-                    '_locale' => 'en|fr',
-                    '_format' => 'html|xml',
-                ])
-            ;
-        };
+        return Routes::config([
+            'article_show' => [
+                'path' => '/articles/{_locale}/search.{_format}',
+                'controller' => [ArticleController::class, 'search'],
+                'locale' => 'en',
+                'format' => 'html',
+                'query' => ['page' => 1],
+                'requirements' => ['_locale' => 'en|fr', '_format' => 'html|xml'],
+            ],
+        ]);
 
 Extra Parameters
 ~~~~~~~~~~~~~~~~
@@ -1113,18 +1133,17 @@ the controllers of the routes:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\BlogController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('blog_index', '/blog/{page}')
-                ->controller([BlogController::class, 'index'])
-                ->defaults([
-                    'page'  => 1,
-                    'title' => 'Hello world!',
-                ])
-            ;
-        };
+        use App\Controller\BlogController;
+
+        return Routes::config([
+            'blog_index' => [
+                'path' => '/blog/{page}',
+                'controller' => [BlogController::class, 'index'],
+                'defaults' => ['page' => 1, 'title' => 'Hello world!'],
+            ],
+        ]);
 
 .. _routing-slash-in-parameters:
 
@@ -1170,17 +1189,17 @@ A possible solution is to change the parameter requirements to be more permissiv
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\DefaultController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('share', '/share/{token}')
-                ->controller([DefaultController::class, 'share'])
-                ->requirements([
-                    'token' => '.+',
-                ])
-            ;
-        };
+        use App\Controller\DefaultController;
+
+        return Routes::config([
+            'share' => [
+                'path' => '/share/{token}',
+                'controller' => [DefaultController::class, 'share'],
+                'requirements' => ['token' => '.+'],
+            ],
+        ]);
 
 .. note::
 
@@ -1237,12 +1256,14 @@ have been renamed. Let's say you have a route called ``product_show``:
     .. code-block:: php
 
         // config/routes.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('product_show', '/product/{id}')
-                    ->controller('App\Controller\ProductController::show');
-        };
+        return Routes::config([
+            'product_show' => [
+                'path' => '/product/{id}',
+                'controller' => [ProductController::class, 'show'],
+            ],
+        ]);
 
 Now, let's say you want to create a new route called ``product_details``
 that acts exactly the same as ``product_show``.
@@ -1284,14 +1305,18 @@ Instead of duplicating the original route, you can create an alias for it.
     .. code-block:: php
 
         // config/routes.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('product_show', '/product/{id}')
-                    ->controller('App\Controller\ProductController::show');
-            // second argument refers to the name of the route declared above
-            $routes->alias('product_details', 'product_show');
-        };
+        return Routes::config([
+            'product_show' => [
+                'path' => '/product/{id}',
+                'controller' => [ProductController::class, 'show'],
+            ],
+            'product_details' => [
+                // "alias" option refers to the name of the route declared above
+                'alias' => ['product_show'],
+            ],
+        ]);
 
 In this example, both ``product_show`` and ``product_details`` routes can
 be used in the application and will produce the same result.
@@ -1364,6 +1389,7 @@ This way, the ``product_show`` alias could be deprecated.
 
     .. code-block:: yaml
 
+        # config/routes.yaml
         # Move the concrete route definition under ``product_details``
         product_details:
             path: /product/{id}
@@ -1389,23 +1415,38 @@ This way, the ``product_show`` alias could be deprecated.
 
     .. code-block:: php
 
-        $routes->add('product_details', '/product/{id}')
-                ->controller('App\Controller\ProductController::show');
+        // config/routes.php
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        $routes->alias('product_show', 'product_details')
-            // this outputs the following generic deprecation message:
-            // Since acme/package 1.2: The "product_show" route alias is deprecated. You should stop using it, as it will be removed in the future.
-            ->deprecate('acme/package', '1.2', '')
+        use App\Controller\ProductController;
 
-            // or
+        return Routes::config([
+            // Move the concrete route definition under ``product_details``
+            'product_details' => [
+                'path' => '/product/{id}',
+                'controller' => [ProductController::class, 'show'],
+            ],
+            // Define the alias and the deprecation under the ``product_show`` definition
+            'product_show' => [
+                'alias' => 'product_details',
 
-            // you can define a custom deprecation message (%alias_id% placeholder is available)
-            ->deprecate(
-                'acme/package',
-                '1.2',
-                'The "%alias_id%" route alias is deprecated. Please use "product_details" instead.'
-            )
-        ;
+                // this outputs the following generic deprecation message:
+                // Since acme/package 1.2: The "product_show" route alias is deprecated. You should stop using it, as it will be removed in the future.
+                'deprecated' => [
+                    'package' => 'acme/package',
+                    'version' => '1.2',
+                ],
+
+                // or
+
+                // you can define a custom deprecation message (%alias_id% placeholder is available)
+                'deprecated' => [
+                    'package' => 'acme/package',
+                    'version' => '1.2',
+                    'message' => 'The "%alias_id%" route alias is deprecated. Please use "product_details" instead.',
+                ],
+            ],
+        ]);
 
 In this example, every time the ``product_show`` alias is used, a deprecation
 warning is triggered, advising you to stop using this route and prefer using ``product_details``.
@@ -1480,32 +1521,28 @@ when importing the routes.
     .. code-block:: php
 
         // config/routes/attributes.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->import(
-                    '../../src/Controller/',
-                    'attribute',
-                    false,
-                    // the optional fourth argument is used to exclude some files
-                    // or subdirectories when loading attributes
-                    // (the value must be a string or an array of PHP glob patterns)
-                    '../../src/Controller/{Debug*Controller.php}'
-                )
+        return Routes::config([
+            'controllers' => [
+                'resource' => '../../src/Controller/',
+                'type' => 'attribute',
                 // this is added to the beginning of all imported route URLs
-                ->prefix('/blog')
+                'prefix' => '/blog',
+                // this is added to the beginning of all imported route names
+                'name_prefix' => 'blog_',
+                // these requirements are added to all imported routes
+                'requirements' => ['_locale' => 'en|es|fr'],
 
                 // An imported route with an empty URL will become "/blog/"
-                // Pass FALSE as the second argument to make that URL "/blog" instead
-                // ->prefix('/blog', false)
+                // Uncomment this option to make that URL "/blog" instead
+                // 'trailing_slash_on_root' => false,
 
-                // this is added to the beginning of all imported route names
-                ->namePrefix('blog_')
-
-                // these requirements are added to all imported routes
-                ->requirements(['_locale' => 'en|es|fr'])
-            ;
-        };
+                // you can optionally exclude some files/subdirectories when loading attributes
+                // (the value must be a string or an array of PHP glob patterns)
+                // 'exclude' => '../../src/Controller/{Debug*Controller.php}',
+            ],
+        ]);
 
 .. warning::
 
@@ -1542,16 +1579,16 @@ defined in the class attribute.
         .. code-block:: php
 
             // config/routes/attributes.php
-            use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+            namespace Symfony\Component\Routing\Loader\Configurator;
 
-            return static function (RoutingConfigurator $routes): void {
-                $routes->import('../../src/Controller/', 'attribute')
-                    // the second argument is the $trailingSlashOnRoot option
-                    ->prefix('/blog', false)
-
-                    // ...
-                ;
-            };
+            return Routes::config([
+                'controllers' => [
+                    'resource' => '../../src/Controller/',
+                    'type' => 'attribute',
+                    'prefix' => '/blog',
+                    'trailing_slash_on_root' => false,
+                ],
+            ]);
 
 .. seealso::
 
@@ -1649,14 +1686,15 @@ Use the ``RedirectController`` to redirect to other routes and URLs:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\DefaultController;
-        use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('doc_shortcut', '/doc')
-                ->controller(RedirectController::class)
-                 ->defaults([
+        use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
+
+        return Routes::config([
+            'doc_shortcut' => [
+                'path' => '/doc',
+                'controller' => [RedirectController::class, 'doc_page'],
+                'defaults' => [
                     'route' => 'doc_page',
                     // optionally you can define some arguments passed to the route
                     'page' => 'index',
@@ -1665,23 +1703,26 @@ Use the ``RedirectController`` to redirect to other routes and URLs:
                     'permanent' => true,
                     // add this to keep the original query string parameters when redirecting
                     'keepQueryParams' => true,
-                    // add this to keep the HTTP method when redirecting. The redirect status changes:
+                    // add this to keep the HTTP method when redirecting. The redirect status changes
                     // * for temporary redirects, it uses the 307 status code instead of 302
                     // * for permanent redirects, it uses the 308 status code instead of 301
                     'keepRequestMethod' => true,
-                ])
-            ;
-
-            $routes->add('legacy_doc', '/legacy/doc')
-                ->controller(RedirectController::class)
-                 ->defaults([
+                    // add this to remove all original route attributes when redirecting
+                    'ignoreAttributes' => true,
+                    // or specify which attributes to ignore:
+                    // 'ignoreAttributes' => ['offset', 'limit'],
+                ],
+            ],
+            'legacy_doc' => [
+                'path' => '/legacy/doc',
+                'controller' => [RedirectController::class, 'legacy_doc'],
+                'defaults' => [
                     // this value can be an absolute path or an absolute URL
                     'path' => 'https://legacy.example.com/doc',
-                    // redirections are temporary by default (code 302) but you can make them permanent (code 301)
                     'permanent' => true,
-                ])
-            ;
-        };
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -1758,18 +1799,21 @@ host name:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\MainController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('mobile_homepage', '/')
-                ->controller([MainController::class, 'mobileHomepage'])
-                ->host('m.example.com')
-            ;
-            $routes->add('homepage', '/')
-                ->controller([MainController::class, 'homepage'])
-            ;
-        };
+        use App\Controller\MainController;
+
+        return Routes::config([
+            'mobile_homepage' => [
+                'path' => '/',
+                'host' => 'm.example.com',
+                'controller' => [MainController::class, 'mobileHomepage'],
+            ],
+            'homepage' => [
+                'path' => '/',
+                'controller' => [MainController::class, 'homepage'],
+            ],
+        ]);
 
 The value of the ``host`` option can include parameters (which is useful in
 multi-tenant applications) and these parameters can be validated too with
@@ -1826,24 +1870,23 @@ multi-tenant applications) and these parameters can be validated too with
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\MainController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('mobile_homepage', '/')
-                ->controller([MainController::class, 'mobileHomepage'])
-                ->host('{subdomain}.example.com')
-                ->defaults([
-                    'subdomain' => 'm',
-                ])
-                ->requirements([
-                    'subdomain' => 'm|mobile',
-                ])
-            ;
-            $routes->add('homepage', '/')
-                ->controller([MainController::class, 'homepage'])
-            ;
-        };
+        use App\Controller\MainController;
+
+        return Routes::config([
+            'mobile_homepage' => [
+                'path' => '/',
+                'host' => '{subdomain}.example.com',
+                'controller' => [MainController::class, 'mobileHomepage'],
+                'defaults' => ['subdomain' => 'm'],
+                'requirements' => ['subdomain' => 'm|mobile'],
+            ],
+            'homepage' => [
+                'path' => '/',
+                'controller' => [MainController::class, 'homepage'],
+            ],
+        ]);
 
 In the above example, the ``subdomain`` parameter defines a default value because
 otherwise you need to include a subdomain value each time you generate a URL using
@@ -1918,17 +1961,19 @@ avoids the need for duplicating routes, which also reduces the potential bugs:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\CompanyController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('about_us', [
-                'en' => '/about-us',
-                'nl' => '/over-ons',
-            ])
-                ->controller([CompanyController::class, 'about'])
-            ;
-        };
+        use App\Controller\CompanyController;
+
+        return Routes::config([
+            'about_us' => [
+                'path' => [
+                    'en' => '/about-us',
+                    'nl' => '/over-ons',
+                ],
+                'controller' => [CompanyController::class, 'about'],
+            ],
+        ]);
 
 .. note::
 
@@ -1963,17 +2008,18 @@ with a locale. This can be done by defining a different prefix for each locale
     .. code-block:: php
 
         // config/routes/attributes.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->import('../../src/Controller/', 'attribute')
-                ->prefix([
-                    // don't prefix URLs for English, the default locale
-                    'en' => '',
+        return Routes::config([
+            'controllers' => [
+                'resource' => '../../src/Controller/',
+                'type' => 'attribute',
+                'prefix' => [
+                    'en' => '', // don't prefix URLs for English, the default locale
                     'nl' => '/nl',
-                ])
-            ;
-        };
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -2004,15 +2050,18 @@ locale.
     .. code-block:: php
 
         // config/routes/attributes.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
-        return static function (RoutingConfigurator $routes): void {
-            $routes->import('../../src/Controller/', 'attribute')
-                ->host([
+        namespace Symfony\Component\Routing\Loader\Configurator;
+
+        return Routes::config([
+            'controllers' => [
+                'resource' => '../../src/Controller/',
+                'type' => 'attribute',
+                'host' => [
                     'en' => 'www.example.com',
                     'nl' => 'www.example.nl',
-                ])
-            ;
-        };
+                ],
+            ],
+        ]);
 
 .. _stateless-routing:
 
@@ -2058,15 +2107,17 @@ session shouldn't be used when matching a request:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\MainController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('homepage', '/')
-                ->controller([MainController::class, 'homepage'])
-                ->stateless()
-            ;
-        };
+        use App\Controller\MainController;
+
+        return Routes::config([
+            'homepage' => [
+                'controller' => [MainController::class, 'homepage'],
+                'path' => '/',
+                'stateless' => true,
+            ],
+        ]);
 
 Now, if the session is used, the application will report it based on your
 ``kernel.debug`` parameter:
@@ -2276,11 +2327,15 @@ The solution is to configure the ``default_uri`` option to define the
     .. code-block:: php
 
         // config/packages/routing.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->router()->defaultUri('https://example.org/my/path/');
-        };
+        return App::config([
+            'framework' => [
+                'router' => [
+                    'default_uri' => 'https://example.org/my/path/',
+                ],
+            ],
+        ]);
 
 Now you'll get the expected results when generating URLs in your commands::
 
@@ -2388,10 +2443,14 @@ method) or globally with these configuration parameters:
     .. code-block:: php
 
         // config/services.php
-        $container->parameters()
-            ->set('router.request_context.scheme', 'https')
-            ->set('asset.request_context.secure', true)
-        ;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'parameters' => [
+                'router.request_context.scheme' => 'https',
+                'asset.request_context.secure' => true,
+            ],
+        ]);
 
 Outside of console commands, use the ``schemes`` option to define the scheme of
 each route explicitly:
@@ -2427,15 +2486,17 @@ each route explicitly:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\SecurityController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->add('login', '/login')
-                ->controller([SecurityController::class, 'login'])
-                ->schemes(['https'])
-            ;
-        };
+        use App\Controller\SecurityController;
+
+        return Routes::config([
+            'login' => [
+                'path' => '/login',
+                'controller' => [SecurityController::class, 'login'],
+                'schemes' => ['https'],
+            ],
+        ]);
 
 The URL generated for the ``login`` route will always use HTTPS. This means that
 when using the ``path()`` Twig function to generate URLs, you may get an
@@ -2472,13 +2533,15 @@ defined as attributes:
     .. code-block:: php
 
         // config/routes/attributes.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->import('../../src/Controller/', 'attribute')
-                ->schemes(['https'])
-            ;
-        };
+        return Routes::config([
+            'controllers' => [
+                'resource' => '../../src/Controller/',
+                'type' => 'attribute',
+                'schemes' => ['https'],
+            ],
+        ]);
 
 .. note::
 

--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -51,32 +51,42 @@ Symfony provides several route loaders for the most common needs:
     .. code-block:: php
 
         // config/routes.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            // loads routes from the given routing file stored in some bundle
-            $routes->import('@AcmeBundle/Resources/config/routing.yaml');
-
-            // loads routes from the PHP attributes (#[Route(...)])
-            // of the controllers found in the given PSR-4 namespace root
-            $routes->import(
-                ['path' => '../src/Controller/', 'namespace' => 'App\Controller'],
-                'attribute',
-            );
-
-            // loads routes from the PHP attributes (#[Route(...)])
-            // of the controllers found in that directory
-            $routes->import('../src/Controller/', 'attribute');
-
-            // loads routes from the PHP attributes (#[Route(...)]) of the given class
-            $routes->import('App\Controller\MyController', 'attribute');
-
-            // loads routes from the YAML or PHP files found in that directory
-            $routes->import('../legacy/routing/', 'directory');
-
-            // loads routes from the YAML or PHP files found in some bundle directory
-            $routes->import('@AcmeOtherBundle/Resources/config/routing/', 'directory');
-        };
+        return Routes::config([
+            'app_file' => [
+                // loads routes from the given routing file stored in some bundle
+                'resource' => '@AcmeBundle/Resources/config/routing.yaml',
+            ],
+            'app_psr4' => [
+                // loads routes from the PHP attributes of the controllers found in the given PSR-4 namespace root
+                'resource' => [
+                    'path' => '../src/Controller/',
+                    'namespace' => 'App\Controller',
+                ],
+                'type' => 'attribute',
+            ],
+            'app_attributes' => [
+                // loads routes from the PHP attributes of the controllers found in that directory
+                'resource' => '../src/Controller/',
+                'type' => 'attribute',
+            ],
+            'app_class_attributes' => [
+                // loads routes from the PHP attributes of the given class
+                'resource' => 'App\Controller\MyController',
+                'type' => 'attribute',
+            ],
+            'app_directory' => [
+                // loads routes from the YAML or PHP files found in that directory
+                'resource' => '../legacy/routing/',
+                'type' => 'directory',
+            ],
+            'app_bundle' => [
+                // loads routes from the YAML or PHP files found in some bundle directory
+                'resource' => '@AcmeOtherBundle/Resources/config/routing/',
+                'type' => 'directory',
+            ],
+        ]);
 
 .. note::
 
@@ -122,11 +132,14 @@ Take these lines from the ``routes.yaml``:
     .. code-block:: php
 
         // config/routes.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->import('../src/Controller', 'attribute');
-        };
+        return Routes::config([
+            'controllers' => [
+                'resource' => '../src/Controller/',
+                'type' => 'attribute',
+            ],
+        ]);
 
 When the main loader parses this, it tries all registered delegate loaders and calls
 their :method:`Symfony\\Component\\Config\\Loader\\LoaderInterface::supports`
@@ -163,11 +176,14 @@ and configure the service and method to call:
     .. code-block:: php
 
         // config/routes.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->import('admin_route_loader::loadRoutes', 'service');
-        };
+        return Routes::config([
+            'admin_routes' => [
+            'resource' => 'admin_route_loader::loadRoutes',
+                'type' => 'service',
+            ],
+        ]);
 
 In this example, the routes are loaded by calling the ``loadRoutes()`` method
 of the service whose ID is ``admin_route_loader``. Your service doesn't have to
@@ -286,13 +302,13 @@ Now define a service for the ``ExtraLoader``:
 
         use App\Routing\ExtraLoader;
 
-        return static function (ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(ExtraLoader::class)
-                ->tag('routing.loader')
-            ;
-        };
+        return App::config([
+            'services' => [
+                ExtraLoader::class => [
+                    'tags' => ['routing.loader'],
+                ],
+            ],
+        ]);
 
 Notice the tag ``routing.loader``. All services with this *tag* will be marked
 as potential route loaders and added as specialized route loaders to the
@@ -317,11 +333,14 @@ What remains to do is adding a few lines to the routing configuration:
     .. code-block:: php
 
         // config/routes.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->import('.', 'extra');
-        };
+        return Routes::config([
+            'app_extra' => [
+                'resource' => '.',
+                'type' => 'extra',
+            ],
+        ]);
 
 The important part here is the ``type`` key. Its value should be ``extra`` as
 this is the type which the ``ExtraLoader`` supports and this will make sure

--- a/security.rst
+++ b/security.rst
@@ -244,18 +244,24 @@ for a user provider in your security configuration:
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Entity\User;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            // ...
+        return App::config([
+            'security' => [
+                // ...
 
-            $security->provider('app_user_provider')
-                ->entity()
-                    ->class(User::class)
-                    ->property('email')
-            ;
-        };
+                'providers' => [
+                    'app_user_provider' => [
+                        'entity' => [
+                            'class' => User::class,
+                            'property' => 'email',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 This user provider knows how to (re)load users from a storage (e.g. a database)
 based on a "user identifier" (e.g. the user's email address or username).
@@ -354,18 +360,21 @@ have done this for you:
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Entity\User;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
-        return static function (SecurityConfig $security): void {
-            // ...
+        return App::config([
+            'security' => [
+                // ...
 
-            // Use native password hasher, which auto-selects and migrates the best
-            // possible hashing algorithm (currently this is "bcrypt")
-            $security->passwordHasher(PasswordAuthenticatedUserInterface::class)
-                ->algorithm('auto')
-            ;
-        };
+                // Use native password hasher, which auto-selects and migrates the best
+                // possible hashing algorithm (currently this is "bcrypt")
+                'password_hashers' => [
+                    PasswordAuthenticatedUserInterface::class => 'auto',
+                ],
+            ],
+        ]);
 
 Now that Symfony knows *how* you want to hash the passwords, you can use the
 ``UserPasswordHasherInterface`` service to do this before saving your users to
@@ -464,29 +473,35 @@ will be able to authenticate (e.g. login form, API token, etc).
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
+        return App::config([
+            'security' => [
+                // ...
 
-            // the order in which firewalls are defined is very important, as the
-            // request will be handled by the first firewall whose pattern matches
-            $security->firewall('dev')
-                ->pattern('^/(_(profiler|wdt)|css|images|js)/')
-                ->security(false)
-            ;
+                'firewalls' => [
+                    // the order in which firewalls are defined is very important, as the
+                    // request will be handled by the first firewall whose pattern matches
+                    'dev' => [
+                        'pattern' => '^/(_(profiler|wdt)|css|images|js)/',
+                        'security' => false,
+                    ],
 
-            // a firewall with no pattern should be defined last because it will match all requests
-            $security->firewall('main')
-                ->lazy(true)
+                    // a firewall with no pattern should be defined last because it will match all requests
+                    'main' => [
+                        'lazy' => true,
+                        // provider that you set earlier inside providers
+                        'provider' => 'app_user_provider',
 
-                // activate different ways to authenticate
-                // https://symfony.com/doc/current/security.html#firewalls-authentication
+                        // activate different ways to authenticate
+                        // https://symfony.com/doc/current/security.html#firewalls-authentication
 
-                // https://symfony.com/doc/current/security/impersonating_user.html
-                // ->switchUser(true)
-            ;
-        };
+                        // https://symfony.com/doc/current/security/impersonating_user.html
+                        // 'switch_user' => true,
+                    ],
+                ],
+            ],
+        ]);
 
 Only one firewall is active on each request: Symfony uses the ``pattern`` key
 to find the first match (you can also
@@ -523,23 +538,24 @@ don't accidentally block Symfony's dev tools - which live under URLs like
         .. code-block:: php
 
             // config/packages/security.php
-            use Symfony\Config\SecurityConfig;
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (SecurityConfig $security): void {
-                // ...
-                $security->firewall('dev')
-                    ->pattern([
-                        '^/_profiler/',
-                        '^/_wdt/',
-                        '^/css/',
-                        '^/images/',
-                        '^/js/',
-                    ])
-                    ->security(false)
-                ;
-
-                // ...
-            };
+            return App::config([
+                'security' => [
+                    // ...
+                    'firewalls' => [
+                        'dev' => [
+                            'pattern' => [
+                                '^/_profiler/',
+                                '^/_wdt/',
+                                '^/css/',
+                                '^/images/',
+                                '^/js/',
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
 
 A firewall can have many modes of authentication, in other words, it enables many
 ways to ask the question "Who are you?". Often, the user is unknown (i.e. not logged in)
@@ -700,19 +716,23 @@ Then, enable the ``FormLoginAuthenticator`` using the ``form_login`` setting:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
+        return App::config([
+            'security' => [
+                // ...
 
-            $mainFirewall = $security->firewall('main');
-
-            // "app_login" is the name of the route created previously
-            $mainFirewall->formLogin()
-                ->loginPath('app_login')
-                ->checkPath('app_login')
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'form_login' => [
+                            // "app_login" is the name of the route created previously
+                            'login_path' => 'app_login',
+                            'check_path' => 'app_login',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -862,17 +882,19 @@ First, you need to enable CSRF on the form login:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall->formLogin()
-                // ...
-                ->enableCsrf(true)
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'secured_area' => [
+                        'form_login' => [
+                            'enable_csrf' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _csrf-login-template:
 
@@ -932,16 +954,20 @@ Enable the authenticator using the ``json_login`` setting:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall->jsonLogin()
-                ->checkPath('api_login')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'json_login' => [
+                            // api_login is a route we will create below
+                            'check_path' => 'api_login',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -1080,14 +1106,19 @@ authentication:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall->httpBasic()
-                ->realm('Secured Area')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'http_basic' => [
+                            'realm' => 'Secured Area',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 That's it! Whenever an unauthenticated user tries to visit a protected
 page, Symfony will inform the browser that it needs to start HTTP basic
@@ -1205,14 +1236,19 @@ Then, enable the X.509 authenticator using ``x509`` on your firewall:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall->x509()
-                ->provider('your_user_provider')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'x509' => [
+                            'provider' => 'your_user_provider',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 By default, Symfony extracts the email address from the DN in two different
 ways:
@@ -1254,14 +1290,19 @@ Enable remote user authentication using the ``remote_user`` key:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall->remoteUser()
-                ->provider('your_user_provider')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'remote_user' => [
+                            'provider' => 'your_user_provider',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -1313,19 +1354,29 @@ Then, enable this feature using the ``login_throttling`` setting:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->enableAuthenticatorManager(true);
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        // by default, the feature allows 5 login attempts per minute
+                        'login_throttling' => null,
 
-            $mainFirewall = $security->firewall('main');
+                        // configure the maximum login attempts
+                        'login_throttling' => [
+                            'max_attempts' => 3, // per minute ...
+                            'interval' => '15 minutes', // ... or in a custom period
+                        ],
 
-            // by default, the feature allows 5 login attempts per minute
-            $mainFirewall->loginThrottling()
-                // ->maxAttempts(3)         // Optional: You can configure the maximum attempts ...
-                // ->interval('15 minutes') // ... and the period of time.
-            ;
-        };
+                        // use a custom rate limiter via its service ID
+                        'login_throttling' => [
+                            'limiter' => 'app.my_login_rate_limiter',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -1395,43 +1446,53 @@ and set the ``limiter`` option to its service ID:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Component\DependencyInjection\ContainerBuilder;
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Symfony\Component\Security\Http\RateLimiter\DefaultLoginRateLimiter;
-        use Symfony\Config\FrameworkConfig;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (ContainerBuilder $container, FrameworkConfig $framework, SecurityConfig $security): void {
-            $framework->rateLimiter()
-                ->limiter('username_ip_login')
-                    ->policy('token_bucket')
-                    ->limit(5)
-                    ->rate()
-                        ->interval('5 minutes')
-            ;
-
-            $framework->rateLimiter()
-                ->limiter('ip_login')
-                    ->policy('sliding_window')
-                    ->limit(50)
-                    ->interval('15 minutes')
-            ;
-
-            $container->register('app.login_rate_limiter', DefaultLoginRateLimiter::class)
-                ->setArguments([
-                    // 1st argument is the limiter for IP
-                    new Reference('limiter.ip_login'),
-                    // 2nd argument is the limiter for username+IP
-                    new Reference('limiter.username_ip_login'),
-                    // 3rd argument is the app secret
-                    param('kernel.secret'),
-                ]);
-
-            $security->firewall('main')
-                ->loginThrottling()
-                    ->limiter('app.login_rate_limiter')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'rate_limiter' => [
+                    // define 2 rate limiters (one for username+IP, the other for IP)
+                    'username_ip_login' => [
+                        'policy' => 'token_bucket',
+                        'limit' => 5,
+                        'rate' => ['interval' => '5 minutes'],
+                    ],
+                    'ip_login' => [
+                        'policy' => 'sliding_window',
+                        'limit' => 50,
+                        'interval' => '15 minutes',
+                    ],
+                ],
+            ],
+            new ServicesConfig(
+                services: [
+                    // our custom login rate limiter
+                    'app.login_rate_limiter' => [
+                        'class' => DefaultLoginRateLimiter::class,
+                        'arguments' => [
+                            // globalFactory is the limiter for IP
+                            '$globalFactory' => service('limiter.ip_login'),
+                            // localFactory is the limiter for username+IP
+                            '$localFactory' => service('limiter.username_ip_login'),
+                            // secret is the app secret
+                            '$secret' => param('kernel.secret'),
+                        ],
+                    ],
+                ],
+            ),
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        // use a custom rate limiter via its service ID
+                        'login_throttling' => [
+                            'limiter' => 'app.login_rate_limiter',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Customize Successful and Failed Authentication Behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1520,20 +1581,22 @@ To enable logging out, activate the  ``logout`` config parameter under your fire
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'logout' => [
+                            'path' => '/logout',
 
-            $mainFirewall = $security->firewall('main');
-            // ...
-            $mainFirewall->logout()
-                ->path('/logout')
-
-                // where to redirect after logout
-                // ->target('app_any_route')
-            ;
-        };
+                            // where to redirect after logout
+                            // 'target' => 'app_any_route',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Symfony will then un-authenticate users navigating to the configured ``path``,
 and redirect them to the configured ``target``.
@@ -1558,11 +1621,14 @@ you have imported the logout route loader in your routes:
     .. code-block:: php
 
         // config/routes/security.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (RoutingConfigurator $routes): void {
-            $routes->import('security.route_loader.logout', 'service');
-        };
+        return Routes::config([
+            '_symfony_logout' => [
+                'resource' => 'security.route_loader.logout',
+                'type' => 'service',
+            ],
+        ]);
 
 Logout programmatically
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1618,7 +1684,7 @@ to execute custom logic::
 
         public static function getSubscribedEvents(): array
         {
-            return [LogoutEvent::class => 'onLogout'];
+            return App::config([LogoutEvent::class => 'onLogout'];
         }
 
         public function onLogout(LogoutEvent $event): void
@@ -1662,16 +1728,17 @@ current locale). In that case, you have to create this route yourself:
     .. code-block:: php
 
         // config/routes.php
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return function (RoutingConfigurator $routes): void {
-            $routes->add('app_logout', [
-                'en' => '/logout',
-                'fr' => '/deconnexion',
-            ])
-                ->methods(['GET'])
-            ;
-        };
+        return Routes::config([
+            'app_logout' => [
+                'path' => [
+                    'en' => '/logout',
+                    'fr' => '/deconnexion',
+                ],
+                'methods' => ['GET'],
+            ],
+        ]);
 
 Then, pass the route name to the ``path`` option:
 
@@ -1692,17 +1759,19 @@ Then, pass the route name to the ``path`` option:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $mainFirewall = $security->firewall('main');
-            // ...
-            $mainFirewall->logout()
-                ->path('app_logout')
-            ;
-        };
+        return [
+            Routes::config([
+                'firewalls' => [
+                    'main' => [
+                        'logout' => [
+                            'path' => 'app_logout',
+                        ],
+                    ],
+                ],
+            ]),
+        ];
 
 .. _retrieving-the-user-object:
 
@@ -1850,14 +1919,16 @@ rules by creating a role hierarchy:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $security->roleHierarchy('ROLE_ADMIN', ['ROLE_USER']);
-            $security->roleHierarchy('ROLE_SUPER_ADMIN', ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH']);
-        };
+        return App::config([
+            'security' => [
+                'role_hierarchy' => [
+                    'ROLE_ADMIN' => ['ROLE_USER'],
+                    'ROLE_SUPER_ADMIN' => ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'],
+                ],
+            ],
+        ]);
 
 Users with the ``ROLE_ADMIN`` role will also have the ``ROLE_USER`` role.
 Users with ``ROLE_SUPER_ADMIN``, will automatically have ``ROLE_ADMIN``,
@@ -1943,32 +2014,28 @@ start with ``/admin``, you can:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->enableAuthenticatorManager(true);
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        // ...
+                    ],
+                ],
+                'access_control' => [
+                    // require ROLE_ADMIN for /admin*
+                    ['path' => '^/admin', 'roles' => 'ROLE_ADMIN'],
 
-            // ...
-            $security->firewall('main')
-            // ...
-            ;
+                    // or require ROLE_ADMIN or IS_AUTHENTICATED_FULLY for /admin*
+                    ['path' => '^/admin', 'roles' => ['IS_AUTHENTICATED_FULLY', 'ROLE_ADMIN']],
 
-            // require ROLE_ADMIN for /admin*
-            $security->accessControl()
-                ->path('^/admin')
-                ->roles(['ROLE_ADMIN']);
-
-            // require ROLE_ADMIN or IS_AUTHENTICATED_FULLY for /admin*
-            $security->accessControl()
-                ->path('^/admin')
-                ->roles(['ROLE_ADMIN', 'IS_AUTHENTICATED_FULLY']);
-
-            // the 'path' value can be any valid regular expression
-            // (this one will match URLs like /api/post/7298 and /api/comment/528491)
-            $security->accessControl()
-                ->path('^/api/(post|comment)/\d+$')
-                ->roles(['ROLE_USER']);
-        };
+                    // the 'path' value can be any valid regular expression
+                    // (this one will match URLs like /api/post/7298 and /api/comment/528491)
+                    ['path' => '^/api/(post|comment)/\d+$', 'roles' => 'ROLE_USER'],
+                ],
+            ],
+        ]);
 
 You can define as many URL patterns as you need - each is a regular expression.
 **BUT**, only **one** will be matched per request: Symfony starts at the top of
@@ -1992,19 +2059,21 @@ the list and stops when it finds the first match:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
+        return App::config([
+            'security' => [
+                // ...
 
-            $security->accessControl()
-                ->path('^/admin/users')
-                ->roles(['ROLE_SUPER_ADMIN']);
+                'access_control' => [
+                    // matches /admin/users/*
+                    ['path' => '^/admin/users', 'roles' => 'ROLE_SUPER_ADMIN'],
 
-            $security->accessControl()
-                ->path('^/admin')
-                ->roles(['ROLE_ADMIN']);
-        };
+                    // matches /admin/* except for anything matching the above rule
+                    ['path' => '^/admin', 'roles' => 'ROLE_ADMIN'],
+                ],
+            ],
+        ]);
 
 Prepending the path with ``^`` means that only URLs *beginning* with the
 pattern are matched. For example, a path of ``/admin`` (without the ``^``)
@@ -2298,25 +2367,20 @@ the login page):
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->enableAuthenticatorManager(true);
-            // ....
+        return App::config([
+            'security' => [
+                // ...
+                'access_control' => [
+                    // allow unauthenticated users to access the login form
+                    ['path' => '^/admin/login', 'roles' => 'PUBLIC_ACCESS'],
 
-            // allow unauthenticated users to access the login form
-            $security->accessControl()
-                ->path('^/admin/login')
-                ->roles([AuthenticatedVoter::PUBLIC_ACCESS])
-            ;
-
-            // but require authentication for all other admin routes
-            $security->accessControl()
-                ->path('^/admin')
-                ->roles(['ROLE_ADMIN'])
-            ;
-        };
+                    // but require authentication for all other admin routes
+                    ['path' => '^/admin', 'roles' => 'ROLE_ADMIN'],
+                ],
+            ],
+        ]);
 
 Granting Anonymous Users Access in a Custom Voter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2496,14 +2560,15 @@ for these events.
 
             use App\EventListener\LogoutSubscriber;
 
-            return function(ContainerConfigurator $container): void {
-                $services = $container->services();
-
-                $services->set(LogoutSubscriber::class)
-                    ->tag('kernel.event_subscriber', [
-                        'dispatcher' => 'security.event_dispatcher.main',
-                    ]);
-            };
+            return [
+                'services' => [
+                    LogoutSubscriber::class => [
+                        'tags' => [
+                            ['kernel.event_subscriber' => ['dispatcher' => 'security.event_dispatcher.main']],
+                        ],
+                    ],
+                ],
+            ]);
 
 Authentication Events
 ~~~~~~~~~~~~~~~~~~~~~

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -65,63 +65,34 @@ Take the following ``access_control`` entries as an example:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Component\DependencyInjection\ContainerBuilder;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (ContainerBuilder $container, SecurityConfig $security): void {
-            $container->setParameter('env(TRUSTED_IPS)', '10.0.0.1, 10.0.0.2');
-            // ...
+        use App\Security\RequestMatcher\MyRequestMatcher;
 
-            $security->accessControl()
-                ->path('^/admin')
-                ->roles(['ROLE_USER_PORT'])
-                ->ips(['127.0.0.1'])
-                ->port(8080)
-            ;
-            $security->accessControl()
-                ->path('^/admin')
-                ->roles(['ROLE_USER_IP'])
-                ->ips(['127.0.0.1'])
-            ;
-            $security->accessControl()
-                ->path('^/admin')
-                ->roles(['ROLE_USER_HOST'])
-                ->host('symfony\.com$')
-            ;
-            $security->accessControl()
-                ->path('^/admin')
-                ->roles(['ROLE_USER_METHOD'])
-                ->methods(['POST', 'PUT'])
-            ;
-            // ips can be comma-separated, which is especially useful when using env variables
-            $security->accessControl()
-                ->path('^/admin')
-                ->roles(['ROLE_USER_IP'])
-                ->ips([env('TRUSTED_IPS')])
-            ;
-            $security->accessControl()
-                ->path('^/admin')
-                ->roles(['ROLE_USER_IP'])
-                ->ips(['127.0.0.1', '::1', env('TRUSTED_IPS')])
-            ;
+        return App::config([
+            'parameters' => [
+                'env(TRUSTED_IPS)' => '10.0.0.1, 10.0.0.2',
+            ],
+            'security' => [
+                'access_control' => [
+                    ['path' => '^/admin', 'roles' => 'ROLE_USER_PORT', 'ips' => ['127.0.0.1'], 'port' => 8080],
+                    ['path' => '^/admin', 'roles' => 'ROLE_USER_IP', 'ips' => ['127.0.0.1']],
+                    ['path' => '^/admin', 'roles' => 'ROLE_USER_HOST', 'host' => 'symfony\.com$'],
+                    ['path' => '^/admin', 'roles' => 'ROLE_USER_METHOD', 'methods' => ['POST', 'PUT']],
 
-            // for custom matching needs, use a request matcher service
-            $security->accessControl()
-                ->roles(['ROLE_USER'])
-                ->requestMatcher('App\Security\RequestMatcher\MyRequestMatcher')
-            ;
+                    // ips can be comma-separated, which is especially useful when using env variables
+                    ['path' => '^/admin', 'roles' => 'ROLE_USER_IP', 'ips' => env('TRUSTED_IPS')],
+                    ['path' => '^/admin', 'roles' => 'ROLE_USER_IP', 'ips' => ['127.0.0.1', '::1', env('TRUSTED_IPS')]],
 
-            // require ROLE_ADMIN for 'admin' route. You can use the shortcut route('xxx') method,
-            // instead of attributes(['_route' => 'xxx']) method
-            $security->accessControl()
-                ->roles(['ROLE_ADMIN'])
-                ->attributes(['_route' => 'admin'])
-            ;
-            $security->accessControl()
-                ->roles(['ROLE_ADMIN'])
-                ->route('admin')
-            ;
-        };
+                    // for custom matching needs, use a request matcher service
+                    ['roles' => 'ROLE_USER', 'request_matcher' => MyRequestMatcher::class],
+
+                    // require ROLE_ADMIN for 'admin' route. You can use the shortcut "route: "xxx", instead of "attributes": ["_route": "xxx"]
+                    ['attributes' => ['_route' => 'admin'], 'roles' => 'ROLE_ADMIN'],
+                    ['route' => 'admin', 'roles' => 'ROLE_ADMIN'],
+                ],
+            ],
+        ]);
 
 For each incoming request, Symfony will decide which ``access_control``
 to use based on the URI, the client's IP address, the incoming host name,
@@ -253,23 +224,17 @@ pattern so that it is only accessible by requests from the local server itself:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $security->accessControl()
-                ->path('^/internal')
-                ->roles(['PUBLIC_ACCESS'])
-                // the 'ips' option supports IP addresses and subnet masks
-                ->ips(['127.0.0.1', '::1'])
-            ;
-
-            $security->accessControl()
-                ->path('^/internal')
-                ->roles(['ROLE_NO_ACCESS'])
-            ;
-        };
+        return App::config([
+            'security' => [
+                'access_control' => [
+                    // the 'ips' option supports IP addresses and subnet masks
+                    ['path' => '^/internal', 'roles' => 'PUBLIC_ACCESS', 'ips' => ['127.0.0.1', '::1', '192.168.0.1/24']],
+                    ['path' => '^/internal', 'roles' => 'ROLE_NO_ACCESS'],
+                ],
+            ],
+        ]);
 
 Here is how it works when the path is ``/internal/something`` coming from
 the external IP address ``10.0.0.1``:
@@ -319,19 +284,21 @@ key:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $security->accessControl()
-                ->path('^/_internal/secure')
-                // the 'role' and 'allow-if' options work like an OR expression, so
-                // access is granted if the expression is TRUE or the user has ROLE_ADMIN
-                ->roles(['ROLE_ADMIN'])
-                ->allowIf('"127.0.0.1" == request.getClientIp() or request.headers.has("X-Secure-Access")')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'access_control' => [
+                    [
+                        'path' => '^/_internal/secure',
+                        // the 'roles' and 'allow_if' options work like an OR expression, so
+                        // access is granted if the expression is TRUE or the user has ROLE_ADMIN
+                        'roles' => 'ROLE_ADMIN',
+                        'allow_if' => '"127.0.0.1" == request.getClientIp() or request.headers.has("X-Secure-Access")',
+                    ],
+                ],
+            ],
+        ]);
 
 In this case, when the user tries to access any URL starting with
 ``/_internal/secure``, they will only be granted access if the IP address is
@@ -376,17 +343,15 @@ access those URLs via a specific port. This could be useful for example for
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $security->accessControl()
-                ->path('^/cart/checkout')
-                ->roles(['PUBLIC_ACCESS'])
-                ->port(8080)
-            ;
-        };
+        return App::config([
+            'security' => [
+                'access_control' => [
+                    ['path' => '^/cart/checkout', 'roles' => 'PUBLIC_ACCESS', 'port' => 8080],
+                ],
+            ],
+        ]);
 
 Forcing a Channel (http, https)
 -------------------------------
@@ -409,14 +374,12 @@ the user will be redirected to ``https``:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $security->accessControl()
-                ->path('^/cart/checkout')
-                ->roles(['PUBLIC_ACCESS'])
-                ->requiresChannel('https')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'access_control' => [
+                    ['path' => '^/cart/checkout', 'roles' => 'PUBLIC_ACCESS', 'requires_channel' => 'https'],
+                ],
+            ],
+        ]);

--- a/security/access_denied_handler.rst
+++ b/security/access_denied_handler.rst
@@ -67,15 +67,19 @@ Now, configure this service ID as the entry point for the firewall:
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Security\AuthenticationEntryPoint;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                // ....
-                ->entryPoint(AuthenticationEntryPoint::class)
-            ;
-        };
+        use App\Security\AuthenticationEntryPoint;
+
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'entry_point' => AuthenticationEntryPoint::class,
+                    ],
+                ],
+            ],
+        ]);
 
 Customize the Forbidden Response
 --------------------------------
@@ -124,15 +128,19 @@ configure it under your firewall:
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Security\AccessDeniedHandler;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                // ....
-                ->accessDeniedHandler(AccessDeniedHandler::class)
-            ;
-        };
+        use App\Security\AccessDeniedHandler;
+
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_denied_handler' => AccessDeniedHandler::class,
+                    ],
+                ],
+            ],
+        ]);
 
 Customizing All Access Denied Responses
 ---------------------------------------

--- a/security/access_token.rst
+++ b/security/access_token.rst
@@ -42,15 +42,21 @@ digital signature, etc.).
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Security\AccessTokenHandler;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler(AccessTokenHandler::class)
-            ;
-        };
+        use App\Security\AccessTokenHandler;
+
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => AccessTokenHandler::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 This handler must implement
 :class:`Symfony\\Component\\Security\\Http\\AccessToken\\AccessTokenHandlerInterface`::
@@ -148,22 +154,28 @@ You can also create a custom extractor. The class must implement
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Security\AccessTokenHandler;
         use App\Security\CustomTokenExtractor;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler(AccessTokenHandler::class)
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => AccessTokenHandler::class,
 
-                    // use a different built-in extractor
-                    ->tokenExtractors('request_body')
+                            // use a different built-in extractor
+                            'token_extractors' => 'request_body',
 
-                    # or provide the service ID of a custom extractor
-                    ->tokenExtractors(CustomTokenExtractor::class)
-            ;
-        };
+                            // or provide the service ID of a custom extractor
+                            'token_extractors' => CustomTokenExtractor::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 It is possible to set multiple extractors. In this case, **the order is
 important**: the first in the list is called first.
@@ -185,20 +197,26 @@ important**: the first in the list is called first.
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Security\AccessTokenHandler;
         use App\Security\CustomTokenExtractor;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler(AccessTokenHandler::class)
-                    ->tokenExtractors([
-                        'header',
-                        CustomTokenExtractor::class,
-                    ])
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => AccessTokenHandler::class,
+                            'token_extractors' => [
+                                'header',
+                                CustomTokenExtractor::class,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 3) Submit a Request
 ~~~~~~~~~~~~~~~~~~~
@@ -238,17 +256,23 @@ and configure the service ID as the ``success_handler``:
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Security\AccessTokenHandler;
         use App\Security\Authentication\AuthenticationSuccessHandler;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler(AccessTokenHandler::class)
-                    ->successHandler(AuthenticationSuccessHandler::class)
-            ;
-        };
+        return App::config([
+            'security' => [
+            'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => AccessTokenHandler::class,
+                            'success_handler' => AuthenticationSuccessHandler::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -293,15 +317,21 @@ and retrieve the user info:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security) {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler()
-                        ->oidcUserInfo('https://www.example.com/realms/demo/protocol/openid-connect/userinfo')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => [
+                                'oidc_user_info' => 'https://www.example.com/realms/demo/protocol/openid-connect/userinfo',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 To enable `OpenID Connect Discovery`_, the ``OidcUserInfoTokenHandler``
 requires the ``symfony/cache`` package to store the OIDC configuration in
@@ -332,18 +362,28 @@ Next, configure the ``base_uri`` and ``discovery`` options:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security) {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler()
-                        ->oidcUserInfo()
-                            ->baseUri('https://www.example.com/realms/demo/')
-                            ->discovery()
-                                ->cache(['id' => 'cache.app'])
-            ;
-        };
+        return App::config([
+            'security' => [
+            'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => [
+                                'oidc_user_info' => [
+                                    'base_uri' => 'https://www.example.com/realms/demo/',
+                                    'discovery' => [
+                                        'cache' => [
+                                            'id' => 'cache.app',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Following the `OpenID Connect Specification`_, the ``sub`` claim is used as user
 identifier by default. To use another claim, specify it using the ``claim`` option:
@@ -365,17 +405,24 @@ identifier by default. To use another claim, specify it using the ``claim`` opti
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security) {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler()
-                        ->oidcUserInfo()
-                            ->claim('email')
-                            ->baseUri('https://www.example.com/realms/demo/protocol/openid-connect/userinfo')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => [
+                                'oidc_user_info' => [
+                                    'claim' => 'email',
+                                    'base_uri' => 'https://www.example.com/realms/demo/protocol/openid-connect/userinfo',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 The ``oidc_user_info`` token handler automatically creates an HTTP client with
 the specified ``base_uri``. If you prefer using your own client, you can
@@ -397,16 +444,23 @@ specify the service name via the ``client`` option:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security) {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler()
-                        ->oidcUserInfo()
-                            ->client('oidc.client')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => [
+                                'oidc_user_info' => [
+                                    'client' => 'oidc.client',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 By default, the ``OidcUserInfoTokenHandler`` creates an ``OidcUser`` with the
 claims. To create your own user object from the claims, you must
@@ -464,31 +518,37 @@ it, and retrieves the user information from it. Optionally, the token can be enc
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security) {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler()
-                        ->oidc()
-                            // Algorithm used to sign the JWS
-                            ->algorithms(['ES256', 'RS256'])
-                            // A JSON-encoded JWKSet (public keys)
-                            ->keyset('{"keys":[{"kty":"...","k":"..."}]}')
-                            // Audience (`aud` claim): required for validation purpose
-                            ->audience('api-example')
-                            // Issuers (`iss` claim): required for validation purpose
-                            ->issuers(['https://oidc.example.com'])
-                            ->encryption()
-                                ->enabled(true) //Default to false
-                                ->enforce(false) //Default to false, requires an encrypted token when true
-                                // Algorithm used to decrypt the JWE
-                                ->algorithms(['ECDH-ES', 'A128GCM'])
-                                // A JSON-encoded JWKSet (private keys)
-                                ->keyset('{"keys":[...]}')
-
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => [
+                                'oidc' => [
+                                    // Algorithms used to sign the JWS
+                                    'algorithms' => ['ES256', 'RS256'],
+                                    // A JSON-encoded JWK
+                                    'keyset' => '{"keys":[{"kty":"...","k":"..."}]}',
+                                    // Audience (`aud` claim): required for validation purpose
+                                    'audience' => 'api-example',
+                                    // Issuers (`iss` claim): required for validation purpose
+                                    'issuers' => ['https://oidc.example.com'],
+                                    // Encryption:
+                                    'encryption' => [
+                                        'enabled' => true, // Default to false
+                                        'enforce' => false, // Default to false, requires an encrypted token when true
+                                        'algorithms' => ['ECDH-ES', 'A128GCM'],
+                                        'keyset' => '{"keys": [...]}' // Encryption private keyset
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 To enable `OpenID Connect Discovery`_, the ``OidcTokenHandler`` requires the
 ``symfony/cache`` package to store the OIDC configuration in the cache. If you
@@ -524,22 +584,32 @@ from the OpenID Connect Discovery), and configure the ``discovery`` option:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security) {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler()
-                        ->oidc()
-                            ->claim('email')
-                            ->algorithms(['ES256', 'RS256'])
-                            ->audience('api-example')
-                            ->issuers(['https://oidc.example.com'])
-                            ->discovery()
-                                ->baseUri('https://www.example.com/realms/demo/')
-                                ->cache(['id' => 'cache.app'])
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => [
+                                'oidc' => [
+                                    'claim' => 'email',
+                                    'algorithms' => ['ES256', 'RS256'],
+                                    'audience' => 'api-example',
+                                    'issuers' => ['https://oidc.example.com'],
+                                    'discovery' => [
+                                        'base_uri' => 'https://www.example.com/realms/demo/',
+                                        'cache' => [
+                                            'id' => 'cache.app',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Following the `OpenID Connect Specification`_, the ``sub`` claim is used by
 default as user identifier. To use another claim, specify it on the
@@ -565,20 +635,27 @@ configuration:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security) {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler()
-                        ->oidc()
-                            ->claim('email')
-                            ->algorithms(['ES256', 'RS256'])
-                            ->keyset('{"keys":[{"kty":"...","k":"..."}]}')
-                            ->audience('api-example')
-                            ->issuers(['https://oidc.example.com'])
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => [
+                                'oidc' => [
+                                    'claim' => 'email',
+                                    'algorithms' => ['ES256', 'RS256'],
+                                    'keyset' => '{"keys":[{"kty":"...","k":"..."}]}',
+                                    'audience' => 'api-example',
+                                    'issuers' => ['https://oidc.example.com'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 By default, the ``OidcTokenHandler`` creates an ``OidcUser`` with the claims. To
 create your own User from the claims, you must
@@ -625,24 +702,34 @@ to validate tokens from different identity providers:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security) {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler()
-                        ->oidc()
-                            ->algorithms(['ES256', 'RS256'])
-                            ->audience('api-example')
-                            ->issuers(['https://oidc1.example.com', 'https://oidc2.example.com'])
-                            ->discovery()
-                                ->baseUri([
-                                    'https://idp1.example.com/realms/demo/',
-                                    'https://idp2.example.com/realms/demo/',
-                                ])
-                                ->cache(['id' => 'cache.app'])
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => [
+                                'oidc' => [
+                                    'algorithms' => ['ES256', 'RS256'],
+                                    'audience' => 'api-example',
+                                    'issuers' => ['https://oidc1.example.com', 'https://oidc2.example.com'],
+                                    'discovery' => [
+                                        'base_uri' => [
+                                            'https://idp1.example.com/realms/demo/',
+                                            'https://idp2.example.com/realms/demo/',
+                                        ],
+                                        'cache' => [
+                                            'id' => 'cache.app',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 The token handler fetches the JWK sets from all configured discovery endpoints
 and builds a combined JWK set for token validation. This lets your application
@@ -705,16 +792,23 @@ You can configure a ``cas`` token handler as follows:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security) {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler()
-                        ->cas()
-                            ->validationUrl('https://www.example.com/cas/validate')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => [
+                                'cas' => [
+                                    'validation_url' => 'https://www.example.com/cas/validate',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 The ``cas`` token handler automatically creates an HTTP client to call
 the specified ``validation_url``. If you prefer using your own client, you can
@@ -737,17 +831,24 @@ specify the service name via the ``http_client`` option:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security) {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler()
-                        ->cas()
-                            ->validationUrl('https://www.example.com/cas/validate')
-                            ->httpClient('cas.client')
-            ;
-        };
+        return App::config([
+            'security' => [
+            'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => [
+                                'cas' => [
+                                    'validation_url' => 'https://www.example.com/cas/validate',
+                                    'http_client' => 'cas.client',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 By default the token handler will read the validation URL XML response with
  ``cas`` prefix but you can configure another prefix:
@@ -769,17 +870,24 @@ By default the token handler will read the validation URL XML response with
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security) {
-            $security->firewall('main')
-                ->accessToken()
-                    ->tokenHandler()
-                        ->cas()
-                            ->validationUrl('https://www.example.com/cas/validate')
-                            ->prefix('cas-example')
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'access_token' => [
+                            'token_handler' => [
+                                'cas' => [
+                                    'validation_url' => 'https://www.example.com/cas/validate',
+                                    'prefix' => 'cas-example',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Creating Users from Token
 -------------------------

--- a/security/csrf.rst
+++ b/security/csrf.rst
@@ -59,18 +59,18 @@ for more information):
         # config/packages/framework.yaml
         framework:
             # ...
-            csrf_protection: ~
+            csrf_protection: true
 
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->csrfProtection()
-                ->enabled(true)
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'csrf_protection' => true,
+            ],
+        ]);
 
 By default, the tokens used for CSRF protection are stored in the session.
 That's why a session is started automatically as soon as you render a form
@@ -132,14 +132,18 @@ Globally, you can configure it under the ``framework.form`` option:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework) {
-            $framework->form()->csrfProtection()
-                ->enabled(true)
-                ->fieldName('custom_token_name')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'form' => [
+                    'csrf_protection' => [
+                        'enabled' => true,
+                        'field_name' => 'custom_token_name',
+                    ],
+                ],
+            ],
+        ]);
 
 .. _form-csrf-configuration:
 
@@ -351,13 +355,15 @@ in applications using :ref:`Symfony Flex <symfony-flex>`.
     .. code-block:: php
 
         // config/packages/csrf.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->csrfProtection()
-                ->statelessTokenIds(['submit', 'authenticate', 'logout'])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'csrf_protection' => [
+                    'stateless_token_ids' => ['submit', 'authenticate', 'logout'],
+                ],
+            ],
+        ]);
 
 Stateless CSRF tokens provide protection without relying on the session. This
 allows you to fully cache pages while still protecting against CSRF attacks.
@@ -398,14 +404,17 @@ own services), and it sets ``submit`` as their default token identifier:
     .. code-block:: php
 
         // config/packages/csrf.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->form()
-                ->csrfProtection()
-                    ->tokenId('submit')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'form' => [
+                    'csrf_protection' => [
+                        'token_id' => 'submit',
+                    ],
+                ],
+            ],
+        ]);
 
 Forms configured with a token identifier listed in the above ``stateless_token_ids``
 option will use the stateless CSRF protection.

--- a/security/custom_authenticator.rst
+++ b/security/custom_authenticator.rst
@@ -121,17 +121,21 @@ should review it:
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Security\ApiKeyAuthenticator;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            $security->enableAuthenticatorManager(true);
-            // ....
-
-            $security->firewall('main')
-                ->customAuthenticators([ApiKeyAuthenticator::class])
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'custom_authenticators' => [
+                            ApiKeyAuthenticator::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 

--- a/security/entry_point.rst
+++ b/security/entry_point.rst
@@ -33,23 +33,25 @@ You can configure this using the ``entry_point`` setting:
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Security\SocialConnectAuthenticator;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            $security->enableAuthenticatorManager(true);
-            // ....
-
-            // allow authentication using a form or HTTP basic
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall
-                ->formLogin()
-                ->customAuthenticators([SocialConnectAuthenticator::class])
-
-                // configure the form authentication as the entry point for unauthenticated users
-                ->entryPoint('form_login');
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        // allow authentication using a form or a custom authenticator
+                        'form_login' => null,
+                        'custom_authenticators' => [
+                            SocialConnectAuthenticator::class,
+                        ],
+                        // configure the form authentication as the entry point for unauthenticated users
+                        'entry_point' => 'form_login',
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -94,24 +96,28 @@ split the configuration into two separate firewalls:
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Security\ApiTokenAuthenticator;
-        use App\Security\LoginFormAuthenticator;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            $apiFirewall = $security->firewall('api');
-            $apiFirewall
-                ->pattern('^/api')
-                ->customAuthenticators([ApiTokenAuthenticator::class])
-            ;
-
-            $mainFirewall = $security->firewall('main');
-            $mainFirewall
-                ->lazy(true)
-                ->formLogin();
-
-            $accessControl = $security->accessControl();
-            $accessControl->path('^/login')->roles(['PUBLIC_ACCESS']);
-            $accessControl->path('^/api')->roles(['ROLE_API_USER']);
-            $accessControl->path('^/')->roles(['ROLE_USER']);
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'api' => [
+                        'pattern' => '^/api',
+                        'custom_authenticators' => [
+                            ApiTokenAuthenticator::class,
+                        ],
+                    ],
+                    'main' => [
+                        'lazy' => true,
+                        'form_login' => null,
+                    ],
+                ],
+                'access_control' => [
+                    ['path' => '^/login', 'roles' => 'PUBLIC_ACCESS'],
+                    ['path' => '^/api', 'roles' => 'ROLE_API_USER'],
+                    ['path' => '^/', 'roles' => 'ROLE_USER'],
+                ],
+            ],
+        ]);

--- a/security/firewall_restriction.rst
+++ b/security/firewall_restriction.rst
@@ -41,16 +41,20 @@ if the request path matches the configured ``pattern``.
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ....
-
-            $security->firewall('secured_area')
-                ->pattern('^/admin')
+        return App::config([
+            'security' => [
                 // ...
-            ;
-        };
+
+                'firewalls' => [
+                    'secured_area' => [
+                        'pattern' => '^/admin',
+                        // ...
+                    ],
+                ],
+            ],
+        ]);
 
 The ``pattern`` is a regular expression. In this example, the firewall will only be
 activated if the path starts (due to the ``^`` regex character) with ``/admin``. If
@@ -80,16 +84,20 @@ only initialize if the host from the request matches against the configuration.
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ....
-
-            $security->firewall('secured_area')
-                ->host('^admin\.example\.com$')
+        return App::config([
+            'security' => [
                 // ...
-            ;
-        };
+
+                'firewalls' => [
+                    'secured_area' => [
+                        'host' => '^admin\.example\.com$',
+                    ],
+                    // ...
+                ],
+            ],
+        ]);
 
 The ``host`` (like the ``pattern``) is a regular expression. In this example,
 the firewall will only be activated if the host is equal exactly (due to
@@ -120,16 +128,19 @@ the provided HTTP methods.
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ....
-
-            $security->firewall('secured_area')
-                ->methods(['GET', 'POST'])
+        return App::config([
+            'security' => [
                 // ...
-            ;
-        };
+
+                'firewalls' => [
+                    'secured_area' => [
+                        'methods' => ['GET', 'POST'],
+                    ],
+                ],
+            ],
+        ]);
 
 In this example, the firewall will only be activated if the HTTP method of the
 request is either ``GET`` or ``POST``. If the method is not in the array of the
@@ -158,14 +169,17 @@ If the above options don't fit your needs you can configure any service implemen
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Security\CustomRequestMatcher;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            // ....
-
-            $security->firewall('secured_area')
-                ->requestMatcher(CustomRequestMatcher::class)
+        return App::config([
+            'security' => [
                 // ...
-            ;
-        };
+                'firewalls' => [
+                    'secured_area' => [
+                        'request_matcher' => CustomRequestMatcher::class,
+                    ],
+                ],
+            ],
+        ]);

--- a/security/force_https.rst
+++ b/security/force_https.rst
@@ -28,29 +28,19 @@ access control:
         .. code-block:: php
 
             // config/packages/security.php
-            use Symfony\Config\SecurityConfig;
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (SecurityConfig $security): void {
-                // ....
-
-                $security->accessControl()
-                    ->path('^/secure')
-                    ->roles(['ROLE_ADMIN'])
-                    ->requiresChannel('https')
-                ;
-
-                $security->accessControl()
-                    ->path('^/login')
-                    ->roles(['PUBLIC_ACCESS'])
-                    ->requiresChannel('https')
-                ;
-
-                $security->accessControl()
-                    ->path('^/')
-                    ->roles(['PUBLIC_ACCESS'])
-                    ->requiresChannel('https')
-                ;
-            };
+            return App::config([
+                'security' => [
+                    // ....
+                    'access_control' => [
+                        ['path' => '^/secure', 'roles' => ['ROLE_ADMIN'], 'requires_channel' => 'https'],
+                        ['path' => '^/login', 'roles' => ['PUBLIC_ACCESS'], 'requires_channel' => 'https'],
+                        // catch all other URLs
+                        ['path' => '^/', 'roles' => ['PUBLIC_ACCESS'], 'requires_channel' => 'https'],
+                    ],
+                ],
+            ]);
 
 To make life easier while developing, you can also use an environment variable,
 like ``requires_channel: '%env(REQUIRED_SCHEME)%'``. In your ``.env`` file, set

--- a/security/form_login.rst
+++ b/security/form_login.rst
@@ -42,18 +42,20 @@ a relative/absolute URL or a Symfony route name:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $security->firewall('main')
+        return App::config([
+            'security' => [
                 // ...
-                ->formLogin()
-                    // ...
-                    ->defaultTargetPath('after_login_route_name')
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'form_login' => [
+                            'default_target_path' => 'after_login_route_name',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Always Redirect to the default Page
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -78,18 +80,20 @@ previously requested URL and always redirect to the default page:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $security->firewall('main')
+        return App::config([
+            'security' => [
                 // ...
-                ->formLogin()
-                    // ...
-                    ->alwaysUseDefaultTargetPath(true)
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'form_login' => [
+                            'always_use_default_target_path' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _control-the-redirect-url-from-inside-the-form:
 
@@ -144,18 +148,20 @@ parameter is included in the request, you may use the value of the
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $security->firewall('main')
+        return App::config([
+            'security' => [
                 // ...
-                ->formLogin()
-                    // ...
-                    ->useReferer(true)
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'form_login' => [
+                            'use_referer' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -189,18 +195,20 @@ option to define a new target via a relative/absolute URL or a Symfony route nam
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $security->firewall('main')
+        return App::config([
+            'security' => [
                 // ...
-                ->formLogin()
-                    // ...
-                    ->failurePath('login_failure_route_name')
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'form_login' => [
+                            'failure_path' => 'login_failure_route_name',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 This option can also be set via the ``_failure_path`` request parameter:
 
@@ -243,19 +251,21 @@ redirects can be customized using the  ``target_path_parameter`` and
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $security->firewall('main')
+        return App::config([
+            'security' => [
                 // ...
-                ->formLogin()
-                    // ...
-                    ->targetPathParameter('go_to')
-                    ->failurePathParameter('back_to')
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'form_login' => [
+                            'target_path_parameter' => 'go_to',
+                            'failure_path_parameter' => 'back_to',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Using the above configuration, the query string parameters and hidden form fields
 are now fully customized:

--- a/security/impersonating_user.rst
+++ b/security/impersonating_user.rst
@@ -25,20 +25,23 @@ listener:
             firewalls:
                 main:
                     # ...
-                    switch_user: true
+                    switch_user: []
 
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->firewall('main')
+        return App::config([
+            'security' => [
                 // ...
-                ->switchUser()
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'switch_user' => [],
+                    ],
+                ],
+            ],
+        ]);
 
 To switch to another user, add a query string with the ``_switch_user``
 parameter and the username (or whatever field our user provider uses to load users)
@@ -74,15 +77,20 @@ as the value to the current URL:
         .. code-block:: php
 
             // config/packages/security.php
-            use Symfony\Config\SecurityConfig;
-            return static function (SecurityConfig $security): void {
-                // ...
-                $security->firewall('main')
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return App::config([
+                'security' => [
                     // ...
-                    ->switchUser()
-                        ->parameter('X-Switch-User')
-                ;
-            };
+                    'firewalls' => [
+                        'main' => [
+                            'switch_user' => [
+                                'parameter' => 'X-Switch-User',
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
 
 To switch back to the original user, use the special ``_exit`` username:
 
@@ -172,17 +180,18 @@ also adjust the query parameter name via the ``parameter`` setting:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
+        return App::config([
+            'security' => [
             // ...
-            $security->firewall('main')
-                // ...
-                ->switchUser()
-                    ->role('ROLE_ADMIN')
-                    ->parameter('_want_to_be_this_user')
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'switch_user' => ['role' => 'ROLE_ADMIN', 'parameter' => '_want_to_be_this_user'],
+                    ],
+                ],
+            ],
+        ]);
 
 Redirecting to a Specific Target Route
 --------------------------------------
@@ -209,16 +218,18 @@ This feature allows you to control the redirection target route via ``target_rou
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->firewall('main')
+        return App::config([
+            'security' => [
                 // ...
-                ->switchUser()
-                    ->targetRoute('app_user_dashboard')
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'switch_user' => ['target_route' => 'app_user_dashboard'],
+                    ],
+                ],
+            ],
+        ]);
 
 Limiting User Switching
 -----------------------
@@ -244,16 +255,18 @@ be called):
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->firewall('main')
+        return App::config([
+            'security' => [
                 // ...
-                ->switchUser()
-                    ->role('CAN_SWITCH_USER')
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'switch_user' => ['role' => 'CAN_SWITCH_USER'],
+                    ],
+                ],
+            ],
+        ]);
 
 Then, create a voter class that responds to this role and includes whatever custom
 logic you want::
@@ -351,10 +364,10 @@ switch users, add an event subscriber on this event::
 
         public static function getSubscribedEvents(): array
         {
-            return [
+            return App::config([
                 // constant for security.switch_user
                 SecurityEvents::SWITCH_USER => 'onSwitchUser',
-            ];
+            ]);
         }
     }
 

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -81,24 +81,30 @@ An LDAP client can be configured using the built-in
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Symfony\Component\Ldap\Adapter\ExtLdap\Adapter;
         use Symfony\Component\Ldap\Ldap;
 
-        $container->register(Ldap::class)
-            ->addArgument(new Reference(Adapter::class))
-            ->tag('ldap');
-
-        $container
-            ->register(Adapter::class)
-            ->setArguments([
-                'host' => 'my-server',
-                'port' => 389,
-                'encryption' => 'tls',
-                'options' => [
-                    'protocol_version' => 3,
-                    'referrals' => false
+        return App::config([
+            'services' => [
+                Ldap::class => [
+                    'arguments' => [service(Adapter::class)],
+                    'tags' => ['ldap'],
                 ],
-            ]);
+                Adapter::class => [
+                    'arguments' => [[
+                        'host' => 'my-server',
+                        'port' => 389,
+                        'encryption' => 'tls',
+                        'options' => [
+                            'protocol_version' => 3,
+                            'referrals' => false,
+                        ],
+                    ]],
+                ],
+            ],
+        ]);
 
 .. _security-ldap-user-provider:
 
@@ -130,21 +136,28 @@ use the ``ldap`` user provider.
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Component\Ldap\Ldap;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->provider('ldap_users')
-                ->ldap()
-                    ->service(Ldap::class)
-                    ->baseDn('dc=example,dc=com')
-                    ->searchDn('cn=read-only-admin,dc=example,dc=com')
-                    ->searchPassword('password')
-                    ->defaultRoles(['ROLE_USER'])
-                    ->uidKey('uid')
-                    ->extraFields(['email'])
-            ;
-        };
+        use Symfony\Component\Ldap\Ldap;
+
+        return App::config([
+            'security' => [
+                // ...
+                'providers' => [
+                    'my_ldap' => [
+                        'ldap' => [
+                            'service' => Ldap::class,
+                            'base_dn' => 'dc=example,dc=com',
+                            'search_dn' => 'cn=read-only-admin,dc=example,dc=com',
+                            'search_password' => 'password',
+                            'default_roles' => ['ROLE_USER'],
+                            'uid_key' => 'uid',
+                            'extra_fields' => ['email'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. danger::
 
@@ -340,16 +353,23 @@ Configuration example for form login
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Component\Ldap\Ldap;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->formLoginLdap()
-                    ->service(Ldap::class)
-                    ->dnString('uid={user_identifier},dc=example,dc=com')
-            ;
-        };
+        use Symfony\Component\Ldap\Ldap;
+
+        return App::config([
+            'security' => [
+                // ...
+                'firewalls' => [
+                    'main' => [
+                        'form_login_ldap' => [
+                            'service' => Ldap::class,
+                            'dn_string' => 'uid={user_identifier},dc=example,dc=com',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Configuration example for HTTP Basic
 ....................................
@@ -372,17 +392,24 @@ Configuration example for HTTP Basic
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Component\Ldap\Ldap;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->stateless(true)
-                ->formLoginLdap()
-                    ->service(Ldap::class)
-                    ->dnString('uid={user_identifier},dc=example,dc=com')
-            ;
-        };
+        use Symfony\Component\Ldap\Ldap;
+
+        return App::config([
+            'security' => [
+                // ...
+                'firewalls' => [
+                    'main' => [
+                        'stateless' => true,
+                        'http_basic_ldap' => [
+                            'service' => Ldap::class,
+                            'dn_string' => 'uid={user_identifier},dc=example,dc=com',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Configuration example for form login and query_string
 .....................................................
@@ -408,20 +435,26 @@ Configuration example for form login and query_string
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Component\Ldap\Ldap;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->stateless(true)
-                ->formLoginLdap()
-                    ->service(Ldap::class)
-                    ->dnString('dc=example,dc=com')
-                    ->queryString('(&(uid={user_identifier})(memberOf=cn=users,ou=Services,dc=example,dc=com))')
-                    ->searchDn('...')
-                    ->searchPassword('the-raw-password')
-            ;
-        };
+        use Symfony\Component\Ldap\Ldap;
+
+        return App::config([
+            'security' => [
+                // ...
+                'firewalls' => [
+                    'main' => [
+                        'form_login_ldap' => [
+                            'service' => Ldap::class,
+                            'dn_string' => 'dc=example,dc=com',
+                            'query_string' => '(&(uid={user_identifier})(memberOf=cn=users,ou=Services,dc=example,dc=com))',
+                            'search_dn' => '...',
+                            'search_password' => 'the-raw-password',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _`LDAP PHP extension`: https://www.php.net/manual/en/intro.ldap.php
 .. _`RFC4515`: https://datatracker.ietf.org/doc/rfc4515/

--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -38,15 +38,20 @@ and ``signature_properties`` (explained below):
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->loginLink()
-                    ->checkRoute('login_check')
-                    ->signatureProperties(['id'])
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'login_link' => [
+                            'check_route' => 'login_check',
+                            'signature_properties' => ['id'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 The ``signature_properties`` are used to create a signed URL. This must
 contain at least one property of your ``User`` object that uniquely
@@ -88,13 +93,11 @@ intercept requests to this route:
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\DefaultController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return function (RoutingConfigurator $routes): void {
-            // ...
-            $routes->add('login_check', '/login_check');
-        };
+        return Routes::config([
+            'login_check' => ['path' => '/login_check'],
+        ]);
 
 2) Generate the Login Link
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -307,16 +310,21 @@ seconds). You can customize this using the ``lifetime`` option:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->loginLink()
-                    ->checkRoute('login_check')
-                    // lifetime in seconds
-                    ->lifetime(300)
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'login_link' => [
+                            'check_route' => 'login_check',
+                            // lifetime in seconds
+                            'lifetime' => 300,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -370,15 +378,20 @@ You can add more properties to the ``hash`` by using the
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->loginLink()
-                    ->checkRoute('login_check')
-                    ->signatureProperties(['id', 'email'])
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'login_link' => [
+                            'check_route' => 'login_check',
+                            'signature_properties' => ['id', 'email'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 The properties are fetched from the user object using the
 :doc:`PropertyAccess component </components/property_access>` (e.g. using
@@ -418,20 +431,24 @@ cache. Enable this support by setting the ``max_uses`` option:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->loginLink()
-                    ->checkRoute('login_check')
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'login_link' => [
+                            'check_route' => 'login_check',
+                            // only allow the link to be used 3 times
+                            'max_uses' => 3,
 
-                    // only allow the link to be used 3 times
-                    ->maxUses(3)
-
-                    // optionally, configure the cache pool
-                    //->usedLinkCache('cache.redis')
-            ;
-        };
+                            // optionally, configure the cache pool
+                            // 'used_link_cache' => 'cache.redis',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Make sure there is enough space left in the cache, otherwise invalid links
 can no longer be stored (and thus become valid again). Expired invalid
@@ -469,16 +486,21 @@ the authenticator only handle HTTP POST methods:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->loginLink()
-                    ->checkRoute('login_check')
-                    ->checkPostOnly(true)
-                    ->maxUses(1)
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'login_link' => [
+                            'check_route' => 'login_check',
+                            'check_post_only' => true,
+                            'max_uses' => 1,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Then, use the ``check_route`` controller to render a page that lets the
 user create this POST request (e.g. by clicking a button)::
@@ -592,18 +614,24 @@ Then, configure this service ID as the ``success_handler``:
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Security\Authentication\AuthenticationSuccessHandler;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->firewall('main')
-                ->loginLink()
-                    ->checkRoute('login_check')
-                    ->lifetime(600)
-                    ->maxUses(1)
-                    ->successHandler(AuthenticationSuccessHandler::class)
-            ;
-        };
+        use App\Security\Authentication\AuthenticationSuccessHandler;
+
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'login_link' => [
+                            'check_route' => 'login_check',
+                            'lifetime' => 600,
+                            'max_uses' => 1,
+                            'success_handler' => AuthenticationSuccessHandler::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 

--- a/security/passwords.rst
+++ b/security/passwords.rst
@@ -38,22 +38,27 @@ optionally some *algorithm options*:
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Entity\User;
         use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            // ...
+        return App::config([
+            'security' => [
+                // ...
 
-            // auto hasher with default options for the User class (and children)
-            $security->passwordHasher(User::class)
-                ->algorithm('auto');
+                'password_hashers' => [
+                    // auto hasher with default options for the User class (and children)
+                    User::class => 'auto',
 
-            // auto hasher with custom options for all PasswordAuthenticatedUserInterface instances
-            $security->passwordHasher(PasswordAuthenticatedUserInterface::class)
-                ->algorithm('auto')
-                ->cost(15);
-        };
+                    // auto hasher with custom options for all PasswordAuthenticatedUserInterface instances
+                    PasswordAuthenticatedUserInterface::class => [
+                        'algorithm' => 'auto',
+                        'cost' => 15,
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -111,23 +116,25 @@ Further in this article, you can find a
         .. code-block:: php
 
             // config/packages/security.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
             use App\Entity\User;
-            use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-            use Symfony\Config\SecurityConfig;
 
-            return static function (SecurityConfig $security, ContainerConfigurator $container): void {
-                // ...
-
-                if ('test' === $container->env()) {
-                    // Use your user class name here
-                    $security->passwordHasher(User::class)
-                        ->algorithm('auto') // This should be the same value as in config/packages/security.yaml
-                        ->cost(4) // Lowest possible value for bcrypt
-                        ->timeCost(2) // Lowest possible value for argon
-                        ->memoryCost(10) // Lowest possible value for argon
-                    ;
-                }
-            };
+            return App::config([
+                'when@test' => [
+                    'security' => [
+                        'password_hashers' => [
+                            // Use your user class name here
+                            User::class => [
+                                'algorithm' => 'auto',
+                                'cost' => 4, // Lowest possible value for bcrypt
+                                'time_cost' => 3, // Lowest possible value for argon
+                                'memory_cost' => 10, // Lowest possible value for argon
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
 
 Hashing the Password
 --------------------
@@ -327,25 +334,29 @@ on the new hasher to point to the old, legacy hasher(s):
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->passwordHasher('legacy')
-                ->algorithm('sha256')
-                ->encodeAsBase64(true)
-                ->iterations(1)
-            ;
-
-            $security->passwordHasher('App\Entity\User')
-                // the new hasher, along with its options
-                ->algorithm('sodium')
-                ->migrateFrom([
-                    'bcrypt', // uses the "bcrypt" hasher with the default options
-                    'legacy', // uses the "legacy" hasher configured above
-                ])
-            ;
-        };
+        return App::config([
+            'security' => [
+                // ...
+                'password_hashers' => [
+                    // a hasher used in the past for some users
+                    'legacy' => [
+                        'algorithm' => 'sha256',
+                        'encode_as_base64' => false,
+                        'iterations' => 1,
+                    ],
+                    User::class => [
+                        // the new hasher, along with its options
+                        'algorithm' => 'sodium',
+                        'migrate_from' => [
+                            'bcrypt', // uses the "bcrypt" hasher with the default options
+                            'legacy', // uses the "legacy" hasher configured above
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -526,15 +537,19 @@ cost. This can be done with named hashers:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
+        return App::config([
+            'security' => [
             // ...
-            $security->passwordHasher('harsh')
-                ->algorithm('auto')
-                ->cost(15)
-            ;
-        };
+                'password_hashers' => [
+                    'harsh' => [
+                        'algorithm' => 'auto',
+                        'cost' => 15,
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -602,15 +617,20 @@ you must register a service for it in order to use it as a named hasher:
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Security\Hasher\MyCustomPasswordHasher;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->passwordHasher('app_hasher')
-                ->id(MyCustomPasswordHasher::class)
-            ;
-        };
+        use App\Security\Hasher\MyCustomPasswordHasher;
+
+        return App::config([
+            'security' => [
+                // ...
+                'password_hashers' => [
+                    'app_hasher' => [
+                        'id' => MyCustomPasswordHasher::class,
+                    ],
+                ],
+            ],
+        ]);
 
 This creates a hasher named ``app_hasher`` from a service with the ID
 ``App\Security\Hasher\MyCustomPasswordHasher``.
@@ -799,16 +819,21 @@ Now, define a password hasher using the ``id`` setting:
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Security\Hasher\CustomVerySecureHasher;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->passwordHasher('app_hasher')
-                // the service ID of your custom hasher (the FQCN using the default services.yaml)
-                ->id(CustomVerySecureHasher::class)
-            ;
-        };
+        use App\Security\Hasher\MyCustomPasswordHasher;
+
+        return App::config([
+            'security' => [
+                // ...
+                'password_hashers' => [
+                    'app_hasher' => [
+                        // the service ID of your custom hasher (the FQCN using the default services.yaml)
+                        'id' => MyCustomPasswordHasher::class,
+                    ],
+                ],
+            ],
+        ]);
 
 .. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
 .. _`PBKDF2`: https://en.wikipedia.org/wiki/PBKDF2

--- a/security/remember_me.rst
+++ b/security/remember_me.rst
@@ -29,22 +29,25 @@ the session lasts using a cookie with the ``remember_me`` firewall option:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->firewall('main')
+        return App::config([
+            'security' => [
                 // ...
-                ->rememberMe()
-                    ->secret('%kernel.secret%')
-                    ->lifetime(604800) // 1 week in seconds
-
-                    // by default, the feature is enabled by checking a
-                    // checkbox in the login form (see below), uncomment
-                    // the following line to always enable it.
-                    // ->alwaysRememberMe(true)
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'remember_me' => [
+                            'secret' => param('kernel.secret'),
+                            'lifetime' => 604800, // 1 week in seconds
+                            // by default, the feature is enabled by checking a
+                            // checkbox in the login form (see below), uncomment the
+                            // following line to always enable it.
+                            // 'always_remember_me' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 After enabling the ``remember_me`` system in the configuration, there are a
 couple more things to do before remember me works correctly:
@@ -142,17 +145,20 @@ allow users to opt-out. In these cases, you can use the
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
+        return App::config([
+            'security' => [
             // ...
-            $security->firewall('main')
-                // ...
-                ->rememberMe()
-                    // ...
-                    ->alwaysRememberMe(true)
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'remember_me' => [
+                            'always_remember_me' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Now, no request parameter is checked and each successful authentication
 will produce a remember me cookie.
@@ -278,17 +284,19 @@ are fetched from the user object using the
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->firewall('main')
-                // ...
-                ->rememberMe()
-                    // ...
-                    ->signatureProperties(['password', 'updatedAt'])
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'remember_me' => [
+                            'signature_properties' => ['password', 'updatedAt'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 In this example, the remember me cookie will no longer be considered valid
 if the ``updatedAt``, password or user identifier for this user changes.
@@ -335,19 +343,21 @@ You can enable the doctrine token provider using the ``doctrine`` setting:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->firewall('main')
-                // ...
-                ->rememberMe()
-                    // ...
-                    ->tokenProvider([
-                        'doctrine' => true,
-                    ])
-            ;
-        };
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'remember_me' => [
+                            'token_provider' => [
+                                'doctrine' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 This also instructs Doctrine to create a table for the remember me tokens.
 If you use the DoctrineMigrationsBundle, you can create a new migration for
@@ -397,20 +407,24 @@ Then, configure the service ID of your custom token provider as ``service``:
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Security\RememberMe\CustomTokenProvider;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->firewall('main')
+        use App\Security\RememberMe\CustomTokenProvider;
+
+        return App::config([
+            'security' => [
                 // ...
-                ->rememberMe()
-                    // ...
-                    ->tokenProvider([
-                        'service' => CustomTokenProvider::class,
-                    ])
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'remember_me' => [
+                            'token_provider' => [
+                                'service' => CustomTokenProvider::class,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _security-remember-me-authorization:
 

--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -86,17 +86,22 @@ is the service id of your user checker:
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Security\UserChecker;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->firewall('main')
-                ->pattern('^/')
-                ->userChecker(UserChecker::class)
+        use App\Security\UserChecker;
+
+        return App::config([
+            'security' => [
                 // ...
-            ;
-        };
+                'firewalls' => [
+                    'main' => [
+                        'pattern' => '^/',
+                        'user_checker' => UserChecker::class,
+                        // ...
+                    ],
+                ],
+            ],
+        ]);
 
 Using Multiple User Checkers
 ----------------------------
@@ -137,16 +142,21 @@ order in which user checkers are called::
         use App\Security\AccountEnabledUserChecker;
         use App\Security\APIAccessAllowedUserChecker;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
-
-            $services->set(AccountEnabledUserChecker::class)
-                ->tag('security.user_checker.api', ['priority' => 10])
-                ->tag('security.user_checker.main', ['priority' => 10]);
-
-            $services->set(APIAccessAllowedUserChecker::class)
-                ->tag('security.user_checker.api', ['priority' => 5]);
-        };
+        return App::config([
+            'services' => [
+                AccountEnabledUserChecker::class => [
+                    'tags' => [
+                        ['security.user_checker.api' => ['priority' => 10]],
+                        ['security.user_checker.main' => ['priority' => 10]],
+                    ],
+                ],
+                APIAccessAllowedUserChecker::class => [
+                    'tags' => [
+                        ['security.user_checker.api' => ['priority' => 5]],
+                    ],
+                ],
+            ],
+        ]);
 
 Once your checker services are tagged, next you will need configure your firewalls to use the
 ``security.user_checker.chain.<firewall>`` service::
@@ -172,19 +182,22 @@ Once your checker services are tagged, next you will need configure your firewal
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-            $security->firewall('api')
-                ->pattern('^/api')
-                ->userChecker('security.user_checker.chain.api')
+        return App::config([
+            'security' => [
                 // ...
-            ;
-
-            $security->firewall('main')
-                ->pattern('^/')
-                ->userChecker('security.user_checker.chain.main')
-                // ...
-            ;
-        };
+                'firewalls' => [
+                    'api' => [
+                        'pattern' => '^/api',
+                        'user_checker' => 'security.user_checker.chain.api',
+                        // ...
+                    ],
+                ],
+                'main' => [
+                    'pattern' => '^/',
+                    'user_checker' => 'security.user_checker.chain.main',
+                    // ...
+                ],
+            ],
+        ]);

--- a/security/user_providers.rst
+++ b/security/user_providers.rst
@@ -48,18 +48,30 @@ the user provider uses :doc:`Doctrine </doctrine>` to retrieve them.
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Entity\User;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            // ...
+        return App::config([
+            'security' => [
+                // ...
 
-            $security->provider('app_user_provider')
-                ->entity()
-                    ->class(User::class)
-                    ->property('email')
-            ;
-        };
+                'providers' => [
+                    'users' => [
+                        'entity' => [
+                            // the class of the entity that represents users
+                            'class' => User::class,
+                            // the property to query by - e.g. email, username, etc
+                            'property' => 'email',
+
+                            // optional: if you're using multiple Doctrine entity
+                            // managers, this option defines which one to use
+                            // 'manager_name' => 'customer',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _authenticating-someone-with-a-custom-entity-provider:
 
@@ -117,17 +129,23 @@ To finish this, remove the ``property`` key from the user provider in
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Entity\User;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            // ...
+        return App::config([
+            'security' => [
+                // ...
 
-            $security->provider('app_user_provider')
-                ->entity()
-                    ->class(User::class)
-            ;
-        };
+                'providers' => [
+                    'users' => [
+                        'entity' => [
+                            'class' => User::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Now, whenever Symfony uses the user provider, the ``loadUserByIdentifier()``
 method on your ``UserRepository`` will be called.
@@ -166,25 +184,24 @@ After setting up hashing, you can configure all the user information in
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Entity\User;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $memoryProvider = $security->provider('app_user_provider')->memory();
-            $memoryProvider
-                ->user('john_admin')
-                    ->password('$2y$13$jxGxc ... IuqDju')
-                    ->roles(['ROLE_ADMIN'])
-            ;
-
-            $memoryProvider
-                ->user('jane_admin')
-                ->password('$2y$13$PFi1I ... rGwXCZ')
-                ->roles(['ROLE_ADMIN', 'ROLE_SUPER_ADMIN'])
-            ;
-        };
+        return App::config([
+            'security' => [
+                'providers' => [
+                    'backend_users' => [
+                        'memory' => [
+                            'users' => [
+                                'john_admin' => ['password' => '$2y$13$jxGxc ... IuqDju', 'roles' => ['ROLE_ADMIN']],
+                                'jane_admin' => ['password' => '$2y$13$PFi1I ... rGwXCZ', 'roles' => ['ROLE_ADMIN', 'ROLE_SUPER_ADMIN']],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. warning::
 
@@ -229,31 +246,35 @@ providers until the user is found:
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Entity\User;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-            $security->provider('backend_users')
-                ->ldap()
+        return App::config([
+            'security' => [
                 // ...
-            ;
-
-            $security->provider('legacy_users')
-                ->entity()
-                // ...
-            ;
-
-            $security->provider('users')
-                ->entity()
-                // ...
-            ;
-
-            $security->provider('all_users')->chain()
-                ->providers(['backend_users', 'legacy_users', 'users'])
-            ;
-        };
+                'providers' => [
+                    'backend_users' => [
+                        'ldap' => [
+                            // ...
+                        ],
+                    ],
+                    'legacy_users' => [
+                        'entity' => [
+                            // ...
+                        ],
+                    ],
+                    'users' => [
+                        'entity' => [
+                            // ...
+                        ],
+                    ],
+                    'all_users' => [
+                        'chain' => [
+                            'providers' => ['legacy_users', 'users', 'backend_users'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. _security-custom-user-provider:
 
@@ -358,17 +379,21 @@ the user provider by adding it in ``security.yaml``:
     .. code-block:: php
 
         // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Security\UserProvider;
-        use Symfony\Config\SecurityConfig;
 
-        return static function (SecurityConfig $security): void {
-            // ...
-
-             $customProvider = $security->provider('your_custom_user_provider')
-                ->id(UserProvider::class)
+        return App::config([
+            'security' => [
                 // ...
-            ;
-        };
+                'providers' => [
+                    // the name of your user provider can be anything
+                    'your_custom_user_provider' => [
+                        'id' => UserProvider::class,
+                    ],
+                ],
+            ],
+        ]);
 
 Lastly, update the ``config/packages/security.yaml`` file to set the
 ``provider`` key to ``your_custom_user_provider`` in all the firewalls which

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -440,14 +440,16 @@ security configuration:
     .. code-block:: php
 
         // config/packages/security.php
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->accessDecisionManager()
-                ->strategy('unanimous')
-                ->allowIfAllAbstain(false)
-            ;
-        };
+        return App::config([
+            'security' => [
+                'access_decision_manager' => [
+                    'strategy' => 'unanimous',
+                    'allow_if_all_abstain' => false,
+                ],
+            ],
+        ]);
 
 Custom Access Decision Strategy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -469,15 +471,17 @@ option to use a custom service (your service must implement the
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Security\MyCustomAccessDecisionStrategy;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->accessDecisionManager()
-                ->strategyService(MyCustomAccessDecisionStrategy::class)
-                // ...
-            ;
-        };
+        use App\Security\MyCustomAccessDecisionStrategy;
+
+        return App::config([
+            'security' => [
+                'access_decision_manager' => [
+                    'strategy_service' => MyCustomAccessDecisionStrategy::class,
+                ],
+            ],
+        ]);
 
 When creating custom decision strategies, you can store additional data in votes
 to be used later when making a decision. For example, if not all votes should
@@ -549,12 +553,14 @@ must implement the :class:`Symfony\\Component\\Security\\Core\\Authorization\\Ac
     .. code-block:: php
 
         // config/packages/security.php
-        use App\Security\MyCustomAccessDecisionManager;
-        use Symfony\Config\SecurityConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (SecurityConfig $security): void {
-            $security->accessDecisionManager()
-                ->service(MyCustomAccessDecisionManager::class)
-                // ...
-            ;
-        };
+        use App\Security\MyCustomAccessDecisionManager;
+
+        return App::config([
+            'security' => [
+                'access_decision_manager' => [
+                    'service' => MyCustomAccessDecisionManager::class,
+                ],
+            ],
+        ]);

--- a/serializer.rst
+++ b/serializer.rst
@@ -320,15 +320,17 @@ instance to disallow extra fields while deserializing:
     .. code-block:: php
 
         // config/packages/serializer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->serializer()
-                ->defaultContext([
-                    'allow_extra_attributes' => false,
-                ])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'serializer' => [
+                    'default_context' => [
+                        'allow_extra_attributes' => false,
+                    ],
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -1211,13 +1213,15 @@ setting the ``name_converter`` setting to
     .. code-block:: php
 
         // config/packages/serializer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->serializer()
-                ->nameConverter('serializer.name_converter.camel_case_to_snake_case')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'serializer' => [
+                    'name_converter' => 'serializer.name_converter.camel_case_to_snake_case',
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -1254,13 +1258,15 @@ setting the ``name_converter`` setting to
     .. code-block:: php
 
         // config/packages/serializer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->serializer()
-                ->nameConverter('serializer.name_converter.snake_case_to_camel_case')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'serializer' => [
+                    'name_converter' => 'serializer.name_converter.snake_case_to_camel_case',
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -1451,17 +1457,17 @@ like:
 
         use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 
-        return function(ContainerConfigurator $container) {
-            // ...
-
-            // if you're using autoconfigure, the tag will be automatically applied
-            $services->set(CustomNormalizer::class)
-                // register the normalizer with a high priority (called earlier)
-                ->tag('serializer.normalizer', [
-                    'priority' => 500,
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                // if you're using autoconfigure, the tag will be automatically applied
+                CustomNormalizer::class => [
+                    'tags' => [
+                        // register the normalizer with a high priority (called earlier)
+                        ['serializer.normalizer' => ['priority' => 500]],
+                    ],
+                ],
+            ],
+        ]);
 
 :class:`Symfony\\Component\\Serializer\\Normalizer\\CustomNormalizer`
     This normalizer calls a method on the PHP object when normalizing. The
@@ -1536,23 +1542,27 @@ the ``named_serializers`` option:
     .. code-block:: php
 
         // config/packages/serializer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->serializer()
-                ->namedSerializer('api_client1')
-                    ->nameConverter('serializer.name_converter.camel_case_to_snake_case')
-                    ->defaultContext([
-                        'enable_max_depth' => true,
-                    ])
-            ;
-            $framework->serializer()
-                ->namedSerializer('api_client2')
-                    ->defaultContext([
-                        'enable_max_depth' => false,
-                    ])
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'serializer' => [
+                    'named_serializers' => [
+                        'api_client1' => [
+                            'name_converter' => 'serializer.name_converter.camel_case_to_snake_case',
+                            'default_context' => [
+                                'enable_max_depth' => true,
+                            ],
+                        ],
+                        'api_client2' => [
+                            'default_context' => [
+                                'enable_max_depth' => false,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 You can inject these different serializer instances
 using :ref:`named aliases <autowiring-multiple-implementations-same-type>`::
@@ -1605,18 +1615,22 @@ or :ref:`serializer.encoder <reference-dic-tags-serializer-encoder>` tags:
 
         use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 
-        return function(ContainerConfigurator $container) {
-            // ...
-
-            $services->set(CustomNormalizer::class)
-                // add this normalizer only to a specific named serializer
-                ->tag('serializer.normalizer', ['serializer' => 'api_client1'])
-                // add this normalizer to several named serializers
-                ->tag('serializer.normalizer', ['serializer' => ['api_client1', 'api_client2']])
-                // add this normalizer to all serializers, including the default one
-                ->tag('serializer.normalizer', ['serializer' => '*'])
-            ;
-        };
+        return App::config([
+            'services' => [
+                CustomNormalizer::class => [
+                    // prevent this normalizer from being automatically added to the default serializer
+                    'autoconfigure' => false,
+                    'tags' => [
+                        // add this normalizer only to a specific named serializer
+                        ['serializer.normalizer' => ['serializer' => 'api_client1']],
+                        // add this normalizer to several named serializers
+                        ['serializer.normalizer' => ['serializer' => ['api_client1', 'api_client2']]],
+                        // add this normalizer to all serializers, including the default one
+                        ['serializer.normalizer' => ['serializer' => '*']],
+                    ],
+                ],
+            ],
+        ]);
 
 When the ``serializer`` attribute is not set, the service is registered only with
 the default serializer.
@@ -1648,15 +1662,20 @@ named serializer by setting the ``include_built_in_normalizers`` and
     .. code-block:: php
 
         // config/packages/serializer.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->serializer()
-                ->namedSerializer('api_client1')
-                    ->includeBuiltInNormalizers(false)
-                    ->includeBuiltInEncoders(true)
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'serializer' => [
+                    'named_serializers' => [
+                        'api_client1' => [
+                            'include_built_in_normalizers' => false,
+                            'include_built_in_encoders' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Debugging the Serializer
 ------------------------

--- a/serializer/custom_name_converter.rst
+++ b/serializer/custom_name_converter.rst
@@ -58,15 +58,17 @@ Then, configure the serializer to use your name converter:
     .. code-block:: php
 
         // config/packages/serializer.php
-        use App\Serializer\OrgPrefixNameConverter;
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework) {
-            $framework->serializer()
-                // pass the service ID of your name converter
-                ->nameConverter(OrgPrefixNameConverter::class)
-            ;
-        };
+        use App\Serializer\OrgPrefixNameConverter;
+
+        return App::config([
+            'framework' => [
+                'serializer' => [
+                    'name_converter' => OrgPrefixNameConverter::class,
+                ],
+            ],
+        ]);
 
 Now, when using the serializer in the application, all attributes will be
 prefixed by ``org_``::

--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -55,9 +55,9 @@ normalization process::
 
         public function getSupportedTypes(?string $format): array
         {
-            return [
+            return App::config([
                 Topic::class => true,
-            ];
+            ]);
         }
     }
 
@@ -93,17 +93,16 @@ If you're not using ``autoconfigure``, you have to tag the service with
 
         use App\Serializer\TopicNormalizer;
 
-        return function(ContainerConfigurator $container) {
-            // ...
-
-            // if you're using autoconfigure, the tag will be automatically applied
-            $services->set(TopicNormalizer::class)
-                // register the normalizer with a high priority (called earlier)
-                ->tag('serializer.normalizer', [
-                    'priority' => 500,
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                TopicNormalizer::class => [
+                    'tags' => [
+                        // register the normalizer with a high priority (called earlier)
+                        ['serializer.normalizer' => ['priority' => 500]],
+                    ],
+                ],
+            ],
+        ]);
 
 Improving Performance of Normalizers/Denormalizers
 --------------------------------------------------
@@ -142,11 +141,11 @@ Here is an example of how to use the ``getSupportedTypes()`` method::
 
         public function getSupportedTypes(?string $format): array
         {
-            return [
+            return App::config([
                 'object' => null,             // doesn't support any classes or interfaces
                 '*' => false,                 // supports any other types, but the decision is not cacheable
                 MyCustomClass::class => true, // supports MyCustomClass and decision is cacheable
-            ];
+            ]);
         }
     }
 

--- a/serializer/encoders.rst
+++ b/serializer/encoders.rst
@@ -369,13 +369,13 @@ to register your class as a service and tag it with
 
         use App\Serializer\NeonEncoder;
 
-        return function(ContainerConfigurator $container) {
-            // ...
-
-            $services->set(NeonEncoder::class)
-                ->tag('serializer.encoder')
-            ;
-        };
+        return App::config([
+            'services' => [
+                NeonEncoder::class => [
+                    'tags' => ['serializer.encoder'],
+                ],
+            ],
+        ]);
 
 Now you'll be able to serialize and deserialize NEON!
 

--- a/service_container.rst
+++ b/service_container.rst
@@ -173,21 +173,20 @@ each time you ask for it.
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return function(ContainerConfigurator $container): void {
-                // default configuration for services in *this* file
-                $services = $container->services()
-                    ->defaults()
-                        ->autowire()      // Automatically injects dependencies in your services.
-                        ->autoconfigure() // Automatically registers your services as commands, event subscribers, etc.
-                ;
-
-                // makes classes in src/ available to be used as services
-                // this creates a service per class whose id is the fully-qualified class name
-                $services->load('App\\', '../src/');
-
-                // order is important in this file because service definitions
-                // always *replace* previous ones; add your own service configuration below
-            };
+            return App::config([
+                'services' => [
+                    // Autowiring and autoconfiguration are enabled by default when using App::config()
+                    // '_defaults' => [
+                    //     'autowire' => true,      // Automatically injects dependencies in your services.
+                    //     'autoconfigure' => true, // Automatically registers your services as commands, event subscribers, etc.
+                    // ],
+                    'App\\' => [
+                        'resource' => '../src/',
+                    ],
+                    // order is important in this file because service definitions
+                    // always *replace* previous ones; add your own service configuration below
+                ],
+            ]);
 
     .. tip::
 
@@ -220,12 +219,14 @@ each time you ask for it.
             // config/services.php
             namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return function(ContainerConfigurator $container): void {
-                // ...
-
-                $services->load('App\\', '../src/')
-                    ->exclude('../src/{SomeDirectory,AnotherDirectory,Kernel.php}');
-            };
+            return App::config([
+                'services' => [
+                    'App\\' => [
+                        'resource' => '../src/',
+                        'exclude' => '../src/{SomeDirectory,AnotherDirectory,Kernel.php}',
+                    ],
+                ],
+            ]);
 
     If you'd prefer to manually wire your service, you can
     :ref:`use explicit configuration <services-explicitly-configure-wire-services>`.
@@ -382,38 +383,28 @@ as arguments of other services:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        use Symfony\Component\DependencyInjection\ContainerInterface;
-        use Symfony\Component\DependencyInjection\Reference;
-
-        return static function (ContainerConfigurator $container) {
-            $services = $container->services();
-
-            $services->set(App\Service\SomeService::class)
-                // string, numeric and boolean arguments can be passed "as is"
-                ->arg(0, 'Foo')
-                ->arg(1, true)
-                ->arg(2, 7)
-                ->arg(3, 3.14)
-
-                // constants: built-in, user-defined, or Enums
-                ->arg(4, E_ALL)
-                ->arg(5, \PDO::FETCH_NUM)
-                ->arg(6, Symfony\Component\HttpKernel\Kernel::VERSION)
-                ->arg(7, App\Config\SomeEnum::SomeCase)
-
-                // when not using autowiring, you can pass service arguments explicitly
-                ->arg(8, service('some-service-id')) # fails if service doesn't exist
-                # passes null if service doesn't exist
-                ->arg(9, new Reference('some-service-id', Reference::IGNORE_ON_INVALID_REFERENCE))
-
-                // collection with mixed argument types
-                ->arg(10, [
-                    'first' => true,
-                    'second' => 'Foo',
-                ]);
-
-            // ...
-        };
+        return App::config([
+            'services' => [
+                App\Service\SomeService::class => [
+                    'arguments' => [
+                        'Foo',
+                        true,
+                        7,
+                        3.14,
+                        E_ALL,
+                        \PDO::FETCH_NUM,
+                        Symfony\Component\HttpKernel\Kernel::VERSION,
+                        App\Config\SomeEnum::SomeCase,
+                        service('some-service-id'),
+                        service('some-service-id')->nullOnInvalid(),
+                        [
+                            'first' => true,
+                            'second' => 'Foo',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Handling Multiple Services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -554,17 +545,16 @@ pass here. No problem! In your configuration, you can explicitly set this argume
 
         use App\Service\SiteUpdateManager;
 
-        return function(ContainerConfigurator $container): void {
-            // ...
-
-            // same as before
-            $services->load('App\\', '../src/')
-                ->exclude('../src/{DependencyInjection,Entity,Kernel.php}');
-
-            $services->set(SiteUpdateManager::class)
-                ->arg('$adminEmail', 'manager@example.com')
-            ;
-        };
+        return App::config([
+            'services' => [
+                // ...
+                SiteUpdateManager::class => [
+                    'arguments' => [
+                        '$adminEmail' => 'manager@example.com',
+                    ],
+                ],
+            ],
+        ]);
 
 Thanks to this, the container will pass ``manager@example.com`` to the ``$adminEmail``
 argument of ``__construct`` when creating the ``SiteUpdateManager`` service. The
@@ -603,21 +593,6 @@ of a regular string. In PHP config use the ``service()`` function:
                     # it by adding another '@' so Symfony doesn't consider it a service
                     # the following example would be parsed as the string '@securepassword'
                     # - '@@securepassword'
-
-    .. code-block:: php
-
-        // config/services.php
-        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
-
-        use App\Service\MessageGenerator;
-
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(MessageGenerator::class)
-                ->args([service('logger')])
-            ;
-        };
 
 Working with container parameters is straightforward using the container's
 accessor methods for parameters::
@@ -696,14 +671,16 @@ But, you can control this and pass in a different logger:
 
         use App\Service\MessageGenerator;
 
-        return function(ContainerConfigurator $container): void {
-            // ... same code as before
-
-            // explicitly configure the service
-            $services->set(MessageGenerator::class)
-                ->arg('$logger', service('monolog.logger.request'))
-            ;
-        };
+        return App::config([
+            'services' => [
+                // ...
+                MessageGenerator::class => [
+                'arguments' => [
+                        '$logger' => service('monolog.logger.request'),
+                    ],
+                ],
+            ],
+        ]);
 
 This tells the container that the ``$logger`` argument to ``__construct`` should use
 service whose id is ``monolog.logger.request``.
@@ -727,22 +704,18 @@ Remove Services
 
 A service can be removed from the service container if needed. This is useful
 for example to make a service unavailable in some :ref:`configuration environment <configuration-environments>`
-(e.g. in the ``test`` environment):
+(e.g. in the ``test`` environment)::
 
-.. configuration-block::
+    // config/services_test.php
+    namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-    .. code-block:: php
+    use App\RemovedService;
 
-        // config/services_test.php
-        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+    return function(ContainerConfigurator $containerConfigurator) {
+        $services = $containerConfigurator->services();
 
-        use App\RemovedService;
-
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
-
-            $services->remove(RemovedService::class);
-        };
+        $services->remove(RemovedService::class);
+    };
 
 Now, the container will not contain the ``App\RemovedService`` in the ``test``
 environment.
@@ -809,15 +782,19 @@ Our configuration looks like this:
 
         use App\Service\MessageGenerator;
 
-        return function(ContainerConfigurator $containerConfigurator): void {
-            // ... same code as before
+        return App::config([
+            'services' => [
+                // ... same code as before
 
-            // explicitly configure the service
-            $services->set(MessageGenerator::class)
-                ->arg('$logger', service('monolog.logger.request'))
-                ->arg('$generateMessageHash', closure('App\Hash\MessageHashGenerator'))
-            ;
-        };
+                // explicitly configure the service
+                MessageGenerator::class => [
+                    'arguments' => [
+                        '$logger' => service('monolog.logger.request'),
+                        '$generateMessageHash' => closure('App\Hash\MessageHashGenerator'),
+                    ],
+                ],
+            ],
+        ]);
 
 .. seealso::
 
@@ -865,29 +842,30 @@ You can also use the ``bind`` keyword to bind specific arguments by name or type
 
         use Psr\Log\LoggerInterface;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services()
-                ->defaults()
-                    // pass this value to any $adminEmail argument for any service
-                    // that's defined in this file (including controller arguments)
-                    ->bind('$adminEmail', 'manager@example.com')
+        return App::config([
+            'services' => [
+                '_defaults' => [
+                    'bind' => [
+                        // pass this value to any $adminEmail argument for any service
+                        // that's defined in this file (including controller arguments)
+                        '$adminEmail' => 'manager@example.com',
 
-                    // pass this service to any $requestLogger argument for any
-                    // service that's defined in this file
-                    ->bind('$requestLogger', service('monolog.logger.request'))
+                        // pass this service to any $requestLogger argument for any
+                        // service that's defined in this file
+                        '$requestLogger' => service('monolog.logger.request'),
 
-                    // pass this service for any LoggerInterface type-hint for any
-                    // service that's defined in this file
-                    ->bind(LoggerInterface::class, service('monolog.logger.request'))
+                        // pass this service for any LoggerInterface type-hint for any
+                        // service that's defined in this file
+                        LoggerInterface::class => service('monolog.logger.request'),
 
-                    // optionally you can define both the name and type of the argument to match
-                    ->bind('string $adminEmail', 'manager@example.com')
-                    ->bind(LoggerInterface::class.' $requestLogger', service('monolog.logger.request'))
-                    ->bind('iterable $rules', tagged_iterator('app.foo.rule'))
-            ;
-
-            // ...
-        };
+                        // optionally you can define both the name and type of the argument to match
+                        'string $adminEmail' => 'manager@example.com',
+                        LoggerInterface::class.' $requestLogger' => service('monolog.logger.request'),
+                        'iterable $rules' => tagged_iterator('app.foo.rule'),
+                    ],
+                ],
+            ],
+        ]);
 
 By putting the ``bind`` key under ``_defaults``, you can specify the value of *any*
 argument for *any* service defined in this file! You can bind arguments by name
@@ -928,19 +906,16 @@ the name of the argument and some short description about its purpose:
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
         use App\Service\MyService;
-        use Psr\Log\LoggerInterface;
-        use Symfony\Component\DependencyInjection\Definition;
-        use Symfony\Component\DependencyInjection\Reference;
 
-        return function(ContainerConfigurator $container) {
-            $services = $container->services();
-
-            $services->set(MyService::class)
-                ->arg('$rootNamespace', abstract_arg('should be defined by Pass'))
-            ;
-
-            // ...
-        };
+        return App::config([
+            'services' => [
+                MyService::class => [
+                    'arguments' => [
+                        '$rootNamespace' => abstract_arg('should be defined by Pass'),
+                    ],
+                ],
+            ],
+        ]);
 
 If you don't replace the value of an abstract argument during runtime, a
 ``RuntimeException`` will be thrown with a message like
@@ -1043,14 +1018,13 @@ setting:
 
         use App\Service\PublicService;
 
-        return function(ContainerConfigurator $container): void {
-            // ... same as code before
-
-            // explicitly configure the service
-            $services->set(Service\PublicService::class)
-                ->public()
-            ;
-        };
+        return App::config([
+            'services' => [
+                PublicService::class => [
+                    'public' => true,
+                ],
+            ],
+        ]);
 
 It is also possible to define a service as public thanks to the ``#[Autoconfigure]``
 attribute. This attribute must be used directly on the class of the service
@@ -1094,14 +1068,16 @@ key. For example, the default Symfony configuration contains this:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            // ...
-
-            // makes classes in src/ available to be used as services
-            // this creates a service per class whose id is the fully-qualified class name
-            $services->load('App\\', '../src/')
-                ->exclude('../src/{DependencyInjection,Entity,Kernel.php}');
-        };
+        return App::config([
+            'services' => [
+                // makes classes in src/ available to be used as services
+                // this creates a service per class whose id is the fully-qualified class name
+                'App\\' => [
+                    'resource' => '../src/',
+                    'exclude' => '../src/{DependencyInjection,Entity,Kernel.php}',
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -1135,33 +1111,7 @@ Multiple Service Definitions Using the Same Namespace
 
 If you define services using the YAML config format, the PHP namespace is used
 as the key of each configuration, so you can't define different service configs
-for classes under the same namespace:
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # config/services.yaml
-        services:
-            App\Domain\:
-                resource: '../src/Domain/*'
-                # ...
-
-    .. code-block:: php
-
-        // config/services.php
-        use Symfony\Component\DependencyInjection\Definition;
-
-        $defaults = new Definition();
-
-        // $this is a reference to the current loader
-        $this->registerClasses(
-            $defaults,
-            'App\\Domain\\',
-            '../src/App/Domain/*'
-        );
-
-        // ...
+for classes under the same namespace.
 
 In order to have multiple definitions, add the ``namespace`` option and use any
 unique string as the key of each service config:
@@ -1179,6 +1129,26 @@ unique string as the key of each service config:
             namespace: App\Domain\
             resource: '../src/Domain/*/EventSubscriber'
             tags: [event_subscriber]
+
+.. code-block:: php
+
+    // config/services.php
+    namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+    return App::config([
+        'services' => [
+            'command_handlers' => [
+                'namespace' => 'App\Domain\\',
+                'resource' => '../src/Domain/*/CommandHandler',
+                'tags' => ['command_handler'],
+            ],
+            'event_subscribers' => [
+                'namespace' => 'App\Domain\\',
+                'resource' => '../src/Domain/*/EventSubscriber',
+                'tags' => ['event_subscriber'],
+            ],
+        ],
+    ]);
 
 .. _services-explicitly-configure-wire-services:
 
@@ -1230,32 +1200,33 @@ admin email. In this case, each needs to have a unique service id:
         use App\Service\MessageGenerator;
         use App\Service\SiteUpdateManager;
 
-        return function(ContainerConfigurator $container): void {
-            // ...
-
-            // site_update_manager.superadmin is the service's id
-            $services->set('site_update_manager.superadmin', SiteUpdateManager::class)
-                // you CAN still use autowiring: we just want to show what it looks like without
-                ->autowire(false)
-                // manually wire all arguments
-                ->args([
-                   service(MessageGenerator::class),
-                   service('mailer'),
-                   'superadmin@example.com',
-                ]);
-
-            $services->set('site_update_manager.normal_users', SiteUpdateManager::class)
-                ->autowire(false)
-                ->args([
-                    service(MessageGenerator::class),
-                    service('mailer'),
-                    'contact@example.com',
-                ]);
-
-            // Create an alias, so that - by default - if you type-hint SiteUpdateManager,
-            // the site_update_manager.superadmin will be used
-            $services->alias(SiteUpdateManager::class, 'site_update_manager.superadmin');
-        };
+        return App::config([
+            'services' => [
+                'site_update_manager.superadmin' => [
+                    'class' => SiteUpdateManager::class,
+                    // you CAN still use autowiring: we just want to show what it looks like without
+                    'autowire' => false,
+                    // manually wire all arguments
+                    'arguments' => [
+                        service(MessageGenerator::class),
+                        service('mailer'),
+                        'superadmin@example.com',
+                    ],
+                ],
+                'site_update_manager.normal_users' => [
+                    'class' => SiteUpdateManager::class,
+                    'autowire' => false,
+                    'arguments' => [
+                        service(MessageGenerator::class),
+                        service('mailer'),
+                        'contact@example.com',
+                    ],
+                ],
+                // Create an alias, so that - by default - if you type-hint SiteUpdateManager,
+                // the site_update_manager.superadmin will be used
+                SiteUpdateManager::class => service('site_update_manager.superadmin'),
+            ],
+        ]);
 
 In this case, *two* services are registered: ``site_update_manager.superadmin``
 and ``site_update_manager.normal_users``. Thanks to the alias, if you type-hint
@@ -1367,15 +1338,15 @@ an adapter for a functional interface through configuration:
         use App\Service\MessageFormatterInterface;
         use App\Service\MessageUtils;
 
-        return function(ContainerConfigurator $container) {
-            // ...
-
-            $container
-                ->set('app.message_formatter', MessageFormatterInterface::class)
-                ->fromCallable([inline_service(MessageUtils::class), 'format'])
-                ->alias(MessageFormatterInterface::class, 'app.message_formatter')
-            ;
-        };
+        return App::config([
+            'services' => [
+                // ...
+                'app.message_formatter' => [
+                    'class' => MessageFormatterInterface::class,
+                    'from_callable' => [inline_service(MessageUtils::class), 'format'],
+                ],
+            ],
+        ]);
 
 By doing so, Symfony will generate a class (also called an *adapter*)
 implementing ``MessageFormatterInterface`` that will forward calls of

--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -42,12 +42,13 @@ You can also control the ``public`` option on a service-by-service basis:
 
         use App\Service\Foo;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(Foo::class)
-                ->public();
-        };
+        return App::config([
+            'services' => [
+                Foo::class => [
+                    'public' => true,
+                ],
+            ],
+        ]);
 
 It is also possible to define a service as public thanks to the ``#[Autoconfigure]``
 attribute. This attribute must be used directly on the class of the service
@@ -127,14 +128,17 @@ services.
 
         use App\Mail\PhpMailer;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(PhpMailer::class)
-                ->private();
-
-            $services->alias('app.mailer', PhpMailer::class);
-        };
+        return App::config([
+            'services' => [
+                PhpMailer::class => [
+                    'private' => true,
+                ],
+                'app.mailer' => [
+                    'alias' => PhpMailer::class,
+                    'public' => true,
+                ],
+            ],
+        ]);
 
 This means that when using the container directly, you can access the
 ``PhpMailer`` service by asking for the ``app.mailer`` service like this::
@@ -203,6 +207,7 @@ or you decided not to maintain it anymore), you can deprecate its definition:
 
     .. code-block:: yaml
 
+        # config/services.yaml
         app.mailer:
             alias: 'App\Mail\PhpMailer'
 
@@ -212,28 +217,40 @@ or you decided not to maintain it anymore), you can deprecate its definition:
                 package: 'acme/package'
                 version: '1.2'
 
-            # you can also define a custom deprecation message (%alias_id% placeholder is available)
+            # you can also define a custom deprecation message (%%alias_id%% placeholder is available)
             deprecated:
                 package: 'acme/package'
                 version: '1.2'
-                message: 'The "%alias_id%" alias is deprecated. Do not use it anymore.'
+                message: 'The "%%alias_id%%" alias is deprecated. Do not use it anymore.'
 
     .. code-block:: php
 
-        $container
-            ->setAlias('app.mailer', 'App\Mail\PhpMailer')
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            // this outputs the following generic deprecation message:
-            // Since acme/package 1.2: The "app.mailer" service alias is deprecated. You should stop using it, as it will be removed in the future
-            ->setDeprecated('acme/package', '1.2')
+        use App\Mail\PhpMailer;
 
-            // you can also define a custom deprecation message (%alias_id% placeholder is available)
-            ->setDeprecated(
-                'acme/package',
-                '1.2',
-                'The "%alias_id%" service alias is deprecated. Don\'t use it anymore.'
-            )
-        ;
+        return App::config([
+            'services' => [
+                'app.mailer' => [
+                    'alias' => PhpMailer::class,
+
+                    // this outputs the following generic deprecation message:
+                    // Since acme/package 1.2: The "app.mailer" service alias is deprecated. You should stop using it, as it will be removed in the future
+                    'deprecated' => [
+                        'package' => 'acme/package',
+                        'version' => '1.2',
+                    ],
+
+                    // you can also define a custom deprecation message (%%alias_id%% placeholder is available)
+                    'deprecated' => [
+                        'package' => 'acme/package',
+                        'version' => '1.2',
+                        'message' => 'The "%%alias_id%%" alias is deprecated. Do not use it anymore.',
+                    ],
+                ],
+            ],
+        ]);
 
 Now, every time this service alias is used, a deprecation warning is triggered,
 advising you to stop or to change your uses of that alias.
@@ -271,12 +288,15 @@ The following example shows how to inject an anonymous service into another serv
         use App\AnonymousBar;
         use App\Foo;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(Foo::class)
-                ->args([inline_service(AnonymousBar::class)]);
-        };
+        return App::config([
+            'services' => [
+                Foo::class => [
+                    'arguments' => [
+                        inline_service(AnonymousBar::class),
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -304,12 +324,13 @@ Using an anonymous service as a factory looks like this:
         use App\AnonymousBar;
         use App\Foo;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(Foo::class)
-                ->factory([inline_service(AnonymousBar::class), 'constructFoo']);
-        };
+        return App::config([
+            'services' => [
+                Foo::class => [
+                    'factory' => [inline_service(AnonymousBar::class), 'constructFoo'],
+                ],
+            ],
+        ]);
 
 Deprecating Services
 --------------------
@@ -326,7 +347,7 @@ or you decided not to maintain it anymore), you can deprecate its definition:
             deprecated:
                 package: 'vendor-name/package-name'
                 version: '2.8'
-                message: The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.
+                message: The "%%service_id%%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.
 
     .. code-block:: php
 
@@ -335,16 +356,17 @@ or you decided not to maintain it anymore), you can deprecate its definition:
 
         use App\Service\OldService;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(OldService::class)
-                ->deprecate(
-                    'vendor-name/package-name',
-                    '2.8',
-                    'The "%service_id%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.'
-                );
-        };
+        return App::config([
+            'services' => [
+                OldService::class => [
+                    'deprecated' => [
+                        'package' => 'vendor-name/package-name',
+                        'version' => '2.8',
+                        'message' => 'The "%%service_id%%" service is deprecated since vendor-name/package-name 2.8 and will be removed in 3.0.',
+                    ],
+                ],
+            ],
+        ]);
 
 Now, every time this service is used, a deprecation warning is triggered,
 advising you to stop or to change your uses of that service.

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -83,20 +83,26 @@ both services:
     .. code-block:: php
 
         // config/services.php
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services()
-                ->defaults()
-                    ->autowire()
-                    ->autoconfigure()
-            ;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            $services->set(TwitterClient::class)
-                // redundant thanks to defaults, but value is overridable on each service
-                ->autowire();
+        use App\Service\TwitterClient;
+        use App\Util\Rot13Transformer;
 
-            $services->set(Rot13Transformer::class)
-                ->autowire();
-        };
+        return App::config([
+            'services' => [
+                '_defaults' => [
+                'autowire' => true,
+                'autoconfigure' => true,
+                ],
+                TwitterClient::class => [
+                    // redundant thanks to defaults, but value is overridable on each service
+                    'autowire' => true,
+                ],
+                Rot13Transformer::class => [
+                    'autowire' => true,
+                ],
+            ],
+        ]);
 
 Now, you can use the ``TwitterClient`` service immediately in a controller::
 
@@ -203,18 +209,21 @@ adding a service alias:
 
         use App\Util\Rot13Transformer;
 
-        return function(ContainerConfigurator $container): void {
-            // ...
+        return App::config([
+            'services' => [
+                // ...
 
-            // the id is not a class, so it won't be used for autowiring
-            $services->set('app.rot13.transformer', Rot13Transformer::class)
-                ->autowire();
+                // the id is not a class, so it won't be used for autowiring
+                'app.rot13.transformer' => [
+                    'class' => Rot13Transformer::class,
+                ],
 
-            // but this fixes it!
-            // the "app.rot13.transformer" service will be injected when
-            // an App\Util\Rot13Transformer type-hint is detected
-            $services->alias(Rot13Transformer::class, 'app.rot13.transformer');
-        };
+                // but this fixes it!
+                // the "app.rot13.transformer" service will be injected when
+                // an App\Util\Rot13Transformer type-hint is detected
+                Rot13Transformer::class => service('app.rot13.transformer'),
+            ],
+        ]);
 
 This creates a service "alias", whose id is ``App\Util\Rot13Transformer``.
 Thanks to this, autowiring sees this and uses it whenever the ``Rot13Transformer``
@@ -294,15 +303,17 @@ To fix that, add an :ref:`alias <service-autowiring-alias>`:
         use App\Util\Rot13Transformer;
         use App\Util\TransformerInterface;
 
-        return function(ContainerConfigurator $container): void {
-            // ...
+        return App::config([
+            'services' => [
+                // ...
 
-            $services->set(Rot13Transformer::class);
+                Rot13Transformer::class => null,
 
-            // the App\Util\Rot13Transformer service will be injected when
-            // an App\Util\TransformerInterface type-hint is detected
-            $services->alias(TransformerInterface::class, Rot13Transformer::class);
-        };
+                // the App\Util\Rot13Transformer service will be injected when
+                // an App\Util\TransformerInterface type-hint is detected
+                TransformerInterface::class => service(Rot13Transformer::class),
+            ],
+        ]);
 
 Thanks to the ``App\Util\TransformerInterface`` alias, the autowiring subsystem
 knows that the ``App\Util\Rot13Transformer`` service should be injected when
@@ -436,32 +447,36 @@ the injection::
         use App\Util\TransformerInterface;
         use App\Util\UppercaseTransformer;
 
-        return function(ContainerConfigurator $container): void {
-            // ...
-
-            $services->set(Rot13Transformer::class)->autowire();
-            $services->set(UppercaseTransformer::class)->autowire();
-
-            // the App\Util\UppercaseTransformer service will be
-            // injected when an App\Util\TransformerInterface
-            // type-hint for a $shoutyTransformer argument is detected
-            $services->alias(TransformerInterface::class.' $shoutyTransformer', UppercaseTransformer::class);
-
-            // If the argument used for injection does not match, but the
-            // type-hint still matches, the App\Util\Rot13Transformer
-            // service will be injected.
-            $services->alias(TransformerInterface::class, Rot13Transformer::class);
-
-            $services->set(TwitterClient::class)
-                // the Rot13Transformer will be passed as the $transformer argument
-                ->autowire()
-
-                // If you wanted to choose the non-default service and do not
-                // want to use a named autowiring alias, wire it manually:
-                //     ->arg('$transformer', service(UppercaseTransformer::class))
+        return App::config([
+            'services' => [
                 // ...
-            ;
-        };
+
+                Rot13Transformer::class => null,
+                UppercaseTransformer::class => null,
+
+                // the App\Util\UppercaseTransformer service will be
+                // injected when an App\Util\TransformerInterface
+                // type-hint for a $shoutyTransformer argument is detected
+                TransformerInterface::class.' $shoutyTransformer' => service(UppercaseTransformer::class),
+
+                // If the argument used for injection does not match, but the
+                // type-hint still matches, the App\Util\Rot13Transformer
+                // service will be injected.
+                TransformerInterface::class => service(Rot13Transformer::class),
+
+                TwitterClient::class => [
+                    // the Rot13Transformer will be passed as the $transformer argument
+                    'autowire' => true,
+
+                    // If you wanted to choose the non-default service and do not
+                    // want to use a named autowiring alias, wire it manually:
+                    // 'arguments' => [
+                    //     '$transformer' => service(UppercaseTransformer::class),
+                    // ],
+                    // ...
+                ],
+            ],
+        ]);
 
 Thanks to the ``App\Util\TransformerInterface`` alias, any argument type-hinted
 with this interface will be passed the ``App\Util\Rot13Transformer`` service.

--- a/service_container/calls.rst
+++ b/service_container/calls.rst
@@ -47,12 +47,15 @@ To configure the container to call the ``setLogger`` method, use the ``calls`` k
 
         use App\Service\MessageGenerator;
 
-        return function(ContainerConfigurator $container): void {
-            // ...
-
-            $services->set(MessageGenerator::class)
-                ->call('setLogger', [service('logger')]);
-        };
+        return App::config([
+            'services' => [
+                MessageGenerator::class => [
+                    'calls' => [
+                        'setLogger' => [service('logger')],
+                    ],
+                ],
+            ],
+        ]);
 
 To provide immutable services, some classes implement immutable setters.
 Such setters return a new instance of the configured class
@@ -96,11 +99,19 @@ The configuration to tell the container it should do so would be like:
     .. code-block:: php
 
         // config/services.php
-        use App\Service\MessageGenerator;
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        $container->register(MessageGenerator::class)
-            ->addMethodCall('withLogger', [new Reference('logger')], true);
+        use App\Service\MessageGenerator;
+
+        return App::config([
+            'services' => [
+                MessageGenerator::class => [
+                    'calls' => [
+                        ['withLogger', [service('logger')], true],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 

--- a/service_container/configurators.rst
+++ b/service_container/configurators.rst
@@ -145,19 +145,20 @@ all the classes are already loaded as services. All you need to do is specify th
         use App\Mail\GreetingCardManager;
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            // Registers all 4 classes as services, including App\Mail\EmailConfigurator
-            $services->load('App\\', '../src/*');
-
-            // override the services to set the configurator
-            $services->set(NewsletterManager::class)
-                ->configurator([service(EmailConfigurator::class), 'configure']);
-
-            $services->set(GreetingCardManager::class)
-                ->configurator([service(EmailConfigurator::class), 'configure']);
-        };
+        return App::config([
+            'services' => [
+                // Registers all 4 classes as services, including App\Mail\EmailConfigurator
+                'App\\' => [
+                    'resource' => '../src/*',
+                ],
+                NewsletterManager::class => [
+                    'configurator' => [service(EmailConfigurator::class), 'configure'],
+                ],
+                GreetingCardManager::class => [
+                    'configurator' => [service(EmailConfigurator::class), 'configure'],
+                ],
+            ],
+        ]);
 
 .. _configurators-invokable:
 
@@ -189,22 +190,24 @@ Services can be configured via invokable configurators (replacing the
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+        use App\Mail\EmailConfigurator;
         use App\Mail\GreetingCardManager;
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            // Registers all 4 classes as services, including App\Mail\EmailConfigurator
-            $services->load('App\\', '../src/*');
-
-            // override the services to set the configurator
-            $services->set(NewsletterManager::class)
-                ->configurator(service(EmailConfigurator::class));
-
-            $services->set(GreetingCardManager::class)
-                ->configurator(service(EmailConfigurator::class));
-        };
+        return App::config([
+            'services' => [
+                // Registers all 4 classes as services, including App\Mail\EmailConfigurator
+                'App\\' => [
+                    'resource' => '../src/*',
+                ],
+                NewsletterManager::class => [
+                    'configurator' => service(EmailConfigurator::class),
+                ],
+                GreetingCardManager::class => [
+                    'configurator' => service(EmailConfigurator::class),
+                ],
+            ],
+        ]);
 
 That's it! When requesting the ``App\Mail\NewsletterManager`` or
 ``App\Mail\GreetingCardManager`` service, the created instance will first be

--- a/service_container/expression_language.rst
+++ b/service_container/expression_language.rst
@@ -35,15 +35,17 @@ to another service: ``App\Mailer``. One way to do this is with an expression:
         use App\Mail\MailerConfiguration;
         use App\Mailer;
 
-        return function(ContainerConfigurator $container): void {
-            // ...
+        return App::config([
+            'services' => [
+                // ...
 
-            $services->set(MailerConfiguration::class);
-
-            $services->set(Mailer::class)
-                // because of the escaping applied by PHP, you must add 4 backslashes for each original backslash
-                ->args([expr("service('App\\\\Mail\\\\MailerConfiguration').getMailerMethod()")]);
-        };
+                MailerConfiguration::class => null,
+                Mailer::class => [
+                    // because of the escaping applied by PHP, you must add 4 backslashes for each original backslash
+                    'arguments' => [expr("service('App\\\\Mail\\\\MailerConfiguration').getMailerMethod()")],
+                ],
+            ],
+        ]);
 
 Learn more about the :doc:`expression language syntax </reference/formats/expression_language>`.
 
@@ -76,12 +78,13 @@ via a ``container`` variable. Here's another example:
 
         use App\Mailer;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(Mailer::class)
-                ->args([expr("container.hasParameter('some_param') ? parameter('some_param') : 'default_value'")]);
-        };
+        return App::config([
+            'services' => [
+                Mailer::class => [
+                    'arguments' => [expr("container.hasParameter('some_param') ? parameter('some_param') : 'default_value'")],
+                ],
+            ],
+        ]);
 
 Expressions can be used in ``arguments``, ``properties``, as arguments with
 ``configurator``, as arguments to ``calls`` (method calls) and in

--- a/service_container/factories.rst
+++ b/service_container/factories.rst
@@ -57,13 +57,15 @@ create its object:
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerStaticFactory;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(NewsletterManager::class)
-                // the first argument is the class and the second argument is the static method
-                ->factory([NewsletterManagerStaticFactory::class, 'createNewsletterManager']);
-        };
+        return App::config([
+            'services' => [
+                // ...
+                NewsletterManager::class => [
+                    // the first argument is the class and the second argument is the static method
+                    'factory' => [NewsletterManagerStaticFactory::class, 'createNewsletterManager'],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -122,13 +124,16 @@ You can omit the class on the factory declaration:
 
         use App\Email\NewsletterManager;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            // Note that we are not using service()
-            $services->set(NewsletterManager::class)
-                ->factory([null, 'create']);
-        };
+        return App::config([
+            'services' => [
+                NewsletterManager::class => [
+                    'factory' => [null, 'create'],
+                    'arguments' => [
+                        '$sender' => 'fabien@symfony.com',
+                    ],
+                ],
+            ],
+        ]);
 
 It is also possible to use the ``constructor`` option, instead of passing ``null``
 as the factory class:
@@ -175,12 +180,16 @@ as the factory class:
 
         use App\Email\NewsletterManager;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
-
-            $services->set(NewsletterManager::class)
-                ->constructor('create');
-        };
+        return App::config([
+            'services' => [
+                NewsletterManager::class => [
+                    'constructor' => 'create',
+                    'arguments' => [
+                        '$sender' => 'fabien@symfony.com',
+                    ],
+                ],
+            ],
+        ]);
 
 Non-Static Factories
 --------------------
@@ -213,17 +222,18 @@ Configuration of the service container then looks like this:
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerFactory;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
+        return App::config([
+            'services' => [
+                // first, create a service for the factory
+                NewsletterManagerFactory::class => null,
 
-            // first, create a service for the factory
-            $services->set(NewsletterManagerFactory::class);
-
-            // second, use the factory service as the first argument of the 'factory'
-            // method and the factory method as the second argument
-            $services->set(NewsletterManager::class)
-                ->factory([service(NewsletterManagerFactory::class), 'createNewsletterManager']);
-        };
+                // second, use the factory service as the first argument of the 'factory'
+                // option and the factory method as the second argument
+                NewsletterManager::class => [
+                    'factory' => [service(NewsletterManagerFactory::class), 'createNewsletterManager'],
+                ],
+            ],
+        ]);
 
 .. _factories-invokable:
 
@@ -269,15 +279,16 @@ method name:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+        use App\Email\InvokableNewsletterManagerFactory;
         use App\Email\NewsletterManager;
-        use App\Email\NewsletterManagerFactory;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(NewsletterManager::class)
-                ->factory(service(InvokableNewsletterManagerFactory::class));
-        };
+        return App::config([
+            'services' => [
+                NewsletterManager::class => [
+                    'factory' => service(InvokableNewsletterManagerFactory::class),
+                ],
+            ],
+        ]);
 
 Using Expressions in Service Factories
 --------------------------------------
@@ -297,8 +308,8 @@ e.g. change the service based on a parameter:
                 # "@=" indicates that this is an expression
                 factory: '@=parameter("kernel.debug") ? service("tracable_newsletter") : service("newsletter")'
 
-            # you can use the arg() function to retrieve an argument from the definition
             App\Email\NewsletterManagerInterface:
+                # you can use the arg() function to retrieve an argument from the definition
                 factory: '@=arg(0).createNewsletterManager() ?: service("default_newsletter_manager")'
                 arguments:
                     - '@App\Email\NewsletterManagerFactory'
@@ -311,22 +322,21 @@ e.g. change the service based on a parameter:
         use App\Email\NewsletterManagerFactory;
         use App\Email\NewsletterManagerInterface;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
-
-            $services->set(NewsletterManagerInterface::class)
-                // use the "tracable_newsletter" service when debug is enabled, "newsletter" otherwise.
-                ->factory(expr("parameter('kernel.debug') ? service('tracable_newsletter') : service('newsletter')"))
-            ;
-
-            // you can use the arg() function to retrieve an argument from the definition
-            $services->set(NewsletterManagerInterface::class)
-                ->factory(expr("arg(0).createNewsletterManager() ?: service('default_newsletter_manager')"))
-                ->args([
-                    service(NewsletterManagerFactory::class),
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                NewsletterManagerInterface::class => [
+                    // use the "tracable_newsletter" service when debug is enabled, "newsletter" otherwise.
+                    'factory' => expr("parameter('kernel.debug') ? service('tracable_newsletter') : service('newsletter')"),
+                ],
+                NewsletterManagerInterface::class => [
+                    // you can use the arg() function to retrieve an argument from the definition
+                    'factory' => expr("arg(0).createNewsletterManager() ?: service('default_newsletter_manager')"),
+                    'arguments' => [
+                        service(NewsletterManagerFactory::class),
+                    ],
+                ],
+            ],
+        ]);
 
 .. _factories-passing-arguments-factory-method:
 
@@ -362,13 +372,13 @@ previous examples takes the ``templating`` service as an argument:
         use App\Email\NewsletterManager;
         use App\Email\NewsletterManagerFactory;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(NewsletterManager::class)
-                ->factory([service(NewsletterManagerFactory::class), 'createNewsletterManager'])
-                ->args([service('templating')])
-            ;
-        };
+        return App::config([
+            'services' => [
+                NewsletterManager::class => [
+                    'factory' => [service(NewsletterManagerFactory::class), 'createNewsletterManager'],
+                    'arguments' => [service('templating')],
+                ],
+            ],
+        ]);
 
 .. _`factory design pattern`: https://en.wikipedia.org/wiki/Factory_(object-oriented_programming)

--- a/service_container/import.rst
+++ b/service_container/import.rst
@@ -41,9 +41,16 @@ decided to move some configuration to a new file:
     .. code-block:: php
 
         // config/services/mailer.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ... some parameters
-        // ... some services
+        return App::config([
+            'parameters' => [
+                // ... some parameters
+            ],
+            'services' => [
+                // ... some services
+            ],
+        ]);
 
 To import this file, use the ``imports`` key from any other file and pass either
 a relative or absolute path to the imported file:
@@ -72,19 +79,24 @@ a relative or absolute path to the imported file:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $container->import('services/mailer.php');
-            // If you want to import a whole directory:
-            $container->import('services/');
+        return App::config([
+            'imports' => [
+                ['resource' => 'services/mailer.php'],
+                // If you want to import a whole directory:
+                ['resource' => 'services/'],
+            ],
+            'services' => [
+                '_defaults' => [
+                    'autowire' => true,
+                    'autoconfigure' => true,
+                ],
+                'App\\' => [
+                    'resource' => '../src/*',
+                ],
 
-            $services = $container->services()
-                ->defaults()
-                    ->autowire()
-                    ->autoconfigure()
-            ;
-
-            $services->load('App\\', '../src/*');
-        };
+                // ...
+            ],
+        ]);
 
 When loading a configuration file, Symfony first processes all imported files in
 the order they are listed under the ``imports`` key. After all imports are processed,
@@ -136,23 +148,25 @@ from auto-registering classes that are defined manually elsewhere:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $container->import('services/mailer.php');
-            // If you want to import a whole directory:
-            $container->import('services/');
-
-            $services = $container->services()
-                ->defaults()
-                    ->autowire()
-                    ->autoconfigure()
-            ;
-
-            $services->load('App\\', '../src/*')
-                ->exclude([
-                    '../src/Mailer/',
-                    '../src/SpecificClass.php',
-                ]);
-        };
+        return App::config([
+            'imports' => [
+                ['resource' => 'services/mailer.php'],
+                // ... other imports
+            ],
+            'services' => [
+                '_defaults' => [
+                    'autowire' => true,
+                    'autoconfigure' => true,
+                ],
+                'App\\' => [
+                    'resource' => '../src/*',
+                    'exclude' => [
+                        '../src/Mailer/',
+                        '../src/SpecificClass.php',
+                    ],
+                ],
+            ],
+        ]);
 
 .. _import-override-services-in-the-same-file:
 
@@ -182,17 +196,24 @@ same file. These later definitions will override the auto-registered ones:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services()
-                ->defaults()
-                    ->autowire()
-                    ->autoconfigure();
+        use App\Mailer\MyMailer;
 
-            $services->load('App\\', '../src/*');
-
-            $services->set(App\Mailer\MyMailer::class)
-                ->arg(0, '%env(MAILER_DSN)%');
-        };
+        return App::config([
+            'services' => [
+                '_defaults' => [
+                    'autowire' => true,
+                    'autoconfigure' => true,
+                ],
+                'App\\' => [
+                    'resource' => '../src/*',
+                ],
+                MyMailer::class => [
+                    'arguments' => [
+                        env('MAILER_DSN'),
+                    ],
+                ],
+            ],
+        ]);
 
 .. _import-control-import-order:
 
@@ -235,43 +256,48 @@ can override the auto-discovered ones.
     .. code-block:: php
 
         // config/services/autodiscovery.php
-        use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function (ContainerConfigurator $container): void {
-            $services = $container->services()
-                ->defaults()
-                    ->autowire()
-                    ->autoconfigure();
-
-            $services->load('App\\', '../../src/*')
-                ->exclude([
-                    '../../src/Mailer/',
-                ]);
-        };
+        return App::config([
+            'services' => [
+                '_defaults' => [
+                    'autowire' => true,
+                    'autoconfigure' => true,
+                ],
+                'App\\' => [
+                    'resource' => '../../src/*',
+                    'exclude' => [
+                        '../../src/Mailer/',
+                    ],
+                ],
+            ],
+        ]);
 
         // config/services/mailer.php
-        use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function (ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(App\Mailer\SpecificMailer::class);
-            // Add any custom configuration here if needed
-        };
+        return App::config([
+            'services' => [
+                App\Mailer\SpecificMailer::class => [
+                    // Add any custom configuration here if needed
+                ],
+            ],
+        ]);
 
         // config/services.php
-        use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function (ContainerConfigurator $container): void {
-            $container->import('services/autodiscovery.php');
-            $container->import('services/mailer.php');
-            $container->import('services/');
-
-            $services = $container->services();
-
-            // definitions here override anything from the imports above
-            // consider keeping most definitions inside imported files
-        };
+        return App::config([
+            'imports' => [
+                ['resource' => 'services/autodiscovery.php'],
+                ['resource' => 'services/mailer.php'],
+                ['resource' => 'services/'],
+            ],
+            'services' => [
+                // definitions here override anything from the imports above
+                // consider keeping most definitions inside imported files
+            ],
+        ]);
 
 .. include:: /components/dependency_injection/_imports-parameters-note.rst.inc
 

--- a/service_container/injection_types.rst
+++ b/service_container/injection_types.rst
@@ -51,12 +51,15 @@ service container configuration:
 
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(NewsletterManager::class)
-                ->args(service('mailer'));
-        };
+        return App::config([
+            'services' => [
+                NewsletterManager::class => [
+                    'arguments' => [
+                        service('mailer'),
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -132,12 +135,19 @@ In order to use this type of injection, don't forget to configure it:
     .. code-block:: php
 
         // config/services.php
-        use App\Mail\NewsletterManager;
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        // ...
-        $container->register('app.newsletter_manager', NewsletterManager::class)
-            ->addMethodCall('withMailer', [new Reference('mailer')], true);
+        use App\Mail\NewsletterManager;
+
+        return App::config([
+            'services' => [
+                NewsletterManager::class => [
+                    'calls' => [
+                        ['withMailer', [service('mailer')], true],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -215,12 +225,15 @@ that accepts the dependency::
 
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(NewsletterManager::class)
-                ->call('setMailer', [service('mailer')]);
-        };
+        return App::config([
+            'services' => [
+                NewsletterManager::class => [
+                    'calls' => [
+                        ['setMailer', [service('mailer')]],
+                    ],
+                ],
+            ],
+        ]);
 
 This time the advantages are:
 
@@ -279,12 +292,15 @@ Another possibility is setting public fields of the class directly::
 
         use App\Mail\NewsletterManager;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set('app.newsletter_manager', NewsletterManager::class)
-                ->property('mailer', service('mailer'));
-        };
+        return App::config([
+            'services' => [
+                NewsletterManager::class => [
+                    'properties' => [
+                        'mailer' => service('mailer'),
+                    ],
+                ],
+            ],
+        ]);
 
 There are mainly only disadvantages to using property injection. It is similar
 to setter injection but with this additional important problem:

--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -49,11 +49,13 @@ You can mark the service as ``lazy`` by manipulating its definition:
 
         use App\Twig\AppExtension;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(AppExtension::class)->lazy();
-        };
+        return App::config([
+            'services' => [
+                AppExtension::class => [
+                    'lazy' => true,
+                ],
+            ],
+        ]);
 
 Once you inject the service into another service, a lazy ghost object with the
 same signature of the class representing the service should be injected. A lazy
@@ -155,14 +157,16 @@ specific interfaces.
         use App\Twig\AppExtension;
         use Twig\Extension\ExtensionInterface;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(AppExtension::class)
-                ->lazy()
-                ->tag('proxy', ['interface' => ExtensionInterface::class])
-            ;
-        };
+        return App::config([
+            'services' => [
+                AppExtension::class => [
+                    'lazy' => ExtensionInterface::class,
+                    'tags' => [
+                        ['proxy' => ['interface' => ExtensionInterface::class]],
+                    ],
+                ],
+            ],
+        ]);
 
 Just like in the :ref:`Configuration <lazy-services_configuration>` section, you can
 use the :class:`Symfony\\Component\\DependencyInjection\\Attribute\\Autoconfigure`

--- a/service_container/optional_dependencies.rst
+++ b/service_container/optional_dependencies.rst
@@ -9,23 +9,20 @@ Setting Missing Dependencies to null
 ------------------------------------
 
 You can use the ``null`` strategy to explicitly set the argument to ``null``
-if the service does not exist:
+if the service does not exist::
 
-.. configuration-block::
+    // config/services.php
+    namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-    .. code-block:: php
+    use App\Newsletter\NewsletterManager;
 
-        // config/services.php
-        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
-
-        use App\Newsletter\NewsletterManager;
-
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(NewsletterManager::class)
-                ->args([service('logger')->nullOnInvalid()]);
-        };
+    return App::config([
+        'services' => [
+            NewsletterManager::class => [
+                'arguments' => [service('logger')->nullOnInvalid()],
+            ],
+        ],
+    ]);
 
 .. note::
 
@@ -58,13 +55,15 @@ call if the service exists and remove the method call if it does not:
 
         use App\Newsletter\NewsletterManager;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(NewsletterManager::class)
-                ->call('setLogger', [service('logger')->ignoreOnInvalid()])
-            ;
-        };
+        return App::config([
+            'services' => [
+                NewsletterManager::class => [
+                    'calls' => [
+                        'setLogger' => [service('logger')->ignoreOnInvalid()],
+                    ],
+                ],
+            ],
+        ]);
 
 .. note::
 

--- a/service_container/parent_services.rst
+++ b/service_container/parent_services.rst
@@ -87,24 +87,24 @@ avoid duplicated service definitions:
         use App\Repository\DoctrinePostRepository;
         use App\Repository\DoctrineUserRepository;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(BaseDoctrineRepository::class)
-                ->abstract()
-                ->args([service('doctrine.orm.entity_manager')])
-                ->call('setLogger', [service('logger')])
-            ;
-
-            $services->set(DoctrineUserRepository::class)
-                // extend the App\Repository\BaseDoctrineRepository service
-                ->parent(BaseDoctrineRepository::class)
-            ;
-
-            $services->set(DoctrinePostRepository::class)
-                ->parent(BaseDoctrineRepository::class)
-            ;
-        };
+        return App::config([
+            'services' => [
+                BaseDoctrineRepository::class => [
+                    'abstract' => true,
+                    'arguments' => [service('doctrine.orm.entity_manager')],
+                    'calls' => [
+                        'setLogger' => [service('logger')],
+                    ],
+                ],
+                DoctrineUserRepository::class => [
+                    // extend the App\Repository\BaseDoctrineRepository service
+                    'parent' => BaseDoctrineRepository::class,
+                ],
+                DoctrinePostRepository::class => [
+                    'parent' => BaseDoctrineRepository::class,
+                ],
+            ],
+        ]);
 
 In this context, having a ``parent`` service implies that the arguments
 and method calls of the parent service should be used for the child services.
@@ -161,30 +161,23 @@ the child class:
         use App\Repository\BaseDoctrineRepository;
         use App\Repository\DoctrinePostRepository;
         use App\Repository\DoctrineUserRepository;
-        // ...
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(BaseDoctrineRepository::class)
-                // ...
-            ;
-
-            $services->set(DoctrineUserRepository::class)
-                ->parent(BaseDoctrineRepository::class)
-
-                // overrides the private setting of the parent service
-                ->public()
-
-                // appends the '@app.username_checker' argument to the parent
-                // argument list
-                ->args([service('app.username_checker')])
-            ;
-
-            $services->set(DoctrinePostRepository::class)
-                ->parent(BaseDoctrineRepository::class)
-
-                # overrides the first argument
-                ->arg(0, service('doctrine.custom_entity_manager'))
-            ;
-        };
+        return App::config([
+            'services' => [
+                DoctrineUserRepository::class => [
+                    'parent' => BaseDoctrineRepository::class,
+                    // overrides the private setting of the parent service
+                    'public' => true,
+                    // appends the 'app.username_checker' service to the parent
+                    // argument list
+                    'arguments' => [service('app.username_checker')],
+                ],
+                DoctrinePostRepository::class => [
+                    'parent' => BaseDoctrineRepository::class,
+                    // overrides the first argument (using the special index_N key)
+                    'arguments' => [
+                        'index_0' => service('doctrine.custom_entity_manager'),
+                    ],
+                ],
+            ],
+        ]);

--- a/service_container/service_closures.rst
+++ b/service_container/service_closures.rst
@@ -66,16 +66,24 @@ argument of type ``service_closure``:
 
         use App\Service\MyService;
 
-        return function (ContainerConfigurator $container): void {
-            $services = $container->services();
+        return App::config([
+            'services' => [
+                MyService::class => [
+                    'arguments' => [service_closure('mailer')],
 
-            $services->set(MyService::class)
-                ->args([service_closure('mailer')]);
+                    // In case the dependency is optional
+                    'arguments' => [service_closure('mailer')->nullOnInvalid()],
+                ],
 
-            // In case the dependency is optional
-            // $services->set(MyService::class)
-            //     ->args([service_closure('mailer')->ignoreOnInvalid()]);
-        };
+                // you can also use the special '@>' syntax as a shortcut of 'service_closure(...)'
+                AnotherService::class => [
+                    'arguments' => ['@>mailer'],
+
+                    // the shortcut also works for optional dependencies
+                    'arguments' => [service_closure('mailer')->nullOnInvalid()],
+                ],
+            ],
+        ]);
 
 .. seealso::
 

--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -24,15 +24,17 @@ When overriding an existing definition, the original service is lost:
         use App\Mailer;
         use App\NewMailer;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
+        return App::config([
+            'services' => [
+                Mailer::class => null,
 
-            $services->set(Mailer::class);
-
-            // this replaces the old App\Mailer definition with the new one, the
-            // old definition is lost
-            $services->set(Mailer::class, NewMailer::class);
-        };
+                // this replaces the old App\Mailer definition with the new one, the
+                // old definition is lost
+                Mailer::class => [
+                    'class' => NewMailer::class,
+                ],
+            ],
+        ]);
 
 Most of the time, that's exactly what you want to do. But sometimes,
 you might want to decorate the old one instead (i.e. apply the `Decorator pattern`_).
@@ -75,16 +77,16 @@ but keeps a reference of the old one as ``.inner``:
         use App\DecoratingMailer;
         use App\Mailer;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(Mailer::class);
-
-            $services->set(DecoratingMailer::class)
-                // overrides the App\Mailer service
-                // but that service is still available as ".inner"
-                ->decorate(Mailer::class);
-        };
+        return App::config([
+            'services' => [
+                Mailer::class => null,
+                DecoratingMailer::class => [
+                    // overrides the App\Mailer service
+                    // but that service is still available as ".inner"
+                    'decorates' => Mailer::class,
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -146,16 +148,16 @@ automatically changed to ``'.inner'``):
         use App\DecoratingMailer;
         use App\Mailer;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(Mailer::class);
-
-            $services->set(DecoratingMailer::class)
-                ->decorate(Mailer::class)
-                // pass the old service as an argument
-                ->args([service('.inner')]);
-        };
+        return App::config([
+            'services' => [
+                Mailer::class => null,
+                DecoratingMailer::class => [
+                    'decorates' => Mailer::class,
+                    // pass the old service as an argument
+                    'arguments' => [service('.inner')],
+                ],
+            ],
+        ]);
 
 When decorating a service, the original service (e.g. ``App\Mailer``) is available
 inside the decorating service (e.g. ``App\DecoratingMailer``) using an ID constructed
@@ -224,6 +226,43 @@ name via the ``decoration_inner_name`` option:
     ``kernel.event_subscriber``, ``kernel.event_listener``, ``kernel.locale_aware``,
     and ``kernel.reset``.
 
+.. note::
+
+    The generated inner id is based on the id of the decorator service
+    (``App\DecoratingMailer`` here), not of the decorated service (``App\Mailer``
+    here). You can control the inner service name via the ``decoration_inner_name``
+    option:
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # config/services.yaml
+            services:
+                App\DecoratingMailer:
+                    # ...
+                    decoration_inner_name: App\DecoratingMailer.wooz
+                    arguments: ['@App\DecoratingMailer.wooz']
+
+        .. code-block:: php
+
+            // config/services.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            use App\DecoratingMailer;
+            use App\Mailer;
+
+            return App::config([
+                'services' => [
+                    Mailer::class => null,
+                    DecoratingMailer::class => [
+                        'decorates' => Mailer::class,
+                        'decoration_inner_name' => DecoratingMailer::class.'.wooz',
+                        'arguments' => [service(DecoratingMailer::class.'.wooz')],
+                    ],
+                ],
+            ]);
+
 Decoration Priority
 -------------------
 
@@ -283,19 +322,25 @@ the ``decoration_priority`` option. Its value is an integer that defaults to
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
+        use App\Bar;
+        use App\Baz;
+        use App\Foo;
 
-            $services->set(\Foo::class);
-
-            $services->set(\Bar::class)
-                ->decorate(\Foo::class, null, 5)
-                ->args([service('.inner')]);
-
-            $services->set(\Baz::class)
-                ->decorate(\Foo::class, null, 1)
-                ->args([service('.inner')]);
-        };
+        return App::config([
+            'services' => [
+                Foo::class => null,
+                Bar::class => [
+                    'decorates' => Foo::class,
+                    'decoration_priority' => 5,
+                    'arguments' => [service('.inner')],
+                ],
+                Baz::class => [
+                    'decorates' => Foo::class,
+                    'decoration_priority' => 1,
+                    'arguments' => [service('.inner')],
+                ],
+            ],
+        ]);
 
 The generated code will be the following::
 
@@ -340,22 +385,37 @@ ordered services, each one decorating the next:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $container->services()
-                ->stack('decorated_foo_stack', [
-                    inline_service(\Baz::class)->args([service('.inner')]),
-                    inline_service(\Bar::class)->args([service('.inner')]),
-                    inline_service(\Foo::class),
-                ])
+        use App\Bar;
+        use App\Baz;
+        use App\Foo;
 
+        return App::config([
+            'services' => [
+                'decorated_foo_stack' => [
+                    'stack' => [
+                        ['class' => Baz::class, 'arguments' => [service('.inner')]],
+                        ['class' => Bar::class, 'arguments' => [service('.inner')]],
+                        ['class' => Foo::class],
+                    ],
+                ],
+                // using the short syntax:
+                'decorated_foo_stack' => [
+                    'stack' => [
+                        [Baz::class => ['arguments' => [service('.inner')]]],
+                        [Bar::class => ['arguments' => [service('.inner')]]],
+                        [Foo::class => null],
+                    ],
+                ],
                 // can be simplified when autowiring is enabled:
-                ->stack('decorated_foo_stack', [
-                    inline_service(\Baz::class),
-                    inline_service(\Bar::class),
-                    inline_service(\Foo::class),
-                ])
-            ;
-        };
+                'decorated_foo_stack' => [
+                    'stack' => [
+                        [Baz::class => null],
+                        [Bar::class => null],
+                        [Foo::class => null],
+                    ],
+                ],
+            ],
+        ]);
 
 The result will be the same as in the previous section::
 
@@ -394,26 +454,33 @@ advanced example of composition:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+        use App\Bar;
+        use App\Baz;
         use App\Decorated;
         use App\Decorator;
+        use App\Foo;
 
-        return function(ContainerConfigurator $container): void {
-            $container->services()
-                ->set('some_decorator', Decorator::class)
-
-                ->stack('embedded_stack', [
-                    service('some_decorator'),
-                    inline_service(Decorated::class),
-                ])
-
-                ->stack('decorated_foo_stack', [
-                    inline_service()->parent('embedded_stack'),
-                    inline_service(\Baz::class),
-                    inline_service(\Bar::class),
-                    inline_service(\Foo::class),
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                'some_decorator' => [
+                    'class' => Decorator::class,
+                ],
+                'embedded_stack' => [
+                    'stack' => [
+                        ['alias' => 'some_decorator'],
+                        [Decorated::class => null],
+                    ],
+                ],
+                'decorated_foo_stack' => [
+                    'stack' => [
+                        ['parent' => 'embedded_stack'],
+                        [Baz::class => null],
+                        [Bar::class => null],
+                        [Foo::class => null],
+                    ],
+                ],
+            ],
+        ]);
 
 The result will be::
 
@@ -444,12 +511,21 @@ The result will be::
 
         .. code-block:: php
 
-            // ...
-            ->stack('decorated_foo_stack', [
-                'first' => inline_service()->parent('embedded_stack'),
-                'second' => inline_service(\Baz::class),
-                // ...
-            ])
+            // config/services.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            use App\Baz;
+
+            return App::config([
+                'services' => [
+                    'decorated_foo_stack' => [
+                        'stack' => [
+                            'first' => ['parent' => 'embedded_stack'],
+                            'second' => [Baz::class => null],
+                        ],
+                    ],
+                ],
+            ]);
 
     The ``Baz`` frame id will now be ``.decorated_foo_stack.second``.
 
@@ -488,30 +564,32 @@ Three different behaviors are available:
     .. code-block:: yaml
 
         # config/services.yaml
-        Foo: ~
+        services:
+            Foo: ~
 
-        Bar:
-            decorates: Foo
-            decoration_on_invalid: ignore
-            arguments: ['@.inner']
+            Bar:
+                decorates: Foo
+                decoration_on_invalid: ignore
+                arguments: ['@.inner']
 
     .. code-block:: php
 
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        use Symfony\Component\DependencyInjection\ContainerInterface;
+        use App\Bar;
+        use App\Foo;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(Foo::class);
-
-            $services->set(Bar::class)
-                ->decorate(Foo::class, null, 0, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)
-                ->args([service('.inner')])
-            ;
-        };
+        return App::config([
+            'services' => [
+                Foo::class => null,
+                Bar::class => [
+                    'decorates' => Foo::class,
+                    'decoration_on_invalid' => 'ignore',
+                    'arguments' => [service('.inner')],
+                ],
+            ],
+        ]);
 
 .. warning::
 

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -86,10 +86,10 @@ in the service subscriber::
 
         public static function getSubscribedServices(): array
         {
-            return [
+            return App::config([
                 'App\FooCommand' => FooHandler::class,
                 'App\BarCommand' => BarHandler::class,
-            ];
+            ]);
         }
 
         public function handle(Command $command): mixed
@@ -146,10 +146,10 @@ service locator::
 
     public static function getSubscribedServices(): array
     {
-        return [
+        return App::config([
             // ...
             LoggerInterface::class,
-        ];
+        ]);
     }
 
 Service types can also be keyed by a service name for internal use::
@@ -158,10 +158,10 @@ Service types can also be keyed by a service name for internal use::
 
     public static function getSubscribedServices(): array
     {
-        return [
+        return App::config([
             // ...
             'logger' => LoggerInterface::class,
-        ];
+        ]);
     }
 
 When extending a class that also implements ``ServiceSubscriberInterface``,
@@ -192,10 +192,10 @@ errors if there's no matching service found in the service container::
 
     public static function getSubscribedServices(): array
     {
-        return [
+        return App::config([
             // ...
             '?'.LoggerInterface::class,
-        ];
+        ]);
     }
 
 .. note::
@@ -228,12 +228,15 @@ service type to a service.
 
         use App\CommandBus;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(CommandBus::class)
-                ->tag('container.service_subscriber', ['key' => 'logger', 'id' => 'monolog.logger.event']);
-        };
+        return App::config([
+            'services' => [
+                CommandBus::class => [
+                    'tags' => [
+                        ['container.service_subscriber' => ['key' => 'logger', 'id' => 'monolog.logger.event']],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -267,7 +270,7 @@ This is done by having ``getSubscribedServices()`` return an array of
 
     public static function getSubscribedServices(): array
     {
-        return [
+        return App::config([
             // ...
             new SubscribedService('logger', LoggerInterface::class, attributes: new Autowire(service: 'monolog.logger.event')),
 
@@ -282,7 +285,7 @@ This is done by having ``getSubscribedServices()`` return an array of
 
             // AutowireLocator
             new SubscribedService('handlers', ContainerInterface::class, attributes: new AutowireLocator('handler.tag')),
-        ];
+        ]);
     }
 
 .. note::
@@ -467,17 +470,20 @@ or directly via PHP attributes:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+        use App\BarCommand;
         use App\CommandBus;
+        use App\FooCommand;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(CommandBus::class)
-                ->args([service_locator([
-                    'App\FooCommand' => service('app.command_handler.foo'),
-                    'App\BarCommand' => service('app.command_handler.bar'),
-                ])]);
-        };
+        return App::config([
+            'services' => [
+                CommandBus::class => [
+                    'arguments' => [service_locator([
+                        FooCommand::class => service('app.command_handler.foo'),
+                        BarCommand::class => service('app.command_handler.bar'),
+                    ]],
+                ],
+            ]),
+        ]);
 
 As shown in the previous sections, the constructor of the ``CommandBus`` class
 must type-hint its argument with ``ContainerInterface``. Then, you can get any of
@@ -512,21 +518,24 @@ other services. To do so, create a new service definition using the
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+        use App\BarCommand;
+        use App\FooCommand;
         use Symfony\Component\DependencyInjection\ServiceLocator;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set('app.command_handler_locator', ServiceLocator::class)
-                ->args([[
-                    'App\FooCommand' => service('app.command_handler.foo'),
-                    'App\BarCommand' => service('app.command_handler.bar'),
-                ]])
-                // if you are not using the default service autoconfiguration,
-                // add the following tag to the service definition:
-                // ->tag('container.service_locator')
-            ;
-        };
+        return App::config([
+            'services' => [
+                'app.command_handler_locator' => [
+                    'class' => ServiceLocator::class,
+                    'arguments' => [[
+                        FooCommand::class => service('app.command_handler.foo'),
+                        BarCommand::class => service('app.command_handler.bar'),
+                    ]],
+                    // if you are not using the default service autoconfiguration,
+                    // add the following tag to the service definition:
+                    // 'tags' => ['container.service_locator'],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -568,12 +577,13 @@ Now you can inject the service locator in any other services:
 
         use App\CommandBus;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(CommandBus::class)
-                ->args([service('app.command_handler_locator')]);
-        };
+        return App::config([
+            'services' => [
+                CommandBus::class => [
+                    'arguments' => [service('app.command_handler_locator')],
+                ],
+            ],
+        ]);
 
 Using Service Locators in Compiler Passes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -654,22 +664,28 @@ to index the services:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
+        use App\Handler\HandlerCollection;
+        use App\Handler\One;
+        use App\Handler\Two;
 
-            $services->set(App\Handler\One::class)
-                ->tag('app.handler', ['key' => 'handler_one'])
-            ;
-
-            $services->set(App\Handler\Two::class)
-                ->tag('app.handler', ['key' => 'handler_two'])
-            ;
-
-            $services->set(App\Handler\HandlerCollection::class)
-                // inject all services tagged with app.handler as first argument
-                ->args([tagged_locator('app.handler', indexAttribute: 'key')])
-            ;
-        };
+        return App::config([
+            'services' => [
+                One::class => [
+                    'tags' => [
+                        ['app.handler' => ['key' => 'handler_one']],
+                    ],
+                ],
+                Two::class => [
+                    'tags' => [
+                        ['app.handler' => ['key' => 'handler_two']],
+                    ],
+                ],
+                HandlerCollection::class => [
+                    // inject all services tagged with app.handler as first argument
+                    'arguments' => [tagged_locator('app.handler', indexAttribute: 'key')],
+                ],
+            ],
+        ]);
 
 In this example, the ``index_by`` option is ``key``. All services define that
 option/attribute, so that will be the value used to index the services. For example,
@@ -738,12 +754,16 @@ get the value used to index the services:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $container->services()
-                ->set(App\HandlerCollection::class)
-                    ->args([tagged_locator('app.handler', defaultIndexMethod: 'getLocatorKey')])
-            ;
-        };
+        use App\Handler\HandlerCollection;
+
+        return App::config([
+            'services' => [
+                HandlerCollection::class => [
+                    // inject all services tagged with app.handler as first argument
+                    'arguments' => [tagged_locator('app.handler', defaultIndexMethod: 'getLocatorKey')],
+                ],
+            ],
+        ]);
 
 If some service class doesn't define the method configured in ``default_index_method``,
 Symfony will fall back to using the service ID as its index inside the locator.

--- a/service_container/shared.rst
+++ b/service_container/shared.rst
@@ -39,12 +39,13 @@ in your service definition:
 
         use App\SomeNonSharedService;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(SomeNonSharedService::class)
-                ->share(false);
-        };
+        return App::config([
+            'services' => [
+                SomeNonSharedService::class => [
+                    'shared' => false,
+                ],
+            ],
+        ]);
 
 Now, whenever you request the ``App\SomeNonSharedService`` from the container,
 you will be passed a new instance.

--- a/service_container/synthetic_services.rst
+++ b/service_container/synthetic_services.rst
@@ -46,13 +46,14 @@ configuration:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            // synthetic services don't specify a class
-            $services->set('app.synthetic_service')
-                ->synthetic();
-        };
+        return App::config([
+            'services' => [
+                'app.synthetic_service' => [
+                    // synthetic services don't specify a class
+                    'synthetic' => true,
+                ],
+            ],
+        ]);
 
 Now, you can inject the instance in the container using
 :method:`Container::set() <Symfony\\Component\\DependencyInjection\\Container::set>`::

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -21,12 +21,13 @@ example:
 
         use App\Twig\AppExtension;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(AppExtension::class)
-                ->tag('twig.extension');
-        };
+        return App::config([
+            'services' => [
+                AppExtension::class => [
+                    'tags' => ['twig.extension'],
+                ],
+            ],
+        ]);
 
 Services tagged with the ``twig.extension`` tag are collected during the
 initialization of TwigBundle and added to Twig as extensions.
@@ -72,15 +73,13 @@ If you want to apply tags automatically for your own services, use the
 
         use App\Security\CustomInterface;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            // this config only applies to the services created by this file
-            $services
-                ->instanceof(CustomInterface::class)
-                    // services whose classes are instances of CustomInterface will be tagged automatically
-                    ->tag('app.custom_tag');
-        };
+        return App::config([
+            'services' => [
+                CustomInterface::class => [
+                    'tags' => ['app.custom_tag'],
+                ],
+            ],
+        ]);
 
 .. warning::
 
@@ -294,11 +293,11 @@ Then, define the chain as a service:
 
         use App\Mail\TransportChain;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(TransportChain::class);
-        };
+        return App::config([
+            'services' => [
+                TransportChain::class => null,
+            ],
+        ]);
 
 Define Services with a Custom Tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -325,18 +324,20 @@ For example, you may add the following transports as services:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
+        use App\MailerSendmailTransport;
+        use App\MailerSmtpTransport;
 
-            $services->set(\MailerSmtpTransport::class)
-                ->args([param('mailer_host')])
-                ->tag('app.mail_transport')
-            ;
-
-            $services->set(\MailerSendmailTransport::class)
-                ->tag('app.mail_transport')
-            ;
-        };
+        return App::config([
+            'services' => [
+                MailerSmtpTransport::class => [
+                    'arguments' => [param('mailer_host')],
+                    'tags' => ['app.mail_transport'],
+                ],
+                MailerSendmailTransport::class => [
+                    'tags' => ['app.mail_transport'],
+                ],
+            ],
+        ]);
 
 Notice that each service was given a tag named ``app.mail_transport``. This is
 the custom tag that you'll use in your compiler pass. The compiler pass is what
@@ -462,18 +463,24 @@ To answer this, change the service declaration:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
+        use App\MailerSendmailTransport;
+        use App\MailerSmtpTransport;
 
-            $services->set(\MailerSmtpTransport::class)
-                ->args([param('mailer_host')])
-                ->tag('app.mail_transport', ['alias' => 'smtp'])
-            ;
-
-            $services->set(\MailerSendmailTransport::class)
-                ->tag('app.mail_transport', ['alias' => ['sendmail', 'anotherAlias']])
-            ;
-        };
+        return App::config([
+            'services' => [
+                MailerSmtpTransport::class => [
+                    'arguments' => [param('mailer_host')],
+                    'tags' => [
+                        ['app.mail_transport' => ['alias' => 'smtp']],
+                    ],
+                ],
+                MailerSendmailTransport::class => [
+                    'tags' => [
+                        ['app.mail_transport' => ['alias' => ['sendmail', 'anotherAlias']]],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -611,22 +618,23 @@ directly via PHP attributes:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
+        use App\Handler\One;
+        use App\Handler\Two;
+        use App\HandlerCollection;
 
-            $services->set(App\Handler\One::class)
-                ->tag('app.handler')
-            ;
-
-            $services->set(App\Handler\Two::class)
-                ->tag('app.handler')
-            ;
-
-            $services->set(App\HandlerCollection::class)
-                // inject all services tagged with app.handler as first argument
-                ->args([tagged_iterator('app.handler')])
-            ;
-        };
+        return App::config([
+            'services' => [
+                One::class => [
+                    'tags' => ['app.handler'],
+                ],
+                Two::class => [
+                    'tags' => ['app.handler'],
+                ],
+                HandlerCollection::class => [
+                    'arguments' => [tagged_iterator('app.handler')],
+                ],
+            ],
+        ]);
 
 .. note::
 
@@ -676,21 +684,19 @@ iterator, add the ``exclude`` option:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        use App\Handler\Three as HandlerThree;
+        use App\HandlerCollection;
 
-            // ...
-
-            // This is the service we want to exclude, even if the 'app.handler' tag is attached
-            $services->set(App\Handler\Three::class)
-                ->tag('app.handler')
-            ;
-
-            $services->set(App\HandlerCollection::class)
-                // inject all services tagged with app.handler as first argument
-                ->args([tagged_iterator('app.handler', exclude: [App\Handler\Three::class])])
-            ;
-        };
+        return App::config([
+            'services' => [
+                HandlerThree::class => [
+                    'tags' => ['app.handler'],
+                ],
+                HandlerCollection::class => [
+                    'arguments' => [tagged_iterator('app.handler', exclude: [HandlerThree::class])],
+                ],
+            ],
+        ]);
 
 In the case the referencing service is itself tagged with the tag being used in the tagged
 iterator, it is automatically excluded from the injected iterable. This behavior can be
@@ -733,21 +739,19 @@ disabled by setting the ``exclude_self`` option to ``false``:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $containerConfigurator) {
-            $services = $containerConfigurator->services();
+        use App\Handler\Three;
+        use App\HandlerCollection;
 
-            // ...
-
-            // This is the service we want to exclude, even if the 'app.handler' tag is attached
-            $services->set(App\Handler\Three::class)
-                ->tag('app.handler')
-            ;
-
-            $services->set(App\HandlerCollection::class)
-                // inject all services tagged with app.handler as first argument
-                ->args([tagged_iterator('app.handler', exclude: [App\Handler\Three::class], excludeSelf: false)])
-            ;
-        };
+        return App::config([
+            'services' => [
+                Three::class => [
+                    'tags' => ['app.handler'],
+                ],
+                HandlerCollection::class => [
+                    'arguments' => [tagged_iterator('app.handler', exclude: [Three::class], excludeSelf: false)],
+                ],
+            ],
+        ]);
 
 .. seealso::
 
@@ -777,13 +781,15 @@ the number, the earlier the tagged service will be located in the collection:
 
         use App\Handler\One;
 
-        return function(ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(One::class)
-                ->tag('app.handler', ['priority' => 20])
-            ;
-        };
+        return App::config([
+            'services' => [
+                One::class => [
+                    'tags' => [
+                        ['app.handler' => ['priority' => 20]],
+                    ],
+                ],
+            ],
+        ]);
 
 Another option, which is particularly useful when using autoconfiguring
 tags, is to implement the static ``getDefaultPriority()`` method on the
@@ -836,17 +842,15 @@ you can define it in the configuration of the collecting service:
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function (ContainerConfigurator $container): void {
-            $services = $container->services();
+        use App\HandlerCollection;
 
-            // ...
-
-            $services->set(App\HandlerCollection::class)
-                ->args([
-                    tagged_iterator('app.handler', null, null, 'getPriority'),
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                HandlerCollection::class => [
+                    'arguments' => [tagged_iterator('app.handler', defaultPriorityMethod: 'getPriority')],
+                ],
+            ],
+        ]);
 
 Tagged Services with Index
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -901,23 +905,25 @@ to index the services:
 
         use App\Handler\One;
         use App\Handler\Two;
+        use App\HandlerCollection;
 
-        return function (ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(One::class)
-                ->tag('app.handler', ['key' => 'handler_one']);
-
-            $services->set(Two::class)
-                ->tag('app.handler', ['key' => 'handler_two']);
-
-            $services->set(App\HandlerCollection::class)
-                ->args([
-                    // 2nd argument is the index attribute name
-                    tagged_iterator('app.handler', 'key'),
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                One::class => [
+                    'tags' => [
+                        ['app.handler' => ['key' => 'handler_one']],
+                    ],
+                ],
+                Two::class => [
+                    'tags' => [
+                        ['app.handler' => ['key' => 'handler_two']],
+                    ],
+                ],
+                HandlerCollection::class => [
+                    'arguments' => [tagged_iterator('app.handler', 'key')],
+                ],
+            ],
+        ]);
 
 In this example, the ``index_by`` option is ``key``. All services define that
 option/attribute, so that will be the value used to index the services. For example,
@@ -984,17 +990,13 @@ get the value used to index the services:
 
         use App\HandlerCollection;
 
-        return function (ContainerConfigurator $container) {
-            $services = $container->services();
-
-            // ...
-
-            $services->set(HandlerCollection::class)
-                ->args([
-                    tagged_iterator('app.handler', null, 'getIndex'),
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                HandlerCollection::class => [
+                    'arguments' => [tagged_iterator('app.handler', defaultIndexMethod: 'getIndex')],
+                ],
+            ],
+        ]);
 
 If some service class doesn't define the method configured in ``default_index_method``,
 Symfony will fall back to using the service ID as its index inside the tagged services.

--- a/session.rst
+++ b/session.rst
@@ -304,23 +304,26 @@ configuration <config-framework-session>` in
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Component\HttpFoundation\Cookie;
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->session()
-                // Enables session support. Note that the session will ONLY be started if you read or write from it.
-                // Remove or comment this section to explicitly disable session support.
-                ->enabled(true)
-                // ID of the service used for session storage
-                // NULL means that Symfony uses PHP default session mechanism
-                ->handlerId(null)
-                // improves the security of the cookies used for sessions
-                ->cookieSecure('auto')
-                ->cookieSamesite(Cookie::SAMESITE_LAX)
-                ->storageFactoryId('session.storage.factory.native')
-            ;
-        };
+        use Symfony\Component\HttpFoundation\Cookie;
+
+        return App::config([
+            'framework' => [
+                'session' => [
+                    // Enables session support. Note that the session will ONLY be started if you read or write from it.
+                    // Remove or comment this section to explicitly disable session support.
+                    'enabled' => true,
+                    // ID of the service used for session storage
+                    // NULL means that Symfony uses PHP default session mechanism
+                    'handler_id' => null,
+                    // improves the security of the cookies used for sessions
+                    'cookie_secure' => 'auto',
+                    'cookie_samesite' => Cookie::SAMESITE_LAX,
+                    'storage_factory_id' => 'session.storage.factory.native',
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -361,15 +364,17 @@ session metadata files:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->session()
-                // ...
-                ->handlerId('session.handler.native_file')
-                ->savePath('%kernel.project_dir%/var/sessions/%kernel.environment%')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'session' => [
+                    // ...
+                    'handler_id' => 'session.handler.native_file',
+                    'save_path' => '%kernel.project_dir%/var/sessions/%kernel.environment%',
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -541,27 +546,35 @@ a Symfony service for the connection to the Redis server:
     .. code-block:: php
 
         // config/services.php
-        use Symfony\Component\DependencyInjection\Reference;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler;
 
-        $container
-            // you can also use \RedisArray, \RedisCluster, \Relay\Relay or \Predis\Client classes
-            ->register('Redis', \Redis::class)
-            ->addMethodCall('connect', ['%env(REDIS_HOST)%', '%env(int:REDIS_PORT)%'])
-            // uncomment the following if your Redis server requires a password:
-            // ->addMethodCall('auth', ['%env(REDIS_PASSWORD)%'])
-            // uncomment the following if your Redis server requires a user and a password (when user is not default):
-            // ->addMethodCall('auth', ['%env(REDIS_USER)%', '%env(REDIS_PASSWORD)%'])
-
-            ->register(RedisSessionHandler::class)
-            ->addArgument(
-                new Reference('Redis'),
-                // you can optionally pass an array of options. The only options are 'prefix' and 'ttl',
-                // which define the prefix to use for the keys to avoid collision on the Redis server
-                // and the expiration time for any given entry (in seconds), defaults are 'sf_s' and null:
-                // ['prefix' => 'my_prefix', 'ttl' => 600],
-            )
-        ;
+        return App::config([
+            'services' => [
+                // ...
+                RedisSessionHandler::class => [
+                    'arguments' => [
+                        service('Redis'),
+                        // you can optionally pass an array of options. The only options are 'prefix' and 'ttl',
+                        // which define the prefix to use for the keys to avoid collision on the Redis server
+                        // and the expiration time for any given entry (in seconds), defaults are 'sf_s' and null:
+                        // ['prefix' => 'my_prefix', 'ttl' => 600],
+                    ],
+                ],
+                \Redis::class => [
+                    // you can also use \RedisArray, \RedisCluster, \Relay\Relay or \Predis\Client classes
+                    'class' => \Redis::class,
+                    'calls' => [
+                        'connect' => [env('REDIS_HOST'), env('REDIS_PORT')->int()],
+                        // uncomment the following if your Redis server requires a password:
+                        // 'auth' => [env('REDIS_PASSWORD')],
+                        // uncomment the following if your Redis server requires a user and a password (when user is not default):
+                        // 'auth' => [env('REDIS_USER'), env('REDIS_PASSWORD')],
+                    ],
+                ],
+            ],
+        ]);
 
 Next, use the :ref:`handler_id <config-framework-session-handler-id>`
 configuration option to tell Symfony to use this service as the session handler:
@@ -579,15 +592,18 @@ configuration option to tell Symfony to use this service as the session handler:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler;
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->session()
-                ->handlerId(RedisSessionHandler::class)
-            ;
-        };
+        use Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler;
+
+        return App::config([
+            'framework' => [
+                // ...
+                'session' => [
+                    'handler_id' => RedisSessionHandler::class,
+                ],
+            ],
+        ]);
 
 Symfony will now use your Redis server to read and write the session data. The
 main drawback of this solution is that Redis does not perform session locking,
@@ -640,18 +656,19 @@ To use it, first register a new handler service with your database credentials:
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
-        return static function (ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(PdoSessionHandler::class)
-                ->args([
-                    env('DATABASE_URL'),
-                    // you can also use PDO configuration, but requires passing two arguments:
-                    // 'mysql:dbname=mydatabase; host=myhost; port=myport',
-                    // ['db_username' => 'myuser', 'db_password' => 'mypassword'],
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                // ...
+                PdoSessionHandler::class => [
+                    'arguments' => [
+                        env('DATABASE_URL'),
+                        // you can also use PDO configuration, but requires passing two arguments
+                        // 'mysql:dbname=mydatabase; host=myhost; port=myport',
+                        // ['db_username' => 'myuser', 'db_password' => 'mypassword'],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -674,15 +691,18 @@ configuration option to tell Symfony to use this service as the session handler:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
+        use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
+
+        return App::config([
+            'framework' => [
             // ...
-            $framework->session()
-                ->handlerId(PdoSessionHandler::class)
-            ;
-        };
+                'session' => [
+                    'handler_id' => PdoSessionHandler::class,
+                ],
+            ],
+        ]);
 
 Configuring the Session Table and Column Names
 ..............................................
@@ -711,16 +731,17 @@ passed to the ``PdoSessionHandler`` service:
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
-        return static function (ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(PdoSessionHandler::class)
-                ->args([
-                    env('DATABASE_URL'),
-                    ['db_table' => 'customer_session', 'db_id_col' => 'guid'],
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                // ...
+                PdoSessionHandler::class => [
+                    'arguments' => [
+                        env('DATABASE_URL'),
+                        ['db_table' => 'customer_session', 'db_id_col' => 'guid'],
+                    ],
+                ],
+            ],
+        ]);
 
 These are parameters that you can configure:
 
@@ -886,16 +907,17 @@ the MongoDB connection as argument, and the required parameters:
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
 
-        return static function (ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(MongoDbSessionHandler::class)
-                ->args([
-                    service('doctrine_mongodb.odm.default_connection'),
-                    ['database' => '%env("MONGODB_DB")%', 'collection' => 'sessions']
-                ])
-            ;
-        };
+        return App::config([
+            'services' => [
+                // ...
+                MongoDbSessionHandler::class => [
+                    'arguments' => [
+                        service('doctrine_mongodb.odm.default_connection'),
+                        ['database' => env('MONGODB_DB'), 'collection' => 'sessions'],
+                    ],
+                ],
+            ],
+        ]);
 
 Next, use the :ref:`handler_id <config-framework-session-handler-id>`
 configuration option to tell Symfony to use this service as the session handler:
@@ -913,15 +935,18 @@ configuration option to tell Symfony to use this service as the session handler:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->session()
-                ->handlerId(MongoDbSessionHandler::class)
-            ;
-        };
+        use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
+
+        return App::config([
+            'framework' => [
+                // ...
+                'session' => [
+                    'handler_id' => MongoDbSessionHandler::class,
+                ],
+            ],
+        ]);
 
 That's all! Symfony will now use your MongoDB server to read and write the
 session data. You do not need to do anything to initialize your session
@@ -964,21 +989,22 @@ configure these values with the second argument passed to the
 
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
 
-        return static function (ContainerConfigurator $container): void {
-            $services = $container->services();
-
-            $services->set(MongoDbSessionHandler::class)
-                ->args([
-                    service('doctrine_mongodb.odm.default_connection'),
-                    [
-                        'database' => '%env('MONGODB_DB')%',
-                        'collection' => 'sessions'
-                        'id_field' => '_guid',
-                        'expiry_field' => 'eol',
+        return App::config([
+            'services' => [
+                // ...
+                MongoDbSessionHandler::class => [
+                    'arguments' => [
+                        service('doctrine_mongodb.odm.default_connection'),
+                        [
+                            'database' => env('MONGODB_DB'),
+                            'collection' => 'sessions',
+                            'id_field' => '_guid',
+                            'expiry_field' => 'eol',
+                        ],
                     ],
-                ])
-            ;
-        };
+                ],
+            ],
+        ]);
 
 These are parameters that you can configure:
 
@@ -1052,14 +1078,21 @@ You need to pass the TTL in the options array of the session handler you are usi
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler;
 
-        $services
-            ->set(RedisSessionHandler::class)
-            ->args([
-                service('Redis'),
-                ['ttl' => 600],
-            ]);
+        return App::config([
+            'services' => [
+                // ...
+                RedisSessionHandler::class => [
+                    'arguments' => [
+                        service('Redis'),
+                        ['ttl' => 600],
+                    ],
+                ],
+            ],
+        ]);
 
 Configure the TTL Dynamically at Runtime
 ........................................
@@ -1090,20 +1123,27 @@ has to return an integer which will be used as TTL.
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\Some\InvokableClass;
         use Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler;
 
-        $services
-            ->set(RedisSessionHandler::class)
-            ->args([
-                service('Redis'),
-                ['ttl' => closure(service('my.ttl.handler'))],
-            ]);
-
-        $services
-            // some class with an __invoke() method
-            ->set('my.ttl.handler', 'Some\InvokableClass')
-            // Inject whatever dependencies you need to be able to resolve a TTL for the current session
-            ->args([service('security')]);
+        return App::config([
+            'services' => [
+                // ...
+                RedisSessionHandler::class => [
+                    'arguments' => [
+                        service('Redis'),
+                        ['ttl' => closure(service('my.ttl.handler'))],
+                    ],
+                ],
+                'my.ttl.handler' => [
+                    'class' => InvokableClass::class,
+                    // Inject whatever dependencies you need to be able to resolve a TTL for the current session
+                    'arguments' => [service('security')],
+                ],
+            ],
+        ]);
 
 .. _locale-sticky-session:
 
@@ -1153,10 +1193,10 @@ can determine the correct locale however you want::
 
         public static function getSubscribedEvents(): array
         {
-            return [
+            return App::config([
                 // must be registered before (i.e. with a higher priority than) the default Locale listener
                 KernelEvents::REQUEST => [['onKernelRequest', 20]],
-            ];
+            ]);
         }
     }
 
@@ -1190,13 +1230,20 @@ via some "Change Locale" route & controller), or create a route with the
         .. code-block:: php
 
             // config/services.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
             use App\EventSubscriber\LocaleSubscriber;
 
-            $container->register(LocaleSubscriber::class)
-                ->addArgument('%kernel.default_locale%')
-                // uncomment the next line if you are not using autoconfigure
-                // ->addTag('kernel.event_subscriber')
-            ;
+            return App::config([
+                'services' => [
+                    // ...
+                    LocaleSubscriber::class => [
+                        'arguments' => [param('kernel.default_locale')],
+                        // uncomment the next line if you are not using autoconfigure
+                        // 'tags' => ['kernel.event_subscriber'],
+                    ],
+                ],
+            ]);
 
 Now celebrate by changing the user's locale and seeing that it's sticky
 throughout the request.
@@ -1258,9 +1305,9 @@ event::
 
         public static function getSubscribedEvents(): array
         {
-            return [
+            return App::config([
                 LoginSuccessEvent::class => 'onLoginSuccess',
-            ];
+            ]);
         }
     }
 
@@ -1300,15 +1347,18 @@ Symfony to use your session handler instead of the default one:
     .. code-block:: php
 
         // config/packages/framework.php
-        use App\Session\CustomSessionHandler;
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
+        use App\Session\CustomSessionHandler;
+
+        return App::config([
+            'framework' => [
             // ...
-            $framework->session()
-                ->handlerId(CustomSessionHandler::class)
-            ;
-        };
+            'session' => [
+                    'handler_id' => CustomSessionHandler::class,
+                ],
+            ],
+        ]);
 
 Keep reading the next sections to learn how to use the session handlers in
 practice to solve two common use cases: encrypt session information and define
@@ -1384,22 +1434,22 @@ Then, register the ``SodiumMarshaller`` service using this key:
     .. code-block:: php
 
         // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use Symfony\Component\Cache\Marshaller\SodiumMarshaller;
-        use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-        // ...
 
-        return function(ContainerConfigurator $container) {
-            $services = $container->services();
-
-            // ...
-
-            $services->set(SodiumMarshaller::class)
-                ->decorate('session.marshaller')
-                ->args([
-                    [env('file:resolve:SESSION_DECRYPTION_FILE')],
-                    service('.inner'),
-                ]);
-        };
+        return App::config([
+            'services' => [
+                // ...
+                SodiumMarshaller::class => [
+                    'decorates' => 'session.marshaller',
+                    'arguments' => [
+                        [env('SESSION_DECRYPTION_FILE')->resolve()->file()],
+                        service('.inner'),
+                    ],
+                ],
+            ],
+        ]);
 
 .. danger::
 
@@ -1474,14 +1524,16 @@ for the ``handler_id``:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->session()
-                ->storageFactoryId('session.storage.factory.php_bridge')
-                ->handlerId(null)
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'session' => [
+                    'storage_factory_id' => 'session.storage.factory.php_bridge',
+                    'handler_id' => null,
+                ],
+            ],
+        ]);
 
     .. code-block:: php-standalone
 
@@ -1517,14 +1569,16 @@ the example below:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->session()
-                ->storageFactoryId('session.storage.factory.php_bridge')
-                ->handlerId('session.handler.native_file')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'session' => [
+                    'storage_factory_id' => 'session.storage.factory.php_bridge',
+                    'handler_id' => 'session.handler.native_file',
+                ],
+            ],
+        ]);
 
 .. note::
 

--- a/templates.rst
+++ b/templates.rst
@@ -233,18 +233,20 @@ Consider the following routing configuration:
     .. code-block:: php
 
         // config/routes.php
+        namespace Symfony\Component\Routing\Loader\Configurator;
+
         use App\Controller\BlogController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
-        return function (RoutingConfigurator $routes): void {
-            $routes->add('blog_index', '/')
-                ->controller([BlogController::class, 'index'])
-            ;
-
-            $routes->add('blog_post', '/articles/{slug}')
-                ->controller([BlogController::class, 'show'])
-            ;
-        };
+        return Routes::config([
+            'blog_index' => [
+                'path' => '/',
+                'controller' => [BlogController::class, 'index'],
+            ],
+            'blog_post' => [
+                'path' => '/article/{slug}',
+                'controller' => [BlogController::class, 'show'],
+            ],
+        ]);
 
 Use the ``path()`` Twig function to link to these pages and pass the route name
 as the first argument and the route parameters as the optional second argument:
@@ -401,13 +403,16 @@ inside the main Twig configuration file:
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            // ...
-
-            $twig->global('ga_tracking')->value('UA-xxxxx-x');
-        };
+        return App::config([
+            'twig' => [
+                // ...
+                'globals' => [
+                    'ga_tracking' => 'UA-xxxxx-x',
+                ],
+            ],
+        ]);
 
 Now, the variable ``ga_tracking`` is available in all Twig templates, so you
 can use it without having to pass it explicitly from the controller or service
@@ -421,11 +426,7 @@ In addition to static values, Twig global variables can also reference services
 from the :doc:`service container </service_container>`. The main drawback is
 that these services are not loaded lazily. In other words, as soon as Twig is
 loaded, your service is instantiated, even if you never use that global
-variable.
-
-To define a service as a global Twig variable, prefix the service ID string
-with the ``@`` character, which is the usual syntax to :ref:`refer to services
-in container parameters <service-container-parameters>`:
+variable:
 
 .. configuration-block::
 
@@ -435,20 +436,22 @@ in container parameters <service-container-parameters>`:
         twig:
             # ...
             globals:
-                # the value is the service's id
+                # the value is the service's id prefixed with '@'
                 uuid: '@App\Generator\UuidGenerator'
 
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
-        use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            // ...
-
-            $twig->global('uuid')->value(service('App\Generator\UuidGenerator'));
-        };
+        return App::config([
+            'twig' => [
+                // ...
+                'globals' => [
+                    'uuid' => service('App\Generator\UuidGenerator'),
+                ],
+            ],
+        ]);
 
 Now you can use the ``uuid`` variable in any Twig template to access to the
 ``UuidGenerator`` service:
@@ -540,10 +543,10 @@ to define the template to render::
             // when using the #[Template] attribute, you only need to return
             // an array with the parameters to pass to the template (the attribute
             // is the one which will create and return the Response object).
-            return [
+            return App::config([
                 'category' => '...',
                 'promotions' => ['...', '...'],
-            ];
+            ]);
         }
     }
 
@@ -601,9 +604,9 @@ a block to render::
         #[Template('product.html.twig', block: 'price_block')]
         public function price(): array
         {
-            return [
+            return App::config([
                 // ...
-            ];
+            ]);
         }
     }
 
@@ -688,13 +691,15 @@ provided by Symfony:
     .. code-block:: php
 
         // config/routes.php
-        use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return function (RoutingConfigurator $routes): void {
-            $routes->add('acme_privacy', '/privacy')
-                ->controller(TemplateController::class)
-                ->defaults([
+        use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
+
+        return Routes::config([
+            'acme_privacy' => [
+                'path' => '/privacy',
+                'controller' => TemplateController::class,
+                'defaults' => [
                     // the path of the template to render
                     'template'  => 'static/privacy.html.twig',
 
@@ -718,9 +723,9 @@ provided by Symfony:
                     'headers' => [
                         'Content-Type' => 'text/html',
                     ]
-                ])
-            ;
-        };
+                ],
+            ],
+        ]);
 
 Checking if a Template Exists
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -985,12 +990,16 @@ template fragments. Configure that special URL in the ``fragments`` option:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->fragments()->path('/_fragment');
-        };
+        return App::config([
+            'framework' => [
+                // ...
+                'fragments' => [
+                    'path' => '/_fragment',
+                ],
+            ],
+        ]);
 
 .. warning::
 
@@ -1041,14 +1050,16 @@ default content rendering some template:
     .. code-block:: php
 
         // config/packages/framework.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->fragments()
-                ->hincludeDefaultTemplate('hinclude.html.twig')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                // ...
+                'fragments' => [
+                    'hinclude_default_template' => 'hinclude.html.twig',
+                ],
+            ],
+        ]);
 
 You can define default templates per ``render()`` function (which will override
 any global default template that is defined):
@@ -1270,16 +1281,20 @@ the ``value`` is the Twig namespace, which is explained later:
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            // ...
+        return App::config([
+            'twig' => [
+                // ...
 
-            // directories are relative to the project root dir (but you
-            // can also use absolute directories)
-            $twig->path('email/default/templates', null);
-            $twig->path('backend/templates', null);
-        };
+                // directories are relative to the project root dir (but you
+                // can also use absolute directories)
+                'paths' => [
+                    'email/default/templates' => null,
+                    'backend/templates' => null,
+                ],
+            ],
+        ]);
 
 When rendering a template, Symfony looks for it first in the ``twig.paths``
 directories that don't define a namespace and then falls back to the default
@@ -1309,14 +1324,17 @@ configuration to define a namespace for each template directory:
     .. code-block:: php
 
         // config/packages/twig.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            // ...
-
-            $twig->path('email/default/templates', 'email');
-            $twig->path('backend/templates', 'admin');
-        };
+        return App::config([
+            'twig' => [
+                // ...
+                'paths' => [
+                    'email/default/templates' => 'email',
+                    'backend/templates' => 'admin',
+                ],
+            ],
+        ]);
 
 Now, if you render the ``layout.html.twig`` template, Symfony will render the
 ``templates/layout.html.twig`` file. Use the special syntax ``@`` + namespace to
@@ -1475,10 +1493,10 @@ callable defined in ``getFilters()``::
     {
         public function getFilters(): array
         {
-            return [
+            return App::config([
                 // the logic of this filter is now implemented in a different class
                 new TwigFilter('price', [AppRuntime::class, 'formatPrice']),
-            ];
+            ]);
         }
     }
 

--- a/testing.rst
+++ b/testing.rst
@@ -155,7 +155,8 @@ Set-up your Test Environment
 
 The tests create a kernel that runs in the ``test``
 :ref:`environment <configuration-environments>`. This allows to have
-special settings for your tests inside ``config/packages/test/``.
+special settings for your tests inside ``config/packages/test/`` or
+using the ``when@test`` key.
 
 If you have Symfony Flex installed, some packages already installed some
 useful test configuration. For example, by default, the Twig bundle is
@@ -166,18 +167,23 @@ code to production:
 
     .. code-block:: yaml
 
-        # config/packages/test/twig.yaml
-        twig:
-            strict_variables: true
+        # config/packages/twig.yaml
+        when@test:
+            twig:
+                strict_variables: true
 
     .. code-block:: php
 
-        // config/packages/test/twig.php
-        use Symfony\Config\TwigConfig;
+        // config/packages/twig.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $twig): void {
-            $twig->strictVariables(true);
-        };
+        return App::config([
+            'when@test' => [
+                'twig' => [
+                    'strict_variables' => true,
+                ],
+            ],
+        ]);
 
 You can also use a different environment entirely, or override the default
 debug mode (``true``) by passing each as options to the ``bootKernel()``

--- a/testing/profiling.rst
+++ b/testing/profiling.rst
@@ -19,24 +19,26 @@ but **disables data collection** by default in the test environment:
 
     .. code-block:: yaml
 
-        # config/packages/test/web_profiler.yaml
-
-        # ...
-        framework:
-            profiler: { enabled: true, collect: false }
+        # config/packages/web_profiler.yaml
+        when@test:
+            framework:
+                profiler: { enabled: true, collect: false }
 
     .. code-block:: php
 
-        // config/packages/test/web_profiler.php
-        use Symfony\Config\FrameworkConfig;
+        // config/packages/web_profiler.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework->profiler()
-                ->enabled(true)
-                ->collect(false)
-            ;
-        };
+        return App::config([
+            'when@test' => [
+                'framework' => [
+                    'profiler' => [
+                        'enabled' => true,
+                        'collect' => false,
+                    ],
+                ],
+            ],
+        ]);
 
 Setting ``collect`` to ``true`` enables profiler data collection for all tests.
 However, if you only need profiler data in a few specific tests, you can keep

--- a/translation.rst
+++ b/translation.rst
@@ -80,16 +80,16 @@ are located:
     .. code-block:: php
 
         // config/packages/translation.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $framework
-                ->defaultLocale('en')
-                ->translator()
-                    ->defaultPath('%kernel.project_dir%/translations')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'default_locale' => 'en',
+                'translator' => [
+                    'default_path' => '%kernel.project_dir%/translations',
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -444,15 +444,21 @@ of your main configuration file using either ``%...%`` or ``{...}`` syntax:
     .. code-block:: php
 
         // config/packages/translator.php
-        use Symfony\Config\TwigConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (TwigConfig $translator): void {
-            // ...
-            // when using the '%' wrapping characters, you must escape them
-            $translator->globals('%%app_name%%')->value('My application');
-            $translator->globals('{app_version}')->value('1.2.3');
-            $translator->globals('{url}')->value(['message' => 'url', 'parameters' => ['scheme' => 'https://']]);
-        };
+        return App::config([
+            'framework' => [
+                // ...
+                'translator' => [
+                    'globals' => [
+                        // when using the '%' wrapping characters, you must escape them
+                        '%%app_name%%' => 'My application',
+                        '{app_version}' => '1.2.3',
+                        '{url}' => ['message' => 'url', 'parameters' => ['scheme' => 'https://']],
+                    ],
+                ],
+            ],
+        ]);
 
 Once defined, you can use these parameters in translation messages anywhere in
 your application:
@@ -613,13 +619,15 @@ if you're generating translations with specialized programs or teams.
         .. code-block:: php
 
             // config/packages/translation.php
-            use Symfony\Config\FrameworkConfig;
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (FrameworkConfig $framework): void {
-                $framework->translator()
-                    ->paths(['%kernel.project_dir%/custom/path/to/translations'])
-                ;
-            };
+            return App::config([
+                'framework' => [
+                    'translator' => [
+                        'paths' => ['%kernel.project_dir%/custom/path/to/translations'],
+                    ],
+                ],
+            ]);
 
 Translations of Doctrine Entities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -716,13 +724,17 @@ configure the ``providers`` option:
     .. code-block:: php
 
         # config/packages/translation.php
-        $container->loadFromExtension('framework', [
-            'translator' => [
-                'providers' => [
-                    'loco' => [
-                        'dsn' => env('LOCO_DSN'),
-                        'domains' => ['messages'],
-                        'locales' => ['en', 'fr'],
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'translator' => [
+                    'providers' => [
+                        'loco' => [
+                            'dsn' => env('LOCO_DSN'),
+                            'domains' => ['messages'],
+                            'locales' => ['en', 'fr'],
+                        ],
                     ],
                 ],
             ],
@@ -914,17 +926,19 @@ A better policy is to include the locale in the URL using the
     .. code-block:: php
 
         // config/routes.php
-        use App\Controller\ContactController;
-        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+        namespace Symfony\Component\Routing\Loader\Configurator;
 
-        return function (RoutingConfigurator $routes): void {
-            $routes->add('contact', '/{_locale}/contact')
-                ->controller([ContactController::class, 'index'])
-                ->requirements([
+        use App\Controller\ContactController;
+
+        return Routes::config([
+            'contact' => [
+                'path' => '/{_locale}/contact',
+                'controller' => [ContactController::class, 'index'],
+                'requirements' => [
                     '_locale' => 'en|fr|de',
-                ])
-            ;
-        };
+                ],
+            ],
+        ]);
 
 When using the special ``_locale`` parameter in a route, the matched locale
 is *automatically set on the Request* and can be retrieved via the
@@ -960,11 +974,13 @@ the framework:
     .. code-block:: php
 
         // config/packages/translation.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->defaultLocale('en');
-        };
+        return App::config([
+            'framework' => [
+                'default_locale' => 'en',
+            ],
+        ]);
 
 This ``default_locale`` is also relevant for the translator, as shown in the
 next section.
@@ -1026,14 +1042,15 @@ checks translation resources for several locales:
        .. code-block:: php
 
            // config/packages/translation.php
-           use Symfony\Config\FrameworkConfig;
+           namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-            return static function (FrameworkConfig $framework): void {
-                // ...
-                $framework->translator()
-                    ->fallbacks(['en'])
-                ;
-            };
+            return [
+                'framework' => [
+                'translator' => [
+                    'fallbacks' => ['en'],
+                ],
+            ],
+        ];
 
 .. note::
 
@@ -1447,25 +1464,26 @@ it in the translator configuration:
     .. code-block:: php
 
         // config/packages/translation.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework) {
-            // ...
-            $framework
-                ->translator()
-                    ->pseudoLocalization()
+        return App::config([
+            'framework' => [
+                'translator' => [
+                    'pseudo_localization' => [
                         // replace characters by their accented version
-                        ->accents(true)
+                        'accents' => true,
                         // wrap strings with brackets
-                        ->brackets(true)
+                        'brackets' => true,
                         // controls how many extra characters are added to make text longer
-                        ->expansionFactor(1.4)
+                        'expansion_factor' => 1.4,
                         // maintain the original HTML tags of the translated contents
-                        ->parseHtml(true)
+                        'parse_html' => true,
                         // also translate the contents of these HTML attributes
-                        ->localizableHtmlAttributes(['title'])
-            ;
-        };
+                        'localizable_html_attributes' => ['title'],
+                    ],
+                ],
+            ],
+        ]);
 
 That's all. The application will now start displaying those strange, but
 readable, contents to help you internationalize it. See for example the

--- a/validation/translations.rst
+++ b/validation/translations.rst
@@ -116,9 +116,9 @@ Now, create a ``validators`` catalog file in the ``translations/`` directory:
     .. code-block:: php
 
         // translations/validators/validators.en.php
-        return [
+        return App::config([
             'author.name.not_blank' => 'Please enter an author name.',
-        ];
+        ]);
 
 You may need to clear your cache (even in the dev environment) after creating
 this file for the first time.
@@ -172,15 +172,15 @@ The default translation domain can be changed globally using the
     .. code-block:: php
 
         // config/packages/validator.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework) {
-            // ...
-            $framework
-                ->validation()
-                    ->translationDomain('validation_errors')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'validation' => [
+                    'translation_domain' => 'validation_errors',
+                ],
+            ],
+        ]);
 
 Or it can be customized for a specific violation from a constraint validator::
 

--- a/webhook.rst
+++ b/webhook.rst
@@ -66,16 +66,20 @@ component routing:
     .. code-block:: php
 
         // config/packages/framework.php
-        use App\Webhook\MailerWebhookParser;
-        use Symfony\Config\FrameworkConfig;
-        return static function (FrameworkConfig $frameworkConfig): void {
-            $webhookConfig = $frameworkConfig->webhook();
-            $webhookConfig
-                ->routing('mailer_mailgun')
-                ->service('mailer.webhook.request_parser.mailgun')
-                ->secret('%env(MAILER_MAILGUN_SECRET)%')
-            ;
-        };
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'webhook' => [
+                    'routing' => [
+                        'mailer_mailgun' => [
+                            'service' => 'mailer.webhook.request_parser.mailgun',
+                            'secret' => env('MAILER_MAILGUN_SECRET'),
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 In this example, we are using ``mailer_mailgun`` as the webhook routing name.
 The routing name must be unique as this is what connects the provider with your

--- a/workflow.rst
+++ b/workflow.rst
@@ -79,42 +79,48 @@ follows:
     .. code-block:: php
 
         // config/packages/workflow.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Entity\BlogPost;
-        use Symfony\Config\FrameworkConfig;
 
-        return static function (FrameworkConfig $framework): void {
-            $blogPublishing = $framework->workflows()->workflows('blog_publishing');
-            $blogPublishing
-                ->type('workflow') // or 'state_machine'
-                ->supports([BlogPost::class])
-                ->initialMarking(['draft']);
-
-            $blogPublishing->auditTrail()->enabled(true);
-            $blogPublishing->markingStore()
-                ->type('method')
-                ->property('currentPlace');
-
-            // defining places manually is optional
-            $blogPublishing->place()->name('draft');
-            $blogPublishing->place()->name('reviewed');
-            $blogPublishing->place()->name('rejected');
-            $blogPublishing->place()->name('published');
-
-            $blogPublishing->transition()
-                ->name('to_review')
-                    ->from(['draft'])
-                    ->to(['reviewed']);
-
-            $blogPublishing->transition()
-                ->name('publish')
-                    ->from(['reviewed'])
-                    ->to(['published']);
-
-            $blogPublishing->transition()
-                ->name('reject')
-                    ->from(['reviewed'])
-                    ->to(['rejected']);
-        };
+        return App::config([
+            'framework' => [
+                'workflows' => [
+                    'blog_publishing' => [
+                        'type' => 'workflow', // or 'state_machine'
+                        'audit_trail' => [
+                            'enabled' => true,
+                        ],
+                        'marking_store' => [
+                            'type' => 'method',
+                            'property' => 'currentPlace',
+                        ],
+                        'supports' => [BlogPost::class],
+                        'initial_marking' => 'draft',
+                        'places' => [
+                            'draft',
+                            'reviewed',
+                            'rejected',
+                            'published',
+                        ],
+                        'transitions' => [
+                            'to_review' => [
+                                'from' => 'draft',
+                                'to' => 'reviewed',
+                            ],
+                            'publish' => [
+                                'from' => 'reviewed',
+                                'to' => 'published',
+                            ],
+                            'reject' => [
+                                'from' => 'reviewed',
+                                'to' => 'rejected',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 
@@ -295,38 +301,41 @@ and transitions:
     .. code-block:: php
 
         // config/packages/workflow.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
         use App\Entity\BlogPost;
         use App\Enumeration\BlogPostStatus;
-        use Symfony\Config\FrameworkConfig;
 
-        return static function (FrameworkConfig $framework): void {
-            $blogPublishing = $framework->workflows()->workflows('blog_publishing');
-            $blogPublishing
-                ->type('workflow')
-                ->supports([BlogPost::class])
-                ->initialMarking([BlogPostStatus::Draft]);
-
-            $blogPublishing->markingStore()
-                ->type('method')
-                ->property('status');
-
-            $blogPublishing->places(BlogPostStatus::cases());
-
-            $blogPublishing->transition()
-                ->name('to_review')
-                    ->from(BlogPostStatus::Draft)
-                    ->to([BlogPostStatus::Reviewed]);
-
-            $blogPublishing->transition()
-                ->name('publish')
-                    ->from([BlogPostStatus::Reviewed])
-                    ->to([BlogPostStatus::Published]);
-
-            $blogPublishing->transition()
-                ->name('reject')
-                    ->from([BlogPostStatus::Reviewed])
-                    ->to([BlogPostStatus::Rejected]);
-        };
+        return App::config([
+            'framework' => [
+                'workflows' => [
+                    'blog_publishing' => [
+                        'type' => 'workflow',
+                        'marking_store' => [
+                            'type' => 'method',
+                            'property' => 'status',
+                        ],
+                        'supports' => [BlogPost::class],
+                        'initial_marking' => BlogPostStatus::Draft,
+                        'places' => BlogPostStatus::cases(),
+                        'transitions' => [
+                            'to_review' => [
+                                'from' => BlogPostStatus::Draft,
+                                'to' => BlogPostStatus::Reviewed,
+                            ],
+                            'publish' => [
+                                'from' => BlogPostStatus::Reviewed,
+                                'to' => BlogPostStatus::Published,
+                            ],
+                            'reject' => [
+                                'from' => BlogPostStatus::Reviewed,
+                                'to' => BlogPostStatus::Rejected,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 The component will now transparently cast the enum to its backing value
 when needed and vice-versa when working with your objects::
@@ -372,21 +381,22 @@ when needed and vice-versa when working with your objects::
         .. code-block:: php
 
             // config/packages/workflow.php
-            use App\Entity\BlogPost;
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
             use App\Enumeration\BlogPostStatus;
-            use Symfony\Config\FrameworkConfig;
 
-            return static function (FrameworkConfig $framework): void {
-                $blogPublishing = $framework->workflows()->workflows('my_workflow_name');
-
-                // with constants:
-                $blogPublishing->places('App\Workflow\MyWorkflow::PLACE_*');
-
-                // with enums:
-                $blogPublishing->places(BlogPostStatus::cases());
-
-                // ...
-            };
+            return App::config([
+                'framework' => [
+                    'workflows' => [
+                        'my_workflow_name' => [
+                            // with constants:
+                            'places' => 'App\Workflow\MyWorkflow::PLACE_*',
+                            // with enums:
+                            'places' => BlogPostStatus::cases(),
+                        ],
+                    ],
+                ],
+            ]);
 
 Using Weighted Transitions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -855,11 +865,11 @@ workflow leaves a place::
 
         public static function getSubscribedEvents(): array
         {
-            return [
+            return App::config([
                 LeaveEvent::getName('blog_publishing') => 'onLeave',
                 // if you prefer, you can write the event name manually like this:
                 // 'workflow.blog_publishing.leave' => 'onLeave',
-            ];
+            ]);
         }
     }
 
@@ -948,9 +958,9 @@ missing a title::
 
         public static function getSubscribedEvents(): array
         {
-            return [
+            return App::config([
                 'workflow.blog_publishing.guard.to_review' => ['guardReview'],
-            ];
+            ]);
         }
     }
 
@@ -982,25 +992,21 @@ to :ref:`Guard events <workflow-usage-guard-events>`, which are always fired:
     .. code-block:: php
 
         // config/packages/workflow.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-
-            $blogPublishing = $framework->workflows()->workflows('blog_publishing');
-
-            // ...
-            // you can pass one or more event names
-            $blogPublishing->eventsToDispatch([
-                'workflow.leave',
-                'workflow.completed',
-            ]);
-
-            // pass an empty array to not dispatch any event
-            $blogPublishing->eventsToDispatch([]);
-
-            // ...
-        };
+        return App::config([
+            'framework' => [
+                'workflows' => [
+                    'blog_publishing' => [
+                        // you can pass one or more event names
+                        'events_to_dispatch' => ['workflow.leave', 'workflow.completed'],
+                        // pass an empty array to not dispatch any event
+                        'events_to_dispatch' => [],
+                        // ...
+                    ],
+                ],
+            ],
+        ]);
 
 You can also disable a specific event from being fired when applying a transition::
 
@@ -1009,10 +1015,8 @@ You can also disable a specific event from being fired when applying a transitio
 
     $post = new BlogPost();
 
-    $workflow = $this->container->get('workflow.blog_publishing');
-
     try {
-        $workflow->apply($post, 'to_review', [
+        $blogPublishingWorkflow->apply($post, 'to_review', [
             Workflow::DISABLE_ANNOUNCE_EVENT => true,
             Workflow::DISABLE_LEAVE_EVENT => true,
         ]);
@@ -1113,33 +1117,35 @@ transition. The value of this option is any valid expression created with the
     .. code-block:: php
 
         // config/packages/workflow.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $blogPublishing = $framework->workflows()->workflows('blog_publishing');
-            // ... previous configuration
-
-            $blogPublishing->transition()
-                ->name('to_review')
-                    // the transition is allowed only if the current user has the ROLE_REVIEWER role.
-                    ->guard('is_granted("ROLE_REVIEWER")')
-                    ->from(['draft'])
-                    ->to(['reviewed']);
-
-            $blogPublishing->transition()
-                ->name('publish')
-                    // or "is_remember_me", "is_fully_authenticated", "is_granted"
-                    ->guard('is_authenticated')
-                    ->from(['reviewed'])
-                    ->to(['published']);
-
-            $blogPublishing->transition()
-                ->name('reject')
-                    // or any valid expression language with "subject" referring to the post
-                    ->guard('is_granted("ROLE_ADMIN") and subject.isStatusReviewed()')
-                    ->from(['reviewed'])
-                    ->to(['rejected']);
-        };
+        return App::config([
+            'framework' => [
+                'workflows' => [
+                    'blog_publishing' => [
+                        'transitions' => [
+                            'to_review' => [
+                                'guard' => 'is_granted("ROLE_REVIEWER")',
+                                'from' => ['draft'],
+                                'to' => ['reviewed'],
+                            ],
+                            'publish' => [
+                                // or "is_remember_me", "is_fully_authenticated", "is_granted"
+                                'guard' => 'is_authenticated',
+                                'from' => ['reviewed'],
+                                'to' => ['published'],
+                            ],
+                            'reject' => [
+                                // or any valid expression language with "subject" referring to the post
+                                'guard' => 'is_granted("ROLE_ADMIN") and subject.isStatusReviewed()',
+                                'from' => ['reviewed'],
+                                'to' => ['rejected'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 You can also use transition blockers to block and return a user-friendly error
 message when you stop a transition from happening.
@@ -1177,9 +1183,9 @@ place::
 
         public static function getSubscribedEvents(): array
         {
-            return [
+            return App::config([
                 'workflow.blog_publishing.guard.publish' => ['guardPublish'],
-            ];
+            ]);
         }
     }
 
@@ -1235,18 +1241,21 @@ it:
     .. code-block:: php
 
         // config/packages/workflow.php
-        use App\Workflow\MarkingStore\ReflectionMarkingStore;
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
+        use App\Workflow\MarkingStore\BlogPostMarkingStore;
 
-            $blogPublishing = $framework->workflows()->workflows('blog_publishing');
-            // ...
-
-            $blogPublishing->markingStore()
-                ->service(BlogPostMarkingStore::class);
-        };
+        return App::config([
+            'framework' => [
+                'workflows' => [
+                    'blog_publishing' => [
+                        'marking_store' => [
+                            'service' => BlogPostMarkingStore::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Usage in Twig
 -------------
@@ -1350,43 +1359,47 @@ be only the title of the workflow or very complex objects:
     .. code-block:: php
 
         // config/packages/workflow.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $blogPublishing = $framework->workflows()->workflows('blog_publishing');
-            // ... previous configuration
-
-            $blogPublishing->metadata([
-                'title' => 'Blog Publishing Workflow'
-            ]);
-
-            // ...
-
-            $blogPublishing->place()
-                ->name('draft')
-                ->metadata([
-                    'max_num_of_words' => 500,
-                ]);
-
-            // ...
-
-            $blogPublishing->transition()
-                ->name('to_review')
-                    ->from(['draft'])
-                    ->to(['reviewed'])
-                    ->metadata([
-                        'priority' => 0.5,
-                    ]);
-
-            $blogPublishing->transition()
-                ->name('publish')
-                    ->from(['reviewed'])
-                    ->to(['published'])
-                    ->metadata([
-                        'hour_limit' => 20,
-                        'explanation' => 'You can not publish after 8 PM.',
-                    ]);
-        };
+        return App::config([
+            'framework' => [
+                'workflows' => [
+                    'blog_publishing' => [
+                        // ... previous configuration
+                        'metadata' => [
+                            'title' => 'Blog Publishing Workflow'
+                        ],
+                        // ...
+                        'places' => [
+                            [
+                                'name' => 'draft',
+                                'metadata' => [
+                                    'max_num_of_words' => 500,
+                                ],
+                            ],
+                            // ...
+                        ],
+                        'transitions' => [
+                            'to_review' => [
+                                'from' => 'draft',
+                                'to' => 'reviewed',
+                                'metadata' => [
+                                    'priority' => 0.5,
+                                ],
+                            ],
+                            'publish' => [
+                                'from' => 'reviewed',
+                                'to' => 'published',
+                                'metadata' => [
+                                    'hour_limit' => 20,
+                                    'explanation' => 'You can not publish after 8 PM.',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 Then you can access this metadata in your controller as follows::
 
@@ -1521,18 +1534,22 @@ After implementing your validator, configure your workflow to use it:
     .. code-block:: php
 
         // config/packages/workflow.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $blogPublishing = $framework->workflows()->workflows('blog_publishing');
-            // ...
+        use App\Workflow\Validator\BlogPublishingValidator;
 
-            $blogPublishing->definitionValidators([
-                App\Workflow\Validator\BlogPublishingValidator::class
-            ]);
-
-            // ...
-        };
+        return App::config([
+            'framework' => [
+                'workflows' => [
+                    'blog_publishing' => [
+                        // ...
+                        'definition_validators' => [
+                            BlogPublishingValidator::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 The ``BlogPublishingValidator`` will be executed during container compilation
 to validate the workflow definition.

--- a/workflow/dumping-workflows.rst
+++ b/workflow/dumping-workflows.rst
@@ -164,70 +164,78 @@ Below is the configuration for the pull request state machine with styling added
     .. code-block:: php
 
         // config/packages/workflow.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            // ...
-            $pullRequest = $framework->workflows()->workflows('pull_request');
-
-            $pullRequest
-                ->type('state_machine')
-                ->supports(['App\Entity\PullRequest'])
-                ->initialMarking(['start']);
-
-            $pullRequest->markingStore()
-                ->type('method')
-                ->property('currentPlace');
-
-            $pullRequest->place()->name('start');
-            $pullRequest->place()->name('coding');
-            $pullRequest->place()->name('test');
-            $pullRequest->place()
-                ->name('review')
-                ->metadata(['description' => 'Human review']);
-            $pullRequest->place()->name('merged');
-            $pullRequest->place()
-                ->name('closed')
-                ->metadata(['bg_color' => 'DeepSkyBlue',]);
-
-            $pullRequest->transition()
-                ->name('submit')
-                    ->from(['start'])
-                    ->to(['test']);
-
-            $pullRequest->transition()
-                ->name('update')
-                    ->from(['coding', 'test', 'review'])
-                    ->to(['test'])
-                    ->metadata(['arrow_color' => 'Turquoise']);
-
-            $pullRequest->transition()
-                ->name('wait_for_review')
-                    ->from(['test'])
-                    ->to(['review'])
-                    ->metadata(['color' => 'Orange']);
-
-            $pullRequest->transition()
-                ->name('request_change')
-                    ->from(['review'])
-                    ->to(['coding']);
-
-            $pullRequest->transition()
-                ->name('accept')
-                    ->from(['review'])
-                    ->to(['merged'])
-                    ->metadata(['label' => 'Accept PR']);
-
-            $pullRequest->transition()
-                ->name('reject')
-                    ->from(['review'])
-                    ->to(['closed']);
-
-            $pullRequest->transition()
-                ->name('accept')
-                    ->from(['closed'])
-                    ->to(['review']);
-        };
+        return App::config([
+            'framework' => [
+                'workflows' => [
+                    'pull_request' => [
+                        'type' => 'state_machine',
+                        'marking_store' => [
+                            'type' => 'method',
+                            'property' => 'currentPlace',
+                        ],
+                        'supports' => ['App\Entity\PullRequest'],
+                        'initial_marking' => 'start',
+                        'places' => [
+                            'start',
+                            'coding',
+                            'test',
+                            'review' => [
+                                'metadata' => [
+                                    'description' => 'Human review',
+                                ],
+                            ],
+                            'merged',
+                            'closed' => [
+                                'metadata' => [
+                                    'bg_color' => 'DeepSkyBlue',
+                                ],
+                            ],
+                        ],
+                        'transitions' => [
+                            'submit' => [
+                                'from' => 'start',
+                                'to' => 'test',
+                            ],
+                            'update' => [
+                                'from' => ['coding', 'test', 'review'],
+                                'to' => 'test',
+                                'metadata' => [
+                                    'arrow_color' => 'Turquoise',
+                                ],
+                            ],
+                            'wait_for_review' => [
+                                'from' => 'test',
+                                'to' => 'review',
+                                'metadata' => [
+                                    'color' => 'Orange',
+                                ],
+                            ],
+                            'request_change' => [
+                                'from' => 'review',
+                                'to' => 'coding',
+                            ],
+                            'accept' => [
+                                'from' => 'review',
+                                'to' => 'merged',
+                                'metadata' => [
+                                    'label' => 'Accept PR',
+                                ],
+                            ],
+                            'reject' => [
+                                'from' => 'review',
+                                'to' => 'closed',
+                            ],
+                            'reopen' => [
+                                'from' => 'closed',
+                                'to' => 'review',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 The PlantUML image will look like this:
 

--- a/workflow/workflow-and-state-machine.rst
+++ b/workflow/workflow-and-state-machine.rst
@@ -118,63 +118,62 @@ Below is the configuration for the pull request state machine.
     .. code-block:: php
 
         // config/packages/workflow.php
-        use Symfony\Config\FrameworkConfig;
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return static function (FrameworkConfig $framework): void {
-            $pullRequest = $framework->workflows()->workflow('pull_request');
-
-            $pullRequest
-                ->type('state_machine')
-                // The "supports" option is useful only if you are using Twig functions ('workflow_*')
-                ->supports(['App\Entity\PullRequest'])
-                ->initialMarking(['start']);
-
-            $pullRequest->markingStore()
-                ->type('method')
-                ->property('currentPlace');
-
-            $pullRequest->place()->name('start');
-            $pullRequest->place()->name('coding');
-            $pullRequest->place()->name('test');
-            $pullRequest->place()->name('review');
-            $pullRequest->place()->name('merged');
-            $pullRequest->place()->name('closed');
-
-            $pullRequest->transition()
-                ->name('submit')
-                    ->from(['start'])
-                    ->to(['test']);
-
-            $pullRequest->transition()
-                ->name('update')
-                    ->from(['coding', 'test', 'review'])
-                    ->to(['test']);
-
-            $pullRequest->transition()
-                ->name('wait_for_review')
-                    ->from(['test'])
-                    ->to(['review']);
-
-            $pullRequest->transition()
-                ->name('request_change')
-                    ->from(['review'])
-                    ->to(['coding']);
-
-            $pullRequest->transition()
-                ->name('accept')
-                    ->from(['review'])
-                    ->to(['merged']);
-
-            $pullRequest->transition()
-                ->name('reject')
-                    ->from(['review'])
-                    ->to(['closed']);
-
-            $pullRequest->transition()
-                ->name('reopen')
-                    ->from(['closed'])
-                    ->to(['review']);
-        };
+        return App::config([
+            'framework' => [
+                'workflows' => [
+                    'pull_request' => [
+                        'type' => 'state_machine',
+                        'marking_store' => [
+                            'type' => 'method',
+                            'property' => 'currentPlace',
+                        ],
+                        // The "supports" option is useful only if you are using Twig functions ('workflow_*')
+                        'supports' => ['App\Entity\PullRequest'],
+                        'initial_marking' => 'start',
+                        'places' => [
+                            'start',
+                            'coding',
+                            'test',
+                            'review',
+                            'merged',
+                            'closed',
+                        ],
+                        'transitions' => [
+                            'submit' => [
+                                'from' => 'start',
+                                'to' => 'test',
+                            ],
+                            'update' => [
+                                'from' => ['coding', 'test', 'review'],
+                                'to' => 'test',
+                            ],
+                            'wait_for_review' => [
+                                'from' => 'test',
+                                'to' => 'review',
+                            ],
+                            'request_change' => [
+                                'from' => 'review',
+                                'to' => 'coding',
+                            ],
+                            'accept' => [
+                                'from' => 'review',
+                                'to' => 'merged',
+                            ],
+                            'reject' => [
+                                'from' => 'review',
+                                'to' => 'closed',
+                            ],
+                            'reopen' => [
+                                'from' => 'closed',
+                                'to' => 'review',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
 .. tip::
 


### PR DESCRIPTION
Related to ~https://github.com/symfony/symfony/pull/62092~ https://github.com/symfony/symfony/pull/62129 and https://symfony.com/blog/new-in-symfony-7-4-deprecated-xml-configuration

The diff itself isn't really interesting. What's interesting is comparing yaml to php arrays.

This can give a nice overview of the new format.
