### PR TITLE
[HttpKernel] Document ControllerMetadata on kernel events

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -340,6 +340,20 @@ of arguments that should be passed when executing that callable.
     ``ValueResolverInterface`` yourself and passing this to the
     ``ArgumentResolver``, you can extend this functionality.
 
+.. note::
+
+    Once the controller and its arguments are resolved, the kernel exposes a
+    :class:`Symfony\\Component\\HttpKernel\\ControllerMetadata\\ControllerMetadata`
+    object on all subsequent kernel events (``kernel.view``, ``kernel.response``,
+    ``kernel.finish_request``, ``kernel.exception``). This gives any listener
+    access to the controller's PHP attributes and resolved arguments via the
+    ``$event->getControllerMetadata()`` method.
+
+.. versionadded:: 8.1
+
+    The ``ControllerMetadata`` and ``ControllerArgumentsMetadata`` classes were
+    introduced in Symfony 8.1.
+
 .. _component-http-kernel-calling-controller:
 
 5) Calling the Controller

--- a/reference/events.rst
+++ b/reference/events.rst
@@ -112,6 +112,48 @@ their priorities:
 
     $ php bin/console debug:event-dispatcher kernel.controller_arguments
 
+.. _controller-metadata-in-events:
+
+Accessing Controller Metadata in Events
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All kernel events dispatched after controller resolution (``kernel.controller_arguments``,
+``kernel.view``, ``kernel.response``, ``kernel.finish_request`` and
+``kernel.exception``) provide access to the controller metadata through the
+``controllerMetadata`` public property. This allows listeners to inspect the
+controller's attributes and arguments without re-reflecting the controller::
+
+    use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        $metadata = $event->controllerMetadata;
+
+        if (null === $metadata) {
+            return;
+        }
+
+        // get the PHP attributes declared on the controller
+        $attributes = $metadata->getAttributes();
+
+        // if the event happens after controller_arguments, you also get
+        // access to the resolved controller arguments
+        $namedArguments = $metadata->getNamedArguments();
+    }
+
+The
+:class:`Symfony\\Component\\HttpKernel\\ControllerMetadata\\ControllerMetadata`
+class provides ``getController()``, ``getReflector()`` and ``getAttributes()``.
+The
+:class:`Symfony\\Component\\HttpKernel\\ControllerMetadata\\ControllerArgumentsMetadata`
+subclass (available from ``kernel.controller_arguments`` onwards) additionally
+provides ``getArguments()`` and ``getNamedArguments()``.
+
+.. versionadded:: 8.1
+
+    The ``getControllerMetadata()`` method on kernel events was introduced in
+    Symfony 8.1.
+
 ``kernel.view``
 ~~~~~~~~~~~~~~~
 

--- a/service_container.rst
+++ b/service_container.rst
@@ -275,11 +275,11 @@ You can limit service registration to specific environments as follows:
 
         <!-- config/services.xml -->
         <services>
-            <service id="App\Service\SomeClass" />
+            <service id="App\Service\SomeClass"/>
 
             <when env="dev">
                 <services>
-                    <service id="App\Service\AnotherClass" />
+                    <service id="App\Service\AnotherClass"/>
                 </services>
             </when>
         </services>


### PR DESCRIPTION
Document `ControllerMetadata` and `ControllerArgumentsMetadata` exposed on kernel events after controller resolution.                                                                                   
                                                                                                                                                                                                          
  Fixes #21851   