### PR TITLE
[DependencyInjection] Update headline alias_private.rst

### DIFF
--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -1,5 +1,5 @@
-How to Create Service Aliases and Mark Services as Private
-==========================================================
+How to Create Service Aliases and Mark Services as Public
+=========================================================
 
 .. _container-private-services:
 


### PR DESCRIPTION
Since services are now private by default and also the name of the configuration option is `public`, the headline `How to Create Service Aliases and Mark Services as Public` appears more appropriate.