### PR TITLE
[HttpKernel] Update http_kernel.rst

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -580,6 +580,17 @@ at the moment the exception was thrown.
 
 .. _http-kernel-creating-listener:
 
+10) Resetting the state of request/response flow
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PHP is designed to be stateless, there are no shared resources across different
+requests. However, with some specific Runtime (ie FrankenPHP in worker mode), the
+kernel can handle multiple request/response, and so you need to take care of cleaning
+some services state to not leak memory if needed.
+
+To do so, your service must implement the :class:`Symfony\\Contracts\\Service\\ResetInterface`
+where you can reset the properties in the ``reset()`` method.
+
 Creating an Event Listener
 --------------------------
 


### PR DESCRIPTION
Hello, I would like to propose this PR more as an RFC

Frankenphp and its worker mode (via the runtime integrated into [symfony in v7.4](https://symfony.com/blog/new-in-symfony-7-4-dx-improvements-part-2#automatic-integration-of-frankenphp-worker-mode)), is integrated more inside the sf codebase

and so the request/response flow may need some tweak, more on the "web worker" side
actually its only on this page https://symfony.com/doc/current/messenger.html#stateless-worker that one can read of "resetinterface" that may be usefull on such mode

this PR text is taken/inspired from it, wdty?
