### PR TITLE
[FrameworkBundle] Add Notifier configuration reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2138,6 +2138,187 @@ Whether to enable or not Messenger.
     For more details, see the :doc:`Messenger component </messenger>`
     documentation.
 
+notifier
+~~~~~~~~
+
+chatter_transports
+..................
+
+**type**: ``array`` **default**: ``[]``
+
+Configures the chatter transports used for chat notifications (e.g. Slack, Telegram).
+The transport name is the key and the DSN is the value:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/notifier.yaml
+        framework:
+            notifier:
+                chatter_transports:
+                    slack: '%env(SLACK_DSN)%'
+                    telegram: '%env(TELEGRAM_DSN)%'
+
+    .. code-block:: php
+
+        // config/packages/notifier.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'notifier' => [
+                    'chatter_transports' => [
+                        'slack' => env('SLACK_DSN'),
+                        'telegram' => env('TELEGRAM_DSN'),
+                    ],
+                ],
+            ],
+        ]);
+
+texter_transports
+.................
+
+**type**: ``array`` **default**: ``[]``
+
+Configures the texter transports used for SMS notifications (e.g. Twilio, Vonage).
+The transport name is the key and the DSN is the value:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/notifier.yaml
+        framework:
+            notifier:
+                texter_transports:
+                    twilio: '%env(TWILIO_DSN)%'
+
+    .. code-block:: php
+
+        // config/packages/notifier.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'notifier' => [
+                    'texter_transports' => [
+                        'twilio' => env('TWILIO_DSN'),
+                    ],
+                ],
+            ],
+        ]);
+
+channel_policy
+..............
+
+**type**: ``array`` **default**: ``[]``
+
+Defines which channels are used for each notification importance level.
+The key is the importance level (``urgent``, ``high``, ``medium``, ``low``)
+and the value is an array of channel names:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/notifier.yaml
+        framework:
+            notifier:
+                channel_policy:
+                    urgent: ['sms', 'chat/slack', 'email']
+                    high: ['chat/slack']
+                    medium: ['browser']
+                    low: ['browser']
+
+    .. code-block:: php
+
+        // config/packages/notifier.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'notifier' => [
+                    'channel_policy' => [
+                        'urgent' => ['sms', 'chat/slack', 'email'],
+                        'high' => ['chat/slack'],
+                        'medium' => ['browser'],
+                        'low' => ['browser'],
+                    ],
+                ],
+            ],
+        ]);
+
+admin_recipients
+................
+
+**type**: ``array`` **default**: ``[]``
+
+Configures the recipients of notifications sent to administrators. Each recipient
+can have an ``email`` and/or a ``phone`` number:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/notifier.yaml
+        framework:
+            notifier:
+                admin_recipients:
+                    - { email: 'admin@example.com' }
+                    - { email: 'lead@example.com', phone: '+1555123456' }
+
+    .. code-block:: php
+
+        // config/packages/notifier.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'notifier' => [
+                    'admin_recipients' => [
+                        ['email' => 'admin@example.com'],
+                        ['email' => 'lead@example.com', 'phone' => '+1555123456'],
+                    ],
+                ],
+            ],
+        ]);
+
+message_bus
+...........
+
+**type**: ``string`` | ``false`` **default**: ``null`` or default bus if Messenger component is installed
+
+Defines which message bus is used to dispatch notification messages. Set to
+``false`` to call the notifier transport directly instead of dispatching
+through the bus:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/notifier.yaml
+        framework:
+            notifier:
+                message_bus: false
+
+    .. code-block:: php
+
+        // config/packages/notifier.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'notifier' => [
+                    'message_bus' => false,
+                ],
+            ],
+        ]);
+
+.. seealso::
+
+    For more details, see the :doc:`Notifier component </notifier>` documentation.
+
 php_errors
 ~~~~~~~~~~
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                              
  - Add missing Notifier configuration to the Framework Configuration Reference                                                                                                                           
  - Document `chatter_transports`, `texter_transports`, `channel_policy`, `admin_recipients` and `message_bus` options                                                                                    
  - Include YAML and PHP configuration examples                                                                                                                                                           
                                                                                                                                                                                                          
  Fixes #21787 