### PR TITLE
[Semaphore] Document LockStore for using Lock as semaphore backend

### DIFF
--- a/components/semaphore.rst
+++ b/components/semaphore.rst
@@ -34,6 +34,84 @@ class, which in turn requires another class to manage the storage::
     $store = new RedisStore($redis);
     $factory = new SemaphoreFactory($store);
 
+.. tip::
+
+    You can also use the :class:`Symfony\\Component\\Semaphore\\Store\\LockStore`
+    to use any :doc:`Lock component </lock>` backend (flock, Redis, PDO, etc.)
+    as a semaphore store:
+
+    .. code-block:: php-standalone
+
+        use Symfony\Component\Lock\LockFactory;
+        use Symfony\Component\Lock\Store\FlockStore;
+        use Symfony\Component\Semaphore\SemaphoreFactory;
+        use Symfony\Component\Semaphore\Store\LockStore;
+
+        $lockFactory = new LockFactory(new FlockStore());
+        $store = new LockStore($lockFactory);
+        $factory = new SemaphoreFactory($store);
+
+    When using the FrameworkBundle, you can configure this with the ``lock://``
+    DSN:
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # config/packages/semaphore.yaml
+            framework:
+                lock: 'flock'
+                semaphore: 'lock://'
+
+        .. code-block:: php
+
+            // config/packages/semaphore.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return App::config([
+                'framework' => [
+                    'lock' => 'flock',
+                    'semaphore' => 'lock://',
+                ],
+            ]);
+
+    You can also reference a specific named lock resource using ``lock://name``:
+
+    .. configuration-block::
+
+        .. code-block:: yaml
+
+            # config/packages/semaphore.yaml
+            framework:
+                lock:
+                    default: 'flock'
+                    my_locks: '%env(REDIS_DSN)%'
+                semaphore:
+                    default: 'lock://'          # uses lock.default.factory
+                    other: 'lock://my_locks'    # uses lock.my_locks.factory
+
+        .. code-block:: php
+
+            // config/packages/semaphore.php
+            namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+            return App::config([
+                'framework' => [
+                    'lock' => [
+                        'default' => 'flock',
+                        'my_locks' => env('REDIS_DSN'),
+                    ],
+                    'semaphore' => [
+                        'default' => 'lock://',         // uses lock.default.factory
+                        'other' => 'lock://my_locks',   // uses lock.my_locks.factory
+                    ],
+                ],
+            ]);
+
+    .. versionadded:: 8.1
+
+        The ``LockStore`` was introduced in Symfony 8.1.
+
 The semaphore is created by calling the
 :method:`Symfony\\Component\\Semaphore\\SemaphoreFactory::createSemaphore`
 method. Its first argument is an arbitrary string that represents the locked

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2623,7 +2623,10 @@ semaphore
 
 **type**: ``string`` | ``array``
 
-The default semaphore adapter. Store's DSN are also allowed.
+The default semaphore adapter. Store's DSN are also allowed. Use ``lock://``
+to use the :doc:`Lock component </lock>` as the semaphore backend (e.g.
+``lock://`` for the default lock, or ``lock://my_locks`` for a named lock
+resource).
 
 .. _reference-semaphore-enabled:
 


### PR DESCRIPTION
Closes #21937

Documents the new `LockStore` added in symfony/symfony#59202, which allows using any Lock component backend (flock, Redis, PDO, etc.) as a semaphore store via the `lock://` DSN.

Changes:
- **`components/semaphore.rst`**: Added a tip block documenting `LockStore` usage (standalone PHP and FrameworkBundle configuration with `lock://` DSN, including named lock resources)
- **`reference/configuration/framework.rst`**: Mentioned `lock://` DSN support in the semaphore configuration description