### PR TITLE
[Form] Mention ``TogglePassword`` depreciation

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -140,3 +140,4 @@ whitelist:
         - '.. versionadded:: 2.2.0' # Panther
         - '* Inline code blocks use double-ticks (````like this````).'
         - 'the `HTML5 color format`_ (``/^#[0-9a-f]{6}$/i``). If it doesn''t match it,'
+        - '.. deprecated:: 2.29' # UX TogglePassword

--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -76,6 +76,12 @@ object.
 Adds "Show"/"Hide" links to the field which toggle the password field to plaintext when clicked.
 See `symfony/ux-toggle-password`_ for more details.
 
+.. deprecated:: 2.29
+
+    The ``ux-toggle-password`` component has been deprecated in Symfony UX
+    2.29 and will be removed in 3.0. See symfony/ux-toggle-password`_ for
+    migration.
+
 Overridden Options
 ------------------
 


### PR DESCRIPTION
UX component TogglePassword [is deprecated](https://github.com/symfony/ux/pull/2972)
Mentioned as required to use the corresponding option in Form, I think we can mention this depreciation
