### PR TITLE
 Remove `App::config()` from `getSubscribedServices()` examples

### DIFF
--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -643,9 +643,9 @@ create a class that implements
 
         public static function getProvidedTypes(): array
         {
-            return App::config([
+            return [
                 'lowercase' => 'string',
-            ]);
+            ];
         }
     }
 

--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -348,9 +348,9 @@ name (FQCN) of the corresponding event class::
     {
         public static function getSubscribedEvents(): array
         {
-            return App::config([
+            return [
                 RequestEvent::class => 'onKernelRequest',
-            ]);
+            ];
         }
 
         public function onKernelRequest(RequestEvent $event): void
@@ -558,9 +558,9 @@ event subscribers, you can learn more about :ref:`how to use them <events-subscr
 
         public static function getSubscribedEvents(): array
         {
-            return App::config([
+            return [
                 KernelEvents::CONTROLLER => 'onKernelController',
-            ]);
+            ];
         }
     }
 
@@ -633,10 +633,10 @@ header on the response if it's found::
 
     public static function getSubscribedEvents(): array
     {
-        return App::config([
+        return [
             KernelEvents::CONTROLLER => 'onKernelController',
             KernelEvents::RESPONSE => 'onKernelResponse',
-        ]);
+        ];
     }
 
 That's it! The ``TokenSubscriber`` is now notified before every controller is
@@ -772,9 +772,9 @@ could listen to the ``mailer.post_send`` event and change the method's return va
 
         public static function getSubscribedEvents(): array
         {
-            return App::config([
+            return [
                 'mailer.post_send' => 'onMailerPostSend',
-            ]);
+            ];
         }
     }
 

--- a/security.rst
+++ b/security.rst
@@ -1684,7 +1684,7 @@ to execute custom logic::
 
         public static function getSubscribedEvents(): array
         {
-            return App::config([LogoutEvent::class => 'onLogout'];
+            return [LogoutEvent::class => 'onLogout'];
         }
 
         public function onLogout(LogoutEvent $event): void

--- a/security/impersonating_user.rst
+++ b/security/impersonating_user.rst
@@ -364,10 +364,10 @@ switch users, add an event subscriber on this event::
 
         public static function getSubscribedEvents(): array
         {
-            return App::config([
+            return [
                 // constant for security.switch_user
                 SecurityEvents::SWITCH_USER => 'onSwitchUser',
-            ]);
+            ];
         }
     }
 

--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -55,9 +55,9 @@ normalization process::
 
         public function getSupportedTypes(?string $format): array
         {
-            return App::config([
+            return [
                 Topic::class => true,
-            ]);
+            ];
         }
     }
 
@@ -141,11 +141,11 @@ Here is an example of how to use the ``getSupportedTypes()`` method::
 
         public function getSupportedTypes(?string $format): array
         {
-            return App::config([
+            return [
                 'object' => null,             // doesn't support any classes or interfaces
                 '*' => false,                 // supports any other types, but the decision is not cacheable
                 MyCustomClass::class => true, // supports MyCustomClass and decision is cacheable
-            ]);
+            ];
         }
     }
 

--- a/service_container/service_subscribers_locators.rst
+++ b/service_container/service_subscribers_locators.rst
@@ -86,10 +86,10 @@ in the service subscriber::
 
         public static function getSubscribedServices(): array
         {
-            return App::config([
+            return [
                 'App\FooCommand' => FooHandler::class,
                 'App\BarCommand' => BarHandler::class,
-            ]);
+            ];
         }
 
         public function handle(Command $command): mixed
@@ -146,10 +146,10 @@ service locator::
 
     public static function getSubscribedServices(): array
     {
-        return App::config([
+        return [
             // ...
             LoggerInterface::class,
-        ]);
+        ];
     }
 
 Service types can also be keyed by a service name for internal use::
@@ -158,10 +158,10 @@ Service types can also be keyed by a service name for internal use::
 
     public static function getSubscribedServices(): array
     {
-        return App::config([
+        return [
             // ...
             'logger' => LoggerInterface::class,
-        ]);
+        ];
     }
 
 When extending a class that also implements ``ServiceSubscriberInterface``,
@@ -192,10 +192,10 @@ errors if there's no matching service found in the service container::
 
     public static function getSubscribedServices(): array
     {
-        return App::config([
+        return [
             // ...
             '?'.LoggerInterface::class,
-        ]);
+        ];
     }
 
 .. note::
@@ -270,7 +270,7 @@ This is done by having ``getSubscribedServices()`` return an array of
 
     public static function getSubscribedServices(): array
     {
-        return App::config([
+        return [
             // ...
             new SubscribedService('logger', LoggerInterface::class, attributes: new Autowire(service: 'monolog.logger.event')),
 
@@ -285,7 +285,7 @@ This is done by having ``getSubscribedServices()`` return an array of
 
             // AutowireLocator
             new SubscribedService('handlers', ContainerInterface::class, attributes: new AutowireLocator('handler.tag')),
-        ]);
+        ];
     }
 
 .. note::

--- a/session.rst
+++ b/session.rst
@@ -1193,10 +1193,10 @@ can determine the correct locale however you want::
 
         public static function getSubscribedEvents(): array
         {
-            return App::config([
+            return [
                 // must be registered before (i.e. with a higher priority than) the default Locale listener
                 KernelEvents::REQUEST => [['onKernelRequest', 20]],
-            ]);
+            ];
         }
     }
 
@@ -1305,9 +1305,9 @@ event::
 
         public static function getSubscribedEvents(): array
         {
-            return App::config([
+            return [
                 LoginSuccessEvent::class => 'onLoginSuccess',
-            ]);
+            ];
         }
     }
 

--- a/templates.rst
+++ b/templates.rst
@@ -604,9 +604,9 @@ a block to render::
         #[Template('product.html.twig', block: 'price_block')]
         public function price(): array
         {
-            return App::config([
+            return [
                 // ...
-            ]);
+            ];
         }
     }
 
@@ -1493,10 +1493,10 @@ callable defined in ``getFilters()``::
     {
         public function getFilters(): array
         {
-            return App::config([
+            return [
                 // the logic of this filter is now implemented in a different class
                 new TwigFilter('price', [AppRuntime::class, 'formatPrice']),
-            ]);
+            ];
         }
     }
 

--- a/workflow.rst
+++ b/workflow.rst
@@ -865,11 +865,11 @@ workflow leaves a place::
 
         public static function getSubscribedEvents(): array
         {
-            return App::config([
+            return [
                 LeaveEvent::getName('blog_publishing') => 'onLeave',
                 // if you prefer, you can write the event name manually like this:
                 // 'workflow.blog_publishing.leave' => 'onLeave',
-            ]);
+            ];
         }
     }
 
@@ -958,9 +958,9 @@ missing a title::
 
         public static function getSubscribedEvents(): array
         {
-            return App::config([
+            return [
                 'workflow.blog_publishing.guard.to_review' => ['guardReview'],
-            ]);
+            ];
         }
     }
 
@@ -1183,9 +1183,9 @@ place::
 
         public static function getSubscribedEvents(): array
         {
-            return App::config([
+            return [
                 'workflow.blog_publishing.guard.publish' => ['guardPublish'],
-            ]);
+            ];
         }
     }
 


### PR DESCRIPTION
The arrays were incorrectly wrapped with `App::config()` in #21511.

I fixed every code examples where an array is directly returned by a method using this regex: `\{\s+return App::config\(\[`
