### PR TITLE
 Fix repository name for intl polyfills in the redirection map

### DIFF
--- a/_build/redirection_map
+++ b/_build/redirection_map
@@ -499,10 +499,10 @@
 /components/polyfill_apcu https://github.com/symfony/polyfill-apcu
 /components/polyfill_ctype https://github.com/symfony/polyfill-ctype
 /components/polyfill_iconv https://github.com/symfony/polyfill-iconv
-/components/polyfill_intl_grapheme https://github.com/symfony/polyfill_intl-grapheme
-/components/polyfill_intl_icu https://github.com/symfony/polyfill_intl-icu
-/components/polyfill_intl_idn https://github.com/symfony/polyfill_intl-idn
-/components/polyfill_intl_normalizer https://github.com/symfony/polyfill_intl-normalizer
+/components/polyfill_intl_grapheme https://github.com/symfony/polyfill-intl-grapheme
+/components/polyfill_intl_icu https://github.com/symfony/polyfill-intl-icu
+/components/polyfill_intl_idn https://github.com/symfony/polyfill-intl-idn
+/components/polyfill_intl_normalizer https://github.com/symfony/polyfill-intl-normalizer
 /components/polyfill_mbstring https://github.com/symfony/polyfill-mbstring
 /components/polyfill_php54 https://github.com/symfony/polyfill-php54
 /components/polyfill_php55 https://github.com/symfony/polyfill-php55


### PR DESCRIPTION
Apparently, polyfill packages will multiple `_` in their page URL were handled wrong when changing how they are documented.
