### PR TITLE
 Fix syntax errors/warnings in 7.3

### DIFF
--- a/emoji.rst
+++ b/emoji.rst
@@ -9,8 +9,6 @@ Symfony provides several utilities to work with emoji characters and sequences
 from the `Unicode CLDR dataset`_. They are available via the Emoji component,
 which you must first install in your application:
 
-.. _installation:
-
 .. code-block:: terminal
 
     $ composer require symfony/emoji

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1109,7 +1109,7 @@ exceptions
 
 **type**: ``array``
 
-Defines the :ref:`log level </logging>`, :ref:`log channel </logging/channels_handlers>`
+Defines the :ref:`log level </logging>`, :doc:`log channel </logging/channels_handlers>`
 and HTTP status code applied to the exceptions that match the given exception class:
 
 .. configuration-block::

--- a/string.rst
+++ b/string.rst
@@ -5,8 +5,6 @@ Symfony provides an object-oriented API to work with Unicode strings (as bytes,
 code points and grapheme clusters). This API is available via the String component,
 which you must first install in your application:
 
-.. _installation:
-
 .. code-block:: terminal
 
     $ composer require symfony/string


### PR DESCRIPTION
Like #21614, but for things introduced in 7.3.