### PR TITLE
[Validation] Adding `#[\Override]` attribute

### DIFF
--- a/validation/custom_constraint.rst
+++ b/validation/custom_constraint.rst
@@ -133,6 +133,7 @@ The validator class only has one required method ``validate()``::
 
     class ContainsAlphanumericValidator extends ConstraintValidator
     {
+        #[\Override]
         public function validate(mixed $value, Constraint $constraint): void
         {
             if (!$constraint instanceof ContainsAlphanumeric) {


### PR DESCRIPTION
Page: https://symfony.com/doc/current/validation/custom_constraint.html#creating-the-validator-itself

Reason: Psalm is complaining about [`MissingOverrideAttribute`](https://psalm.dev/358) - don't know if you want to have it in the docs.

Targeting 8.0 branch, cause `#[\Override]`  was introduced in PHP 8.3, and all lower Symfony versions allow lower PHP versions.