### PR TITLE
[RateLimiter] Fix wrong rate limiter name in PHP configuration example for Compound Rate Limiter

### DIFF
--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -678,7 +678,7 @@ You can configure multiple rate limiters to work together:
                 ;
 
             $framework->rateLimiter()
-                ->limiter('two_per_minute')
+                ->limiter('five_per_hour')
                     ->policy('fixed_window')
                     ->limit(5)
                     ->interval('1 hour')


### PR DESCRIPTION
This PR fix wrong rate limiter name in PHP configuration example for Compound Rate Limiter