### PR TITLE
[Validator] Make public property requirement clearer for constraint options

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -266,7 +266,7 @@ You can use custom validators like the ones provided by Symfony itself:
             }
         }
 
-If your constraint contains options, then they should be public properties
+If your constraint contains options, then they must be public properties
 on the custom Constraint class you created earlier. These options can be
 configured like options on core Symfony constraints.
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
The current language seems to allow for non-public properties, but in practice this fails, because the corresponding property remains uninitialized after deserialization.

An accidental private option can also be a bit of a headscratcher to pin down, since it may occur only once it is run in a production environment (due to different cache configurations).