### PR TITLE
[Logger] Adding `app` channel

### DIFF
--- a/logging/channels_handlers.rst
+++ b/logging/channels_handlers.rst
@@ -2,7 +2,7 @@ How to Log Messages to different Files
 ======================================
 
 The Symfony Framework organizes log messages into channels. By default, there
-are several channels, including ``doctrine``, ``event``, ``security``, ``request``
+are several channels, including ``app``, ``doctrine``, ``event``, ``security``, ``request``
 and more. The channel is printed in the log message and can also be used
 to direct different channels to different places/files.
 


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/logging/channels_handlers.html

Reason: `app` is the default channel.