### PR TITLE
[Cache] Use new PHP array config in cache.rst

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -84,14 +84,16 @@ adapter (template) they use by using the ``app`` and ``system`` key like:
     .. code-block:: php
 
         // config/packages/cache.php
-        use Symfony\Config\FrameworkConfig;
+        use Symfony\Component\DependencyInjection\Loader\Configurator\App;
 
-        return static function (FrameworkConfig $framework): void {
-            $framework->cache()
-                ->app('cache.adapter.filesystem')
-                ->system('cache.adapter.system')
-            ;
-        };
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'app' => 'cache.adapter.filesystem',
+                    'system' => 'cache.adapter.system',
+                ],
+            ],
+        ]);
 
 .. tip::
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->

Updates PHP config examples to use the new array format.
I only updated one spot because I don't know if this is wanted. If I get approval, I will finish migrating the cache.rst file.
