### PR TITLE
[Logger] Removing `channels: ~`

### DIFF
--- a/logging/channels_handlers.rst
+++ b/logging/channels_handlers.rst
@@ -108,13 +108,13 @@ You can specify the configuration in different ways:
 
 .. code-block:: yaml
 
-    channels: ~    # Include all the channels
-
     channels: foo  # Include only channel 'foo'
     channels: '!foo' # Include all channels, except 'foo'
 
     channels: [foo, bar]   # Include only channels 'foo' and 'bar'
     channels: ['!foo', '!bar'] # Include all channels, except 'foo' and 'bar'
+
+To include *all* channels, just omit the ``channels`` key.
 
 Creating your own Channel
 -------------------------


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/logging/channels_handlers.html

Reason: PHP's equivalent of YAML's `~` is `null`, right? However, I couldn't get this to work with Symfony's new array shape config, so I'm figuring this info does more harm than good.

See also https://github.com/symfony/monolog-bundle/issues/564 for a ~related issue.
