### PR TITLE
 Fix formatting of access token documentation

### DIFF
--- a/security/access_token.rst
+++ b/security/access_token.rst
@@ -122,8 +122,7 @@ The application is now ready to handle incoming tokens. A *token extractor*
 retrieves the token from the request (e.g. a header or request body).
 
 By default, the access token is read from the request header parameter
-``Authorization`` with the scheme ``Bearer`` (e.g. ``Authorization: Bearer
-the-token-value``).
+``Authorization`` with the scheme ``Bearer`` (e.g. ``Authorization: Bearer the-token-value``).
 
 Symfony provides other extractors as per the `RFC6750`_:
 


### PR DESCRIPTION
- Line break to respect guideline that lines should break on column 80 was causing an undue line break in the highlighted text.
