### PR TITLE
[Validator] Consistently use `Assert\...` when referring to assertions

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -474,11 +474,11 @@ invalid answer and will only be able to proceed if their input is valid.
     validate the input by using the :method:`Symfony\\Component\\Validator\\Validation::createCallable`
     method::
 
-        use Symfony\Component\Validator\Constraints\Regex;
+        use Symfony\Component\Validator\Constraints as Assert;
         use Symfony\Component\Validator\Validation;
 
         $question = new Question('Please enter the name of the bundle', 'AcmeDemoBundle');
-        $validation = Validation::createCallable(new Regex(
+        $validation = Validation::createCallable(new Assert\Regex(
             pattern: '/^[a-zA-Z]+Bundle$/',
             message: 'The name of the bundle should be suffixed with \'Bundle\'',
         ));

--- a/components/form.rst
+++ b/components/form.rst
@@ -685,8 +685,7 @@ option when building each field:
         use Symfony\Component\Form\Extension\Core\Type\DateType;
         use Symfony\Component\Form\Extension\Core\Type\TextType;
         use Symfony\Component\HttpFoundation\Response;
-        use Symfony\Component\Validator\Constraints\NotBlank;
-        use Symfony\Component\Validator\Constraints\Type;
+        use Symfony\Component\Validator\Constraints as Assert;
 
         class DefaultController extends AbstractController
         {
@@ -694,12 +693,12 @@ option when building each field:
             {
                 $form = $this->createFormBuilder()
                     ->add('task', TextType::class, [
-                        'constraints' => new NotBlank(),
+                        'constraints' => new Assert\NotBlank(),
                     ])
                     ->add('dueDate', DateType::class, [
                         'constraints' => [
-                            new NotBlank(),
-                            new Type(\DateTime::class),
+                            new Assert\NotBlank(),
+                            new Assert\Type(\DateTime::class),
                         ],
                     ])
                     ->getForm();
@@ -711,17 +710,16 @@ option when building each field:
 
         use Symfony\Component\Form\Extension\Core\Type\DateType;
         use Symfony\Component\Form\Extension\Core\Type\TextType;
-        use Symfony\Component\Validator\Constraints\NotBlank;
-        use Symfony\Component\Validator\Constraints\Type;
+        use Symfony\Component\Validator\Constraints as Assert;
 
         $form = $formFactory->createBuilder()
             ->add('task', TextType::class, [
-                'constraints' => new NotBlank(),
+                'constraints' => new Assert\NotBlank(),
             ])
             ->add('dueDate', DateType::class, [
                 'constraints' => [
-                    new NotBlank(),
-                    new Type(\DateTime::class),
+                    new Assert\NotBlank(),
+                    new Assert\Type(\DateTime::class),
                 ],
             ])
             ->getForm();

--- a/components/options_resolver.rst
+++ b/components/options_resolver.rst
@@ -389,12 +389,12 @@ returns ``true`` for acceptable values and ``false`` for invalid values::
     method::
 
         use Symfony\Component\OptionsResolver\OptionsResolver;
-        use Symfony\Component\Validator\Constraints\Length;
+        use Symfony\Component\Validator\Constraints as Assert;
         use Symfony\Component\Validator\Validation;
 
         // ...
         $resolver->setAllowedValues('transport', Validation::createIsValidCallable(
-            new Length(min: 10)
+            new Assert\Length(min: 10)
         ));
 
 In sub-classes, you can use :method:`Symfony\\Component\\OptionsResolver\\OptionsResolver::addAllowedValues`

--- a/components/validator.rst
+++ b/components/validator.rst
@@ -30,14 +30,13 @@ The Validator component behavior is based on two concepts:
 The following example shows how to validate that a string is at least 10
 characters long::
 
-    use Symfony\Component\Validator\Constraints\Length;
-    use Symfony\Component\Validator\Constraints\NotBlank;
+    use Symfony\Component\Validator\Constraints as Assert;
     use Symfony\Component\Validator\Validation;
 
     $validator = Validation::createValidator();
     $violations = $validator->validate('Bernhard', [
-        new Length(min: 10),
-        new NotBlank(),
+        new Assert\Length(min: 10),
+        new Assert\NotBlank(),
     ]);
 
     if (0 !== count($violations)) {

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -54,7 +54,7 @@ so Symfony doesn't try to get/set its value from the related entity::
     use Symfony\Component\Form\Extension\Core\Type\FileType;
     use Symfony\Component\Form\FormBuilderInterface;
     use Symfony\Component\OptionsResolver\OptionsResolver;
-    use Symfony\Component\Validator\Constraints\File;
+    use Symfony\Component\Validator\Constraints as Assert;
 
     class ProductType extends AbstractType
     {
@@ -75,7 +75,7 @@ so Symfony doesn't try to get/set its value from the related entity::
                     // unmapped fields can't define their validation using attributes
                     // in the associated entity, so you can use the PHP constraint classes
                     'constraints' => [
-                        new File(
+                        new Assert\File(
                             maxSize: '1024k',
                             extensions: ['pdf'],
                             extensionsMessage: 'Please upload a valid PDF document',

--- a/form/without_class.rst
+++ b/form/without_class.rst
@@ -89,19 +89,18 @@ but here's a short example::
 
     use Symfony\Component\Form\Extension\Core\Type\TextType;
     use Symfony\Component\Form\FormBuilderInterface;
-    use Symfony\Component\Validator\Constraints\Length;
-    use Symfony\Component\Validator\Constraints\NotBlank;
+    use Symfony\Component\Validator\Constraints as Assert;
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('firstName', TextType::class, [
-                'constraints' => new Length(min: 3),
+                'constraints' => new Assert\Length(min: 3),
             ])
             ->add('lastName', TextType::class, [
                 'constraints' => [
-                    new NotBlank(),
-                    new Length(min: 3),
+                    new Assert\NotBlank(),
+                    new Assert\Length(min: 3),
                 ],
             ])
         ;
@@ -113,7 +112,9 @@ but here's a short example::
     ``Default`` group when creating the form, or set the correct group on
     the constraint you are adding::
 
-        new NotBlank(['groups' => ['create', 'update']]);
+        use Symfony\Component\Validator\Constraints as Assert;
+
+        new Assert\NotBlank(groups: ['create', 'update']);
 
 .. tip::
 
@@ -137,9 +138,7 @@ This can be done by setting the ``constraints`` option in the
     use Symfony\Component\Form\Extension\Core\Type\TextType;
     use Symfony\Component\Form\FormBuilderInterface;
     use Symfony\Component\OptionsResolver\OptionsResolver;
-    use Symfony\Component\Validator\Constraints\Collection;
-    use Symfony\Component\Validator\Constraints\Length;
-    use Symfony\Component\Validator\Constraints\NotBlank;
+    use Symfony\Component\Validator\Constraints as Assert;
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
@@ -152,11 +151,11 @@ This can be done by setting the ``constraints`` option in the
     {
         $resolver->setDefaults([
             'data_class' => null,
-            'constraints' => new Collection([
-                'firstName' => new Length(min: 3),
+            'constraints' => new Assert\Collection([
+                'firstName' => new Assert\Length(min: 3),
                 'lastName' => [
-                    new NotBlank(),
-                    new Length(min: 3),
+                    new Assert\NotBlank(),
+                    new Assert\Length(min: 3),
                 ],
             ]),
         ]);
@@ -165,12 +164,14 @@ This can be done by setting the ``constraints`` option in the
 This means you can also do this when using the ``createFormBuilder()`` method
 in your controller::
 
+    use Symfony\Component\Validator\Constraints as Assert;
+
     $form = $this->createFormBuilder($defaultData, [
             'constraints' => [
-                'firstName' => new Length(['min' => 3]),
+                'firstName' => new Assert\Length(min: 3),
                 'lastName' => [
-                    new NotBlank(),
-                    new Length(['min' => 3]),
+                    new Assert\NotBlank(),
+                    new Assert\Length(min: 3),
                 ],
             ],
         ])

--- a/forms.rst
+++ b/forms.rst
@@ -540,8 +540,7 @@ object.
         // src/Entity/Task.php
         namespace App\Entity;
 
-        use Symfony\Component\Validator\Constraints\NotBlank;
-        use Symfony\Component\Validator\Constraints\Type;
+        use Symfony\Component\Validator\Constraints as Assert;
         use Symfony\Component\Validator\Mapping\ClassMetadata;
 
         class Task
@@ -550,12 +549,12 @@ object.
 
             public static function loadValidatorMetadata(ClassMetadata $metadata): void
             {
-                $metadata->addPropertyConstraint('task', new NotBlank());
+                $metadata->addPropertyConstraint('task', new Assert\NotBlank());
 
-                $metadata->addPropertyConstraint('dueDate', new NotBlank());
+                $metadata->addPropertyConstraint('dueDate', new Assert\NotBlank());
                 $metadata->addPropertyConstraint(
                     'dueDate',
-                    new Type(\DateTimeInterface::class)
+                    new Assert\Type(\DateTimeInterface::class)
                 );
             }
         }

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -97,7 +97,7 @@ If your valid choice list is simple, you can pass them in directly via the
             {
                 $metadata->addPropertyConstraint(
                     'city',
-                    new Assert\Choice(['New York', 'Berlin', 'Tokyo'])
+                    new Assert\Choice(choices: ['New York', 'Berlin', 'Tokyo'])
                 );
 
                 $metadata->addPropertyConstraint('genre', new Assert\Choice(

--- a/reference/constraints/Collection.rst
+++ b/reference/constraints/Collection.rst
@@ -144,10 +144,10 @@ following:
                         'personal_email' => new Assert\Email(),
                         'short_bio' => [
                             new Assert\NotBlank(),
-                            new Assert\Length([
-                                'max' => 100,
-                                'maxMessage' => 'Your short bio is too long!',
-                            ]),
+                            new Assert\Length(
+                                max: 100,
+                                maxMessage: 'Your short bio is too long!',
+                            ),
                         ],
                     ],
                     allowMissingFields: true,
@@ -293,8 +293,8 @@ groups. Take the following example::
 
     $constraint = new Assert\Collection(
         fields: [
-            'name' => new Assert\NotBlank(['groups' => 'basic']),
-            'email' => new Assert\NotBlank(['groups' => 'contact']),
+            'name' => new Assert\NotBlank(groups: 'basic'),
+            'email' => new Assert\NotBlank(groups: 'contact'),
         ],
     );
 

--- a/validation.rst
+++ b/validation.rst
@@ -95,7 +95,7 @@ following:
         // src/Entity/Author.php
         namespace App\Entity;
         // ...
-        use Symfony\Component\Validator\Constraints\NotBlank;
+        use Symfony\Component\Validator\Constraints as Assert;
         use Symfony\Component\Validator\Mapping\ClassMetadata;
 
         class Author
@@ -104,7 +104,7 @@ following:
 
             public static function loadValidatorMetadata(ClassMetadata $metadata): void
             {
-                $metadata->addPropertyConstraint('name', new NotBlank());
+                $metadata->addPropertyConstraint('name', new Assert\NotBlank());
             }
         }
 
@@ -340,12 +340,14 @@ Constraints in Form Classes
 Constraints can be defined while building the form via the ``constraints`` option
 of the form fields::
 
+    use Symfony\Component\Validator\Constraints as Assert;
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('myField', TextType::class, [
                 'required' => true,
-                'constraints' => [new Length(['min' => 3])],
+                'constraints' => [new Assert\Length(min: 3)],
             ])
         ;
     }

--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -243,7 +243,7 @@ You can use custom validators like the ones provided by Symfony itself:
         namespace App\Entity;
 
         use App\Validator\ContainsAlphanumeric;
-        use Symfony\Component\Validator\Constraints\NotBlank;
+        use Symfony\Component\Validator\Constraints as Assert;
         use Symfony\Component\Validator\Mapping\ClassMetadata;
 
         class User
@@ -254,7 +254,7 @@ You can use custom validators like the ones provided by Symfony itself:
 
             public static function loadValidatorMetadata(ClassMetadata $metadata): void
             {
-                $metadata->addPropertyConstraint('name', new NotBlank());
+                $metadata->addPropertyConstraint('name', new Assert\NotBlank());
                 $metadata->addPropertyConstraint('name', new ContainsAlphanumeric(mode: 'loose'));
             }
         }
@@ -401,7 +401,7 @@ the custom options like you pass any other option in built-in constraints:
         namespace App\Entity;
 
         use App\Validator\ContainsAlphanumeric;
-        use Symfony\Component\Validator\Constraints\NotBlank;
+        use Symfony\Component\Validator\Constraints as Assert;
         use Symfony\Component\Validator\Mapping\ClassMetadata;
 
         class AcmeEntity
@@ -410,7 +410,7 @@ the custom options like you pass any other option in built-in constraints:
 
             public static function loadValidatorMetadata(ClassMetadata $metadata)
             {
-                $metadata->addPropertyConstraint('name', new NotBlank());
+                $metadata->addPropertyConstraint('name', new Assert\NotBlank());
                 $metadata->addPropertyConstraint('name', new Foo(
                     mandatoryFooOption: 'bar',
                     optionalBarOption: true,

--- a/validation/raw_values.rst
+++ b/validation/raw_values.rst
@@ -65,27 +65,27 @@ Validation of arrays is possible using the ``Collection`` constraint::
         ],
     ];
 
-    $groups = new Assert\GroupSequence(['Default', 'custom']);
+    $groups = new Assert\GroupSequence(groups: ['Default', 'custom']);
 
     $constraint = new Assert\Collection([
         // the keys correspond to the keys in the input array
         'name' => new Assert\Collection([
-            'first_name' => new Assert\Length(['min' => 101]),
-            'last_name' => new Assert\Length(['min' => 1]),
+            'first_name' => new Assert\Length(min: 101),
+            'last_name' => new Assert\Length(min: 1),
         ]),
         'email' => new Assert\Email(),
-        'simple' => new Assert\Length(['min' => 102]),
-        'eye_color' => new Assert\Choice([3, 4]),
+        'simple' => new Assert\Length(min: 102),
+        'eye_color' => new Assert\Choice(choices: [3, 4]),
         'file' => new Assert\File(),
-        'password' => new Assert\Length(['min' => 60]),
+        'password' => new Assert\Length(min: 60),
         'tags' => new Assert\Optional([
             new Assert\Type('array'),
-            new Assert\Count(['min' => 1]),
+            new Assert\Count(min: 1),
             new Assert\All([
                 new Assert\Collection([
                     'slug' => [
                         new Assert\NotBlank(),
-                        new Assert\Type(['type' => 'string']),
+                        new Assert\Type(type: 'string'),
                     ],
                     'label' => [
                         new Assert\NotBlank(),

--- a/validation/translations.rst
+++ b/validation/translations.rst
@@ -74,7 +74,7 @@ property is not empty, add the following:
         namespace App\Entity;
 
         // ...
-        use Symfony\Component\Validator\Constraints\NotBlank;
+        use Symfony\Component\Validator\Constraints as Assert;
         use Symfony\Component\Validator\Mapping\ClassMetadata;
 
         class Author
@@ -83,7 +83,7 @@ property is not empty, add the following:
 
             public static function loadValidatorMetadata(ClassMetadata $metadata): void
             {
-                $metadata->addPropertyConstraint('name', new NotBlank(
+                $metadata->addPropertyConstraint('name', new Assert\NotBlank(
                     message: 'author.name.not_blank',
                 ));
             }


### PR DESCRIPTION
I noticed a slight inconsistency in the docs when showing examples of using `Constraint` classes. In some examples, the class is `use`d and shown with the short class name. In other cases, the `Symfony\Component\Validator\Constraints` namespace is used as `Assert`, and references being made as `Assert\NotBlank` and similar.

Personally, I like the `Assert\` prefix, since it triggers the "ah, that's a constraint" wiring in my head, but I don't mind. Generally, I'd prefer consistency, since I noticed that this caused confusion in my team.

Additionally, this PR fixes a few places where we are still showing the use of array-based options instead of named arguments, a change that was made in 7.3.