### PR TITLE
[Form] Document automatic min/max attributes for BirthdayType

### DIFF
--- a/reference/forms/types/birthday.rst
+++ b/reference/forms/types/birthday.rst
@@ -11,6 +11,25 @@ This type is essentially the same as the :doc:`DateType </reference/forms/types/
 type, but with a more appropriate default for the `years`_ option. The `years`_
 option defaults to 120 years ago to the current year.
 
+When the ``widget`` option is set to ``single_text``, the field automatically
+adds ``min`` and ``max`` HTML attributes based on the `years`_ option. These
+attributes are set to January 1st of the first year and December 31st of the
+last year respectively. To change the year range, use the `years`_ option.
+You can also override them with custom dates using the ``attr`` option::
+
+    $builder->add('birthday', BirthdayType::class, [
+        'widget' => 'single_text',
+        'attr' => [
+            'min' => '2000-01-01',
+            'max' => '2010-12-31',
+        ],
+    ]);
+
+.. versionadded:: 8.1
+
+    The ``min``/``max`` attributes usage with default values for ``single_text`` widget were
+    introduced in Symfony 8.1.
+
 +---------------------------+-------------------------------------------------------------------------------+
 | Underlying Data Type      | can be ``DateTime``, ``string``, ``timestamp``, or ``array``                  |
 |                           | (see the :ref:`input option <form-reference-date-input>`)                     |


### PR DESCRIPTION
Closes #21939

Documents the new behavior introduced in symfony/symfony#58871: when the `widget` option is set to `single_text`, `BirthdayType` now automatically adds `min` and `max` HTML attributes based on the `years` option (January 1st of the first year and December 31st of the last year). Users can override these by passing custom values in the `attr` option.