### PR TITLE
[Workflow] Fix method name for retrieving workflow configuration

### DIFF
--- a/workflow/workflow-and-state-machine.rst
+++ b/workflow/workflow-and-state-machine.rst
@@ -197,7 +197,7 @@ Below is the configuration for the pull request state machine.
         use Symfony\Config\FrameworkConfig;
 
         return static function (FrameworkConfig $framework): void {
-            $pullRequest = $framework->workflows()->workflows('pull_request');
+            $pullRequest = $framework->workflows()->workflow('pull_request');
 
             $pullRequest
                 ->type('state_machine')


### PR DESCRIPTION
I think this is "wrong" all over the documentation from 7.x up?

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
