### PR TITLE
[Security] Fix getAccessDecision example

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2707,7 +2707,7 @@ permission in :ref:`your custom security voters <creating-the-custom-voter>`::
         public function generateReport(): void
         {
             $voterDecision = $this->security->getAccessDecision('ROLE_SALES_ADMIN');
-            if ($voterDecision->isGranted('ROLE_SALES_ADMIN')) {
+            if ($voterDecision->isGranted) {
                 // ...
             } else {
                 // do something with $voterDecision->getMessage()


### PR DESCRIPTION
There is no `isGranted()` method on the decision, as it has already been made, instead there is an `isGranted` property.

Targeting 7.4 as this is the first time that example is present.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
