### PR TITLE
[Form][FrameworkBundle] Document `AbstractController::createFormFlowBuilder()`

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -168,6 +168,34 @@ Templating and Twig are explained more in the
 .. _controller-accessing-services:
 .. _accessing-other-services:
 
+Creating Form Flow Builders
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Symfony 8.1 adds a shortcut method to create form flow builders directly
+from controllers extending
+:class:``Symfony\Bundle\FrameworkBundle\Controller\AbstractController``.
+
+Use the :method:``Symfony\Bundle\FrameworkBundle\Controller\AbstractController::createFormFlowBuilder``
+method to create a form flow builder using the ``FormFlowType`` and the
+form factory::
+
+    public function index(): Response
+    {
+        $flowBuilder = $this->createFormFlowBuilder($data, [
+            // options
+        ]);
+
+        // ...
+    }
+
+The method accepts optional initial data and an array of options, and
+returns a
+:class:``Symfony\Component\Form\FormFlowBuilderInterface``.
+
+.. versionadded:: 8.1
+
+    The ``createFormFlowBuilder`` shortcut method was introduced in Symfony 8.1.
+
 Fetching Services
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR documents the new createFormFlowBuilder() helper added to AbstractController in Symfony 8.1.

The method allows creating a FormFlowBuilder directly from controllers using the FormFlowType and the form factory.

Issue: https://github.com/symfony/symfony-docs/issues/21731