### PR TITLE
[Lock] Document project-scoped semaphore and flock stores

### DIFF
--- a/components/lock.rst
+++ b/components/lock.rst
@@ -432,6 +432,17 @@ when the PHP process ends)::
     // if none is given, sys_get_temp_dir() is used internally.
     $store = new FlockStore('/var/stores');
 
+.. note::
+
+    When used inside the FrameworkBundle, the ``FlockStore`` is automatically
+    scoped to a project-specific subdirectory (based on ``kernel.project_id``)
+    to prevent lock collisions between multiple applications on the same server.
+
+.. versionadded:: 8.1
+
+    Automatic project-scoped lock directories for ``FlockStore`` were introduced
+    in Symfony 8.1.
+
 .. warning::
 
     Beware that some file systems (such as some types of NFS) do not support
@@ -638,6 +649,14 @@ The SemaphoreStore uses the `PHP semaphore functions`_ to create the locks::
     use Symfony\Component\Lock\Store\SemaphoreStore;
 
     $store = new SemaphoreStore();
+
+    // optionally, pass a project identifier to scope locks and avoid
+    // collisions between multiple applications on the same server
+    $store = new SemaphoreStore($projectId);
+
+.. versionadded:: 8.1
+
+    The ``$projectId`` parameter was introduced in Symfony 8.1.
 
 .. _lock-store-combined:
 

--- a/lock.rst
+++ b/lock.rst
@@ -36,6 +36,17 @@ By default, Symfony provides a :ref:`Semaphore <lock-store-semaphore>`
 when available, or a :ref:`Flock <lock-store-flock>` otherwise. You can configure
 this behavior by using the ``lock`` key like:
 
+.. note::
+
+    Since Symfony 8.1, the ``flock`` and ``semaphore`` stores are automatically
+    scoped by ``kernel.project_id``, preventing lock collisions between multiple
+    applications running on the same server.
+
+.. versionadded:: 8.1
+
+    Automatic scoping of ``flock`` and ``semaphore`` stores by
+    ``kernel.project_id`` was introduced in Symfony 8.1.
+
 .. configuration-block::
 
     .. code-block:: yaml


### PR DESCRIPTION
Document that `SemaphoreStore` and `FlockStore` are now scoped by `kernel.project_id` to prevent lock collisions between applications on the same server.

Fixes https://github.com/symfony/symfony-docs/issues/21853