### PR TITLE
 Add json_streamer.enabled option to Framework Configuration Reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2318,6 +2318,21 @@ Another alternative is to set the ``xdebug.file_link_format`` option in your
         // by removing the `/path/to/root/` (note trailing `/`), it becomes relative
         'jetbrains://php-storm/navigate/reference?project=my-project&path=%%f:%%l&/path/to/root/>'
 
+json_streamer
+~~~~~~~~~~~~~
+
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``true`` or ``false`` depending on your installation
+
+Whether to enable or not the JSON Streamer support.
+
+.. seealso::
+
+    For more details, see the :doc:`Streaming JSON </serializer/streaming_json>`
+    documentation.
+
 .. _reference-lock:
 
 lock


### PR DESCRIPTION
Fix #21949

The `framework.json_streamer.enabled` option was missing from the Framework Configuration Reference. This adds the `json_streamer` section between `ide` and `lock` (alphabetical order), following the same pattern used by similar options.