### PR TITLE
[DependencyInjection] Add controller.service_arguments to the service tags reference

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -337,6 +337,18 @@ Value resolvers implement the
 and are used to resolve argument values for controllers as described here:
 :doc:`/controller/value_resolver`.
 
+controller.service_arguments
+----------------------------
+
+**Purpose**: Enable injection of services into controller action arguments
+
+This tag allows controller action methods to receive services as arguments
+without explicitly defining them as service arguments. It is automatically
+applied when using the ``#[AsController]`` attribute or when your controllers
+extend ``AbstractController``.
+
+For details, read the :doc:`/controller/service` article.
+
 data_collector
 --------------
 


### PR DESCRIPTION
The `controller.service_arguments` tag was missing from the built-in
service tags reference page, even though it is documented in the
[How to Define Controllers as Services](/controller/service.rst) article.

This adds it between `controller.argument_value_resolver` and
`data_collector`, following the alphabetical order of the existing tags.

Fixes #21921