### PR TITLE
[Validator] Remove generic constraint options

### DIFF
--- a/reference/constraints/Callback.rst
+++ b/reference/constraints/Callback.rst
@@ -214,10 +214,9 @@ You can then use the following configuration to invoke this validator:
         {
             public static function loadValidatorMetadata(ClassMetadata $metadata): void
             {
-                $metadata->addConstraint(new Assert\Callback([
-                    Validator::class,
-                    'validate',
-                ]));
+                $metadata->addConstraint(new Assert\Callback(
+                    callback: [Validator::class, 'validate'],
+                ));
             }
         }
 

--- a/reference/constraints/Sequentially.rst
+++ b/reference/constraints/Sequentially.rst
@@ -119,13 +119,15 @@ You can validate each of these constraints sequentially to solve these issues:
 
             public static function loadValidatorMetadata(ClassMetadata $metadata): void
             {
-                $metadata->addPropertyConstraint('address', new Assert\Sequentially([
-                    new Assert\NotNull(),
-                    new Assert\Type('string'),
-                    new Assert\Length(min: 10),
-                    new Assert\Regex(self::ADDRESS_REGEX),
-                    new AcmeAssert\Geolocalizable(),
-                ]));
+                $metadata->addPropertyConstraint('address', new Assert\Sequentially(
+                    constraints: [
+                        new Assert\NotNull(),
+                        new Assert\Type('string'),
+                        new Assert\Length(min: 10),
+                        new Assert\Regex(self::ADDRESS_REGEX),
+                        new AcmeAssert\Geolocalizable(),
+                    ],
+                ));
             }
         }
 

--- a/reference/constraints/UniqueEntity.rst
+++ b/reference/constraints/UniqueEntity.rst
@@ -256,11 +256,11 @@ Consider this example:
 
             public static function loadValidatorMetadata(ClassMetadata $metadata): void
             {
-                $metadata->addConstraint(new UniqueEntity([
-                    'fields' => ['host', 'port'],
-                    'message' => 'This port is already in use on that host.',
-                    'errorPath' => 'port',
-                ]));
+                $metadata->addConstraint(new UniqueEntity(
+                    fields: ['host', 'port'],
+                    message: 'This port is already in use on that host.',
+                    errorPath: 'port',
+                ));
             }
         }
 

--- a/validation/raw_values.rst
+++ b/validation/raw_values.rst
@@ -81,11 +81,11 @@ Validation of arrays is possible using the ``Collection`` constraint::
         'tags' => new Assert\Optional(constraints: [
             new Assert\Type(type: 'array'),
             new Assert\Count(min: 1),
-            new Assert\All([
-                new Assert\Collection(constraints: [
+            new Assert\All(constraints: [
+                new Assert\Collection(fields: [
                     'slug' => [
                         new Assert\NotBlank(),
-                        new Assert\Type(['type' => 'string']),
+                        new Assert\Type(type: 'string'),
                     ],
                     'label' => [
                         new Assert\NotBlank(),


### PR DESCRIPTION
This PR updates the documentation to reflect the removal of generic constraint option handling in Symfony 8.0.
Fix #21261