### PR TITLE
 Fix “construtor” typos across docs (no style changes)

### DIFF
--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -219,7 +219,7 @@ service. Now you have two ways of injecting it in any service or controller:
 
 **(1) Use a specific argument name**
 
-Type-hint your construtor/method argument with ``HtmlSanitizerInterface`` and name
+Type-hint your constructor/method argument with ``HtmlSanitizerInterface`` and name
 the argument using this pattern: "HTML sanitizer name in camelCase". For example, to
 inject the ``app.post_sanitizer`` defined earlier, use an argument named ``$appPostSanitizer``::
 

--- a/lock.rst
+++ b/lock.rst
@@ -289,7 +289,7 @@ them in any service or controller:
 
 **(1) Use a specific argument name**
 
-Type-hint your construtor/method argument with ``LockFactory`` and name the
+Type-hint your constructor/method argument with ``LockFactory`` and name the
 argument using this pattern: "lock name in camelCase" + ``LockFactory`` suffix.
 For example, to inject the ``invoice`` package defined earlier::
 

--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -227,7 +227,7 @@ them in any service or controller:
 
 **(1) Use a specific argument name**
 
-Type-hint your construtor/method argument with ``RateLimiterFactory`` and name
+Type-hint your constructor/method argument with ``RateLimiterFactory`` and name
 the argument using this pattern: "rate limiter name in camelCase" + ``Limiter`` suffix.
 For example, to inject the ``anonymous_api`` limiter defined earlier, use an
 argument named ``$anonymousApiLimiter``::

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2554,7 +2554,7 @@ them in any service or controller:
 
 **(1) Use a specific argument name**
 
-Type-hint your construtor/method argument with ``PackageInterface`` and name
+Type-hint your constructor/method argument with ``PackageInterface`` and name
 the argument using this pattern: "asset package name in camelCase". For example,
 to inject the ``foo_package`` package defined earlier::
 

--- a/workflow.rst
+++ b/workflow.rst
@@ -332,7 +332,7 @@ injecting each workflow in any service or controller:
 
 **(1) Use a specific argument name**
 
-Type-hint your construtor/method argument with ``WorkflowInterface`` and name the
+Type-hint your constructor/method argument with ``WorkflowInterface`` and name the
 argument using this pattern: "workflow name in camelCase" + ``Workflow`` suffix.
 If it is a state machine type, use the ``StateMachine`` suffix.
 


### PR DESCRIPTION
This PR fixes all occurrences of “construtor” → “constructor”.
Token-only changes; no style/wording/formatting edits.

- html_sanitizer.rst
- lock.rst
- rate_limiter.rst
- reference/configuration/framework.rst
- workflow.rst