### PR TITLE
[Serializer] Update versionadded directive for NumberNormalizer

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -1420,9 +1420,9 @@ normalizers (in order of priority):
     This normalizer converts between :phpclass:`BcMath\\Number` or :phpclass:`GMP` objects and
     strings or integers.
 
-.. versionadded:: 7.2
+.. versionadded:: 7.3
 
-    The ``NumberNormalizer`` was introduced in Symfony 7.2.
+    The ``NumberNormalizer`` was introduced in Symfony 7.3.
 
 :class:`Symfony\\Component\\Serializer\\Normalizer\\DataUriNormalizer`
     This normalizer converts between :phpclass:`SplFileInfo` objects and a


### PR DESCRIPTION
See the symfony/serializer changelog https://github.com/symfony/serializer/blob/7.3/CHANGELOG.md#73

```
7.3
....
Add NumberNormalizer to normalize BcMath\Number and GMP as string
```