### PR TITLE
[DependencyInjection] Add example for `#[Exclude]` attribute

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -1309,6 +1309,17 @@ key. For example, the default Symfony configuration contains this:
     may use the :class:`Symfony\\Component\\DependencyInjection\\Attribute\\Exclude`
     attribute directly on your class to exclude it.
 
+    ::
+
+        // src/Service/SomeService.php
+        namespace App\Service;
+
+        #[Exclude]
+        class SomeService
+        {
+            // ...
+        }
+
     .. versionadded:: 6.3
 
         The :class:`Symfony\\Component\\DependencyInjection\\Attribute\\Exclude`


### PR DESCRIPTION
I'd like to propose to add a basic example for the `#[Exclude]` attribute.
It is not mandatory for understanding, but it will help finding the related documentation (`exclude` being too much of a generic word, it's not easy to find by a search).