### PR TITLE
[Security] mention abstract `Voter` implements CacheableVoterInterface

### DIFF
--- a/security/voters.rst
+++ b/security/voters.rst
@@ -48,6 +48,13 @@ which makes creating a voter even easier::
         abstract protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool;
     }
 
+.. note::
+
+    The Voter class also implements
+    :class:`Symfony\\Component\\Security\\Core\\Authorization\\Voter\\CacheableVoterInterface`
+    whith methods used to improve
+    :ref:`voting performance <voter-improve-performance>` thanks to caching.
+
 .. _how-to-use-the-voter-in-a-controller:
 
 Setup: Checking for Access in a Controller
@@ -287,6 +294,8 @@ with ``ROLE_SUPER_ADMIN``::
 If you're using the :ref:`default services.yaml configuration <service-container-services-load-example>`,
 you're done! Symfony will automatically pass the ``security.helper``
 service when instantiating your voter (thanks to autowiring).
+
+.. _voter-improve-performance:
 
 Improving Voter Performance
 ---------------------------


### PR DESCRIPTION
Add a precision about interfaces implemented by `Voter` abstract class
I remember this detail has already caused me trouble 😅 