### PR TITLE
 Fix typo in encoders.rst (Serveral → Several)

### DIFF
--- a/serializer/encoders.rst
+++ b/serializer/encoders.rst
@@ -59,7 +59,7 @@ All context options available for the JSON encoder are:
 The ``CsvEncoder``
 ------------------
 
-The ``CsvEncoder`` encodes to and decodes from CSV. Serveral :ref:`context options <serializer-context>`
+The ``CsvEncoder`` encodes to and decodes from CSV. Several :ref:`context options <serializer-context>`
 are available to customize the behavior of the encoder:
 
 ``csv_delimiter`` (default: ``,``)


### PR DESCRIPTION
This PR fixes a clear typo only — no style/wording/formatting changes.
- serializer/encoders.rst: Serveral → Several