### PR TITLE
[Mercure] Fix a minor RST syntax issue

### DIFF
--- a/mercure.rst
+++ b/mercure.rst
@@ -703,7 +703,7 @@ Debugging
     The WebProfiler panel was introduced in MercureBundle 0.2.
 
 MercureBundle is shipped with a debug panel. Install the Debug pack to
-enable it::
+enable it:
 
 .. code-block:: terminal
 


### PR DESCRIPTION
This issue doesn't impact the rendered docs (https://symfony.com/doc/6.4/mercure.html#debugging) but let's fix it anyways.