### PR TITLE
[Config] Document ServicesConfig and RoutesConfig array-shape helpers

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -78,6 +78,62 @@ readable. These are the main advantages and disadvantages of each format:
   arrays, and benefits from auto completion and static analysis using
   array shapes.
 
+When using the PHP format, you can wrap your configuration arrays with
+:class:`Symfony\\Config\\ServicesConfig` or :class:`Symfony\\Config\\RoutesConfig`.
+These wrappers are entirely optional but provide
+`psalm array-shape <https://psalm.dev/docs/annotating_code/type_syntax/array_types/#array-shapes>`_
+type definitions that enable autocompletion and static analysis in IDEs.
+
+For service configuration (``config/services.php``)::
+
+    // config/services.php
+    use App\Service\MyService;
+    use Symfony\Config\ServicesConfig;
+
+    return new ServicesConfig(
+        defaults: [
+            'autowire' => true,
+            'autoconfigure' => true,
+        ],
+        services: [
+            'App\\' => ['resource' => '../src/'],
+            MyService::class => null,
+        ],
+    );
+
+For routing configuration (``config/routes.php``)::
+
+    // config/routes.php
+    use Symfony\Config\RoutesConfig;
+
+    return new RoutesConfig([
+        'controllers' => [
+            'resource' => '../src/Controller/',
+            'type' => 'attribute',
+        ],
+    ]);
+
+.. tip::
+
+    The ``ServicesConfig`` constructor also accepts ``imports``, ``parameters``
+    and ``instanceof`` arguments. The ``_defaults`` and ``_instanceof`` keys
+    should not be included in the ``services`` array; use the dedicated
+    ``defaults`` and ``instanceof`` parameters instead.
+
+These wrappers also work with environment-specific configuration using
+``when@env``::
+
+    // config/services.php
+    use Symfony\Config\ServicesConfig;
+
+    return [
+        'when@dev' => new ServicesConfig(
+            services: [
+                'App\\' => ['resource' => '../src/', 'exclude' => '../src/{Entity,Kernel.php}'],
+            ],
+        ),
+    ];
+
 Importing Configuration Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/routing.rst
+++ b/routing.rst
@@ -77,9 +77,9 @@ the ``list()`` method of the ``BlogController`` class.
 .. warning::
 
     If you define multiple PHP classes in the same file, Symfony only loads the
-    routes of the first class and ignores all the other routes. The route
-    attribute always takes precedence over routes defined in YAML or PHP
-    files, so Symfony will always load the route attribute.
+    routes of the first class, ignoring all the other routes. The route attribute
+    always wins over routes defined in YAML or PHP files and Symfony will always
+    load the route attribute.
 
 The route name (``blog_list``) is not important for now, but it will be
 essential later when :ref:`generating URLs <routing-generating-urls>`. You only


### PR DESCRIPTION
Expands the brief mention of array shapes in the configuration docs with concrete examples of `ServicesConfig` and `RoutesConfig` wrappers, including usage with `when@env`.

Fixes #21485