### PR TITLE
 Remove some idioms and simplify expressions

### DIFF
--- a/best_practices.rst
+++ b/best_practices.rst
@@ -32,7 +32,7 @@ to create new Symfony applications:
 
     $ symfony new my_project_directory
 
-Under the hood, this Symfony binary command executes the needed `Composer`_
+Internally, this Symfony binary command executes the needed `Composer`_
 command to :ref:`create a new Symfony application <creating-symfony-applications>`
 based on the current stable version.
 

--- a/components/cache/cache_pools.rst
+++ b/components/cache/cache_pools.rst
@@ -51,7 +51,7 @@ and deleting cache items using only two methods and a callback::
     // ... and to remove the cache key
     $cache->delete('my_cache_key');
 
-Out of the box, using this interface provides stampede protection via locking
+Using this interface provides automatic stampede protection via locking
 and early expiration. Early expiration can be controlled via the third "beta"
 argument of the :method:`Symfony\\Contracts\\Cache\\CacheInterface::get` method.
 See the :doc:`/components/cache` article for more information.

--- a/components/expression_language.rst
+++ b/components/expression_language.rst
@@ -162,7 +162,7 @@ Both methods need to tokenize and parse the expression. This is done by the
 method. It  returns a :class:`Symfony\\Component\\ExpressionLanguage\\ParsedExpression`.
 Now, the ``compile()`` method just returns the string conversion of this object.
 The ``evaluate()`` method needs to loop through the "nodes" (pieces of an
-expression saved in the ``ParsedExpression``) and evaluate them on the fly.
+expression saved in the ``ParsedExpression``) and evaluate them dynamically.
 
 To save time, the ``ExpressionLanguage`` caches the ``ParsedExpression`` so
 it can skip the tokenization and parsing steps with duplicate expressions. The

--- a/components/form.rst
+++ b/components/form.rst
@@ -69,7 +69,7 @@ method::
 
     $form->handleRequest();
 
-Behind the scenes, this uses a :class:`Symfony\\Component\\Form\\NativeRequestHandler`
+Internally, this uses a :class:`Symfony\\Component\\Form\\NativeRequestHandler`
 object to read data off of the correct PHP superglobals (i.e. ``$_POST`` or
 ``$_GET``) based on the HTTP method configured on the form (POST is default).
 

--- a/components/http_foundation.rst
+++ b/components/http_foundation.rst
@@ -896,7 +896,7 @@ It is possible to delete the file after the response is sent with the
 :method:`Symfony\\Component\\HttpFoundation\\BinaryFileResponse::deleteFileAfterSend` method.
 Please note that this will not work when the ``X-Sendfile`` header is set.
 
-If the size of the served file is unknown (e.g. because it's being generated on the fly,
+If the size of the served file is unknown (e.g. because it's being generated dynamically,
 or because a PHP stream filter is registered on it, etc.), you can pass a ``Stream``
 instance to ``BinaryFileResponse``. This will disable ``Range`` and ``Content-Length``
 handling, switching to chunked encoding instead::

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -321,7 +321,7 @@ Baseline Deprecations
 
 You can also take a snapshot of deprecations currently triggered by your application
 code, and ignore those during your test runs, still reporting newly added ones.
-The trick is to create a file with the allowed deprecations and define it as the
+To do so, create a file with the allowed deprecations and define it as the
 "deprecation baseline". Deprecations inside that file are ignored but the rest of
 deprecations are still reported.
 
@@ -892,7 +892,7 @@ namespaces in the ``phpunit.xml`` file, as done for example in the
         </listeners>
     </phpunit>
 
-Under the hood, a PHPUnit listener injects the mocked functions in the tested
+Internally, a PHPUnit listener injects the mocked functions in the tested
 classes' namespace. In order to work as expected, the listener has to run before
 the tested class ever runs.
 

--- a/configuration/front_controllers_and_kernel.rst
+++ b/configuration/front_controllers_and_kernel.rst
@@ -15,7 +15,7 @@ process, you need to understand three parts that work together:
 
     Usually, you will not need to define your own front controller or
     ``Kernel`` class as Symfony provides sensible default implementations.
-    This article is provided to explain what is going on behind the scenes.
+    This article is provided to explain what is going on internally.
 
 .. _architecture-front-controller:
 

--- a/create_framework/event_dispatcher.rst
+++ b/create_framework/event_dispatcher.rst
@@ -288,7 +288,7 @@ And here is the new version of ``ContentLengthListener``::
     events as needed.
 
 To make your framework truly flexible, don't hesitate to add more events; and
-to make it more awesome out of the box, add more listeners. Again, this book
+to make it more awesome, add more listeners. Again, this book
 is not about creating a generic framework, but one that is tailored to your
 needs. Stop whenever you see fit, and further evolve the code from there.
 

--- a/create_framework/front_controller.rst
+++ b/create_framework/front_controller.rst
@@ -121,7 +121,7 @@ To access a page, you must now use the ``front.php`` script:
     and remove the front controller script so that your users will be able to
     type ``http://127.0.0.1:4321/hello?name=Fabien``, which looks much better.
 
-The trick is the usage of the ``Request::getPathInfo()`` method which returns
+The key is to use the ``Request::getPathInfo()`` method, which returns
 the path of the Request by removing the front controller script name including
 its sub-directories (only if needed -- see above tip).
 

--- a/create_framework/http_kernel_httpkernel_class.rst
+++ b/create_framework/http_kernel_httpkernel_class.rst
@@ -113,7 +113,7 @@ client; that's what the ``ResponseListener`` does::
 
     $dispatcher->addSubscriber(new HttpKernel\EventListener\ResponseListener('UTF-8'));
 
-If you want out of the box support for streamed responses, subscribe
+If you want support for streamed responses, subscribe
 to ``StreamedResponseListener``::
 
     $dispatcher->addSubscriber(new HttpKernel\EventListener\StreamedResponseListener());
@@ -193,8 +193,8 @@ of registering event listeners/subscribers.
 
 Hopefully, you now have a better understanding of why the simple looking
 ``HttpKernelInterface`` is so powerful. Its default implementation,
-``HttpKernel``, gives you access to a lot of cool features, ready to be used
-out of the box, with no efforts. And because HttpKernel is actually the code
+``HttpKernel``, gives you access to a lot of cool and ready to be used features,
+with no efforts. And because HttpKernel is actually the code
 that powers the Symfony framework, you have the best of both
 worlds: a custom framework, tailored to your needs, but based on a rock-solid
 and well maintained low-level architecture that has been proven to work for

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -327,7 +327,7 @@ before, execute your migrations:
     $ php bin/console doctrine:migrations:migrate
 
 This will only execute the *one* new migration file, because DoctrineMigrationsBundle
-knows that the first migration was already executed earlier. Behind the scenes, it
+knows that the first migration was already executed earlier. Internally, it
 manages a ``migration_versions`` table to track this.
 
 Each time you make a change to your schema, run these two commands to generate the

--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -504,7 +504,7 @@ you will learn about next!).
     you'll need to do a little bit more work to ensure that the correct side
     of the relationship is modified.
 
-    The trick is to make sure that the single "Task" is set on each "Tag".
+    The solution is to make sure that the single "Task" is set on each "Tag".
     One way to do this is to add some extra logic to ``addTag()``, which
     is called by the form type since ``by_reference`` is set to ``false``::
 

--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -476,7 +476,7 @@ Variable                Usage
 
 .. tip::
 
-    Behind the scenes, these variables are made available to the ``FormView``
+    Internally, these variables are made available to the ``FormView``
     object of your form when the Form component calls ``buildView()`` and
     ``finishView()`` on each "node" of your form tree. To see what "view"
     variables a particular field has, find the source code for the form

--- a/form/tailwindcss.rst
+++ b/form/tailwindcss.rst
@@ -5,7 +5,7 @@ Symfony provides a minimal form theme for `Tailwind CSS`_. Tailwind is a *utilit
 CSS framework and provides *unlimited ways* to customize your forms. Tailwind has
 an official `form plugin`_ that provides a basic form reset that standardizes their look
 on all browsers. This form theme requires this plugin and adds a few basic tailwind
-classes so out of the box, your forms will look decent. Customization is almost always
+classes so your forms will look decent by default. Customization is almost always
 going to be required so this theme makes that easy.
 
 .. image:: /_images/form/tailwindcss-form.png

--- a/forms.rst
+++ b/forms.rst
@@ -950,7 +950,7 @@ the submitted data, those fields will be explicitly set to ``null``.
 Learn more
 ----------
 
-When building forms, keep in mind that the first goal of a form is to translate
+When building forms, remember that the first goal of a form is to translate
 data from an object (``Task``) to an HTML form so that the user can modify that
 data. The second goal of a form is to take the data submitted by the user and to
 re-apply it to the object.

--- a/frontend/encore/code-splitting.rst
+++ b/frontend/encore/code-splitting.rst
@@ -47,7 +47,7 @@ the code via AJAX when it's needed:
 By using ``import()`` like a function, the module will be downloaded async and
 the ``.then()`` callback will be executed when it's finished. The ``VideoPlayer``
 argument to the callback will be the loaded module. In other words, it works like
-normal AJAX calls! Behind the scenes, Webpack will package the ``VideoPlayer`` module
+normal AJAX calls! Internally, Webpack will package the ``VideoPlayer`` module
 into a separate file (e.g. ``0.js``) so it can be downloaded. All the details are
 handled for you.
 

--- a/frontend/encore/custom-loaders-plugins.rst
+++ b/frontend/encore/custom-loaders-plugins.rst
@@ -4,7 +4,7 @@ Adding Custom Loaders & Plugins with Webpack Encore
 Adding Custom Loaders
 ---------------------
 
-Encore already comes with a variety of different loaders out of the box,
+Encore already comes with a variety of different loaders,
 but if there is a specific loader that you want to use that is not currently supported, you
 can add your own loader through the ``addLoader`` function.
 The ``addLoader`` takes any valid webpack rules config.

--- a/http_client.rst
+++ b/http_client.rst
@@ -1154,7 +1154,7 @@ To force HTTP/2 for ``http`` URLs, you need to enable it explicitly via the
 
         $client = HttpClient::create(['http_version' => '2.0']);
 
-Support for HTTP/2 PUSH works out of the box when using a compatible client:
+Support for HTTP/2 PUSH works automatically when using a compatible client:
 pushed responses are put into a temporary cache and are used when a
 subsequent request is triggered for the corresponding URLs.
 
@@ -1507,7 +1507,7 @@ Caching Requests and Responses
 This component provides a :class:`Symfony\\Component\\HttpClient\\CachingHttpClient`
 decorator that allows caching responses and serving them from the local storage
 for next requests. The implementation leverages the
-:class:`Symfony\\Component\\HttpKernel\\HttpCache\\HttpCache` class under the hood
+:class:`Symfony\\Component\\HttpKernel\\HttpCache\\HttpCache` class internally
 so that the :doc:`HttpKernel component </components/http_kernel>` needs to be
 installed in your application::
 

--- a/mailer.rst
+++ b/mailer.rst
@@ -17,7 +17,7 @@ integration, CSS inlining, file attachments and a lot more. Get them installed w
 Transport Setup
 ---------------
 
-Emails are delivered via a "transport". Out of the box, you can deliver emails
+Emails are delivered via a "transport". By default, you can deliver emails
 over SMTP by configuring the DSN in your ``.env`` file (the ``user``,
 ``pass`` and ``port`` parameters are optional):
 

--- a/mercure.rst
+++ b/mercure.rst
@@ -19,7 +19,7 @@ server to clients. It is a modern and efficient alternative to timer-based
 polling and to WebSocket.
 
 Because it is built on top `Server-Sent Events (SSE)`_, Mercure is supported
-out of the box in modern browsers (old versions of Edge and IE require
+natively in modern browsers (old versions of Edge and IE require
 `a polyfill`_) and has `high-level implementations`_ in many programming
 languages.
 
@@ -351,7 +351,7 @@ in a ``Link`` HTTP header.
     ></object>
 
 You can create ``Link`` headers with the ``Discovery`` helper class
-(under the hood, it uses the :doc:`WebLink Component </web_link>`)::
+(internally, it uses the :doc:`WebLink Component </web_link>`)::
 
     // src/Controller/DiscoverController.php
     namespace App\Controller;

--- a/migration.rst
+++ b/migration.rst
@@ -49,7 +49,7 @@ faster on fixing deprecations to be able to upgrade.
 .. tip::
 
     When upgrading to Symfony you might be tempted to also use
-    :ref:`Flex <symfony-flex>`. Please keep in mind that it primarily
+    :ref:`Flex <symfony-flex>`. Please note that it primarily
     focuses on bootstrapping a new Symfony application according to best
     practices regarding the directory structure. When you work in the
     constraints of an existing application you might not be able to

--- a/page_creation.rst
+++ b/page_creation.rst
@@ -150,7 +150,7 @@ The Web Debug Toolbar: Debugging Dream
 
 One of Symfony's *amazing* features is the Web Debug Toolbar: a bar that displays
 a *huge* amount of debugging information along the bottom of your page while
-developing. This is all included out of the box using a :ref:`Symfony pack <symfony-packs>`
+developing. This is all included by default when using a :ref:`Symfony pack <symfony-packs>`
 called ``symfony/profiler-pack``.
 
 You will see a dark bar along the bottom of the page. You'll learn more about

--- a/performance.rst
+++ b/performance.rst
@@ -1,7 +1,7 @@
 Performance
 ===========
 
-Symfony is fast, right out of the box. However, you can make it faster if you
+Symfony is fast. However, you can make it faster if you
 optimize your servers and your applications as explained in the following
 performance checklists.
 

--- a/quick_tour/flex_recipes.rst
+++ b/quick_tour/flex_recipes.rst
@@ -42,7 +42,7 @@ So how can we install and configure Twig? By running one single command:
 
     $ composer require twig
 
-Two *very* interesting things happen behind the scenes thanks to Symfony Flex: a
+Two *very* interesting things happen internally thanks to Symfony Flex: a
 Composer plugin that is already installed in our project.
 
 First, ``twig`` is not the name of a Composer package: it's a Flex *alias* that

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -974,7 +974,7 @@ security.voter
 **Purpose**: To add a custom voter to Symfony's authorization logic
 
 When you call ``isGranted()`` on Symfony's authorization checker, a system of "voters"
-is used behind the scenes to determine if the user should have access. The
+is used internally to determine if the user should have access. The
 ``security.voter`` tag allows you to add your own custom voter to that system.
 
 For more information, read the :doc:`/security/voters` article.

--- a/reference/forms/types/options/by_reference.rst.inc
+++ b/reference/forms/types/options/by_reference.rst.inc
@@ -24,7 +24,7 @@ To explain this further, here's a simple example::
                 ->add('email', EmailType::class)
         )
 
-If ``by_reference`` is true, the following takes place behind the scenes
+If ``by_reference`` is true, the following takes place internally
 when you call ``submit()`` (or ``handleRequest()``) on the form::
 
     $article->setTitle('...');

--- a/routing.rst
+++ b/routing.rst
@@ -92,7 +92,7 @@ the ``list()`` method of the ``BlogController`` class.
 
 The route name (``blog_list``) is not important for now, but it will be
 essential later when :ref:`generating URLs <routing-generating-urls>`. You only
-have to keep in mind that each route name must be unique in the application.
+have to remember that each route name must be unique in the application.
 
 Creating Routes in YAML, XML or PHP Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -478,7 +478,7 @@ You can also use these functions:
     The ``service(string $alias)`` function and ``#[AsRoutingConditionService]``
     attribute were introduced in Symfony 6.1.
 
-Behind the scenes, expressions are compiled down to raw PHP. Because of this,
+Internally, expressions are compiled down to raw PHP. Because of this,
 using the ``condition`` key causes no extra overhead beyond the time it takes
 for the underlying PHP to execute.
 

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -248,7 +248,7 @@ options:
 
 .. tip::
 
-    Behind the scenes, the array value of ``roles`` is passed as the
+    Internally, the array value of ``roles`` is passed as the
     ``$attributes`` argument to each voter in the application with the
     :class:`Symfony\\Component\\HttpFoundation\\Request` as ``$subject``. You
     can learn how to use your custom attributes by reading

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -353,7 +353,7 @@ your users have the following two DN: ``dc=companyA,dc=example,dc=com`` and
 ``dc=companyB,dc=example,dc=com``, then ``dn_string`` should be
 ``dc=example,dc=com``.
 
-Bear in mind that usernames must be unique across both DN, as the authentication
+Note that usernames must be unique across both DN, as the authentication
 provider won't be able to select the correct user for the bind process if more
 than one is found.
 

--- a/security/passwords.rst
+++ b/security/passwords.rst
@@ -230,7 +230,7 @@ Reset Password
 --------------
 
 Using `MakerBundle`_ and `SymfonyCastsResetPasswordBundle`_, you can create
-a secure out of the box solution to handle forgotten passwords. First,
+a secure solution to handle forgotten passwords. First,
 install the SymfonyCastsResetPasswordBundle:
 
 .. code-block:: terminal

--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -31,7 +31,7 @@ until you interact with the proxy in some way.
 
 .. versionadded:: 6.2
 
-    Starting from Symfony 6.2, service laziness is supported out of the box
+    Starting from Symfony 6.2, service laziness is supported natively
     without having to install any additional package.
 
 .. _lazy-services_configuration:
@@ -137,7 +137,7 @@ laziness, and supports lazy-autowiring of union types::
 Interface Proxifying
 --------------------
 
-Under the hood, proxies generated to lazily load services inherit from the class
+Internally, proxies generated to lazily load services inherit from the class
 used by the service. However, sometimes this is not possible at all (e.g. because
 the class is `final`_ and can not be extended) or not convenient.
 

--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -743,7 +743,7 @@ Three different behaviors are available:
 .. note::
 
     Sometimes, you may want to add a compiler pass that creates service
-    definitions on the fly. If you want to decorate such a service,
+    definitions dynamically. If you want to decorate such a service,
     be sure that your compiler pass is registered with ``PassConfig::TYPE_BEFORE_OPTIMIZATION``
     type so that the decoration pass will be able to find the created services.
 

--- a/testing.rst
+++ b/testing.rst
@@ -889,8 +889,7 @@ The second optional argument is used to override the default form field values.
 .. note::
 
     Notice that you select form buttons and not forms, as a form can have several
-    buttons. If you use the traversing API, keep in mind that you must look for a
-    button.
+    buttons. If you use the traversing API, remember that you must look for a button.
 
 If you need access to the :class:`Symfony\\Component\\DomCrawler\\Form` object
 that provides helpful methods specific to forms (such as ``getUri()``,

--- a/testing/end_to_end.rst
+++ b/testing/end_to_end.rst
@@ -718,7 +718,7 @@ Integrating Panther In Your CI
 Github Actions
 ~~~~~~~~~~~~~~
 
-Panther works out of the box with `GitHub Actions`_.
+Panther also works with `GitHub Actions`_.
 Here is a minimal ``.github/workflows/panther.yaml`` file to run Panther tests:
 
 .. code-block:: yaml
@@ -745,7 +745,7 @@ Here is a minimal ``.github/workflows/panther.yaml`` file to run Panther tests:
 Travis CI
 ~~~~~~~~~
 
-Panther will work out of the box with `Travis CI`_ if you add the Chrome addon.
+Panther works with `Travis CI`_ if you add the Chrome addon.
 Here is a minimal ``.travis.yaml`` file to run Panther tests:
 
 .. code-block:: yaml
@@ -791,7 +791,7 @@ with `Gitlab CI`_:
 AppVeyor
 ~~~~~~~~
 
-Panther will work out of the box with `AppVeyor`_ as long as Google Chrome
+Panther works with `AppVeyor`_ as long as Google Chrome
 is installed. Here is a minimal ``appveyor.yaml`` file to run Panther tests:
 
 .. code-block:: yaml

--- a/validation.rst
+++ b/validation.rst
@@ -230,7 +230,7 @@ The ``validator`` is designed to validate objects against *constraints* (i.e.
 rules). In order to validate an object, simply map one or more constraints
 to its class and then pass it to the ``validator`` service.
 
-Behind the scenes, a constraint is simply a PHP object that makes an assertive
+Internally, a constraint is a PHP object that makes an assertive
 statement. In real life, a constraint could be: ``'The cake must not be burned'``.
 In Symfony, constraints are similar: they are assertions that a condition
 is true. Given a value, a constraint will tell you if that value


### PR DESCRIPTION
The audience of Symfony docs is worlwide and mostly non-native in English, so let's try to use simpler expressions if possible.