### PR TITLE
 Remove -dev version from setup.rst in symfony 8

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -48,10 +48,10 @@ application:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ symfony new my_project_directory --version="8.0.x-dev" --webapp
+    $ symfony new my_project_directory --version="8.0.x" --webapp
 
     # run this if you are building a microservice, console application or API
-    $ symfony new my_project_directory --version="8.0.x-dev"
+    $ symfony new my_project_directory --version="8.0.x"
 
 The only difference between these two commands is the number of packages
 installed by default. The ``--webapp`` option installs extra packages to give
@@ -63,12 +63,12 @@ Symfony application using Composer:
 .. code-block:: terminal
 
     # run this if you are building a traditional web application
-    $ composer create-project symfony/skeleton:"8.0.x-dev" my_project_directory
+    $ composer create-project symfony/skeleton:"8.0.x" my_project_directory
     $ cd my_project_directory
     $ composer require webapp
 
     # run this if you are building a microservice, console application or API
-    $ composer create-project symfony/skeleton:"8.0.x-dev" my_project_directory
+    $ composer create-project symfony/skeleton:"8.0.x" my_project_directory
 
 No matter which command you run to create the Symfony application. All of them
 will create a new ``my_project_directory/`` directory, download some dependencies


### PR DESCRIPTION
Since version 8.0.0 has already been released, the -dev suffix can be removed from the version in the installation instructions.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
