### PR TITLE
 Remove mention to old `MonologBundle` version

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -130,8 +130,6 @@ whitelist:
         - '"foo",' # assertion for var_dumper - components/var_dumper.rst
         - '$var .= "Because of this `\xE9` octet (\\xE9),\n";'
         - '.. versionadded:: 0.2' # MercureBundle
-        - '.. versionadded:: 3.6' # MonologBundle
-        - '.. versionadded:: 3.8' # MonologBundle
         - '.. versionadded:: 3.5' # Monolog
         - '.. versionadded:: 3.0' # Doctrine ORM
         - '.. _`a feature to test applications using Mercure`: https://github.com/symfony/panther#creating-isolated-browsers-to-test-apps-using-mercure-or-websocket'

--- a/logging/monolog_email.rst
+++ b/logging/monolog_email.rst
@@ -1,11 +1,6 @@
 How to Configure Monolog to Email Errors
 ========================================
 
-.. versionadded:: 3.6
-
-    Support for emailing errors using :doc:`Symfony mailer </mailer>` was added
-    in MonologBundle 3.6.
-
 `Monolog`_ can be configured to send an email when an error occurs within an
 application. The configuration for this requires a few nested handlers
 in order to avoid receiving too many emails. This configuration looks

--- a/logging/processors.rst
+++ b/logging/processors.rst
@@ -150,10 +150,6 @@ The ``#[AsMonologProcessor]`` attribute takes these optional arguments:
 * ``method``: the method that processes the records (useful when applying
   the attribute to the entire class instead of a single method).
 
-.. versionadded:: 3.8
-
-    The ``#[AsMonologProcessor]`` attribute was introduced in MonologBundle 3.8.
-
 Symfony's MonologBridge provides processors that can be registered inside your application.
 
 :class:`Symfony\\Bridge\\Monolog\\Processor\\DebugProcessor`


### PR DESCRIPTION
`MonologBundle` 3 doesn't support Symfony 8, I think there is no more value to mention in which minor version those features were added 

This is my last about this topic ;)