### PR TITLE
[Console] Fix wrong method name to add a command to an application

### DIFF
--- a/components/console.rst
+++ b/components/console.rst
@@ -48,11 +48,6 @@ Then, you can register the commands using
     // ...
     $application->addCommand(new GenerateAdminCommand());
 
-.. versionadded:: 7.4
-
-    The ``addCommand()`` method was introduced in Symfony 7.4. In earlier
-    versions, you had to use the ``add()`` method of the same class.
-
 You can also register inline commands and define their behavior thanks to the
 ``Command::setCode()`` method::
 


### PR DESCRIPTION
The method `add` of the class Application does not exist anymore in Symfony 8.0 !