### PR TITLE
 Update DOCtor-RST

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -67,6 +67,7 @@ rules:
     typo: ~
     unused_links: ~
     use_deprecated_directive_instead_of_versionadded: ~
+    use_double_backticks_for_inline_literals: ~
     use_named_constructor_without_new_keyword_rule: ~
     use_https_xsd_urls: ~
     valid_inline_highlighted_namespaces: ~

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
                     key: ${{ runner.os }}-doctor-rst-${{ steps.extract_base_branch.outputs.branch }}
 
             -   name: "Run DOCtor-RST"
-                uses: docker://oskarstark/doctor-rst:1.70.2
+                uses: docker://oskarstark/doctor-rst:1.72.0
                 with:
                     args: --short --error-format=github --cache-file=/github/workspace/.cache/doctor-rst.cache
 

--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -23,7 +23,7 @@ rest of the Symfony documentation:
 Example
 ~~~~~~~
 
-.. code-block:: text
+.. code-block:: rst
 
     Example
     =======

--- a/reference/constraints/Length.rst
+++ b/reference/constraints/Length.rst
@@ -181,7 +181,7 @@ Parameter               Description
 
 .. versionadded:: 6.3
 
-    The `{{ value_length }}` parameter was introduced in Symfony 6.3.
+    The ``{{ value_length }}`` parameter was introduced in Symfony 6.3.
 
 .. include:: /reference/constraints/_groups-option.rst.inc
 
@@ -215,7 +215,7 @@ Parameter               Description
 
 .. versionadded:: 6.3
 
-    The `{{ value_length }}` parameter was introduced in Symfony 6.3.
+    The ``{{ value_length }}`` parameter was introduced in Symfony 6.3.
 
 ``min``
 ~~~~~~~
@@ -251,7 +251,7 @@ Parameter               Description
 
 .. versionadded:: 6.3
 
-    The `{{ value_length }}` parameter was introduced in Symfony 6.3.
+    The ``{{ value_length }}`` parameter was introduced in Symfony 6.3.
 
 .. include:: /reference/constraints/_normalizer-option.rst.inc
 


### PR DESCRIPTION
Update DOCtor-RST and enable the new `use_double_backticks_for_inline_literals` rule to ensure proper inline literal markup in RST documentation.
