### PR TITLE
 Document autoconfiguration attributes on abstract classes

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -82,9 +82,9 @@ the ``list()`` method of the ``BlogController`` class.
 .. warning::
 
     If you define multiple PHP classes in the same file, Symfony only loads the
-    routes of the first class, ignoring all the other routes.The route attribute
-    is always wins over route with yaml, xml or PHP file and Symfony will always
-    load the route attribute.
+    routes of the first class, ignoring all the other routes. The route attribute
+    always wins over routes defined in YAML, XML or PHP files and Symfony will
+    always load the route attribute.
 
 The route name (``blog_list``) is not important for now, but it will be
 essential later when :ref:`generating URLs <routing-generating-urls>`. You only

--- a/service_container.rst
+++ b/service_container.rst
@@ -1278,6 +1278,12 @@ Autoconfiguration also works with attributes. Some attributes like
 for autoconfiguration. Any class using these attributes will have tags applied
 to them.
 
+.. versionadded:: 7.4
+
+    In Symfony 7.4, autoconfiguration attributes on abstract classes are also
+    parsed when using resource-based service loading. Previously, abstract
+    classes were skipped entirely during this process.
+
 Linting Service Definitions
 ---------------------------
 

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -147,6 +147,14 @@ When no tag name is specified, the fully qualified class name (FQCN) of the targ
     like their laziness, their bindings or their calls for example, you may rely
     on the :class:`Symfony\\Component\\DependencyInjection\\Attribute\\Autoconfigure` attribute.
 
+.. versionadded:: 7.4
+
+    In Symfony 7.4, autoconfiguration attributes (such as ``#[AutoconfigureTag]``)
+    placed on abstract classes are also parsed when using
+    :ref:`resource-based service loading <service-container-services-load-example>`.
+    Previously, abstract classes were skipped during this process, meaning their
+    attributes were not fully processed.
+
 For more advanced needs, you can define the automatic tags using the
 :method:`Symfony\\Component\\DependencyInjection\\ContainerBuilder::registerForAutoconfiguration` method.
 


### PR DESCRIPTION
This PR documents the new behavior introduced in symfony/symfony#61578.

Fixes #21337