### PR TITLE
[Config] Document deprecation of $this in PHP config files

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -91,6 +91,12 @@ readable. These are the main advantages and disadvantages of each format:
 
     Array shapes were introduced in Symfony 7.4.
 
+.. deprecated:: 7.4
+
+    Using ``$this`` or accessing the internal scope of the file loader in PHP
+    config files was deprecated in Symfony 7.4. Use the ``$loader`` variable
+    instead, which only exposes the loader's public API.
+
 Importing Configuration Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -194,8 +194,8 @@ allow_if_equal_granted_denied
 
 This option is only used by the ``consensus`` strategy. If the number of
 :doc:`voters </security/voters>` granting access is equal to the number of
- voters denying access, this option determines the final decision. If ``true``
- (the default), access is granted in case of a tie.
+voters denying access, this option determines the final decision. If ``true``
+(the default), access is granted in case of a tie.
 
 service
 .......

--- a/routing.rst
+++ b/routing.rst
@@ -82,10 +82,9 @@ the ``list()`` method of the ``BlogController`` class.
 .. warning::
 
     If you define multiple PHP classes in the same file, Symfony only loads the
-    routes of the first class, ignoring all the other routes.The route attribute 
-    is always wins over route with yaml, xml or PHP file and Symfony will always 
-    load the route attribute.
-    
+    routes of the first class, ignoring all the other routes. The route attribute
+    always wins over routes defined in YAML, XML or PHP files and Symfony will
+    always load the route attribute.
 
 The route name (``blog_list``) is not important for now, but it will be
 essential later when :ref:`generating URLs <routing-generating-urls>`. You only


### PR DESCRIPTION
Documents the deprecation of using `$this` or the internal scope of the file loader in PHP configuration files. The `$loader` variable should be used instead.

Fixes #21441