### PR TITLE
 Change `opcache.max_accelerated_files` to 32531

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -144,8 +144,8 @@ it's recommended to change these settings as follows:
     ; maximum memory that OPcache can use to store compiled PHP files
     opcache.memory_consumption=256
 
-    ; maximum number of files that can be stored in the cache
-    opcache.max_accelerated_files=20000
+    ; maximum number of files that can be stored in the cache ( actually value used is equal or greater specific set of prime numbers )
+    opcache.max_accelerated_files=32531
 
 .. _performance-dont-check-timestamps:
 


### PR DESCRIPTION
Updated opcache.max_accelerated_files value and comment.

Described by @dragoonis in his SymfonyCon Talk in Amsterdam 2025: https://live.symfony.com/account/replay/video/1166

Also reference: https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.max-accelerated-files

So the set of prime numbers in the PHP documentation is:

```
{ 223, 463, 983, 1979, 3907, 7963, 16229, 32531, 65407, 130987, 262237, 524521, 1048793 }
```

So it will use with 20000 the value 32531.
