### PR TITLE
[JsonStreamer] Fix example in streaming_json.rst

### DIFF
--- a/serializer/streaming_json.rst
+++ b/serializer/streaming_json.rst
@@ -148,10 +148,10 @@ method to perform the actual JSON parsing:
 
             public function __construct(
                 private StreamReaderInterface $jsonStreamReader,
-                #[Autowire(param: 'kernel.root_dir')]
-                string $rootDir,
+                #[Autowire(param: 'kernel.project_dir')]
+                string $projectDir,
             ) {
-                $this->catsJsonFile = sprintf('%s/var/cats.json', $rootDir);
+                $this->catsJsonFile = sprintf('%s/var/cats.json', $projectDir);
             }
 
             public function pickTheTenthCat(): ?Cat


### PR DESCRIPTION
Replace non existing parameter name in Decoding objects example

The `kernel.root_dir` parameter has been removed and should be replaced by `kernel.project_dir`
