### PR TITLE
 Update DOCtor-RST to 1.77.0 and enable `no_relative_doc_path` rule

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -63,6 +63,7 @@ rules:
     no_namespace_after_use_statements: ~
     no_non_breaking_space: ~
     no_php_open_tag_in_code_block_php_directive: ~
+    no_relative_doc_path: ~
     no_space_before_self_xml_closing_tag: ~
     no_typographic_quotes: ~
     non_static_phpunit_assertions: ~
@@ -108,6 +109,8 @@ exclude_rule_for_file:
       rule_name: no_php_open_tag_in_code_block_php_directive
     - path: frontend/create_ux_bundle.rst
       rule_name: argument_variable_must_match_type
+    - path: contributing/documentation/format.rst
+      rule_name: no_relative_doc_path
 
 # do not report as violation
 whitelist:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
                     key: ${{ runner.os }}-doctor-rst-${{ steps.extract_base_branch.outputs.branch }}
 
             -   name: "Run DOCtor-RST"
-                uses: docker://oskarstark/doctor-rst:1.76.0
+                uses: docker://oskarstark/doctor-rst:1.77.0
                 with:
                     args: --short --error-format=github --cache-file=/github/workspace/.cache/doctor-rst.cache
 

--- a/components/validator/resources.rst
+++ b/components/validator/resources.rst
@@ -11,7 +11,7 @@ The Validator component collects that metadata using a set of loaders.
 
 .. seealso::
 
-    You'll learn how to define the metadata in :doc:`metadata`.
+    You'll learn how to define the metadata in :doc:`/components/validator/metadata`.
 
 The StaticMethodLoader
 ----------------------

--- a/contributing/code/bugs.rst
+++ b/contributing/code/bugs.rst
@@ -7,7 +7,7 @@ us make a better Symfony.
 .. warning::
 
     If you think you've found a security issue, please use the special
-    :doc:`procedure <security>` instead.
+    :doc:`procedure </contributing/code/security>` instead.
 
 Before submitting a bug:
 
@@ -44,7 +44,7 @@ If your problem definitely looks like a bug, report it using the official bug
   **Be wary that stack traces may contain sensitive information, and if it is
   the case, be sure to redact them prior to posting your stack trace.**
 
-* *(optional)* Attach a :doc:`patch <pull_requests>`.
+* *(optional)* Attach a :doc:`patch </contributing/code/pull_requests>`.
 
 .. _`Stack Overflow`: https://stackoverflow.com/questions/tagged/symfony
 .. _the Symfony Slack: https://symfony.com/slack-invite

--- a/contributing/code/conventions.rst
+++ b/contributing/code/conventions.rst
@@ -1,7 +1,7 @@
 Conventions
 ===========
 
-The :doc:`standards` document describes the coding standards for the Symfony
+The :doc:`standards </contributing/code/standards>` document describes the coding standards for the Symfony
 projects and the internal and third-party bundles. This document describes
 coding standards and conventions used in the core framework to make it more
 consistent and predictable. You are encouraged to follow them in your own

--- a/contributing/code/pull_requests.rst
+++ b/contributing/code/pull_requests.rst
@@ -107,7 +107,7 @@ Check that the current Tests Pass
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Now that Symfony is installed, check that all unit tests pass for your
-environment as explained in the dedicated :doc:`document <tests>`.
+environment as explained in the dedicated :doc:`document </contributing/code/tests>`.
 
 .. _step-2-work-on-your-patch:
 
@@ -216,8 +216,8 @@ Work on your Pull Request
 Work on the code as much as you want and commit as much as you want; but keep
 in mind the following:
 
-* Read about the Symfony :doc:`conventions <conventions>` and follow the
-  coding :doc:`standards <standards>` (use ``git diff --check`` to check for
+* Read about the Symfony :doc:`conventions </contributing/code/conventions>` and follow the
+  coding :doc:`standards </contributing/code/standards>` (use ``git diff --check`` to check for
   trailing spaces -- also read the tip below);
 
 * Add unit tests to prove that the bug is fixed or that the new feature

--- a/contributing/code/standards.rst
+++ b/contributing/code/standards.rst
@@ -249,7 +249,7 @@ Naming Conventions
   or ``Boolean``), ``int`` (instead of ``integer``), ``float`` (instead of
   ``double`` or ``real``);
 
-* Don't forget to look at the more verbose :doc:`conventions` document for
+* Don't forget to look at the more verbose :doc:`conventions </contributing/code/conventions>` document for
   more subjective naming considerations.
 
 .. _service-naming-conventions:

--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -4,11 +4,11 @@ Running Symfony Tests
 =====================
 
 The Symfony project uses a CI (Continuous Integration) service which automatically runs tests
-for any submitted :doc:`patch <pull_requests>`. If the new code breaks any test,
+for any submitted :doc:`patch </contributing/code/pull_requests>`. If the new code breaks any test,
 the pull request will show an error message with a link to the full error details.
 
 In any case, it's a good practice to run tests locally before submitting a
-:doc:`patch <pull_requests>` for inclusion, to check that you have not broken anything.
+:doc:`patch </contributing/code/pull_requests>` for inclusion, to check that you have not broken anything.
 
 .. _phpunit:
 .. _dependencies_optional:

--- a/contributing/community/reviews.rst
+++ b/contributing/community/reviews.rst
@@ -125,7 +125,7 @@ Pick a pull request from the `PRs in need of review`_ and follow these steps:
    pull request. Is that branch correct?
 
    * Bugs should be fixed in the oldest, maintained version that contains the
-     bug. Check :doc:`Symfony's Release Schedule <releases>` to find the oldest
+     bug. Check :doc:`Symfony's Release Schedule </contributing/community/releases>` to find the oldest
      currently supported version.
 
    * New features should always be added to the current development version.

--- a/frontend/encore/copy-files.rst
+++ b/frontend/encore/copy-files.rst
@@ -56,7 +56,7 @@ install any missing dependencies. After running that command and restarting
 Encore, you're done!
 
 This will copy all files from ``assets/images`` into ``public/build/images``.
-If you have :doc:`versioning enabled <versioning>`, the copied files will
+If you have :doc:`versioning enabled </frontend/encore/versioning>`, the copied files will
 include a hash based on their content.
 
 To render inside Twig, use the ``asset()`` function:

--- a/index.rst
+++ b/index.rst
@@ -6,11 +6,11 @@ Symfony Documentation
 Quick Tour
 ----------
 
-Get started fast with the Symfony :doc:`Quick Tour <quick_tour/index>`:
+Get started fast with the Symfony :doc:`Quick Tour </quick_tour/index>`:
 
-* :doc:`quick_tour/the_big_picture`
-* :doc:`quick_tour/flex_recipes`
-* :doc:`quick_tour/the_architecture`
+* :doc:`/quick_tour/the_big_picture`
+* :doc:`/quick_tour/flex_recipes`
+* :doc:`/quick_tour/the_architecture`
 
 Getting Started
 ---------------

--- a/reference/constraints/IsFalse.rst
+++ b/reference/constraints/IsFalse.rst
@@ -5,7 +5,7 @@ Validates that a value is ``false``. Specifically, this checks to see if
 the value is exactly ``false``, exactly the integer ``0``, or exactly the
 string ``'0'``.
 
-Also see :doc:`IsTrue <IsTrue>`.
+Also see :doc:`IsTrue </reference/constraints/IsTrue>`.
 
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`

--- a/reference/constraints/IsNull.rst
+++ b/reference/constraints/IsNull.rst
@@ -5,7 +5,7 @@ Validates that a value is exactly equal to ``null``. To force that a property
 is blank (blank string or ``null``), see the  :doc:`/reference/constraints/Blank`
 constraint. To ensure that a property is not null, see :doc:`/reference/constraints/NotNull`.
 
-Also see :doc:`NotNull <NotNull>`.
+Also see :doc:`NotNull </reference/constraints/NotNull>`.
 
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`

--- a/reference/constraints/IsTrue.rst
+++ b/reference/constraints/IsTrue.rst
@@ -4,7 +4,7 @@ IsTrue
 Validates that a value is ``true``. Specifically, this checks if the value is
 exactly ``true``, exactly the integer ``1``, or exactly the string ``'1'``.
 
-Also see :doc:`IsFalse <IsFalse>`.
+Also see :doc:`IsFalse </reference/constraints/IsFalse>`.
 
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`

--- a/routing.rst
+++ b/routing.rst
@@ -446,7 +446,7 @@ can use any of these variables created by Symfony:
 You can also use these functions:
 
 ``env(string $name)``
-    Returns the value of a variable using :doc:`Environment Variable Processors <configuration/env_var_processors>`
+    Returns the value of a variable using :doc:`Environment Variable Processors </configuration/env_var_processors>`
 
 ``service(string $alias)``
     Returns a routing condition service.

--- a/routing/routing_from_database.rst
+++ b/routing/routing_from_database.rst
@@ -18,7 +18,7 @@ For these cases, the ``DynamicRouter`` offers an alternative approach:
 * Writes only affect the index of the database, which is very efficient.
 
 When all routes are known during deploy time and the number is not too
-high, using a :doc:`custom route loader <custom_route_loader>` is the
+high, using a :doc:`custom route loader </routing/custom_route_loader>` is the
 preferred way to add more routes. When working with only one type of
 objects, a slug parameter on the object and the ``#[ParamConverter]``
 attribute works fine (see `FrameworkExtraBundle`_) .

--- a/security.rst
+++ b/security.rst
@@ -467,7 +467,7 @@ You can also manually hash a password by running:
     $ php bin/console security:hash-password
 
 Read more about all available hashers and password migration in
-:doc:`security/passwords`.
+:doc:`/security/passwords`.
 
 .. versionadded:: 6.2
 

--- a/setup/symfony_cli.rst
+++ b/setup/symfony_cli.rst
@@ -366,7 +366,7 @@ Docker Integration
 ------------------
 
 The Symfony CLI provides full `Docker`_ integration for projects that
-use it. To learn more about Docker and Symfony, see :doc:`docker`.
+use it. To learn more about Docker and Symfony, see :doc:`/setup/docker`.
 The local server automatically detects Docker services and exposes their
 connection information as environment variables.
 

--- a/testing.rst
+++ b/testing.rst
@@ -364,7 +364,7 @@ After that, you can create the test database and all tables using:
 .. tip::
 
     You can run these commands to create the database during the
-    :doc:`test bootstrap process <testing/bootstrap>`.
+    :doc:`test bootstrap process </testing/bootstrap>`.
 
 .. tip::
 


### PR DESCRIPTION
- Require DOCtor-RST 1.77.0
- Enable `no_relative_doc_path` rule to ensure `:doc:` directives use absolute paths

### Refs
* https://github.com/symfony/symfony-docs/pull/21614#discussion_r2573199528 @wouterj 
* https://github.com/OskarStark/doctor-rst/issues/2180
* https://github.com/OskarStark/doctor-rst/pull/2213

I will take care of the upmerge and fixing the other issues in the upper branches, once approved.