### PR TITLE
 Clarify removal of controller entity auto-mapping

### DIFF
--- a/controller/value_resolver.rst
+++ b/controller/value_resolver.rst
@@ -189,6 +189,13 @@ In addition, some components, bridges and official bundles provide other value r
     To learn more about the use of the ``EntityValueResolver``, see the dedicated
     section :ref:`Automatically Fetching Objects <doctrine-entity-value-resolver>`.
 
+.. versionadded:: 8.0
+
+    Automatic mapping of Doctrine entities to controller arguments has been removed.
+
+    Doctrine entities must now be mapped explicitly, for example by using the
+    ``#[MapEntity]`` attribute or mapped route parameters.
+
 PSR-7 Objects Resolver:
     Injects a Symfony HttpFoundation ``Request`` object created from a PSR-7 object
     of type ``Psr\Http\Message\ServerRequestInterface``,

--- a/service_container.rst
+++ b/service_container.rst
@@ -275,11 +275,11 @@ You can limit service registration to specific environments as follows:
 
         <!-- config/services.xml -->
         <services>
-            <service id="App\Service\SomeClass" />
+            <service id="App\Service\SomeClass"/>
 
             <when env="dev">
                 <services>
-                    <service id="App\Service\AnotherClass" />
+                    <service id="App\Service\AnotherClass"/>
                 </services>
             </when>
         </services>


### PR DESCRIPTION
Clarifies that automatic Doctrine entity mapping to controller arguments has been removed in Symfony 8.0.
Fixes https://github.com/symfony/symfony-docs/issues/21227