### PR TITLE
[Serializer][Validator] Document compile-time attribute metadata for Validator and Serializer

### DIFF
--- a/components/validator/resources.rst
+++ b/components/validator/resources.rst
@@ -105,6 +105,34 @@ To enable the attribute loader, call the
 To disable the attribute loader after it was enabled, call
 :method:`Symfony\\Component\\Validator\\ValidatorBuilder::disableAttributeMapping`.
 
+Compile-Time Attribute Metadata
+...............................
+
+.. versionadded:: 7.4
+
+    Compile-time discovery of classes using constraint attributes was introduced
+    in Symfony 7.4.
+
+When using the Symfony framework with :ref:`autoconfiguration <services-autoconfigure>`,
+classes that use constraint attributes (such as ``#[Assert\NotBlank]``,
+``#[Assert\Length]``, etc.) are automatically discovered at compile time. This
+allows the attribute loader to only process the classes that are known to have
+constraint attributes, improving performance in production.
+
+If you need to explicitly register a class that uses constraint attributes
+(e.g. from a third-party library that is not part of your service
+definitions), tag it with ``validator.attribute_metadata`` and
+``container.excluded``:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+    services:
+        Vendor\Library\SomeModel:
+            tags:
+                - { name: container.excluded }
+                - { name: validator.attribute_metadata }
+
 Using Multiple Loaders
 ----------------------
 

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -194,8 +194,8 @@ allow_if_equal_granted_denied
 
 This option is only used by the ``consensus`` strategy. If the number of
 :doc:`voters </security/voters>` granting access is equal to the number of
- voters denying access, this option determines the final decision. If ``true``
- (the default), access is granted in case of a tie.
+voters denying access, this option determines the final decision. If ``true``
+(the default), access is granted in case of a tie.
 
 service
 .......

--- a/routing.rst
+++ b/routing.rst
@@ -82,10 +82,9 @@ the ``list()`` method of the ``BlogController`` class.
 .. warning::
 
     If you define multiple PHP classes in the same file, Symfony only loads the
-    routes of the first class, ignoring all the other routes.The route attribute 
-    is always wins over route with yaml, xml or PHP file and Symfony will always 
-    load the route attribute.
-    
+    routes of the first class, ignoring all the other routes. The route attribute
+    always wins over routes defined in YAML, XML or PHP files and Symfony will
+    always load the route attribute.
 
 The route name (``blog_list``) is not important for now, but it will be
 essential later when :ref:`generating URLs <routing-generating-urls>`. You only

--- a/serializer.rst
+++ b/serializer.rst
@@ -2637,6 +2637,41 @@ You can use any serialization attribute on the source class properties, includin
 
     The ``#[ExtendsSerializationFor]`` attribute was introduced in Symfony 7.4.
 
+Compile-Time Attribute Metadata
+...............................
+
+.. versionadded:: 7.4
+
+    Compile-time discovery of classes using serializer attributes was introduced
+    in Symfony 7.4.
+
+When using the Symfony framework with :ref:`autoconfiguration <services-autoconfigure>`,
+classes that use serializer attributes (such as ``#[Groups]``,
+``#[SerializedName]``, ``#[MaxDepth]``, ``#[Ignore]``, ``#[Context]``,
+``#[SerializedPath]`` or ``#[DiscriminatorMap]``) are automatically discovered
+at compile time. This allows the attribute loader to only process the classes
+that are known to have serializer attributes, improving performance in
+production.
+
+If you need to explicitly register a class that uses serializer attributes
+(e.g. from a third-party library that is not part of your service
+definitions), tag it with ``serializer.attribute_metadata`` and
+``container.excluded``:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+    services:
+        Vendor\Library\SomeModel:
+            tags:
+                - { name: container.excluded }
+                - { name: serializer.attribute_metadata }
+
+.. deprecated:: 7.4
+
+    The ``ClassMetadataFactoryCompiler`` class is deprecated in Symfony 7.4
+    in favor of compile-time attribute metadata discovery.
+
 .. _serializer-enabling-metadata-cache:
 
 Configuring the Metadata Cache


### PR DESCRIPTION
## Summary
- Document compile-time attribute metadata discovery for the Validator component (issue #21344, symfony/symfony#61528)
- Document compile-time attribute metadata discovery for the Serializer component (issue #21345, symfony/symfony#61532)
- Document the deprecation of `ClassMetadataFactoryCompiler` in Symfony 7.4

Fixes #21344
Fixes #21345