### PR TITLE
[Console] Deprecate the add() method

### DIFF
--- a/components/console.rst
+++ b/components/console.rst
@@ -43,10 +43,15 @@ First, you need to create a PHP script to define the console application::
     $application->run();
 
 Then, you can register the commands using
-:method:`Symfony\\Component\\Console\\Application::add`::
+:method:`Symfony\\Component\\Console\\Application::addCommand`::
 
     // ...
-    $application->add(new GenerateAdminCommand());
+    $application->addCommand(new GenerateAdminCommand());
+
+.. versionadded:: 7.4
+
+    The ``addCommand()`` method was introduced in Symfony 7.4. In earlier
+    versions, you had to use the ``add()`` method of the same class.
 
 You can also register inline commands and define their behavior thanks to the
 ``Command::setCode()`` method::

--- a/components/console/single_command_tool.rst
+++ b/components/console/single_command_tool.rst
@@ -36,7 +36,7 @@ You can still register a command as usual::
     $application = new Application('echo', '1.0.0');
     $command = new DefaultCommand();
 
-    $application->add($command);
+    $application->addCommand($command);
 
     $application->setDefaultCommand($command->getName(), true);
     $application->run();


### PR DESCRIPTION
Related to #21602. It fixes the second part of https://github.com/symfony/symfony-docs/issues/21074#issuecomment-3568239620