### PR TITLE
 Add scheduler.enabled option to Framework Configuration Reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3119,6 +3119,22 @@ name
 
 Name of the semaphore you want to create.
 
+
+scheduler
+~~~~~~~~~
+
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``true`` or ``false`` depending on your installation
+
+Whether to enable or not the Scheduler support.
+
+.. seealso::
+
+    For more details, see the :doc:`Scheduler </scheduler>`
+    documentation.
+
 .. _configuration-framework-serializer:
 
 serializer


### PR DESCRIPTION
Fix #21951

The `framework.scheduler.enabled` option was missing from the Framework Configuration Reference. This adds the scheduler section between `semaphore` and `serializer` (alphabetical order), following the same pattern used by similar options (messenger, serializer, etc.).