### PR TITLE
[Form] Add missing choice_lazy and choice_loader to EntityType inherited options

### DIFF
--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -229,6 +229,10 @@ These options inherit from the :doc:`ChoiceType </reference/forms/types/choice>`
 
 .. include:: /reference/forms/types/options/choice_attr.rst.inc
 
+.. include:: /reference/forms/types/options/choice_lazy.rst.inc
+
+.. include:: /reference/forms/types/options/choice_loader.rst.inc
+
 .. include:: /reference/forms/types/options/choice_translation_domain_disabled.rst.inc
 
 .. include:: /reference/forms/types/options/expanded.rst.inc


### PR DESCRIPTION
## Summary

- Added `choice_lazy` and `choice_loader` to the EntityType's inherited options from ChoiceType
- These options were missing from the inherited options section, as reported in the issue
- Uses the existing `.rst.inc` include files, consistent with how other inherited options are included

Related to #20104 (re-check all form types inherited options).

Fixes #21855