### PR TITLE
 Document variadic argument support for #[MapRequestPayload]

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -633,6 +633,21 @@ using the ``type`` option of the attribute::
         // ...
     }
 
+You can also use a variadic argument to achieve the same result without the
+``type`` option::
+
+    public function dashboard(
+        #[MapRequestPayload] UserDto ...$users
+    ): Response
+    {
+        // ...
+    }
+
+.. versionadded:: 8.1
+
+    Support for variadic arguments with ``#[MapRequestPayload]`` was introduced
+    in Symfony 8.1.
+
 .. _controller_map-uploaded-file:
 
 Mapping Uploaded Files


### PR DESCRIPTION
This documents the support for variadic arguments with `#[MapRequestPayload]`, introduced in Symfony 8.1 via symfony/symfony#54817.

## Changes

Added a code example in `controller.rst` showing that you can use a variadic argument (`UserDto ...$users`) as an alternative to the existing `array` + `type` option approach for mapping arrays of DTOs from request payloads.

Fixes #21961