### PR TITLE
 [HttpKernel] Document request and args variables in Cache attribute expressions

### DIFF
--- a/http_cache/validation.rst
+++ b/http_cache/validation.rst
@@ -220,6 +220,69 @@ the response status code to ``304``, removes the content, and removes some
 headers that must not be present for ``304`` responses (see
 :method:`Symfony\\Component\\HttpFoundation\\Response::setNotModified`).
 
+.. _cache-attribute-expressions:
+
+Using Expressions in the Cache Attribute
+----------------------------------------
+
+The ``#[Cache]`` attribute supports using expressions for the ``etag`` and
+``lastModified`` options. These expressions are evaluated using the
+:doc:`ExpressionLanguage component </components/expression_language>` and
+have access to the following variables:
+
+``request``
+    The current :class:`Symfony\\Component\\HttpFoundation\\Request` object,
+    giving you access to headers, query parameters, and other request data.
+
+``args``
+    An array containing all controller action arguments (including those
+    resolved via :doc:`argument value resolvers </controller/value_resolver>`).
+
+In addition to these variables, all request attributes (such as route parameters)
+are also available directly by name.
+
+Here's an example using expressions to compute the ``ETag`` and ``Last-Modified``
+values dynamically::
+
+    // src/Controller/ArticleController.php
+    namespace App\Controller;
+
+    use App\Entity\Article;
+    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpKernel\Attribute\Cache;
+    use Symfony\Component\Routing\Attribute\Route;
+
+    class ArticleController extends AbstractController
+    {
+        #[Route('/article/{id}')]
+        #[Cache(
+            etag: "args['article'].computeETag()",
+            lastModified: "args['article'].getUpdatedAt()",
+            public: true,
+        )]
+        public function show(Article $article): Response
+        {
+            return $this->render('article/show.html.twig', [
+                'article' => $article,
+            ]);
+        }
+    }
+
+You can also use the ``request`` variable to include request-specific data
+in the cache key::
+
+    #[Cache(etag: "request.headers.get('Accept-Language') ~ args['article'].getId()")]
+    public function show(Article $article): Response
+    {
+        // ...
+    }
+
+.. versionadded:: 8.1
+
+    The ``request`` and ``args`` variables in ``#[Cache]`` attribute expressions
+    were introduced in Symfony 8.1.
+
 .. _`expiration model`: https://tools.ietf.org/html/rfc2616#section-13.2
 .. _`validation model`: https://tools.ietf.org/html/rfc2616#section-13.3
 .. _`HTTP ETag`: https://en.wikipedia.org/wiki/HTTP_ETag

--- a/service_container.rst
+++ b/service_container.rst
@@ -275,11 +275,11 @@ You can limit service registration to specific environments as follows:
 
         <!-- config/services.xml -->
         <services>
-            <service id="App\Service\SomeClass" />
+            <service id="App\Service\SomeClass"/>
 
             <when env="dev">
                 <services>
-                    <service id="App\Service\AnotherClass" />
+                    <service id="App\Service\AnotherClass"/>
                 </services>
             </when>
         </services>


### PR DESCRIPTION
 Description:
This PR documents the new `request` and `args` variables available in `#[Cache]` attribute expressions, added in Symfony 8.1.

Fixes #21675 