### PR TITLE
 Symfony Service Definition Objects

### DIFF
--- a/service_container/compiler_passes.rst
+++ b/service_container/compiler_passes.rst
@@ -2,7 +2,7 @@ How to Work with Compiler Passes
 ================================
 
 Compiler passes give you an opportunity to manipulate other
-:doc:`service definitions </service_container/definitions>` that have been
+:doc:`service definitions </dmanifestor/symfony-docs>` that have been
 registered with the service container.
 
 .. _kernel-as-compiler-pass:


### PR DESCRIPTION
Service definitions are the instructions describing how the container should build a service. They are not the actual services used by your applications. The container will create the actual class instances based on the configuration in the definition.

Normally, you would use YAML or PHP to describe the service definitions. But if you're doing advanced things with the service container, like working with a [Compiler Pass](https://symfony.com/doc/current/service_container/compiler_passes.html) or creating a [Dependency Injection Extension](https://symfony.com/doc/current/bundles/extension.html), you may need to work directly with the Definition objects that define how a service will be instantiated.