### PR TITLE
[Cache] Document Redis auth option and DSN username/auth parameters

### DIFF
--- a/components/cache/adapters/redis_adapter.rst
+++ b/components/cache/adapters/redis_adapter.rst
@@ -72,8 +72,8 @@ helper method allows creating and configuring the Redis client class instance us
     ``valkey[s]:`` scheme instead of the ``redis[s]:`` one in your DSNs.
 
 The DSN can specify either an IP/host (and an optional port) or a socket path, as well as a
-password and a database index. To enable TLS for connections, the scheme ``redis`` must be
-replaced by ``rediss`` (the second ``s`` means "secure").
+username, password and a database index. To enable TLS for connections, the scheme ``redis``
+must be replaced by ``rediss`` (the second ``s`` means "secure").
 
 .. note::
 
@@ -109,7 +109,10 @@ Below are common examples of valid DSNs showing a combination of available value
     RedisAdapter::createConnection('redis:?host[redis1:6379]&dbindex=3');
 
     // providing credentials with alternate DSN syntax
-    RedisAdapter::createConnection('redis:default:verysecurepassword@?host[redis1:6379]&dbindex=3');
+    RedisAdapter::createConnection('redis:myusername:verysecurepassword@?host[redis1:6379]&dbindex=3');
+
+    // providing credentials with auth parameters
+    RedisAdapter::createConnection('redis://host?auth[]=myusername&auth[]=verysecurepassword');
 
     // a single DSN can also define multiple servers
     RedisAdapter::createConnection(
@@ -134,6 +137,31 @@ parameter to set the name of your service group::
         'redis:default:verysecurepassword@?host[redis1:26379]&host[redis2:26379]&host[redis3:26379]&redis_sentinel=mymaster&dbindex=3'
     );
 
+When the Redis master and the sentinels use different credentials, provide the
+master credentials in the DSN userinfo and the sentinel credentials via the
+``auth`` query parameter or option::
+
+    // master password in userinfo, sentinel password in auth query parameter
+    RedisAdapter::createConnection(
+        'redis://master-password@?host[redis1:26379]&host[redis2:26379]&redis_sentinel=mymaster&auth=sentinel-password'
+    );
+
+    // master user+password in userinfo, sentinel user+password in auth query parameter (ACL)
+    RedisAdapter::createConnection(
+        'redis://master-user:master-pass@?host[redis1:26379]&host[redis2:26379]&redis_sentinel=mymaster&auth[]=sentinel-user&auth[]=sentinel-pass'
+    );
+
+    // or using the auth option
+    RedisAdapter::createConnection(
+        'redis://master-password@?host[redis1:26379]&host[redis2:26379]&redis_sentinel=mymaster',
+        ['auth' => ['sentinel-user', 'sentinel-pass']]
+    );
+
+.. versionadded:: 7.4
+
+    Support for separate sentinel and master authentication was introduced in
+    Symfony 7.4.
+
 .. note::
 
     See the :class:`Symfony\\Component\\Cache\\Traits\\RedisTrait` for more options
@@ -156,6 +184,7 @@ array of ``key => value`` pairs representing option names and their respective v
         // associative array of configuration options
         [
             'class' => null,
+            'auth' => null,
             'persistent' => 0,
             'persistent_id' => null,
             'timeout' => 30,
@@ -180,6 +209,21 @@ Available Options
     If none is specified, fallback value is in following order, depending which one is available first:
     ``\Redis``, ``\Relay\Relay``, ``\Predis\Client``. Explicitly set this to ``\Predis\Client`` for Sentinel if you are
     running into issues when retrieving master information.
+
+``auth`` (type: ``string|string[]``, default: ``null``)
+    Specifies the authentication credentials for the Redis connection. Use a string
+    for password-only authentication or an array with two elements ``[username, password]``
+    for ACL-based authentication. When ``null``, the credentials are extracted from
+    the DSN (e.g. ``redis://user:password@host``).
+
+    When using Redis Sentinel, this option is used for the **sentinel** credentials.
+    The **master** credentials should be provided via the DSN userinfo
+    (e.g. ``redis://master-pass@host``).
+
+    .. note::
+
+        When using `Predis`_, this option is ignored. Provide credentials via the
+        DSN instead.
 
 ``persistent`` (type: ``int``, default: ``0``)
     Enables or disables use of persistent connections. A value of ``0`` disables persistent

--- a/messenger.rst
+++ b/messenger.rst
@@ -1884,6 +1884,15 @@ The Redis transport DSN may looks like this:
     MESSENGER_TRANSPORT_DSN=rediss://localhost:6379/messages
     # Multiple Redis Sentinel Hosts Example
     MESSENGER_TRANSPORT_DSN=redis:?host[redis1:26379]&host[redis2:26379]&host[redis3:26379]&sentinel_master=db
+    # Redis Sentinel with separate master and sentinel credentials
+    MESSENGER_TRANSPORT_DSN=redis://master-pass@?host[redis1:26379]&host[redis2:26379]&sentinel_master=db&auth=sentinel-pass
+    # Redis Sentinel with ACL credentials for both master and sentinel
+    MESSENGER_TRANSPORT_DSN=redis://master-user:master-pass@?host[redis1:26379]&host[redis2:26379]&sentinel_master=db&auth[]=sentinel-user&auth[]=sentinel-pass
+
+.. versionadded:: 7.4
+
+    Support for separate sentinel and master authentication was introduced in
+    Symfony 7.4.
 
 A number of options can be configured via the DSN or via the ``options`` key
 under the transport in ``messenger.yaml``:
@@ -1914,7 +1923,11 @@ under the transport in ``messenger.yaml``:
     Whether to create the Redis group automatically
 
 ``auth``
-    The Redis password
+    The Redis password. Use a string for password-only authentication or an
+    array with two elements ``[username, password]`` for ACL-based authentication.
+    When using Redis Sentinel, this option is used for the **sentinel**
+    credentials. The **master** credentials should be provided via the DSN
+    userinfo (e.g. ``redis://master-pass@host``)
 
 ``delete_after_ack`` (default: ``true``)
     If ``true``, messages are deleted automatically after processing them


### PR DESCRIPTION
This PR documents the previously undocumented `auth` connection option for the Redis cache adapter and improves the DSN authentication examples.

**Changes:**                                                                                                                                                 
- Mention username support in the DSN description text                                                                                                       
- Update DSN example to use a custom username instead of `default`                                                                                         
- Add example for `auth[]` query parameter syntax                                                                                                          
- Document the `auth` option in the options array and the "Available Options" section                                                                    
- Add note that Predis ignores the `auth` option (credentials must be provided via DSN)                                                                    

**Context:**                                                                                                                                                 

This was requested in the discussion on symfony/symfony#63324, where it was pointed out that the `auth` parameter was undocumented.