### PR TITLE
 Remove mention to old `webpack encore` version

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -123,9 +123,7 @@ whitelist:
         - '#. The most important config file is ``app/config/services.yml``, which now is'
         - 'The bin/console Command'
         - '.. _`LDAP injection`: http://projects.webappsec.org/w/page/13246947/LDAP%20Injection'
-        - '.. versionadded:: 1.9.0' # Encore
         - '.. versionadded:: 1.18' # Flex in setup/upgrade_minor.rst
-        - '.. versionadded:: 1.0.0' # Encore
         - '123,' # assertion for var_dumper - components/var_dumper.rst
         - '"foo",' # assertion for var_dumper - components/var_dumper.rst
         - '$var .= "Because of this `\xE9` octet (\\xE9),\n";'

--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -143,10 +143,4 @@ templates, set the following options:
 The ``static.watch`` option is required to disable the default reloading of
 files from the static directory, as those files are already handled by HMR.
 
-.. versionadded:: 1.0.0
-
-    Before Encore 1.0, you needed to pass a ``--hot`` flag at the command line
-    to enable HMR. You also needed to disable CSS extraction to enable HMR for
-    CSS. That is no longer needed.
-
 .. _`webpack-dev-server`: https://webpack.js.org/configuration/dev-server/

--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -152,14 +152,11 @@ Instead, you can point directly to the final built files or write code to parse
 ``entrypoints.json`` manually. The entrypoints file is needed only if you're using
 certain optional features, like ``splitEntryChunks()``.
 
-.. versionadded:: 1.9.0
-
-    The ``defer`` attribute on the ``script`` tags delays the execution of the
-    JavaScript until the page loads (similar to putting the ``script`` at the
-    bottom of the page). The ability to always add this attribute was introduced
-    in WebpackEncoreBundle 1.9.0 and is automatically enabled in that bundle's
-    recipe in the ``config/packages/webpack_encore.yaml`` file. See
-    `WebpackEncoreBundle Configuration`_ for more details.
+The ``defer`` attribute on the ``script`` tags delays the execution of the
+JavaScript until the page loads (similar to putting the ``script`` at the
+bottom of the page). This is automatically enabled in that bundle's recipe
+in the ``config/packages/webpack_encore.yaml`` file. See
+`WebpackEncoreBundle Configuration`_ for more details.
 
 Requiring JavaScript Modules
 ----------------------------
@@ -460,7 +457,7 @@ Encore supports many more features! For a full list of what you can do, see
 `Encore's index.js file`_. Or, go back to :ref:`list of Frontend articles <encore-toc>`.
 
 .. _`Encore's index.js file`: https://github.com/symfony/webpack-encore/blob/master/index.js
-.. _`WebpackEncoreBundle Configuration`: https://github.com/symfony/webpack-encore-bundle#configuration
+.. _`WebpackEncoreBundle Configuration`: https://symfony.com/bundles/WebpackEncoreBundle/current/index.html#configuration
 .. _`Stimulus`: https://stimulus.hotwired.dev/
 .. _`Stimulus Documentation`: https://stimulus.hotwired.dev/handbook/introduction
 .. _StimulusBundle & the UX System: https://symfony.com/bundles/StimulusBundle/current/index.html


### PR DESCRIPTION
In the same way as DoctrineBundle, `WebpackEncoreBundle` 1 is no longer maintained and did not support Symfony 8

I kept the note about `defer` cause this point seems still relevant
I updated a link because there is no longer a configuration part in this bundle readme