### PR TITLE
 Update DOCtor-RST and enable new rules

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -21,6 +21,17 @@ rules:
     ensure_order_of_code_blocks_in_configuration_block: ~
     ensure_php_reference_syntax: ~
     extend_abstract_controller: ~
+    filepath_and_namespace_should_match:
+        namespace_mapping:
+            'src/': 'App\'
+            'tests/': 'App\Tests\'
+        ignored_namespaces:
+            - '/^Acme/'
+            - '/^Shared/'
+        ignored_paths:
+            - '/^config\//'
+            - '/^example\.com\//'
+            - '/^apps\/api\/tests\//'
     # extension_xlf_instead_of_xliff: ~
     forbidden_directives:
         directives:
@@ -43,12 +54,14 @@ rules:
     no_composer_req: ~
     no_directive_after_shorthand: ~
     no_duplicate_use_statements: ~
+    no_empty_directive: ~
     no_empty_literals: ~
     no_explicit_use_of_code_block_php: ~
     no_footnotes: ~
     no_inheritdoc: ~
     no_merge_conflict: ~
     no_namespace_after_use_statements: ~
+    no_non_breaking_space: ~
     no_php_open_tag_in_code_block_php_directive: ~
     no_space_before_self_xml_closing_tag: ~
     no_typographic_quotes: ~

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
                     key: ${{ runner.os }}-doctor-rst-${{ steps.extract_base_branch.outputs.branch }}
 
             -   name: "Run DOCtor-RST"
-                uses: docker://oskarstark/doctor-rst:1.73.0
+                uses: docker://oskarstark/doctor-rst:1.76.0
                 with:
                     args: --short --error-format=github --cache-file=/github/workspace/.cache/doctor-rst.cache
 

--- a/bundles/prepend_extension.rst
+++ b/bundles/prepend_extension.rst
@@ -20,7 +20,7 @@ on another bundle being loaded as well.
 To give an Extension the power to do this, it needs to implement
 :class:`Symfony\\Component\\DependencyInjection\\Extension\\PrependExtensionInterface`::
 
-    // src/Acme/HelloBundle/DependencyInjection/AcmeHelloExtension.php
+    // src/DependencyInjection/AcmeHelloExtension.php
     namespace Acme\HelloBundle\DependencyInjection;
 
     use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -138,12 +138,12 @@ a directory containing multiple test suites with their own ``phpunit.xml.dist``.
 .. code-block:: terminal
 
     ├── tests/
-    │   ├── Functional/
-    │   │   ├── ...
-    │   │   └── phpunit.xml.dist
-    │   ├── Unit/
-    │   │   ├── ...
-    │   │   └── phpunit.xml.dist
+    │   ├── Functional/
+    │   │   ├── ...
+    │   │   └── phpunit.xml.dist
+    │   ├── Unit/
+    │   │   ├── ...
+    │   │   └── phpunit.xml.dist
 
 .. code-block:: terminal
 

--- a/console/style.rst
+++ b/console/style.rst
@@ -476,7 +476,7 @@ your commands. Thanks to the ``StyleInterface`` you won't need to change the cod
 of your commands to change their appearance::
 
     // src/Command/GreetCommand.php
-    namespace App\Console;
+    namespace App\Command;
 
     use App\Console\CustomStyle;
     use Symfony\Component\Console\Command\Command;

--- a/contributing/documentation/standards.rst
+++ b/contributing/documentation/standards.rst
@@ -101,7 +101,7 @@ Example
 .. code-block:: php
 
     // src/Foo/Bar.php
-    namespace Foo;
+    namespace App\Foo;
 
     use Acme\Demo\Cat;
     // ...

--- a/mercure.rst
+++ b/mercure.rst
@@ -635,7 +635,7 @@ During unit testing it's usually not needed to send updates to Mercure.
 
 You can instead make use of the ``MockHub`` class::
 
-    // tests/FunctionalTest.php
+    // tests/Unit/Controller/FunctionalTest.php
     namespace App\Tests\Unit\Controller;
 
     use App\Controller\MessageController;

--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -83,7 +83,7 @@ If your valid choice list is simple, you can pass them in directly via the
 
     .. code-block:: php
 
-        // src/EntityAuthor.php
+        // src/Entity/Author.php
         namespace App\Entity;
 
         use Symfony\Component\Validator\Constraints as Assert;
@@ -170,7 +170,7 @@ constraint.
 
     .. code-block:: php
 
-        // src/EntityAuthor.php
+        // src/Entity/Author.php
         namespace App\Entity;
 
         use Symfony\Component\Validator\Constraints as Assert;

--- a/reference/constraints/Compound.rst
+++ b/reference/constraints/Compound.rst
@@ -53,7 +53,7 @@ You can now use it anywhere you need it:
     .. code-block:: php-attributes
 
         // src/Entity/User.php
-        namespace App\Entity\User;
+        namespace App\Entity;
 
         use App\Validator\Constraints as Assert;
 
@@ -89,7 +89,7 @@ You can now use it anywhere you need it:
     .. code-block:: php
 
         // src/Entity/User.php
-        namespace App\Entity\User;
+        namespace App\Entity;
 
         use App\Validator\Constraints as Assert;
         use Symfony\Component\Validator\Mapping\ClassMetadata;

--- a/security.rst
+++ b/security.rst
@@ -1940,7 +1940,7 @@ You can logout user programmatically using the ``logout()`` method of the
 :class:`Symfony\\Bundle\\SecurityBundle\\Security` helper::
 
     // src/Controller/SecurityController.php
-    namespace App\Controller\SecurityController;
+    namespace App\Controller;
 
     use Symfony\Bundle\SecurityBundle\Security;
 

--- a/templates.rst
+++ b/templates.rst
@@ -156,7 +156,7 @@ quick access to complex PHP variables. Consider the following template:
 
 .. code-block:: html+twig
 
-    <p>{{ user.name }} added this comment on {{ comment.publishedAt|date }}</p>
+    <p>{{ user.name }} added this comment on {{ comment.publishedAt|date }}</p>
 
 The ``user.name`` notation means that you want to display some information
 (``name``) stored in a variable (``user``). Is ``user`` an array or an object?

--- a/workflow.rst
+++ b/workflow.rst
@@ -573,7 +573,7 @@ The context is accessible in all events except for the ``workflow.guard`` events
 Here is an example of how to enable logging for every time a "blog_publishing"
 workflow leaves a place::
 
-    // src/App/EventSubscriber/WorkflowLoggerSubscriber.php
+    // src/EventSubscriber/WorkflowLoggerSubscriber.php
     namespace App\EventSubscriber;
 
     use Psr\Log\LoggerInterface;
@@ -666,7 +666,7 @@ list of the guard event names.
 This example stops any blog post being transitioned to "reviewed" if it is
 missing a title::
 
-    // src/App/EventSubscriber/BlogPostReviewSubscriber.php
+    // src/EventSubscriber/BlogPostReviewSubscriber.php
     namespace App\EventSubscriber;
 
     use App\Entity\BlogPost;
@@ -958,7 +958,7 @@ This example has been simplified; in production you may prefer to use the
 :doc:`Translation </translation>` component to manage messages in one
 place::
 
-    // src/App/EventSubscriber/BlogPostPublishSubscriber.php
+    // src/EventSubscriber/BlogPostPublishSubscriber.php
     namespace App\EventSubscriber;
 
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;


### PR DESCRIPTION
- Require DOCtor-RST 1.74.0
- Enable NoNonBreakingSpace rule
- Enable NoEmptyDirective rule
- Enable FilepathAndNamespaceShouldMatch rule (configured for src/ and tests/)
