### PR TITLE
 Correct escape type for HTML attribute example

### DIFF
--- a/frontend/server-data.rst
+++ b/frontend/server-data.rst
@@ -38,13 +38,13 @@ Fetch this in JavaScript:
         const user = JSON.parse(userRating.dataset.user);
 
 There is no size limit for the value of the ``data-*`` attributes, so you can
-store any content. In Twig, use the ``html_attr`` escaping strategy to avoid messing
+store any content. In Twig, use the ``html`` escaping strategy to avoid messing
 with HTML attributes. For example, if your ``User`` object has some ``getProfileData()``
 method that returns an array, you could do the following:
 
 .. code-block:: html+twig
 
-    <div data-user-profile="{{ app.user ? app.user.profileData|json_encode|e('html_attr') }}">
+    <div data-user-profile="{{ app.user ? app.user.profileData|json_encode|e('html') }}">
         <!-- ... -->
     </div>
 


### PR DESCRIPTION
From the [Twig documentation](https://twig.symfony.com/doc/3.x/filters/escape.html) the different html escapes are (emphasis mine):
- `html`: escapes a string for the HTML body context, or for **HTML attributes values inside quotes**.
- `html_attr`: escapes a string when used as an HTML attribute name, and also when used as the value of an **HTML attribute without quotes** (e.g. `data-attribute={{ some_value }}`).

The example code here is inside quotes:
```
<div data-user-profile="{{ app.user ? app.user.profileData|json_encode|e('html') }}">
    <!-- ... -->
</div>
```
so it seems better to recommend `html` as the escape strategy. It'd perhaps be better still to highlight this difference in the Symfony docs?