### PR TITLE
 Remove mentions to legacy PHP versions

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -500,13 +500,13 @@ Running the following command will display the full stack trace:
 Testing with Multiple PHPUnit Versions
 --------------------------------------
 
-When testing a library that has to be compatible with several versions of PHP,
+When testing a library that has to be compatible with legacy versions of PHP,
 the test suite cannot use the latest versions of PHPUnit because:
 
 * PHPUnit 8 deprecated several methods in favor of other methods which are not
   available in older versions (e.g. PHPUnit 4);
 * PHPUnit 8 added the ``void`` return type to the ``setUp()`` method, which is
-  not compatible with PHP 5.5;
+  not compatible with legacy PHP versions;
 * PHPUnit switched to namespaced classes starting from PHPUnit 6, so tests must
   work with and without namespaces.
 
@@ -526,7 +526,8 @@ When running the ``simple-phpunit`` script with the ``SYMFONY_PHPUNIT_REMOVE_RET
 environment variable set to ``1``, the PHPUnit bridge will alter the code of
 PHPUnit to remove the return type (introduced in PHPUnit 8) from ``setUp()``,
 ``tearDown()``, ``setUpBeforeClass()`` and ``tearDownAfterClass()`` methods.
-This allows you to write a test compatible with both PHP 5 and PHPUnit 8.
+This allows you to write a test compatible with both legacy PHP versions and
+PHPUnit 8.
 
 Using Namespaced PHPUnit Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/migration.rst
+++ b/migration.rst
@@ -69,9 +69,9 @@ and check if it is working will give you an even more reliable result.
 
 .. tip::
 
-    If your current project is running on an older PHP version such as
-    PHP 5.x upgrading to a recent version will give you a performance
-    boost without having to change your code.
+    If your current project is running on a legacy PHP version, upgrading to a
+    recent version will give you a performance boost without having to change
+    your code.
 
 Setting up Composer
 ~~~~~~~~~~~~~~~~~~~

--- a/performance.rst
+++ b/performance.rst
@@ -18,7 +18,7 @@ for maximum performance:
 * **Production Server Checklist**:
 
   #. :ref:`Dump the service container into a single file <performance-service-container-single-file>`
-  #. :ref:`Use the OPcache byte code cache <performance-use-opcache>`
+  #. :ref:`Use the OPcache bytecode cache <performance-use-opcache>`
   #. :ref:`Configure OPcache for maximum performance <performance-configure-opcache>`
   #. :ref:`Don't check PHP files timestamps <performance-dont-check-timestamps>`
   #. :ref:`Configure the PHP realpath Cache <performance-configure-realpath-cache>`
@@ -40,7 +40,7 @@ Dump the Service Container into a Single File
 Symfony compiles the :doc:`service container </service_container>` into multiple
 small files by default. Set this parameter to ``true`` to compile the entire
 container into a single file, which could improve performance when using
-"class preloading" in PHP 7.4 or newer versions:
+PHP `class preloading`_:
 
 .. configuration-block::
 
@@ -74,29 +74,27 @@ container into a single file, which could improve performance when using
             $container->parameters()->set('.container.dumper.inline_factories', true);
         };
 
-.. _performance-use-opcache:
-
 .. tip::
 
     The ``.`` prefix denotes a parameter that is only used during compilation of the container.
     See :ref:`Configuration Parameters <configuration-parameters>` for more details.
 
-Use the OPcache Byte Code Cache
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _performance-use-opcache:
 
-OPcache stores the compiled PHP files to avoid having to recompile them for
-every request. There are some `byte code caches`_ available, but as of PHP
-5.5, PHP comes with `OPcache`_ built-in. For older versions, the most widely
-used byte code cache is APC.
+Use the OPcache Bytecode Cache
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+OPcache caches the compiled bytecode of PHP scripts to avoid recompiling them on
+each request. PHP ships with `OPcache`_, but depending on your setup, you may
+need to enable it explicitly.
 
 .. _performance-use-preloading:
 
 Use the OPcache class preloading
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting from PHP 7.4, OPcache can compile and load classes at start-up and
-make them available to all requests until the server is restarted, improving
-performance significantly.
+OPcache can compile and load classes at start-up and make them available to all
+requests until the server is restarted, improving performance significantly.
 
 During container compilation (e.g. when running the ``cache:clear`` command),
 Symfony generates a file with the list of classes to preload in the
@@ -158,9 +156,9 @@ server OPcache by executing some command in your terminal. These are some of the
 possible solutions:
 
 1. Restart the web server;
-2. Call the ``apc_clear_cache()`` or ``opcache_reset()`` functions via the
-   web server (i.e. by having these in a script that you execute over the web);
-3. Use the `cachetool`_ utility to control APC and OPcache from the CLI.
+2. Call the ``opcache_reset()`` function via the web server (i.e. by having these
+   in a script that you execute over the web);
+3. Use the `cachetool`_ utility to control OPcache from the CLI.
 
 .. _performance-configure-realpath-cache:
 
@@ -384,8 +382,7 @@ Learn more
 
 * :doc:`/http_cache/varnish`
 
-.. _`byte code caches`: https://en.wikipedia.org/wiki/List_of_PHP_accelerators
-.. _`OPcache`: https://www.php.net/manual/en/book.opcache.php
+.. _`OPcache`: https://php.net/book.opcache.php
 .. _`Composer's autoloader optimization`: https://getcomposer.org/doc/articles/autoloader-optimization.md
 .. _`cachetool`: https://github.com/gordalina/cachetool
 .. _`open_basedir`: https://www.php.net/manual/ini.core.php#ini.open-basedir
@@ -393,3 +390,4 @@ Learn more
 .. _`full-featured demo`: https://demo.blackfire.io?utm_source=symfony&utm_medium=symfonycom_docs&utm_campaign=performance
 .. _`Stopwatch component`: https://symfony.com/components/Stopwatch
 .. _`real-world stopwatch`: https://en.wikipedia.org/wiki/Stopwatch
+.. _`class preloading`: https://php.net/opcache.preloading.php

--- a/security/passwords.rst
+++ b/security/passwords.rst
@@ -753,8 +753,8 @@ used back when they were hashed.
 The Sodium Password Hasher
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It uses the `Argon2 key derivation function`_. Argon2 support was introduced
-in PHP 7.2 by bundling the `libsodium`_ extension.
+It uses the `Argon2 key derivation function`_. Argon2 support is available in
+PHP via the bundled `libsodium`_ extension.
 
 The hashed passwords are ``96`` characters long, but due to the hashing
 requirements saved in the resulting hash this may change in the future, so make


### PR DESCRIPTION
Symfony 6.4 requires PHP 8.1, so there's no need to mention PHP 5, 6 or 7 in the docs.