### PR TITLE
[Webhook] re-structure and fill out missing parts

### DIFF
--- a/webhook.rst
+++ b/webhook.rst
@@ -5,9 +5,13 @@ Webhook
 
     The Webhook component was introduced in Symfony 6.3.
 
-The Webhook component is used to respond to remote webhooks to trigger actions
-in your application. This document focuses on using webhooks to listen to remote
-events in other Symfony components.
+Essentially, webhooks serve as event notification mechanisms, typically via HTTP POST requests, enabling real-time updates.
+
+The Webhook component has two primary functions:
+1. Consumer: Listen and respond to remote webhooks dispatched by 3rd party services.
+2. Provider: Dispatch webhooks to 3rd party services.
+
+This document provides guidance on utilizing the Webhook component within the context of a full-stack Symfony application.
 
 Installation
 ------------
@@ -16,8 +20,75 @@ Installation
 
     $ composer require symfony/webhook
 
+
+Consuming Webhooks
+------------------
+
+Consider a third-party API that allows you to track stock levels for various products and can send webhooks to your
+Symfony application.
+
+From the perspective of your application (the *consumer*), which receives the webhook, three primary phases need to be anticipated:
+
+1) Receiving the webhook
+
+2) Verifying the webhook and constructing the corresponding Remote Event
+
+3) Using the received data.
+
+Symfony Webhook, when used alongside Symfony RemoteEvent, streamlines the management of these fundamental phases.
+
+A Single Entry Endpoint: Receive
+--------------------------------
+
+Through the built-in :class:`Symfony\\Component\\Webhook\\Controller\\WebhookController`, a unique entry point is offered to manage all webhooks
+that our application may receive, whether from the Twilio API, a custom API, or other sources.
+
+By default, any URL prefixed with ``/webhook`` will be routed to this :class:`Symfony\\Component\\Webhook\\Controller\\WebhookController`.
+Additionally, you have the flexibility to customize this URL prefix and rename it according to your preferences.
+
+.. code-block:: yaml
+
+    # config/routes/webhook.yaml
+    webhook:
+        resource: '@FrameworkBundle/Resources/config/routing/webhook.xml'
+        prefix: /webhook # or possible to customize
+
+Additionally, you must specify the parser service responsible for analyzing and parsing incoming webhooks.
+It's crucial to understand that the :class:`Symfony\\Component\\Webhook\\Controller\\WebhookController` itself remains provider-agnostic, utilizing
+a routing mechanism to determine which parser should handle incoming webhooks for analysis.
+
+As mentioned earlier, incoming webhooks require a specific prefix to be directed to the :class:`Symfony\\Component\\Webhook\\Controller\\WebhookController`.
+This prefix forms the initial part of the URL following the domain name.
+The subsequent part of the URL, following this prefix, should correspond to the routing name chosen in your configuration.
+
+The routing name must be unique as this is what connects the provider with your
+webhook consumer code.
+
+.. code-block:: yaml
+
+    # config/webhook.yaml
+    # e.g https://example.com/webhook/my_first_parser
+
+    framework:
+      webhook:
+        routing:
+          my_first_parser: # routing name
+            service: App\Webhook\ExampleRequestParser
+          # secret: your_secret_here # optionally
+
+At this point in the configuration, you can also define a secret for webhooks that require one.
+
+All parser services defined for each routing name of incoming webhooks will be injected into the :class:`Symfony\\Component\\Webhook\\Controller\\WebhookController`.
+
+
+A Service Parser: Verifying and Constructing the Corresponding Remote Event
+---------------------------------------------------------------------------
+
+It's important to note that Symfony provides built-in parser services.
+In such cases, configuring the service name and optionally the required secret in the configuration is sufficient; there's no need to create your own parser.
+
 Usage in Combination with the Mailer Component
-----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When using a third-party mailer provider, you can use the Webhook component to
 receive webhook calls from this provider.
@@ -94,8 +165,6 @@ component routing:
         };
 
 In this example, we are using ``mailer_mailgun`` as the webhook routing name.
-The routing name must be unique as this is what connects the provider with your
-webhook consumer code.
 
 The webhook routing name is part of the URL you need to configure at the
 third-party mailer provider. The URL is the concatenation of your domain name
@@ -106,7 +175,195 @@ For Mailgun, you will get a secret for the webhook. Store this secret as
 MAILER_MAILGUN_SECRET (in the :doc:`secrets management system
 </configuration/secrets>` or in a ``.env`` file).
 
-When done, add a :class:`Symfony\\Component\\RemoteEvent\\RemoteEvent` consumer
+Usage in Combination with the Notifier Component
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The usage of the Webhook component when using a third-party transport in
+the Notifier is very similar to the usage with the Mailer.
+
+Currently, the following third-party SMS transports support webhooks:
+
+============ ==========================================
+SMS service  Parser service name
+============ ==========================================
+Twilio       ``notifier.webhook.request_parser.twilio``
+Vonage       ``notifier.webhook.request_parser.vonage``
+============ ==========================================
+
+A custom Parser
+~~~~~~~~~~~~~~~
+
+However, if your webhook, as illustrated in the example discussed, originates from a custom API,
+you will need to create a parser service that implements :class:`Symfony\\Component\\Webhook\\Client\\RequestParserInterface` or extends :class:`Symfony\\Component\\Webhook\\Client\\AbstractRequestParser`.
+
+By extending the :class:`Symfony\\Component\\Webhook\\Client\\AbstractRequestParser`, you'll inherit a predefined structure for the incoming webhook analysis step. You'll only need to implement the
+:method:`Symfony\\Component\\Webhook\\Client\\AbstractRequestParser::doParse` method and specify any RequestMatcher(s) you want to apply to the incoming webhooks in the `Symfony\\Component\\Webhook\\Client\\AbstractRequestParser::getRequestMatcher` method.
+
+This process can be simplified using a command:
+
+.. code-block:: terminal
+
+    $ php bin/console make:webhook
+
+.. tip::
+
+    Starting in `MakerBundle`_ ``v1.58.0``, you can run ``php bin/console make:webhook``
+    to generate the request parser and consumer files needed to create your own
+    Webhook.
+
+Depending on the routing name provided to this command, which corresponds, as discussed earlier,
+to the second and final part of the incoming webhook URL, the command will generate the parser service responsible for parsing your webhook.
+
+Additionally, it allows you to specify which RequestMatcher(s) from the HttpFoundation component should be applied to the incoming webhook request.
+This constitutes the initial step of your gateway process, ensuring that the format of the incoming webhook is validated before proceeding to its thorough analysis.
+
+Furthermore, the command will create the RemoteEvent consumer class implementing the :class:`Symfony\\Component\\RemoteEvent\\Consumer\\ConsumerInterface`, which manages the remote event returned by the parser.
+
+Moreover, this command will automatically update the previously discussed configuration with the webhook's routing name.
+This ensures that not only are the parser and consumer generated, but also that the configuration is seamlessly updated::
+
+    // src/Webhook/ExampleRequestParser.php
+    final class ExampleRequestParser extends AbstractRequestParser
+    {
+        protected function getRequestMatcher(): RequestMatcherInterface
+        {
+            return new ChainRequestMatcher([
+                new IsJsonRequestMatcher(),
+                new MethodRequestMatcher('POST'),
+                new HostRequestMatcher('regex'),
+                new ExpressionRequestMatcher(new ExpressionLanguage(), new Expression('expression')),
+                new PathRequestMatcher('regex'),
+                new IpsRequestMatcher(['127.0.0.1']),
+                new PortRequestMatcher(443),
+                new SchemeRequestMatcher('https'),
+            ]);
+        }
+
+        /**
+         * @throws JsonException
+         */
+        protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?RemoteEvent
+        {
+            // Adapt or replace the content of this method to fit your need.
+            // e.g Validate the request against $secret and/or Validate the request payload
+            // and/or Parse the request payload and return a RemoteEvent object or throw an exception
+
+            return new RemoteEvent(
+                $payload['name'],
+                $payload['id'],
+                $payload,
+            );
+        }
+    }
+
+
+Now, imagine that in your case, you receive a notification of a product stock outage, and the received JSON contains details about the affected product and the severity of the outage.
+Depending on the specific product and the severity of the stock outage, your application can trigger different remote events.
+
+For instance, you might define ``HighPriorityStockRefillEvent``, ``MediumPriorityStockRefillEvent`` and ``LowPriorityStockRefillEvent``.
+
+
+By implementing the :class:`Symfony\\Component\\RemoteEvent\\PayloadConverterInterface` and its :method:`Symfony\\Component\\RemoteEvent\\PayloadConverterInterface::convert` method, you can encapsulate all the business logic
+involved in creating the appropriate remote event. This converter will be invoked by your parser.
+
+For inspiration, you can refer to :class:`Symfony\\Component\\Mailer\\Bridge\\Mailgun\\RemoteEvent\\MailGunPayloadConverter`::
+
+    // src/Webhook/ExampleRequestParser.php
+    final class ExampleRequestParser extends AbstractRequestParser
+    {
+        protected function getRequestMatcher(): RequestMatcherInterface
+        {
+            ...
+        }
+
+        /**
+         * @throws JsonException
+         */
+        protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?RemoteEvent
+        {
+            // Adapt or replace the content of this method to fit your need.
+            // e.g Validate the request against $secret and/or Validate the request payload
+            // and/or Parse the request payload and return a RemoteEvent object or throw an exception
+
+            try {
+                return $this->converter->convert($content['...']);
+            } catch (ParseException $e) {
+                throw new RejectWebhookException(406, $e->getMessage(), $e);
+            }
+        }
+    }
+
+    // src/RemoteEvent/ExamplePayloadConverter.php
+    final class ExamplePayloadConverter implements PayloadConverterInterface
+    {
+        public function convert(array $payload): AbstractPriorityStockRefillEvent
+        {
+            ...
+
+            if (....) {
+                $event = new HighPriorityStockRefillEvent($name, $payload['id]', $payload])
+            } elseif {
+                $event = new MediumPriorityStockRefillEvent($name, $payload['id]', $payload])
+            } else {
+                $event = new LowPriorityStockRefillEvent($name, $payload['id]', $payload])
+            }
+
+            ....
+
+            return $event;
+        }
+    }
+
+From this, we can see that the RemoteEvent component is highly beneficial for handling webhooks.
+It enables you to convert the incoming webhook data into validated objects that can be efficiently manipulated and utilized according to your requirements.
+
+Remote Event Consumer: Handling and Manipulating The Received Data
+------------------------------------------------------------------
+
+It is important to note that when the incoming webhook is processed by the :class:`Symfony\\Component\\Webhook\\Controller\\WebhookController`, you have the option to handle the consumption of remote events asynchronously.
+Indeed, this can be configured using a bus, with the default setting pointing to the Messenger component's default bus.
+For more details, refer to the :doc:`Symfony Messenger </components/messenger>` documentation
+
+
+Whether the remote event is processed synchronously or asynchronously, you'll need a consumer that implements the :class:`Symfony\\Component\\RemoteEvent\\Consumer\\ConsumerInterface`.
+If you used the command to set this up, it was created automatically
+
+.. code-block:: terminal
+
+    $ php bin/console make:webhook
+
+Otherwise, you'll need to manually add it with the ``AsRemoteEventConsumer`` attribute which will allow you to designate this class as a consumer implementing :class:`Symfony\\Component\\RemoteEvent\\Consumer\\ConsumerInterface`,
+making it recognizable to the RemoteEvent component so it can pass the converted object to it.
+Additionally, the name passed to your attribute is critical; it must match the configuration entry under routing that you specified in the ``webhook.yaml`` file, which in your case is ``my_first_parser``.
+
+In the :method:`Symfony\\Component\\RemoteEvent\\Consumer\\ConsumerInterface::consume` method,
+you can access your object containing the event data that triggered the webhook, allowing you to respond appropriately.
+
+For example, you can use Mercure to broadcast updates to clients of the hub, among other actions ...::
+
+    // src/Webhook/ExampleRequestParser.php
+    #[AsRemoteEventConsumer('my_first_parser')] # routing name
+    final class ExampleWebhookConsumer implements ConsumerInterface
+    {
+        public function __construct()
+        {
+        }
+
+        public function consume(RemoteEvent $event): void
+        {
+            // Implement your own logic here
+        }
+    }
+
+
+If you are using it alongside other components that already include built-in parsers,
+you will need to configure the settings (as mentioned earlier) and also create your own consumer.
+This is necessary because it involves your own business logic and your specific reactions to the remote event(s) that may be received from the built-in parsers.
+
+Usage in Combination with the Mailer Component
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can add a :class:`Symfony\\Component\\RemoteEvent\\RemoteEvent` consumer
 to react to incoming webhooks (the webhook routing name is what connects your
 class to the provider).
 
@@ -122,7 +379,7 @@ events::
     use Symfony\Component\RemoteEvent\RemoteEvent;
 
     #[AsRemoteEventConsumer('mailer_mailgun')]
-    class WebhookListener implements ConsumerInterface
+    class MailerWebhookConsumer implements ConsumerInterface
     {
         public function consume(RemoteEvent $event): void
         {
@@ -148,19 +405,7 @@ events::
     }
 
 Usage in Combination with the Notifier Component
-------------------------------------------------
-
-The usage of the Webhook component when using a third-party transport in
-the Notifier is very similar to the usage with the Mailer.
-
-Currently, the following third-party SMS transports support webhooks:
-
-============ ==========================================
-SMS service  Parser service name
-============ ==========================================
-Twilio       ``notifier.webhook.request_parser.twilio``
-Vonage       ``notifier.webhook.request_parser.vonage``
-============ ==========================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For SMS webhooks, react to the
 :class:`Symfony\\Component\\RemoteEvent\\Event\\Sms\\SmsEvent` event::
@@ -189,13 +434,67 @@ For SMS webhooks, react to the
         }
     }
 
-Creating a Custom Webhook
--------------------------
 
-.. tip::
+Providing Webhooks
+------------------
 
-    Starting in `MakerBundle`_ ``v1.58.0``, you can run ``php bin/console make:webhook``
-    to generate the request parser and consumer files needed to create your own
-    Webhook.
+Continuing with our example, but this time from the provider's perspective rather than the consumer's.
+Let's assume that a webhook has been registered to be notified when certain events occur, such as stock depletion for a specific product.
+
+During the registration of this webhook, several pieces of information were included in the POST request,
+including the endpoint to be called upon the occurrence of an event, such as stock depletion for a certain product:
+
+.. code-block:: json
+
+    {
+      "name": "a name",
+      "url": "something/webhook/routing_name",
+      "signature": "...",
+      "events": ["out_of_stock_event"],
+      ....
+    }
+
+
+Consider a scenario where, after several updates via API calls, a product's stock is depleted.
+Now, let's assume the API has a mechanism that allows it to react and trigger the sending of webhooks in response to this event.
+At this point, the API needs to be able to dispatch these webhook notifications to the endpoints specified by subscribers during their webhook registration.
+
+Symfony Webhook and Symfony RemoteEvent, when combined with Symfony Messenger, are also useful for APIs responsible for dispatching webhooks.
+
+For instance, you can utilize the specific :class:`Symfony\\Component\\Webhook\\Messenger\\SendWebhookMessage` and
+:class:`Symfony\\Component\\Webhook\\Messenger\\SendWebhookHandler` provided to dispatch the webhook either synchronously or asynchronously using the Symfony Messenger component.
+
+The SendWebhookMessage takes a :class:`Symfony\\Component\\Webhook\\Subscriber` as its first argument, which includes the destination URL and the mandatory secret.
+If the secret is missing, an exception will be thrown.
+
+As a second argument, it expects a :class:`Symfony\\Component\\RemoteEvent\\RemoteEvent` containing the webhook event name, the ID, and the payload, which is the substantial information you wish to communicate::
+
+    $subscriber = new Subscriber($urlCallback, $secret);
+    $event = new RemoteEvent(‘out_of_stock_event, ‘1’, […]);
+    $this->bus->dispatch(new SendWebhookMessage($subscriber, $event));
+
+The :class:`Symfony\\Component\\Webhook\\Messenger\\SendWebhookHandler` configures the headers, the body of the request,
+and finally sign the headers before making an HTTP request to the specified URL using Symfony's HttpClient component::
+
+By default, it will add the following headers:
+
+1) Webhook-Event with the event name
+2) Webhook-Id with the id of the event
+3) Webhook-Signature with the signature, generated as a hmac (using sha256 by default) of the concatenation of the event name,
+   event id and body, using the secret of the subscriber. The value of the header provides the algorithm used for the signature::
+
+    -options: array:2 [▼
+        "headers" => array:4 [▼
+          "Webhook-Event" => "out_of_stockt"
+          "Webhook-Id" => "1"
+          "Content-Type" => "application/json"
+          "Webhook-Signature" => "sha256=...."
+        ]
+        "body" => "{"id":1,"product":"...", ...}"
+      ]
+
+However it is also entirely possible to create your own mechanism by defining your own message - handler or by reusing differently the
+:class:`Symfony\\Component\\Webhook\\Server\\TransportInterface` in your own logic and code structure to ensure that the webhook events are correctly sent to the correct destination.
+
 
 .. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html

--- a/webhook.rst
+++ b/webhook.rst
@@ -266,8 +266,7 @@ encapsulate transformation logic:
     use Symfony\Component\RemoteEvent\PayloadConverterInterface;
     use Symfony\Component\RemoteEvent\RemoteEvent;
 
-    final class AcmeWebhookPayloadConverter
-        implements PayloadConverterInterface
+    final class AcmeWebhookPayloadConverter implements PayloadConverterInterface
     {
         public function convert(array $payload): RemoteEvent
         {
@@ -292,6 +291,12 @@ Then use it in your parser:
 .. code-block:: php
 
     use Symfony\Component\Webhook\Exception\RejectWebhookException;
+    use App\RemoteEvent\AcmeWebhookPayloadConverter;
+
+    public function __construct(
+        #[Autowire(service: AcmeWebhookPayloadConverter::class)]
+        private readonly PayloadConverterInterface $payloadConverter,
+    ) {}
 
     protected function doParse(
         Request $request,

--- a/webhook.rst
+++ b/webhook.rst
@@ -32,7 +32,7 @@ The Webhook component, combined with RemoteEvent, enables you to receive and pro
 3. Consuming the event in your application logic
 
 A Centralized Webhook Endpoint
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :class:`Symfony\\Component\\Webhook\\Controller\\WebhookController` provides a single entry point for receiving all incoming webhooks, regardless of their source (third-party services, custom APIs, etc.).
 
@@ -55,7 +55,7 @@ By default, any URL prefixed with ``/webhook`` routes to this controller. You ca
             xsi:schemaLocation="http://symfony.com/schema/routing
                 https://symfony.com/schema/routing/routing-1.0.xsd">
             <import resource="@FrameworkBundle/Resources/config/routing/webhook.xml"
-                prefix="/webhook" />
+                prefix="/webhook"/>
         </routes>
 
     .. code-block:: php
@@ -144,7 +144,7 @@ For webhooks originating from other Symfony applications, you can use the built-
 :class:`Symfony\\Component\\Webhook\\Client\\RequestParser` instead of creating a custom parser.
 
 This parser handles the standard Symfony webhook request format and is perfect for
-consuming webhooks from Symfony apps:
+consuming webhooks from Symfony applications:
 
 .. configuration-block::
 
@@ -186,7 +186,7 @@ The built-in parser automatically handles request validation and signature verif
 allowing you to focus on consuming the RemoteEvent in your application logic.
 
 Creating a Custom Parser
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 For webhooks from custom APIs, implement a parser using the :class:`Symfony\\Component\\Webhook\\Client\\RequestParserInterface` or extend :class:`Symfony\\Component\\Webhook\\Client\\AbstractRequestParser`.
 
@@ -204,18 +204,18 @@ When extending :class:`Symfony\\Component\\Webhook\\Client\\AbstractRequestParse
 
 :method:`Symfony\\Component\\Webhook\\Client\\AbstractRequestParser::getRequestMatcher` - Validate the incoming request format:
 
-.. code-block:: php
+::
 
     // src/Webhook/AcmeWebhookRequestParser.php
     namespace App\Webhook;
 
-    use Symfony\Component\Webhook\Client\AbstractRequestParser;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\RequestMatcher\ChainRequestMatcher;
     use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
     use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
     use Symfony\Component\HttpFoundation\RequestMatcher\RequestMatcherInterface;
     use Symfony\Component\RemoteEvent\RemoteEvent;
+    use Symfony\Component\Webhook\Client\AbstractRequestParser;
 
     final class AcmeWebhookRequestParser extends AbstractRequestParser
     {
@@ -252,13 +252,13 @@ The method receives the request and secret. You should:
 - Return a :class:`Symfony\\Component\\RemoteEvent\\RemoteEvent` on success
 
 Handling Complex Payload Transformations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For complex webhook payloads, use the
 :class:`Symfony\\Component\\RemoteEvent\\PayloadConverterInterface` to
 encapsulate transformation logic:
 
-.. code-block:: php
+::
 
     // src/RemoteEvent/AcmeWebhookPayloadConverter.php
     namespace App\RemoteEvent;
@@ -288,10 +288,10 @@ encapsulate transformation logic:
 
 Then use it in your parser:
 
-.. code-block:: php
+::
 
-    use Symfony\Component\Webhook\Exception\RejectWebhookException;
     use App\RemoteEvent\AcmeWebhookPayloadConverter;
+    use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
     public function __construct(
         #[Autowire(service: AcmeWebhookPayloadConverter::class)]
@@ -327,7 +327,7 @@ it manually using the
 :class:`Symfony\\Component\\RemoteEvent\\Attribute\\AsRemoteEventConsumer`
 attribute:
 
-.. code-block:: php
+::
 
     // src/RemoteEvent/AcmeWebhookConsumer.php
     namespace App\RemoteEvent;
@@ -469,7 +469,7 @@ The routing name becomes part of your webhook URL (e.g., ``https://example.com/w
 
 Then create a consumer to handle delivery and engagement events:
 
-.. code-block:: php
+::
 
     // src/RemoteEvent/MailerWebhookConsumer.php
     namespace App\RemoteEvent;
@@ -518,7 +518,7 @@ Vonage       ``notifier.webhook.request_parser.vonage``
 Configure similarly to mailers, then consume
 :class:`Symfony\\Component\\RemoteEvent\\Event\\Sms\\SmsEvent`:
 
-.. code-block:: php
+::
 
     // src/RemoteEvent/SmsWebhookConsumer.php
     namespace App\RemoteEvent;
@@ -564,12 +564,12 @@ To send a webhook, dispatch a
 :class:`Symfony\\Component\\Webhook\\Messenger\\SendWebhookMessage` via
 the Messenger component:
 
-.. code-block:: php
+::
 
+    use Symfony\Component\Messenger\MessageBusInterface;
+    use Symfony\Component\RemoteEvent\RemoteEvent;
     use Symfony\Component\Webhook\Messenger\SendWebhookMessage;
     use Symfony\Component\Webhook\Subscriber;
-    use Symfony\Component\RemoteEvent\RemoteEvent;
-    use Symfony\Component\Messenger\MessageBusInterface;
 
     // In a service or controller
 

--- a/webhook.rst
+++ b/webhook.rst
@@ -345,7 +345,8 @@ attribute:
         }
     }
 
-The routing name in the attribute must match the configuration entry.
+The routing name in the attribute must match the configuration entry of the
+webhook routing.
 
 Asynchronous Processing
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -379,7 +380,7 @@ Messenger, configure routing for the
                 <framework:messenger>
                     <framework:routing
                         message-class="Symfony\Component\RemoteEvent\Messenger\ConsumeRemoteEventMessage">
-                        <framework:bus>async</framework:bus>
+                        <framework:sender service="async"/>
                     </framework:routing>
                 </framework:messenger>
             </framework:config>
@@ -394,7 +395,7 @@ Messenger, configure routing for the
         return static function (FrameworkConfig $config): void {
             $config->messenger()
                 ->routing(ConsumeRemoteEventMessage::class)
-                ->bus('async');
+                ->senders(['async']);
         };
 
 With this configuration, consumers are invoked asynchronously via the

--- a/webhook.rst
+++ b/webhook.rst
@@ -286,8 +286,62 @@ attribute:
     }
 
 The routing name in the attribute must match the configuration entry.
-Webhooks are processed asynchronously by default (via Messenger);
-configure the bus in your webhook settings if needed.
+
+Asynchronous Processing
+^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, webhook consumers are invoked synchronously when the
+RemoteEvent is dispatched. To process webhooks asynchronously using
+Messenger, configure routing for the
+:class:`Symfony\\Component\\RemoteEvent\\Messenger\\ConsumeRemoteEventMessage`:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/messenger.yaml
+        framework:
+            messenger:
+                routing:
+                    Symfony\Component\RemoteEvent\Messenger\ConsumeRemoteEventMessage:
+                        async: 'async'
+
+    .. code-block:: xml
+
+        <!-- config/packages/messenger.xml -->
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+            <framework:config>
+                <framework:messenger>
+                    <framework:routing
+                        message-class="Symfony\Component\RemoteEvent\Messenger\ConsumeRemoteEventMessage">
+                        <framework:bus>async</framework:bus>
+                    </framework:routing>
+                </framework:messenger>
+            </framework:config>
+        </container>
+
+    .. code-block:: php
+
+        // config/packages/messenger.php
+        use Symfony\Component\RemoteEvent\Messenger\ConsumeRemoteEventMessage;
+        use Symfony\Config\FrameworkConfig;
+
+        return static function (FrameworkConfig $config): void {
+            $config->messenger()
+                ->routing(ConsumeRemoteEventMessage::class)
+                ->bus('async');
+        };
+
+With this configuration, consumers are invoked asynchronously via the
+message bus. Without it, consumers are processed synchronously during
+the webhook handling.
+
 
 Built-in Integrations
 ~~~~~~~~~~~~~~~~~~~~~

--- a/webhook.rst
+++ b/webhook.rst
@@ -231,11 +231,7 @@ When extending :class:`Symfony\\Component\\Webhook\\Client\\AbstractRequestParse
             Request $request,
             #[\SensitiveParameter] string $secret
         ): ?RemoteEvent {
-            $payload = json_decode(
-                $request->getContent(),
-                true,
-                flags: JSON_THROW_ON_ERROR
-            );
+            $payload = $request->toArray();
 
             return new RemoteEvent(
                 $payload['event_type'],
@@ -302,11 +298,7 @@ Then use it in your parser:
         #[\SensitiveParameter] string $secret
     ): ?RemoteEvent {
         try {
-            $payload = json_decode(
-                $request->getContent(),
-                true,
-                flags: JSON_THROW_ON_ERROR
-            );
+            $payload = $request->toArray();
 
             return $this->converter->convert($payload);
         } catch (ParseException|JsonException $e) {

--- a/webhook.rst
+++ b/webhook.rst
@@ -122,8 +122,71 @@ unique and connects the webhook source to your consumer code.
 
 All parsers are automatically injected into the WebhookController.
 
-Creating a Custom Parser
+Parsing Webhook Requests
 ~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once a webhook request arrives at your endpoint, it must be parsed and validated before
+your application can process it. Parsing involves verifying the request's authenticity
+(typically via signature validation), extracting the payload, and converting it into a
+:class:`Symfony\\Component\\RemoteEvent\\RemoteEvent` object that your application can work with.
+
+Symfony provides two approaches to handle parsing:
+
+1. **Built-in Parser**: Use the standard :class:`Symfony\\Component\\Webhook\\Client\\RequestParser` for webhooks from other Symfony applications
+2. **Custom Parser**: Create your own parser for webhooks from third-party services or custom APIs
+
+Choose the approach that best fits your webhook source.
+
+Using the Built-in Parser
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For webhooks originating from other Symfony applications, you can use the built-in
+:class:`Symfony\\Component\\Webhook\\Client\\RequestParser` instead of creating a custom parser.
+
+This parser handles the standard Symfony webhook request format and is perfect for
+consuming webhooks from Symfony apps:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/framework.yaml
+        framework:
+            webhook:
+                routing:
+                    acme_webhook:
+                        service: Symfony\Component\Webhook\Client\RequestParser
+                        secret: '%env(WEBHOOK_SECRET)%'
+
+    .. code-block:: xml
+
+        <!-- config/packages/framework.xml -->
+        <framework:config>
+            <framework:webhook enabled="true">
+                <framework:routing type="acme_webhook">
+                    <framework:service>Symfony\Component\Webhook\Client\RequestParser</framework:service>
+                    <framework:secret>%env(WEBHOOK_SECRET)%</framework:secret>
+                </framework:routing>
+            </framework:webhook>
+        </framework:config>
+
+    .. code-block:: php
+
+        // config/packages/framework.php
+        use Symfony\Config\FrameworkConfig;
+
+        return static function (FrameworkConfig $config): void {
+            $config->webhook()
+                ->routing('acme_webhook')
+                ->service(Symfony\Component\Webhook\Client\RequestParser::class)
+                ->secret('%env(WEBHOOK_SECRET)%');
+        };
+
+The built-in parser automatically handles request validation and signature verification,
+allowing you to focus on consuming the RemoteEvent in your application logic.
+
+Creating a Custom Parser
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For webhooks from custom APIs, implement a parser using the :class:`Symfony\\Component\\Webhook\\Client\\RequestParserInterface` or extend :class:`Symfony\\Component\\Webhook\\Client\\AbstractRequestParser`.
 

--- a/webhook.rst
+++ b/webhook.rst
@@ -38,24 +38,83 @@ The :class:`Symfony\\Component\\Webhook\\Controller\\WebhookController` provides
 
 By default, any URL prefixed with ``/webhook`` routes to this controller. You can customize this prefix in your routing configuration:
 
-.. code-block:: yaml
+.. configuration-block::
 
-    # config/routes/webhook.yaml
-    webhook:
-        resource: '@FrameworkBundle/Resources/config/routing/webhook.xml'
-        prefix: /webhook  # customize as needed
+    .. code-block:: yaml
 
-Next, configure the parser services that will handle incoming webhooks. The controller uses a routing mechanism to map incoming requests to the appropriate parser:
+        # config/routes/webhook.yaml
+        webhook:
+            resource: '@FrameworkBundle/Resources/config/routing/webhook.php'
+            prefix: /webhook  # customize as needed
 
-.. code-block:: yaml
+    .. code-block:: xml
 
-    # config/webhook.yaml
-    framework:
-      webhook:
-        routing:
-          acme_webhook:  # routing name, maps to /webhook/acme_webhook
-            service: App\Webhook\AcmeWebhookRequestParser
-            secret: '%env(WEBHOOK_SECRET)%'  # optional
+        <!-- config/routes/webhook.xml -->
+        <routes xmlns="http://symfony.com/schema/routing"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/routing
+                https://symfony.com/schema/routing/routing-1.0.xsd">
+            <import resource="@FrameworkBundle/Resources/config/routing/webhook.php"
+                prefix="/webhook" />
+        </routes>
+
+    .. code-block:: php
+
+        // config/routes/webhook.php
+        use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+        return static function (RoutingConfigurator $routes): void {
+            $routes->import('@FrameworkBundle/Resources/config/routing/webhook.php')
+                ->prefix('/webhook');
+        };
+
+Next, configure the parser services that will handle incoming webhooks.
+The controller uses a routing mechanism to map incoming requests to the
+appropriate parser:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/webhook.yaml
+        framework:
+          webhook:
+            routing:
+              acme_webhook:  # routing name, maps to /webhook/acme_webhook
+                service: App\Webhook\AcmeWebhookRequestParser
+                secret: '%env(WEBHOOK_SECRET)%'  # optional
+
+    .. code-block:: xml
+
+        <!-- config/packages/framework.xml -->
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+            <framework:config>
+                <framework:webhook enabled="true">
+                    <framework:routing type="acme_webhook">
+                        <framework:service>App\Webhook\AcmeWebhookRequestParser</framework:service>
+                        <framework:secret>%env(WEBHOOK_SECRET)%</framework:secret>
+                    </framework:routing>
+                </framework:webhook>
+            </framework:config>
+        </container>
+
+    .. code-block:: php
+
+        // config/packages/framework.php
+        use Symfony\Config\FrameworkConfig;
+
+        return static function (FrameworkConfig $config): void {
+            $config->webhook()
+                ->routing('acme_webhook')
+                ->service('App\Webhook\AcmeWebhookRequestParser')
+                ->secret('%env(WEBHOOK_SECRET)%');
+        };
 
 The routing name becomes part of the webhook URL (e.g.,
 ``https://example.com/webhook/acme_webhook``). Each routing name must be

--- a/webhook.rst
+++ b/webhook.rst
@@ -21,7 +21,6 @@ Installation
 
     $ composer require symfony/webhook
 
-
 Consuming Webhooks
 ------------------
 
@@ -402,7 +401,6 @@ With this configuration, consumers are invoked asynchronously via the
 message bus. Without it, consumers are processed synchronously during
 the webhook handling.
 
-
 Built-in Integrations
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -543,7 +541,6 @@ Configure similarly to mailers, then consume
             // Update SMS delivery status in database, etc.
         }
     }
-
 
 Sending Webhooks
 ----------------

--- a/webhook.rst
+++ b/webhook.rst
@@ -44,7 +44,7 @@ By default, any URL prefixed with ``/webhook`` routes to this controller. You ca
 
         # config/routes/webhook.yaml
         webhook:
-            resource: '@FrameworkBundle/Resources/config/routing/webhook.php'
+            resource: '@FrameworkBundle/Resources/config/routing/webhook.xml'
             prefix: /webhook  # customize as needed
 
     .. code-block:: xml
@@ -54,7 +54,7 @@ By default, any URL prefixed with ``/webhook`` routes to this controller. You ca
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/routing
                 https://symfony.com/schema/routing/routing-1.0.xsd">
-            <import resource="@FrameworkBundle/Resources/config/routing/webhook.php"
+            <import resource="@FrameworkBundle/Resources/config/routing/webhook.xml"
                 prefix="/webhook" />
         </routes>
 
@@ -64,7 +64,7 @@ By default, any URL prefixed with ``/webhook`` routes to this controller. You ca
         use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
         return static function (RoutingConfigurator $routes): void {
-            $routes->import('@FrameworkBundle/Resources/config/routing/webhook.php')
+            $routes->import('@FrameworkBundle/Resources/config/routing/webhook.xml')
                 ->prefix('/webhook');
         };
 
@@ -76,7 +76,7 @@ appropriate parser:
 
     .. code-block:: yaml
 
-        # config/webhook.yaml
+        # config/packages/webhook.yaml
         framework:
             webhook:
                 routing:
@@ -303,8 +303,7 @@ Messenger, configure routing for the
         framework:
             messenger:
                 routing:
-                    Symfony\Component\RemoteEvent\Messenger\ConsumeRemoteEventMessage:
-                        async: 'async'
+                    'Symfony\Component\RemoteEvent\Messenger\ConsumeRemoteEventMessage': async
 
     .. code-block:: xml
 

--- a/webhook.rst
+++ b/webhook.rst
@@ -554,6 +554,11 @@ The Webhook component also enables your application to dispatch webhooks to
 external endpoints when your application events occur. This is useful when
 building APIs that notify subscribers of important events.
 
+.. note::
+
+    To send webhooks, ensure you have installed both the HttpClient and Serializer
+    component via ``composer require symfony/http-client symfony/serializer``.
+
 Basic Usage
 ~~~~~~~~~~~
 

--- a/webhook.rst
+++ b/webhook.rst
@@ -608,16 +608,28 @@ which:
 3. Signs the request using the subscriber's secret
 4. Sends via Symfony's HttpClient component
 
-Webhook Signature
-~~~~~~~~~~~~~~~~~
+Resulting HTTP Request
+~~~~~~~~~~~~~~~~~~~~~~
 
-By default, signatures use HMAC-SHA256. The signature header format is:
+When the webhook is sent, it generates an HTTP POST request with the following format:
 
 .. code-block:: text
 
-    Webhook-Signature: sha256=<base64-encoded-hmac>
+    POST /webhook/symfony HTTP/1.1
+    Host: example.com
+    Content-Type: application/json
+    Webhook-Event: resource.created
+    Webhook-Id: 550e8400-e29b-41d4-a716-446655440000
+    Webhook-Signature: sha256=9f86d081884c7d6d9ffd60bb51d3263112c4b2486f80fa12ab5807265dc789d6
 
-Receiving endpoints should verify this signature using the shared secret
+    {
+        "resource_id": 12345,
+        "email": "user@example.com",
+        "created_at": 1234567890
+    }
+
+By default, the signature uses HMAC-SHA256 of the concatenated event name, event ID, and JSON body,
+encoded in base64. Receiving endpoints should verify this signature using the shared secret
 to ensure webhook authenticity.
 
 Custom Sending Logic

--- a/webhook.rst
+++ b/webhook.rst
@@ -78,11 +78,11 @@ appropriate parser:
 
         # config/webhook.yaml
         framework:
-          webhook:
-            routing:
-              acme_webhook:  # routing name, maps to /webhook/acme_webhook
-                service: App\Webhook\AcmeWebhookRequestParser
-                secret: '%env(WEBHOOK_SECRET)%'  # optional
+            webhook:
+                routing:
+                    acme_webhook:  # routing name, maps to /webhook/acme_webhook
+                        service: App\Webhook\AcmeWebhookRequestParser
+                        secret: '%env(WEBHOOK_SECRET)%'  # optional
 
     .. code-block:: xml
 
@@ -527,7 +527,6 @@ the Messenger component:
         new SendWebhookMessage($subscriber, $event)
     );
 
-
 The message will be queued and processed by
 :class:`Symfony\\Component\\Webhook\\Messenger\\SendWebhookHandler`,
 which:
@@ -547,7 +546,9 @@ which:
 Webhook Signature
 ~~~~~~~~~~~~~~~~~
 
-By default, signatures use HMAC-SHA256. The signature header format is::
+By default, signatures use HMAC-SHA256. The signature header format is:
+
+.. code-block:: text
 
     Webhook-Signature: sha256=<base64-encoded-hmac>
 

--- a/webhook.rst
+++ b/webhook.rst
@@ -5,12 +5,14 @@ Webhook
 
     The Webhook component was introduced in Symfony 6.3.
 
-Webhooks are event notification mechanisms typically delivered via HTTP POST requests, enabling real-time updates between systems.
+In web-development a Webhook is a remote-notification mechanism, typically
+delivered via HTTP POST requests.
+Webhooks enable real-time updates between systems.
 
 The Webhook component provides two primary capabilities:
 
-1. **Consuming**: Receive and process webhook calls from remote systems
-2. **Sending**: Dispatch webhooks to registered endpoints when events occur
+1. **Consuming**: Receive and process webhook calls from remote systems;
+2. **Sending**: Dispatch webhook callbacks to registered endpoints when events occur.
 
 This document covers both capabilities in the context of a full-stack Symfony application.
 
@@ -420,8 +422,8 @@ attribute:
 The routing name in the attribute must match the configuration entry of the
 webhook routing.
 
-Asynchronous Processing
-^^^^^^^^^^^^^^^^^^^^^^^
+Asynchronous Consuming
+^^^^^^^^^^^^^^^^^^^^^^
 
 By default, webhook consumers are invoked synchronously when the
 RemoteEvent is dispatched. To process webhooks asynchronously using
@@ -618,9 +620,9 @@ Configure similarly to mailers, then consume
 Sending Webhooks
 ----------------
 
-The Webhook component also enables your application to dispatch webhooks to
-external endpoints when your application events occur. This is useful when
-building APIs that notify subscribers of important events.
+The Webhook component also enables your application to invoke webhooks on
+remote endpoints. This is useful, as an example, when building APIs that notify
+subscribers of important events.
 
 .. note::
 
@@ -662,7 +664,7 @@ the Messenger component:
         new SendWebhookMessage($subscriber, $event)
     );
 
-The message will be queued and processed by
+The message will be queued and processed by the
 :class:`Symfony\\Component\\Webhook\\Messenger\\SendWebhookHandler`,
 which:
 
@@ -676,7 +678,7 @@ which:
    - ``Content-Type``: application/json
 
 3. Signs the request using the subscriber's secret
-4. Sends via Symfony's HttpClient component
+4. Sends the HTTP request by using the Symfony HttpClient component
 
 Resulting HTTP Request
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -705,7 +707,7 @@ to ensure webhook authenticity.
 Custom Sending Logic
 ~~~~~~~~~~~~~~~~~~~~
 
-For advanced use cases, you can build custom sending logic using
+For advanced use cases, you can build a custom sending logic by implementing the
 :class:`Symfony\\Component\\Webhook\\Server\\TransportInterface`.
 
 


### PR DESCRIPTION
Replaces #19974 by improving the examples, taking into account the review comments and re-structuring the outline.
Fixes #19921

I've briefly discussed this in Slack and was asked to built upon @alli83|'s previous work, so I've just started with her commit.
I did not find a way to update that previous PR's branch, so here is a new one.

This completes the currently very incomplete documentation.
It explains how webhooks are received (using either the built-in or a custom parser, a payload-converter), consumed and sent, giving a complete picture of the capabilities of this component.