### PR TITLE
 Fix syntax errors/warnings in 6.4

### DIFF
--- a/components/index.rst
+++ b/components/index.rst
@@ -1,0 +1,9 @@
+The Components
+==============
+
+.. toctree::
+    :maxdepth: 1
+    :glob:
+
+    using_components
+    *

--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -675,20 +675,20 @@ Symfony provides the following env var processors:
 
         .. code-block:: php
 
-        // config/services.php
-        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+            // config/services.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            // ...
+            return function(ContainerConfigurator $container): void {
+                // ...
 
-            $services->set(SomeService::class)
-                ->arg('$host', '%env(string:key:host:url:DATABASE_URL)%')
-                ->arg('$port', '%env(int:key:port:url:DATABASE_URL)%')
-                ->arg('$username', '%env(string:key:user:url:DATABASE_URL)%')
-                ->arg('$password', '%env(string:key:pass:url:DATABASE_URL)%')
-                ->arg('$database_name', '%env(key:path:url:DATABASE_URL)%')
-            ;
-        };
+                $services->set(SomeService::class)
+                    ->arg('$host', '%env(string:key:host:url:DATABASE_URL)%')
+                    ->arg('$port', '%env(int:key:port:url:DATABASE_URL)%')
+                    ->arg('$username', '%env(string:key:user:url:DATABASE_URL)%')
+                    ->arg('$password', '%env(string:key:pass:url:DATABASE_URL)%')
+                    ->arg('$database_name', '%env(key:path:url:DATABASE_URL)%')
+                ;
+            };
 
     .. warning::
 
@@ -738,17 +738,17 @@ Symfony provides the following env var processors:
 
         .. code-block:: php
 
-        // config/services.php
-        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+            // config/services.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-        return function(ContainerConfigurator $container): void {
-            // ...
+            return function(ContainerConfigurator $container): void {
+                // ...
 
-            $services->set(SomeService::class)
-                ->arg('$serverVersion', '%env(string:key:serverVersion:query_string:DATABASE_URL)%')
-                ->arg('$charset', '%env(int:string:charset:query_string:DATABASE_URL)%')
-            ;
-        };
+                $services->set(SomeService::class)
+                    ->arg('$serverVersion', '%env(string:key:serverVersion:query_string:DATABASE_URL)%')
+                    ->arg('$charset', '%env(int:string:charset:query_string:DATABASE_URL)%')
+                ;
+            };
 
 ``env(enum:FooEnum:BAR)``
     Tries to convert an environment variable to an actual ``\BackedEnum`` value.

--- a/contributing/core_team.rst
+++ b/contributing/core_team.rst
@@ -231,7 +231,7 @@ following these rules:
 * **Feature**: For new features and deprecations; Pull requests must be merged
   in the development branch.
 * **Bug**: Only for bug fixes; We are very conservative when it comes to
-  merging older, but still maintained, branches. Read the :doc:`maintenance`
+  merging older, but still maintained, branches. Read the :doc:`/contributing/code/maintenance`
   document for more information.
 * **Minor**: For everything that does not change the code or when they don't
   need to be listed in the CHANGELOG files: typos, Markdown files, test files,


### PR DESCRIPTION
Some syntax warnings found by the phpDocument parser that were introduced in the past year.

I'll see if I can maybe add a new CI job with the new parser, which is a lot more detailed about syntax mistakes. That'll help us prepare for the migration.