### PR TITLE
[Console] Document Validator constraints support for Console Questions

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -537,6 +537,36 @@ invalid answer and will only be able to proceed if their input is valid.
         ));
         $question->setValidator($validation);
 
+Using Validator Constraints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of writing custom validation logic, you can pass
+:doc:`Validator constraints </reference/constraints>` directly to the question
+using the :method:`Symfony\\Component\\Console\\Question\\Question::setConstraints`
+method::
+
+    // ...
+    $question = new Question('Please enter your email');
+    $question->setConstraints([
+        new Assert\NotBlank(),
+        new Assert\Email(),
+    ]);
+
+    $email = $helper->ask($input, $output, $question);
+
+When the input fails validation, the error messages are displayed in the console
+and the user is prompted again (the same behavior as ``setValidator()``). You can
+also call ``setMaxAttempts()`` to limit the number of retries.
+
+If both constraints and a custom validator are set on the same question, the
+constraints are validated first and the custom validator is only called if all
+constraints pass.
+
+.. versionadded:: 8.1
+
+    The :method:`Symfony\\Component\\Console\\Question\\Question::setConstraints`
+    method was introduced in Symfony 8.1.
+
 Validating a Hidden Response
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/console/input.rst
+++ b/console/input.rst
@@ -543,6 +543,32 @@ they are assigned to the DTO::
 With this setup, when the command input is resolved, the email is lowercased
 and trimmed, and roles are uppercased.
 
+Validating Input with Constraints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can validate interactive input by passing
+:doc:`Validator constraints </reference/constraints>` to the ``constraints``
+option of the ``#[Ask]`` attribute::
+
+    #[Argument]
+    #[Ask(constraints: [new Assert\NotBlank, new Assert\Email])]
+    string $email,
+
+When the user provides an invalid value, the validation error messages are
+displayed in the console and the user is prompted again until valid input is
+given.
+
+.. versionadded:: 8.1
+
+    The ``constraints`` option of the ``#[Ask]`` attribute was introduced
+    in Symfony 8.1.
+
+.. seealso::
+
+    For more details on validating console questions, see
+    :ref:`Validating the Answer <console-validate-question-answer>` in
+    the QuestionHelper documentation.
+
 .. _console-input-file:
 
 File Input


### PR DESCRIPTION
This documents the new `Question::setConstraints()` method and the `constraints` parameter of the `#[Ask]` attribute, introduced in Symfony 8.1 via symfony/symfony#63359.

## Changes

- **`components/console/helpers/questionhelper.rst`**: Added "Using Validator Constraints" subsection under "Validating the Answer", documenting `setConstraints()` with a code example, execution order with custom validators, and a `versionadded` directive.
- **`console/input.rst`**: Added "Validating Input with Constraints" subsection under the invokable commands input DTO section, documenting the `constraints` parameter of `#[Ask]` with a code example, a `versionadded` directive, and a `seealso` cross-reference.

Fixes #21963