### PR TITLE
 Wrong callable in async cache computation example

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -869,7 +869,7 @@ First, create a service that will compute the item's value::
 
     class CacheComputation
     {
-        public function compute(ItemInterface $item): string
+        public static function compute(ItemInterface $item): string
         {
             $item->expiresAfter(5);
 


### PR DESCRIPTION
The function must be static or the callable needs the object instead of class name.