### PR TITLE
[Messenger] Add full retry strategy example with delay and jitter

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1092,7 +1092,7 @@ this is configurable for each transport:
 
 .. configuration-block::
 
-  .. code-block:: yaml
+    .. code-block:: yaml
 
       # config/packages/messenger.yaml
       framework:
@@ -1110,12 +1110,11 @@ this is configurable for each transport:
                           jitter: 0.1             # randomness to avoid thundering herd effect
                           # service: null         # optionally override with a custom RetryStrategyInterface service
 
-.. note::
+    .. note::
 
       You can configure the retry strategy for a Messenger transport using options like
       ``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``.
       This allows controlling how failed messages are retried and the delay between attempts.
-
 
     .. code-block:: xml
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -1116,8 +1116,6 @@ this is configurable for each transport:
       ``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``.
       This allows controlling how failed messages are retried and the delay between attempts.
 
-::
-
 
 
     .. code-block:: xml

--- a/messenger.rst
+++ b/messenger.rst
@@ -1092,29 +1092,31 @@ this is configurable for each transport:
 
 .. configuration-block::
 
-   .. code-block:: yaml
+  .. code-block:: yaml
 
-    # config/packages/messenger.yaml
-    framework:
-        messenger:
-            transports:
-                async_priority_high:
-                    dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+      # config/packages/messenger.yaml
+      framework:
+          messenger:
+              transports:
+                  async_priority_high:
+                      dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
 
-                    # retry strategy configuration
-                    retry_strategy:
-                        max_retries: 3          # maximum number of retries
-                        delay: 1000             # initial delay in milliseconds
-                        multiplier: 2           # increases delay exponentially before each retry
-                        max_delay: 10000        # maximum delay in milliseconds
-                        jitter: 0.1             # randomness to avoid thundering herd effect
-                        # service: null         # optionally override with a custom RetryStrategyInterface service
+                      # retry strategy configuration
+                      retry_strategy:
+                          max_retries: 3          # maximum number of retries
+                          delay: 1000             # initial delay in milliseconds
+                          multiplier: 2           # increases delay exponentially before each retry
+                          max_delay: 10000        # maximum delay in milliseconds
+                          jitter: 0.1             # randomness to avoid thundering herd effect
+                          # service: null         # optionally override with a custom RetryStrategyInterface service
 
-.. note::
+  .. note::
 
-    You can configure the retry strategy for a Messenger transport using options like
-    ``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``.
-    This allows controlling how failed messages are retried and the delay between attempts.
+      You can configure the retry strategy for a Messenger transport using options like
+      ``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``.
+      This allows controlling how failed messages are retried and the delay between attempts.
+
+::
 
 
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -1110,9 +1110,11 @@ this is configurable for each transport:
                         jitter: 0.1             # randomness to avoid thundering herd effect
                         # service: null         # optionally override with a custom RetryStrategyInterface service
 
-You can configure the retry strategy for a Messenger transport using options like
-``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``. This allows controlling
-how failed messages are retried and the delay between attempts.
+.. note::
+
+    You can configure the retry strategy for a Messenger transport using options like
+    ``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``.
+    This allows controlling how failed messages are retried and the delay between attempts.
 
 
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -1092,30 +1092,28 @@ this is configurable for each transport:
 
 .. configuration-block::
 
-    .. code-block:: yaml
+   .. code-block:: yaml
 
-        # config/packages/messenger.yaml
-        framework:
-            messenger:
-                transports:
-                    async_priority_high:
-                        dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+    # config/packages/messenger.yaml
+    framework:
+        messenger:
+            transports:
+                async_priority_high:
+                    dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
 
-                        # default configuration
-                        retry_strategy:
-                            max_retries: 3
-                            # milliseconds delay
-                            delay: 1000
-                            # causes the delay to be higher before each retry
-                            # e.g. 1 second delay, 2 seconds, 4 seconds
-                            multiplier: 2
-                            max_delay: 0
-                            # applies randomness to the delay that can prevent the thundering herd effect
-                            # the value (between 0 and 1.0) is the percentage of 'delay' that will be added/subtracted
-                            jitter: 0.1
-                            # override all of this with a service that
-                            # implements Symfony\Component\Messenger\Retry\RetryStrategyInterface
-                            # service: null
+                    # retry strategy configuration
+                    retry_strategy:
+                        max_retries: 3          # maximum number of retries
+                        delay: 1000             # initial delay in milliseconds
+                        multiplier: 2           # increases delay exponentially before each retry
+                        max_delay: 10000        # maximum delay in milliseconds
+                        jitter: 0.1             # randomness to avoid thundering herd effect
+                        # service: null         # optionally override with a custom RetryStrategyInterface service
+
+You can configure the retry strategy for a Messenger transport using options like
+`max_retries`, `delay`, `multiplier`, `max_delay` and `jitter`. This allows controlling
+how failed messages are retried and the delay between attempts.
+
 
     .. code-block:: xml
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -1092,7 +1092,7 @@ this is configurable for each transport:
 
 .. configuration-block::
 
-.. code-block:: yaml
+   .. code-block:: yaml
 
     # config/packages/messenger.yaml
     framework:
@@ -1109,11 +1109,14 @@ this is configurable for each transport:
                         max_delay: 10000        # maximum delay in milliseconds
                         jitter: 0.1             # randomness to avoid thundering herd effect
                         # service: null         # optionally override with a custom RetryStrategyInterface service
+
 .. note::
 
     You can configure the retry strategy for a Messenger transport using options like
     ``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``.
     This allows controlling how failed messages are retried and the delay between attempts.
+
+
 
     .. code-block:: xml
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -1111,10 +1111,10 @@ this is configurable for each transport:
                           # service: null         # optionally override with a custom RetryStrategyInterface service
 
   .. note::
-
       You can configure the retry strategy for a Messenger transport using options like
       ``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``.
       This allows controlling how failed messages are retried and the delay between attempts.
+
 
 
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -1109,14 +1109,11 @@ this is configurable for each transport:
                         max_delay: 10000        # maximum delay in milliseconds
                         jitter: 0.1             # randomness to avoid thundering herd effect
                         # service: null         # optionally override with a custom RetryStrategyInterface service
-
 .. note::
 
     You can configure the retry strategy for a Messenger transport using options like
     ``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``.
     This allows controlling how failed messages are retried and the delay between attempts.
-
-
 
     .. code-block:: xml
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -1110,7 +1110,7 @@ this is configurable for each transport:
                           jitter: 0.1             # randomness to avoid thundering herd effect
                           # service: null         # optionally override with a custom RetryStrategyInterface service
 
-  .. note::
+.. note::
 
       You can configure the retry strategy for a Messenger transport using options like
       ``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``.

--- a/messenger.rst
+++ b/messenger.rst
@@ -1111,11 +1111,10 @@ this is configurable for each transport:
                           # service: null         # optionally override with a custom RetryStrategyInterface service
 
   .. note::
+
       You can configure the retry strategy for a Messenger transport using options like
       ``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``.
       This allows controlling how failed messages are retried and the delay between attempts.
-
-
 
 
     .. code-block:: xml

--- a/messenger.rst
+++ b/messenger.rst
@@ -1092,7 +1092,7 @@ this is configurable for each transport:
 
 .. configuration-block::
 
-   .. code-block:: yaml
+.. code-block:: yaml
 
     # config/packages/messenger.yaml
     framework:
@@ -1111,8 +1111,9 @@ this is configurable for each transport:
                         # service: null         # optionally override with a custom RetryStrategyInterface service
 
 You can configure the retry strategy for a Messenger transport using options like
-`max_retries`, `delay`, `multiplier`, `max_delay` and `jitter`. This allows controlling
+``max_retries``, ``delay``, ``multiplier``, ``max_delay`` and ``jitter``. This allows controlling
 how failed messages are retried and the delay between attempts.
+
 
 
     .. code-block:: xml


### PR DESCRIPTION
This PR adds a complete example showing how to configure a retry strategy for a Messenger transport in Symfony.

The example includes max_retries, delay, multiplier, max_delay, and jitter, demonstrating how to control the number of retries and the delay between failed message attempts.

It is added to the messenger.rst documentation under the transport configuration section. No changes to actual code or behavior are made.
