### PR TITLE
[HttpKernel] document flat controller attributes in events

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -281,6 +281,16 @@ Another typical use-case for this event is to retrieve the attributes from
 the controller using the :method:`Symfony\\Component\\HttpKernel\\Event\\ControllerEvent::getAttributes`
 method. See the Symfony section below for some examples.
 
+Controller attributes are stored in the ``_controller_attributes`` request
+attribute. This decouples them from the controller source code, allowing
+listeners to override attributes at runtime (e.g. to change caching behavior
+for specific requests without modifying the controller).
+
+.. versionadded:: 8.1
+
+    Storing controller attributes in the ``_controller_attributes`` request
+    attribute was introduced in Symfony 8.1.
+
 Listeners to this event can also change the controller callable completely
 by calling :method:`ControllerEvent::setController <Symfony\\Component\\HttpKernel\\Event\\ControllerEvent::setController>`
 on the event object that's passed to listeners on this event.

--- a/reference/events.rst
+++ b/reference/events.rst
@@ -69,6 +69,34 @@ even to change the controller entirely::
         $event->setController($myCustomController);
     }
 
+You can also use ``getAttributes()`` to retrieve PHP attributes declared on the
+controller:
+
+.. code-block:: php-attributes
+
+    use Symfony\Component\HttpKernel\Event\ControllerEvent;
+
+    public function onKernelController(ControllerEvent $event): void
+    {
+        // get all attributes, grouped by class name
+        $allAttributes = $event->getAttributes();
+
+        // get all attributes as a flat list (not grouped)
+        $flatAttributes = $event->getAttributes('*');
+
+        // get attributes of a specific class
+        $cacheAttributes = $event->getAttributes(Cache::class);
+    }
+
+Controller attributes are stored in the ``_controller_attributes`` request
+attribute, which means they can be overridden at runtime to change the behavior
+of attribute-based listeners without modifying the controller source code.
+
+.. versionadded:: 8.1
+
+    Storing controller attributes in the ``_controller_attributes`` request
+    attribute was introduced in Symfony 8.1.
+
 .. seealso::
 
     Read more on the :ref:`kernel.controller event <component-http-kernel-kernel-controller>`.
@@ -196,6 +224,30 @@ before sending it back (e.g. add/modify HTTP headers, add cookies, etc.)::
 
         // ... modify the response object
     }
+
+You can use ``getControllerAttributes()`` to retrieve PHP attributes declared
+on the controller that handled the request:
+
+.. code-block:: php-attributes
+
+    use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        // get all controller attributes, grouped by class name
+        $allAttributes = $event->getControllerAttributes();
+
+        // get all controller attributes as a flat list (not grouped)
+        $flatAttributes = $event->getControllerAttributes('*');
+
+        // get attributes of a specific class
+        $cacheAttributes = $event->getControllerAttributes(Cache::class);
+    }
+
+.. versionadded:: 8.1
+
+    The ``ResponseEvent::getControllerAttributes()`` method was introduced in
+    Symfony 8.1.
 
 .. seealso::
 

--- a/service_container.rst
+++ b/service_container.rst
@@ -271,19 +271,6 @@ You can limit service registration to specific environments as follows:
             services:
                 App\Service\AnotherClass: ~
 
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-        <services>
-            <service id="App\Service\SomeClass"/>
-
-            <when env="dev">
-                <services>
-                    <service id="App\Service\AnotherClass"/>
-                </services>
-            </when>
-        </services>
-
     .. code-block:: php
 
         // config/services.php


### PR DESCRIPTION
Document the Symfony 8.1 change where controller attributes are returned as a flat list when using ControllerEvent and ControllerArgumentsEvent.

Grouped attributes passed to setController() are now deprecated.
Fixes https://github.com/symfony/symfony-docs/issues/21723