### PR TITLE
[Console][LockableTrait] Remove parent::__construct() from the example which shows how to inject your own LockFactory

### DIFF
--- a/console/lockable_trait.rst
+++ b/console/lockable_trait.rst
@@ -60,8 +60,6 @@ a ``$lockFactory`` property with your own lock factory::
         public function __construct(LockFactory $lockFactory)
         {
             $this->lockFactory = $lockFactory;
-
-            parent::__construct();
         }
 
         // ...


### PR DESCRIPTION
In this PR https://github.com/symfony/symfony-docs/pull/21507/files , when pointing out that constructor property promotion should not be used when injecting `$lockFactory`, I also wrongly introduced a  `parent::__construct()` call. As in the current example attribute is used and the example command class is no longer extending `Symfony\Component\Console\Command\Command`,  the call to the constructor of the parent class is actually wrong.

I just wanted to fix this and to apologize for any inconvenience I caused with the back-and-forth related to this issue.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
