### PR TITLE
[EventDispatcher] Fix example in event_dispatcher.rst

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -561,6 +561,7 @@ event subscribers, you can learn more about :ref:`how to use them <events-subscr
     namespace App\EventSubscriber;
 
     use App\Controller\TokenAuthenticatedController;
+    use Symfony\Component\DependencyInjection\Attribute\Autowire;
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
     use Symfony\Component\HttpKernel\Event\ControllerEvent;
     use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -569,6 +570,7 @@ event subscribers, you can learn more about :ref:`how to use them <events-subscr
     class TokenSubscriber implements EventSubscriberInterface
     {
         public function __construct(
+            #[Autowire(param: 'tokens')]
             private array $tokens
         ) {
         }


### PR DESCRIPTION
Injection of ``tokens`` was missing.