### PR TITLE
[DependencyInjection] `#[AutoconfigureTag]` can be used without tag name

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -131,6 +131,16 @@ base class or interface::
         // ...
     }
 
+When no tag name is specified, the fully qualified class name (FQCN) of the target is used::
+
+    // src/Security/CustomInterface.php
+
+    #[AutoconfigureTag] // equivalent to #[AutoconfigureTag(self::class)]
+    interface CustomInterface
+    {
+        // ...
+    }
+
 .. tip::
 
     If you need more capabilities to autoconfigure instances of your base class


### PR DESCRIPTION
This was never documented, but when the tag name in `#[AutoconfigureTag]` is not specified, the fully qualified class name of the target is automatically used.