### PR TITLE
[DependencyInjection] Document exclude option for imports

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -93,6 +93,9 @@ configuration files, even if they use a different format:
             # ignore_errors: true silently discards all errors (including invalid code and not found)
             - { resource: 'my_other_config_file.php', ignore_errors: true }
 
+            # exclude specific files when using glob patterns
+            - { resource: 'services/*.yaml', exclude: ['services/legacy_*.yaml'] }
+
         # ...
 
     .. code-block:: php
@@ -112,6 +115,9 @@ configuration files, even if they use a different format:
 
                 // ignore_errors: true silently discards all errors (including invalid code and not found)
                 ['resource' => 'my_other_config_file.xml', 'ignore_errors' => true],
+
+                // exclude specific files when using glob patterns
+                ['resource' => 'services/*.php', 'exclude' => ['services/legacy_*.php']],
             ],
         ]);
 

--- a/service_container/import.rst
+++ b/service_container/import.rst
@@ -98,6 +98,32 @@ a relative or absolute path to the imported file:
             ],
         ]);
 
+When importing a directory or using glob patterns, you can use the ``exclude``
+option to skip specific files or patterns:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+        imports:
+            - { resource: services/, exclude: ['services/legacy_*.yaml'] }
+
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'imports' => [
+                ['resource' => 'services/', 'exclude' => ['services/legacy_*.php']],
+            ],
+        ]);
+
+.. versionadded:: 8.1
+
+    The ``exclude`` option for ``imports`` was introduced in Symfony 8.1.
+
 When loading a configuration file, Symfony first processes all imported files in
 the order they are listed under the ``imports`` key. After all imports are processed,
 it then processes the parameters and services defined directly in the current file.


### PR DESCRIPTION
Document the `exclude` option for `imports`, allowing to skip specific files when importing directories or glob patterns.                                                                               

Fixes: #21748   