### PR TITLE
[DependencyInjection] Document target parameter for #[AsAlias] attribute

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -275,11 +275,11 @@ You can limit service registration to specific environments as follows:
 
         <!-- config/services.xml -->
         <services>
-            <service id="App\Service\SomeClass" />
+            <service id="App\Service\SomeClass"/>
 
             <when env="dev">
                 <services>
-                    <service id="App\Service\AnotherClass" />
+                    <service id="App\Service\AnotherClass"/>
                 </services>
             </when>
         </services>

--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -197,6 +197,80 @@ The ``#[AsAlias]`` attribute can also be limited to one or more specific
             // ...
         }
 
+You can also use the ``target`` parameter to create aliases for specific
+:ref:`named autowiring <autowiring-multiple-implementations-same-type>` targets.
+This is useful when you have multiple implementations of the same interface
+and need to inject a specific one based on context.
+
+For example, you might have different mailer implementations for different types of emails::
+
+    // src/Mail/SmtpMailer.php
+    namespace App\Mail;
+
+    use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+    #[AsAlias(MailerInterface::class, target: 'notificationMailer')]
+    class SmtpMailer implements MailerInterface
+    {
+        // ...
+    }
+
+    #[AsAlias(MailerInterface::class, target: 'transactionalMailer')]
+    class TransactionalMailer implements MailerInterface
+    {
+        // ...
+    }
+
+You can then inject the specific implementation by matching the argument name
+to the target::
+
+    class UserNotificationService
+    {
+        public function __construct(
+            private MailerInterface $notificationMailer,
+        ) {
+        }
+    }
+
+::
+
+    class OrderConfirmationService
+    {
+        public function __construct(
+            private MailerInterface $transactionalMailer,
+        ) {
+        }
+    }
+
+Alternatively, you can use the :ref:`#[Target] attribute <autowiring-multiple-implementations-same-type>`
+to be more explicit::
+
+    use Symfony\Component\DependencyInjection\Attribute\Target;
+
+    class UserNotificationService
+    {
+        public function __construct(
+            #[Target('notificationMailer')]
+            private MailerInterface $mailer,
+        ) {
+        }
+    }
+
+::
+
+    class OrderConfirmationService
+    {
+        public function __construct(
+            #[Target('transactionalMailer')]
+            private MailerInterface $mailer,
+        ) {
+        }
+    }
+
+.. versionadded:: 8.1
+
+    The ``target`` parameter for the ``#[AsAlias]`` attribute was introduced in Symfony 8.1.
+
 Deprecating Service Aliases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR documents the new `target` parameter for the `#[AsAlias]` attribute, which allows creating aliases for specific named autowiring targets. This enables multiple implementations of the same     
  interface to coexist and be injected based on the `#[Target]` attribute.                                                                                                                                
                                                                                                                                                                                                          
  Fixes #21813