### PR TITLE
[Security] Fix incorrect checkPostAuth() signature in UserChecker documentation

### DIFF
--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -42,7 +42,7 @@ displayed to the user::
             }
         }
 
-        public function checkPostAuth(UserInterface $user, TokenInterface $token): void
+        public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
         {
             if (!$user instanceof AppUser) {
                 return;


### PR DESCRIPTION
The documentation for `UserChecker::checkPostAuth()` currently shows the following signature:

`public function checkPostAuth(UserInterface $user, TokenInterface $token): void`

This is incorrect for Symfony 7.3, where the $token argument is:
- nullable
- optional

and handled internally via func_get_arg() for backward compatibility

The correct signature for 7.3 should be:

`public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void`