### PR TITLE
 Fix some typos

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -1025,7 +1025,7 @@ be lost without notifying the running processes.
 
 .. tip::
 
-    To use ZooKeeper's high-availability feature, you can setup a cluster of
+    To use ZooKeeper's high-availability feature, you can set up a cluster of
     multiple servers so that in case one of the server goes down, the majority
     will still be up and serving the requests. All the available servers in the
     cluster will see the same state.

--- a/mailer.rst
+++ b/mailer.rst
@@ -361,7 +361,7 @@ may be specified as SHA1 or MD5 hash::
 Overriding default SMTP authenticators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, SMTP transports will try to login using all authentication methods
+By default, SMTP transports will try to log in using all authentication methods
 available on the SMTP server, one after the other. In some cases, it may be
 useful to redefine the supported authentication methods to ensure that the
 preferred method will be used first.

--- a/migration.rst
+++ b/migration.rst
@@ -139,7 +139,7 @@ services like a database. To automate this you have to make sure that you can
 get a test instance of your system running as easily as possible and making
 sure that external systems do not change your production environment, e.g.
 provide a separate test database with (anonymized) data from a production
-system or being able to setup a new schema with a basic dataset for your test
+system or being able to set up a new schema with a basic dataset for your test
 environment. Since these tests do not rely as much on isolating testable code
 and instead look at the interconnected system, writing them is usually easier
 and more productive when doing a migration. You can then limit your effort on

--- a/security/access_denied_handler.rst
+++ b/security/access_denied_handler.rst
@@ -41,7 +41,7 @@ unauthenticated user tries to access a protected resource::
         public function start(Request $request, ?AuthenticationException $authException = null): RedirectResponse
         {
             // add a custom flash message and redirect to the login page
-            $request->getSession()->getFlashBag()->add('note', 'You have to login in order to access this page.');
+            $request->getSession()->getFlashBag()->add('note', 'You have to log in to access this page.');
 
             return new RedirectResponse($this->urlGenerator->generate('security_login'));
         }

--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -206,7 +206,7 @@ link is created using
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Now the link is created, it needs to be sent to the user. Anyone with the
-link is able to login as this user, so you need to make sure to send it to
+link is able to log in as this user, so you need to make sure to send it to
 a known device of them (e.g. using e-mail or SMS).
 
 You can send the link using any library or method. However the login link
@@ -321,7 +321,7 @@ Limit Login Link Lifetime
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is important for login links to have a limited lifetime. This reduces
-the risk that someone can intercept the link and use it to login as
+the risk that someone can intercept the link and use it to log in as
 somebody else. By default, Symfony defines a lifetime of 10 minutes (600
 seconds). You can customize this using the ``lifetime`` option:
 
@@ -638,7 +638,7 @@ user create this POST request (e.g. by clicking a button)::
     {% extends 'base.html.twig' %}
 
     {% block body %}
-        <h2>Hi! You are about to login to ...</h2>
+        <h2>Hi! You are about to log in to ...</h2>
 
         <!-- for instance, use a form with hidden fields to
              create the POST request -->

--- a/security/passwords.rst
+++ b/security/passwords.rst
@@ -1,7 +1,7 @@
 Password Hashing and Verification
 =================================
 
-Most applications use passwords to login users. These passwords should be
+Most applications use passwords to log in users. These passwords should be
 hashed to securely store them. Symfony's PasswordHasher component provides
 all utilities to safely hash and verify passwords.
 


### PR DESCRIPTION
This PR fixes some typos related to two pairs of words that are commonly misused in Symfony docs:

* setup (noun) vs set up (verb)
* login (noun) vs log in (verb)