### PR TITLE
[Messenger] Add regex support for transport name matching in `messenger:consume` command

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -450,6 +450,30 @@ The first argument is the receiver's name (or service id if you routed to a
 custom service). By default, the command will run forever: looking for new messages
 on your transport and handling them. This command is called your "worker".
 
+You can also use regular expressions as the receiver's name to match multiple
+transports at once. This is useful when you have multiple transports with
+similar names (e.g. prefix matching):
+
+.. code-block:: terminal
+
+    # match all transports starting with "scheduler_"
+    $ php bin/console messenger:consume scheduler_.*
+
+    # match multiple transports using multiple patterns or specific names
+    $ php bin/console messenger:consume "(?i)THIRD.*" second.* normal
+
+When a regular expression matches multiple transports, they are consumed in the order they
+are defined in your configuration. If you specify multiple receiver names or
+regular expressions, they are processed in the order you provided them in the command.
+
+.. versionadded:: 8.1
+
+    The ability to use regular expressions as the receiver's name was introduced in Symfony 8.1.
+
+.. note::
+
+    Regular expression matching only works when the command is not run in interactive mode.
+
 If you want to consume messages from all available receivers, you can use the
 command with the ``--all`` option:
 

--- a/scheduler.rst
+++ b/scheduler.rst
@@ -138,6 +138,11 @@ on a particular schedule::
 
 .. tip::
 
+    You can consume all your scheduler transports at once by using a regular expression
+    with the ``messenger:consume`` command (e.g. ``php bin/console messenger:consume scheduler_.*``).
+
+.. tip::
+
     `Memoizing`_ your schedule is a good practice to prevent unnecessary reconstruction
     if the ``getSchedule()`` method is checked by another service.
 


### PR DESCRIPTION
Closes https://github.com/symfony/symfony-docs/issues/21810

This PR was made with the help of Gemini 3 Flash
