### PR TITLE
[Security] Fix namespace of `IsSignatureValid` attribute in Routing docs

### DIFF
--- a/components/clock.rst
+++ b/components/clock.rst
@@ -148,9 +148,9 @@ is expired or not, by modifying the clock's time::
             // Clock sleeps for 10 minutes, so now is '2022-11-16 15:30:00'
             $clock->sleep(600); // Instantly changes time as if we waited for 10 minutes (600 seconds)
 
-            // modify the clock, accepts all formats supported by DateTimeImmutable::modify()
             $this->assertTrue($expirationChecker->isExpired($validUntil));
 
+            // modify the clock, accepts all formats supported by DateTimeImmutable::modify()
             $clock->modify('2022-11-16 15:00:00');
 
             // $validUntil is in the future again, so it is no longer expired

--- a/routing.rst
+++ b/routing.rst
@@ -3180,7 +3180,7 @@ a ``SignedUriException`` will be thrown::
     // src/Controller/SomeController.php
     // ...
 
-    use App\Security\Attribute\IsSignatureValid;
+    use Symfony\Component\HttpKernel\Attribute\IsSignatureValid;
 
     #[IsSignatureValid]
     public function someAction(): Response


### PR DESCRIPTION
Hi,

I think this is a mistake in the docs. It shows `App\Security\Attribute\IsSignatureValid` whereas I think it should be `Symfony\Component\HttpKernel\Attribute\IsSignatureValid`