### PR TITLE
[Validator] Fix parent constructor call to use null instead of empty array

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -29,10 +29,10 @@ First you need to create a Constraint class and extend :class:`Symfony\\Componen
             // all configurable options must be passed to the constructor
             public function __construct(?string $mode = null, ?string $message = null, ?array $groups = null, $payload = null)
             {
-                parent::__construct([], $groups, $payload);
-
                 $this->mode = $mode ?? $this->mode;
                 $this->message = $message ?? $this->message;
+
+                parent::__construct(null, $groups, $payload);
             }
         }
 
@@ -62,7 +62,7 @@ You can use ``#[HasNamedArguments]`` to make some constraint options required::
             ?array $groups = null,
             mixed $payload = null,
         ) {
-            parent::__construct([], $groups, $payload);
+            parent::__construct(null, $groups, $payload);
         }
     }
 
@@ -93,7 +93,7 @@ in the ``__sleep()`` method to ensure they are serialized correctly::
             ?array $groups = null,
             mixed $payload = null,
         ) {
-            parent::__construct([], $groups, $payload);
+            parent::__construct(null, $groups, $payload);
         }
 
         public function __sleep(): array


### PR DESCRIPTION
This is the new method that prevents the following deprecation message:
`Since symfony/validator 7.4: Support for evaluating options in the base Constraint class is deprecated. Initialize properties in the constructor of App\Validator\Custom instead`
Honestly I don't totally understand what the "mode" option/variable in the 2nd and 3rd examples is doing so I'm not sure if some other change needs to be made for those ones. 