### PR TITLE
 Replace PHPDoc dataProvider with attribute syntax

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -403,13 +403,12 @@ checks that all application URLs load successfully::
     // tests/ApplicationAvailabilityFunctionalTest.php
     namespace App\Tests;
 
+    use PHPUnit\Framework\Attributes\DataProvider;
     use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-
+    
     class ApplicationAvailabilityFunctionalTest extends WebTestCase
     {
-        /**
-         * @dataProvider urlProvider
-         */
+        #[DataProvider('urlProvider')]
         public function testPageIsSuccessful($url): void
         {
             $client = self::createClient();
@@ -418,7 +417,7 @@ checks that all application URLs load successfully::
             $this->assertResponseIsSuccessful();
         }
 
-        public function urlProvider(): \Generator
+        public static function urlProvider(): \Generator
         {
             yield ['/'];
             yield ['/posts'];


### PR DESCRIPTION
The attribute syntax is supported in PHPUnit v10, v11, and v12.  It should be encouraged in Symfony 8.x, and maybe backport to Symfony 7.x?

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
