### PR TITLE
[Cache] Wrong callable in async cache computation example

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -888,11 +888,12 @@ First, create a service that will compute the item's value::
     // src/Cache/CacheComputation.php
     namespace App\Cache;
 
-    use Symfony\Contracts\Cache\ItemInterface;
+    use Psr\Cache\CacheItemInterface;
+    use Symfony\Contracts\Cache\CallbackInterface;
 
-    class CacheComputation
+    class CacheComputation implements CallbackInterface
     {
-        public function compute(ItemInterface $item): string
+        public function __invoke(CacheItemInterface $item, bool &$save): string
         {
             $item->expiresAfter(5);
 
@@ -916,10 +917,10 @@ In the following example, the value is requested from a controller::
     class CacheController extends AbstractController
     {
         #[Route('/cache', name: 'cache')]
-        public function index(CacheInterface $asyncCache): Response
+        public function index(CacheInterface $asyncCache, CacheComputation $cacheComputation): Response
         {
             // pass to the cache the service method that refreshes the item
-            $cachedValue = $asyncCache->get('my_value', [CacheComputation::class, 'compute'])
+            $cachedValue = $asyncCache->get('my_value', $cacheComputation)
 
             // ...
         }


### PR DESCRIPTION
Already mentioned in #21587, but now with fix in 6.4 Branch with a reversible service.

I've noticed the fix for closures in early-expiration callbacks: https://github.com/symfony/symfony/pull/62398 in 6.4 and 7.4 (RC2) which fixed my issue in the dev environment: https://github.com/symfony/symfony-docs/pull/21587#issuecomment-3563653410