### PR TITLE
[Form] Update CurrencyType, remove extra translation domain notice

### DIFF
--- a/reference/forms/types/currency.rst
+++ b/reference/forms/types/currency.rst
@@ -86,8 +86,6 @@ regardless of their legal tender status.
 
     The ``legal_tender`` option was introduced in Symfony 7.4.
 
-.. include:: /reference/forms/types/options/choice_translation_domain.rst.inc
-
 ``not_active_at``
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Remove `choice_translation_domain` from the `legal_tender` setting

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->

See:
https://symfony.com/doc/7.4/reference/forms/types/currency.html#legal-tender
> This option determines if the choice values should be translated and in which translation domain.

this notice is shown twice, once for [choice_translation_domain](https://symfony.com/doc/7.4/reference/forms/types/currency.html#choice-translation-domain) (good) and once for [legal_tender](https://symfony.com/doc/7.4/reference/forms/types/currency.html#legal-tender) (bad)
