### PR TITLE
 Add remote-event.enabled option to Framework Configuration Reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2811,6 +2811,21 @@ The name of the rate limiting algorithm to use. Example names are ``fixed_window
 ``sliding_window`` and ``no_limit``. See :ref:`Rate Limiter Policies <rate-limiter-policies>`)
 for more information.
 
+remote-event
+~~~~~~~~~~~~
+
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``true`` or ``false`` depending on your installation
+
+Whether to enable or not the RemoteEvent support.
+
+.. seealso::
+
+    For more details, see the :doc:`Webhook </webhook>`
+    documentation.
+
 request
 ~~~~~~~
 


### PR DESCRIPTION
Fix #21950

The `framework.remote-event.enabled` option was missing from the Framework Configuration Reference. This adds the `remote-event` section between `rate_limiter` and `request` (alphabetical order), following the same pattern used by similar options.