### PR TITLE
 Refactor password hashing method in security.rst

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -426,10 +426,7 @@ the database::
             $plaintextPassword = ...;
 
             // hash the password (based on the security.yaml config for the $user class)
-            $hashedPassword = $passwordHasher->hashPassword(
-                $user,
-                $plaintextPassword
-            );
+            $hashedPassword = $this->passwordHasher->hash($plaintextPassword);
             $user->setPassword($hashedPassword);
 
             // ...


### PR DESCRIPTION
Method "hashPassword" does not exist in Symfony\Component\PasswordHasher\PasswordHasherInterface in Symfony 7.3

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
