### PR TITLE
 Fix some code examples by removing the constructor return type

### DIFF
--- a/lock.rst
+++ b/lock.rst
@@ -299,7 +299,7 @@ For example, to inject the ``invoice`` package defined earlier::
     {
         public function __construct(
             private LockFactory $invoiceLockFactory
-        ): void {
+        ) {
             // ...
         }
     }
@@ -319,7 +319,7 @@ For example, to select the ``invoice`` lock defined earlier::
     {
         public function __construct(
             #[Target('lock.invoice.factory')] private LockFactory $lockFactory
-        ): void {
+        ) {
             // ...
         }
     }

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2564,7 +2564,7 @@ to inject the ``foo_package`` package defined earlier::
     {
         public function __construct(
             private PackageInterface $fooPackage
-        ): void {
+        ) {
             // ...
         }
     }
@@ -2584,7 +2584,7 @@ For example, to select the ``foo_package`` package defined earlier::
     {
         public function __construct(
             #[Target('foo_package.package')] private PackageInterface $package
-        ): void {
+        ) {
             // ...
         }
     }


### PR DESCRIPTION
Constructors in PHP cannot define a return type, so let's fix this.

This is the regex used in my editor to find these: `function\s+__construct\s*\([^;{]*\)\s*:\s*void`

I couldn't find other examples in upper branches, so this is all that needs to be fixed.