### PR TITLE
[Console] Document image/file input support

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -571,6 +571,53 @@ You can also use a validator with a hidden question::
         return Command::SUCCESS;
     }
 
+Asking for a File
+-----------------
+
+.. versionadded:: 8.1
+
+    The ``FileQuestion`` class and ``InputFile`` class were introduced in Symfony 8.1.
+
+The ``FileQuestion`` class lets you ask the
+user for a file. In terminals that support image protocols (such as Kitty, Ghostty,
+iTerm2, WezTerm, etc.), users can paste images directly from their clipboard.
+In other terminals, the question falls back to asking for a file path::
+
+    // ...
+    public function __invoke(InputInterface $input, OutputInterface $output): int
+    {
+        $helper = new QuestionHelper();
+
+        $question = new FileQuestion(
+            'Provide an image:',
+            allowedMimeTypes: ['image/png', 'image/jpeg'],
+            maxFileSize: 5 * 1024 * 1024, // 5 MB (the default)
+        );
+
+        $file = $helper->ask($input, $output, $question);
+
+        $output->writeln('MIME type: '.$file->getMimeType());
+        $output->writeln('Size: '.$file->getHumanReadableSize());
+        $output->writeln('Contents length: '.strlen($file->getContents()));
+
+        // move the file to a permanent location (needed for temp files from paste)
+        if ($file->isTempFile()) {
+            $file->move('/path/to/target/directory', 'uploaded.png');
+        }
+
+        return Command::SUCCESS;
+    }
+
+The ``InputFile`` class extends
+``\SplFileInfo`` and provides additional methods for working with the received
+file:
+
+* ``getMimeType()`` - Returns the MIME type of the file
+* ``getContents()`` - Returns the file contents as a string
+* ``getHumanReadableSize()`` - Returns a human-readable file size (e.g. ``1.5 MB``)
+* ``move()`` - Moves the file to a new location
+* ``isTempFile()`` - Returns ``true`` if the file was created from pasted data (temporary files are cleaned up automatically at shutdown)
+
 Testing a Command that Expects Input
 ------------------------------------
 

--- a/console/input.rst
+++ b/console/input.rst
@@ -537,6 +537,60 @@ they are assigned to the DTO::
 With this setup, when the command input is resolved, the email is lowercased
 and trimmed, and roles are uppercased.
 
+.. _console-input-file:
+
+File Input
+----------
+
+.. versionadded:: 8.1
+
+    File input support in invokable commands was introduced in Symfony 8.1.
+
+You can ask the user for a file by typing a parameter as
+:class:`Symfony\\Component\\Console\\Input\\File\\InputFile` and combining the ``#[Argument]`` and ``#[Ask]`` attributes. The console
+will automatically prompt for file input (paste or path):
+
+::
+
+    use Symfony\Component\Console\Attribute\Argument;
+    use Symfony\Component\Console\Attribute\AsCommand;
+    use Symfony\Component\Console\Attribute\Ask;
+    use Symfony\Component\Console\Command\Command;
+    use Symfony\Component\Console\Style\SymfonyStyle;
+
+    // ...
+
+    #[AsCommand(name: 'app:analyze')]
+    class AnalyzeCommand
+    {
+        public function __invoke(
+            SymfonyStyle $io,
+            #[Argument(description: 'The image to analyze')]
+            #[Ask('Provide an image (paste or enter path):')]
+            InputFile $image,
+        ): int {
+            $io->writeln('MIME type: '.$image->getMimeType());
+            $io->writeln('Size: '.$image->getHumanReadableSize());
+
+            if ($image->isTempFile()) {
+                $image->move('/path/to/storage', 'image.png');
+            }
+
+            return Command::SUCCESS;
+        }
+    }
+
+In terminals that support image protocols (such as Kitty, Ghostty, iTerm2,
+WezTerm, etc.), users can paste images directly from their clipboard. In other
+terminals, the question falls back to asking for a file path. In non-interactive
+mode, file paths are accepted as regular arguments.
+
+.. seealso::
+
+    For more advanced options (e.g. restricting allowed MIME types or file
+    size), see the ``FileQuestion`` class in the
+    :doc:`QuestionHelper documentation </components/console/helpers/questionhelper>`.
+
 Options with optional arguments
 -------------------------------
 

--- a/console/style.rst
+++ b/console/style.rst
@@ -356,6 +356,24 @@ User Input Methods
 
         $io->choice('Select the queue to analyze', ['queue1', 'queue2', 'queue3'], multiSelect: true);
 
+.. versionadded:: 8.1
+
+    The ``askFile()`` method was introduced in Symfony 8.1.
+
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::askFile`
+    It asks the user to provide a file (via paste or file path) and returns
+    an ``InputFile`` instance.
+
+.. code-block:: php-standalone
+
+    $file = $io->askFile('Provide an image:');
+
+You can restrict the allowed MIME types by passing them as the second argument:
+
+.. code-block:: php-standalone
+
+    $file = $io->askFile('Provide an image:', ['image/png', 'image/jpeg']);
+
 .. _symfony-style-blocks:
 
 Result Methods


### PR DESCRIPTION
## Summary
- Document `FileQuestion` class for asking users to provide files (paste from clipboard or file path) in `questionhelper.rst`
- Document `SymfonyStyle::askFile()` convenience method in `style.rst`
- Document `InputFile` with `#[Argument]` + `#[Ask]` attributes for invokable commands in `input.rst`

Fixes #21946

## Related
- symfony/symfony#63293
