### PR TITLE
[Form] Revamp the form events docs

### DIFF
--- a/form/dynamic_form_modification.rst
+++ b/form/dynamic_form_modification.rst
@@ -1,51 +1,61 @@
 How to Dynamically Modify Forms Using Form Events
 =================================================
 
-Oftentimes, a form can't be created statically. In this article, you'll learn
-how to customize your form based on three common use-cases:
+This article shows practical examples of using :doc:`form events </form/events>`
+to create dynamic forms. Each example includes the complete code you need.
 
-1) :ref:`Customizing your Form Based on the Underlying Data <form-events-underlying-data>`
-
-   Example: you have a "Product" form and need to modify/add/remove a field
-   based on the data on the underlying Product being edited.
-
-2) :ref:`How to Dynamically Generate Forms Based on User Data <form-events-user-data>`
-
-   Example: you create a "Friend Message" form and need to build a drop-down
-   that contains only users that are friends with the *current* authenticated
-   user.
-
-3) :ref:`Dynamic Generation for Submitted Forms <form-events-submitted-data>`
-
-   Example: on a registration form, you have a "country" field and a "state"
-   field which should populate dynamically based on the value in the "country"
-   field.
-
-If you wish to learn more about the basics behind form events, you can
-take a look at the :doc:`Form Events </form/events>` documentation.
+If you're new to form events, read the :doc:`form events documentation </form/events>`
+first to understand when to use each event and how they work.
 
 .. _form-events-underlying-data:
 
-Customizing your Form Based on the Underlying Data
---------------------------------------------------
+Showing Fields Only for New Entities
+------------------------------------
 
-Before starting with dynamic form generation, remember what
-a bare form class looks like::
+A common pattern is showing certain fields only when creating a new entity,
+but hiding them when editing. For example, you might allow setting a username
+during user registration or setting a SKU during product creation but prevent
+changes afterward.
 
-    // src/Form/Type/ProductType.php
-    namespace App\Form\Type;
+Use ``PRE_SET_DATA`` to check if the entity has an ID (is persisted) or not (is new)::
+
+    // src/Form/ProductType.php
+    namespace App\Form;
 
     use App\Entity\Product;
     use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\Event\PreSetDataEvent;
+    use Symfony\Component\Form\Extension\Core\Type\TextType;
     use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Component\Form\FormEvents;
     use Symfony\Component\OptionsResolver\OptionsResolver;
 
     class ProductType extends AbstractType
     {
         public function buildForm(FormBuilderInterface $builder, array $options): void
         {
-            $builder->add('name');
-            $builder->add('price');
+            $builder
+                ->add('description')
+                ->add('price')
+            ;
+
+            $builder->addEventListener(
+                FormEvents::PRE_SET_DATA,
+                function (PreSetDataEvent $event): void {
+                    $product = $event->getData();
+                    $form = $event->getForm();
+
+                    // product is new if there's no data or no ID
+                    $isNew = !$product || null === $product->getId();
+
+                    if ($isNew) {
+                        // SKU can only be set when creating, not editing
+                        $form->add('sku', TextType::class, [
+                            'help' => 'Cannot be changed after creation',
+                        ]);
+                    }
+                }
+            );
         }
 
         public function configureOptions(OptionsResolver $resolver): void
@@ -56,541 +66,591 @@ a bare form class looks like::
         }
     }
 
-.. note::
+.. tip::
 
-    If this particular section of code isn't already familiar to you, you
-    probably need to take a step back and first review the :doc:`Forms article </forms>`
-    before proceeding.
+    For simple cases like this, consider using form options instead::
 
-Assume for a moment that this form utilizes an imaginary "Product" class
-that has only two properties ("name" and "price"). The form generated from
-this class will look the exact same regardless if a new Product is being created
-or if an existing product is being edited (e.g. a product fetched from the database).
+        $form = $this->createForm(ProductType::class, $product, [
+            'is_new' => null === $product->getId(),
+        ]);
 
-Suppose now, that you don't want the user to be able to change the ``name`` value
-once the object has been created. To do this, you can rely on Symfony's
-:doc:`EventDispatcher component </components/event_dispatcher>`
-system to analyze the data on the object and modify the form based on the
-Product object's data. In this article, you'll learn how to add this level of
-flexibility to your forms.
+        // then in buildForm(), check $options['is_new']
 
-Adding an Event Listener to a Form Class
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-So, instead of directly adding that ``name`` widget, the responsibility of
-creating that particular field is delegated to an event listener::
-
-    // src/Form/Type/ProductType.php
-    namespace App\Form\Type;
-
-    // ...
-    use Symfony\Component\Form\FormEvent;
-    use Symfony\Component\Form\FormEvents;
-
-    class ProductType extends AbstractType
-    {
-        public function buildForm(FormBuilderInterface $builder, array $options): void
-        {
-            $builder->add('price');
-
-            $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
-                // ... adding the name field if needed
-            });
-        }
-
-        // ...
-    }
-
-The goal is to create a ``name`` field *only* if the underlying ``Product``
-object is new (e.g. hasn't been persisted to the database). Based on that,
-the event listener might look like the following::
-
-    // ...
-    public function buildForm(FormBuilderInterface $builder, array $options): void
-    {
-        // ...
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
-            $product = $event->getData();
-            $form = $event->getForm();
-
-            // checks if the Product object is "new"
-            // If no data is passed to the form, the data is "null".
-            // This should be considered a new "Product"
-            if (!$product || null === $product->getId()) {
-                $form->add('name', TextType::class);
-            }
-        });
-    }
-
-.. note::
-
-    The ``FormEvents::PRE_SET_DATA`` line actually resolves to the string
-    ``form.pre_set_data``. :class:`Symfony\\Component\\Form\\FormEvents`
-    serves an organizational purpose. It is a centralized location in which
-    you can find all of the various form events available. You can view the
-    full list of form events via the
-    :class:`Symfony\\Component\\Form\\FormEvents` class.
-
-Adding an Event Subscriber to a Form Class
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For better reusability or if there is some heavy logic in your event listener,
-you can also move the logic for creating the ``name`` field to an
-:ref:`event subscriber <event_dispatcher-using-event-subscribers>`::
-
-    // src/Form/EventSubscriber/AddNameFieldSubscriber.php
-    namespace App\Form\EventSubscriber;
-
-    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-    use Symfony\Component\Form\Extension\Core\Type\TextType;
-    use Symfony\Component\Form\FormEvent;
-    use Symfony\Component\Form\FormEvents;
-
-    class AddNameFieldSubscriber implements EventSubscriberInterface
-    {
-        public static function getSubscribedEvents(): array
-        {
-            // Tells the dispatcher that you want to listen on the form.pre_set_data
-            // event and that the preSetData method should be called.
-            return [FormEvents::PRE_SET_DATA => 'preSetData'];
-        }
-
-        public function preSetData(FormEvent $event): void
-        {
-            $product = $event->getData();
-            $form = $event->getForm();
-
-            if (!$product || null === $product->getId()) {
-                $form->add('name', TextType::class);
-            }
-        }
-    }
-
-Great! Now use that in your form class::
-
-    // src/Form/Type/ProductType.php
-    namespace App\Form\Type;
-
-    // ...
-    use App\Form\EventSubscriber\AddNameFieldSubscriber;
-
-    class ProductType extends AbstractType
-    {
-        public function buildForm(FormBuilderInterface $builder, array $options): void
-        {
-            $builder->add('price');
-
-            $builder->addEventSubscriber(new AddNameFieldSubscriber());
-        }
-
-        // ...
-    }
-
-.. _form-events-user-data:
-
-How to Dynamically Generate Forms Based on User Data
-----------------------------------------------------
-
-Sometimes you want a form to be generated dynamically based not only on data
-from the form but also on something else - like some data from the current user.
-Suppose you have a social website where a user can only message people marked
-as friends on the website. In this case, a "choice list" of whom to message
-should only contain users that are the current user's friends.
-
-Creating the Form Type
-~~~~~~~~~~~~~~~~~~~~~~
-
-Using an event listener, your form might look like this::
-
-    // src/Form/Type/FriendMessageFormType.php
-    namespace App\Form\Type;
-
-    use Symfony\Component\Form\AbstractType;
-    use Symfony\Component\Form\Extension\Core\Type\TextareaType;
-    use Symfony\Component\Form\Extension\Core\Type\TextType;
-    use Symfony\Component\Form\FormBuilderInterface;
-    use Symfony\Component\Form\FormEvent;
-    use Symfony\Component\Form\FormEvents;
-
-    class FriendMessageFormType extends AbstractType
-    {
-        public function buildForm(FormBuilderInterface $builder, array $options): void
-        {
-            $builder
-                ->add('subject', TextType::class)
-                ->add('body', TextareaType::class)
-            ;
-            $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
-                // ... add a choice list of friends of the current application user
-            });
-        }
-    }
-
-The problem is now to get the current user and create a choice field that
-contains only this user's friends. This can be done by injecting the ``Security``
-service into the form type so you can get the current user object::
-
-    use Symfony\Bundle\SecurityBundle\Security;
-    // ...
-
-    class FriendMessageFormType extends AbstractType
-    {
-        public function __construct(
-            private Security $security,
-        ) {
-        }
-
-        // ....
-    }
-
-Customizing the Form Type
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Now that you have all the basics in place you can use the features of the
-security helper to fill in the listener logic::
-
-    // src/Form/Type/FriendMessageFormType.php
-    namespace App\Form\Type;
-
-    use App\Entity\User;
-    use Doctrine\ORM\EntityRepository;
-    use Symfony\Bridge\Doctrine\Form\Type\EntityType;
-    use Symfony\Bundle\SecurityBundle\Security;
-    use Symfony\Component\Form\Extension\Core\Type\TextareaType;
-    use Symfony\Component\Form\Extension\Core\Type\TextType;
-    // ...
-
-    class FriendMessageFormType extends AbstractType
-    {
-        public function __construct(
-            private Security $security,
-        ) {
-        }
-
-        public function buildForm(FormBuilderInterface $builder, array $options): void
-        {
-            $builder
-                ->add('subject', TextType::class)
-                ->add('body', TextareaType::class)
-            ;
-
-            // grab the user, do a quick sanity check that one exists
-            $user = $this->security->getUser();
-            if (!$user) {
-                throw new \LogicException(
-                    'The FriendMessageFormType cannot be used without an authenticated user!'
-                );
-            }
-
-            $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($user): void {
-                if (null !== $event->getData()->getFriend()) {
-                    // we don't need to add the friend field because
-                    // the message will be addressed to a fixed friend
-                    return;
-                }
-
-                $form = $event->getForm();
-
-                $formOptions = [
-                    'class' => User::class,
-                    'choice_label' => 'fullName',
-                    'query_builder' => function (UserRepository $userRepository) use ($user): void {
-                        // call a method on your repository that returns the query builder
-                        // return $userRepository->createFriendsQueryBuilder($user);
-                    },
-                ];
-
-                // create the field, this is similar the $builder->add()
-                // field name, field type, field options
-                $form->add('friend', EntityType::class, $formOptions);
-            });
-        }
-
-        // ...
-    }
-
-.. note::
-
-    You might wonder, now that you have access to the ``User`` object, why not
-    just use it directly in ``buildForm()`` and omit the event listener? This is
-    because doing so in the ``buildForm()`` method would result in the whole
-    form type being modified and not just this one form instance. This may not
-    usually be a problem, but technically a single form type could be used on a
-    single request to create many forms or fields.
-
-Using the Form
-~~~~~~~~~~~~~~
-
-If you're using the :ref:`default services.yaml configuration <service-container-services-load-example>`,
-your form is ready to be used thanks to :ref:`autowire <services-autowire>` and
-:ref:`autoconfigure <services-autoconfigure>`.
-Otherwise, :ref:`register the form class as a service <service-container-creating-service>`
-and :doc:`tag it </service_container/tags>` with the ``form.type`` tag.
-
-In a controller, create the form like normal::
-
-    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-    use Symfony\Component\HttpFoundation\Request;
-    use Symfony\Component\HttpFoundation\Response;
-
-    class FriendMessageController extends AbstractController
-    {
-        public function new(Request $request): Response
-        {
-            $form = $this->createForm(FriendMessageFormType::class);
-
-            // ...
-        }
-    }
-
-You can also  embed the form type into another form::
-
-    // inside some other "form type" class
-    public function buildForm(FormBuilderInterface $builder, array $options): void
-    {
-        $builder->add('message', FriendMessageFormType::class);
-    }
+    Form options are simpler but less flexible than events.
 
 .. _form-events-submitted-data:
 
-Dynamic Generation for Submitted Forms
---------------------------------------
+Dependent Selects (Country/State Pattern)
+-----------------------------------------
 
-Another case that can appear is that you want to customize the form specific to
-the data that was submitted by the user. For example, imagine you have a registration
-form for sports gatherings. Some events will allow you to specify your preferred
-position on the field. This would be a ``choice`` field for example. However, the
-possible choices will depend on each sport. Football will have attack, defense,
-goalkeeper etc... Baseball will have a pitcher but will not have a goalkeeper. You
-will need the correct options in order for validation to pass.
+The most common use case for form events is dependent selects, where one
+field's choices depend on another field's value. The classic example is
+Country and State/Province fields.
 
-The meetup is passed as an entity field to the form. So we can access each
-sport like this::
+This requires handling two scenarios:
 
-    // src/Form/Type/SportMeetupType.php
-    namespace App\Form\Type;
+#. **Initial render**: Populate the State field based on the entity's current
+   Country value
+#. **Form submission**: Update the State field based on the submitted Country
+   value
 
-    use App\Entity\Position;
-    use App\Entity\Sport;
+Here's the complete implementation::
+
+    // src/Form/AddressType.php
+    namespace App\Form;
+
+    use App\Entity\Address;
+    use App\Entity\Country;
+    use App\Entity\State;
+    use App\Repository\StateRepository;
     use Symfony\Bridge\Doctrine\Form\Type\EntityType;
     use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\Event\PostSetDataEvent;
+    use Symfony\Component\Form\Event\PostSubmitEvent;
     use Symfony\Component\Form\FormBuilderInterface;
-    use Symfony\Component\Form\FormEvent;
     use Symfony\Component\Form\FormEvents;
-    // ...
+    use Symfony\Component\Form\FormInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
 
-    class SportMeetupType extends AbstractType
+    class AddressType extends AbstractType
+    {
+        public function __construct(
+            private StateRepository $stateRepository,
+        ) {
+        }
+
+        public function buildForm(FormBuilderInterface $builder, array $options): void
+        {
+            $builder
+                ->add('street')
+                ->add('city')
+                ->add('country', EntityType::class, [
+                    'class' => Country::class,
+                    'choice_label' => 'name',
+                    'placeholder' => 'Select a country',
+                ])
+            ;
+
+            // this closure adds the State field with appropriate choices
+            $addStateField = function (FormInterface $form, ?Country $country): void {
+                $states = null === $country
+                    ? []
+                    : $this->stateRepository->findByCountry($country);
+
+                $form->add('state', EntityType::class, [
+                    'class' => State::class,
+                    'choices' => $states,
+                    'choice_label' => 'name',
+                    'placeholder' => null === $country
+                        ? 'Select country first'
+                        : ([] === $states ? 'No states available' : 'Select a state'),
+                ]);
+            };
+
+            // 1) handle initial render: add State based on entity's Country
+            $builder->addEventListener(
+                FormEvents::POST_SET_DATA,
+                function (PostSetDataEvent $event) use ($addStateField): void {
+                    $address = $event->getData();
+                    $country = $address?->getCountry();
+
+                    $addStateField($event->getForm(), $country);
+                }
+            );
+
+            // 2) handle submission: update State when Country changes:
+            // listen to Country field's POST_SUBMIT (after Country is processed)
+            $builder->get('country')->addEventListener(
+                FormEvents::POST_SUBMIT,
+                function (PostSubmitEvent $event) use ($addStateField): void {
+                    // get the selected Country entity (not the raw ID)
+                    $country = $event->getForm()->getData();
+
+                    // add State field to the PARENT form
+                    $addStateField($event->getForm()->getParent(), $country);
+                }
+            );
+        }
+
+        public function configureOptions(OptionsResolver $resolver): void
+        {
+            $resolver->setDefaults([
+                'data_class' => Address::class,
+            ]);
+        }
+    }
+
+.. note::
+
+    The key is to listen to ``POST_SUBMIT`` on the Country field (child), then
+    modify the State field on the parent form. You cannot modify the form that
+    fired the event, but you can modify its parent.
+
+Adding JavaScript for Dynamic Updates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The PHP code above handles form submission correctly. For a better user
+experience, add JavaScript to update the State field immediately when the
+user changes the Country:
+
+.. code-block:: html+twig
+
+    {# templates/address/form.html.twig #}
+    {{ form_start(form, {attr: {id: 'address-form'}}) }}
+        {{ form_row(form.street) }}
+        {{ form_row(form.city) }}
+        {{ form_row(form.country) }}
+        {{ form_row(form.state) }}
+    {{ form_end(form) }}
+
+    <script>
+    const form = document.getElementById('address-form');
+    const countrySelect = document.getElementById('address_country');
+    const stateSelect = document.getElementById('address_state');
+
+    countrySelect.addEventListener('change', async function() {
+        // submit just the country field to get updated state options
+        const formData = new FormData();
+        formData.append(this.name, this.value);
+
+        const response = await fetch(form.action, {
+            method: form.method,
+            body: new URLSearchParams(formData),
+        });
+
+        // parse the response HTML and extract the new state options
+        const html = await response.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const newStateSelect = doc.getElementById('address_state');
+
+        stateSelect.innerHTML = newStateSelect.innerHTML;
+    });
+    </script>
+
+This reuses your existing form processing logic on the server. No additional
+endpoints needed.
+
+.. tip::
+
+    For a more polished solution, consider using `Symfony UX Live Component`_
+    which handles dependent fields automatically without custom JavaScript.
+
+.. _form-events-conditional-fields:
+
+Conditional Fields Based on Checkboxes
+--------------------------------------
+
+Show additional fields when a checkbox is checked. This requires handling
+both the initial render and submission::
+
+    // src/Form/OrderType.php
+    namespace App\Form;
+
+    use App\Entity\Order;
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\Event\PostSetDataEvent;
+    use Symfony\Component\Form\Event\PreSubmitEvent;
+    use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+    use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+    use Symfony\Component\Form\Extension\Core\Type\TextType;
+    use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Component\Form\FormEvents;
+    use Symfony\Component\Form\FormInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
+    use Symfony\Component\Validator\Constraints\NotBlank;
+
+    class OrderType extends AbstractType
     {
         public function buildForm(FormBuilderInterface $builder, array $options): void
         {
             $builder
-                ->add('sport', EntityType::class, [
-                    'class' => Sport::class,
-                    'placeholder' => '',
+                ->add('product')
+                ->add('isGift', CheckboxType::class, [
+                    'required' => false,
+                    'label' => 'This is a gift',
                 ])
+            ;
+
+            $addGiftFields = function (FormInterface $form, bool $isGift): void {
+                if ($isGift) {
+                    $form->add('giftRecipient', TextType::class, [
+                        'label' => 'Recipient name',
+                        'constraints' => [new NotBlank()],
+                    ]);
+                    $form->add('giftMessage', TextareaType::class, [
+                        'required' => false,
+                        'label' => 'Gift message',
+                    ]);
+                }
+            };
+
+            // 1) handle initial render
+            $builder->addEventListener(
+                FormEvents::POST_SET_DATA,
+                function (PostSetDataEvent $event) use ($addGiftFields): void {
+                    $order = $event->getData();
+                    $isGift = $order?->isGift() ?? false;
+
+                    $addGiftFields($event->getForm(), $isGift);
+                }
+            );
+
+            // 2) handle submission
+            $builder->addEventListener(
+                FormEvents::PRE_SUBMIT,
+                function (PreSubmitEvent $event) use ($addGiftFields): void {
+                    // raw submitted data (array of strings)
+                    $data = $event->getData();
+                    $isGift = isset($data['isGift']) && $data['isGift'];
+
+                    $addGiftFields($event->getForm(), $isGift);
+                }
+            );
+        }
+
+        public function configureOptions(OptionsResolver $resolver): void
+        {
+            $resolver->setDefaults([
+                'data_class' => Order::class,
+            ]);
+        }
+    }
+
+.. note::
+
+    Notice that ``PRE_SUBMIT`` uses raw request data (array), while
+    ``POST_SET_DATA`` uses the entity. The checkbox value in raw data is a
+    string ``"1"`` or not present, not a boolean. Use ``POST_SET_DATA``
+    (not ``PRE_SET_DATA``) when modifying the form structure based on data;
+    ``PRE_SET_DATA`` is meant for modifying the data itself via ``$event->setData()``.
+
+.. _form-events-dynamic-validation:
+
+Adding Different Fields Based on a Selection
+--------------------------------------------
+
+Sometimes the fields to display depend on the value of another field (e.g.
+different payment methods require different details). Use ``PRE_SUBMIT`` to
+add the right fields based on the submitted value::
+
+    // src/Form/PaymentType.php
+    namespace App\Form;
+
+    use App\Entity\Payment;
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\Event\PreSubmitEvent;
+    use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+    use Symfony\Component\Form\Extension\Core\Type\TextType;
+    use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Component\Form\FormEvents;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
+    use Symfony\Component\Validator\Constraints as Assert;
+
+    class PaymentType extends AbstractType
+    {
+        public function buildForm(FormBuilderInterface $builder, array $options): void
+        {
+            $builder->add('method', ChoiceType::class, [
+                'choices' => [
+                    'Credit Card' => 'card',
+                    'Bank Transfer' => 'bank',
+                    'PayPal' => 'paypal',
+                ],
+                'placeholder' => 'Choose payment method',
+            ]);
+
+            $builder->addEventListener(
+                FormEvents::PRE_SUBMIT,
+                function (PreSubmitEvent $event): void {
+                    $data = $event->getData();
+                    $form = $event->getForm();
+                    $method = $data['method'] ?? null;
+
+                    match ($method) {
+                        'card' => $form
+                            ->add('cardNumber', TextType::class, [
+                                'constraints' => [
+                                    new Assert\NotBlank(),
+                                    new Assert\Luhn(), // checks the credit card number
+                                ],
+                            ])
+                            ->add('cardExpiry', TextType::class, [
+                                'constraints' => [new Assert\NotBlank()],
+                            ]),
+                        'bank' => $form->add('iban', TextType::class, [
+                            'constraints' => [
+                                new Assert\NotBlank(),
+                                new Assert\Iban(),
+                            ],
+                        ]),
+                        'paypal' => $form->add('paypalEmail', TextType::class, [
+                            'constraints' => [new Assert\NotBlank()],
+                        ]),
+                        default => null,
+                    };
+                }
+            );
+        }
+
+        public function configureOptions(OptionsResolver $resolver): void
+        {
+            $resolver->setDefaults([
+                'data_class' => Payment::class,
+            ]);
+        }
+    }
+
+.. tip::
+
+    If you only need different *validation rules* (not different fields) based
+    on a value, use the :doc:`When constraint </reference/constraints/When>` instead.
+
+.. _form-events-preprocessing-data:
+
+Preprocessing Submitted Data
+----------------------------
+
+Use ``PRE_SUBMIT`` to normalize or sanitize user input before the form
+processes it::
+
+    // src/Form/ContactType.php
+    namespace App\Form;
+
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\Event\PreSubmitEvent;
+    use Symfony\Component\Form\Extension\Core\Type\EmailType;
+    use Symfony\Component\Form\Extension\Core\Type\TelType;
+    use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+    use Symfony\Component\Form\Extension\Core\Type\TextType;
+    use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Component\Form\FormEvents;
+
+    class ContactType extends AbstractType
+    {
+        public function buildForm(FormBuilderInterface $builder, array $options): void
+        {
+            $builder
+                ->add('name', TextType::class)
+                ->add('email', EmailType::class)
+                ->add('phone', TelType::class, ['required' => false])
+                ->add('message', TextareaType::class)
+            ;
+
+            $builder->addEventListener(
+                FormEvents::PRE_SUBMIT,
+                function (PreSubmitEvent $event): void {
+                    $data = $event->getData();
+
+                    // normalize phone: keep only digits
+                    if (!empty($data['phone'])) {
+                        $data['phone'] = preg_replace('/\D/', '', $data['phone']);
+                    }
+
+                    // normalize email: lowercase
+                    if (!empty($data['email'])) {
+                        $data['email'] = strtolower(trim($data['email']));
+                    }
+
+                    // clean message: normalize whitespace
+                    if (!empty($data['message'])) {
+                        $data['message'] = preg_replace('/\s+/', ' ', trim($data['message']));
+                    }
+
+                    $event->setData($data);
+                }
+            );
+        }
+    }
+
+.. _form-events-external-services:
+
+Populating Fields from External Services
+----------------------------------------
+
+Fetch data from APIs or services to populate form fields. Use ``PRE_SET_DATA``
+to load data when the form is built::
+
+    // src/Form/ProfileType.php
+    namespace App\Form;
+
+    use App\Entity\Profile;
+    use App\Service\GeocodingService;
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\Event\PreSetDataEvent;
+    use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+    use Symfony\Component\Form\Extension\Core\Type\TextType;
+    use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Component\Form\FormEvents;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
+
+    class ProfileType extends AbstractType
+    {
+        public function __construct(
+            private GeocodingService $geocoding,
+        ) {
+        }
+
+        public function buildForm(FormBuilderInterface $builder, array $options): void
+        {
+            $builder
+                ->add('name', TextType::class)
+                ->add('postalCode', TextType::class)
             ;
 
             $builder->addEventListener(
                 FormEvents::PRE_SET_DATA,
-                function (FormEvent $event): void {
+                function (PreSetDataEvent $event): void {
+                    $profile = $event->getData();
                     $form = $event->getForm();
 
-                    // this would be your entity, i.e. SportMeetup
-                    $data = $event->getData();
+                    // fetch cities based on current postal code
+                    $postalCode = $profile?->getPostalCode();
+                    $cities = $postalCode
+                        ? $this->geocoding->getCitiesForPostalCode($postalCode)
+                        : [];
 
-                    $sport = $data->getSport();
-                    $positions = null === $sport ? [] : $sport->getAvailablePositions();
-
-                    $form->add('position', EntityType::class, [
-                        'class' => Position::class,
-                        'placeholder' => '',
-                        'choices' => $positions,
+                    $form->add('city', ChoiceType::class, [
+                        'choices' => array_combine($cities, $cities),
+                        'placeholder' => $cities ? 'Select a city' : 'Enter postal code first',
                     ]);
                 }
             );
         }
 
-        // ...
-    }
-
-When you're building this form to display to the user for the first time,
-then this example works perfectly.
-
-However, things get more difficult when you handle the form submission. This
-is because the ``PRE_SET_DATA`` event tells us the data that you're starting
-with (e.g. an empty ``SportMeetup`` object), *not* the submitted data.
-
-On a form, we can usually listen to the following events:
-
-* ``PRE_SET_DATA``
-* ``POST_SET_DATA``
-* ``PRE_SUBMIT``
-* ``SUBMIT``
-* ``POST_SUBMIT``
-
-The key is to add a ``POST_SUBMIT`` listener to the field that your new field
-depends on. If you add a ``POST_SUBMIT`` listener to a form child (e.g. ``sport``),
-and add new children to the parent form, the Form component will detect the
-new field automatically and map it to the submitted client data.
-
-The type would now look like::
-
-    // src/Form/Type/SportMeetupType.php
-    namespace App\Form\Type;
-
-    use App\Entity\Position;
-    use App\Entity\Sport;
-    use Symfony\Bridge\Doctrine\Form\Type\EntityType;
-    use Symfony\Component\Form\FormInterface;
-    // ...
-
-    class SportMeetupType extends AbstractType
-    {
-        public function buildForm(FormBuilderInterface $builder, array $options): void
+        public function configureOptions(OptionsResolver $resolver): void
         {
-            $builder
-                ->add('sport', EntityType::class, [
-                    'class' => Sport::class,
-                    'placeholder' => '',
-                ])
-            ;
-
-            $formModifier = function (FormInterface $form, ?Sport $sport = null): void {
-                $positions = null === $sport ? [] : $sport->getAvailablePositions();
-
-                $form->add('position', EntityType::class, [
-                    'class' => Position::class,
-                    'placeholder' => '',
-                    'choices' => $positions,
-                ]);
-            };
-
-            $builder->addEventListener(
-                FormEvents::PRE_SET_DATA,
-                function (FormEvent $event) use ($formModifier): void {
-                    // this would be your entity, i.e. SportMeetup
-                    $data = $event->getData();
-
-                    $formModifier($event->getForm(), $data->getSport());
-                }
-            );
-
-            $builder->get('sport')->addEventListener(
-                FormEvents::POST_SUBMIT,
-                function (FormEvent $event) use ($formModifier): void {
-                    // It's important here to fetch $event->getForm()->getData(), as
-                    // $event->getData() will get you the client data (that is, the ID)
-                    $sport = $event->getForm()->getData();
-
-                    // since we've added the listener to the child, we'll have to pass on
-                    // the parent to the callback function!
-                    $formModifier($event->getForm()->getParent(), $sport);
-                }
-            );
-
-            // by default, action does not appear in the <form> tag
-            // you can set this value by passing the controller route
-            $builder->setAction($options['action']);
-        }
-
-        // ...
-    }
-
-You can see that you need to listen on these two events and have different
-callbacks only because in two different scenarios, the data that you can use is
-available in different events. Other than that, the listeners always perform
-exactly the same things on a given form.
-
-.. tip::
-
-    The ``FormEvents::POST_SUBMIT`` event does not allow modifications to the form
-    the listener is bound to, but it allows modifications to its parent.
-
-One piece that is still missing is the client-side updating of your form after
-the sport is selected. This should be handled by making an AJAX callback to
-your application. Assume that you have a sport meetup creation controller::
-
-    // src/Controller/MeetupController.php
-    namespace App\Controller;
-
-    use App\Entity\SportMeetup;
-    use App\Form\Type\SportMeetupType;
-    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-    use Symfony\Component\HttpFoundation\Request;
-    use Symfony\Component\HttpFoundation\Response;
-    // ...
-
-    class MeetupController extends AbstractController
-    {
-        #[Route('/create', name: 'app_meetup_create', methods: ['GET', 'POST'])]
-        public function create(Request $request): Response
-        {
-            $meetup = new SportMeetup();
-            $form = $this->createForm(SportMeetupType::class, $meetup, ['action' => $this->generateUrl('app_meetup_create')]);
-            $form->handleRequest($request);
-            if ($form->isSubmitted() && $form->isValid()) {
-                // ... save the meetup, redirect etc.
-            }
-
-            return $this->render('meetup/create.html.twig', [
-                'form' => $form,
+            $resolver->setDefaults([
+                'data_class' => Profile::class,
             ]);
         }
-
-        // ...
     }
 
-The associated template uses some JavaScript to update the ``position`` form
-field according to the current selection in the ``sport`` field:
+.. warning::
 
-.. code-block:: html+twig
+    Be careful with external service calls in form events. They run on every
+    form render and submission, which can cause performance issues.
 
-    {# templates/meetup/create.html.twig #}
-    {{ form_start(form, { attr: { id: 'sport_meetup_form' } }) }}
-        {{ form_row(form.sport) }}    {# <select id="meetup_sport" ... #}
-        {{ form_row(form.position) }} {# <select id="meetup_position" ... #}
-        {# ... #}
-    {{ form_end(form) }}
+.. _form-events-reusable-subscriber:
 
-    <script>
-        const form = document.getElementById('sport_meetup_form');
-        const form_select_sport = document.getElementById('meetup_sport');
-        const form_select_position = document.getElementById('meetup_position');
+Creating Reusable Event Subscribers
+-----------------------------------
 
-        const updateForm = async (data, url, method) => {
-          const req = await fetch(url, {
-            method: method,
-            body: data,
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-                'charset': 'utf-8'
+If you use the same event logic across multiple forms, create an event
+subscriber class::
+
+    // src/Form/EventSubscriber/TimestampFieldsSubscriber.php
+    namespace App\Form\EventSubscriber;
+
+    use Symfony\Component\DependencyInjection\Attribute\Exclude;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Component\Form\Event\PreSetDataEvent;
+    use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+    use Symfony\Component\Form\FormEvents;
+
+    /**
+     * Adds read-only createdAt/updatedAt fields for entities with timestamps.
+     *
+     * The #[Exclude] attribute prevents this class from being registered as a
+     * service in the container. Form event subscribers should only be attached
+     * to forms (via addEventSubscriber()), not the kernel event dispatcher.
+     */
+    #[Exclude]
+    class TimestampFieldsSubscriber implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                FormEvents::PRE_SET_DATA => 'addTimestampFields',
+            ];
+        }
+
+        public function addTimestampFields(PreSetDataEvent $event): void
+        {
+            $entity = $event->getData();
+            $form = $event->getForm();
+
+            // skip for new entities
+            if (!$entity || !method_exists($entity, 'getCreatedAt')) {
+                return;
             }
-          });
 
-          const text = await req.text();
+            if (null !== $entity->getCreatedAt()) {
+                $form->add('createdAt', DateTimeType::class, [
+                    'disabled' => true,
+                    'label' => 'Created',
+                ]);
+            }
 
-          return text;
-        };
+            if (method_exists($entity, 'getUpdatedAt') && null !== $entity->getUpdatedAt()) {
+                $form->add('updatedAt', DateTimeType::class, [
+                    'disabled' => true,
+                    'label' => 'Last modified',
+                ]);
+            }
+        }
+    }
 
-        const parseTextToHtml = (text) => {
-          const parser = new DOMParser();
-          const html = parser.parseFromString(text, 'text/html');
+Use it in any form type::
 
-          return html;
-        };
+    use App\Form\EventSubscriber\TimestampFieldsSubscriber;
 
-        const changeOptions = async (e) => {
-          const requestBody = e.target.getAttribute('name') + '=' + e.target.value;
-          const updateFormResponse = await updateForm(requestBody, form.getAttribute('action'), form.getAttribute('method'));
-          const html = parseTextToHtml(updateFormResponse);
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title')
+            ->add('content')
+            // ...
+            ->addEventSubscriber(new TimestampFieldsSubscriber())
+        ;
+    }
 
-          const new_form_select_position = html.getElementById('meetup_position');
-          form_select_position.innerHTML = new_form_select_position.innerHTML;
-        };
+If your subscriber needs dependencies, inject them into the form type and pass
+them to the subscriber. This keeps the subscriber excluded from the container
+(avoiding unwanted auto-configuration as a kernel event subscriber)::
 
-        form_select_sport.addEventListener('change', (e) => changeOptions(e));
-    </script>
+    // src/Form/EventSubscriber/AuditFieldsSubscriber.php
+    namespace App\Form\EventSubscriber;
 
-The major benefit of submitting the whole form to just extract the updated
-``position`` field is that no additional server-side code is needed; all the
-code from above to generate the submitted form can be reused.
+    use App\Repository\UserRepository;
+    use Symfony\Component\DependencyInjection\Attribute\Exclude;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Component\Form\Event\PreSetDataEvent;
+    use Symfony\Component\Form\FormEvents;
+
+    #[Exclude]
+    class AuditFieldsSubscriber implements EventSubscriberInterface
+    {
+        public function __construct(
+            private UserRepository $userRepository,
+        ) {
+        }
+
+        public static function getSubscribedEvents(): array
+        {
+            return [FormEvents::PRE_SET_DATA => 'addAuditFields'];
+        }
+
+        public function addAuditFields(PreSetDataEvent $event): void
+        {
+            // use $this->userRepository to fetch user names for audit display
+            // ...
+        }
+    }
+
+Then inject the dependencies into your form type and instantiate the subscriber::
+
+    public function __construct(
+        private UserRepository $userRepository,
+    ) {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            // ...
+            ->addEventSubscriber(new AuditFieldsSubscriber($this->userRepository))
+        ;
+    }
+
+.. _`Symfony UX Live Component`: https://ux.symfony.com/live-component

--- a/form/events.rst
+++ b/form/events.rst
@@ -1,257 +1,323 @@
 Form Events
 ===========
 
-The Form component provides a structured process to let you customize your
-forms, by making use of the
-:doc:`EventDispatcher component </components/event_dispatcher>`.
-Using form events, you may modify information or fields at different steps
-of the workflow: from the population of the form to the submission of the
-data from the request.
+Form events let you hook into the :ref:`form lifecycle <form-events-lifecycle>`
+to :doc:`modify forms dynamically </form/dynamic_form_modification>`, transform
+data, or react to submissions. This article explains when (and when not) to use
+form events, how to choose the right event, and how to debug issues.
 
-For example, if you need to add a field depending on request values, you can
-register an event listener to the ``FormEvents::PRE_SUBMIT`` event as follows::
+.. seealso::
 
-    // ...
+    For practical examples using form events, see
+    :doc:`/form/dynamic_form_modification`.
 
-    use Symfony\Component\Form\FormEvent;
+.. _form-events-when-to-use:
+
+When to Use Form Events
+-----------------------
+
+Form events are the right tool when you need to modify a form based on
+**runtime data** that isn't known when the form type is defined. Common
+scenarios include:
+
+**Adding or removing fields based on entity state**
+    Show a "name" field only for new entities, or hide certain fields when
+    editing existing records.
+
+**Changing field options based on submitted data**
+    Update the choices of a ``<select>`` field based on another field's value
+    (for example, showing states/provinces based on selected country).
+
+**Modifying submitted data before processing**
+    Normalize, sanitize, or transform user input before validation.
+
+**Populating fields from external sources**
+    Fetch data from APIs or services to fill in form fields dynamically.
+
+.. _form-events-decision-table:
+
+Choosing the Right Event
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use this decision table to select the appropriate event:
+
+=======================================================================  ===============
+Scenario                                                                 Event to use
+=======================================================================  ===============
+Modify initial data before the form processes it                         ``PRE_SET_DATA``
+Modify form structure based on initial data (entity is new vs existing)  ``POST_SET_DATA``
+Modify or sanitize raw submitted data before processing                  ``PRE_SUBMIT``
+Add/remove fields based on submitted values (like dependent selects)     ``PRE_SUBMIT`` (on parent) or ``POST_SUBMIT`` (on the child)
+Modify normalized submitted data                                         ``SUBMIT``
+React after submission is complete (for logging, etc.)                   ``POST_SUBMIT``
+=======================================================================  ===============
+
+.. tip::
+
+    When in doubt between ``PRE_SET_DATA`` and ``PRE_SUBMIT``, ask yourself:
+    "Do I need to react to *initial* data or *submitted* data?" Initial data
+    comes from your object; submitted data comes from the HTTP request.
+
+.. _form-events-when-not-to-use:
+
+When NOT to Use Form Events
+---------------------------
+
+Before reaching for events, consider these simpler alternatives:
+
+**For static conditional fields**, use form options::
+
+    // instead of events, pass options to your form type
+    $form = $this->createForm(ProductType::class, $product, [
+        'show_advanced_fields' => $user->isAdmin(),
+    ]);
+
+    // in your form type
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('name');
+
+        if ($options['show_advanced_fields']) {
+            $builder->add('internalCode');
+        }
+    }
+
+**For data that depends on the logged in user**, inject the
+:class:`Symfony\\Bundle\\SecurityBundle\\Security` service::
+
+    class MessageType extends AbstractType
+    {
+        public function __construct(
+            private Security $security,
+            private UserRepository $userRepository,
+        ) {
+        }
+
+        public function buildForm(FormBuilderInterface $builder, array $options): void
+        {
+            $builder->add('body', TextareaType::class);
+
+            $currentUser = $this->security->getUser();
+            $friends = $this->userRepository->findFriendsOf($currentUser);
+
+            $builder->add('recipient', EntityType::class, [
+                'class' => User::class,
+                'choices' => $friends,
+                'choice_label' => 'displayName',
+                'placeholder' => 'Select a friend',
+            ]);
+        }
+
+        // ...
+    }
+
+**For data transformation**, use :doc:`data transformers </form/data_transformers>`
+instead. They're designed specifically for converting between formats.
+
+**For custom data mapping**, use :doc:`data mappers </form/data_mappers>` or
+the ``getter``/``setter`` field options.
+
+**For validation logic**, use :doc:`validation constraints </validation>` with
+:doc:`validation groups </form/validation_groups>` or the :doc:`When </reference/constraints/When>`
+constraint.
+
+**For setting default values**, use the ``empty_data`` option or populate your
+object before passing it to the form.
+
+.. _form-events-lifecycle:
+
+The Form Lifecycle
+------------------
+
+Understanding when each event fires helps you choose the right one. A form goes
+through two phases: it is first **built and pre-populated**, then it **handles a
+submission**. Each phase moves the data between three representations: *model*
+(your objects), *normalized* (an intermediate format), and *view* (the strings
+and arrays used in HTML). Submission walks the same path in reverse, which is why
+the events form two symmetric groups.
+
+**Phase 1: Building and pre-populating**
+
+This phase runs when you call ``createForm()`` and then ``setData()``, either
+directly or through ``handleRequest()`` before the form is submitted:
+
+#. ``createForm(TaskType::class, $task)`` creates the form, and ``buildForm()``
+   defines its fields.
+#. ``FormEvents::PRE_SET_DATA`` fires with the model data, before any
+   transformation. The fields are not fully built yet, so this is where you add
+   or remove fields based on the object being edited.
+#. The data is transformed from the model to the normalized and then the view
+   representation (``Data transformed (Model -> Norm -> View)``).
+#. ``FormEvents::POST_SET_DATA`` fires once all three representations are set.
+   The form is fully populated, so this event reads the final data. You can still
+   add or remove fields here, although ``PRE_SET_DATA`` is preferred.
+#. The form is ready to render.
+
+**Phase 2: Handling submission**
+
+This phase runs when the user submits the form and ``handleRequest()`` processes
+the request:
+
+#. ``FormEvents::PRE_SUBMIT`` fires with the raw request data, as strings and
+   arrays. This is where you modify the submitted values or add and remove fields
+   based on what the user sent.
+#. The view data is reverse-transformed into the normalized representation
+   (``Data transformed (View -> Norm)``).
+#. ``FormEvents::SUBMIT`` fires with the normalized data. You can change those
+   values, but the field structure is locked: you cannot add or remove fields
+   from this event onward.
+#. The normalized data is reverse-transformed into the model data
+   (``Data transformed (Norm -> Model)``).
+#. ``FormEvents::POST_SUBMIT`` fires with the fully transformed data. The current
+   form's structure is fixed, so dependent fields are added to the parent form
+   instead (see :ref:`form-events-nested-forms`).
+#. Validation runs through a listener on ``POST_SUBMIT``, so a populated and
+   validated object is available once submission completes.
+
+.. _form-events-nested-forms:
+
+Events in Nested Forms
+----------------------
+
+Each form in the tree has its own event dispatcher, which is immutable after
+the form is built. This means you must register all event listeners during
+``buildForm()``; you cannot add listeners later.
+
+When you embed forms within forms, events fire in a specific order. Consider
+a ``TaskType`` that embeds a ``CategoryType``:
+
+.. code-block:: text
+
+    TaskType
+    └── CategoryType (embedded as 'category' field)
+
+**During pre-population (setData):**
+
+Events fire from parent to children. Setting data in children corresponds to
+the ``Data transformed (Model -> Norm -> View)`` step in the
+:ref:`lifecycle above <form-events-lifecycle>`:
+
+#. ``TaskType::PRE_SET_DATA``
+#. ``CategoryType::PRE_SET_DATA``
+#. ``CategoryType::POST_SET_DATA``
+#. ``TaskType::POST_SET_DATA``
+
+**During submission:**
+
+The submit phase starts on the parent form. After the parent ``PRE_SUBMIT``,
+children are *fully* submitted (including their own ``PRE_SUBMIT``, ``SUBMIT``,
+and ``POST_SUBMIT`` events) before the parent continues. This corresponds to
+the step before ``Data transformed (View -> Norm)`` in the
+:ref:`lifecycle above <form-events-lifecycle>`:
+
+#. ``TaskType::PRE_SUBMIT``
+#. ``CategoryType::PRE_SUBMIT``
+#. ``CategoryType::SUBMIT``
+#. ``CategoryType::POST_SUBMIT``
+#. ``TaskType::SUBMIT``
+#. ``TaskType::POST_SUBMIT``
+
+This order matters when you need to modify parent forms based on child data.
+That's why dependent fields typically listen to ``POST_SUBMIT`` on the child:
+by that point, the child's data is fully processed.
+
+**Practical example**: For a Country/State dependent select, listen to
+``POST_SUBMIT`` on the Country field to update the State field choices:
+
+#. Country field: ``POST_SUBMIT`` fires
+#. Listener reads selected country
+#. Listener modifies parent form's ``State`` field
+#. Parent form continues submit (``State`` field now has correct choices)
+
+.. _form-events-listeners-vs-subscribers:
+
+Form Event Listeners vs Subscribers
+-----------------------------------
+
+Form events are dispatched by the Form component for each form instance. They
+are not part of the :doc:`application-wide event system </event_dispatcher>`
+used for events like ``kernel.request``. You cannot listen to form events from
+a regular event subscriber registered in the service container.
+
+You can register form event handlers in two ways: **listeners** and **subscribers**.
+
+Event Listeners
+~~~~~~~~~~~~~~~
+
+Best for simple, form-specific logic. They are defined as inline closures or methods::
+
+    $builder->addEventListener(
+        FormEvents::PRE_SET_DATA,
+        function (PreSetDataEvent $event): void {
+            // ...
+        }
+    );
+
+    // or reference a method on the form type
+    $builder->addEventListener(
+        FormEvents::PRE_SET_DATA,
+        $this->onPreSetData(...)
+    );
+
+Event Subscribers
+~~~~~~~~~~~~~~~~~
+
+Best for reusable logic across multiple forms. They are defined in dedicated classes::
+
+    // src/Form/EventSubscriber/AddTimestampFieldsSubscriber.php
+    namespace App\Form\EventSubscriber;
+
+    use Symfony\Component\DependencyInjection\Attribute\Exclude;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Component\Form\Event\PreSetDataEvent;
     use Symfony\Component\Form\FormEvents;
 
-    $listener = function (FormEvent $event): void {
-        // ...
-    };
+    #[Exclude]
+    class AddTimestampFieldsSubscriber implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                FormEvents::PRE_SET_DATA => 'onPreSetData',
+            ];
+        }
 
-    $form = $formFactory->createBuilder()
-        // ... add form fields
-        ->addEventListener(FormEvents::PRE_SUBMIT, $listener);
+        public function onPreSetData(PreSetDataEvent $event): void
+        {
+            $form = $event->getForm();
 
-    // ...
+            // add created/updated display fields if entity has timestamps
+            $entity = $event->getData();
+            if ($entity && method_exists($entity, 'getCreatedAt')) {
+                $form->add('createdAt', DateTimeType::class, [
+                    'disabled' => true,
+                ]);
+            }
+        }
+    }
 
-The Form Workflow
------------------
+Then, register it in your form type::
 
-In the lifecycle of a form, there are two moments where the form data can
-be updated:
+    use App\Form\EventSubscriber\AddTimestampFieldsSubscriber;
 
-1. During **pre-population** (``setData()``) when building the form;
-2. When handling **form submission** (``handleRequest()``) to update the
-   form data based on the values the user entered.
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title')
+            // ...
+            ->addEventSubscriber(new AddTimestampFieldsSubscriber())
+        ;
+    }
 
-.. raw:: html
+.. _form-events-reference:
 
-    <object data="../_images/form/form_workflow.svg" type="image/svg+xml"
-        alt="A generic flow diagram showing the two phases. These are
-        described in the next subsections."
-    ></object>
+Event Reference
+---------------
 
-1) Pre-populating the Form (``FormEvents::PRE_SET_DATA`` and ``FormEvents::POST_SET_DATA``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. raw:: html
-
-    <object data="../_images/form/form_prepopulation_workflow.svg" type="image/svg+xml"
-        alt="A flow diagram showing the two events that are dispatched during pre-population."
-    ></object>
-
-Two events are dispatched during pre-population of a form, when
-:method:`Form::setData() <Symfony\\Component\\Form\\Form::setData>`
-is called: ``FormEvents::PRE_SET_DATA`` and ``FormEvents::POST_SET_DATA``.
-
-A) The ``FormEvents::PRE_SET_DATA`` Event
-.........................................
-
-The ``FormEvents::PRE_SET_DATA`` event is dispatched at the beginning of the
-``Form::setData()`` method. It is used to modify the data given during
-pre-population with
-:method:`FormEvent::setData() <Symfony\\Component\\Form\\FormEvent::setData>`.
-The method :method:`Form::setData() <Symfony\\Component\\Form\\Form::setData>`
-is locked since the event is dispatched from it and will throw an exception
-if called from a listener.
-
-====================  ======================================
-Data Type             Value
-====================  ======================================
-Event data            Model data injected into ``setData()``
-Form model data       ``null``
-Form normalized data  ``null``
-Form view data        ``null``
-====================  ======================================
-
-.. seealso::
-
-    See all form events at a glance in the
-    :ref:`Form Events Information Table <component-form-event-table>`.
-
-.. sidebar:: ``FormEvents::PRE_SET_DATA`` in the Form component
-
-    The ``Symfony\Component\Form\Extension\Core\Type\CollectionType`` form type relies
-    on the ``Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener``
-    subscriber, listening to the ``FormEvents::PRE_SET_DATA`` event in order
-    to reorder the form's fields depending on the data from the pre-populated
-    object, by removing and adding all form rows.
-
-B) The ``FormEvents::POST_SET_DATA`` Event
-..........................................
-
-The ``FormEvents::POST_SET_DATA`` event is dispatched at the end of the
-:method:`Form::setData() <Symfony\\Component\\Form\\Form::setData>`
-method. This event can be used to modify a form depending on the populated data
-(adding or removing fields dynamically).
-
-====================  ====================================================
-Data Type             Value
-====================  ====================================================
-Event data            Model data injected into ``setData()``
-Form model data       Model data injected into ``setData()``
-Form normalized data  Model data transformed using a model transformer
-Form view data        Normalized data transformed using a view transformer
-====================  ====================================================
-
-.. seealso::
-
-    See all form events at a glance in the
-    :ref:`Form Events Information Table <component-form-event-table>`.
-
-.. sidebar:: ``FormEvents::POST_SET_DATA`` in the Form component
-
-    The ``Symfony\Component\Form\Extension\DataCollector\EventListener\DataCollectorListener``
-    class is subscribed to listen to the ``FormEvents::POST_SET_DATA`` event
-    in order to collect information about the forms from the denormalized
-    model and view data.
-
-2) Submitting a Form (``FormEvents::PRE_SUBMIT``, ``FormEvents::SUBMIT`` and ``FormEvents::POST_SUBMIT``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. raw:: html
-
-    <object data="../_images/form/form_submission_workflow.svg" type="image/svg+xml"
-        alt="A flow diagram showing the three events that are dispatched when handling form submissions."
-    ></object>
-
-Three events are dispatched when
-:method:`Form::handleRequest() <Symfony\\Component\\Form\\Form::handleRequest>`
-or :method:`Form::submit() <Symfony\\Component\\Form\\Form::submit>` are
-called: ``FormEvents::PRE_SUBMIT``, ``FormEvents::SUBMIT``,
-``FormEvents::POST_SUBMIT``.
-
-A) The ``FormEvents::PRE_SUBMIT`` Event
-.......................................
-
-The ``FormEvents::PRE_SUBMIT`` event is dispatched at the beginning of the
-:method:`Form::submit() <Symfony\\Component\\Form\\Form::submit>` method.
-
-It can be used to:
-
-* Change data from the request, before submitting the data to the form;
-* Add or remove form fields, before submitting the data to the form.
-
-====================  ========================================
-Data Type             Value
-====================  ========================================
-Event data            Data from the request
-Form model data       Same as in ``FormEvents::POST_SET_DATA``
-Form normalized data  Same as in ``FormEvents::POST_SET_DATA``
-Form view data        Same as in ``FormEvents::POST_SET_DATA``
-====================  ========================================
-
-.. seealso::
-
-    See all form events at a glance in the
-    :ref:`Form Events Information Table <component-form-event-table>`.
-
-.. sidebar:: ``FormEvents::PRE_SUBMIT`` in the Form component
-
-    The ``Symfony\Component\Form\Extension\Core\EventListener\TrimListener``
-    subscriber subscribes to the ``FormEvents::PRE_SUBMIT`` event in order to
-    trim the request's data (for string values).
-    The ``Symfony\Component\Form\Extension\Csrf\EventListener\CsrfValidationListener``
-    subscriber subscribes to the ``FormEvents::PRE_SUBMIT`` event in order to
-    validate the CSRF token.
-
-B) The ``FormEvents::SUBMIT`` Event
-...................................
-
-The ``FormEvents::SUBMIT`` event is dispatched right before the
-:method:`Form::submit() <Symfony\\Component\\Form\\Form::submit>` method
-transforms back the normalized data to the model and view data.
-
-It can be used to change data from the normalized representation of the data.
-
-====================  ===================================================================================
-Data Type             Value
-====================  ===================================================================================
-Event data            Data from the request reverse-transformed from the request using a view transformer
-Form model data       Same as in ``FormEvents::POST_SET_DATA``
-Form normalized data  Same as in ``FormEvents::POST_SET_DATA``
-Form view data        Same as in ``FormEvents::POST_SET_DATA``
-====================  ===================================================================================
-
-.. seealso::
-
-    See all form events at a glance in the
-    :ref:`Form Events Information Table <component-form-event-table>`.
-
-.. warning::
-
-    At this point, you cannot add or remove fields to the form.
-
-.. sidebar:: ``FormEvents::SUBMIT`` in the Form component
-
-    The ``Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener``
-    subscribes to the ``FormEvents::SUBMIT`` event in order to prepend a default
-    protocol to URL fields that were submitted without a protocol.
-
-C) The ``FormEvents::POST_SUBMIT`` Event
-........................................
-
-The ``FormEvents::POST_SUBMIT`` event is dispatched after the
-:method:`Form::submit() <Symfony\\Component\\Form\\Form::submit>` once the
-model and view data have been denormalized.
-
-It can be used to fetch data after denormalization.
-
-====================  ===================================================================================
-Data Type             Value
-====================  ===================================================================================
-Event data            Normalized data transformed using a view transformer
-Form model data       Normalized data reverse-transformed using a model transformer
-Form normalized data  Data from the request reverse-transformed from the request using a view transformer
-Form view data        Normalized data transformed using a view transformer
-====================  ===================================================================================
-
-.. seealso::
-
-    See all form events at a glance in the
-    :ref:`Form Events Information Table <component-form-event-table>`.
-
-.. warning::
-
-    At this point, you cannot add or remove fields to the current form and its
-    children.
-
-.. sidebar:: ``FormEvents::POST_SUBMIT`` in the Form component
-
-    The ``Symfony\Component\Form\Extension\DataCollector\EventListener\DataCollectorListener``
-    subscribes to the ``FormEvents::POST_SUBMIT`` event in order to collect
-    information about the forms.
-    The ``Symfony\Component\Form\Extension\Validator\EventListener\ValidationListener``
-    subscribes to the ``FormEvents::POST_SUBMIT`` event in order to
-    automatically validate the denormalized object.
-
-Registering Event Listeners or Event Subscribers
-------------------------------------------------
-
-In order to be able to use Form events, you need to create an event listener
-or an event subscriber and register it to an event.
-
-The name of each of the "form" events is defined as a constant on the
-:class:`Symfony\\Component\\Form\\FormEvents` class.
-Additionally, each event callback (listener or subscriber method) is passed a
-single argument, which is an instance of
-:class:`Symfony\\Component\\Form\\FormEvent`. The event object contains a
-reference to the current state of the form and the current data being
-processed.
-
+.. _form-events-data-summary:
 .. _component-form-event-table:
+
+This table summarizes what data you can access in each event explained below:
 
 ======================  =============================  ===============
 Name                    ``FormEvents`` Constant        Event's Data
@@ -263,153 +329,325 @@ Name                    ``FormEvents`` Constant        Event's Data
 ``form.post_submit``    ``FormEvents::POST_SUBMIT``    View data
 ======================  =============================  ===============
 
-Event Listeners
-~~~~~~~~~~~~~~~
+.. _form-events-pre-set-data:
 
-An event listener may be any type of valid callable. For example, you can
-define an event listener function inline right in the ``addEventListener``
-method of the ``FormFactory``::
+PRE_SET_DATA
+~~~~~~~~~~~~
 
-    // ...
+Fires at the start of ``setData()``, before any data transformation.
 
-    use Symfony\Component\Form\Event\PreSubmitEvent;
-    use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-    use Symfony\Component\Form\Extension\Core\Type\EmailType;
-    use Symfony\Component\Form\Extension\Core\Type\TextType;
-    use Symfony\Component\Form\FormEvents;
+**When to use:**
 
-    $form = $formFactory->createBuilder()
-        ->add('username', TextType::class)
-        ->add('showEmail', CheckboxType::class)
-        ->addEventListener(FormEvents::PRE_SUBMIT, function (PreSubmitEvent $event): void {
-            $user = $event->getData();
-            $form = $event->getForm();
+* Add or remove fields based on whether the entity is new or existing
+* Modify initial data before the form processes it
 
-            if (!$user) {
-                return;
-            }
+**What you can access:**
 
-            // checks whether the user has chosen to display their email or not.
-            // If the data was submitted previously, the additional value that is
-            // included in the request variables needs to be removed.
-            if (isset($user['showEmail']) && $user['showEmail']) {
-                $form->add('email', EmailType::class);
-            } else {
-                unset($user['email']);
-                $event->setData($user);
-            }
-        })
-        ->getForm();
+* ``$event->getData()``: The model data (your object or array)
+* ``$event->getForm()``: The form instance (fields may not be fully built yet)
 
-    // ...
+**What you can do:**
 
-When you have created a form type class, you can use one of its methods as a
-callback for better readability::
+* Add or remove form fields
+* Call ``$event->setData()`` to modify the initial data
 
-    // src/Form/SubscriptionType.php
-    namespace App\Form;
+**Example**: Show "name" field only for new products::
 
     use Symfony\Component\Form\Event\PreSetDataEvent;
-    use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-    use Symfony\Component\Form\Extension\Core\Type\TextType;
     use Symfony\Component\Form\FormEvents;
 
-    // ...
-    class SubscriptionType extends AbstractType
-    {
-        public function buildForm(FormBuilderInterface $builder, array $options): void
-        {
-            $builder
-                ->add('username', TextType::class)
-                ->add('showEmail', CheckboxType::class)
-                ->addEventListener(
-                    FormEvents::PRE_SET_DATA,
-                    [$this, 'onPreSetData']
-                )
-            ;
+    $builder->addEventListener(
+        FormEvents::PRE_SET_DATA,
+        function (PreSetDataEvent $event): void {
+            $product = $event->getData();
+            $form = $event->getForm();
+
+            $isNew = !$product || null === $product->getId();
+
+            if ($isNew) {
+                $form->add('name', TextType::class);
+            }
         }
+    );
 
-        public function onPreSetData(PreSetDataEvent $event): void
-        {
-            // ...
+.. _form-events-post-set-data:
+
+POST_SET_DATA
+~~~~~~~~~~~~~
+
+Fires after ``setData()`` completes and all data transformations finish.
+
+**When to use:**
+
+* Access fully transformed data (model, normalized, and view data are all set)
+* Add fields that depend on computed values from transformers
+
+**What you can access:**
+
+* ``$event->getData()``: The model data
+* ``$event->getForm()->getNormData()``: The normalized data
+* ``$event->getForm()->getViewData()``: The view data
+
+**What you can do:**
+
+* Add or remove form fields (mainly useful for unmapped fields, since mapped
+  fields won't receive initial data from the object because the data was already set
+  in the previous step; adding fields in ``PRE_SET_DATA`` is generally preferred)
+* Set values in unmapped child fields using
+  ``$event->getForm()->get('child_name')->setData(...)`` (this is the ideal
+  event for this, as the value set here takes precedence over the child's default data)
+* Read (but typically don't modify) the data
+
+**Example**: Add a computed summary field::
+
+    use Symfony\Component\Form\Event\PostSetDataEvent;
+    use Symfony\Component\Form\FormEvents;
+
+    $builder->addEventListener(
+        FormEvents::POST_SET_DATA,
+        function (PostSetDataEvent $event): void {
+            $order = $event->getData();
+            $form = $event->getForm();
+
+            // add a read-only field showing computed total
+            if ($order && $order->getItems()->count() > 0) {
+                $form->add('totalDisplay', TextType::class, [
+                    'mapped' => false,
+                    'disabled' => true,
+                    'data' => $order->calculateTotal(),
+                ]);
+            }
         }
-    }
+    );
 
-Event Subscribers
-~~~~~~~~~~~~~~~~~
+.. _form-events-pre-submit:
 
-Event subscribers have different uses:
+PRE_SUBMIT
+~~~~~~~~~~
 
-* Improving readability;
-* Listening to multiple events;
-* Regrouping multiple listeners inside a single class.
+Fires at the start of ``submit()`` (called directly or via ``handleRequest()``),
+with raw request data.
 
-Consider the following example of a form event subscriber::
+**When to use:**
 
-    // src/Form/EventListener/AddEmailFieldListener.php
-    namespace App\Form\EventListener;
+* Modify, sanitize, or normalize submitted data before processing
+* Add or remove fields based on what the user submitted
+* Handle dependent fields (alternative to ``POST_SUBMIT`` on child)
 
-    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-    use Symfony\Component\Form\Event\PreSetDataEvent;
+**What you can access:**
+
+* ``$event->getData()``: Raw request data (array of strings, typically)
+* ``$event->getForm()``: The form with its current structure
+
+**What you can do:**
+
+* Add or remove form fields
+* Call ``$event->setData()`` to modify submitted data
+
+**Example**: Normalize phone number input::
+
     use Symfony\Component\Form\Event\PreSubmitEvent;
-    use Symfony\Component\Form\Extension\Core\Type\EmailType;
     use Symfony\Component\Form\FormEvents;
 
-    class AddEmailFieldListener implements EventSubscriberInterface
-    {
-        public static function getSubscribedEvents(): array
-        {
-            return [
-                FormEvents::PRE_SET_DATA => 'onPreSetData',
-                FormEvents::PRE_SUBMIT   => 'onPreSubmit',
-            ];
-        }
+    $builder->addEventListener(
+        FormEvents::PRE_SUBMIT,
+        function (PreSubmitEvent $event): void {
+            $data = $event->getData();
 
-        public function onPreSetData(PreSetDataEvent $event): void
-        {
-            $user = $event->getData();
+            if (isset($data['phone'])) {
+                // remove all non-digit characters
+                $data['phone'] = preg_replace('/\D/', '', $data['phone']);
+                $event->setData($data);
+            }
+        }
+    );
+
+**Example**: Add field based on submitted checkbox::
+
+    use Symfony\Component\Form\Event\PreSubmitEvent;
+    use Symfony\Component\Form\FormEvents;
+
+    $builder->addEventListener(
+        FormEvents::PRE_SUBMIT,
+        function (PreSubmitEvent $event): void {
+            $data = $event->getData();
             $form = $event->getForm();
 
-            // checks whether the user from the initial data has chosen to
-            // display their email or not.
-            if (true === $user->isShowEmail()) {
-                $form->add('email', EmailType::class);
+            if (!empty($data['hasDiscount'])) {
+                $form->add('discountCode', TextType::class, [
+                    'constraints' => [new NotBlank()],
+                ]);
             }
         }
+    );
 
-        public function onPreSubmit(PreSubmitEvent $event): void
-        {
-            $user = $event->getData();
-            $form = $event->getForm();
+.. _form-events-submit:
 
-            if (!$user) {
-                return;
-            }
+SUBMIT
+~~~~~~
 
-            // checks whether the user has chosen to display their email or not.
-            // If the data was submitted previously, the additional value that
-            // is included in the request variables needs to be removed.
-            if (isset($user['showEmail']) && $user['showEmail']) {
-                $form->add('email', EmailType::class);
-            } else {
-                unset($user['email']);
-                $event->setData($user);
+Fires after view-to-norm transformation, before norm-to-model transformation.
+
+**When to use:**
+
+* Modify normalized data (rarely needed; consider :doc:`data transformers </form/data_transformers>`
+instead)
+
+**What you can access:**
+
+* ``$event->getData()``: Normalized data (after view transformer)
+* ``$event->getForm()``: The form instance
+
+**What you can do:**
+
+* Call ``$event->setData()`` to modify normalized data (this can also be used
+  to populate the data of a compound form based on the data submitted in its children)
+* You **cannot** add or remove fields
+
+**Example**: Ensure URL has a protocol::
+
+    use Symfony\Component\Form\Event\SubmitEvent;
+    use Symfony\Component\Form\FormEvents;
+
+    $builder->get('website')->addEventListener(
+        FormEvents::SUBMIT,
+        function (SubmitEvent $event): void {
+            $url = $event->getData();
+
+            if ($url && !preg_match('~^https?://~i', $url)) {
+                $event->setData('https://' . $url);
             }
         }
-    }
+    );
 
-To register the event subscriber, use the ``addEventSubscriber()`` method::
+.. note::
 
-    use App\Form\EventListener\AddEmailFieldListener;
-    use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-    use Symfony\Component\Form\Extension\Core\Type\TextType;
+    Symfony's :doc:`UrlType </reference/forms/types/url>` already does this via
+    ``FixUrlProtocolListener``. This is just an example of modifying normalized data.
 
-    // ...
+.. _form-events-post-submit:
 
-    $form = $formFactory->createBuilder()
-        ->add('username', TextType::class)
-        ->add('showEmail', CheckboxType::class)
-        ->addEventSubscriber(new AddEmailFieldListener())
-        ->getForm();
+POST_SUBMIT
+~~~~~~~~~~~
 
-    // ...
+Fires after all transformations complete. Validation is triggered by listeners
+that run on ``POST_SUBMIT``.
+
+**When to use:**
+
+* Implement dependent fields (listen on the field your new field depends on)
+* Perform custom validation or logging
+* React to the final submitted state
+
+**What you can access:**
+
+* ``$event->getData()``: View data
+* ``$event->getForm()->getData()``: Model data
+* ``$event->getForm()->getNormData()``: Normalized data
+
+**What you can do:**
+
+* You **cannot** add or remove fields on the form the listener is attached to
+* You **can** add fields to the parent form (used for dependent fields)
+* You **can** add custom ``FormError`` instances to the form (useful for validation
+  logic that is harder to achieve with constraints, e.g. involving unmapped children)
+
+**Example**: Dependent Country/State select (on child's ``POST_SUBMIT``)::
+
+    use Symfony\Component\Form\Event\PostSubmitEvent;
+    use Symfony\Component\Form\FormEvents;
+
+    // listen to the country field's POST_SUBMIT
+    $builder->get('country')->addEventListener(
+        FormEvents::POST_SUBMIT,
+        function (PostSubmitEvent $event): void {
+            $country = $event->getForm()->getData();
+            $parentForm = $event->getForm()->getParent();
+
+            // add/update the state field on the parent form
+            $parentForm->add('state', ChoiceType::class, [
+                'choices' => $this->getStatesForCountry($country),
+                'placeholder' => 'Select a state',
+            ]);
+        }
+    );
+
+.. warning::
+
+    You cannot modify the form that the listener is attached to during
+    ``POST_SUBMIT``. Always modify the parent form instead.
+
+Troubleshooting
+---------------
+
+The :doc:`Symfony Profiler </profiler>` is the first tool you should check to
+debug any form event issues. You'll see all forms and their fields, submitted
+data at each level, validation errors and their sources and the data class and
+options for each form.
+
+Field Not Appearing After Submission
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You added the field in ``PRE_SET_DATA`` but not in ``PRE_SUBMIT``. When the form
+is submitted, ``PRE_SET_DATA`` runs with the *original* data, not the submitted data.
+
+Add the field in both events, or use ``PRE_SUBMIT`` if the field depends on
+submitted values.
+
+"This Form Should Not Contain Extra Fields" Error
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The form structure at submission time doesn't match what was rendered. A field
+exists in the submitted data but not in the form.
+
+Ensure fields are added consistently. If you add a field dynamically when
+rendering, you must also add it when processing the submission.
+
+Data Transformer Exception During Submit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A field was added with a data transformer, but the submitted value doesn't match
+what the transformer expects.
+
+Check that ``$event->getForm()->getData()`` vs ``$event->getData()`` give you
+the right type. On child fields, ``getData()`` returns the client data (usually
+a string ID), while ``getForm()->getData()`` returns the transformed object.
+
+Changes in POST_SUBMIT Not Reflected
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You're trying to modify the form that the listener is attached to.
+``POST_SUBMIT`` doesn't allow modifications to its own form.
+
+Attach the listener to a child field and modify the parent form.
+
+Checking Form State
+~~~~~~~~~~~~~~~~~~~
+
+Use these methods to understand the form's current state::
+
+    // in any event listener
+    $form = $event->getForm();
+
+    // is this the root form or a child?
+    $form->isRoot();          // true for the main form
+    $form->getParent();       // null for root, parent FormInterface otherwise
+
+    // what's the form's name?
+    $form->getName();         // e.g., 'task', 'category', etc.
+
+    // has the form been submitted?
+    $form->isSubmitted();     // true after handleRequest() processes data
+
+    // is the data synchronized (no transformer errors)?
+    $form->isSynchronized();  // false if a transformer threw an exception
+
+Learn More
+----------
+
+.. toctree::
+    :maxdepth: 1
+
+    /form/dynamic_form_modification
+    /form/data_transformers
+    /form/data_mappers


### PR DESCRIPTION
This updates the Symfony form event docs entirely. The docs are completely new, so the "git diff" view is not very useful. I tried to expand all the explanations, add more details and, most of all, add many common practical examples of form events.

This will need careful review by Symfony Form experts because I might have made mistakes 🙏  Thanks!