### PR TITLE
[Routing] : Adding hint about `_route`

### DIFF
--- a/controller/forwarding.rst
+++ b/controller/forwarding.rst
@@ -11,9 +11,9 @@ and calls the defined controller. The ``forward()`` method returns the
 :class:`Symfony\\Component\\HttpFoundation\\Response` object that is returned
 from *that* controller::
 
-    public function index(string $name): Response
+    public function __invoke(string $name): Response
     {
-        $response = $this->forward('App\Controller\OtherController::fancy', [
+        $response = $this->forward(OtherController::class, [
             'name'  => $name,
             'color' => 'green',
         ]);
@@ -26,10 +26,16 @@ from *that* controller::
 The array passed to the method becomes the arguments for the resulting controller.
 The target controller method might look something like this::
 
-    public function fancy(string $name, string $color): Response
+    public function __invoke(string $name, string $color): Response
     {
         // ... create and return a Response object
     }
 
 Like when creating a controller for a route, the order of the arguments of the
-``fancy()`` method doesn't matter: the matching is done by name.
+target method doesn't matter: the matching is done by name.
+
+.. note::
+
+    Twig's ``app.current_route``, ``app.current_route_parameters``, and ``_route_params``
+    will be empty after such a ``->forward()``. But you can set its value manually
+    by adding an array key ``_route`` to `forward()``'s second argument.


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/controller/forwarding.html

Info is taken from https://github.com/symfony/symfony/issues/5804#issuecomment-17379777

Also switched to invokable controller syntax - even though I'm not sure if this is a good idea here...
