### PR TITLE
 Fix some grammar issues

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -276,7 +276,7 @@ instead of ``Product/EditForm.html.twig``).
 Prefix Template Fragments with an Underscore
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Template fragments, also called *"partial templates"*, allow to
+Template fragments, also called *"partial templates"*, allow you to
 :ref:`reuse template contents <templates-reuse-contents>`. Prefix their names
 with an underscore to better differentiate them from complete templates (e.g.
 ``_user_metadata.html.twig`` or ``_caution_message.html.twig``).

--- a/bundles/best_practices.rst
+++ b/bundles/best_practices.rst
@@ -169,7 +169,7 @@ Doctrine Entities/Documents
 
 If the bundle includes Doctrine ORM entities and/or ODM documents, it's
 recommended to define their mapping using XML files stored in
-``config/doctrine/``. This allows to override that mapping using the
+``config/doctrine/``. This allows you to override that mapping using the
 :doc:`standard Symfony mechanism to override bundle parts </bundles/override>`.
 This is not possible when using attributes to define the mapping.
 

--- a/bundles/configuration.rst
+++ b/bundles/configuration.rst
@@ -111,7 +111,7 @@ class, you can add all the logic related to processing the configuration in that
 
 .. tip::
 
-    The ``AbstractBundle::configure()`` method also allows to import the
+    The ``AbstractBundle::configure()`` method also allows importing the
     configuration definition from one or more files::
 
         // src/AcmeSocialBundle.php

--- a/components/asset.rst
+++ b/components/asset.rst
@@ -28,7 +28,7 @@ simple. Hardcoding URLs can be a disadvantage because:
   versioning strategies for each package;
 * **Moving assets' location** is cumbersome and error-prone: it requires you to
   carefully update the URLs of all assets included in all templates. The Asset
-  component allows to move assets effortlessly just by changing the base path
+  component allows moving assets effortlessly just by changing the base path
   value associated with the package of assets;
 * **It's nearly impossible to use multiple CDNs**: this technique requires
   you to change the URL of the asset randomly for each request. The Asset component
@@ -382,7 +382,7 @@ they all have different base paths::
 
     $packages = new Packages($defaultPackage, $namedPackages);
 
-The ``Packages`` class allows to define a default package, which will be applied
+The ``Packages`` class allows you to define a default package, which will be applied
 to assets that don't define the name of the package to use. In addition, this
 application defines a package named ``img`` to serve images from an external
 domain and a ``doc`` package to avoid repeating long paths when linking to a

--- a/components/browser_kit.rst
+++ b/components/browser_kit.rst
@@ -121,7 +121,7 @@ provides access to the link properties (e.g. ``$link->getMethod()``,
 The :method:`Symfony\\Component\\BrowserKit\\AbstractBrowser::click` and
 :method:`Symfony\\Component\\BrowserKit\\AbstractBrowser::clickLink` methods
 can take an optional ``serverParameters`` argument. This
-parameter allows to send additional information like headers when clicking
+parameter allows sending additional information like headers when clicking
 on a link::
 
     use Acme\Client;

--- a/components/clock.rst
+++ b/components/clock.rst
@@ -36,7 +36,7 @@ Usage
 -----
 
 The :class:`Symfony\\Component\\Clock\\Clock` class returns the current time and
-allows to use any `PSR-20`_ compatible implementation as a global clock in your
+allows you to use any `PSR-20`_ compatible implementation as a global clock in your
 application::
 
     use Symfony\Component\Clock\Clock;

--- a/components/event_dispatcher.rst
+++ b/components/event_dispatcher.rst
@@ -193,7 +193,7 @@ determine which instance is passed.
             ->addTag('kernel.event_subscriber');
 
     ``RegisterListenersPass`` resolves aliased class names which for instance
-    allows to refer to an event via the fully qualified class name (FQCN) of the
+    allows you to refer to an event via the fully qualified class name (FQCN) of the
     event class. The pass will read the alias mapping from a dedicated container
     parameter. This parameter can be extended by registering another compiler pass,
     ``AddEventAliasesPass``::

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -726,7 +726,7 @@ Streaming a JSON Response
     The :class:`Symfony\\Component\\HttpFoundation\\StreamedJsonResponse` class was
     introduced in Symfony 6.3.
 
-The :class:`Symfony\\Component\\HttpFoundation\\StreamedJsonResponse` allows to
+The :class:`Symfony\\Component\\HttpFoundation\\StreamedJsonResponse` allows you to
 stream large JSON responses using PHP generators to keep the used resources low.
 
 The class constructor expects an array which represents the JSON structure and

--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -747,7 +747,7 @@ applications. One of the key features of the bundles is that you can use logic
 paths instead of physical paths to refer to any of their resources (config files,
 templates, controllers, translation files, etc.)
 
-This allows to import resources even if you don't know where in the filesystem a
+This allows you to import resources even if you don't know where in the filesystem a
 bundle will be installed. For example, the ``services.xml`` file stored in the
 ``Resources/config/`` directory of a bundle called FooBundle can be referenced as
 ``@FooBundle/Resources/config/services.xml`` instead of ``__DIR__/Resources/config/services.xml``.

--- a/components/intl.rst
+++ b/components/intl.rst
@@ -275,7 +275,7 @@ can change if the number is used in cash transactions or in other scenarios
     $fractionDigits = Currencies::getFractionDigits('SEK');         // returns: 2
     $cashFractionDigits = Currencies::getCashFractionDigits('SEK'); // returns: 0
 
-Some currencies require to round numbers to the nearest increment of some value
+Some currencies require rounding numbers to the nearest increment of some value
 (e.g. 5 cents). This increment might be different if numbers are formatted for
 cash transactions or other scenarios (e.g. accounting)::
 

--- a/components/lock.rst
+++ b/components/lock.rst
@@ -916,7 +916,7 @@ The PdoStore relies on the `ACID`_ properties of the SQL engine.
 
 .. warning::
 
-    Some SQL engines like MySQL allow to disable the unique constraint check.
+    Some SQL engines like MySQL allow disabling the unique constraint check.
     Ensure that this is not the case ``SET unique_checks=1;``.
 
 In order to purge old locks, this store uses a current datetime to define an

--- a/components/mime.rst
+++ b/components/mime.rst
@@ -246,7 +246,7 @@ indicates its priority, so the first returned extension is the preferred one.
 Guessing the MIME Type
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Another useful utility allows to guess the MIME type of any given file::
+Another useful utility lets you guess the MIME type of any given file::
 
     use Symfony\Component\Mime\MimeTypes;
 

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -25,7 +25,7 @@ It comes with the following features:
   #. running tests in parallel when a test suite is split in several phpunit.xml files;
   #. recording and replaying skipped tests;
 
-* It allows to create tests that are compatible with multiple PHPUnit versions
+* It allows you to create tests that are compatible with multiple PHPUnit versions
   (because it provides polyfills for missing methods, namespaced aliases for
   non-namespaced classes, etc.).
 

--- a/components/property_access.rst
+++ b/components/property_access.rst
@@ -420,7 +420,7 @@ see `Enable other Features`_::
 Writing to Array Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``PropertyAccessor`` class allows to update the content of arrays stored in
+The ``PropertyAccessor`` class allows updating the content of arrays stored in
 properties through *adder* and *remover* methods::
 
     // ...

--- a/components/string.rst
+++ b/components/string.rst
@@ -440,7 +440,7 @@ different sequences of code points represent the same character. For example,
 the Swedish letter ``å`` can be a single code point (``U+00E5`` = *"latin small
 letter A with ring above"*) or a sequence of two code points (``U+0061`` =
 *"latin small letter A"* + ``U+030A`` = *"combining ring above"*). The
-``normalize()`` method allows to pick the normalization mode::
+``normalize()`` method allows you to pick the normalization mode::
 
     // these encode the letter as a single code point: U+00E5
     u('å')->normalize(UnicodeString::NFC);
@@ -457,7 +457,7 @@ is not optimal. For example, consider a hash value that requires certain
 computation to obtain and which you might end up not using it.
 
 In those cases, it's better to use the :class:`Symfony\\Component\\String\\LazyString`
-class that allows to store a string whose value is only generated when you need it::
+class that allows storing a string whose value is only generated when you need it::
 
     use Symfony\Component\String\LazyString;
 

--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -178,7 +178,7 @@ Outside a Symfony application, use the :class:`Symfony\\Component\\VarDumper\\Du
     The second argument of :class:`Symfony\\Component\\VarDumper\\Dumper\\ServerDumper`
     is a :class:`Symfony\\Component\\VarDumper\\Dumper\\DataDumperInterface` instance
     used as a fallback when the server is unreachable. The third argument are the
-    context providers, which allow to gather some info about the context in which the
+    context providers, which allow you to gather some info about the context in which the
     data was dumped. The built-in context providers are: ``cli``, ``request`` and ``source``.
 
 Then you can use the following command to start a server out-of-the-box:

--- a/components/var_exporter.rst
+++ b/components/var_exporter.rst
@@ -2,7 +2,7 @@ The VarExporter Component
 =========================
 
     The VarExporter component exports any serializable PHP data structure to
-    plain PHP code and allows to instantiate and populate objects without
+    plain PHP code and allows you to instantiate and populate objects without
     calling their constructors.
 
 Installation
@@ -231,7 +231,7 @@ initialized::
     ``createLazyGhost()`` method is deprecated since Symfony 6.4. Pass
     a single closure that initializes the whole object instead.
 
-:class:`Symfony\\Component\\VarExporter\\LazyGhostTrait` also allows to
+:class:`Symfony\\Component\\VarExporter\\LazyGhostTrait` also allows you to
 convert non-lazy classes to lazy ones::
 
     namespace App\Hash;
@@ -304,9 +304,9 @@ of :ref:`Virtual Proxies <var-exporter_virtual-proxies>`.
 LazyProxyTrait
 ~~~~~~~~~~~~~~
 
-The purpose of virtual proxies in the same one as
+The purpose of virtual proxies is the same as
 :ref:`ghost objects <var-exporter_ghost-objects>`, but their internal behavior is
-totally different. Where ghost objects requires to extend a base class, virtual
+completely different. Where ghost objects requires extending a base class, virtual
 proxies take advantage of the **Liskov Substitution principle**. This principle
 describes that if two objects are implementing the same interface, you can swap
 between the different implementations without breaking your application. This is

--- a/components/yaml.rst
+++ b/components/yaml.rst
@@ -193,8 +193,8 @@ Numeric Literals
 ................
 
 Long numeric literals, being integer, float or hexadecimal, are known for their
-poor readability in code and configuration files. That's why YAML files allow to
-add underscores to improve their readability:
+poor readability in code and configuration files. That's why YAML files allow
+adding underscores to improve their readability:
 
 .. code-block:: yaml
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -478,7 +478,7 @@ files directly in the ``config/packages/`` directory.
                 webpack_encore:
                     strict_mode: false
 
-            # YAML syntax allows to reuse contents using "anchors" (&some_name) and "aliases" (*some_name).
+            # YAML syntax allows you to reuse contents using "anchors" (&some_name) and "aliases" (*some_name).
             # In this example, 'test' configuration uses the exact same configuration as in 'prod'
             when@prod: &webpack_prod
                 webpack_encore:

--- a/configuration/front_controllers_and_kernel.rst
+++ b/configuration/front_controllers_and_kernel.rst
@@ -199,7 +199,7 @@ As mentioned above, the ``Kernel`` has to implement another method -
 This method is responsible for loading the application's configuration from the
 right *environment*.
 
-:ref:`Configuration environments <configuration-environments>` allow to execute
+:ref:`Configuration environments <configuration-environments>` allow you to execute
 the same code using different configuration. Symfony provides three environments
 by default called ``dev``, ``prod`` and ``test``.
 

--- a/console.rst
+++ b/console.rst
@@ -179,7 +179,7 @@ You can optionally define a description, help message and the
 .. tip::
 
     Defining the ``$defaultDescription`` static property instead of using the
-    ``setDescription()`` method allows to get the command description without
+    ``setDescription()`` method allows you to get the command description without
     instantiating its class. This makes the ``php bin/console list`` command run
     much faster.
 
@@ -620,13 +620,13 @@ message whenever a command doesn't finish with the ``0`` `exit status`_.
 Using Events And Handling Signals
 ---------------------------------
 
-When a command is running, many events are dispatched, one of them allows to
+When a command is running, many events are dispatched, one of them allows you to
 react to signals, read more in :doc:`this section </components/console/events>`.
 
 Profiling Commands
 ------------------
 
-Symfony allows to profile the execution of any command, including yours. First,
+Symfony allows you to profile the execution of any command, including yours. First,
 make sure that the :ref:`debug mode <debug-mode>` and the :doc:`profiler </profiler>`
 are enabled. Then, add the ``--profile`` option when running the command:
 
@@ -675,7 +675,7 @@ tools capable of helping you with different tasks:
 * :doc:`/components/console/helpers/table`: displays tabular data as a table
 * :doc:`/components/console/helpers/debug_formatter`: provides functions to
   output debug information when running an external program
-* :doc:`/components/console/helpers/processhelper`: allows to run processes using ``DebugFormatterHelper``
-* :doc:`/components/console/helpers/cursor`: allows to manipulate the cursor in the terminal
+* :doc:`/components/console/helpers/processhelper`: allows you to run processes using ``DebugFormatterHelper``
+* :doc:`/components/console/helpers/cursor`: allows you to manipulate the cursor in the terminal
 
 .. _`exit status`: https://en.wikipedia.org/wiki/Exit_status

--- a/console/calling_commands.rst
+++ b/console/calling_commands.rst
@@ -53,8 +53,8 @@ method)::
 
 .. note::
 
-    Using ``doRun()`` instead of ``run()`` prevents autoexiting and allows to
-    return the exit code instead.
+    Using ``doRun()`` instead of ``run()`` prevents autoexiting and allows
+    you to return the exit code instead.
 
     Also, using ``$this->getApplication()->doRun()`` instead of
     ``$this->getApplication()->find('demo:greet')->run()`` will allow proper

--- a/console/input.rst
+++ b/console/input.rst
@@ -144,7 +144,7 @@ how many times in a row the message should be printed::
             InputOption::VALUE_REQUIRED,
             // the option description displayed when showing the command help
             'How many times should the message be printed?',
-            // the default value of the option (for those which allow to pass values)
+            // the default value of the option (for those which allow you to pass values)
             1
         )
     ;

--- a/console/lazy_commands.rst
+++ b/console/lazy_commands.rst
@@ -13,7 +13,7 @@ The traditional way of adding commands to your application is to use
 This approach can have downsides as some commands might be expensive to
 instantiate in which case you may want to lazy-load them. Note however that lazy-loading
 is not absolute. Indeed a few commands such as ``list``, ``help`` or ``_complete`` can
-require to instantiate other commands although they are lazy. For example ``list`` needs
+require instantiating other commands although they are lazy. For example ``list`` needs
 to get the name and description of all commands, which might require the command to be
 instantiated to get.
 

--- a/console/style.rst
+++ b/console/style.rst
@@ -37,7 +37,7 @@ unnecessarily.
 
 In order to reduce that boilerplate code, Symfony commands can optionally use the
 **Symfony Style Guide**. These styles are implemented as a set of helper methods
-which allow to create *semantic* commands and forget about their styling.
+which allow you to create *semantic* commands and forget about their styling.
 
 Basic Usage
 -----------

--- a/contributing/code/bc.rst
+++ b/contributing/code/bc.rst
@@ -496,7 +496,7 @@ Making Code Changes in a Backward Compatible Way
 As you read above, many changes are not allowed because they would represent a
 backward compatibility break. However, we want to be able to improve the code and
 its features over time and that can be done thanks to some strategies that
-allow to still do some unallowed changes in several steps that ensure backward
+allow you to still do some unallowed changes in several steps that ensure backward
 compatibility and a smooth upgrade path. Some of them are described in the next
 sections.
 

--- a/controller/value_resolver.rst
+++ b/controller/value_resolver.rst
@@ -231,7 +231,7 @@ Managing Value Resolvers
 For each argument, every resolver tagged with ``controller.argument_value_resolver``
 will be called until one provides a value. The order in which they are called depends
 on their priority. For example, the ``SessionValueResolver`` will be called before the
-``DefaultValueResolver`` because its priority is higher. This allows to write e.g.
+``DefaultValueResolver`` because its priority is higher. This allows you to write e.g.
 ``SessionInterface $session = null`` to get the session if there is one, or ``null``
 if there is none.
 
@@ -276,7 +276,7 @@ You can target a resolver by passing its name as ``ValueResolver``'s first argum
 For convenience, built-in resolvers' name are their FQCN.
 
 A targeted resolver can also be disabled by passing ``ValueResolver``'s ``$disabled``
-argument to ``true``; this is how :ref:`MapEntity allows to disable the
+argument to ``true``; this is how :ref:`MapEntity allows you to disable the
 EntityValueResolver for a specific controller <doctrine-entity-value-resolver>`.
 Yes, ``MapEntity`` extends ``ValueResolver``!
 

--- a/form/bootstrap5.rst
+++ b/form/bootstrap5.rst
@@ -138,7 +138,7 @@ Form type or ``ChoiceType`` configuration) to the label class.
 Switches
 ~~~~~~~~
 
-Bootstrap 5 allows to render checkboxes as `switches`_. You can enable this
+Bootstrap 5 allows you to render checkboxes as `switches`_. You can enable this
 feature on your Symfony Form ``CheckboxType`` by adding the ``checkbox-switch``
 class to the label:
 

--- a/form/create_custom_field_type.rst
+++ b/form/create_custom_field_type.rst
@@ -232,7 +232,7 @@ better).
 Adding Configuration Options for the Form Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Imagine that your project requires to make the ``PostalAddressType``
+Imagine that your project requires making the ``PostalAddressType``
 configurable in two ways:
 
 * In addition to "address line 1" and "address line 2", some addresses should be
@@ -240,7 +240,7 @@ configurable in two ways:
 * Instead of displaying a free text input, some addresses should be able to
   restrict the possible states to a given list.
 
-This is solved with "form type options", which allow to configure the behavior
+This is solved with "form type options", which allow you to configure the behavior
 of the form types. The options are defined in the ``configureOptions()`` method
 and you can use all the :doc:`OptionsResolver component features </components/options_resolver>`
 to define, validate and process their values::

--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -132,7 +132,7 @@ fields, so you no longer have to deal with form themes:
 Form Rendering Variables
 ------------------------
 
-Some of the Twig functions mentioned in the previous section allow to pass
+Some of the Twig functions mentioned in the previous section allow you to pass
 variables to configure their behavior. For example, the ``form_label()``
 function lets you define a custom label to override the one defined in the form:
 
@@ -348,7 +348,7 @@ label, errors, help and widget.
     {{ form_row(form.name, {'label': 'foo'}) }}
 
 The second argument to ``form_row()`` is an array of variables. The templates
-provided in Symfony only allow to override the label as shown in the example
+provided in Symfony only allow you to override the label as shown in the example
 above.
 
 See ":ref:`twig-reference-form-variables`" to learn about the ``variables``

--- a/frontend/encore/advanced-config.rst
+++ b/frontend/encore/advanced-config.rst
@@ -317,7 +317,7 @@ The following loaders are configurable with ``configureLoaderRule()``:
 Configuring Aliases When Importing or Requiring Modules
 -------------------------------------------------------
 
-The `Webpack resolve.alias option`_ allows to create aliases to simplify the
+The `Webpack resolve.alias option`_ allows creating aliases to simplify the
 ``import`` or ``require`` of certain modules (e.g. by aliasing commonly used ``src/``
 folders). In Webpack Encore you can use this option via the ``addAliases()`` method:
 
@@ -338,7 +338,7 @@ With the above config, you could now import certain modules more concisely:
 Excluding Some Dependencies from Output Bundles
 -----------------------------------------------
 
-The `Webpack externals option`_ allows to prevent bundling of certain imported
+The `Webpack externals option`_ allows you to prevent bundling of certain imported
 packages and instead retrieve those external dependencies at runtime. This feature
 is mostly useful for JavaScript library developers, so you probably won't need it.
 

--- a/http_client.rst
+++ b/http_client.rst
@@ -744,7 +744,7 @@ Retry Failed Requests
 ~~~~~~~~~~~~~~~~~~~~~
 
 Sometimes, requests fail because of network issues or temporary server errors.
-Symfony's HttpClient allows to retry failed requests automatically using the
+Symfony's HttpClient allows retrying failed requests automatically using the
 :ref:`retry_failed option <reference-http-client-retry-failed>`.
 
 By default, failed requests are retried up to 3 times, with an exponential delay
@@ -1054,7 +1054,7 @@ is installed and enabled, and will fall back as explained above.
 Configuring CurlHttpClient Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-PHP allows to configure lots of `cURL options`_ via the :phpfunction:`curl_setopt`
+PHP allows configuring lots of `cURL options`_ via the :phpfunction:`curl_setopt`
 function. In order to make the component more portable when not using cURL, the
 :class:`Symfony\\Component\\HttpClient\\CurlHttpClient` only uses some of those
 options (and they are ignored in the rest of clients).
@@ -1197,7 +1197,7 @@ following methods::
     // returns detailed logs about the requests and responses of the HTTP transaction
     $httpLogs = $response->getInfo('debug');
 
-    // the special "pause_handler" info item is a callable that allows to delay the request
+    // the special "pause_handler" info item is a callable that allows you to delay the request
     // for a given number of seconds; this allows you to delay retries, throttle streams, etc.
     $response->getInfo('pause_handler')(2);
 
@@ -2269,7 +2269,7 @@ test it in a real application::
 Testing Using HAR Files
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Modern browsers (via their network tab) and HTTP clients allow to export the
+Modern browsers (via their network tab) and HTTP clients allow you to export the
 information of one or more HTTP requests using the `HAR`_ (HTTP Archive) format.
 You can use those ``.har`` files to perform tests with Symfony's HTTP Client.
 

--- a/mailer.rst
+++ b/mailer.rst
@@ -1705,7 +1705,7 @@ MessageEvent
 
 **Event Class**: :class:`Symfony\\Component\\Mailer\\Event\\MessageEvent`
 
-``MessageEvent`` allows to change the Mailer message and the envelope before
+``MessageEvent`` allows changing the Mailer message and the envelope before
 the email is sent::
 
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/mercure.rst
+++ b/mercure.rst
@@ -622,7 +622,7 @@ hypermedia API, and automatic update broadcasting through the Mercure hub::
     }
 
 As showcased `in this recording`_, the API Platform Client Generator also
-allows to scaffold complete React and React Native applications from this API.
+allows you to scaffold complete React and React Native applications from this API.
 These applications will render the content of Mercure updates in real-time.
 
 Checkout `the dedicated API Platform documentation`_ to learn more about

--- a/profiler.rst
+++ b/profiler.rst
@@ -391,7 +391,7 @@ template access to the collected information::
     }
 
 In the simplest case, you want to display the information in the toolbar
-without providing a profiler panel. This requires to define the ``toolbar``
+without providing a profiler panel. This requires defining the ``toolbar``
 block and set the value of two variables called ``icon`` and ``text``:
 
 .. code-block:: html+twig

--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -442,7 +442,7 @@ the :class:`Symfony\\Component\\RateLimiter\\Reservation` object returned by the
 Storing Rate Limiter State
 --------------------------
 
-All rate limiter policies require to store their state (e.g. how many hits were
+All rate limiter policies require storing their state (e.g. how many hits were
 already made in the current time window). By default, all limiters use the
 ``cache.rate_limiter`` cache pool created with the :doc:`Cache component </cache>`.
 This means that every time you clear the cache, the rate limiter will be reset.

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2663,7 +2663,7 @@ paths
 
 **type**: ``array`` **default**: ``[]``
 
-This option allows to define an array of paths where the component will look
+This option allows you to define an array of paths where the component will look
 for translation files. The later a path is added, the more priority it has
 (translations from later paths overwrite earlier ones). Translations from the
 :ref:`default_path <reference-translator-default_path>` have more priority than
@@ -2676,7 +2676,7 @@ default_path
 
 **type**: ``string`` **default**: ``%kernel.project_dir%/translations``
 
-This option allows to define the path where the application translations files
+This option allows you to define the path where the application translations files
 are stored.
 
 .. _reference-translator-providers:
@@ -2878,7 +2878,7 @@ endpoint
 
 By default, the :doc:`NotCompromisedPassword </reference/constraints/NotCompromisedPassword>`
 constraint uses the public API provided by `haveibeenpwned.com`_. This option
-allows to define a different, but compatible, API endpoint to make the password
+allows you to define a different, but compatible, API endpoint to make the password
 checks. It's useful for example when the Symfony application is run in an
 intranet without public access to the internet.
 
@@ -2919,7 +2919,7 @@ paths
 
 **type**: ``array`` **default**: ``['config/validation/']``
 
-This option allows to define an array of paths with files or directories where
+This option allows you to define an array of paths with files or directories where
 the component will look for additional validation files:
 
 .. configuration-block::
@@ -3085,7 +3085,7 @@ paths
 
 **type**: ``array`` **default**: ``[]``
 
-This option allows to define an array of paths with files or directories where
+This option allows you to define an array of paths with files or directories where
 the component will look for additional serialization files.
 
 default_context

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -499,7 +499,7 @@ By default, when users log out from any firewall, their sessions are invalidated
 This means that logging out from one firewall automatically logs them out from
 all the other firewalls.
 
-The ``invalidate_session`` option allows to redefine this behavior. Set this
+The ``invalidate_session`` option allows you to redefine this behavior. Set this
 option to ``false`` in every firewall and the user will only be logged out from
 the current firewall and not the other ones.
 

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -71,7 +71,7 @@ compilation time based on the filename of the template. This means for example
 that the contents of a ``*.html.twig`` template are escaped for HTML and the
 contents of ``*.js.twig`` are escaped for JavaScript.
 
-This option allows to define the Symfony service which will be used to determine
+This option allows you to define the Symfony service which will be used to determine
 the default escaping applied to the template.
 
 autoescape_service_method

--- a/reference/constraints/DisableAutoMapping.rst
+++ b/reference/constraints/DisableAutoMapping.rst
@@ -1,8 +1,8 @@
 DisableAutoMapping
 ==================
 
-This constraint allows to disable :ref:`Doctrine's auto mapping <doctrine_auto-mapping>`
-on a class or a property. Automapping allows to determine validation rules based
+This constraint allows you to disable :ref:`Doctrine's auto mapping <doctrine_auto-mapping>`
+on a class or a property. Automapping allows you to determine validation rules based
 on Doctrine's attributes. You may use this constraint when
 automapping is globally enabled, but you still want to disable this feature for
 a class or a property specifically.

--- a/reference/constraints/EnableAutoMapping.rst
+++ b/reference/constraints/EnableAutoMapping.rst
@@ -1,8 +1,8 @@
 EnableAutoMapping
 =================
 
-This constraint allows to enable :ref:`Doctrine's auto mapping <doctrine_auto-mapping>`
-on a class or a property. Automapping allows to determine validation rules based
+This constraint allows you to enable :ref:`Doctrine's auto mapping <doctrine_auto-mapping>`
+on a class or a property. Automapping allows you to determine validation rules based
 on Doctrine's attributes. You may use this constraint when
 automapping is globally disabled, but you still want to enable this feature for
 a class or a property specifically.

--- a/reference/constraints/PasswordStrength.rst
+++ b/reference/constraints/PasswordStrength.rst
@@ -128,7 +128,7 @@ The default message supplied when the password does not reach the minimum requir
     class User
     {
         #[Assert\PasswordStrength([
-            'message' => 'Your password is too easy to guess. Company\'s security policy requires to use a stronger password.'
+            'message' => 'Your password is too easy to guess. Company\'s security policy requires using a stronger password.'
         ])]
         protected $rawPassword;
     }

--- a/reference/constraints/_normalizer-option.rst.inc
+++ b/reference/constraints/_normalizer-option.rst.inc
@@ -3,7 +3,7 @@
 
 **type**: a `PHP callable`_ **default**: ``null``
 
-This option allows to define the PHP callable applied to the given value before
+This option allows you to define the PHP callable applied to the given value before
 checking if it is valid.
 
 For example, you may want to pass the ``'trim'`` string to apply the

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -1084,8 +1084,8 @@ extractor to find and extract translation keys from Twig templates and PHP files
 
 Symfony includes two PHP extractors: :class:`Symfony\\Component\\Translation\\Extractor\\PhpExtractor`
 and :class:`Symfony\\Component\\Translation\\Extractor\\PhpAstExtractor`. The
-first one is simple but doesn't require to install any packages; the second one
-is much more advanced, but requires to install this dependency in your project:
+first one is simple but doesn't require installing any packages; the second one
+is much more advanced, but requires installing this dependency in your project:
 
 .. code-block:: terminal
 

--- a/reference/formats/message_format.rst
+++ b/reference/formats/message_format.rst
@@ -83,7 +83,7 @@ and replaced by its placeholder::
 Selecting Different Messages Based on a Condition
 -------------------------------------------------
 
-The curly brace syntax allows to "modify" the output of the variable. One of
+The curly brace syntax allows you to "modify" the output of the variable. One of
 these functions is the ``select`` function. It acts like PHP's `switch statement`_
 and allows you to use different strings based on the value of the variable. A
 typical usage of this is gender:

--- a/reference/formats/yaml.rst
+++ b/reference/formats/yaml.rst
@@ -316,7 +316,7 @@ Symfony Specific Features
 The Yaml component provides some additional features that are not part of the
 official YAML specification but are useful in Symfony applications:
 
-* ``!php/const`` allows to get the value of a PHP constant. This tag takes the
+* ``!php/const`` allows you to get the value of a PHP constant. This tag takes the
   fully-qualified class name of the constant as its argument:
 
   .. code-block:: yaml
@@ -324,7 +324,7 @@ official YAML specification but are useful in Symfony applications:
       data:
           page_limit: !php/const App\Pagination\Paginator::PAGE_LIMIT
 
-* ``!php/object`` allows to pass the serialized representation of a PHP
+* ``!php/object`` allows you to pass the serialized representation of a PHP
   object (created with the `serialize()`_ function), which will be deserialized
   when parsing the YAML file:
 
@@ -333,7 +333,7 @@ official YAML specification but are useful in Symfony applications:
       data:
           my_object: !php/object 'O:8:"stdClass":1:{s:3:"bar";i:2;}'
 
-* ``!php/enum`` allows to use a PHP enum case. This tag takes the fully-qualified
+* ``!php/enum`` allows you to use a PHP enum case. This tag takes the fully-qualified
   class name of the enum case as its argument:
 
   .. code-block:: yaml

--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -205,7 +205,7 @@ prototype_options
     The ``prototype_options`` option was introduced in Symfony 6.1.
 
 This is the array that's passed to the form type specified in the `entry_type`_
-option when creating its prototype. It allows to have different options depending
+option when creating its prototype. It allows having different options depending
 on whether you are adding a new entry or editing an existing entry::
 
     use Symfony\Component\Form\Extension\Core\Type\CollectionType;

--- a/reference/forms/types/enum.rst
+++ b/reference/forms/types/enum.rst
@@ -37,7 +37,7 @@ short) defined somewhere in your application. This enum has to be of type
     }
 
 Instead of using the values of the enumeration in a ``choices`` option, the
-``EnumType`` only requires to define the ``class`` option pointing to the enum::
+``EnumType`` only requires defining the ``class`` option pointing to the enum::
 
     use App\Config\TextAlign;
     use Symfony\Component\Form\Extension\Core\Type\EnumType;

--- a/reference/forms/types/options/choice_loader.rst.inc
+++ b/reference/forms/types/options/choice_loader.rst.inc
@@ -4,7 +4,7 @@ choice_loader
 **type**: :class:`Symfony\\Component\\Form\\ChoiceList\\Loader\\ChoiceLoaderInterface`
 
 The ``choice_loader`` option can be used instead of the ``choices`` option. It
-allows to create a list lazily or partially when fetching only the choices for a
+allows you to create a list lazily or partially when fetching only the choices for a
 set of submitted values (i.e. querying a search engine like ``ElasticSearch``
 can be a heavy process).
 

--- a/scheduler.rst
+++ b/scheduler.rst
@@ -159,7 +159,7 @@ the frequency of the message. Symfony provides different types of triggers:
 :class:`Symfony\\Component\\Scheduler\\Trigger\\JitterTrigger`
     A trigger that adds a random jitter to a given trigger. The jitter is some
     time that is added to the original triggering date/time. This
-    allows to distribute the load of the scheduled tasks instead of running them
+    allows distributing the load of the scheduled tasks instead of running them
     all at the exact same time.
 
 :class:`Symfony\\Component\\Scheduler\\Trigger\\PeriodicalTrigger`
@@ -278,7 +278,7 @@ For example::
 Periodical Triggers
 ~~~~~~~~~~~~~~~~~~~
 
-These triggers allows to configure the frequency using different data types
+These triggers allows you to configure the frequency using different data types
 (``string``, ``integer``, ``DateInterval``). They also support the `relative formats`_
 defined by PHP datetime functions::
 
@@ -323,7 +323,7 @@ is scheduled hourly, it will run at 9:33, 10:33, 11:33, etc.
 Custom Triggers
 ~~~~~~~~~~~~~~~
 
-Custom triggers allow to configure any frequency dynamically. They are created
+Custom triggers allow you to configure any frequency dynamically. They are created
 as services that implement :class:`Symfony\\Component\\Scheduler\\Trigger\\TriggerInterface`.
 
 For example, if you want to send customer reports daily except for holiday periods::
@@ -716,7 +716,7 @@ being transferred and processed by its handler::
                     // can target directly the RecurringMessage being processed
                     $schedule->removeById($messageContext->id);
 
-                    // allow to call the ShouldCancel() and avoid the message to be handled
+                    // allows calling ShouldCancel() to avoid handling the message
                     $event->shouldCancel(true);
                 })
                 ->after(function(PostRunEvent $event) {
@@ -736,7 +736,7 @@ PreRunEvent
 
 **Event Class**: :class:`Symfony\\Component\\Scheduler\\Event\\PreRunEvent`
 
-``PreRunEvent`` allows to modify the :class:`Symfony\\Component\\Scheduler\\Schedule`
+``PreRunEvent`` allows you to modify the :class:`Symfony\\Component\\Scheduler\\Schedule`
 or cancel a message before it's consumed::
 
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -766,7 +766,7 @@ PostRunEvent
 
 **Event Class**: :class:`Symfony\\Component\\Scheduler\\Event\\PostRunEvent`
 
-``PostRunEvent`` allows to modify the :class:`Symfony\\Component\\Scheduler\\Schedule`
+``PostRunEvent`` allows you to modify the :class:`Symfony\\Component\\Scheduler\\Schedule`
 after a message is consumed::
 
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -793,7 +793,7 @@ FailureEvent
 
 **Event Class**: :class:`Symfony\\Component\\Scheduler\\Event\\FailureEvent`
 
-``FailureEvent`` allows to modify the :class:`Symfony\\Component\\Scheduler\\Schedule`
+``FailureEvent`` allows you to modify the :class:`Symfony\\Component\\Scheduler\\Schedule`
 when a message consumption throws an exception::
 
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -984,7 +984,7 @@ If a worker is restarted on day 2, the message will be sent 3 days from the rest
 
 While this behavior may not necessarily pose a problem, there is a possibility that it may not align with what you are seeking.
 
-That's why the scheduler allows to remember the last execution date of a message
+That's why the scheduler allows you to remember the last execution date of a message
 via the ``stateful`` option (and the :doc:`Cache component </components/cache>`).
 This allows the system to retain the state of the schedule, ensuring that when a worker is restarted, it resumes from the point it left off.::
 

--- a/security/access_token.rst
+++ b/security/access_token.rst
@@ -349,7 +349,7 @@ Using OpenID Connect (OIDC)
 `OpenID Connect (OIDC)`_ is the third generation of OpenID technology and it's a
 RESTful HTTP API that uses JSON as its data format. OpenID Connect is an
 authentication layer on top of the OAuth 2.0 authorization framework. It allows
-to verify the identity of an end user based on the authentication performed by
+you to verify the identity of an end user based on the authentication performed by
 an authorization server.
 
 1) Configure the OidcUserInfoTokenHandler

--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -763,7 +763,7 @@ Customizing the Login Link
 --------------------------
 
 The ``createLoginLink()`` method accepts a second optional argument to pass the
-``Request`` object used when generating the login link. This allows to customize
+``Request`` object used when generating the login link. This allows you to customize
 features such as the locale used to generate the link::
 
     // src/Controller/SecurityController.php

--- a/security/user_checkers.rst
+++ b/security/user_checkers.rst
@@ -15,7 +15,7 @@ perform checks before and after user authentication. If one or more conditions
 are not met, throw an exception which extends the
 :class:`Symfony\\Component\\Security\\Core\\Exception\\AccountStatusException` class.
 Consider using :class:`Symfony\\Component\\Security\\Core\\Exception\\CustomUserMessageAccountStatusException`,
-which extends ``AccountStatusException`` and allows to customize the error message
+which extends ``AccountStatusException`` and allows you to customize the error message
 displayed to the user::
 
     namespace App\Security;

--- a/templates.rst
+++ b/templates.rst
@@ -175,7 +175,7 @@ in the following order:
    exception if the :ref:`strict_variables <config-twig-strict-variables>`
    option is enabled).
 
-This allows to evolve your application code without having to change the
+This allows you to evolve your application code without having to change the
 template code (you can start with array variables for the application proof of
 concept, then move to objects with methods, etc.)
 

--- a/testing.rst
+++ b/testing.rst
@@ -154,7 +154,7 @@ Set-up your Test Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The tests create a kernel that runs in the ``test``
-:ref:`environment <configuration-environments>`. This allows to have
+:ref:`environment <configuration-environments>`. This allows you to have
 special settings for your tests inside ``config/packages/test/``.
 
 If you have Symfony Flex installed, some packages already installed some

--- a/testing/end_to_end.rst
+++ b/testing/end_to_end.rst
@@ -623,7 +623,7 @@ Chrome Specific Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``PANTHER_NO_SANDBOX``
-    Disable `Chrome's sandboxing`_ (unsafe, but allows to use Panther in containers)
+    Disable `Chrome's sandboxing`_ (unsafe, but allows you to use Panther in containers)
 ``PANTHER_CHROME_ARGUMENTS``
     Customize Chrome arguments. You need to set ``PANTHER_NO_HEADLESS`` to ``1``
     to fully customize


### PR DESCRIPTION
This PR fixes

* allow to:
  * wrong: allow to [infinitive] 
  * correct: allow [object (e.g. "you")] to [infinitive] 
  * correct: allow [gerund]
* require to:
  * wrong: require to [infinitive] 
  * correct: require [object (e.g. "you")] to [infinitive] 
  * correct: require [gerund]

@OskarStark given that we make this mistake so frequently, maybe we could create a DOCtor-RST rule for it. Thanks!