### PR TITLE
[Mailer] Mention MJML as an alternative to Inky

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1163,6 +1163,11 @@ the entire email contents from Markdown to HTML:
 Inky Email Templating Language
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. tip::
+
+    Symfony recommends Inky, but you can also use `MJML`_, a more actively
+    maintained alternative for responsive email templates.
+
 Creating beautifully designed emails that work on every email client is so
 complex that there are HTML/CSS frameworks dedicated to that. One of the most
 popular frameworks is called `Inky`_. It defines a syntax based on some HTML-like
@@ -2012,3 +2017,4 @@ the :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\MailerAssertionsTrait`::
 .. _`S/MIME`: https://en.wikipedia.org/wiki/S/MIME
 .. _`Scaleway`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Scaleway/README.md
 .. _`SendGrid`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Sendgrid/README.md
+.. _`MJML`: https://github.com/mjmlio/mjml


### PR DESCRIPTION
This is an alternative to #21585. Inky is still the Symfony recommendation, so we cannot remove it yet. But, let's mention MJML as a valid alternative.