### PR TITLE
[Uid] Add UID configuration to Framework Configuration Reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3822,6 +3822,51 @@ The ``trusted_proxies`` option is needed to get precise information about the
 client (e.g. their IP address) when running Symfony behind a load balancer or a
 reverse proxy. See :doc:`/deployment/proxies`.
 
+uid
+~~~
+
+default_uuid_version
+....................
+
+**type**: ``integer`` **default**: ``7``
+
+The version of UUID to generate by default (used by the ``create()`` method of
+the UUID factory and for time-based UUIDs).
+
+name_based_uuid_version
+.......................
+
+**type**: ``integer`` **default**: ``5``
+
+The version of UUID to generate for name-based UUIDs.
+
+name_based_uuid_namespace
+.........................
+
+**type**: ``string`` **default**: ``null``
+
+A UUID that serves as the namespace for generating name-based UUIDs
+(e.g. ``'6ba7b810-9dad-11d1-80b4-00c04fd430c8'``).
+
+time_based_uuid_version
+.......................
+
+**type**: ``integer`` **default**: ``7``
+
+The version of UUID to generate for time-based UUIDs.
+
+time_based_uuid_node
+....................
+
+**type**: ``string`` | ``integer`` **default**: ``null``
+
+The node to use for generating time-based UUIDs (e.g. ``'121212121212'``).
+
+.. seealso::
+
+    For more details, see the :doc:`UID component </components/uid>`
+    documentation.
+
 .. _reference-validation:
 
 validation


### PR DESCRIPTION
Closes #21934

The Framework Configuration Reference was missing the `uid` section. This PR adds documentation for all UID configuration options:

- `default_uuid_version`
- `name_based_uuid_version`
- `name_based_uuid_namespace`
- `time_based_uuid_version`
- `time_based_uuid_node`

The section is inserted in alphabetical order (between `trusted_proxies` and `validation`) and follows the same format as other configuration entries.