### PR TITLE
 opcache.max_accelerated_files must be prime

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -133,8 +133,8 @@ it's recommended to change these settings as follows:
     ; maximum memory that OPcache can use to store compiled PHP files
     opcache.memory_consumption=256
 
-    ; maximum number of files that can be stored in the cache
-    opcache.max_accelerated_files=20000
+    ; maximum number of files that can be stored in the cache (must be a prime number)
+    opcache.max_accelerated_files=19997
 
 .. _performance-dont-check-timestamps:
 


### PR DESCRIPTION
See https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.max-accelerated-files

We are lucky that the nearest prime is 19.997

