### PR TITLE
[HttpKernel] Split cache examples (as it's not repeatable)

### DIFF
--- a/http_cache/cache_vary.rst
+++ b/http_cache/cache_vary.rst
@@ -41,8 +41,13 @@ attribute::
         // ...
 
         #[Cache(vary: ['Accept-Encoding'])]
+        public function foo(): Response
+        {
+            // ...
+        }
+
         #[Cache(vary: ['Accept-Encoding', 'User-Agent'])]
-        public function index(): Response
+        public function bar(): Response
         {
             // ...
         }


### PR DESCRIPTION
Since `#[Cache]` attribute is not repeatable, I propose to correct the example in the doc with this new version in order to avoid in confusion