### PR TITLE
[Twig] Controller return array with `Template` attribute

### DIFF
--- a/templates.rst
+++ b/templates.rst
@@ -543,10 +543,10 @@ to define the template to render::
             // when using the #[Template] attribute, you only need to return
             // an array with the parameters to pass to the template (the attribute
             // is the one which will create and return the Response object).
-            return App::config([
+            return [
                 'category' => '...',
                 'promotions' => ['...', '...'],
-            ]);
+            ];
         }
     }
 


### PR DESCRIPTION
Fix code example returning `App::config` instead of array when used with `Template` attribute 
