### PR TITLE
 Fix three obvious typos (no style changes)

### DIFF
--- a/components/console/helpers/processhelper.rst
+++ b/components/console/helpers/processhelper.rst
@@ -29,7 +29,7 @@ It will result in more detailed output with debug verbosity (e.g. ``-vvv``):
 In case the process fails, debugging is easier:
 
 .. image:: /_images/components/console/process-helper-error-debug.png
-    :alt: The last line shows "RES 127 Command dit not run successfully", and the output lines show more the error information from the command.
+    :alt: The last line shows "RES 127 Command did not run successfully", and the output lines show more the error information from the command.
 
 .. note::
 

--- a/contributing/core_team.rst
+++ b/contributing/core_team.rst
@@ -291,7 +291,7 @@ The process follows these steps:
 
 .. code-block:: terminal
 
-    # 'origin' is refered to as the main upstream project
+    # 'origin' is referred to as the main upstream project
     $ git fetch origin
 
     # update the local branches

--- a/introduction/http_fundamentals.rst
+++ b/introduction/http_fundamentals.rst
@@ -20,7 +20,7 @@ to communicate with each other. For example, when checking for the latest
 .. raw:: html
 
     <object data="../_images/http/xkcd-full.svg" type="image/svg+xml"
-        alt="A sequence diagram showing the browser sending &quot;Can I see today's comic?&quot; to the xkcd server. The server prepares the page's HTML and sents it back to the browser."
+        alt="A sequence diagram showing the browser sending &quot;Can I see today's comic?&quot; to the xkcd server. The server prepares the page's HTML and sends it back to the browser."
     ></object>
 
 HTTP is the term used to describe this text-based language. The goal of


### PR DESCRIPTION
This PR fixes three clear typos only — no style/wording/formatting changes.

* `contributing/core_team.rst`: refered → referred
* `introduction/http_fundamentals.rst`: sents → sends (alt text)
* `components/console/helpers/processhelper.rst`: dit not → did not (alt text)

Only the misspelled tokens were changed.