### PR TITLE
 Update references from Platform.sh to Upsun in documentation

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -736,7 +736,7 @@ To do so, define a parameter with the same name as the env var using this syntax
 
 .. tip::
 
-    Some hosts - like Platform.sh - offer easy `utilities to manage env vars`_
+    Some hosts - like Upsun - offer easy `utilities to manage env vars`_
     in production.
 
 .. note::

--- a/deployment.rst
+++ b/deployment.rst
@@ -61,7 +61,7 @@ Using Platforms as a Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Using a Platform as a Service (PaaS) can be a great way to deploy your Symfony
-app quickly. There are many PaaS, but we recommend `Platform.sh`_ as it
+app quickly. There are many PaaS, but we recommend `Upsun`_ as it
 provides a dedicated Symfony integration and helps fund the Symfony development.
 
 Using Build Scripts and other Tools
@@ -268,6 +268,6 @@ Learn More
 .. _`Symfony plugin`: https://github.com/capistrano/symfony/
 .. _`Deployer`: https://deployer.org/
 .. _`Git Tagging`: https://git-scm.com/book/en/v2/Git-Basics-Tagging
-.. _`Platform.sh`: https://symfony.com/cloud
+.. _`Upsun`: https://symfony.com/cloud
 .. _`Symfony CLI`: https://symfony.com/download
 .. _`symfony/apache-pack`: https://packagist.org/packages/symfony/apache-pack

--- a/setup/symfony_cli.rst
+++ b/setup/symfony_cli.rst
@@ -598,11 +598,11 @@ Symfony Cloud Integration
 -------------------------
 
 The Symfony CLI provides seamless integration with `Symfony Cloud`_ (powered by
-`Platform.sh`_):
+`Upsun`_):
 
 .. code-block:: terminal
 
-    # open Platform.sh web UI
+    # open Upsun web UI
     $ symfony cloud:web
 
     # deploy your project to production
@@ -647,8 +647,8 @@ variables are properly exposed:
 .. _`symfony.com/download`: https://symfony.com/download
 .. _`Docker`: https://en.wikipedia.org/wiki/Docker_(software)
 .. _`Symfony Cloud`: https://symfony.com/cloud/
-.. _`Platform.sh`: https://platform.sh/
-.. _`Symfony Cloud documentation`: https://docs.platform.sh/frameworks/symfony.html
+.. _`Upsun`: https://upsun.com/
+.. _`Symfony Cloud documentation`: https://docs.upsun.com/get-started/stacks/symfony/integration.html
 .. _`Proxy settings in Windows`: https://www.dummies.com/computers/operating-systems/windows-10/how-to-set-up-a-proxy-in-windows-10/
 .. _`Proxy settings in macOS`: https://support.apple.com/guide/mac-help/enter-proxy-server-settings-on-mac-mchlp2591/mac
 .. _`Proxy settings in Ubuntu`: https://help.ubuntu.com/stable/ubuntu-help/net-proxy.html.en


### PR DESCRIPTION
These changes reflect the Platform.sh name change to Upsun. Updated references and links.
