### PR TITLE
[JsonStreamer] Document synthetic properties via PropertyMetadata::cr…

### DIFF
--- a/serializer/streaming_json.rst
+++ b/serializer/streaming_json.rst
@@ -658,9 +658,8 @@ configurations, providing more flexibility than attributes::
                 unset($propertyMetadataMap[$jsonKey]);
             }
 
-            // you can add virtual properties
-            $propertyMetadataMap['is_sensitive'] = new PropertyMetadata(
-                name: 'theNameWontBeUsed',
+            // you can add synthetic properties (not backed by a class property)
+            $propertyMetadataMap['is_sensitive'] = PropertyMetadata::createSynthetic(
                 type: Type::bool(),
                 valueTransformers: [fn() => true],
             );
@@ -668,6 +667,11 @@ configurations, providing more flexibility than attributes::
             return $propertyMetadataMap;
         }
     }
+
+.. versionadded:: 7.4
+
+    The ``PropertyMetadata::createSynthetic()`` method was introduced in
+    Symfony 7.4.
 
 .. versionadded:: 7.4
 


### PR DESCRIPTION
 Document `PropertyMetadata::createSynthetic()` for adding properties not backed by a class property during JSON streaming.                                                                              

Fixes: #21529 