### PR TITLE
 add relative path mapping example to `framework.ide`

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -377,6 +377,10 @@ Another alternative is to set the ``xdebug.file_link_format`` option in your
         // example for PhpStorm
         'phpstorm://open?file=%%f&line=%%l&/var/www/app/>/projects/my_project/'
 
+        // example for JetBrains Toolbox, using a relative path
+        // by removing the `/path/to/root/` (note trailing `/`), it becomes relative
+        'jetbrains://php-storm/navigate/reference?project=my-project&path=%%f:%%l&/path/to/root/>'
+
 .. _reference-framework-test:
 
 test


### PR DESCRIPTION
Added example for JetBrains Toolbox with relative path.

Relates to [#60338](https://github.com/symfony/symfony/issues/60338)