### PR TITLE
[Messenger] Document TransportMessageIdStamp support in AMQP transport

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1666,6 +1666,16 @@ your Envelope::
         new AmqpStamp('custom-routing-key', AMQP_NOPARAM, $attributes),
     ]);
 
+The AMQP transport automatically adds a
+:class:`Symfony\\Component\\Messenger\\Stamp\\TransportMessageIdStamp` to
+messages when they are sent and received. This stamp tracks the AMQP message
+ID, which improves logging context when messages fail and are retried.
+
+.. versionadded:: 7.3
+
+    The ``TransportMessageIdStamp`` support in the AMQP transport was
+    introduced in Symfony 7.3.
+
 .. warning::
 
     The consumers do not show up in an admin panel as this transport does not rely on


### PR DESCRIPTION
Fixes #20659