### PR TITLE
[JsonStreamer] Update PropertyMetadata value transformers documentation

### DIFF
--- a/serializer/streaming_json.rst
+++ b/serializer/streaming_json.rst
@@ -637,7 +637,7 @@ configurations, providing more flexibility than attributes::
                 if (in_array($metadata->getName(), $className::getPropertiesToEncrypt(), true)) {
                     $propertyMetadataMap[$jsonKey] = $metadata
                         ->withType(Type::string())
-                        ->withAdditionalNativeToStreamValueTransformer(EncryptorValueTransformer::class);
+                        ->withAdditionalValueTransformer(EncryptorValueTransformer::class);
                 }
             }
 
@@ -658,12 +658,24 @@ configurations, providing more flexibility than attributes::
             $propertyMetadataMap['is_sensitive'] = new PropertyMetadata(
                 name: 'theNameWontBeUsed',
                 type: Type::bool(),
-                nativeToStreamValueTransformers: [fn() => true],
+                valueTransformers: [fn() => true],
             );
 
             return $propertyMetadataMap;
         }
     }
+
+.. versionadded:: 7.4
+
+    The ``valueTransformers`` parameter and the ``withAdditionalValueTransformer()``
+    method were introduced in Symfony 7.4.
+
+.. deprecated:: 7.4
+
+    The ``nativeToStreamValueTransformers`` and ``streamToNativeValueTransformers``
+    constructor parameters, as well as the ``withAdditionalNativeToStreamValueTransformer()``
+    and ``withAdditionalStreamToNativeValueTransformer()`` methods, were deprecated
+    in Symfony 7.4.
 
 Although powerful, this approach introduces complexity. Decorating property
 metadata loaders requires a deep understanding of the internals.

--- a/service_container.rst
+++ b/service_container.rst
@@ -314,11 +314,11 @@ You can limit service registration to specific environments as follows:
 
         <!-- config/services.xml -->
         <services>
-            <service id="App\Service\SomeClass" />
+            <service id="App\Service\SomeClass"/>
 
             <when env="dev">
                 <services>
-                    <service id="App\Service\AnotherClass" />
+                    <service id="App\Service\AnotherClass"/>
                 </services>
             </when>
         </services>


### PR DESCRIPTION
This PR updates the PropertyMetadata documentation to use the merged valueTransformers parameter instead of the separate nativeToStreamValueTransformers and                            
  streamToNativeValueTransformers. Fixes #21535 