### PR TITLE
[Symfony CLI] Move "different TLD" block above

### DIFF
--- a/setup/symfony_cli.rst
+++ b/setup/symfony_cli.rst
@@ -335,6 +335,12 @@ You can also use wildcards:
 This allows accessing subdomains like ``https://api.my-app.wip`` or
 ``https://admin.my-app.wip``.
 
+.. tip::
+
+    If you prefer to use a different TLD, edit the ``~/.symfony5/proxy.json``
+    file (where ``~`` means the path to your user directory) and change the
+    value of the ``tld`` option from ``wip`` to any other TLD.
+
 When running console commands, set the ``https_proxy`` environment variable
 to make custom domains work:
 
@@ -353,12 +359,6 @@ to make custom domains work:
 
     Although environment variable names are typically uppercase, the ``https_proxy``
     variable `is treated differently`_ and must be written in lowercase.
-
-.. tip::
-
-    If you prefer to use a different TLD, edit the ``~/.symfony5/proxy.json``
-    file (where ``~`` means the path to your user directory) and change the
-    value of the ``tld`` option from ``wip`` to any other TLD.
 
 .. _symfony-server-docker:
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->

While reading the documentation, I find it weird that the blocks about `symfony proxy:url` and `https_proxy` env var were
between the two code blocks about defining a local domain and changing the TLD.