### PR TITLE
 improve value for `opcache.max_accelerated_files`

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -145,7 +145,7 @@ it's recommended to change these settings as follows:
     opcache.memory_consumption=256
 
     ; maximum number of files that can be stored in the cache
-    opcache.max_accelerated_files=20000
+    opcache.max_accelerated_files=32531
 
 .. _performance-dont-check-timestamps:
 


### PR DESCRIPTION
According to Paul Dragoonis' talk delivered at the SymfonyCon yesterday, using a non-prime number forces PHP to calculate the next one, adding a small overhead.
References:
* https://github.com/dragoonis/symfonycon-2025-scaling/blob/main/php.ini.md#php-opcache-ini-settings
* https://tideways.com/profiler/blog/fine-tune-your-opcache-configuration-to-avoid-caching-suprises

I'm not sure if we want to also add a note in Symfony doc to explain the reason