### PR TITLE
[Serializer] Named serializer normalizers are no longer added to default

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -1717,8 +1717,6 @@ or :ref:`serializer.encoder <reference-dic-tags-serializer-encoder>` tags:
             # ...
 
             Symfony\Component\Serializer\Normalizer\CustomNormalizer:
-                # prevent this normalizer from being automatically added to the default serializer
-                autoconfigure: false
                 tags:
                     # add this normalizer only to a specific named serializer
                     - serializer.normalizer: { serializer: 'api_client1' }
@@ -1739,11 +1737,7 @@ or :ref:`serializer.encoder <reference-dic-tags-serializer-encoder>` tags:
             <services>
                 <!-- ... -->
 
-                <!-- prevent this normalizer from being automatically added to the default serializer -->
-                <service
-                    id="Symfony\Component\Serializer\Normalizer\CustomNormalizer"
-                    autoconfigure="false"
-                >
+                <service id="Symfony\Component\Serializer\Normalizer\CustomNormalizer">
                     <!-- add this normalizer only to a specific named serializer -->
                     <tag name="serializer.normalizer" serializer="api_client1"/>
 
@@ -1768,9 +1762,6 @@ or :ref:`serializer.encoder <reference-dic-tags-serializer-encoder>` tags:
             // ...
 
             $services->set(CustomNormalizer::class)
-                // prevent this normalizer from being automatically added to the default serializer
-                ->autoconfigure(false)
-
                 // add this normalizer only to a specific named serializer
                 ->tag('serializer.normalizer', ['serializer' => 'api_client1'])
                 // add this normalizer to several named serializers


### PR DESCRIPTION
It is no longer necessary to set `autoconfigure` to `false` since https://github.com/symfony/symfony/pull/61526.