### PR TITLE
[Serializer] `'*'` context group serializes all properties including those without groups

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -853,6 +853,8 @@ You can add the ``#[Groups]`` attribute to your class:
             #[Groups(["public-view"])]
             private bool $sportsperson;
 
+            private string $email;
+
             // ...
         }
 
@@ -867,6 +869,7 @@ You can add the ``#[Groups]`` attribute to your class:
                     groups: ['public-view']
                 sportsperson:
                     groups: ['public-view']
+                # email has no groups defined
 
     .. code-block:: xml
 
@@ -887,6 +890,7 @@ You can add the ``#[Groups]`` attribute to your class:
                 <attribute name="sportsperson">
                     <group>public-view</group>
                 </attribute>
+                <!-- email has no groups defined -->
             </class>
         </serializer>
 
@@ -907,13 +911,14 @@ You can now choose which groups to use when serializing::
     );
     // $json contains {"name":"Jane Doe","age":32,"sportsperson":false}
 
-    // or use the special "*" value to select all groups
+    // or use the special "*" value to serialize all properties
+    // (including those without any groups)
     $json = $serializer->serialize(
         $person,
         'json',
         ['groups' => '*']
     );
-    // $json contains {"name":"Jane Doe","age":32,"sportsperson":false}
+    // $json contains {"name":"Jane Doe","age":32,"sportsperson":false,"email":"jane.doe@exemple.com"}
 
 Using the Serialization Context
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
While reading the [documentation](https://symfony.com/doc/6.4/serializer.html#selecting-specific-properties), I thought that `'*'` should only serialize properties that have at least one group, so I opened an issue on symfony/symfony ([#62912](https://github.com/symfony/symfony/issues/62912))

Since the issue was closed, I’m clarifying the documentation based on the explanation provided there https://github.com/symfony/symfony/issues/62912#issuecomment-3705467027:

> Additionally, the example in the documentation may be misleading. In the shown result, all properties are serialized, but in the corresponding class definition, all properties have at least one group. This makes it impossible to determine whether all properties are serialized because `'*'` selects all properties, or because `'*'` selects only properties with at least one group.

to make this behavior explicit and avoid confusion for other readers.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
