### PR TITLE
[Symfony CLI] Add precision about ``server:log`` command

### DIFF
--- a/setup/symfony_cli.rst
+++ b/setup/symfony_cli.rst
@@ -136,6 +136,11 @@ Now you can continue working in the terminal and run other commands:
     # stop the background server
     $ symfony server:stop
 
+.. note::
+
+    The ``server:log`` command tails the logs from the web server, PHP, and
+    your application.
+
 .. tip::
 
     On macOS, when starting the Symfony server you might see a warning dialog asking


### PR DESCRIPTION
This PR aims to : 
- provides a bit more details about what the server:log command can do
- mention this command in text to make it easier to find with search