### PR TITLE
[Console] Document BackedEnum support in console #[Argument] and #[Option]

### DIFF
--- a/console/input.rst
+++ b/console/input.rst
@@ -67,6 +67,48 @@ The argument mode (required, optional, array) is inferred from the parameter typ
 * **Optional**: Parameters with a default value (e.g. ``string $name = ''`` or ``?string $name = null``);
 * **Array**: Parameters with the ``array`` type (e.g. ``array $names = []``);
 
+You can also use ``BackedEnum`` types for arguments. The string input is
+automatically converted to the enum case using ``BackedEnum::from()``, and
+autocompletion is provided based on the enum cases.
+
+Given a backed enum like this::
+
+    // src/Enum/Format.php
+    namespace App\Enum;
+
+    enum Format: string
+    {
+        case Json = 'json';
+        case Xml = 'xml';
+    }
+
+You can type-hint it directly in your command::
+
+    // ...
+    use App\Enum\Format;
+    use Symfony\Component\Console\Attribute\Argument;
+    use Symfony\Component\Console\Attribute\AsCommand;
+
+    #[AsCommand(name: 'app:export')]
+    class ExportCommand
+    {
+        public function __invoke(
+            #[Argument]
+            Format $format,
+        ): int {
+            // $format is an instance of the Format enum
+            // ...
+        }
+    }
+
+If the user provides a value that doesn't match any enum case, a clear error
+message is displayed along with the list of valid values.
+
+.. versionadded:: 7.4
+
+    Support for ``BackedEnum`` in ``#[Argument]`` and ``#[Option]`` was
+    introduced in Symfony 7.4.
+
 Using the Classic configure() Method
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -271,6 +313,10 @@ The option mode is inferred from the parameter type and default value:
   or ``--output=file.txt`` (returns ``'file.txt'``)::
 
       #[Option] string|bool $output = false
+
+* **BackedEnum** (``VALUE_REQUIRED``): ``BackedEnum`` types. The input value is
+  automatically converted to the enum case, and autocompletion is provided
+  (e.g. ``Format $format = Format::Json`` or ``?Format $format = null``).
 
 .. seealso::
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -194,8 +194,8 @@ allow_if_equal_granted_denied
 
 This option is only used by the ``consensus`` strategy. If the number of
 :doc:`voters </security/voters>` granting access is equal to the number of
- voters denying access, this option determines the final decision. If ``true``
- (the default), access is granted in case of a tie.
+voters denying access, this option determines the final decision. If ``true``
+(the default), access is granted in case of a tie.
 
 service
 .......

--- a/routing.rst
+++ b/routing.rst
@@ -82,10 +82,9 @@ the ``list()`` method of the ``BlogController`` class.
 .. warning::
 
     If you define multiple PHP classes in the same file, Symfony only loads the
-    routes of the first class, ignoring all the other routes.The route attribute 
-    is always wins over route with yaml, xml or PHP file and Symfony will always 
-    load the route attribute.
-    
+    routes of the first class, ignoring all the other routes. The route attribute
+    always wins over routes defined in YAML, XML or PHP files and Symfony will
+    always load the route attribute.
 
 The route name (``blog_list``) is not important for now, but it will be
 essential later when :ref:`generating URLs <routing-generating-urls>`. You only


### PR DESCRIPTION
Documents the support for `BackedEnum` types in invokable commands with `#[Argument]` and `#[Option]` attributes:
- Automatic conversion from string input to enum case
- Autocompletion based on enum cases
- Error messages with valid values when input doesn't match

Fixes #21076