### PR TITLE
[Lock] fix(documentation): reorder service id on target attribute

### DIFF
--- a/lock.rst
+++ b/lock.rst
@@ -308,7 +308,7 @@ For example, to inject the ``invoice`` package defined earlier::
 
 When :ref:`dealing with multiple implementations of the same type <autowiring-multiple-implementations-same-type>`
 the ``#[Target]`` attribute helps you select which one to inject. Symfony creates
-a target called "asset package name" + ``.lock.factory`` suffix.
+a target called ``lock.`` + "asset package name" + ``.factory``.
 
 For example, to select the ``invoice`` lock defined earlier::
 
@@ -318,7 +318,7 @@ For example, to select the ``invoice`` lock defined earlier::
     class SomeService
     {
         public function __construct(
-            #[Target('invoice.lock.factory')] private LockFactory $lockFactory
+            #[Target('lock.invoice.factory')] private LockFactory $lockFactory
         ): void {
             // ...
         }


### PR DESCRIPTION
When I use the name of named configuration with suffix `.lock.factory`, the service was not found.

After a `debug:container LockFatory`, I see the service ID is `lock.xxx.factory`. `xxx` being the named configured lock wanted.

My version is 6.4, but I haven't checked whether this error is still present in the current version.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
