### PR TITLE
 Add kernel.allowed_http_method_override and kernel.trusted_headers to Kernel Reference

### DIFF
--- a/reference/configuration/kernel.rst
+++ b/reference/configuration/kernel.rst
@@ -239,6 +239,16 @@ This parameter stores the value of
 This parameter stores the value of
 :ref:`the framework.http_method_override parameter <configuration-framework-http_method_override>`.
 
+``kernel.allowed_http_method_override``
+---------------------------------------
+
+This parameter stores the value of
+:ref:`the framework.allowed_http_method_override parameter <configuration-framework-allowed_http_method_override>`.
+
+.. versionadded:: 7.4
+
+    The ``kernel.allowed_http_method_override`` parameter was introduced in Symfony 7.4.
+
 ``kernel.logs_dir``
 -------------------
 
@@ -368,6 +378,12 @@ method of the kernel class, which you can override to return a different value.
 
 This parameter stores the value of
 :ref:`the framework.trust_x_sendfile_type_header parameter <configuration-framework-http_method_override>`.
+
+``kernel.trusted_headers``
+--------------------------
+
+This parameter stores the value of
+:ref:`the framework.trusted_headers parameter <reference-framework-trusted-headers>`.
 
 ``kernel.trusted_hosts``
 ------------------------

--- a/service_container.rst
+++ b/service_container.rst
@@ -314,11 +314,11 @@ You can limit service registration to specific environments as follows:
 
         <!-- config/services.xml -->
         <services>
-            <service id="App\Service\SomeClass" />
+            <service id="App\Service\SomeClass"/>
 
             <when env="dev">
                 <services>
-                    <service id="App\Service\AnotherClass" />
+                    <service id="App\Service\AnotherClass"/>
                 </services>
             </when>
         </services>


### PR DESCRIPTION
Fixes #21930

Adds the two missing kernel parameters to the Kernel Configuration Reference:

- `kernel.allowed_http_method_override` (introduced in 7.4, references `framework.allowed_http_method_override`)
- `kernel.trusted_headers` (references `framework.trusted_headers`)