### PR TITLE
[Serializer][Validator] Document JSON schema for YAML mapping files

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -486,6 +486,24 @@ property. For instance, to configure the datetime format:
     * All ``*.yaml`` and ``*.xml`` files in the ``Resources/config/serialization/``
       directory of a bundle.
 
+.. tip::
+
+    Symfony provides a JSON schema for serializer mapping files that enables
+    autocompletion and validation in IDEs like PhpStorm. Add the following
+    ``$schema`` key at the beginning of your YAML files to enable this feature:
+
+    .. code-block:: yaml
+
+        # config/serializer/person.yaml
+        '$schema': https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.json
+        App\Model\Person:
+            attributes:
+                # your IDE will now provide autocompletion here...
+
+    .. versionadded:: 7.4
+
+        The JSON schema for serializer mapping files was introduced in Symfony 7.4.
+
 You can also specify a context specific to normalization or denormalization:
 
 .. configuration-block::

--- a/validation.rst
+++ b/validation.rst
@@ -45,7 +45,25 @@ valid. For this to work, you'll configure a list of rules (called
 :ref:`constraints <validation-constraints>`) that the object must follow in
 order to be valid. These rules are usually defined using PHP code or
 attributes but they can also be defined as ``.yaml`` or ``.xml`` files inside
-the ``config/validator/`` directory:
+the ``config/validator/`` directory.
+
+.. tip::
+
+    Symfony provides a JSON schema for validation mapping files that enables
+    autocompletion and validation in IDEs like PhpStorm. Add the following
+    ``$schema`` key at the beginning of your YAML files to enable this feature:
+
+    .. code-block:: yaml
+
+        # config/validator/validation.yaml
+        '$schema': https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.json
+        App\Entity\Author:
+            properties:
+                # your IDE will now provide autocompletion here...
+
+    .. versionadded:: 7.4
+
+        The JSON schema for validation mapping files was introduced in Symfony 7.4.
 
 For example, to indicate that the ``$name`` property must not be empty, add the
 following:


### PR DESCRIPTION
 This PR documents the JSON schemas for Serializer and Validator YAML mapping files, which enable autocompletion and validation in IDEs like PhpStorm.                                                   
                                                                                                                                                                                                          
  Fixes #21334    