### PR TITLE
 Document segmentation fault issue in tagged service iterator

### DIFF
--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -1185,6 +1185,10 @@ to get the ``App\Handler\Two`` service::
         }
     }
 
+.. hint::
+
+    A Segmentation fault with ``iterator_to_array`` in ``__construct`` happens if you have a dependency cycle.
+
 If some service doesn't define the option/attribute configured in ``index_by``,
 Symfony applies this fallback process:
 


### PR DESCRIPTION
Add hint about segmentation fault with iterator_to_array in __construct

This is documenting the non-symfony issue raised in https://github.com/symfony/symfony/issues/48782
