### PR TITLE
[Translation] Use Xliff version 2.0

### DIFF
--- a/reference/formats/xliff.rst
+++ b/reference/formats/xliff.rst
@@ -20,7 +20,7 @@ loaded/dumped inside a Symfony application:
 .. code-block:: xml
 
     <?xml version="1.0" encoding="UTF-8" ?>
-    <xliff xmlns="urn:oasis:names:tc:xliff:document:2.1" version="2.1"
+    <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0"
         srcLang="fr-FR" trgLang="en-US">
         <file id="messages.en_US">
             <unit id="LCa0a2j" name="original-content">
@@ -37,4 +37,4 @@ loaded/dumped inside a Symfony application:
         </file>
     </xliff>
 
-.. _XLIFF: https://docs.oasis-open.org/xliff/xliff-core/v2.1/xliff-core-v2.1.html
+.. _XLIFF: https://docs.oasis-open.org/xliff/xliff-core/v2.0/xliff-core-v2.0.html


### PR DESCRIPTION
A [code issue](https://github.com/symfony/symfony/issues/63244) highlighted that Xliff 2.1 is not supported yet by Symfony