### PR TITLE
[Validator] Document clock-awareness for comparison and range validators

### DIFF
--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -284,6 +284,18 @@ current time:
             }
         }
 
+Clock-aware Date Comparisons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.1
+
+    The clock-awareness of comparison validators was introduced in Symfony 8.1.
+
+When the :doc:`Clock component </components/clock>` is installed and registered
+as a service, comparison validators automatically use it to resolve relative date
+strings (e.g. ``today``, ``+5 hours``). This makes date comparisons deterministic
+and testable by using :class:`Symfony\\Component\\Clock\\MockClock`.
+
 Options
 -------
 

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -286,6 +286,18 @@ current time:
             }
         }
 
+Clock-aware Date Comparisons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.1
+
+    The clock-awareness of comparison validators was introduced in Symfony 8.1.
+
+When the :doc:`Clock component </components/clock>` is installed and registered
+as a service, comparison validators automatically use it to resolve relative date
+strings (e.g. ``today``, ``+5 hours``). This makes date comparisons deterministic
+and testable by using :class:`Symfony\\Component\\Clock\\MockClock`.
+
 Options
 -------
 

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -286,6 +286,18 @@ can check that a person must be at least 18 years old like this:
             }
         }
 
+Clock-aware Date Comparisons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.1
+
+    The clock-awareness of comparison validators was introduced in Symfony 8.1.
+
+When the :doc:`Clock component </components/clock>` is installed and registered
+as a service, comparison validators automatically use it to resolve relative date
+strings (e.g. ``today``, ``-18 years``). This makes date comparisons deterministic
+and testable by using :class:`Symfony\\Component\\Clock\\MockClock`.
+
 Options
 -------
 

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -285,6 +285,18 @@ can check that a person must be at least 18 years old like this:
             }
         }
 
+Clock-aware Date Comparisons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.1
+
+    The clock-awareness of comparison validators was introduced in Symfony 8.1.
+
+When the :doc:`Clock component </components/clock>` is installed and registered
+as a service, comparison validators automatically use it to resolve relative date
+strings (e.g. ``today``, ``-18 years``). This makes date comparisons deterministic
+and testable by using :class:`Symfony\\Component\\Clock\\MockClock`.
+
 Options
 -------
 

--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -301,6 +301,18 @@ can check that a delivery date starts within the next five hours like this:
             }
         }
 
+Clock-aware Date Ranges
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.1
+
+    The clock-awareness of the Range validator was introduced in Symfony 8.1.
+
+When the :doc:`Clock component </components/clock>` is installed and registered
+as a service, the Range validator automatically uses it to resolve relative date
+strings (e.g. ``now``, ``+5 hours``). This makes date range comparisons
+deterministic and testable by using :class:`Symfony\\Component\\Clock\\MockClock`.
+
 Options
 -------
 


### PR DESCRIPTION
This PR documents the clock-awareness feature added to comparison and range validators in symfony/symfony#63360.

When the Clock component is installed and registered as a service, the comparison validators (`GreaterThan`, `GreaterThanOrEqual`, `LessThan`, `LessThanOrEqual`) and `Range` validator automatically use it to resolve relative date strings. This makes date comparisons deterministic and testable using `MockClock`.

Fixes #21959