### PR TITLE
[Validator] Deprecate implicit constraint option names in YAML/XML mapping files

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -513,7 +513,8 @@ object.
                     - NotBlank: ~
                 dueDate:
                     - NotBlank: ~
-                    - Type: \DateTimeInterface
+                    - Type:
+                        type: \DateTimeInterface
 
     .. code-block:: xml
 
@@ -530,7 +531,9 @@ object.
                 </property>
                 <property name="dueDate">
                     <constraint name="NotBlank"/>
-                    <constraint name="Type">\DateTimeInterface</constraint>
+                    <constraint name="Type">
+                        <option name="type">\DateTimeInterface</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/All.rst
+++ b/reference/constraints/All.rst
@@ -41,9 +41,10 @@ entry in that array:
             properties:
                 favoriteColors:
                     - All:
-                        - NotBlank:  ~
-                        - Length:
-                            min: 5
+                        constraints:
+                            - NotBlank:  ~
+                            - Length:
+                                min: 5
 
     .. code-block:: xml
 

--- a/reference/constraints/AtLeastOneOf.rst
+++ b/reference/constraints/AtLeastOneOf.rst
@@ -53,7 +53,8 @@ The following constraints ensure that:
             properties:
                 password:
                     - AtLeastOneOf:
-                        - Regex: '/#/'
+                        - Regex:
+                            pattern: '/#/'
                         - Length:
                             min: 10
                 grades:
@@ -61,7 +62,9 @@ The following constraints ensure that:
                         - Count:
                             min: 3
                         - All:
-                            - GreaterThanOrEqual: 5
+                            constraints:
+                                - GreaterThanOrEqual:
+                                    value: 5
 
     .. code-block:: xml
 
@@ -93,7 +96,7 @@ The following constraints ensure that:
                             <constraint name="All">
                                 <option name="constraints">
                                     <constraint name="GreaterThanOrEqual">
-                                        5
+                                        <option name="value">5</option>
                                     </constraint>
                                 </option>
                             </constraint>

--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -50,7 +50,8 @@ Configuration
         # config/validator/validation.yaml
         App\Entity\Author:
             constraints:
-                - Callback: validate
+                - Callback:
+                    callback: validate
 
     .. code-block:: xml
 
@@ -61,7 +62,9 @@ Configuration
             xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
 
             <class name="App\Entity\Author">
-                <constraint name="Callback">validate</constraint>
+                <constraint name="Callback">
+                    <option name="callback">validate</option>
+                </constraint>
             </class>
         </constraint-mapping>
 
@@ -177,7 +180,8 @@ You can then use the following configuration to invoke this validator:
         # config/validator/validation.yaml
         App\Entity\Author:
             constraints:
-                - Callback: [Acme\Validator, validate]
+                - Callback:
+                    callback: [Acme\Validator, validate]
 
     .. code-block:: xml
 
@@ -189,8 +193,10 @@ You can then use the following configuration to invoke this validator:
 
             <class name="App\Entity\Author">
                 <constraint name="Callback">
-                    <value>Acme\Validator</value>
-                    <value>validate</value>
+                    <option name="callback">
+                        <value>Acme\Validator</value>
+                        <value>validate</value>
+                    </option>
                 </constraint>
             </class>
         </constraint-mapping>

--- a/reference/constraints/Charset.rst
+++ b/reference/constraints/Charset.rst
@@ -41,7 +41,8 @@ class uses UTF-8, you could do the following:
         App\Entity\FileDTO:
             properties:
                 content:
-                    - Charset: 'UTF-8'
+                    - Charset:
+                        charset: 'UTF-8'
 
     .. code-block:: xml
 

--- a/reference/constraints/DivisibleBy.rst
+++ b/reference/constraints/DivisibleBy.rst
@@ -49,7 +49,8 @@ The following constraints ensure that:
         App\Entity\Item:
             properties:
                 weight:
-                    - DivisibleBy: 0.25
+                    - DivisibleBy:
+                        value: 0.25
                 quantity:
                     - DivisibleBy:
                         value: 5
@@ -65,7 +66,7 @@ The following constraints ensure that:
             <class name="App\Entity\Item">
                 <property name="weight">
                     <constraint name="DivisibleBy">
-                        <value>0.25</value>
+                        <option name="value">0.25</option>
                     </constraint>
                 </property>
                 <property name="quantity">

--- a/reference/constraints/EqualTo.rst
+++ b/reference/constraints/EqualTo.rst
@@ -48,7 +48,8 @@ and that the ``age`` is ``20``, you could do the following:
         App\Entity\Person:
             properties:
                 firstName:
-                    - EqualTo: Mary
+                    - EqualTo:
+                        value: Mary
                 age:
                     - EqualTo:
                         value: 20
@@ -64,7 +65,7 @@ and that the ``age`` is ``20``, you could do the following:
             <class name="App\Entity\Person">
                 <property name="firstName">
                     <constraint name="EqualTo">
-                        Mary
+                        <option name="value">Mary</option>
                     </constraint>
                 </property>
                 <property name="age">

--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -46,7 +46,8 @@ The following constraints ensure that:
         App\Entity\Person:
             properties:
                 siblings:
-                    - GreaterThan: 5
+                    - GreaterThan:
+                        value: 5
                 age:
                     - GreaterThan:
                         value: 18
@@ -62,7 +63,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
                 <property name="siblings">
                     <constraint name="GreaterThan">
-                        5
+                        <option name="value">5</option>
                     </constraint>
                 </property>
                 <property name="age">
@@ -182,7 +183,8 @@ dates. If you want to fix the timezone, append it to the date string:
         App\Entity\Order:
             properties:
                 deliveryDate:
-                    - GreaterThan: today UTC
+                    - GreaterThan:
+                        value: today UTC
 
     .. code-block:: xml
 
@@ -194,7 +196,9 @@ dates. If you want to fix the timezone, append it to the date string:
 
             <class name="App\Entity\Order">
                 <property name="deliveryDate">
-                    <constraint name="GreaterThan">today UTC</constraint>
+                    <constraint name="GreaterThan">
+                        <option name="value">today UTC</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>
@@ -242,7 +246,8 @@ current time:
         App\Entity\Order:
             properties:
                 deliveryDate:
-                    - GreaterThan: +5 hours
+                    - GreaterThan:
+                        value: +5 hours
 
     .. code-block:: xml
 
@@ -254,7 +259,9 @@ current time:
 
             <class name="App\Entity\Order">
                 <property name="deliveryDate">
-                    <constraint name="GreaterThan">+5 hours</constraint>
+                    <constraint name="GreaterThan">
+                        <option name="value">+5 hours</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -45,7 +45,8 @@ The following constraints ensure that:
         App\Entity\Person:
             properties:
                 siblings:
-                    - GreaterThanOrEqual: 5
+                    - GreaterThanOrEqual:
+                        value: 5
                 age:
                     - GreaterThanOrEqual:
                         value: 18
@@ -61,7 +62,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
                 <property name="siblings">
                     <constraint name="GreaterThanOrEqual">
-                        5
+                        <option name="value">5</option>
                     </constraint>
                 </property>
                 <property name="age">
@@ -122,7 +123,8 @@ that a date must at least be the current day:
         App\Entity\Order:
             properties:
                 deliveryDate:
-                    - GreaterThanOrEqual: today
+                    - GreaterThanOrEqual:
+                        value: today
 
     .. code-block:: xml
 
@@ -134,7 +136,9 @@ that a date must at least be the current day:
 
             <class name="App\Entity\Order">
                 <property name="deliveryDate">
-                    <constraint name="GreaterThanOrEqual">today</constraint>
+                    <constraint name="GreaterThanOrEqual">
+                        <option name="value">today</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>
@@ -181,7 +185,8 @@ dates. If you want to fix the timezone, append it to the date string:
         App\Entity\Order:
             properties:
                 deliveryDate:
-                    - GreaterThanOrEqual: today UTC
+                    - GreaterThanOrEqual:
+                        value: today UTC
 
     .. code-block:: xml
 
@@ -193,7 +198,9 @@ dates. If you want to fix the timezone, append it to the date string:
 
             <class name="App\Entity\Order">
                 <property name="deliveryDate">
-                    <constraint name="GreaterThanOrEqual">today UTC</constraint>
+                    <constraint name="GreaterThanOrEqual">
+                        <option name="value">today UTC</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>
@@ -241,7 +248,8 @@ current time:
         App\Entity\Order:
             properties:
                 deliveryDate:
-                    - GreaterThanOrEqual: +5 hours
+                    - GreaterThanOrEqual:
+                        value: +5 hours
 
     .. code-block:: xml
 
@@ -253,7 +261,9 @@ current time:
 
             <class name="App\Entity\Order">
                 <property name="deliveryDate">
-                    <constraint name="GreaterThanOrEqual">+5 hours</constraint>
+                    <constraint name="GreaterThanOrEqual">
+                        <option name="value">+5 hours</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/IdenticalTo.rst
+++ b/reference/constraints/IdenticalTo.rst
@@ -51,7 +51,8 @@ The following constraints ensure that:
         App\Entity\Person:
             properties:
                 firstName:
-                    - IdenticalTo: Mary
+                    - IdenticalTo:
+                        value: Mary
                 age:
                     - IdenticalTo:
                         value: 20
@@ -67,7 +68,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
                 <property name="firstName">
                     <constraint name="IdenticalTo">
-                        Mary
+                        <option name="value">Mary</option>
                     </constraint>
                 </property>
                 <property name="age">

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -46,7 +46,8 @@ The following constraints ensure that:
         App\Entity\Person:
             properties:
                 siblings:
-                    - LessThan: 5
+                    - LessThan:
+                        value: 5
                 age:
                     - LessThan:
                         value: 80
@@ -62,7 +63,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
                 <property name="siblings">
                     <constraint name="LessThan">
-                        5
+                        <option name="value">5</option>
                     </constraint>
                 </property>
                 <property name="age">
@@ -123,7 +124,8 @@ that a date must be in the past like this:
         App\Entity\Person:
             properties:
                 dateOfBirth:
-                    - LessThan: today
+                    - LessThan:
+                        value: today
 
     .. code-block:: xml
 
@@ -135,7 +137,9 @@ that a date must be in the past like this:
 
             <class name="App\Entity\Person">
                 <property name="dateOfBirth">
-                    <constraint name="LessThan">today</constraint>
+                    <constraint name="LessThanOrEqual">
+                        <option name="value">today</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>
@@ -182,7 +186,8 @@ dates. If you want to fix the timezone, append it to the date string:
         App\Entity\Person:
             properties:
                 dateOfBirth:
-                    - LessThan: today UTC
+                    - LessThan:
+                        value: today UTC
 
     .. code-block:: xml
 
@@ -194,7 +199,9 @@ dates. If you want to fix the timezone, append it to the date string:
 
             <class name="App\Entity\Person">
                 <property name="dateOfBirth">
-                    <constraint name="LessThan">today UTC</constraint>
+                    <constraint name="LessThanOrEqual">
+                        <option name="value">today UTC</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>
@@ -241,7 +248,8 @@ can check that a person must be at least 18 years old like this:
         App\Entity\Person:
             properties:
                 dateOfBirth:
-                    - LessThan: -18 years
+                    - LessThan:
+                        value: -18 years
 
     .. code-block:: xml
 
@@ -253,7 +261,9 @@ can check that a person must be at least 18 years old like this:
 
             <class name="App\Entity\Person">
                 <property name="dateOfBirth">
-                    <constraint name="LessThan">-18 years</constraint>
+                    <constraint name="LessThanOrEqual">
+                        <option name="value">-18 years</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -45,7 +45,8 @@ The following constraints ensure that:
         App\Entity\Person:
             properties:
                 siblings:
-                    - LessThanOrEqual: 5
+                    - LessThanOrEqual:
+                        value: 5
                 age:
                     - LessThanOrEqual:
                         value: 80
@@ -61,7 +62,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
                 <property name="siblings">
                     <constraint name="LessThanOrEqual">
-                        5
+                        <option name="value">5</option>
                     </constraint>
                 </property>
                 <property name="age">
@@ -122,7 +123,8 @@ that a date must be today or in the past like this:
         App\Entity\Person:
             properties:
                 dateOfBirth:
-                    - LessThanOrEqual: today
+                    - LessThanOrEqual:
+                        value: today
 
     .. code-block:: xml
 
@@ -134,7 +136,9 @@ that a date must be today or in the past like this:
 
             <class name="App\Entity\Person">
                 <property name="dateOfBirth">
-                    <constraint name="LessThanOrEqual">today</constraint>
+                    <constraint name="LessThanOrEqual">
+                        <option name="value">today</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>
@@ -181,7 +185,8 @@ dates. If you want to fix the timezone, append it to the date string:
         App\Entity\Person:
             properties:
                 dateOfBirth:
-                    - LessThanOrEqual: today UTC
+                    - LessThanOrEqual:
+                        value: today UTC
 
     .. code-block:: xml
 
@@ -193,7 +198,9 @@ dates. If you want to fix the timezone, append it to the date string:
 
             <class name="App\Entity\Person">
                 <property name="dateOfBirth">
-                    <constraint name="LessThanOrEqual">today UTC</constraint>
+                    <constraint name="LessThanOrEqual">
+                        <option name="value">today UTC</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>
@@ -240,7 +247,8 @@ can check that a person must be at least 18 years old like this:
         App\Entity\Person:
             properties:
                 dateOfBirth:
-                    - LessThanOrEqual: -18 years
+                    - LessThanOrEqual:
+                        value: -18 years
 
     .. code-block:: xml
 
@@ -252,7 +260,9 @@ can check that a person must be at least 18 years old like this:
 
             <class name="App\Entity\Person">
                 <property name="dateOfBirth">
-                    <constraint name="LessThanOrEqual">-18 years</constraint>
+                    <constraint name="LessThanOrEqual">
+                        <option name="value">-18 years</option>
+                    </constraint>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/Negative.rst
+++ b/reference/constraints/Negative.rst
@@ -50,7 +50,7 @@ The following constraint ensures that the ``withdraw`` of a  bank account
 
             <class name="App\Entity\TransferItem">
                 <property name="withdraw">
-                    <constraint name="Negative"></constraint>
+                    <constraint name="Negative"/>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/NegativeOrZero.rst
+++ b/reference/constraints/NegativeOrZero.rst
@@ -49,7 +49,7 @@ is a negative number or equal to zero:
 
             <class name="App\Entity\UnderGroundGarage">
                 <property name="level">
-                    <constraint name="NegativeOrZero"></constraint>
+                    <constraint name="NegativeOrZero"/>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/NotCompromisedPassword.rst
+++ b/reference/constraints/NotCompromisedPassword.rst
@@ -49,7 +49,7 @@ The following constraint ensures that the ``rawPassword`` property of the
 
             <class name="App\Entity\User">
                 <property name="rawPassword">
-                    <constraint name="NotCompromisedPassword"></constraint>
+                    <constraint name="NotCompromisedPassword"/>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/NotEqualTo.rst
+++ b/reference/constraints/NotEqualTo.rst
@@ -50,7 +50,8 @@ the following:
         App\Entity\Person:
             properties:
                 firstName:
-                    - NotEqualTo: Mary
+                    - NotEqualTo:
+                        value: Mary
                 age:
                     - NotEqualTo:
                         value: 15
@@ -66,7 +67,7 @@ the following:
             <class name="App\Entity\Person">
                 <property name="firstName">
                     <constraint name="NotEqualTo">
-                        Mary
+                        <option name="value">Mary</option>
                     </constraint>
                 </property>
                 <property name="age">

--- a/reference/constraints/NotIdenticalTo.rst
+++ b/reference/constraints/NotIdenticalTo.rst
@@ -51,7 +51,8 @@ The following constraints ensure that:
         App\Entity\Person:
             properties:
                 firstName:
-                    - NotIdenticalTo: Mary
+                    - NotIdenticalTo:
+                        value: Mary
                 age:
                     - NotIdenticalTo:
                         value: 15
@@ -67,7 +68,7 @@ The following constraints ensure that:
             <class name="App\Entity\Person">
             <property name="firstName">
                     <constraint name="NotIdenticalTo">
-                        Mary
+                        <option name="value">Mary</option>
                     </constraint>
                 </property>
                 <property name="age">

--- a/reference/constraints/PasswordStrength.rst
+++ b/reference/constraints/PasswordStrength.rst
@@ -53,7 +53,7 @@ By default, the minimum required score is ``2``.
 
             <class name="App\Entity\User">
                 <property name="rawPassword">
-                    <constraint name="PasswordStrength"></constraint>
+                    <constraint name="PasswordStrength"/>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/Positive.rst
+++ b/reference/constraints/Positive.rst
@@ -50,7 +50,7 @@ positive number (greater than zero):
 
             <class name="App\Entity\Employee">
                 <property name="income">
-                    <constraint name="Positive"></constraint>
+                    <constraint name="Positive"/>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/PositiveOrZero.rst
+++ b/reference/constraints/PositiveOrZero.rst
@@ -49,7 +49,7 @@ is positive or zero:
 
             <class name="App\Entity\Person">
                 <property name="siblings">
-                    <constraint name="PositiveOrZero"></constraint>
+                    <constraint name="PositiveOrZero"/>
                 </property>
             </class>
         </constraint-mapping>

--- a/reference/constraints/Regex.rst
+++ b/reference/constraints/Regex.rst
@@ -38,7 +38,8 @@ more word characters at the beginning of your string:
         App\Entity\Author:
             properties:
                 description:
-                    - Regex: '/^\w+/'
+                    - Regex:
+                        pattern: '/^\w+/'
 
     .. code-block:: xml
 

--- a/reference/constraints/Sequentially.rst
+++ b/reference/constraints/Sequentially.rst
@@ -64,9 +64,11 @@ You can validate each of these constraints sequentially to solve these issues:
                 address:
                     - Sequentially:
                         - NotNull: ~
-                        - Type: string
+                        - Type:
+                            value: string
                         - Length: { min: 10 }
-                        - Regex: !php/const App\Localization\Place::ADDRESS_REGEX
+                        - Regex:
+                            pattern: !php/const App\Localization\Place::ADDRESS_REGEX
                         - App\Validator\Constraints\Geolocalizable: ~
 
     .. code-block:: xml
@@ -81,7 +83,9 @@ You can validate each of these constraints sequentially to solve these issues:
                 <property name="address">
                     <constraint name="Sequentially">
                             <constraint name="NotNull"/>
-                            <constraint name="Type">string</constraint>
+                            <constraint name="Type">
+                                <option name="type">string</option>
+                            </constraint>
                             <constraint name="Length">
                                 <option name="min">10</option>
                             </constraint>

--- a/reference/constraints/Traverse.rst
+++ b/reference/constraints/Traverse.rst
@@ -167,7 +167,8 @@ disable validating:
         # config/validator/validation.yaml
         App\Entity\BookCollection:
             constraints:
-                - Traverse: false
+                - Traverse:
+                    traverse: false
 
     .. code-block:: xml
 
@@ -178,7 +179,9 @@ disable validating:
             xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
 
             <class name="App\Entity\BookCollection">
-                <constraint name="Traverse">false</constraint>
+                <constraint name="Traverse">
+                    <option name="traverse">false</option>
+                </constraint>
             </class>
         </constraint-mapping>
 

--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -58,10 +58,12 @@ The following example checks if ``emailAddress`` is an instance of ``Symfony\Com
         App\Entity\Author:
             properties:
                 emailAddress:
-                    - Type: Symfony\Component\Mime\Address
+                    - Type:
+                        type: Symfony\Component\Mime\Address
 
                 firstName:
-                    - Type: string
+                    - Type:
+                        type: string
 
                 age:
                     - Type:

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -56,7 +56,8 @@ between all of the rows in your user table:
         # config/validator/validation.yaml
         App\Entity\User:
             constraints:
-                - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity: email
+                - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
+                    fields: email
             properties:
                 email:
                     - Email: ~

--- a/reference/constraints/When.rst
+++ b/reference/constraints/When.rst
@@ -85,7 +85,8 @@ One way to accomplish this is with the When constraint:
         App\Model\Discount:
             properties:
                 value:
-                    - GreaterThan: 0
+                    - GreaterThan:
+                        value: 0
                     - When:
                         expression: "this.getType() == 'percent'"
                         constraints:
@@ -106,7 +107,9 @@ One way to accomplish this is with the When constraint:
             xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
             <class name="App\Model\Discount">
                 <property name="value">
-                    <constraint name="GreaterThan">0</constraint>
+                    <constraint name="GreaterThan">
+                        <option name="value">0</option>
+                    </constraint>
                     <constraint name="When">
                         <option name="expression">
                             this.getType() == 'percent'


### PR DESCRIPTION
Fix #21411

I updated xml and yaml examples to explicitly defined options names.

Do you think a deprecated section is needed ? If yes, where ?  