### PR TITLE
[Yaml] Add @= expression syntax to YAML format reference

### DIFF
--- a/reference/formats/yaml.rst
+++ b/reference/formats/yaml.rst
@@ -357,6 +357,22 @@ official YAML specification but are useful in Symfony applications:
     The support for using the enum FQCN without specifying a case
     was introduced in Symfony 7.1.
 
+* The ``@=`` prefix is used by the :doc:`Dependency Injection </service_container>`
+  component to inject values computed by :doc:`expressions </reference/formats/expression_language>`.
+  In YAML configuration files, any string starting with ``@=`` is treated as an
+  expression:
+
+  .. code-block:: yaml
+
+      services:
+          App\Mailer:
+              arguments:
+                  - '@=service("App\\Mail\\MailerConfiguration").getMailerMethod()'
+
+  Expressions have access to the ``service()``, ``parameter()`` and ``env()``
+  functions among others. See :doc:`/service_container/expression_language` for
+  full details.
+
 Unsupported YAML Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

- Added the `@=` expression prefix to the "Symfony Specific Features" section of the YAML format reference
- Documents that strings starting with `@=` are treated as expressions by the DI component
- Includes a code example and links to the full expression language documentation

As suggested by @Mynyx in the issue discussion, the "Symfony Specific Features" section is the right place for this since it's DI-specific behavior, not part of the YAML spec itself.

Fixes #21917