### PR TITLE
[Security] Clarify that APP_SECRET is still required in remember_me docs

### DIFF
--- a/security/remember_me.rst
+++ b/security/remember_me.rst
@@ -79,9 +79,10 @@ the session lasts using a cookie with the ``remember_me`` firewall option:
 
 .. versionadded:: 7.2
 
-    The ``secret`` option is no longer required starting from Symfony 7.2. By
-    default, ``%kernel.secret%`` is used, which is defined using the
-    ``APP_SECRET`` environment variable.
+    The ``secret`` option defaults to ``%kernel.secret%`` and no longer
+    needs to be set explicitly. However, the ``APP_SECRET`` environment
+    variable **must** still be defined in your environment (especially in
+    production), as it is used as the value for ``kernel.secret``.
 
 After enabling the ``remember_me`` system in the configuration, there are a
 couple more things to do before remember me works correctly:


### PR DESCRIPTION
## Summary

The versionadded note for Symfony 7.2 in `remember_me.rst` stated that "The secret option is no longer required", which was misleading — it implied that `APP_SECRET` itself was no longer needed. This led to production failures when no secret was configured.

The reworded note clarifies that:
- The `secret` **option** now defaults to `%kernel.secret%` and doesn't need to be set explicitly
- The `APP_SECRET` environment variable **must** still be defined, especially in production

Fixes #21372